### PR TITLE
refactor(core): use DelimiterPunctuation enum for volume_pages_delimiter

### DIFF
--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -9,6 +9,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Much of the logic that CSL 1.0 handles in procedural template conditionals is
 //! instead configured declaratively here.
 
+use crate::template::DelimiterPunctuation;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -47,9 +48,10 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub punctuation_in_quote: bool,
     /// Delimiter between volume/issue and pages for serial sources.
-    /// Extracted from CSL group delimiters. Examples: ", " (APA), ": " (Chicago).
+    /// Processor adds trailing space when rendering.
+    /// Examples: Comma (APA ", "), Colon (Chicago ": ").
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_pages_delimiter: Option<String>,
+    pub volume_pages_delimiter: Option<DelimiterPunctuation>,
     /// Unknown fields captured for forward compatibility.
     #[serde(flatten)]
     pub _extra: HashMap<String, serde_json::Value>,

--- a/crates/csln_core/src/template.rs
+++ b/crates/csln_core/src/template.rs
@@ -449,7 +449,7 @@ pub struct TemplateList {
 }
 
 /// Delimiter punctuation options.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum DelimiterPunctuation {
     #[default]
@@ -463,6 +463,44 @@ pub enum DelimiterPunctuation {
     Hyphen,
     Space,
     None,
+}
+
+impl DelimiterPunctuation {
+    /// Convert to string with trailing space (for most delimiters).
+    /// Returns the punctuation followed by a space, except for Space and None.
+    pub fn to_string_with_space(&self) -> &'static str {
+        match self {
+            Self::Comma => ", ",
+            Self::Semicolon => "; ",
+            Self::Period => ". ",
+            Self::Colon => ": ",
+            Self::Ampersand => " & ",
+            Self::VerticalLine => " | ",
+            Self::Slash => "/",
+            Self::Hyphen => "-",
+            Self::Space => " ",
+            Self::None => "",
+        }
+    }
+
+    /// Parse from a CSL delimiter string.
+    /// Handles common patterns like ", ", ": ", etc.
+    pub fn from_csl_string(s: &str) -> Self {
+        let trimmed = s.trim();
+        match trimmed {
+            "," | ", " => Self::Comma,
+            ";" | "; " => Self::Semicolon,
+            "." | ". " => Self::Period,
+            ":" | ": " => Self::Colon,
+            "&" | " & " => Self::Ampersand,
+            "|" | " | " => Self::VerticalLine,
+            "/" => Self::Slash,
+            "-" => Self::Hyphen,
+            " " => Self::Space,
+            "" => Self::None,
+            _ => Self::Comma, // Default fallback
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/csln_migrate/src/options_extractor.rs
+++ b/crates/csln_migrate/src/options_extractor.rs
@@ -16,6 +16,7 @@ use csln_core::options::{
     ProcessingCustom, ShortenListOptions, Sort, SortKey, SortSpec, SubsequentAuthorSubstituteRule,
     Substitute as CslnSubstitute, SubstituteKey, TitlesConfig,
 };
+use csln_core::template::DelimiterPunctuation;
 
 /// Extracts global configuration options from a CSL 1.0 style.
 pub struct OptionsExtractor;
@@ -57,7 +58,7 @@ impl OptionsExtractor {
 
     /// Extract the delimiter between volume/issue and pages from serial source macros.
     /// This looks for groups that contain both volume and page variables.
-    fn extract_volume_pages_delimiter(style: &Style) -> Option<String> {
+    fn extract_volume_pages_delimiter(style: &Style) -> Option<DelimiterPunctuation> {
         let bib_macros = Self::collect_bibliography_macros(style);
 
         for macro_def in &style.macros {
@@ -65,14 +66,7 @@ impl OptionsExtractor {
                 if let Some(delimiter) =
                     Self::find_volume_pages_delimiter_in_nodes(&macro_def.children)
                 {
-                    // Normalize: ensure punctuation delimiters have trailing space
-                    // CSL typically uses ": " not ":" alone
-                    let normalized = if delimiter == ":" || delimiter == ";" {
-                        format!("{} ", delimiter)
-                    } else {
-                        delimiter
-                    };
-                    return Some(normalized);
+                    return Some(DelimiterPunctuation::from_csl_string(&delimiter));
                 }
             }
         }

--- a/crates/csln_migrate/src/template_compiler.rs
+++ b/crates/csln_migrate/src/template_compiler.rs
@@ -420,7 +420,7 @@ impl TemplateCompiler {
 
         Some(TemplateComponent::List(TemplateList {
             items: cleaned_items,
-            delimiter: list.delimiter.clone(),
+            delimiter: list.delimiter,
             rendering: list.rendering.clone(),
             ..Default::default()
         }))


### PR DESCRIPTION
## Summary

- Replaces `Option<String>` with `Option<DelimiterPunctuation>` for type-safe delimiter handling
- Adds `Copy` trait to `DelimiterPunctuation` (simple fieldless enum)
- Adds `to_string_with_space()` and `from_csl_string()` conversion methods
- Updates `options_extractor` to return enum from CSL parsing
- Updates `main.rs` to use enum for type comparisons

This aligns volume-pages delimiter handling with the existing enum-based punctuation system used elsewhere in the codebase (e.g., citation delimiters, list delimiters).

## Test Results

- All unit tests pass
- APA oracle E2E: 5/5 citations, 5/5 bibliography

🤖 Generated with [Claude Code](https://claude.ai/code)