### PR TITLE
feat(core): add json schema generation support

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -16,6 +16,7 @@ Transition the citation management ecosystem from CSL 1.0 (procedural XML) to CS
 ```
 crates/
   csl_legacy/      # CSL 1.0 XML parser (complete)
+  csln_cli/        # CLI tools (schema generation)
   csln_core/       # CSLN types: Style, Template, Options, Locale
   csln_migrate/    # CSL 1.0 → CSLN conversion
   csln_processor/  # Citation/bibliography rendering engine
@@ -211,6 +212,9 @@ cd scripts && node oracle-e2e.js ../styles/apa.csl
 
 # Run CSLN processor  
 cargo run --bin csln_processor -- examples/apa-style.yaml
+
+# Generate JSON Schema
+cargo run --bin csln_cli -- schema > csln.schema.json
 
 # Analyze all styles for feature usage
 cargo run --bin csln_analyze -- styles/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +66,52 @@ checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e34525d5bbbd55da2bb745d34b36121baac88d07619a9a09cfcf4a6c0832785"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a20016a20a3da95bef50ec7238dbd09baeef4311dcdd38ec15aba69812fb61"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "csl_legacy"
@@ -40,9 +136,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "csln_cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "csln_core",
+ "schemars",
+ "serde_json",
+]
+
+[[package]]
 name = "csln_core"
 version = "0.1.0"
 dependencies = [
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -73,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "edtf"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +223,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -152,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +322,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +369,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -245,6 +411,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -288,6 +460,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "crates/csln_core",
     "crates/csln_migrate",
     "crates/csln_processor",
-    "crates/csln_analyze"
+    "crates/csln_analyze",
+    "crates/csln_cli"
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Remaining high-priority:
 ```
 crates/
 ├── csl_legacy/      # CSL 1.0 XML parser (read-only)
+├── csln_cli/        # CLI tools (schema generation, etc.)
 ├── csln_core/       # CSLN schema and types
 │   ├── options.rs   # Style configuration
 │   ├── template.rs  # Template components
@@ -314,6 +315,20 @@ Citations: 5/5 match
 ```bash
 cargo doc --workspace --open
 ```
+
+### JSON Schema Generation
+
+You can generate a formal JSON Schema for CSLN styles using the CLI:
+
+```bash
+# Output schema to stdout
+cargo run --bin csln_cli -- schema
+
+# Save to file
+cargo run --bin csln_cli -- schema > csln.schema.json
+```
+
+This schema can be used to validate styles or provide intellisense in editors like VS Code.
 
 ## Roadmap
 

--- a/crates/csln_cli/Cargo.toml
+++ b/crates/csln_cli/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "csln_cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.4", features = ["derive"] }
+serde_json = "1.0"
+schemars = "0.8"
+csln_core = { path = "../csln_core" }

--- a/crates/csln_cli/src/main.rs
+++ b/crates/csln_cli/src/main.rs
@@ -1,0 +1,27 @@
+use clap::{Parser, Subcommand};
+use csln_core::Style;
+use schemars::schema_for;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate JSON schema for CSLN styles
+    Schema,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Schema => {
+            let schema = schema_for!(Style);
+            println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+        }
+    }
+}

--- a/crates/csln_core/Cargo.toml
+++ b/crates/csln_core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+schemars = { version = "0.8", features = ["derive"] }

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -20,7 +21,7 @@ pub type Template = Vec<TemplateComponent>;
 ///
 /// This is the target schema for CSLN, featuring declarative options
 /// and simple template components instead of procedural conditionals.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Style {
     /// Style schema version.
@@ -50,7 +51,7 @@ fn default_version() -> String {
 }
 
 /// Citation specification.
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct CitationSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,7 +63,7 @@ pub struct CitationSpec {
 }
 
 /// Bibliography specification.
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct BibliographySpec {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,7 +75,7 @@ pub struct BibliographySpec {
 }
 
 /// Style metadata.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct StyleInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -90,7 +91,7 @@ pub struct StyleInfo {
 // These will be deprecated once migration is complete
 // ============================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum ItemType {
     Article,
@@ -132,7 +133,7 @@ pub enum ItemType {
     Standard,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum Variable {
     Author,
@@ -209,7 +210,7 @@ pub enum Variable {
     YearSuffix,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct CslnStyle {
     pub info: CslnInfo,
@@ -218,18 +219,18 @@ pub struct CslnStyle {
     pub bibliography: Vec<CslnNode>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 pub struct CslnLocale {
     pub terms: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CslnInfo {
     pub title: String,
     pub id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum CslnNode {
     Text { value: String },
@@ -240,7 +241,7 @@ pub enum CslnNode {
     Condition(ConditionBlock),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct VariableBlock {
     pub variable: Variable,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -251,7 +252,7 @@ pub struct VariableBlock {
     pub overrides: HashMap<ItemType, FormattingOptions>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct GroupBlock {
     pub children: Vec<CslnNode>,
     pub delimiter: Option<String>,
@@ -259,7 +260,7 @@ pub struct GroupBlock {
     pub formatting: FormattingOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ConditionBlock {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub if_item_type: Vec<ItemType>,
@@ -269,7 +270,7 @@ pub struct ConditionBlock {
     pub else_branch: Option<Vec<CslnNode>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct LabelOptions {
     pub form: LabelForm,
     pub pluralize: bool,
@@ -277,7 +278,7 @@ pub struct LabelOptions {
     pub formatting: FormattingOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum LabelForm {
     Long,
@@ -287,7 +288,7 @@ pub enum LabelForm {
     VerbShort,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DateBlock {
     pub variable: Variable,
     #[serde(flatten)]
@@ -296,7 +297,7 @@ pub struct DateBlock {
     pub formatting: FormattingOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct NamesBlock {
     pub variable: Variable,
     #[serde(flatten)]
@@ -305,7 +306,7 @@ pub struct NamesBlock {
     pub formatting: FormattingOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct NamesOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -330,7 +331,7 @@ pub struct NamesOptions {
     pub substitute: Vec<Variable>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum NameMode {
     Long,
@@ -338,14 +339,14 @@ pub enum NameMode {
     Count,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum AndTerm {
     Text,
     Symbol,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DelimiterPrecedes {
     Contextual,
@@ -354,7 +355,7 @@ pub enum DelimiterPrecedes {
     Never,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum NameAsSortOrder {
     First,
@@ -362,7 +363,7 @@ pub enum NameAsSortOrder {
 }
 
 /// Configuration for et-al abbreviation in names.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct EtAlOptions {
     /// Minimum number of names to trigger abbreviation.
@@ -378,14 +379,14 @@ pub struct EtAlOptions {
     pub formatting: FormattingOptions,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct EtAlSubsequent {
     pub min: u8,
     pub use_first: u8,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct DateOptions {
     pub form: Option<DateForm>,
@@ -399,14 +400,14 @@ pub struct DateOptions {
     pub day_form: Option<DatePartForm>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DateForm {
     Text,
     Numeric,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DateParts {
     Year,
@@ -414,7 +415,7 @@ pub enum DateParts {
     YearMonthDay,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DatePartForm {
     Numeric,
@@ -424,7 +425,7 @@ pub enum DatePartForm {
     Short,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct FormattingOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -445,7 +446,7 @@ pub struct FormattingOptions {
     pub suffix: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum FontStyle {
     Normal,
@@ -453,14 +454,14 @@ pub enum FontStyle {
     Oblique,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum FontVariant {
     Normal,
     SmallCaps,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum FontWeight {
     Normal,
@@ -468,14 +469,14 @@ pub enum FontWeight {
     Light,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum TextDecoration {
     None,
     Underline,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum VerticalAlign {
     Baseline,

--- a/crates/csln_core/src/locale.rs
+++ b/crates/csln_core/src/locale.rs
@@ -9,11 +9,12 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! for citation formatting.
 
 use crate::template::ContributorRole;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// A locale definition containing language-specific terms and formatting rules.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Locale {
     /// The locale identifier (e.g., "en-US", "de-DE").
@@ -144,7 +145,7 @@ impl Locale {
 }
 
 /// Form for term lookup.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
 pub enum TermForm {
     Long,
     Short,
@@ -153,7 +154,7 @@ pub enum TermForm {
 }
 
 /// General terms used in citations and bibliographies.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Terms {
     /// The word "and" (e.g., "Smith and Jones").
@@ -220,7 +221,7 @@ impl Terms {
 }
 
 /// A simple term with long and short forms.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 pub struct SimpleTerm {
     /// The long form of the term.
     pub long: String,
@@ -229,7 +230,7 @@ pub struct SimpleTerm {
 }
 
 /// Terms for contributor roles.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 pub struct ContributorTerm {
     /// Singular form (editor, translator).
     pub singular: SimpleTerm,
@@ -240,7 +241,7 @@ pub struct ContributorTerm {
 }
 
 /// Date-related terms.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 pub struct DateTerms {
     /// Month names.
     #[serde(default)]
@@ -266,7 +267,7 @@ impl DateTerms {
 }
 
 /// Month name lists.
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
 pub struct MonthNames {
     /// Full month names.
     pub long: Vec<String>,

--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -9,11 +9,12 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Much of the logic that CSL 1.0 handles in procedural template conditionals is
 //! instead configured declaratively here.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Top-level style configuration.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// Substitution rules for missing data.
@@ -46,7 +47,7 @@ pub struct Config {
 }
 
 /// Page range formatting options.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum PageRangeFormat {
@@ -64,7 +65,7 @@ pub enum PageRangeFormat {
 }
 
 /// Title formatting configuration by title type.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TitlesConfig {
     /// Formatting for component titles (articles, chapters).
@@ -82,7 +83,7 @@ pub struct TitlesConfig {
 }
 
 /// Rendering options for titles.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TitleRendering {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -94,7 +95,7 @@ pub struct TitleRendering {
 }
 
 /// Processing mode for citation/bibliography generation.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum Processing {
@@ -106,7 +107,7 @@ pub enum Processing {
 }
 
 /// Custom processing configuration.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct ProcessingCustom {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -165,7 +166,7 @@ impl Processing {
 }
 
 /// Disambiguation settings.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Disambiguation {
     pub names: bool,
@@ -185,7 +186,7 @@ impl Default for Disambiguation {
 }
 
 /// Date formatting configuration.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct DateConfig {
     pub month: MonthFormat,
@@ -204,7 +205,7 @@ impl Default for DateConfig {
 }
 
 /// Month display format.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum MonthFormat {
     #[default]
@@ -214,7 +215,7 @@ pub enum MonthFormat {
 }
 
 /// Contributor formatting configuration.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct ContributorConfig {
     /// When to display a contributor's name in sort order.
@@ -254,7 +255,7 @@ pub struct ContributorConfig {
 }
 
 /// Options for demoting non-dropping particles.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DemoteNonDroppingParticle {
     Never,
@@ -264,7 +265,7 @@ pub enum DemoteNonDroppingParticle {
 }
 
 /// When to display names in sort order (family-first).
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum DisplayAsSort {
     All,
@@ -274,7 +275,7 @@ pub enum DisplayAsSort {
 }
 
 /// Conjunction options between contributors.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum AndOptions {
@@ -285,7 +286,7 @@ pub enum AndOptions {
 }
 
 /// Role display options.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct RoleOptions {
     /// Contributor roles for which to omit the role description.
@@ -296,7 +297,7 @@ pub struct RoleOptions {
 }
 
 /// When to use delimiter before last contributor.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DelimiterPrecedesLast {
     AfterInvertedName,
@@ -307,7 +308,7 @@ pub enum DelimiterPrecedesLast {
 }
 
 /// Et al. / list shortening options.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct ShortenListOptions {
     /// Minimum number of names to trigger shortening.
@@ -334,7 +335,7 @@ impl Default for ShortenListOptions {
 }
 
 /// How to render "and others" / et al.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum AndOtherOptions {
     #[default]
@@ -343,7 +344,7 @@ pub enum AndOtherOptions {
 }
 
 /// Localization scope settings.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Localize {
     pub scope: Scope,
@@ -358,7 +359,7 @@ impl Default for Localize {
 }
 
 /// Localization scope.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum Scope {
     #[default]
@@ -367,14 +368,14 @@ pub enum Scope {
 }
 
 /// Grouping configuration for bibliography.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Group {
     pub template: Vec<SortKey>,
 }
 
 /// Bibliography-specific configuration.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct BibliographyConfig {
     /// String to substitute for repeating authors (e.g., "———").
@@ -392,7 +393,7 @@ pub struct BibliographyConfig {
 }
 
 /// Rules for subsequent author substitution.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum SubsequentAuthorSubstituteRule {
     /// Substitute only if ALL authors match.
@@ -407,7 +408,7 @@ pub enum SubsequentAuthorSubstituteRule {
 }
 
 /// Substitution rules for missing author data.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Substitute {
     /// Form to use for contributor roles when substituting.
@@ -431,7 +432,7 @@ impl Default for Substitute {
 }
 
 /// Fields that can be used as author substitutes.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum SubstituteKey {
     Editor,
@@ -440,7 +441,7 @@ pub enum SubstituteKey {
 }
 
 /// Sorting configuration.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct Sort {
     /// Shorten name lists for sorting the same as for display.
@@ -454,7 +455,7 @@ pub struct Sort {
 }
 
 /// A single sort specification.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct SortSpec {
     pub key: SortKey,
@@ -467,7 +468,7 @@ fn default_ascending() -> bool {
 }
 
 /// Available sort keys.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum SortKey {

--- a/crates/csln_core/src/template.rs
+++ b/crates/csln_core/src/template.rs
@@ -33,6 +33,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //!
 //! This keeps all conditional logic in the style, making it testable and portable.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -45,7 +46,7 @@ use std::collections::HashMap;
 ///   prefix: "In "
 /// ```
 /// Rather than nesting under a `rendering:` key.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", default)]
 pub struct Rendering {
     /// Render in italics/emphasis.
@@ -76,7 +77,7 @@ pub struct Rendering {
 }
 
 /// Punctuation to wrap a component in.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum WrapPunctuation {
     Parentheses,
@@ -88,7 +89,7 @@ pub enum WrapPunctuation {
 /// A template component - the building blocks of citation/bibliography templates.
 ///
 /// Each variant handles a specific data type with appropriate formatting options.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum TemplateComponent {
@@ -115,7 +116,7 @@ impl TemplateComponent {
 }
 
 /// A contributor component for rendering names.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TemplateContributor {
     /// Which contributor role to render (author, editor, etc.).
@@ -137,7 +138,7 @@ pub struct TemplateContributor {
 }
 
 /// Name display order.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum NameOrder {
     /// Display as "Given Family" (e.g., "John Smith").
@@ -148,7 +149,7 @@ pub enum NameOrder {
 }
 
 /// How to render contributor names.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum ContributorForm {
     #[default]
@@ -159,7 +160,7 @@ pub enum ContributorForm {
 }
 
 /// Contributor roles.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum ContributorRole {
@@ -184,7 +185,7 @@ pub enum ContributorRole {
 }
 
 /// A date component for rendering dates.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TemplateDate {
     pub date: DateVariable,
@@ -197,7 +198,7 @@ pub struct TemplateDate {
 }
 
 /// Date variables.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DateVariable {
     #[default]
@@ -209,7 +210,7 @@ pub enum DateVariable {
 }
 
 /// Date rendering forms.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DateForm {
     #[default]
@@ -220,7 +221,7 @@ pub enum DateForm {
 }
 
 /// A title component.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TemplateTitle {
     pub title: TitleType,
@@ -237,7 +238,7 @@ pub struct TemplateTitle {
 }
 
 /// Types of titles.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum TitleType {
@@ -251,7 +252,7 @@ pub enum TitleType {
 }
 
 /// Title rendering forms.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum TitleForm {
     Short,
@@ -260,7 +261,7 @@ pub enum TitleForm {
 }
 
 /// A number component (volume, issue, pages, etc.).
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TemplateNumber {
     pub number: NumberVariable,
@@ -277,7 +278,7 @@ pub struct TemplateNumber {
 }
 
 /// Number variables.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum NumberVariable {
@@ -293,7 +294,7 @@ pub enum NumberVariable {
 }
 
 /// Number rendering forms.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum NumberForm {
     #[default]
@@ -303,7 +304,7 @@ pub enum NumberForm {
 }
 
 /// A simple variable component (DOI, ISBN, URL, etc.).
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TemplateVariable {
     pub variable: SimpleVariable,
@@ -318,7 +319,7 @@ pub struct TemplateVariable {
 }
 
 /// Simple string variables.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum SimpleVariable {
@@ -348,7 +349,7 @@ pub enum SimpleVariable {
 }
 
 /// A list component for grouping multiple items with a delimiter.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub struct TemplateList {
     pub items: Vec<TemplateComponent>,
@@ -365,7 +366,7 @@ pub struct TemplateList {
 }
 
 /// Delimiter punctuation options.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DelimiterPunctuation {
     #[default]


### PR DESCRIPTION
- Add schemars dependency to csln_core
- Derive JsonSchema for all relevant style, locale, and template types
- Create csln_cli crate with 'schema' command to generate JSON schema
- Update workspace members to include csln_cli

This allows style authors and tool developers to validate CSLN styles against a formal JSON schema.