### PR TITLE
feat: implement name and given-name disambiguation

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -111,12 +111,12 @@ Run `cargo run --bin csln_analyze -- styles/` to regenerate these statistics.
 | `is-uncertain-date` | 1,668 uses | Handled by preferring else branch |
 | `and` (text/symbol) | 172 styles | Conjunction between names |
 | `name-as-sort-order` | 48 styles | Family-first formatting |
+| `disambiguate-add-givenname`| 935 styles | Add initials when ambiguous |
+| `disambiguate-add-names` | 1,241 styles | Add more authors to resolve ambiguity |
 
 ### High Priority (Not Yet Implemented)
 | Feature | Usage | Notes |
 |---------|-------|-------|
-| `demote-non-dropping-particle` | 2,570 styles | "van Gogh" sorting |
-| `disambiguate-add-givenname` | 935 styles | Add initials when ambiguous |
 | `subsequent-author-substitute` | 314 styles | "———" for repeated authors |
 
 ### Implemented ✅

--- a/.agent/state.json
+++ b/.agent/state.json
@@ -2,8 +2,8 @@
   "phase": "cleanup_complete",
   "status": "ready_for_collaboration",
   "repo": "https://github.com/bdarcus/csl26",
-  "last_updated": "2026-01-28T19:15:00Z",
-  "citation_status": "5/5 exact match with citeproc-js oracle",
+  "last_updated": "2026-01-28T20:33:00Z",
+  "citation_status": "5/5 exact match with citeproc-js oracle (including disambiguation)",
   "bibliography_status": "~85% match - core elements working",
   "structure": {
     ".agent/": "LLM agent instructions (AGENTS.md) and state (state.json)",
@@ -17,5 +17,5 @@
     "Chicago author-date style support",
     "bulk migration of all 2,844 styles"
   ],
-  "tests_passing": 40
+  "tests_passing": 48
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ Features implemented:
 ✓ initialize-with (1,437 styles) - name initialization
 ✓ name-as-sort-order (2,100+ styles) - family-first ordering
 ✓ is-uncertain-date handling - [1962?] format
+✓ disambiguate-add-givenname (935 styles) - name expansion
+✓ disambiguate-add-names (1,241 styles) - et-al expansion
 
 Remaining high-priority:
-○ demote-non-dropping-particle (2,570 styles)
-○ disambiguate-add-givenname (935 styles)
 ○ subsequent-author-substitute (314 styles)
 ```
 

--- a/crates/csl_legacy/src/bin/main.rs
+++ b/crates/csl_legacy/src/bin/main.rs
@@ -1,7 +1,7 @@
-use std::fs;
+use csl_legacy::parser::parse_style;
 use roxmltree::Document;
 use serde_json::to_string_pretty;
-use csl_legacy::parser::parse_style;
+use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let text = fs::read_to_string("../styles/chicago-author-date.csl")?;

--- a/crates/csl_legacy/src/bin/stats.rs
+++ b/crates/csl_legacy/src/bin/stats.rs
@@ -1,6 +1,6 @@
-use std::fs;
-use roxmltree::Document;
 use csl_legacy::parser::parse_style;
+use roxmltree::Document;
+use std::fs;
 
 fn main() {
     let styles_dir = "styles";
@@ -19,49 +19,51 @@ fn main() {
 
     println!("Starting analysis of styles in {}...", styles_dir);
 
-    for entry in entries {
-        if let Ok(entry) = entry {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) == Some("csl") {
-                total += 1;
-                
-                // Read file
-                let text = match fs::read_to_string(&path) {
-                    Ok(t) => t,
-                    Err(_) => {
-                        *error_types.entry("File read error".to_string()).or_insert(0) += 1;
-                        errors += 1;
-                        continue;
-                    }
-                };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("csl") {
+            total += 1;
 
-                // Parse XML
-                let doc = match Document::parse(&text) {
-                    Ok(d) => d,
-                    Err(e) => {
-                        *error_types.entry(format!("XML Parse Error: {}", e)).or_insert(0) += 1;
-                        errors += 1;
-                        continue;
-                    }
-                };
+            // Read file
+            let text = match fs::read_to_string(&path) {
+                Ok(t) => t,
+                Err(_) => {
+                    *error_types
+                        .entry("File read error".to_string())
+                        .or_insert(0) += 1;
+                    errors += 1;
+                    continue;
+                }
+            };
 
-                // Parse CSL
-                match parse_style(doc.root_element()) {
-                    Ok(_) => success += 1,
-                    Err(e) => {
-                        // Simplify error message to group them
-                        let simple_err = if e.contains("missing") {
-                            e.split_whitespace().collect::<Vec<_>>().join(" ")
-                        } else {
-                            e.clone()
-                        };
-                        *error_types.entry(simple_err).or_insert(0) += 1;
-                        errors += 1;
-                        // Optional: Print first few failures
-                        // if errors <= 5 {
-                        //     println!("Failed: {:?} -> {}", path.file_name().unwrap(), e);
-                        // }
-                    }
+            // Parse XML
+            let doc = match Document::parse(&text) {
+                Ok(d) => d,
+                Err(e) => {
+                    *error_types
+                        .entry(format!("XML Parse Error: {}", e))
+                        .or_insert(0) += 1;
+                    errors += 1;
+                    continue;
+                }
+            };
+
+            // Parse CSL
+            match parse_style(doc.root_element()) {
+                Ok(_) => success += 1,
+                Err(e) => {
+                    // Simplify error message to group them
+                    let simple_err = if e.contains("missing") {
+                        e.split_whitespace().collect::<Vec<_>>().join(" ")
+                    } else {
+                        e.clone()
+                    };
+                    *error_types.entry(simple_err).or_insert(0) += 1;
+                    errors += 1;
+                    // Optional: Print first few failures
+                    // if errors <= 5 {
+                    //     println!("Failed: {:?} -> {}", path.file_name().unwrap(), e);
+                    // }
                 }
             }
         }
@@ -69,10 +71,18 @@ fn main() {
 
     println!("\n=== ANALYSIS COMPLETE ===");
     println!("Total Styles: {}", total);
-    println!("Success:      {} ({:.1}%)", success, (success as f64 / total as f64) * 100.0);
-    println!("Failures:     {} ({:.1}%)", errors, (errors as f64 / total as f64) * 100.0);
+    println!(
+        "Success:      {} ({:.1}%)",
+        success,
+        (success as f64 / total as f64) * 100.0
+    );
+    println!(
+        "Failures:     {} ({:.1}%)",
+        errors,
+        (errors as f64 / total as f64) * 100.0
+    );
     println!("\n=== TOP ERRORS ===");
-    
+
     let mut err_vec: Vec<_> = error_types.iter().collect();
     err_vec.sort_by(|a, b| b.1.cmp(a.1));
 

--- a/crates/csl_legacy/src/model.rs
+++ b/crates/csl_legacy/src/model.rs
@@ -59,6 +59,8 @@ pub struct Citation {
     pub et_al_min: Option<usize>,
     pub et_al_use_first: Option<usize>,
     pub disambiguate_add_year_suffix: Option<bool>,
+    pub disambiguate_add_names: Option<bool>,
+    pub disambiguate_add_givenname: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/csln_analyze/src/batch_test.rs
+++ b/crates/csln_analyze/src/batch_test.rs
@@ -18,7 +18,7 @@ use walkdir::WalkDir;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    
+
     if args.len() < 2 {
         eprintln!("Usage: csln_batch_test <styles_dir> [--verbose] [--sample N]");
         eprintln!();
@@ -28,28 +28,34 @@ fn main() {
         eprintln!("  --json       Output as JSON");
         std::process::exit(1);
     }
-    
+
     let styles_dir = &args[1];
     let verbose = args.contains(&"--verbose".to_string());
     let json_output = args.contains(&"--json".to_string());
-    let sample_size: Option<usize> = args.iter()
+    let sample_size: Option<usize> = args
+        .iter()
         .position(|a| a == "--sample")
         .and_then(|i| args.get(i + 1))
         .and_then(|s| s.parse().ok());
-    
+
     // Collect all .csl files
     let mut styles: Vec<_> = WalkDir::new(styles_dir)
         .into_iter()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map(|ext| ext == "csl").unwrap_or(false))
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "csl")
+                .unwrap_or(false)
+        })
         .map(|e| e.path().to_path_buf())
         .collect();
-    
+
     // Sample if requested
     if let Some(n) = sample_size {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
-        
+
         // Deterministic shuffle based on filename hash
         styles.sort_by(|a, b| {
             let mut ha = DefaultHasher::new();
@@ -60,16 +66,16 @@ fn main() {
         });
         styles.truncate(n);
     }
-    
+
     let total = styles.len();
     let mut results = BatchResults::default();
-    
+
     eprintln!("Testing {} styles...\n", total);
-    
+
     for (i, path) in styles.iter().enumerate() {
         let result = test_style(path);
         let name = path.file_stem().unwrap().to_string_lossy().to_string();
-        
+
         match &result {
             TestResult::Success => {
                 results.migration_success += 1;
@@ -79,35 +85,62 @@ fn main() {
             }
             TestResult::MigrationFailed(err) => {
                 results.migration_failed += 1;
-                *results.migration_errors.entry(categorize_error(err)).or_insert(0) += 1;
+                *results
+                    .migration_errors
+                    .entry(categorize_error(err))
+                    .or_insert(0) += 1;
                 if verbose {
-                    eprintln!("[{}/{}] ❌ {} - Migration: {}", i + 1, total, name, truncate(err, 60));
+                    eprintln!(
+                        "[{}/{}] ❌ {} - Migration: {}",
+                        i + 1,
+                        total,
+                        name,
+                        truncate(err, 60)
+                    );
                 }
             }
             TestResult::ProcessorFailed(err) => {
                 results.processor_failed += 1;
-                *results.processor_errors.entry(categorize_error(err)).or_insert(0) += 1;
+                *results
+                    .processor_errors
+                    .entry(categorize_error(err))
+                    .or_insert(0) += 1;
                 if verbose {
-                    eprintln!("[{}/{}] ⚠️  {} - Processor: {}", i + 1, total, name, truncate(err, 60));
+                    eprintln!(
+                        "[{}/{}] ⚠️  {} - Processor: {}",
+                        i + 1,
+                        total,
+                        name,
+                        truncate(err, 60)
+                    );
                 }
             }
             TestResult::YamlInvalid(err) => {
                 results.yaml_invalid += 1;
-                *results.yaml_errors.entry(categorize_error(err)).or_insert(0) += 1;
+                *results
+                    .yaml_errors
+                    .entry(categorize_error(err))
+                    .or_insert(0) += 1;
                 if verbose {
-                    eprintln!("[{}/{}] ❌ {} - Invalid YAML: {}", i + 1, total, name, truncate(err, 60));
+                    eprintln!(
+                        "[{}/{}] ❌ {} - Invalid YAML: {}",
+                        i + 1,
+                        total,
+                        name,
+                        truncate(err, 60)
+                    );
                 }
             }
         }
-        
+
         // Progress indicator every 100 styles
         if !verbose && (i + 1) % 100 == 0 {
             eprintln!("  Processed {}/{}", i + 1, total);
         }
     }
-    
+
     results.total = total;
-    
+
     if json_output {
         println!("{}", serde_json::to_string_pretty(&results).unwrap());
     } else {
@@ -140,49 +173,49 @@ fn test_style(path: &Path) -> TestResult {
         .args(["run", "-q", "--bin", "csln_migrate", "--"])
         .arg(path)
         .output();
-    
+
     let migrate_output = match migrate_output {
         Ok(o) => o,
         Err(e) => return TestResult::MigrationFailed(format!("spawn error: {}", e)),
     };
-    
+
     if !migrate_output.status.success() {
         let stderr = String::from_utf8_lossy(&migrate_output.stderr);
         return TestResult::MigrationFailed(stderr.to_string());
     }
-    
+
     let yaml_content = String::from_utf8_lossy(&migrate_output.stdout);
-    
+
     // Step 2: Validate YAML parses as Style
     let style_result: Result<csln_core::Style, _> = serde_yaml::from_str(&yaml_content);
     if let Err(e) = style_result {
         return TestResult::YamlInvalid(e.to_string());
     }
-    
+
     // Step 3: Write to temp file and run processor
     let temp_path = std::env::temp_dir().join("csln_batch_test.yaml");
     if let Err(e) = fs::write(&temp_path, yaml_content.as_bytes()) {
         return TestResult::ProcessorFailed(format!("write error: {}", e));
     }
-    
+
     let proc_output = Command::new("cargo")
         .args(["run", "-q", "--bin", "csln_processor", "--"])
         .arg(&temp_path)
         .output();
-    
+
     let proc_output = match proc_output {
         Ok(o) => o,
         Err(e) => return TestResult::ProcessorFailed(format!("spawn error: {}", e)),
     };
-    
+
     if !proc_output.status.success() {
         let stderr = String::from_utf8_lossy(&proc_output.stderr);
         return TestResult::ProcessorFailed(stderr.to_string());
     }
-    
+
     // Clean up
     let _ = fs::remove_file(&temp_path);
-    
+
     TestResult::Success
 }
 
@@ -190,7 +223,10 @@ fn categorize_error(err: &str) -> String {
     // Extract meaningful error category from error message
     if err.contains("unknown attribute") {
         if let Some(attr) = err.split("unknown attribute: ").nth(1) {
-            return format!("unknown attr: {}", attr.split_whitespace().next().unwrap_or("?"));
+            return format!(
+                "unknown attr: {}",
+                attr.split_whitespace().next().unwrap_or("?")
+            );
         }
     }
     if err.contains("Unknown top-level tag") {
@@ -198,7 +234,10 @@ fn categorize_error(err: &str) -> String {
     }
     if err.contains("missing field") {
         if let Some(field) = err.split("missing field").nth(1) {
-            return format!("missing field:{}", field.chars().take(20).collect::<String>());
+            return format!(
+                "missing field:{}",
+                field.chars().take(20).collect::<String>()
+            );
         }
     }
     if err.contains("unknown variant") {
@@ -207,9 +246,14 @@ fn categorize_error(err: &str) -> String {
     if err.contains("Error parsing style") {
         return "parse error".to_string();
     }
-    
+
     // Truncate to first line
-    err.lines().next().unwrap_or("unknown").chars().take(40).collect()
+    err.lines()
+        .next()
+        .unwrap_or("unknown")
+        .chars()
+        .take(40)
+        .collect()
 }
 
 fn truncate(s: &str, max: usize) -> String {
@@ -225,23 +269,26 @@ fn print_results(results: &BatchResults) {
     println!("\n=== Batch Migration Test Results ===\n");
     println!("Total styles tested: {}", results.total);
     println!();
-    
+
     let success_rate = (results.migration_success as f64 / results.total as f64) * 100.0;
-    println!("Migration + Processor Success: {} ({:.1}%)", results.migration_success, success_rate);
+    println!(
+        "Migration + Processor Success: {} ({:.1}%)",
+        results.migration_success, success_rate
+    );
     println!("Migration Failed: {}", results.migration_failed);
     println!("YAML Invalid: {}", results.yaml_invalid);
     println!("Processor Failed: {}", results.processor_failed);
-    
+
     if !results.migration_errors.is_empty() {
         println!("\n--- Migration Errors ---");
         print_error_summary(&results.migration_errors);
     }
-    
+
     if !results.yaml_errors.is_empty() {
         println!("\n--- YAML Validation Errors ---");
         print_error_summary(&results.yaml_errors);
     }
-    
+
     if !results.processor_errors.is_empty() {
         println!("\n--- Processor Errors ---");
         print_error_summary(&results.processor_errors);
@@ -251,7 +298,7 @@ fn print_results(results: &BatchResults) {
 fn print_error_summary(errors: &HashMap<String, usize>) {
     let mut items: Vec<_> = errors.iter().collect();
     items.sort_by(|a, b| b.1.cmp(a.1));
-    
+
     for (error, count) in items.iter().take(10) {
         println!("  {:5} - {}", count, error);
     }

--- a/crates/csln_analyze/src/main.rs
+++ b/crates/csln_analyze/src/main.rs
@@ -18,30 +18,37 @@ use walkdir::WalkDir;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    
+
     if args.len() < 2 {
         eprintln!("Usage: csln_analyze <styles_dir> [--json]");
         eprintln!();
         eprintln!("Analyzes all .csl files in the directory and reports statistics.");
         std::process::exit(1);
     }
-    
+
     let styles_dir = &args[1];
     let json_output = args.contains(&"--json".to_string());
-    
+
     let mut stats = StyleStats::default();
-    
+
     // Walk directory and analyze each .csl file
     for entry in WalkDir::new(styles_dir)
         .into_iter()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().map(|ext| ext == "csl").unwrap_or(false))
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "csl")
+                .unwrap_or(false)
+        })
     {
         if let Err(e) = analyze_style(entry.path(), &mut stats) {
-            stats.parse_errors.push(format!("{}: {}", entry.path().display(), e));
+            stats
+                .parse_errors
+                .push(format!("{}: {}", entry.path().display(), e));
         }
     }
-    
+
     if json_output {
         println!("{}", serde_json::to_string_pretty(&stats).unwrap());
     } else {
@@ -53,7 +60,7 @@ fn main() {
 struct StyleStats {
     total_styles: u32,
     parse_errors: Vec<String>,
-    
+
     // Style-level attributes
     style_class: Counter,
     initialize_with: Counter,
@@ -63,18 +70,18 @@ struct StyleStats {
     and_option: Counter,
     demote_non_dropping_particle: Counter,
     page_range_format: Counter,
-    
+
     // Citation attributes
     disambiguate_add_year_suffix: Counter,
     disambiguate_add_givenname: Counter,
     givenname_disambiguation_rule: Counter,
     citation_et_al_min: Counter,
     citation_et_al_use_first: Counter,
-    
+
     // Bibliography attributes
     subsequent_author_substitute: Counter,
     bib_et_al_min: Counter,
-    
+
     // Condition patterns (in choose blocks)
     condition_type: Counter,
     condition_variable: Counter,
@@ -82,7 +89,7 @@ struct StyleStats {
     condition_is_uncertain_date: Counter,
     condition_locator: Counter,
     condition_position: Counter,
-    
+
     // Element usage
     element_names: Counter,
     element_date: Counter,
@@ -91,16 +98,16 @@ struct StyleStats {
     element_label: Counter,
     element_group: Counter,
     element_choose: Counter,
-    
+
     // Name element options
     name_form: Counter,
     name_initialize: Counter,
     name_initialize_with: Counter,
-    
-    // Date element options  
+
+    // Date element options
     date_form: Counter,
     date_parts: Counter,
-    
+
     // Unhandled attributes (for gap analysis)
     unhandled_style_attrs: Counter,
     unhandled_name_attrs: Counter,
@@ -109,22 +116,20 @@ struct StyleStats {
 type Counter = HashMap<String, u32>;
 
 fn analyze_style(path: &Path, stats: &mut StyleStats) -> Result<(), String> {
-    let content = fs::read_to_string(path)
-        .map_err(|e| format!("read error: {}", e))?;
-    
-    let doc = roxmltree::Document::parse(&content)
-        .map_err(|e| format!("parse error: {}", e))?;
-    
+    let content = fs::read_to_string(path).map_err(|e| format!("read error: {}", e))?;
+
+    let doc = roxmltree::Document::parse(&content).map_err(|e| format!("parse error: {}", e))?;
+
     let root = doc.root_element();
-    
+
     stats.total_styles += 1;
-    
+
     // Analyze style-level attributes
     analyze_style_attrs(&root, stats);
-    
+
     // Walk all nodes and collect statistics
     analyze_nodes(&root, stats);
-    
+
     Ok(())
 }
 
@@ -133,7 +138,7 @@ fn analyze_style_attrs(node: &roxmltree::Node, stats: &mut StyleStats) {
     if let Some(v) = node.attribute("class") {
         *stats.style_class.entry(v.to_string()).or_insert(0) += 1;
     }
-    
+
     // Name formatting
     if let Some(v) = node.attribute("initialize-with") {
         *stats.initialize_with.entry(format!("{:?}", v)).or_insert(0) += 1;
@@ -145,56 +150,89 @@ fn analyze_style_attrs(node: &roxmltree::Node, stats: &mut StyleStats) {
         *stats.name_as_sort_order.entry(v.to_string()).or_insert(0) += 1;
     }
     if let Some(v) = node.attribute("delimiter-precedes-last") {
-        *stats.delimiter_precedes_last.entry(v.to_string()).or_insert(0) += 1;
+        *stats
+            .delimiter_precedes_last
+            .entry(v.to_string())
+            .or_insert(0) += 1;
     }
     if let Some(v) = node.attribute("and") {
         *stats.and_option.entry(v.to_string()).or_insert(0) += 1;
     }
     if let Some(v) = node.attribute("demote-non-dropping-particle") {
-        *stats.demote_non_dropping_particle.entry(v.to_string()).or_insert(0) += 1;
+        *stats
+            .demote_non_dropping_particle
+            .entry(v.to_string())
+            .or_insert(0) += 1;
     }
     if let Some(v) = node.attribute("page-range-format") {
         *stats.page_range_format.entry(v.to_string()).or_insert(0) += 1;
     }
-    
+
     // Check for unhandled style-level attributes
     let known_attrs = [
-        "xmlns", "version", "class", "default-locale",
-        "initialize-with", "names-delimiter", "name-as-sort-order",
-        "delimiter-precedes-last", "and", "demote-non-dropping-particle",
-        "page-range-format", "sort-separator", "name-delimiter",
+        "xmlns",
+        "version",
+        "class",
+        "default-locale",
+        "initialize-with",
+        "names-delimiter",
+        "name-as-sort-order",
+        "delimiter-precedes-last",
+        "and",
+        "demote-non-dropping-particle",
+        "page-range-format",
+        "sort-separator",
+        "name-delimiter",
     ];
     for attr in node.attributes() {
         if !known_attrs.contains(&attr.name()) {
-            *stats.unhandled_style_attrs.entry(attr.name().to_string()).or_insert(0) += 1;
+            *stats
+                .unhandled_style_attrs
+                .entry(attr.name().to_string())
+                .or_insert(0) += 1;
         }
     }
 }
 
 fn analyze_nodes(node: &roxmltree::Node, stats: &mut StyleStats) {
     let tag = node.tag_name().name();
-    
+
     match tag {
         "citation" => {
             if let Some(v) = node.attribute("disambiguate-add-year-suffix") {
-                *stats.disambiguate_add_year_suffix.entry(v.to_string()).or_insert(0) += 1;
+                *stats
+                    .disambiguate_add_year_suffix
+                    .entry(v.to_string())
+                    .or_insert(0) += 1;
             }
             if let Some(v) = node.attribute("disambiguate-add-givenname") {
-                *stats.disambiguate_add_givenname.entry(v.to_string()).or_insert(0) += 1;
+                *stats
+                    .disambiguate_add_givenname
+                    .entry(v.to_string())
+                    .or_insert(0) += 1;
             }
             if let Some(v) = node.attribute("givenname-disambiguation-rule") {
-                *stats.givenname_disambiguation_rule.entry(v.to_string()).or_insert(0) += 1;
+                *stats
+                    .givenname_disambiguation_rule
+                    .entry(v.to_string())
+                    .or_insert(0) += 1;
             }
             if let Some(v) = node.attribute("et-al-min") {
                 *stats.citation_et_al_min.entry(v.to_string()).or_insert(0) += 1;
             }
             if let Some(v) = node.attribute("et-al-use-first") {
-                *stats.citation_et_al_use_first.entry(v.to_string()).or_insert(0) += 1;
+                *stats
+                    .citation_et_al_use_first
+                    .entry(v.to_string())
+                    .or_insert(0) += 1;
             }
         }
         "bibliography" => {
             if let Some(v) = node.attribute("subsequent-author-substitute") {
-                *stats.subsequent_author_substitute.entry(format!("{:?}", v)).or_insert(0) += 1;
+                *stats
+                    .subsequent_author_substitute
+                    .entry(format!("{:?}", v))
+                    .or_insert(0) += 1;
             }
             if let Some(v) = node.attribute("et-al-min") {
                 *stats.bib_et_al_min.entry(v.to_string()).or_insert(0) += 1;
@@ -219,7 +257,10 @@ fn analyze_nodes(node: &roxmltree::Node, stats: &mut StyleStats) {
             }
             if let Some(v) = node.attribute("is-uncertain-date") {
                 for t in v.split_whitespace() {
-                    *stats.condition_is_uncertain_date.entry(t.to_string()).or_insert(0) += 1;
+                    *stats
+                        .condition_is_uncertain_date
+                        .entry(t.to_string())
+                        .or_insert(0) += 1;
                 }
             }
             if let Some(v) = node.attribute("locator") {
@@ -244,18 +285,31 @@ fn analyze_nodes(node: &roxmltree::Node, stats: &mut StyleStats) {
                 *stats.name_initialize.entry(v.to_string()).or_insert(0) += 1;
             }
             if let Some(v) = node.attribute("initialize-with") {
-                *stats.name_initialize_with.entry(format!("{:?}", v)).or_insert(0) += 1;
+                *stats
+                    .name_initialize_with
+                    .entry(format!("{:?}", v))
+                    .or_insert(0) += 1;
             }
-            
+
             // Check for unhandled name attributes
             let known = [
-                "form", "initialize", "initialize-with", "and", "delimiter",
-                "delimiter-precedes-last", "et-al-min", "et-al-use-first",
-                "name-as-sort-order", "sort-separator",
+                "form",
+                "initialize",
+                "initialize-with",
+                "and",
+                "delimiter",
+                "delimiter-precedes-last",
+                "et-al-min",
+                "et-al-use-first",
+                "name-as-sort-order",
+                "sort-separator",
             ];
             for attr in node.attributes() {
                 if !known.contains(&attr.name()) {
-                    *stats.unhandled_name_attrs.entry(attr.name().to_string()).or_insert(0) += 1;
+                    *stats
+                        .unhandled_name_attrs
+                        .entry(attr.name().to_string())
+                        .or_insert(0) += 1;
                 }
             }
         }
@@ -285,7 +339,7 @@ fn analyze_nodes(node: &roxmltree::Node, stats: &mut StyleStats) {
         }
         _ => {}
     }
-    
+
     // Recurse into children
     for child in node.children() {
         if child.is_element() {
@@ -298,7 +352,7 @@ fn print_stats(stats: &StyleStats) {
     println!("=== CSL Style Analysis ===\n");
     println!("Total styles analyzed: {}", stats.total_styles);
     println!("Parse errors: {}\n", stats.parse_errors.len());
-    
+
     println!("=== Style-Level Attributes ===\n");
     print_counter("class", &stats.style_class);
     print_counter("initialize-with", &stats.initialize_with);
@@ -306,54 +360,93 @@ fn print_stats(stats: &StyleStats) {
     print_counter("name-as-sort-order", &stats.name_as_sort_order);
     print_counter("delimiter-precedes-last", &stats.delimiter_precedes_last);
     print_counter("and", &stats.and_option);
-    print_counter("demote-non-dropping-particle", &stats.demote_non_dropping_particle);
+    print_counter(
+        "demote-non-dropping-particle",
+        &stats.demote_non_dropping_particle,
+    );
     print_counter("page-range-format", &stats.page_range_format);
-    
+
     println!("\n=== Citation Attributes ===\n");
-    print_counter("disambiguate-add-year-suffix", &stats.disambiguate_add_year_suffix);
-    print_counter("disambiguate-add-givenname", &stats.disambiguate_add_givenname);
-    print_counter("givenname-disambiguation-rule", &stats.givenname_disambiguation_rule);
+    print_counter(
+        "disambiguate-add-year-suffix",
+        &stats.disambiguate_add_year_suffix,
+    );
+    print_counter(
+        "disambiguate-add-givenname",
+        &stats.disambiguate_add_givenname,
+    );
+    print_counter(
+        "givenname-disambiguation-rule",
+        &stats.givenname_disambiguation_rule,
+    );
     print_counter("et-al-min (citation)", &stats.citation_et_al_min);
-    
+
     println!("\n=== Bibliography Attributes ===\n");
-    print_counter("subsequent-author-substitute", &stats.subsequent_author_substitute);
+    print_counter(
+        "subsequent-author-substitute",
+        &stats.subsequent_author_substitute,
+    );
     print_counter("et-al-min (bibliography)", &stats.bib_et_al_min);
-    
+
     println!("\n=== Condition Patterns ===\n");
     print_counter("type conditions", &stats.condition_type);
     print_counter("variable conditions", &stats.condition_variable);
     print_counter("is-numeric conditions", &stats.condition_is_numeric);
-    print_counter("is-uncertain-date conditions", &stats.condition_is_uncertain_date);
+    print_counter(
+        "is-uncertain-date conditions",
+        &stats.condition_is_uncertain_date,
+    );
     print_counter("position conditions", &stats.condition_position);
-    
+
     println!("\n=== Name Element Options ===\n");
     print_counter("name form", &stats.name_form);
     print_counter("name initialize", &stats.name_initialize);
     print_counter("name initialize-with", &stats.name_initialize_with);
-    
+
     println!("\n=== Date Element Options ===\n");
     print_counter("date form", &stats.date_form);
     print_counter("date-parts", &stats.date_parts);
-    
+
     println!("\n=== Element Usage ===\n");
-    println!("  names:  {}", stats.element_names.get("count").unwrap_or(&0));
-    println!("  date:   {}", stats.element_date.get("count").unwrap_or(&0));
-    println!("  text:   {}", stats.element_text.get("count").unwrap_or(&0));
-    println!("  number: {}", stats.element_number.get("count").unwrap_or(&0));
-    println!("  label:  {}", stats.element_label.get("count").unwrap_or(&0));
-    println!("  group:  {}", stats.element_group.get("count").unwrap_or(&0));
-    println!("  choose: {}", stats.element_choose.get("count").unwrap_or(&0));
-    
+    println!(
+        "  names:  {}",
+        stats.element_names.get("count").unwrap_or(&0)
+    );
+    println!(
+        "  date:   {}",
+        stats.element_date.get("count").unwrap_or(&0)
+    );
+    println!(
+        "  text:   {}",
+        stats.element_text.get("count").unwrap_or(&0)
+    );
+    println!(
+        "  number: {}",
+        stats.element_number.get("count").unwrap_or(&0)
+    );
+    println!(
+        "  label:  {}",
+        stats.element_label.get("count").unwrap_or(&0)
+    );
+    println!(
+        "  group:  {}",
+        stats.element_group.get("count").unwrap_or(&0)
+    );
+    println!(
+        "  choose: {}",
+        stats.element_choose.get("count").unwrap_or(&0)
+    );
+
     if !stats.unhandled_style_attrs.is_empty() {
         println!("\n=== Unhandled Style Attributes (Gap Analysis) ===\n");
         print_counter("style-level", &stats.unhandled_style_attrs);
     }
-    
+
     if !stats.unhandled_name_attrs.is_empty() {
         println!("\n=== Unhandled Name Attributes ===\n");
         print_counter("name element", &stats.unhandled_name_attrs);
     }
-    
+
     if !stats.parse_errors.is_empty() {
         println!("\n=== Parse Errors ===\n");
         for (i, err) in stats.parse_errors.iter().take(10).enumerate() {
@@ -369,14 +462,14 @@ fn print_counter(name: &str, counter: &Counter) {
     if counter.is_empty() {
         return;
     }
-    
+
     let total: u32 = counter.values().sum();
     println!("{}: {} occurrences", name, total);
-    
+
     // Sort by count descending
     let mut items: Vec<_> = counter.iter().collect();
     items.sort_by(|a, b| b.1.cmp(a.1));
-    
+
     for (value, count) in items.iter().take(8) {
         let pct = (**count as f64 / total as f64) * 100.0;
         println!("  {:40} {:5} ({:.1}%)", value, count, pct);

--- a/crates/csln_core/src/bin/render_demo.rs
+++ b/crates/csln_core/src/bin/render_demo.rs
@@ -1,6 +1,6 @@
-use std::fs;
+use csln_core::{CitationItem, CslnStyle, ItemType, Renderer, Variable};
 use std::collections::HashMap;
-use csln_core::{CslnStyle, Renderer, CitationItem, ItemType, Variable};
+use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Load the Migrated Style

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub mod renderer; // Expose the renderer
-pub use renderer::{Renderer, CitationItem};
+pub use renderer::{CitationItem, Renderer};
 
 // New CSLN schema modules
 pub mod locale;
@@ -77,28 +77,120 @@ pub struct StyleInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum ItemType {
-    Article, ArticleJournal, ArticleMagazine, ArticleNewspaper, Bill, Book, Broadcast, 
-    Chapter, Dataset, Entry, EntryDictionary, EntryEncyclopedia, Figure, Graphic, 
-    Interview, LegalCase, Legislation, Manuscript, Map, MotionPicture, MusicalScore, 
-    Pamphlet, PaperConference, Patent, PersonalCommunication, Post, PostWeblog, 
-    Report, Review, ReviewBook, Song, Speech, Thesis, Treaty, Webpage, Software, Standard,
+    Article,
+    ArticleJournal,
+    ArticleMagazine,
+    ArticleNewspaper,
+    Bill,
+    Book,
+    Broadcast,
+    Chapter,
+    Dataset,
+    Entry,
+    EntryDictionary,
+    EntryEncyclopedia,
+    Figure,
+    Graphic,
+    Interview,
+    LegalCase,
+    Legislation,
+    Manuscript,
+    Map,
+    MotionPicture,
+    MusicalScore,
+    Pamphlet,
+    PaperConference,
+    Patent,
+    PersonalCommunication,
+    Post,
+    PostWeblog,
+    Report,
+    Review,
+    ReviewBook,
+    Song,
+    Speech,
+    Thesis,
+    Treaty,
+    Webpage,
+    Software,
+    Standard,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum Variable {
-    Author, CollectionEditor, Composer, ContainerAuthor, Director, Editor, 
-    EditorialDirector, Illustrator, Interviewer, OriginalAuthor, Recipient, 
-    ReviewedAuthor, Translator, Accessed, AvailableDate, EventDate, Issued, 
-    OriginalDate, Submitted, ChapterNumber, CollectionNumber, Edition, Issue, 
-    Number, NumberOfPages, NumberOfVolumes, Volume, Abstract, Annote, Archive, 
-    ArchiveLocation, ArchivePlace, Authority, CallNumber, CitationLabel, 
-    CitationNumber, CollectionTitle, ContainerTitle, ContainerTitleShort, 
-    Dimensions, DOI, Event, EventPlace, FirstReferenceNoteNumber, Genre, ISBN, 
-    ISSN, Jurisdiction, Keyword, Locator, Medium, Note, OriginalPublisher, 
-    OriginalPublisherPlace, OriginalTitle, Page, PageFirst, PMCID, PMID, 
-    Publisher, PublisherPlace, References, ReviewedTitle, Scale, Section, 
-    Source, Status, Title, TitleShort, URL, Version, YearSuffix,
+    Author,
+    CollectionEditor,
+    Composer,
+    ContainerAuthor,
+    Director,
+    Editor,
+    EditorialDirector,
+    Illustrator,
+    Interviewer,
+    OriginalAuthor,
+    Recipient,
+    ReviewedAuthor,
+    Translator,
+    Accessed,
+    AvailableDate,
+    EventDate,
+    Issued,
+    OriginalDate,
+    Submitted,
+    ChapterNumber,
+    CollectionNumber,
+    Edition,
+    Issue,
+    Number,
+    NumberOfPages,
+    NumberOfVolumes,
+    Volume,
+    Abstract,
+    Annote,
+    Archive,
+    ArchiveLocation,
+    ArchivePlace,
+    Authority,
+    CallNumber,
+    CitationLabel,
+    CitationNumber,
+    CollectionTitle,
+    ContainerTitle,
+    ContainerTitleShort,
+    Dimensions,
+    DOI,
+    Event,
+    EventPlace,
+    FirstReferenceNoteNumber,
+    Genre,
+    ISBN,
+    ISSN,
+    Jurisdiction,
+    Keyword,
+    Locator,
+    Medium,
+    Note,
+    OriginalPublisher,
+    OriginalPublisherPlace,
+    OriginalTitle,
+    Page,
+    PageFirst,
+    PMCID,
+    PMID,
+    Publisher,
+    PublisherPlace,
+    References,
+    ReviewedTitle,
+    Scale,
+    Section,
+    Source,
+    Status,
+    Title,
+    TitleShort,
+    URL,
+    Version,
+    YearSuffix,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -224,19 +316,34 @@ pub struct NamesOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum NameMode { Long, Short, Count }
+pub enum NameMode {
+    Long,
+    Short,
+    Count,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum AndTerm { Text, Symbol }
+pub enum AndTerm {
+    Text,
+    Symbol,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum DelimiterPrecedes { Contextual, AfterInvertedName, Always, Never }
+pub enum DelimiterPrecedes {
+    Contextual,
+    AfterInvertedName,
+    Always,
+    Never,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum NameAsSortOrder { First, All }
+pub enum NameAsSortOrder {
+    First,
+    All,
+}
 
 /// Configuration for et-al abbreviation in names.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -278,15 +385,28 @@ pub struct DateOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum DateForm { Text, Numeric }
+pub enum DateForm {
+    Text,
+    Numeric,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum DateParts { Year, YearMonth, YearMonthDay }
+pub enum DateParts {
+    Year,
+    YearMonth,
+    YearMonthDay,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum DatePartForm { Numeric, NumericLeadingZeros, Ordinal, Long, Short }
+pub enum DatePartForm {
+    Numeric,
+    NumericLeadingZeros,
+    Ordinal,
+    Long,
+    Short,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -311,23 +431,41 @@ pub struct FormattingOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum FontStyle { Normal, Italic, Oblique }
+pub enum FontStyle {
+    Normal,
+    Italic,
+    Oblique,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum FontVariant { Normal, SmallCaps }
+pub enum FontVariant {
+    Normal,
+    SmallCaps,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum FontWeight { Normal, Bold, Light }
+pub enum FontWeight {
+    Normal,
+    Bold,
+    Light,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum TextDecoration { None, Underline }
+pub enum TextDecoration {
+    None,
+    Underline,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum VerticalAlign { Baseline, Superscript, Subscript }
+pub enum VerticalAlign {
+    Baseline,
+    Superscript,
+    Subscript,
+}
 
 #[cfg(test)]
 mod tests {
@@ -382,8 +520,8 @@ options:
         let yaml = r#"
 info:
   title: APA
-options: 
-  substitute: 
+options:
+  substitute:
     contributor-role-form: short
     template:
       - editor
@@ -398,7 +536,7 @@ citation:
       form: short
     - date: issued
       form: year
-bibliography: 
+bibliography:
   template:
     - contributor: author
       form: long
@@ -413,31 +551,34 @@ bibliography:
     - variable: doi
 "#;
         let style: Style = serde_yaml::from_str(yaml).unwrap();
-        
+
         // Verify info
         assert_eq!(style.info.title.as_ref().unwrap(), "APA");
-        
+
         // Verify options
         let options = style.options.unwrap();
         assert_eq!(options.processing, Some(options::Processing::AuthorDate));
         assert!(options.substitute.is_some());
-        
+
         // Verify citation
         let citation = style.citation.unwrap();
         assert_eq!(citation.template.len(), 2);
-        
-        // Verify bibliography  
+
+        // Verify bibliography
         let bib = style.bibliography.unwrap();
         assert_eq!(bib.template.len(), 6);
-        
+
         // Verify flattened rendering worked
         match &bib.template[1] {
             template::TemplateComponent::Date(d) => {
-                assert_eq!(d.rendering.wrap, Some(template::WrapPunctuation::Parentheses));
+                assert_eq!(
+                    d.rendering.wrap,
+                    Some(template::WrapPunctuation::Parentheses)
+                );
             }
             _ => panic!("Expected Date"),
         }
-        
+
         match &bib.template[3] {
             template::TemplateComponent::Title(t) => {
                 assert_eq!(t.rendering.prefix, Some("In ".to_string()));

--- a/crates/csln_core/src/locale.rs
+++ b/crates/csln_core/src/locale.rs
@@ -33,24 +33,60 @@ impl Locale {
     /// Create a new English (US) locale with default terms.
     pub fn en_us() -> Self {
         let mut roles = HashMap::new();
-        
-        roles.insert(ContributorRole::Editor, ContributorTerm {
-            singular: SimpleTerm { long: "editor".into(), short: "Ed.".into() },
-            plural: SimpleTerm { long: "editors".into(), short: "Eds.".into() },
-            verb: SimpleTerm { long: "edited by".into(), short: "Ed.".into() },
-        });
-        
-        roles.insert(ContributorRole::Translator, ContributorTerm {
-            singular: SimpleTerm { long: "translator".into(), short: "Trans.".into() },
-            plural: SimpleTerm { long: "translators".into(), short: "Trans.".into() },
-            verb: SimpleTerm { long: "translated by".into(), short: "Trans.".into() },
-        });
 
-        roles.insert(ContributorRole::Director, ContributorTerm {
-            singular: SimpleTerm { long: "director".into(), short: "Dir.".into() },
-            plural: SimpleTerm { long: "directors".into(), short: "dirs.".into() },
-            verb: SimpleTerm { long: "directed by".into(), short: "dir.".into() },
-        });
+        roles.insert(
+            ContributorRole::Editor,
+            ContributorTerm {
+                singular: SimpleTerm {
+                    long: "editor".into(),
+                    short: "Ed.".into(),
+                },
+                plural: SimpleTerm {
+                    long: "editors".into(),
+                    short: "Eds.".into(),
+                },
+                verb: SimpleTerm {
+                    long: "edited by".into(),
+                    short: "Ed.".into(),
+                },
+            },
+        );
+
+        roles.insert(
+            ContributorRole::Translator,
+            ContributorTerm {
+                singular: SimpleTerm {
+                    long: "translator".into(),
+                    short: "Trans.".into(),
+                },
+                plural: SimpleTerm {
+                    long: "translators".into(),
+                    short: "Trans.".into(),
+                },
+                verb: SimpleTerm {
+                    long: "translated by".into(),
+                    short: "Trans.".into(),
+                },
+            },
+        );
+
+        roles.insert(
+            ContributorRole::Director,
+            ContributorTerm {
+                singular: SimpleTerm {
+                    long: "director".into(),
+                    short: "Dir.".into(),
+                },
+                plural: SimpleTerm {
+                    long: "directors".into(),
+                    short: "dirs.".into(),
+                },
+                verb: SimpleTerm {
+                    long: "directed by".into(),
+                    short: "dir.".into(),
+                },
+            },
+        );
 
         Self {
             locale: "en-US".into(),
@@ -90,9 +126,19 @@ impl Locale {
     pub fn month_name(&self, month: u8, short: bool) -> &str {
         let idx = (month.saturating_sub(1)) as usize;
         if short {
-            self.dates.months.short.get(idx).map(|s| s.as_str()).unwrap_or("")
+            self.dates
+                .months
+                .short
+                .get(idx)
+                .map(|s| s.as_str())
+                .unwrap_or("")
         } else {
-            self.dates.months.long.get(idx).map(|s| s.as_str()).unwrap_or("")
+            self.dates
+                .months
+                .long
+                .get(idx)
+                .map(|s| s.as_str())
+                .unwrap_or("")
         }
     }
 }
@@ -151,12 +197,18 @@ impl Terms {
             and: Some("and".into()),
             and_symbol: Some("&".into()),
             and_others: Some("and others".into()),
-            anonymous: SimpleTerm { long: "anonymous".into(), short: "anon.".into() },
+            anonymous: SimpleTerm {
+                long: "anonymous".into(),
+                short: "anon.".into(),
+            },
             at: Some("at".into()),
             accessed: Some("accessed".into()),
             available_at: Some("available at".into()),
             by: Some("by".into()),
-            circa: SimpleTerm { long: "circa".into(), short: "c.".into() },
+            circa: SimpleTerm {
+                long: "circa".into(),
+                short: "c.".into(),
+            },
             et_al: Some("et al.".into()),
             from: Some("from".into()),
             ibid: Some("ibid.".into()),
@@ -204,7 +256,10 @@ impl DateTerms {
         Self {
             months: MonthNames::en_us(),
             seasons: vec![
-                "Spring".into(), "Summer".into(), "Autumn".into(), "Winter".into(),
+                "Spring".into(),
+                "Summer".into(),
+                "Autumn".into(),
+                "Winter".into(),
             ],
         }
     }
@@ -224,14 +279,32 @@ impl MonthNames {
     pub fn en_us() -> Self {
         Self {
             long: vec![
-                "January".into(), "February".into(), "March".into(), "April".into(),
-                "May".into(), "June".into(), "July".into(), "August".into(),
-                "September".into(), "October".into(), "November".into(), "December".into(),
+                "January".into(),
+                "February".into(),
+                "March".into(),
+                "April".into(),
+                "May".into(),
+                "June".into(),
+                "July".into(),
+                "August".into(),
+                "September".into(),
+                "October".into(),
+                "November".into(),
+                "December".into(),
             ],
             short: vec![
-                "Jan.".into(), "Feb.".into(), "Mar.".into(), "Apr.".into(),
-                "May".into(), "June".into(), "July".into(), "Aug.".into(),
-                "Sept.".into(), "Oct.".into(), "Nov.".into(), "Dec.".into(),
+                "Jan.".into(),
+                "Feb.".into(),
+                "Mar.".into(),
+                "Apr.".into(),
+                "May".into(),
+                "June".into(),
+                "July".into(),
+                "Aug.".into(),
+                "Sept.".into(),
+                "Oct.".into(),
+                "Nov.".into(),
+                "Dec.".into(),
             ],
         }
     }
@@ -261,7 +334,7 @@ mod tests {
     #[test]
     fn test_role_terms() {
         let locale = Locale::en_us();
-        
+
         assert_eq!(
             locale.role_term(&ContributorRole::Editor, false, TermForm::Short),
             Some("Ed.")
@@ -282,9 +355,9 @@ mod tests {
             "locale": "en-US",
             "dates": {
                 "months": {
-                    "long": ["January", "February", "March", "April", "May", "June", 
+                    "long": ["January", "February", "March", "April", "May", "June",
                              "July", "August", "September", "October", "November", "December"],
-                    "short": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", 
+                    "short": ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                               "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
                 },
                 "seasons": ["Spring", "Summer", "Autumn", "Winter"]
@@ -295,7 +368,7 @@ mod tests {
                 "et-al": "et al."
             }
         }"#;
-        
+
         let locale: Locale = serde_json::from_str(json).unwrap();
         assert_eq!(locale.locale, "en-US");
         assert_eq!(locale.dates.months.long[0], "January");

--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -116,12 +116,24 @@ impl Processing {
                     shorten_names: false,
                     render_substitutions: false,
                     template: vec![
-                        SortSpec { key: SortKey::Author, ascending: true },
-                        SortSpec { key: SortKey::Year, ascending: true },
+                        SortSpec {
+                            key: SortKey::Author,
+                            ascending: true,
+                        },
+                        SortSpec {
+                            key: SortKey::Year,
+                            ascending: true,
+                        },
                     ],
                 }),
-                group: Some(Group { template: vec![SortKey::Author, SortKey::Year] }),
-                disambiguate: Some(Disambiguation { names: true, year_suffix: true }),
+                group: Some(Group {
+                    template: vec![SortKey::Author, SortKey::Year],
+                }),
+                disambiguate: Some(Disambiguation {
+                    names: true,
+                    add_givenname: true,
+                    year_suffix: true,
+                }),
             },
             Processing::Numeric => ProcessingCustom {
                 sort: None,
@@ -131,7 +143,11 @@ impl Processing {
             Processing::Note => ProcessingCustom {
                 sort: None,
                 group: None,
-                disambiguate: Some(Disambiguation { names: true, year_suffix: false }),
+                disambiguate: Some(Disambiguation {
+                    names: true,
+                    add_givenname: false,
+                    year_suffix: false,
+                }),
             },
             Processing::Custom(custom) => custom.clone(),
         }
@@ -143,12 +159,18 @@ impl Processing {
 #[serde(rename_all = "kebab-case")]
 pub struct Disambiguation {
     pub names: bool,
+    #[serde(default)]
+    pub add_givenname: bool,
     pub year_suffix: bool,
 }
 
 impl Default for Disambiguation {
     fn default() -> Self {
-        Self { names: true, year_suffix: false }
+        Self {
+            names: true,
+            add_givenname: false,
+            year_suffix: false,
+        }
     }
 }
 
@@ -161,7 +183,9 @@ pub struct DateConfig {
 
 impl Default for DateConfig {
     fn default() -> Self {
-        Self { month: MonthFormat::Long }
+        Self {
+            month: MonthFormat::Long,
+        }
     }
 }
 
@@ -307,7 +331,9 @@ pub struct Localize {
 
 impl Default for Localize {
     fn default() -> Self {
-        Self { scope: Scope::Global }
+        Self {
+            scope: Scope::Global,
+        }
     }
 }
 
@@ -438,6 +464,9 @@ contributors:
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(config.substitute.is_some());
         assert_eq!(config.processing, Some(Processing::AuthorDate));
-        assert_eq!(config.contributors.as_ref().unwrap().and, Some(AndOptions::Symbol));
+        assert_eq!(
+            config.contributors.as_ref().unwrap().and,
+            Some(AndOptions::Symbol)
+        );
     }
 }

--- a/crates/csln_core/src/renderer.rs
+++ b/crates/csln_core/src/renderer.rs
@@ -1,4 +1,6 @@
-use crate::{CslnNode, Variable, ItemType, VariableBlock, DateBlock, NamesBlock, GroupBlock, ConditionBlock};
+use crate::{
+    ConditionBlock, CslnNode, DateBlock, GroupBlock, ItemType, NamesBlock, Variable, VariableBlock,
+};
 use std::collections::HashMap;
 
 /// A mock citation item with metadata.
@@ -32,7 +34,7 @@ impl Renderer {
     fn render_variable(&self, block: &VariableBlock, item: &CitationItem) -> String {
         if let Some(val) = item.variables.get(&block.variable) {
             let mut text = val.clone();
-            
+
             if let Some(label_opts) = &block.label {
                 let prefix = label_opts.formatting.prefix.as_deref().unwrap_or("");
                 let suffix = label_opts.formatting.suffix.as_deref().unwrap_or("");
@@ -62,7 +64,10 @@ impl Renderer {
         let active_val = if let Some(val) = item.variables.get(&block.variable) {
             Some(val.clone())
         } else {
-            block.options.substitute.iter()
+            block
+                .options
+                .substitute
+                .iter()
                 .find_map(|sub_var| item.variables.get(sub_var).cloned())
         };
 
@@ -72,11 +77,11 @@ impl Renderer {
                     formatted = format!("{} [Init: {}]", formatted, init);
                 }
             }
-            
+
             if let Some(order) = &block.options.name_as_sort_order {
                 formatted = format!("{} [Sort: {:?}]", formatted, order);
             }
-            
+
             self.apply_formatting(&formatted, &block.formatting)
         } else {
             String::new()
@@ -98,20 +103,25 @@ impl Renderer {
 
         let delimiter = block.delimiter.as_deref().unwrap_or("");
         let content = parts.join(delimiter);
-        
+
         self.apply_formatting(&content, &block.formatting)
     }
 
     fn render_condition(&self, block: &ConditionBlock, item: &CitationItem) -> String {
-        let type_match = block.if_item_type.is_empty() || block.if_item_type.contains(&item.item_type);
-        let var_match = block.if_variables.is_empty() || block.if_variables.iter().any(|v| item.variables.contains_key(v));
-        
+        let type_match =
+            block.if_item_type.is_empty() || block.if_item_type.contains(&item.item_type);
+        let var_match = block.if_variables.is_empty()
+            || block
+                .if_variables
+                .iter()
+                .any(|v| item.variables.contains_key(v));
+
         let match_found = if block.if_item_type.is_empty() && block.if_variables.is_empty() {
             false
         } else {
             type_match && var_match
         };
-        
+
         if match_found {
             let mut output = String::new();
             for child in &block.then_branch {
@@ -132,7 +142,7 @@ impl Renderer {
     fn apply_formatting(&self, text: &str, fmt: &crate::FormattingOptions) -> String {
         let prefix = fmt.prefix.as_deref().unwrap_or("");
         let suffix = fmt.suffix.as_deref().unwrap_or("");
-        
+
         let mut res = text.to_string();
         if fmt.font_style == Some(crate::FontStyle::Italic) {
             res = format!("_{}_", res);

--- a/crates/csln_core/src/template.rs
+++ b/crates/csln_core/src/template.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Rendering instructions applied to template components.
-/// 
+///
 /// These fields are flattened into parent structs, so in YAML you write:
 /// ```yaml
 /// - title: primary
@@ -383,14 +383,14 @@ form: long
 "#;
         let components: Vec<TemplateComponent> = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(components.len(), 3);
-        
+
         match &components[0] {
             TemplateComponent::Contributor(c) => {
                 assert_eq!(c.contributor, ContributorRole::Author);
             }
             _ => panic!("Expected Contributor"),
         }
-        
+
         match &components[1] {
             TemplateComponent::Date(d) => {
                 assert_eq!(d.date, DateVariable::Issued);
@@ -412,7 +412,7 @@ form: long
 "#;
         let components: Vec<TemplateComponent> = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(components.len(), 2);
-        
+
         match &components[0] {
             TemplateComponent::Title(t) => {
                 assert_eq!(t.rendering.prefix, Some("In ".to_string()));
@@ -420,7 +420,7 @@ form: long
             }
             _ => panic!("Expected Title"),
         }
-        
+
         match &components[1] {
             TemplateComponent::Date(d) => {
                 assert_eq!(d.rendering.wrap, Some(WrapPunctuation::Parentheses));
@@ -440,7 +440,7 @@ wrap: parentheses
         assert_eq!(comp.contributor, ContributorRole::Publisher);
         assert_eq!(comp.rendering.wrap, Some(WrapPunctuation::Parentheses));
     }
-    
+
     #[test]
     fn test_variable_deserialization() {
         // Test that `variable: publisher` parses as Variable, not Number
@@ -453,7 +453,7 @@ wrap: parentheses
             _ => panic!("Expected Variable(Publisher), got {:?}", comp),
         }
     }
-    
+
     #[test]
     fn test_variable_array_parsing() {
         let yaml = r#"

--- a/crates/csln_migrate/src/bin/migrate_all.rs
+++ b/crates/csln_migrate/src/bin/migrate_all.rs
@@ -1,7 +1,7 @@
-use std::fs;
-use roxmltree::Document;
 use csl_legacy::parser::parse_style;
 use csln_migrate::{MacroInliner, Upsampler};
+use roxmltree::Document;
+use std::fs;
 
 use csl_legacy::model::CslNode as LNode;
 use csln_core::CslnNode as CNode;
@@ -25,77 +25,91 @@ fn main() {
 
     println!("Starting BULK MIGRATION of styles in {}...", styles_dir);
 
-    for entry in entries {
-        if let Ok(entry) = entry {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) == Some("csl") {
-                total += 1;
-                
-                // 1. Read & Parse (Legacy)
-                let text = match fs::read_to_string(&path) {
-                    Ok(t) => t,
-                    Err(_) => continue,
-                };
-                
-                let doc = match Document::parse(&text) {
-                    Ok(d) => d,
-                    Err(_) => continue,
-                };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("csl") {
+            total += 1;
 
-                let legacy_style = match parse_style(doc.root_element()) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        *error_types.entry(format!("Legacy Parse Error: {}", e)).or_insert(0) += 1;
-                        failures += 1;
-                        continue;
-                    }
-                };
+            // 1. Read & Parse (Legacy)
+            let text = match fs::read_to_string(&path) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
 
-                // 2. Migration
-                let inliner = MacroInliner::new(&legacy_style);
-                let flattened_bib = inliner.inline_bibliography(&legacy_style).unwrap_or_default();
-                let flattened_cit = inliner.inline_citation(&legacy_style);
+            let doc = match Document::parse(&text) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
 
-                let upsampler = Upsampler;
-                let csln_bib = upsampler.upsample_nodes(&flattened_bib);
-                let csln_cit = upsampler.upsample_nodes(&flattened_cit);
-
-                // Stats
-                let input_count = count_legacy_nodes(&flattened_bib) + count_legacy_nodes(&flattened_cit);
-                let output_count = count_csln_nodes(&csln_bib) + count_csln_nodes(&csln_cit);
-                
-                total_input_nodes += input_count;
-                total_output_nodes += output_count;
-
-                if csln_bib.is_empty() && csln_cit.is_empty() {
-                     *error_types.entry("Empty Output".to_string()).or_insert(0) += 1;
-                     failures += 1;
-                } else {
-                    success += 1;
+            let legacy_style = match parse_style(doc.root_element()) {
+                Ok(s) => s,
+                Err(e) => {
+                    *error_types
+                        .entry(format!("Legacy Parse Error: {}", e))
+                        .or_insert(0) += 1;
+                    failures += 1;
+                    continue;
                 }
-                
-                // Track dropped nodes by inspecting the upsampler's decision?
-                // Hard to do from outside.
-                // Let's just trust the 100% success for now and investigate the retention later.
-                
-                if total % 100 == 0 {
-                    print!(".");
-                    use std::io::Write;
-                    std::io::stdout().flush().unwrap();
-                }
+            };
+
+            // 2. Migration
+            let inliner = MacroInliner::new(&legacy_style);
+            let flattened_bib = inliner
+                .inline_bibliography(&legacy_style)
+                .unwrap_or_default();
+            let flattened_cit = inliner.inline_citation(&legacy_style);
+
+            let upsampler = Upsampler;
+            let csln_bib = upsampler.upsample_nodes(&flattened_bib);
+            let csln_cit = upsampler.upsample_nodes(&flattened_cit);
+
+            // Stats
+            let input_count =
+                count_legacy_nodes(&flattened_bib) + count_legacy_nodes(&flattened_cit);
+            let output_count = count_csln_nodes(&csln_bib) + count_csln_nodes(&csln_cit);
+
+            total_input_nodes += input_count;
+            total_output_nodes += output_count;
+
+            if csln_bib.is_empty() && csln_cit.is_empty() {
+                *error_types.entry("Empty Output".to_string()).or_insert(0) += 1;
+                failures += 1;
+            } else {
+                success += 1;
+            }
+
+            // Track dropped nodes by inspecting the upsampler's decision?
+            // Hard to do from outside.
+            // Let's just trust the 100% success for now and investigate the retention later.
+
+            if total % 100 == 0 {
+                print!(".");
+                use std::io::Write;
+                std::io::stdout().flush().unwrap();
             }
         }
     }
 
     println!("\n\n=== MIGRATION STATS ===");
     println!("Total Styles: {}", total);
-    println!("Success:      {} ({:.1}%)", success, (success as f64 / total as f64) * 100.0);
-    println!("Failures:     {} ({:.1}%)", failures, (failures as f64 / total as f64) * 100.0);
-    
+    println!(
+        "Success:      {} ({:.1}%)",
+        success,
+        (success as f64 / total as f64) * 100.0
+    );
+    println!(
+        "Failures:     {} ({:.1}%)",
+        failures,
+        (failures as f64 / total as f64) * 100.0
+    );
+
     println!("\n=== DATA RETENTION ===");
     println!("Input Nodes:  {}", total_input_nodes);
     println!("Output Nodes: {}", total_output_nodes);
-    println!("Retention:    {:.1}%", (total_output_nodes as f64 / total_input_nodes as f64) * 100.0);
+    println!(
+        "Retention:    {:.1}%",
+        (total_output_nodes as f64 / total_input_nodes as f64) * 100.0
+    );
     println!("(Note: Retention < 100% is expected due to node collapsing/upsampling)");
 
     println!("\n=== TOP ERRORS ===");
@@ -115,8 +129,12 @@ fn count_legacy_nodes(nodes: &[LNode]) -> usize {
             LNode::Names(n) => count += count_legacy_nodes(&n.children),
             LNode::Choose(c) => {
                 count += count_legacy_nodes(&c.if_branch.children);
-                for b in &c.else_if_branches { count += count_legacy_nodes(&b.children); }
-                if let Some(e) = &c.else_branch { count += count_legacy_nodes(e); }
+                for b in &c.else_if_branches {
+                    count += count_legacy_nodes(&b.children);
+                }
+                if let Some(e) = &c.else_branch {
+                    count += count_legacy_nodes(e);
+                }
             }
             LNode::Substitute(s) => count += count_legacy_nodes(&s.children),
             _ => {}
@@ -133,7 +151,9 @@ fn count_csln_nodes(nodes: &[CNode]) -> usize {
             CNode::Group(g) => count += count_csln_nodes(&g.children),
             CNode::Condition(c) => {
                 count += count_csln_nodes(&c.then_branch);
-                if let Some(e) = &c.else_branch { count += count_csln_nodes(e); }
+                if let Some(e) = &c.else_branch {
+                    count += count_csln_nodes(e);
+                }
             }
             _ => {}
         }

--- a/crates/csln_migrate/src/compressor.rs
+++ b/crates/csln_migrate/src/compressor.rs
@@ -13,7 +13,11 @@ impl Compressor {
                     let else_compressed = cond.else_branch.map(|e| self.compress_nodes(e));
 
                     // Attempt Merge
-                    if let Some(merged) = self.try_merge_branches(&cond.if_item_type, &then_compressed, &else_compressed) {
+                    if let Some(merged) = self.try_merge_branches(
+                        &cond.if_item_type,
+                        &then_compressed,
+                        &else_compressed,
+                    ) {
                         compressed.push(merged);
                     } else {
                         // Keep Condition if merge fails, but use compressed children
@@ -36,16 +40,25 @@ impl Compressor {
         compressed
     }
 
-    fn try_merge_branches(&self, if_types: &[ItemType], then_nodes: &[CslnNode], else_nodes: &Option<Vec<CslnNode>>) -> Option<CslnNode> {
+    fn try_merge_branches(
+        &self,
+        if_types: &[ItemType],
+        then_nodes: &[CslnNode],
+        else_nodes: &Option<Vec<CslnNode>>,
+    ) -> Option<CslnNode> {
         // Simple Case: 1 node in THEN, 1 node in ELSE (or empty ELSE)
         // And they are the SAME VARIABLE.
-        
-        if then_nodes.len() != 1 { return None; }
-        
+
+        if then_nodes.len() != 1 {
+            return None;
+        }
+
         // Handle "Then vs Else"
         if let Some(else_nodes) = else_nodes {
-            if else_nodes.len() != 1 { return None; }
-            
+            if else_nodes.len() != 1 {
+                return None;
+            }
+
             let then_node = &then_nodes[0];
             let else_node = &else_nodes[0];
 
@@ -53,7 +66,7 @@ impl Compressor {
                 if v1.variable == v2.variable {
                     // MERGE!
                     let mut merged = v2.clone(); // Start with base (else) defaults
-                    // Add override for the 'if' condition
+                                                 // Add override for the 'if' condition
                     for t in if_types {
                         merged.overrides.insert(t.clone(), v1.formatting.clone());
                     }

--- a/crates/csln_migrate/src/lib.rs
+++ b/crates/csln_migrate/src/lib.rs
@@ -1,15 +1,15 @@
-use csl_legacy::model::{Style, CslNode};
+use csl_legacy::model::{CslNode, Style};
 use std::collections::HashMap;
 
-pub mod upsampler;
 pub mod compressor;
 pub mod options_extractor;
 pub mod template_compiler;
+pub mod upsampler;
 
-pub use upsampler::Upsampler;
 pub use compressor::Compressor;
 pub use options_extractor::OptionsExtractor;
 pub use template_compiler::TemplateCompiler;
+pub use upsampler::Upsampler;
 pub struct MacroInliner {
     macros: HashMap<String, Vec<CslNode>>,
 }
@@ -74,7 +74,10 @@ impl MacroInliner {
 
     /// Returns a version of the bibliography layout with all macros inlined.
     pub fn inline_bibliography(&self, style: &Style) -> Option<Vec<CslNode>> {
-        style.bibliography.as_ref().map(|bib| self.expand_nodes(&bib.layout.children))
+        style
+            .bibliography
+            .as_ref()
+            .map(|bib| self.expand_nodes(&bib.layout.children))
     }
 
     /// Returns a version of the citation layout with all macros inlined.

--- a/crates/csln_migrate/src/main.rs
+++ b/crates/csln_migrate/src/main.rs
@@ -1,15 +1,15 @@
-use std::fs;
-use roxmltree::Document;
 use csl_legacy::parser::parse_style;
-use csln_migrate::{MacroInliner, Upsampler, Compressor, OptionsExtractor, TemplateCompiler};
-use csln_core::{Style, StyleInfo, CitationSpec, BibliographySpec, template::TemplateComponent};
+use csln_core::{template::TemplateComponent, BibliographySpec, CitationSpec, Style, StyleInfo};
+use csln_migrate::{Compressor, MacroInliner, OptionsExtractor, TemplateCompiler, Upsampler};
+use roxmltree::Document;
+use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
     let path = args.get(1).map(|s| s.as_str()).unwrap_or("styles/apa.csl");
-    
+
     eprintln!("Migrating {} to CSLN...", path);
-    
+
     let text = fs::read_to_string(path)?;
     let doc = Document::parse(&text)?;
     let legacy_style = parse_style(doc.root_element())?;
@@ -19,7 +19,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 1. Deconstruction
     let inliner = MacroInliner::new(&legacy_style);
-    let flattened_bib = inliner.inline_bibliography(&legacy_style).unwrap_or_default();
+    let flattened_bib = inliner
+        .inline_bibliography(&legacy_style)
+        .unwrap_or_default();
     let flattened_cit = inliner.inline_citation(&legacy_style);
 
     // 2. Semantic Upsampling
@@ -36,59 +38,77 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let template_compiler = TemplateCompiler;
     let mut new_bib = template_compiler.compile_bibliography(&csln_bib);
     let mut new_cit = template_compiler.compile_citation(&csln_cit);
-    
+
     // For author-date styles, apply standard formatting
-    if matches!(options.processing, Some(csln_core::options::Processing::AuthorDate)) {
+    if matches!(
+        options.processing,
+        Some(csln_core::options::Processing::AuthorDate)
+    ) {
         // Citation: ensure author (short) + date (year)
         let has_author = new_cit.iter().any(|c| {
             matches!(c, TemplateComponent::Contributor(tc) if tc.contributor == csln_core::template::ContributorRole::Author)
         });
         if !has_author {
-            new_cit.insert(0, TemplateComponent::Contributor(csln_core::template::TemplateContributor {
-                contributor: csln_core::template::ContributorRole::Author,
-                form: csln_core::template::ContributorForm::Short,
-                name_order: None,
-                delimiter: None,
-                rendering: csln_core::template::Rendering::default(),
-            }));
+            new_cit.insert(
+                0,
+                TemplateComponent::Contributor(csln_core::template::TemplateContributor {
+                    contributor: csln_core::template::ContributorRole::Author,
+                    form: csln_core::template::ContributorForm::Short,
+                    name_order: None,
+                    delimiter: None,
+                    rendering: csln_core::template::Rendering::default(),
+                }),
+            );
         }
         let has_date = new_cit.iter().any(|c| {
             matches!(c, TemplateComponent::Date(td) if td.date == csln_core::template::DateVariable::Issued)
         });
         if !has_date {
-            let insert_pos = new_cit.iter().position(|c| !matches!(c, TemplateComponent::Contributor(_))).unwrap_or(1);
-            new_cit.insert(insert_pos, TemplateComponent::Date(csln_core::template::TemplateDate {
-                date: csln_core::template::DateVariable::Issued,
-                form: csln_core::template::DateForm::Year,
-                rendering: csln_core::template::Rendering::default(),
-            }));
+            let insert_pos = new_cit
+                .iter()
+                .position(|c| !matches!(c, TemplateComponent::Contributor(_)))
+                .unwrap_or(1);
+            new_cit.insert(
+                insert_pos,
+                TemplateComponent::Date(csln_core::template::TemplateDate {
+                    date: csln_core::template::DateVariable::Issued,
+                    form: csln_core::template::DateForm::Year,
+                    rendering: csln_core::template::Rendering::default(),
+                }),
+            );
         }
         // Keep only essential citation components for author-date
         new_cit.retain(|c| {
-            matches!(c, 
+            matches!(c,
                 TemplateComponent::Contributor(tc) if tc.contributor == csln_core::template::ContributorRole::Author
-            ) || matches!(c, 
+            ) || matches!(c,
                 TemplateComponent::Date(td) if td.date == csln_core::template::DateVariable::Issued
             )
         });
-        
+
         // Bibliography: fix author form (long), date wrap (parentheses), title emph
         for component in &mut new_bib {
             match component {
-                TemplateComponent::Contributor(tc) if tc.contributor == csln_core::template::ContributorRole::Author => {
+                TemplateComponent::Contributor(tc)
+                    if tc.contributor == csln_core::template::ContributorRole::Author =>
+                {
                     tc.form = csln_core::template::ContributorForm::Long;
                 }
-                TemplateComponent::Date(td) if td.date == csln_core::template::DateVariable::Issued => {
+                TemplateComponent::Date(td)
+                    if td.date == csln_core::template::DateVariable::Issued =>
+                {
                     td.form = csln_core::template::DateForm::Year;
                     td.rendering.wrap = Some(csln_core::template::WrapPunctuation::Parentheses);
                 }
-                TemplateComponent::Title(tt) if tt.title == csln_core::template::TitleType::Primary => {
+                TemplateComponent::Title(tt)
+                    if tt.title == csln_core::template::TitleType::Primary =>
+                {
                     tt.rendering.emph = Some(true);
                 }
                 _ => {}
             }
         }
-        
+
         // Add editor for chapters: "In Editor (Eds.), Container"
         let has_editor = new_bib.iter().any(|c| {
             matches!(c, TemplateComponent::Contributor(tc) if tc.contributor == csln_core::template::ContributorRole::Editor)
@@ -100,20 +120,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 matches!(c, TemplateComponent::Title(tt) if tt.title == csln_core::template::TitleType::ParentMonograph)
             });
             if let Some(pos) = container_pos {
-                new_bib.insert(pos, TemplateComponent::Contributor(csln_core::template::TemplateContributor {
-                    contributor: csln_core::template::ContributorRole::Editor,
-                    form: csln_core::template::ContributorForm::Verb,
-                    name_order: Some(csln_core::template::NameOrder::GivenFirst),  // APA: "K. A. Ericsson", not "Ericsson, K. A."
-                    delimiter: None,
-                    rendering: csln_core::template::Rendering {
-                        prefix: Some("In ".to_string()),
-                        suffix: Some(", ".to_string()),
-                        ..Default::default()
-                    },
-                }));
+                new_bib.insert(
+                    pos,
+                    TemplateComponent::Contributor(csln_core::template::TemplateContributor {
+                        contributor: csln_core::template::ContributorRole::Editor,
+                        form: csln_core::template::ContributorForm::Verb,
+                        name_order: Some(csln_core::template::NameOrder::GivenFirst), // APA: "K. A. Ericsson", not "Ericsson, K. A."
+                        delimiter: None,
+                        rendering: csln_core::template::Rendering {
+                            prefix: Some("In ".to_string()),
+                            suffix: Some(", ".to_string()),
+                            ..Default::default()
+                        },
+                    }),
+                );
             }
         }
-        
+
         // Combine volume and issue into a List component
         let vol_pos = new_bib.iter().position(|c| {
             matches!(c, TemplateComponent::Number(n) if n.number == csln_core::template::NumberVariable::Volume)
@@ -121,16 +144,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let issue_pos = new_bib.iter().position(|c| {
             matches!(c, TemplateComponent::Number(n) if n.number == csln_core::template::NumberVariable::Issue)
         });
-        
+
         if let (Some(vol_idx), Some(issue_idx)) = (vol_pos, issue_pos) {
             // Remove both and insert a List at the earlier position
             let min_idx = vol_idx.min(issue_idx);
             let max_idx = vol_idx.max(issue_idx);
-            
+
             // Remove from end first to preserve indices
             new_bib.remove(max_idx);
             new_bib.remove(min_idx);
-            
+
             // Create volume(issue) list
             let vol_issue_list = TemplateComponent::List(csln_core::template::TemplateList {
                 items: vec![
@@ -150,49 +173,67 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         overrides: None,
                     }),
                 ],
-                delimiter: Some(csln_core::template::DelimiterPunctuation::None),  // No delimiter between volume and (issue)
+                delimiter: Some(csln_core::template::DelimiterPunctuation::None), // No delimiter between volume and (issue)
                 rendering: csln_core::template::Rendering::default(),
                 overrides: None,
             });
-            
+
             new_bib.insert(min_idx, vol_issue_list);
         }
-        
+
         // Add type-specific overrides
         for component in &mut new_bib {
             match component {
                 // Container-title (parent-serial): journals use comma suffix
-                TemplateComponent::Title(t) if t.title == csln_core::template::TitleType::ParentSerial => {
+                TemplateComponent::Title(t)
+                    if t.title == csln_core::template::TitleType::ParentSerial =>
+                {
                     let mut overrides = std::collections::HashMap::new();
-                    overrides.insert("article-journal".to_string(), csln_core::template::Rendering {
-                        suffix: Some(",".to_string()),
-                        ..Default::default()
-                    });
+                    overrides.insert(
+                        "article-journal".to_string(),
+                        csln_core::template::Rendering {
+                            suffix: Some(",".to_string()),
+                            ..Default::default()
+                        },
+                    );
                     t.overrides = Some(overrides);
                 }
                 // Pages: different formatting per type
-                TemplateComponent::Number(n) if n.number == csln_core::template::NumberVariable::Pages => {
+                TemplateComponent::Number(n)
+                    if n.number == csln_core::template::NumberVariable::Pages =>
+                {
                     let mut overrides = std::collections::HashMap::new();
                     // Chapters need "(pp. pages)"
-                    overrides.insert("chapter".to_string(), csln_core::template::Rendering {
-                        prefix: Some("pp. ".to_string()),
-                        wrap: Some(csln_core::template::WrapPunctuation::Parentheses),
-                        ..Default::default()
-                    });
+                    overrides.insert(
+                        "chapter".to_string(),
+                        csln_core::template::Rendering {
+                            prefix: Some("pp. ".to_string()),
+                            wrap: Some(csln_core::template::WrapPunctuation::Parentheses),
+                            ..Default::default()
+                        },
+                    );
                     // Journals: comma prefix to connect with volume
-                    overrides.insert("article-journal".to_string(), csln_core::template::Rendering {
-                        prefix: Some(", ".to_string()),
-                        ..Default::default()
-                    });
+                    overrides.insert(
+                        "article-journal".to_string(),
+                        csln_core::template::Rendering {
+                            prefix: Some(", ".to_string()),
+                            ..Default::default()
+                        },
+                    );
                     n.overrides = Some(overrides);
                 }
                 // Publisher: suppress for journal articles
-                TemplateComponent::Variable(v) if v.variable == csln_core::template::SimpleVariable::Publisher => {
+                TemplateComponent::Variable(v)
+                    if v.variable == csln_core::template::SimpleVariable::Publisher =>
+                {
                     let mut overrides = std::collections::HashMap::new();
-                    overrides.insert("article-journal".to_string(), csln_core::template::Rendering {
-                        suppress: Some(true),
-                        ..Default::default()
-                    });
+                    overrides.insert(
+                        "article-journal".to_string(),
+                        csln_core::template::Rendering {
+                            suppress: Some(true),
+                            ..Default::default()
+                        },
+                    );
                     v.overrides = Some(overrides);
                 }
                 _ => {}

--- a/crates/csln_processor/src/lib.rs
+++ b/crates/csln_processor/src/lib.rs
@@ -69,7 +69,9 @@ pub mod values;
 
 pub use error::ProcessorError;
 pub use processor::{ProcessedReferences, Processor};
-pub use reference::{Bibliography, Citation, CitationItem, DateVariable, Name, Reference, StringOrNumber};
+pub use reference::{
+    Bibliography, Citation, CitationItem, DateVariable, Name, Reference, StringOrNumber,
+};
 pub use render::{citation_to_string, refs_to_string, ProcTemplate, ProcTemplateComponent};
 pub use values::{ComponentValues, ProcHints, ProcValues, RenderContext, RenderOptions};
 

--- a/crates/csln_processor/src/main.rs
+++ b/crates/csln_processor/src/main.rs
@@ -11,8 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use csln_core::Style;
 use csln_processor::{
-    Bibliography, Citation, CitationItem, DateVariable, Name, Processor, Reference,
-    StringOrNumber,
+    Bibliography, Citation, CitationItem, DateVariable, Name, Processor, Reference, StringOrNumber,
 };
 use std::collections::HashMap;
 use std::env;
@@ -142,7 +141,9 @@ fn create_test_bibliography() -> Bibliography {
                 Name::new("Hoffman", "Robert R."),
             ]),
             title: Some("The Role of Deliberate Practice".to_string()),
-            collection_title: Some("The Cambridge Handbook of Expertise and Expert Performance".to_string()),
+            collection_title: Some(
+                "The Cambridge Handbook of Expertise and Expert Performance".to_string(),
+            ),
             issued: Some(DateVariable::year(2006)),
             publisher: Some("Cambridge University Press".to_string()),
             page: Some("683-703".to_string()),

--- a/crates/csln_processor/src/reference.rs
+++ b/crates/csln_processor/src/reference.rs
@@ -102,14 +102,9 @@ pub struct Reference {
 }
 
 /// A name (person or organization).
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct Name {
-    /// Family name (surname)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub family: Option<String>,
-    /// Given name (first name)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub given: Option<String>,
     /// Literal name (for organizations or single-field names)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -145,7 +140,8 @@ impl Name {
 
     /// Get the family name or literal.
     pub fn family_or_literal(&self) -> &str {
-        self.family.as_deref()
+        self.family
+            .as_deref()
             .or(self.literal.as_deref())
             .unwrap_or("")
     }
@@ -294,7 +290,10 @@ mod tests {
         let reference: Reference = serde_json::from_str(json).unwrap();
         assert_eq!(reference.id, "kuhn1962");
         assert_eq!(reference.ref_type, "book");
-        assert_eq!(reference.author.as_ref().unwrap()[0].family, Some("Kuhn".to_string()));
+        assert_eq!(
+            reference.author.as_ref().unwrap()[0].family,
+            Some("Kuhn".to_string())
+        );
         assert_eq!(reference.issued.as_ref().unwrap().year_value(), Some(1962));
     }
 

--- a/crates/csln_processor/src/values.rs
+++ b/crates/csln_processor/src/values.rs
@@ -10,7 +10,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use crate::reference::{DateVariable, Name, Reference};
 use csln_core::locale::{Locale, TermForm};
-use csln_core::options::{AndOptions, Config, DemoteNonDroppingParticle, DisplayAsSort, ShortenListOptions, SubstituteKey};
+use csln_core::options::{
+    AndOptions, Config, DemoteNonDroppingParticle, DisplayAsSort, ShortenListOptions, SubstituteKey,
+};
 use csln_core::template::{
     ContributorForm, ContributorRole, DateForm, DateVariable as TemplateDateVar,
     DelimiterPunctuation, NumberVariable, SimpleVariable, TemplateComponent, TemplateContributor,
@@ -28,17 +30,20 @@ pub struct ProcValues {
     pub suffix: Option<String>,
 }
 
-/// Processing hints for disambiguation and grouping.
 #[derive(Debug, Clone, Default)]
 pub struct ProcHints {
-    /// Whether this reference needs disambiguation.
+    /// Whether disambiguation is active (triggers year-suffix).
     pub disamb_condition: bool,
-    /// Index within the disambiguation group (1-based).
+    /// Index in the disambiguation group (1-based).
     pub group_index: usize,
-    /// Total references in the group.
+    /// Total size of the disambiguation group.
     pub group_length: usize,
-    /// The grouping key (author-year).
+    /// The grouping key used.
     pub group_key: String,
+    /// Whether to expand given names for disambiguation.
+    pub expand_given_names: bool,
+    /// Minimum number of names to show to resolve ambiguity (overrides et-al-use-first).
+    pub min_names_to_show: Option<usize>,
 }
 
 /// Context for rendering (citation vs bibliography).
@@ -89,7 +94,7 @@ impl ComponentValues for TemplateContributor {
     fn values(
         &self,
         reference: &Reference,
-        _hints: &ProcHints,
+        hints: &ProcHints,
         options: &RenderOptions<'_>,
     ) -> Option<ProcValues> {
         let names = match self.contributor {
@@ -100,7 +105,9 @@ impl ComponentValues for TemplateContributor {
         };
 
         // Handle substitution if author is empty
-        if names.map(|n| n.is_empty()).unwrap_or(true) && matches!(self.contributor, ContributorRole::Author) {
+        if names.map(|n| n.is_empty()).unwrap_or(true)
+            && matches!(self.contributor, ContributorRole::Author)
+        {
             if let Some(substitute) = &options.config.substitute {
                 for key in &substitute.template {
                     match key {
@@ -108,9 +115,18 @@ impl ComponentValues for TemplateContributor {
                             if let Some(editors) = &reference.editor {
                                 if !editors.is_empty() {
                                     // Substituted editors use the contributor's name_order
-                                    let formatted = format_names(editors, &self.form, options, self.name_order.as_ref());
+                                    let formatted = format_names(
+                                        editors,
+                                        &self.form,
+                                        options,
+                                        self.name_order.as_ref(),
+                                        hints,
+                                    );
                                     // Add role suffix if configured
-                                    let suffix = substitute.contributor_role_form.as_ref().map(|_| " (Ed.)".to_string());
+                                    let suffix = substitute
+                                        .contributor_role_form
+                                        .as_ref()
+                                        .map(|_| " (Ed.)".to_string());
                                     return Some(ProcValues {
                                         value: formatted,
                                         prefix: None,
@@ -131,7 +147,13 @@ impl ComponentValues for TemplateContributor {
                         SubstituteKey::Translator => {
                             if let Some(translators) = &reference.translator {
                                 if !translators.is_empty() {
-                                    let formatted = format_names(translators, &self.form, options, self.name_order.as_ref());
+                                    let formatted = format_names(
+                                        translators,
+                                        &self.form,
+                                        options,
+                                        self.name_order.as_ref(),
+                                        hints,
+                                    );
                                     return Some(ProcValues {
                                         value: formatted,
                                         prefix: None,
@@ -152,8 +174,8 @@ impl ComponentValues for TemplateContributor {
         }
 
         // Use explicit name_order if provided on this contributor template
-        let formatted = format_names(names, &self.form, options, self.name_order.as_ref());
-        
+        let formatted = format_names(names, &self.form, options, self.name_order.as_ref(), hints);
+
         // Add role label suffix for verb forms (e.g., "Name (Ed.)")
         let suffix = match (&self.form, &self.contributor) {
             (ContributorForm::Verb | ContributorForm::VerbShort, role) => {
@@ -162,7 +184,9 @@ impl ComponentValues for TemplateContributor {
                     ContributorForm::VerbShort => TermForm::Short,
                     _ => TermForm::Short, // Use short for label: (Ed.) not (editor)
                 };
-                options.locale.role_term(role, plural, form)
+                options
+                    .locale
+                    .role_term(role, plural, form)
                     .map(|t| format!(" ({})", t))
             }
             _ => None,
@@ -182,10 +206,11 @@ impl ComponentValues for TemplateContributor {
 /// for this specific rendering. Used when editors need "Given Family" format
 /// even when the global setting is "Family, Given".
 fn format_names(
-    names: &[Name], 
-    form: &ContributorForm, 
+    names: &[Name],
+    form: &ContributorForm,
     options: &RenderOptions<'_>,
     name_order: Option<&csln_core::template::NameOrder>,
+    hints: &ProcHints,
 ) -> String {
     if names.is_empty() {
         return String::new();
@@ -201,9 +226,16 @@ fn format_names(
         None
     };
     let (display_names, use_et_al) = if let Some(opts) = shorten {
-        if names.len() >= opts.min as usize {
-            let display: Vec<&Name> = names.iter().take(opts.use_first as usize).collect();
-            (display, true)
+        let use_first = hints.min_names_to_show.unwrap_or(opts.use_first as usize);
+        if names.len() >= opts.min as usize
+            || (hints.min_names_to_show.is_some() && names.len() > 1)
+        {
+            if use_first >= names.len() {
+                (names.iter().collect(), false)
+            } else {
+                let display: Vec<&Name> = names.iter().take(use_first).collect();
+                (display, true)
+            }
         } else {
             (names.iter().collect(), false)
         }
@@ -216,11 +248,22 @@ fn format_names(
     let display_as_sort = config.and_then(|c| c.display_as_sort.clone());
     let initialize_with = config.and_then(|c| c.initialize_with.as_ref());
     let demote_ndp = config.and_then(|c| c.demote_non_dropping_particle.as_ref());
-    
+
     let formatted: Vec<String> = display_names
         .iter()
         .enumerate()
-        .map(|(i, name)| format_single_name(name, form, i, &display_as_sort, name_order, initialize_with, demote_ndp))
+        .map(|(i, name)| {
+            format_single_name(
+                name,
+                form,
+                i,
+                &display_as_sort,
+                name_order,
+                initialize_with,
+                demote_ndp,
+                hints.expand_given_names,
+            )
+        })
         .collect();
 
     // Join with appropriate delimiter and "and" from locale
@@ -246,9 +289,9 @@ fn format_names(
             Some(DelimiterPrecedesLast::Never) => false,
             Some(DelimiterPrecedesLast::AfterInvertedName) => {
                 // Use delimiter if last displayed name was inverted (family-first)
-                display_as_sort.as_ref().map_or(false, |das| {
-                    matches!(das, DisplayAsSort::All) || 
-                    (matches!(das, DisplayAsSort::First) && display_names.len() == 1)
+                display_as_sort.as_ref().is_some_and(|das| {
+                    matches!(das, DisplayAsSort::All)
+                        || (matches!(das, DisplayAsSort::First) && display_names.len() == 1)
                 })
             }
             Some(DelimiterPrecedesLast::Contextual) | None => {
@@ -256,7 +299,7 @@ fn format_names(
                 display_names.len() > 1
             }
         };
-        
+
         if use_delimiter {
             format!("{}, {}", result, locale.et_al())
         } else {
@@ -268,6 +311,7 @@ fn format_names(
 }
 
 /// Format a single name.
+#[allow(clippy::too_many_arguments)]
 fn format_single_name(
     name: &Name,
     form: &ContributorForm,
@@ -276,9 +320,10 @@ fn format_single_name(
     name_order: Option<&csln_core::template::NameOrder>,
     initialize_with: Option<&String>,
     demote_ndp: Option<&DemoteNonDroppingParticle>,
+    expand_given_names: bool,
 ) -> String {
     use csln_core::template::NameOrder;
-    
+
     // Handle literal names (e.g., corporate authors)
     if let Some(literal) = &name.literal {
         return literal.clone();
@@ -294,16 +339,21 @@ fn format_single_name(
     let inverted = match name_order {
         Some(NameOrder::GivenFirst) => false,
         Some(NameOrder::FamilyFirst) => true,
-        None => {
-            match display_as_sort {
-                Some(DisplayAsSort::All) => true,
-                Some(DisplayAsSort::First) => index == 0,
-                _ => false,
-            }
-        }
+        None => match display_as_sort {
+            Some(DisplayAsSort::All) => true,
+            Some(DisplayAsSort::First) => index == 0,
+            _ => false,
+        },
     };
 
-    match form {
+    // Determine effective form
+    let effective_form = if expand_given_names && matches!(form, ContributorForm::Short) {
+        &ContributorForm::Long
+    } else {
+        form
+    };
+
+    match effective_form {
         ContributorForm::Short => {
             // Short form usually just family name, but includes non-dropping particle
             // e.g. "van Beethoven" (unless demoted? CSL spec says demote only affects sorting/display of full names mostly?)
@@ -315,11 +365,11 @@ fn format_single_name(
                 family.to_string()
             };
             full_family
-        },
+        }
         ContributorForm::Long | ContributorForm::Verb | ContributorForm::VerbShort => {
             // Determine parts based on demotion
             let demote = matches!(demote_ndp, Some(DemoteNonDroppingParticle::DisplayAndSort));
-            
+
             let family_part = if !ndp.is_empty() && !demote {
                 format!("{} {}", ndp, family)
             } else {
@@ -340,7 +390,7 @@ fn format_single_name(
             } else {
                 given.to_string()
             };
-            
+
             // Construct particle part (dropping + demoted non-dropping)
             let mut particle_part = String::new();
             if !dp.is_empty() {
@@ -356,37 +406,45 @@ fn format_single_name(
             if inverted {
                 // "Family, Given" format
                 // Family Part + "," + Given Part + Particle Part + Suffix
-                let mut parts = Vec::new();
-                
-                parts.push(family_part);
-                
                 let mut suffix_part = String::new();
                 if !given_part.is_empty() {
                     suffix_part.push_str(&given_part);
                 }
                 if !particle_part.is_empty() {
-                    if !suffix_part.is_empty() { suffix_part.push(' '); }
+                    if !suffix_part.is_empty() {
+                        suffix_part.push(' ');
+                    }
                     suffix_part.push_str(&particle_part);
                 }
                 if !suffix.is_empty() {
-                    if !suffix_part.is_empty() { suffix_part.push(' '); }
+                    if !suffix_part.is_empty() {
+                        suffix_part.push(' ');
+                    }
                     suffix_part.push_str(suffix);
                 }
-                
+
                 if !suffix_part.is_empty() {
-                    format!("{}, {}", parts[0], suffix_part)
+                    format!("{}, {}", family_part, suffix_part)
                 } else {
-                    parts[0].clone()
+                    family_part
                 }
             } else {
                 // "Given Family" format
                 // Given Part + Particle Part + Family Part + Suffix
                 let mut parts = Vec::new();
-                if !given_part.is_empty() { parts.push(given_part); }
-                if !particle_part.is_empty() { parts.push(particle_part); }
-                if !family_part.is_empty() { parts.push(family_part); }
-                if !suffix.is_empty() { parts.push(suffix.to_string()); }
-                
+                if !given_part.is_empty() {
+                    parts.push(given_part);
+                }
+                if !particle_part.is_empty() {
+                    parts.push(particle_part);
+                }
+                if !family_part.is_empty() {
+                    parts.push(family_part);
+                }
+                if !suffix.is_empty() {
+                    parts.push(suffix.to_string());
+                }
+
                 parts.join(" ")
             }
         }
@@ -432,21 +490,38 @@ impl ComponentValues for TemplateDate {
                 let month = date.month_value();
                 let day = date.day_value();
                 match (month, day) {
-                    (Some(m), Some(d)) => Some(format!("{} {}, {}", locale.month_name(m as u8, false), d, year)),
-                    (Some(m), None) => Some(format!("{} {}", locale.month_name(m as u8, false), year)),
+                    (Some(m), Some(d)) => Some(format!(
+                        "{} {}, {}",
+                        locale.month_name(m as u8, false),
+                        d,
+                        year
+                    )),
+                    (Some(m), None) => {
+                        Some(format!("{} {}", locale.month_name(m as u8, false), year))
+                    }
                     _ => Some(year.to_string()),
                 }
             }
         };
 
         // Handle disambiguation suffix (a, b, c...)
-        let suffix = if hints.disamb_condition && formatted.as_ref().map(|s| s.len() == 4).unwrap_or(false) {
+        let suffix = if hints.disamb_condition
+            && formatted.as_ref().map(|s| s.len() == 4).unwrap_or(false)
+        {
             // Check if year suffix is enabled
-            let use_suffix = options.config.processing
+            let use_suffix = options
+                .config
+                .processing
                 .as_ref()
-                .map(|p| p.config().disambiguate.as_ref().map(|d| d.year_suffix).unwrap_or(false))
+                .map(|p| {
+                    p.config()
+                        .disambiguate
+                        .as_ref()
+                        .map(|d| d.year_suffix)
+                        .unwrap_or(false)
+                })
                 .unwrap_or(false);
-            
+
             if use_suffix {
                 int_to_letter((hints.group_index % 26) as u32)
             } else {
@@ -465,7 +540,9 @@ impl ComponentValues for TemplateDate {
 }
 
 fn int_to_letter(n: u32) -> Option<String> {
-    if n == 0 { return None; }
+    if n == 0 {
+        return None;
+    }
     char::from_u32(n + 96).map(|c| c.to_string())
 }
 
@@ -501,9 +578,10 @@ impl ComponentValues for TemplateNumber {
         let value = match self.number {
             NumberVariable::Volume => reference.volume.as_ref().map(|v| v.to_string()),
             NumberVariable::Issue => reference.issue.as_ref().map(|v| v.to_string()),
-            NumberVariable::Pages => reference.page.clone().map(|p| {
-                format_page_range(&p, options.config.page_range_format.as_ref())
-            }),
+            NumberVariable::Pages => reference
+                .page
+                .clone()
+                .map(|p| format_page_range(&p, options.config.page_range_format.as_ref())),
             NumberVariable::Edition => reference.edition.as_ref().map(|v| v.to_string()),
             _ => None,
         };
@@ -521,38 +599,36 @@ impl ComponentValues for TemplateNumber {
 /// Formats: expanded (default), minimal, minimal-two, chicago, chicago-16
 fn format_page_range(pages: &str, format: Option<&csln_core::options::PageRangeFormat>) -> String {
     use csln_core::options::PageRangeFormat;
-    
+
     // First, replace hyphen with en-dash
     let pages = pages.replace("-", "–");
-    
+
     // If no range or no format specified, return as-is
     let format = match format {
         Some(f) => f,
         None => return pages, // Default: just convert to en-dash
     };
-    
+
     // Check if this is a range (contains en-dash)
     let parts: Vec<&str> = pages.split('–').collect();
     if parts.len() != 2 {
         return pages; // Not a simple range
     }
-    
+
     let start = parts[0].trim();
     let end = parts[1].trim();
-    
+
     // Parse as numbers
     let start_num: Option<u32> = start.parse().ok();
     let end_num: Option<u32> = end.parse().ok();
-    
+
     match (start_num, end_num) {
         (Some(s), Some(e)) if e > s => {
             let formatted_end = match format {
                 PageRangeFormat::Expanded => end.to_string(),
                 PageRangeFormat::Minimal => format_minimal(start, end, 1),
                 PageRangeFormat::MinimalTwo => format_minimal(start, end, 2),
-                PageRangeFormat::Chicago | PageRangeFormat::Chicago16 => {
-                    format_chicago(s, e)
-                }
+                PageRangeFormat::Chicago | PageRangeFormat::Chicago16 => format_chicago(s, e),
                 _ => end.to_string(), // Future variants: default to expanded
             };
             format!("{}–{}", start, formatted_end)
@@ -565,11 +641,11 @@ fn format_page_range(pages: &str, format: Option<&csln_core::options::PageRangeF
 fn format_minimal(start: &str, end: &str, min_digits: usize) -> String {
     let start_chars: Vec<char> = start.chars().collect();
     let end_chars: Vec<char> = end.chars().collect();
-    
+
     if start_chars.len() != end_chars.len() {
         return end.to_string();
     }
-    
+
     // Find first differing position
     let mut first_diff = 0;
     for (i, (s, e)) in start_chars.iter().zip(end_chars.iter()).enumerate() {
@@ -578,7 +654,7 @@ fn format_minimal(start: &str, end: &str, min_digits: usize) -> String {
             break;
         }
     }
-    
+
     // Keep at least min_digits from the end
     let keep_from = first_diff.min(end_chars.len().saturating_sub(min_digits));
     end_chars[keep_from..].iter().collect()
@@ -590,26 +666,26 @@ fn format_chicago(start: u32, end: u32) -> String {
     // - Under 100: use all digits (3–10, 71–72, 96–117)
     // - 100+, same hundreds: use changed part only for 2+ digits (107–8, 321–28, 1536–38)
     // - Different hundreds: use all digits (107–108, 321–328 if change of hundreds)
-    
+
     if start < 100 || end < 100 {
         return end.to_string();
     }
-    
+
     let start_str = start.to_string();
     let end_str = end.to_string();
-    
+
     if start_str.len() != end_str.len() {
         return end_str;
     }
-    
+
     // Check if same hundreds
     let start_prefix = start / 100;
     let end_prefix = end / 100;
-    
+
     if start_prefix != end_prefix {
         return end_str; // Different hundreds, use full number
     }
-    
+
     // Same hundreds: use minimal-two style
     format_minimal(&start_str, &end_str, 2)
 }
@@ -649,27 +725,29 @@ impl ComponentValues for TemplateList {
         options: &RenderOptions<'_>,
     ) -> Option<ProcValues> {
         use csln_core::template::WrapPunctuation;
-        
+
         // Collect values from all items, applying their rendering
-        let values: Vec<String> = self.items
+        let values: Vec<String> = self
+            .items
             .iter()
             .filter_map(|item| {
                 let v = item.values(reference, hints, options)?;
                 if v.value.is_empty() {
                     return None;
                 }
-                
+
                 // Apply rendering from the item
                 let rendering = item.rendering();
-                let (wrap_open, wrap_close) = match rendering.wrap.as_ref().unwrap_or(&WrapPunctuation::None) {
-                    WrapPunctuation::Parentheses => ("(", ")"),
-                    WrapPunctuation::Brackets => ("[", "]"),
-                    WrapPunctuation::None => ("", ""),
-                };
-                
+                let (wrap_open, wrap_close) =
+                    match rendering.wrap.as_ref().unwrap_or(&WrapPunctuation::None) {
+                        WrapPunctuation::Parentheses => ("(", ")"),
+                        WrapPunctuation::Brackets => ("[", "]"),
+                        WrapPunctuation::None => ("", ""),
+                    };
+
                 let prefix = rendering.prefix.as_deref().unwrap_or_default();
                 let suffix = rendering.suffix.as_deref().unwrap_or_default();
-                
+
                 // Build the formatted value
                 let mut s = String::new();
                 s.push_str(wrap_open);
@@ -683,7 +761,7 @@ impl ComponentValues for TemplateList {
                 }
                 s.push_str(suffix);
                 s.push_str(wrap_close);
-                
+
                 Some(s)
             })
             .collect();
@@ -693,7 +771,11 @@ impl ComponentValues for TemplateList {
         }
 
         // Join with delimiter
-        let delimiter = match self.delimiter.as_ref().unwrap_or(&DelimiterPunctuation::Comma) {
+        let delimiter = match self
+            .delimiter
+            .as_ref()
+            .unwrap_or(&DelimiterPunctuation::Comma)
+        {
             DelimiterPunctuation::Comma => ", ",
             DelimiterPunctuation::Semicolon => "; ",
             DelimiterPunctuation::Period => ". ",
@@ -756,7 +838,11 @@ mod tests {
     fn test_contributor_values() {
         let config = make_config();
         let locale = make_locale();
-        let options = RenderOptions { config: &config, locale: &locale, context: RenderContext::Citation };
+        let options = RenderOptions {
+            config: &config,
+            locale: &locale,
+            context: RenderContext::Citation,
+        };
         let reference = make_reference();
         let hints = ProcHints::default();
 
@@ -776,7 +862,11 @@ mod tests {
     fn test_date_values() {
         let config = make_config();
         let locale = make_locale();
-        let options = RenderOptions { config: &config, locale: &locale, context: RenderContext::Citation };
+        let options = RenderOptions {
+            config: &config,
+            locale: &locale,
+            context: RenderContext::Citation,
+        };
         let reference = make_reference();
         let hints = ProcHints::default();
 
@@ -794,7 +884,11 @@ mod tests {
     fn test_et_al() {
         let config = make_config();
         let locale = make_locale();
-        let options = RenderOptions { config: &config, locale: &locale, context: RenderContext::Citation };
+        let options = RenderOptions {
+            config: &config,
+            locale: &locale,
+            context: RenderContext::Citation,
+        };
         let hints = ProcHints::default();
 
         let reference = Reference {
@@ -823,34 +917,64 @@ mod tests {
     #[test]
     fn test_format_page_range_expanded() {
         use csln_core::options::PageRangeFormat;
-        assert_eq!(format_page_range("321-328", Some(&PageRangeFormat::Expanded)), "321–328");
-        assert_eq!(format_page_range("42-45", Some(&PageRangeFormat::Expanded)), "42–45");
+        assert_eq!(
+            format_page_range("321-328", Some(&PageRangeFormat::Expanded)),
+            "321–328"
+        );
+        assert_eq!(
+            format_page_range("42-45", Some(&PageRangeFormat::Expanded)),
+            "42–45"
+        );
     }
 
     #[test]
     fn test_format_page_range_minimal() {
         use csln_core::options::PageRangeFormat;
         // minimal: keep only differing digits
-        assert_eq!(format_page_range("321-328", Some(&PageRangeFormat::Minimal)), "321–8");
-        assert_eq!(format_page_range("42-45", Some(&PageRangeFormat::Minimal)), "42–5");
-        assert_eq!(format_page_range("12-17", Some(&PageRangeFormat::Minimal)), "12–7");
+        assert_eq!(
+            format_page_range("321-328", Some(&PageRangeFormat::Minimal)),
+            "321–8"
+        );
+        assert_eq!(
+            format_page_range("42-45", Some(&PageRangeFormat::Minimal)),
+            "42–5"
+        );
+        assert_eq!(
+            format_page_range("12-17", Some(&PageRangeFormat::Minimal)),
+            "12–7"
+        );
     }
 
     #[test]
     fn test_format_page_range_minimal_two() {
         use csln_core::options::PageRangeFormat;
         // minimal-two: at least 2 digits
-        assert_eq!(format_page_range("321-328", Some(&PageRangeFormat::MinimalTwo)), "321–28");
-        assert_eq!(format_page_range("42-45", Some(&PageRangeFormat::MinimalTwo)), "42–45");
+        assert_eq!(
+            format_page_range("321-328", Some(&PageRangeFormat::MinimalTwo)),
+            "321–28"
+        );
+        assert_eq!(
+            format_page_range("42-45", Some(&PageRangeFormat::MinimalTwo)),
+            "42–45"
+        );
     }
 
     #[test]
     fn test_format_page_range_chicago() {
         use csln_core::options::PageRangeFormat;
         // Chicago: special rules for under 100 and same hundreds
-        assert_eq!(format_page_range("71-72", Some(&PageRangeFormat::Chicago)), "71–72");
-        assert_eq!(format_page_range("321-328", Some(&PageRangeFormat::Chicago)), "321–28");
-        assert_eq!(format_page_range("1536-1538", Some(&PageRangeFormat::Chicago)), "1536–38");
+        assert_eq!(
+            format_page_range("71-72", Some(&PageRangeFormat::Chicago)),
+            "71–72"
+        );
+        assert_eq!(
+            format_page_range("321-328", Some(&PageRangeFormat::Chicago)),
+            "321–28"
+        );
+        assert_eq!(
+            format_page_range("1536-1538", Some(&PageRangeFormat::Chicago)),
+            "1536–38"
+        );
     }
 
     #[test]
@@ -862,7 +986,7 @@ mod tests {
     #[test]
     fn test_et_al_delimiter_never() {
         use csln_core::options::DelimiterPrecedesLast;
-        
+
         let mut config = make_config();
         if let Some(ref mut contributors) = config.contributors {
             contributors.shorten = Some(ShortenListOptions {
@@ -872,18 +996,19 @@ mod tests {
             });
             contributors.delimiter_precedes_et_al = Some(DelimiterPrecedesLast::Never);
         }
-        
+
         let locale = make_locale();
-        let options = RenderOptions { config: &config, locale: &locale, context: RenderContext::Citation };
+        let options = RenderOptions {
+            config: &config,
+            locale: &locale,
+            context: RenderContext::Citation,
+        };
         let hints = ProcHints::default();
 
         let reference = Reference {
             id: "multi".to_string(),
             ref_type: "article-journal".to_string(),
-            author: Some(vec![
-                Name::new("Smith", "John"),
-                Name::new("Jones", "Jane"),
-            ]),
+            author: Some(vec![Name::new("Smith", "John"), Name::new("Jones", "Jane")]),
             ..Default::default()
         };
 
@@ -903,7 +1028,7 @@ mod tests {
     #[test]
     fn test_et_al_delimiter_always() {
         use csln_core::options::DelimiterPrecedesLast;
-        
+
         let mut config = make_config();
         if let Some(ref mut contributors) = config.contributors {
             contributors.shorten = Some(ShortenListOptions {
@@ -913,18 +1038,19 @@ mod tests {
             });
             contributors.delimiter_precedes_et_al = Some(DelimiterPrecedesLast::Always);
         }
-        
+
         let locale = make_locale();
-        let options = RenderOptions { config: &config, locale: &locale, context: RenderContext::Citation };
+        let options = RenderOptions {
+            config: &config,
+            locale: &locale,
+            context: RenderContext::Citation,
+        };
         let hints = ProcHints::default();
 
         let reference = Reference {
             id: "multi".to_string(),
             ref_type: "article-journal".to_string(),
-            author: Some(vec![
-                Name::new("Smith", "John"),
-                Name::new("Jones", "Jane"),
-            ]),
+            author: Some(vec![Name::new("Smith", "John"), Name::new("Jones", "Jane")]),
             ..Default::default()
         };
 
@@ -963,6 +1089,7 @@ mod tests {
             None,
             None,
             Some(&DemoteNonDroppingParticle::Never),
+            false,
         );
         assert_eq!(res_never, "van Beethoven, Ludwig");
 
@@ -976,6 +1103,7 @@ mod tests {
             None,
             None,
             Some(&DemoteNonDroppingParticle::DisplayAndSort),
+            false,
         );
         assert_eq!(res_demote, "Beethoven, Ludwig van");
 
@@ -989,6 +1117,7 @@ mod tests {
             None,
             None,
             Some(&DemoteNonDroppingParticle::SortOnly),
+            false,
         );
         assert_eq!(res_sort_only, "van Beethoven, Ludwig");
 
@@ -1002,6 +1131,7 @@ mod tests {
             None,
             None,
             Some(&DemoteNonDroppingParticle::DisplayAndSort),
+            false,
         );
         assert_eq!(res_straight, "Ludwig van Beethoven");
     }

--- a/crates/csln_processor/tests/oracle_comparison.rs
+++ b/crates/csln_processor/tests/oracle_comparison.rs
@@ -5,7 +5,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Integration test comparing CSLN processor output with citeproc-js.
 
-use csln_core::options::{AndOptions, ContributorConfig, DisplayAsSort, Processing, ShortenListOptions};
+use csln_core::options::{
+    AndOptions, ContributorConfig, DisplayAsSort, Processing, ShortenListOptions,
+};
 use csln_core::template::{
     ContributorForm, ContributorRole, DateForm, DateVariable as TDateVar, Rendering,
     TemplateComponent, TemplateContributor, TemplateDate, TemplateTitle, TitleType,
@@ -143,7 +145,7 @@ fn test_apa_single_author_citation() {
     };
 
     let result = processor.process_citation(&citation).unwrap();
-    
+
     // Expected: (Kuhn, 1962) - matches citeproc-js APA output
     assert_eq!(result, "(Kuhn, 1962)");
 }
@@ -163,7 +165,7 @@ fn test_apa_multi_author_citation_et_al() {
     };
 
     let result = processor.process_citation(&citation).unwrap();
-    
+
     // Expected: (LeCun et al., 2015) - matches citeproc-js APA output for 3+ authors
     assert_eq!(result, "(LeCun et al., 2015)");
 }
@@ -175,11 +177,14 @@ fn test_apa_bibliography_entry() {
     let processor = Processor::new(style, bib);
 
     let result = processor.render_bibliography();
-    
+
     // Check Kuhn entry has correct format
     assert!(result.contains("Kuhn, T."), "Should have 'Kuhn, T.'");
     assert!(result.contains("(1962)"), "Should have '(1962)'");
-    assert!(result.contains("_The Structure of Scientific Revolutions_"), "Should have italicized title");
+    assert!(
+        result.contains("_The Structure of Scientific Revolutions_"),
+        "Should have italicized title"
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Add additive disambiguation (Names -> GivenNames -> YearSuffix)
- Add min_names_to_show hint in ProcHints for et-al expansion
- Update name rendering to respect disambiguation hints
- Add check_names_resolution with multi-author support
- Refine make_group_key for base citation form collisions
- Support combined expansion (multiple names + initials)
- Update README.md and AGENTS.md status
- Fix compilation errors in parser and reference models