### PR TITLE
refactor(core): remove feature gate from embedded templates

### DIFF
--- a/.agent/design/STYLE_ALIASING.md
+++ b/.agent/design/STYLE_ALIASING.md
@@ -479,7 +479,7 @@ The CSLN approach separates "what to render" (templates) from "how to render" (o
    - Each preset has a `config()` method to expand to concrete values
 
 2. **Phase 2: Embedded templates** (PR #38)
-   - Added `csln_core::embedded` module (feature-gated via `embedded-templates`)
+   - Added `csln_core::embedded` module (always included)
    - Pre-built citation and bibliography templates for APA, Chicago, Vancouver, IEEE, Harvard
 
 3. **Phase 3: Migration updates** (PR #40)

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ crates/
 ├── csln_core/       # CSLN schema and types
 │   ├── options.rs   # Style configuration
 │   ├── presets.rs   # Named configuration bundles (APA, Chicago, etc.)
-│   ├── embedded.rs  # Pre-built templates for priority styles (feature-gated)
+│   ├── embedded.rs  # Pre-built templates for priority styles
 │   ├── template.rs  # Template components
 │   └── locale.rs    # Localization (terms, dates)
 ├── csln_migrate/    # CSL 1.0 → CSLN converter
@@ -353,7 +353,7 @@ This schema can be used to validate styles or provide intellisense in editors li
 - [ ] WASM build for browser use
 - [x] Additional locales (de-DE, fr-FR, tr-TR, etc.)
 - [x] Style presets vocabulary (see [STYLE_ALIASING.md](.agent/design/STYLE_ALIASING.md))
-- [x] Embedded priority templates (feature-gated)
+- [x] Embedded priority templates (APA, Chicago, Vancouver, IEEE, Harvard)
 - [x] Preset-aware migration (emit preset names instead of expanded config)
 - [ ] Note-bibliography citation style support
 

--- a/crates/csln_core/Cargo.toml
+++ b/crates/csln_core/Cargo.toml
@@ -3,12 +3,6 @@ name = "csln_core"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-default = []
-# Include embedded templates for priority styles (APA, Chicago, etc.)
-# Useful for migration tooling and reference implementations.
-embedded-templates = []
-
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -16,4 +10,3 @@ serde_yaml = "0.9"
 schemars = { version = "0.8", features = ["derive", "url"] }
 edtf = "0.2"
 url = { version = "2.5", features = ["serde"] }
-

--- a/crates/csln_core/src/embedded.rs
+++ b/crates/csln_core/src/embedded.rs
@@ -12,15 +12,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! - **Reference implementations**: Battle-tested templates for testing
 //! - **Fallback defaults**: When a style omits templates but specifies presets
 //!
-//! ## Feature Gate
-//!
-//! This module is only available when the `embedded-templates` feature is enabled:
-//!
-//! ```toml
-//! [dependencies]
-//! csln_core = { version = "0.1", features = ["embedded-templates"] }
-//! ```
-//!
 //! ## Priority Styles
 //!
 //! Based on analysis of dependent styles, these are the top parent styles:

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -12,8 +12,7 @@ pub mod presets;
 pub mod reference;
 pub mod template;
 
-// Embedded templates for priority styles (feature-gated)
-#[cfg(feature = "embedded-templates")]
+// Embedded templates for priority styles (APA, Chicago, Vancouver, IEEE, Harvard)
 pub mod embedded;
 
 pub use locale::Locale;


### PR DESCRIPTION
## Summary

Removes the `embedded-templates` feature gate from `csln_core`. Embedded templates are now always included.

### Rationale

Evaluated from all 4 personas:

| Persona | Verdict | Reason |
|---------|---------|--------|
| **Style Author** | Neutral | No direct impact until `use-preset` syntax is implemented |
| **Web Developer** | Prefers no gate | Simpler integration, no hidden features |
| **Systems Architect** | Prefers no gate | Minimal overhead (~500 lines static data), simpler code path |
| **Domain Expert** | Prefers no gate | Reference implementations should be discoverable |

### Changes

- Removed `[features]` section from `csln_core/Cargo.toml`
- Removed `#[cfg(feature = "embedded-templates")]` from `lib.rs`
- Updated module documentation in `embedded.rs`
- Updated README architecture diagram and roadmap
- Updated STYLE_ALIASING.md implementation status

### Test Results

All workspace tests pass ✅

🤖 Generated with [Claude Code](https://claude.ai/code)
