### PR TITLE
feat(analyze): add parent style ranking for dependent styles

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -307,13 +307,43 @@ Branch naming conventions:
 
 ## Priority Styles
 
-**Important**: Do not over-optimize for any single style. APA is widely used but represents just one pattern among many. Test changes against multiple styles to avoid regressions.
+**Important**: Do not over-optimize for any single style. Test changes against multiple parent styles to avoid regressions.
 
-1. **APA 7th** - Widely used, complex requirements
-2. **Chicago Author-Date** - Different patterns (full names, different punctuation)
-3. **Academy of Management Review** - Author-date with different conventions
-4. **IEEE** - Numeric citation style
-5. **Vancouver** - Numeric style for medicine
-6. **All 2,844 styles** - Bulk migration target
+See **[docs/STYLE_PRIORITY.md](./docs/STYLE_PRIORITY.md)** for detailed impact analysis based on dependent style counts.
 
-When implementing features, verify they work across style families rather than hard-coding patterns from a single style.
+### Top Parent Styles by Impact
+
+The CSL repository has ~7,987 dependent styles that alias ~300 parent styles. Prioritize by dependent count:
+
+| Parent Style | Dependents | Format | Impact |
+|-------------|------------|--------|--------|
+| apa | 783 | author-date | 9.8% |
+| elsevier-with-titles | 672 | numeric | 8.4% |
+| elsevier-harvard | 665 | author-date | 8.3% |
+| springer-basic-author-date | 460 | author-date | 5.8% |
+| ieee | 176 | numeric | 2.2% |
+
+**The top 10 parent styles cover 60% of dependent styles.**
+
+### Development Order
+
+1. **Author-date styles first** (40% of corpus) - APA, Elsevier Harvard, Springer, Chicago
+2. **Numeric styles second** (57% of corpus) - Elsevier Vancouver, IEEE, AMA
+3. **Note styles last** (2% of corpus) - Chicago Notes, OSCOLA
+
+### Measuring Impact
+
+When reporting progress, calculate impact as:
+```
+Impact = sum(dependent_count for passing parent styles) / 7987 * 100
+```
+
+### Running the Analyzer
+
+```bash
+# Rank parent styles by dependent count
+cargo run --bin csln_analyze -- styles/ --rank-parents
+
+# Filter by citation format
+cargo run --bin csln_analyze -- styles/ --rank-parents --format author-date --json
+```

--- a/crates/csln_analyze/src/main.rs
+++ b/crates/csln_analyze/src/main.rs
@@ -5,10 +5,16 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! CSL Style Analyzer
 //!
-//! Analyzes all CSL 1.0 styles in a directory to collect statistics
+//! Analyzes CSL 1.0 styles in a directory to collect statistics
 //! and identify patterns for guiding migration development.
 //!
-//! Usage: csln_analyze <styles_dir> [--json]
+//! Usage:
+//!   csln_analyze <styles_dir> [--json]              # Full style analysis
+//!   csln_analyze <styles_dir> --rank-parents [--json] [--format <format>]
+//!                                                    # Rank parent styles by dependent count
+//!
+//! The --rank-parents mode analyzes dependent styles to identify which parent
+//! styles are most widely used. This helps prioritize rendering development.
 
 use std::collections::HashMap;
 use std::env;
@@ -20,15 +26,381 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
-        eprintln!("Usage: csln_analyze <styles_dir> [--json]");
-        eprintln!();
-        eprintln!("Analyzes all .csl files in the directory and reports statistics.");
+        print_usage();
         std::process::exit(1);
     }
 
     let styles_dir = &args[1];
     let json_output = args.contains(&"--json".to_string());
+    let rank_parents = args.contains(&"--rank-parents".to_string());
 
+    // Check for format filter (--format author-date, --format numeric, etc.)
+    let format_filter = args
+        .iter()
+        .position(|a| a == "--format")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.as_str());
+
+    if rank_parents {
+        run_parent_ranker(styles_dir, json_output, format_filter);
+    } else {
+        run_style_analyzer(styles_dir, json_output);
+    }
+}
+
+fn print_usage() {
+    eprintln!("CSL Style Analyzer");
+    eprintln!();
+    eprintln!("Usage:");
+    eprintln!("  csln_analyze <styles_dir> [--json]");
+    eprintln!("      Analyze all .csl files and report feature statistics.");
+    eprintln!();
+    eprintln!("  csln_analyze <styles_dir> --rank-parents [--json] [--format <format>]");
+    eprintln!("      Rank parent styles by how many dependent styles reference them.");
+    eprintln!(
+        "      Use --format to filter by citation format (author-date, numeric, note, label)."
+    );
+    eprintln!();
+    eprintln!("Examples:");
+    eprintln!("  csln_analyze styles/");
+    eprintln!("  csln_analyze styles/ --rank-parents");
+    eprintln!("  csln_analyze styles/ --rank-parents --format author-date --json");
+}
+
+// ============================================================================
+// Parent Style Ranker
+// ============================================================================
+
+/// Statistics for parent style ranking.
+#[derive(Default, serde::Serialize)]
+struct ParentRankerStats {
+    /// Total dependent styles analyzed
+    total_dependent: u32,
+    /// Total independent (parent) styles found
+    total_independent: u32,
+    /// Parse errors encountered
+    parse_errors: Vec<String>,
+    /// Filter applied (if any)
+    format_filter: Option<String>,
+    /// Parent styles ranked by dependent count
+    parent_rankings: Vec<ParentRanking>,
+    /// Citation format distribution
+    format_distribution: HashMap<String, u32>,
+}
+
+/// A parent style and its usage statistics.
+#[derive(serde::Serialize, Clone)]
+struct ParentRanking {
+    /// Parent style ID (usually a Zotero URL)
+    parent_id: String,
+    /// Extracted short name from the ID
+    short_name: String,
+    /// Number of dependent styles that reference this parent
+    dependent_count: u32,
+    /// Percentage of all dependents (for the filtered set)
+    percentage: f64,
+    /// Citation format (author-date, numeric, note, label)
+    format: Option<String>,
+    /// Fields/disciplines that use this parent
+    fields: Vec<String>,
+}
+
+fn run_parent_ranker(styles_dir: &str, json_output: bool, format_filter: Option<&str>) {
+    let mut stats = ParentRankerStats {
+        format_filter: format_filter.map(|s| s.to_string()),
+        ..Default::default()
+    };
+
+    // Maps: parent_id -> (count, format, fields)
+    let mut parent_counts: HashMap<String, (u32, Option<String>, Vec<String>)> = HashMap::new();
+
+    // First, scan independent styles to get their format
+    let independent_dir = Path::new(styles_dir);
+    let mut independent_formats: HashMap<String, String> = HashMap::new();
+
+    for entry in WalkDir::new(independent_dir)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "csl")
+                .unwrap_or(false)
+        })
+    {
+        if let Ok(info) = extract_style_info(entry.path()) {
+            stats.total_independent += 1;
+            if let Some(format) = info.citation_format {
+                let style_url = format!(
+                    "http://www.zotero.org/styles/{}",
+                    entry.path().file_stem().unwrap().to_string_lossy()
+                );
+                independent_formats.insert(style_url, format);
+            }
+        }
+    }
+
+    // Scan dependent styles directory
+    let dependent_dir = Path::new(styles_dir).join("dependent");
+    if !dependent_dir.exists() {
+        eprintln!(
+            "Warning: No 'dependent' subdirectory found in {}",
+            styles_dir
+        );
+        eprintln!("Dependent styles are typically in styles/dependent/");
+    }
+
+    for entry in WalkDir::new(&dependent_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "csl")
+                .unwrap_or(false)
+        })
+    {
+        match extract_dependent_info(entry.path()) {
+            Ok(info) => {
+                // Track format distribution
+                if let Some(ref fmt) = info.citation_format {
+                    *stats.format_distribution.entry(fmt.clone()).or_insert(0) += 1;
+                }
+
+                // Apply format filter if specified
+                if let Some(filter) = format_filter {
+                    if info.citation_format.as_deref() != Some(filter) {
+                        continue;
+                    }
+                }
+
+                stats.total_dependent += 1;
+
+                if let Some(parent_id) = info.parent_id {
+                    let entry = parent_counts.entry(parent_id.clone()).or_insert_with(|| {
+                        let format = independent_formats.get(&parent_id).cloned();
+                        (0, format, Vec::new())
+                    });
+                    entry.0 += 1;
+                    for field in info.fields {
+                        if !entry.2.contains(&field) {
+                            entry.2.push(field);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                stats
+                    .parse_errors
+                    .push(format!("{}: {}", entry.path().display(), e));
+            }
+        }
+    }
+
+    // Build ranked list
+    let mut rankings: Vec<ParentRanking> = parent_counts
+        .into_iter()
+        .map(|(parent_id, (count, format, mut fields))| {
+            let short_name = parent_id
+                .rsplit('/')
+                .next()
+                .unwrap_or(&parent_id)
+                .to_string();
+            fields.sort();
+            fields.dedup();
+            ParentRanking {
+                parent_id,
+                short_name,
+                dependent_count: count,
+                percentage: (count as f64 / stats.total_dependent.max(1) as f64) * 100.0,
+                format,
+                fields,
+            }
+        })
+        .collect();
+
+    // Sort by dependent count descending
+    rankings.sort_by(|a, b| b.dependent_count.cmp(&a.dependent_count));
+    stats.parent_rankings = rankings;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&stats).unwrap());
+    } else {
+        print_parent_rankings(&stats);
+    }
+}
+
+/// Information extracted from a dependent style.
+struct DependentInfo {
+    parent_id: Option<String>,
+    citation_format: Option<String>,
+    fields: Vec<String>,
+}
+
+fn extract_dependent_info(path: &Path) -> Result<DependentInfo, String> {
+    let content = fs::read_to_string(path).map_err(|e| format!("read error: {}", e))?;
+    let doc = roxmltree::Document::parse(&content).map_err(|e| format!("parse error: {}", e))?;
+
+    let root = doc.root_element();
+    let mut parent_id = None;
+    let mut citation_format = None;
+    let mut fields = Vec::new();
+
+    // Find info element
+    for child in root.children() {
+        if child.tag_name().name() == "info" {
+            for info_child in child.children() {
+                match info_child.tag_name().name() {
+                    "link" => {
+                        if info_child.attribute("rel") == Some("independent-parent") {
+                            parent_id = info_child.attribute("href").map(|s| s.to_string());
+                        }
+                    }
+                    "category" => {
+                        if let Some(fmt) = info_child.attribute("citation-format") {
+                            citation_format = Some(fmt.to_string());
+                        }
+                        if let Some(field) = info_child.attribute("field") {
+                            fields.push(field.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(DependentInfo {
+        parent_id,
+        citation_format,
+        fields,
+    })
+}
+
+/// Information extracted from an independent style.
+struct StyleInfo {
+    citation_format: Option<String>,
+}
+
+fn extract_style_info(path: &Path) -> Result<StyleInfo, String> {
+    let content = fs::read_to_string(path).map_err(|e| format!("read error: {}", e))?;
+    let doc = roxmltree::Document::parse(&content).map_err(|e| format!("parse error: {}", e))?;
+
+    let root = doc.root_element();
+    let mut citation_format = None;
+
+    for child in root.children() {
+        if child.tag_name().name() == "info" {
+            for info_child in child.children() {
+                if info_child.tag_name().name() == "category" {
+                    if let Some(fmt) = info_child.attribute("citation-format") {
+                        citation_format = Some(fmt.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(StyleInfo { citation_format })
+}
+
+fn print_parent_rankings(stats: &ParentRankerStats) {
+    println!("=== Parent Style Rankings ===\n");
+
+    if let Some(ref filter) = stats.format_filter {
+        println!("Filter: citation-format = {}\n", filter);
+    }
+
+    println!("Dependent styles analyzed: {}", stats.total_dependent);
+    println!("Independent styles found: {}", stats.total_independent);
+    println!(
+        "Unique parent styles referenced: {}",
+        stats.parent_rankings.len()
+    );
+    println!();
+
+    // Format distribution
+    if !stats.format_distribution.is_empty() && stats.format_filter.is_none() {
+        println!("=== Citation Format Distribution ===\n");
+        let mut formats: Vec<_> = stats.format_distribution.iter().collect();
+        formats.sort_by(|a, b| b.1.cmp(a.1));
+        for (format, count) in formats {
+            println!("  {:20} {:5}", format, count);
+        }
+        println!();
+    }
+
+    println!("=== Top Parent Styles by Usage ===\n");
+    println!(
+        "{:4}  {:40} {:>8}  {:>6}  {:15}",
+        "Rank", "Parent Style", "Count", "%", "Format"
+    );
+    println!("{}", "-".repeat(80));
+
+    for (i, ranking) in stats.parent_rankings.iter().take(50).enumerate() {
+        println!(
+            "{:4}  {:40} {:>8}  {:>5.1}%  {:15}",
+            i + 1,
+            truncate(&ranking.short_name, 40),
+            ranking.dependent_count,
+            ranking.percentage,
+            ranking.format.as_deref().unwrap_or("-")
+        );
+    }
+
+    if stats.parent_rankings.len() > 50 {
+        println!(
+            "\n... and {} more parent styles",
+            stats.parent_rankings.len() - 50
+        );
+    }
+
+    // Show top styles by format for prioritization
+    println!("\n=== Priority Styles by Format ===\n");
+    println!("These parent styles should be prioritized for rendering development:\n");
+
+    for format in ["author-date", "numeric", "note"] {
+        let top_for_format: Vec<_> = stats
+            .parent_rankings
+            .iter()
+            .filter(|r| r.format.as_deref() == Some(format))
+            .take(5)
+            .collect();
+
+        if !top_for_format.is_empty() {
+            println!("  {} styles:", format);
+            for r in top_for_format {
+                println!("    - {} ({} dependents)", r.short_name, r.dependent_count);
+            }
+            println!();
+        }
+    }
+
+    if !stats.parse_errors.is_empty() {
+        println!("=== Parse Errors ===\n");
+        for (i, err) in stats.parse_errors.iter().take(5).enumerate() {
+            println!("  {}. {}", i + 1, err);
+        }
+        if stats.parse_errors.len() > 5 {
+            println!("  ... and {} more", stats.parse_errors.len() - 5);
+        }
+    }
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len - 3])
+    }
+}
+
+// ============================================================================
+// Original Style Analyzer (unchanged)
+// ============================================================================
+
+fn run_style_analyzer(styles_dir: &str, json_output: bool) {
     let mut stats = StyleStats::default();
 
     // Walk directory and analyze each .csl file

--- a/docs/STYLE_PRIORITY.md
+++ b/docs/STYLE_PRIORITY.md
@@ -1,0 +1,138 @@
+# CSL Style Priority for Rendering Development
+
+This document identifies which citation styles should be prioritized for rendering development based on real-world usage. The data is derived from analyzing the 7,987 dependent CSL styles that reference parent styles.
+
+## How CSL Style Aliasing Works
+
+CSL 1.0 has two types of styles:
+
+1. **Independent styles** (~2,844 styles): Full style definitions with complete formatting rules
+2. **Dependent styles** (~7,987 styles): Lightweight aliases that reference a parent style
+
+For example, hundreds of journals use APA formatting - instead of duplicating the APA style definition, they create dependent styles that point to the APA parent style. This means supporting the top parent styles provides coverage for thousands of journals.
+
+## Priority Ranking by Impact
+
+### Tier 1: High Priority (80%+ dependent coverage)
+
+| Parent Style | Dependents | Format | Coverage |
+|-------------|------------|--------|----------|
+| apa | 783 | author-date | 9.8% |
+| elsevier-with-titles | 672 | numeric | 8.4% |
+| elsevier-harvard | 665 | author-date | 8.3% |
+| elsevier-vancouver | 502 | numeric | 6.3% |
+| springer-vancouver-brackets | 472 | numeric | 5.9% |
+| springer-basic-author-date | 460 | author-date | 5.8% |
+| springer-basic-brackets | 352 | numeric | 4.4% |
+| springer-socpsych-author-date | 317 | author-date | 4.0% |
+| american-medical-association | 293 | numeric | 3.7% |
+| taylor-and-francis-chicago-author-date | 234 | author-date | 2.9% |
+
+**Combined Tier 1 coverage: ~60% of all dependent styles**
+
+### Tier 2: Medium Priority
+
+| Parent Style | Dependents | Format |
+|-------------|------------|--------|
+| springer-mathphys-brackets | 201 | numeric |
+| multidisciplinary-digital-publishing-institute | 180 | numeric |
+| ieee | 176 | numeric |
+| nlm-citation-sequence-superscript | 121 | numeric |
+| nlm-citation-sequence | 116 | numeric |
+| karger-journals | 85 | numeric |
+| institute-of-physics-numeric | 82 | numeric |
+| thieme-german | 74 | numeric |
+| mary-ann-liebert-vancouver | 72 | numeric |
+| biomed-central | 66 | numeric |
+
+### Tier 3: Note Styles (19% of corpus)
+
+| Parent Style | Dependents | Format |
+|-------------|------------|--------|
+| chicago-shortened-notes-bibliography | 38 | note |
+| thomson-reuters-legal-tax-and-accounting | 26 | note |
+| oscola | 12 | note |
+| modern-humanities-research-association-3rd-edition-note | 9 | note |
+| chicago-fullnote-bibliography | 8 | note |
+
+## Citation Format Distribution
+
+All dependent styles break down by citation format:
+
+| Format | Count | Percentage |
+|--------|-------|------------|
+| numeric | 4,581 | 57.4% |
+| author-date | 3,231 | 40.4% |
+| note | 170 | 2.1% |
+| author | 5 | 0.1% |
+
+## AI Agent Instructions
+
+When working on rendering improvements, prioritize work that benefits the most users:
+
+### Priority Order for Development
+
+1. **Author-date styles first** - Start with APA (783 dependents), then Elsevier Harvard (665), Springer Basic Author-Date (460)
+
+2. **Test against multiple parent styles** - Don't optimize for a single style. Changes should work across:
+   - APA (American Psychological Association)
+   - Chicago Author-Date
+   - Harvard variants (Elsevier, Springer)
+   - Taylor & Francis Chicago
+
+3. **Numeric styles second** - After author-date works reliably:
+   - Elsevier Vancouver/With-Titles
+   - Springer Vancouver
+   - IEEE
+   - AMA (American Medical Association)
+
+4. **Note styles last** - Lower priority due to smaller corpus:
+   - Chicago Notes
+   - OSCOLA (legal)
+   - MHRA
+
+### Measuring Impact
+
+When reporting progress, calculate impact as:
+```
+Impact = sum(dependent_count for passing parent styles) / 7987 * 100
+```
+
+For example, if APA, Elsevier Harvard, and Springer Basic Author-Date all pass:
+```
+Impact = (783 + 665 + 460) / 7987 * 100 = 23.9% of dependent corpus
+```
+
+### Running the Analyzer
+
+To regenerate this data:
+
+```bash
+# Full ranking
+cargo run --bin csln_analyze -- styles/ --rank-parents
+
+# Filter by citation format
+cargo run --bin csln_analyze -- styles/ --rank-parents --format author-date
+
+# JSON output for programmatic use
+cargo run --bin csln_analyze -- styles/ --rank-parents --json
+```
+
+## Fields/Disciplines by Top Styles
+
+| Parent Style | Primary Fields |
+|-------------|----------------|
+| apa | psychology, social science, linguistics |
+| elsevier-harvard | multidisciplinary |
+| elsevier-vancouver | medicine |
+| springer-* | science, medicine, engineering |
+| ieee | engineering, physics, communications |
+| american-medical-association | medicine, biology |
+| chicago-* | humanities |
+
+## Recommendations
+
+1. **Focus on author-date first** - 40% of corpus, includes APA which alone covers 10%
+2. **Build shared infrastructure** - Many author-date styles share patterns (author + year + title + source)
+3. **Test oracle against top 10 parent styles** - Provides coverage for 60% of dependent styles
+4. **Track regression** - A bug in APA affects 783+ journals, so oracle verification is critical


### PR DESCRIPTION
## Summary

Adds a new `--rank-parents` mode to `csln_analyze` that analyzes dependent styles to identify which parent styles are most widely used. This data-driven approach helps prioritize rendering development for maximum user impact.

### Features

- **Ranks parent styles** by how many dependent styles reference them
- **Citation format distribution** (numeric 57%, author-date 40%, note 2%)
- **Filter by format** with `--format author-date|numeric|note`
- **JSON output** with `--json` for programmatic use
- **Field/discipline data** collected per parent style

### Key Findings

| Parent Style | Dependents | Coverage |
|-------------|------------|----------|
| apa | 783 | 9.8% |
| elsevier-with-titles | 672 | 8.4% |
| elsevier-harvard | 665 | 8.3% |
| springer-basic-author-date | 460 | 5.8% |
| ieee | 176 | 2.2% |

**The top 10 parent styles cover 60% of all dependent styles.**

### Documentation

Adds `docs/STYLE_PRIORITY.md` with:
- Complete ranking tables
- AI agent prioritization instructions
- Impact calculation formula
- Development order recommendations

### Usage

```bash
# Full ranking
cargo run --bin csln_analyze -- styles/ --rank-parents

# Filter by format
cargo run --bin csln_analyze -- styles/ --rank-parents --format author-date

# JSON output
cargo run --bin csln_analyze -- styles/ --rank-parents --json
```

## Test Results

- All existing tests pass
- Tested against full CSL style repository (7,987 dependent styles)

🤖 Generated with [Claude Code](https://claude.ai/code)