### PR TITLE
feat(bib): implement subsequent author substitution

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -113,11 +113,11 @@ Run `cargo run --bin csln_analyze -- styles/` to regenerate these statistics.
 | `name-as-sort-order` | 48 styles | Family-first formatting |
 | `disambiguate-add-givenname`| 935 styles | Add initials when ambiguous |
 | `disambiguate-add-names` | 1,241 styles | Add more authors to resolve ambiguity |
+| `subsequent-author-substitute` | 314 styles | "———" for repeated authors |
 
 ### High Priority (Not Yet Implemented)
 | Feature | Usage | Notes |
 |---------|-------|-------|
-| `subsequent-author-substitute` | 314 styles | "———" for repeated authors |
 
 ### Implemented ✅
 | Feature | Usage | Notes |
@@ -174,9 +174,14 @@ All changes must be made on feature branches. The user will handle merging via G
    git checkout -b feat/my-feature
    ```
 
-2. **Make changes and commit**
+   ```
+2. **Format code before committing**
    ```bash
-   git add -A && git commit -m "feat: description"
+   cargo fmt
+   ```
+3. **Make changes and commit**
+   ```bash
+   git add -A && git commit -m "feat(scope): description"
    ```
 
 3. **Stop here.** Do NOT attempt to merge. The user will review and merge when ready.

--- a/.agent/state.json
+++ b/.agent/state.json
@@ -2,7 +2,7 @@
   "phase": "cleanup_complete",
   "status": "ready_for_collaboration",
   "repo": "https://github.com/bdarcus/csl26",
-  "last_updated": "2026-01-28T20:33:00Z",
+  "last_updated": "2026-01-29T01:55:00Z",
   "citation_status": "5/5 exact match with citeproc-js oracle (including disambiguation)",
   "bibliography_status": "~85% match - core elements working",
   "structure": {

--- a/crates/csl_legacy/src/model.rs
+++ b/crates/csl_legacy/src/model.rs
@@ -71,6 +71,8 @@ pub struct Bibliography {
     pub et_al_min: Option<usize>,
     pub et_al_use_first: Option<usize>,
     pub hanging_indent: Option<bool>,
+    pub subsequent_author_substitute: Option<String>,
+    pub subsequent_author_substitute_rule: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/csl_legacy/src/parser.rs
+++ b/crates/csl_legacy/src/parser.rs
@@ -203,6 +203,13 @@ fn parse_bibliography(node: Node) -> Result<Bibliography, String> {
         .and_then(|s| s.parse().ok());
     let hanging_indent = node.attribute("hanging-indent").map(|s| s == "true");
 
+    let subsequent_author_substitute = node
+        .attribute("subsequent-author-substitute")
+        .map(|s| s.to_string());
+    let subsequent_author_substitute_rule = node
+        .attribute("subsequent-author-substitute-rule")
+        .map(|s| s.to_string());
+
     for child in node.children() {
         if !child.is_element() {
             continue;
@@ -219,6 +226,8 @@ fn parse_bibliography(node: Node) -> Result<Bibliography, String> {
         et_al_min,
         et_al_use_first,
         hanging_indent,
+        subsequent_author_substitute,
+        subsequent_author_substitute_rule,
     })
 }
 

--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -36,6 +36,9 @@ pub struct Config {
     /// Page range formatting (expanded, minimal, chicago).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub page_range_format: Option<PageRangeFormat>,
+    /// Bibliography-specific settings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bibliography: Option<BibliographyConfig>,
 }
 
 /// Page range formatting options.
@@ -351,6 +354,36 @@ pub enum Scope {
 #[serde(rename_all = "kebab-case")]
 pub struct Group {
     pub template: Vec<SortKey>,
+}
+
+/// Bibliography-specific configuration.
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BibliographyConfig {
+    /// String to substitute for repeating authors (e.g., "———").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subsequent_author_substitute: Option<String>,
+    /// Rule for when to apply the substitute.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subsequent_author_substitute_rule: Option<SubsequentAuthorSubstituteRule>,
+    /// Whether to use a hanging indent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hanging_indent: Option<bool>,
+}
+
+/// Rules for subsequent author substitution.
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SubsequentAuthorSubstituteRule {
+    /// Substitute only if ALL authors match.
+    #[default]
+    CompleteAll,
+    /// Substitute each matching name individually.
+    CompleteEach,
+    /// Substitute each matching name until the first mismatch.
+    PartialEach,
+    /// Substitute only the first name if it matches.
+    PartialFirst,
 }
 
 /// Substitution rules for missing author data.

--- a/crates/csln_processor/tests/subsequent_author_substitute.rs
+++ b/crates/csln_processor/tests/subsequent_author_substitute.rs
@@ -1,0 +1,123 @@
+use csln_core::{
+    options::{BibliographyConfig, Config, ContributorConfig, Processing},
+    template::{
+        ContributorForm, ContributorRole, DateForm, DateVariable as TDateVar, Rendering,
+        TemplateComponent, TemplateContributor, TemplateDate,
+    },
+    BibliographySpec, Style, StyleInfo,
+};
+use csln_processor::{
+    reference::{DateVariable, Name, Reference},
+    Processor,
+};
+use std::collections::HashMap;
+
+fn make_style_with_substitute(substitute: Option<String>) -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("Subsequent Author Substitute Test".to_string()),
+            id: Some("sub-test".to_string()),
+            ..Default::default()
+        },
+        templates: None,
+        options: Some(Config {
+            processing: Some(Processing::AuthorDate),
+            bibliography: Some(BibliographyConfig {
+                subsequent_author_substitute: substitute,
+                ..Default::default()
+            }),
+            contributors: Some(ContributorConfig {
+                display_as_sort: Some(csln_core::options::DisplayAsSort::First),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        citation: None,
+        bibliography: Some(BibliographySpec {
+            options: None,
+            template: vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author,
+                    form: ContributorForm::Long,
+                    name_order: None,
+                    delimiter: None,
+                    rendering: Rendering::default(),
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
+                    rendering: Rendering::default(),
+                }),
+            ],
+        }),
+    }
+}
+
+#[test]
+fn test_subsequent_author_substitute() {
+    let style = make_style_with_substitute(Some("———".to_string()));
+
+    let mut bib = HashMap::new();
+    bib.insert(
+        "ref1".to_string(),
+        Reference {
+            id: "ref1".to_string(),
+            ref_type: "book".to_string(),
+            author: Some(vec![Name::new("Smith", "John")]),
+            issued: Some(DateVariable::year(2020)),
+            ..Default::default()
+        },
+    );
+    bib.insert(
+        "ref2".to_string(),
+        Reference {
+            id: "ref2".to_string(),
+            ref_type: "book".to_string(),
+            author: Some(vec![Name::new("Smith", "John")]),
+            issued: Some(DateVariable::year(2021)),
+            ..Default::default()
+        },
+    );
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    // ref1 comes first (2020), then ref2 (2021). ref2 should have substituted author.
+    // Note: Implicit separator ". " + Implicit suffix "."
+    let expected = "Smith, John. 2020.\n\n———. 2021.";
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_no_substitute_if_different() {
+    let style = make_style_with_substitute(Some("———".to_string()));
+
+    let mut bib = HashMap::new();
+    bib.insert(
+        "ref1".to_string(),
+        Reference {
+            id: "ref1".to_string(),
+            ref_type: "book".to_string(),
+            author: Some(vec![Name::new("Smith", "John")]),
+            issued: Some(DateVariable::year(2020)),
+            ..Default::default()
+        },
+    );
+    bib.insert(
+        "ref2".to_string(),
+        Reference {
+            id: "ref2".to_string(),
+            ref_type: "book".to_string(),
+            author: Some(vec![Name::new("Doe", "Jane")]),
+            issued: Some(DateVariable::year(2021)),
+            ..Default::default()
+        },
+    );
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    // Doe comes before Smith alphabetically
+    let expected = "Doe, Jane. 2021.\n\nSmith, John. 2020.";
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
Also fixed bug in sort_references where year sort was hardcoded to descending and ascending flag was ignored.