### PR TITLE
feat(locale): implement punctuation-in-quote as locale option

### DIFF
--- a/crates/csln_core/src/locale.rs
+++ b/crates/csln_core/src/locale.rs
@@ -28,6 +28,10 @@ pub struct Locale {
     /// General terms (and, et al., etc.).
     #[serde(default)]
     pub terms: Terms,
+    /// Whether to place periods/commas inside quotation marks.
+    /// true = American style ("text."), false = British style ("text".)
+    #[serde(default)]
+    pub punctuation_in_quote: bool,
 }
 
 impl Locale {
@@ -94,6 +98,7 @@ impl Locale {
             dates: DateTerms::en_us(),
             roles,
             terms: Terms::en_us(),
+            punctuation_in_quote: true, // American English convention
         }
     }
 
@@ -442,6 +447,11 @@ impl Locale {
 
     /// Convert a RawLocale to a Locale.
     fn from_raw(raw: RawLocale) -> Self {
+        // Determine punctuation-in-quote from locale ID
+        // en-US uses American style (inside), en-GB and others use outside
+        let punctuation_in_quote = raw.locale.starts_with("en-US")
+            || (raw.locale.starts_with("en") && !raw.locale.starts_with("en-GB"));
+
         let mut locale = Locale {
             locale: raw.locale,
             dates: DateTerms {
@@ -453,6 +463,7 @@ impl Locale {
             },
             roles: HashMap::new(),
             terms: Terms::default(),
+            punctuation_in_quote,
         };
 
         // Map raw terms to structured terms

--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -41,6 +41,11 @@ pub struct Config {
     /// Bibliography-specific settings.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bibliography: Option<BibliographyConfig>,
+    /// Whether to place periods/commas inside quotation marks.
+    /// true = American style ("text."), false = British style ("text".)
+    /// Defaults to false; en-US locale typically sets this to true.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub punctuation_in_quote: bool,
     /// Unknown fields captured for forward compatibility.
     #[serde(flatten)]
     pub _extra: HashMap<String, serde_json::Value>,

--- a/crates/csln_migrate/src/options_extractor.rs
+++ b/crates/csln_migrate/src/options_extractor.rs
@@ -45,7 +45,28 @@ impl OptionsExtractor {
             // 7. Extract bibliography-specific settings
             bibliography: Self::extract_bibliography_config(style),
 
+            // 8. Punctuation-in-quote from locale (en-US has true by default)
+            punctuation_in_quote: Self::extract_punctuation_in_quote(style),
+
             ..Config::default()
+        }
+    }
+
+    /// Extract punctuation-in-quote setting from locale.
+    /// en-US locale uses American style (punctuation inside quotes).
+    /// Most other locales default to false.
+    fn extract_punctuation_in_quote(style: &Style) -> bool {
+        // Check default-locale attribute; en-US/en-GB have different conventions
+        // en-US: punctuation inside quotes (true)
+        // en-GB and most others: punctuation outside quotes (false)
+        match style.default_locale.as_deref() {
+            Some(locale) if locale.starts_with("en-US") => true,
+            Some(locale) if locale.starts_with("en-GB") => false,
+            // Default to true for unspecified (CSL defaults to en-US)
+            // or generic "en" which is typically American
+            Some(locale) if locale.starts_with("en") => true,
+            None => true, // CSL default locale is en-US
+            _ => false,   // Other languages typically don't use American style
         }
     }
 

--- a/crates/csln_processor/src/render.rs
+++ b/crates/csln_processor/src/render.rs
@@ -59,6 +59,14 @@ pub fn refs_to_string(proc_templates: Vec<ProcTemplate>) -> String {
         if i > 0 {
             output.push_str("\n\n");
         }
+
+        // Check locale option for punctuation placement in quotes.
+        // Extract from first component's config (all components share the same config).
+        let punctuation_in_quote = proc_template
+            .first()
+            .and_then(|c| c.config.as_ref())
+            .is_some_and(|cfg| cfg.punctuation_in_quote);
+
         for (j, component) in proc_template.iter().enumerate() {
             let rendered = render_component(component);
             // Skip empty components (e.g., suppressed by type override)
@@ -87,8 +95,8 @@ pub fn refs_to_string(proc_templates: Vec<ProcTemplate>) -> String {
                     }
                 } else if !matches!(last_char, '.' | ',' | ':' | ';' | ' ') {
                     // Default: add period-space separator
-                    // American typography: periods go inside quotation marks
-                    if last_char == '"' {
+                    // Locale option: place periods inside quotation marks (American style)
+                    if punctuation_in_quote && last_char == '"' {
                         output.pop(); // Remove closing quote
                         output.push_str(".\" "); // Add period inside, then quote + space
                     } else {
@@ -117,8 +125,8 @@ pub fn refs_to_string(proc_templates: Vec<ProcTemplate>) -> String {
                 )
             });
         if !output.ends_with('.') && !last_is_link {
-            // American typography: periods go inside quotation marks
-            if output.ends_with('"') {
+            // Locale option: place periods inside quotation marks (American style)
+            if punctuation_in_quote && output.ends_with('"') {
                 output.pop();
                 output.push_str(".\"");
             } else {


### PR DESCRIPTION
## Summary
- Add `punctuation_in_quote` field to `Locale` and `Config` structs
- Extract setting from style's `default-locale` (en-US = true, en-GB/others = false)
- Use locale option in render.rs instead of hardcoding American style

## Background
Per CSL 1.0 spec, `punctuation-in-quote` is a locale option that controls whether periods/commas go inside quotation marks (American style) or outside (British style).

References:
- [CSL Spec: Locale Options](https://docs.citationstyles.org/en/stable/specification.html#locale-options)
- [Schema Issue #379](https://github.com/citation-style-language/schema/issues/379)

## Test Results
- **APA**: 5/5 citations, 5/5 bibliography ✅
- **Chicago Author-Date**: 5/5 citations, 2/5 bibliography (no regression)

## Implementation
The option is derived from the style's `default-locale`:
- `en-US` or generic `en`: punctuation inside quotes (true)
- `en-GB` and other locales: punctuation outside quotes (false)
- No locale specified: defaults to true (CSL default is en-US)

🤖 Generated with [Claude Code](https://claude.com/claude-code)