### PR TITLE
ci: add rust caching for faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
## Summary
- Adds `Swatinem/rust-cache@v2` action to cache Cargo registry, index, and target directories
- Typically reduces CI build times by 50-70% on subsequent runs

## Changes
- Modified `.github/workflows/ci.yml` to include caching step after Rust toolchain setup

🤖 Generated with [Claude Code](https://claude.ai/code)
