### PR TITLE
feat(migrate): extract volume-pages delimiter from CSL styles

### DIFF
--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -46,6 +46,10 @@ pub struct Config {
     /// Defaults to false; en-US locale typically sets this to true.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub punctuation_in_quote: bool,
+    /// Delimiter between volume/issue and pages for serial sources.
+    /// Extracted from CSL group delimiters. Examples: ", " (APA), ": " (Chicago).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume_pages_delimiter: Option<String>,
     /// Unknown fields captured for forward compatibility.
     #[serde(flatten)]
     pub _extra: HashMap<String, serde_json::Value>,


### PR DESCRIPTION
## Summary
- Add `volume_pages_delimiter` field to Config
- Extract delimiter from CSL group structures containing volume and page variables
- Apply style-specific delimiter for journal article pages
- Adjust parent-serial suffix based on delimiter (comma vs space)
- Set volume-issue spacing based on delimiter (APA: none, Chicago: space)

## How It Works
The extraction looks for groups in bibliography macros that contain both `volume` and `page` variables, then extracts the group's delimiter:
- **APA**: `, ` (comma) → volume-issue no space, comma prefix on pages
- **Chicago**: `: ` (colon) → volume-issue with space, colon prefix on pages

## Test Results
- **APA**: 5/5 citations, 5/5 bibliography ✅
- **Chicago Author-Date**: 5/5 citations, 2/5 bibliography (improved)
  - Entry 4 (journal article) now matches oracle output

## Remaining Chicago Issues
1. Trailing period after DOI/URL
2. Publisher-place not showing for journals (e.g., "(Chicago)")
3. Chapter formatting (editor verb form, page suppression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)