### PR TITLE
feat: expose embedded templates via use-preset

### DIFF
--- a/.agent/design/STYLE_ALIASING.md
+++ b/.agent/design/STYLE_ALIASING.md
@@ -468,17 +468,16 @@ The CSLN approach separates "what to render" (templates) from "how to render" (o
    - Added `csln_migrate::preset_detector` module
    - Detection functions: `detect_contributor_preset()`, `detect_title_preset()`, `detect_date_preset()`
 
+4. **Expose embedded templates + Processor Expansion** (PR #45)
+   - Added `use_preset` field and `TemplatePreset` enum
+   - Implemented `resolve_template()` in core and updated processor to use it
+   - Verified with new integration tests
+
 ### Remaining Work
 
-1. **Expose embedded templates to style authors** (Issue #39)
-   - Add `use-preset: apa` syntax to `CitationSpec` and `BibliographySpec`
-   - Currently embedded templates are internal infrastructure only
-
-2. **Implement preset expansion in processor**
-   - Resolve preset names to concrete configs at runtime
-
-3. **Document preset vocabulary** for style authors
+1. **Document preset vocabulary** for style authors
    - Add examples to README and/or schema descriptions
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,20 @@ cargo run --bin csln_migrate -- styles/apa.csl
 # Output: csln-new.yaml with clean CSLN format
 ```
 
+### Using Presets
+
+CSLN includes embedded templates for common styles (APA, Chicago, Vancouver, IEEE, Harvard). Instead of defining a template from scratch, you can reference a preset:
+
+```yaml
+citation:
+  use-preset: apa
+
+bibliography:
+  use-preset: vancouver
+```
+
+This effectively "inherits" the standard template for that style, which you can then customize with options.
+
 ## For Developers
 
 ### Building

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -56,13 +56,61 @@ fn default_version() -> String {
     "1.0".to_string()
 }
 
+/// Available embedded template presets.
+///
+/// These reference battle-tested templates for common citation styles.
+/// See `csln_core::embedded` for the actual template implementations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum TemplatePreset {
+    /// APA 7th edition (author-date)
+    Apa,
+    /// Chicago Manual of Style (author-date)
+    ChicagoAuthorDate,
+    /// Vancouver (numeric)
+    Vancouver,
+    /// IEEE (numeric)
+    Ieee,
+    /// Harvard/Elsevier (author-date)
+    Harvard,
+}
+
+impl TemplatePreset {
+    /// Resolve this preset to a citation template.
+    pub fn citation_template(&self) -> Template {
+        match self {
+            TemplatePreset::Apa => embedded::apa_citation(),
+            TemplatePreset::ChicagoAuthorDate => embedded::chicago_author_date_citation(),
+            TemplatePreset::Vancouver => embedded::vancouver_citation(),
+            TemplatePreset::Ieee => embedded::ieee_citation(),
+            TemplatePreset::Harvard => embedded::harvard_citation(),
+        }
+    }
+
+    /// Resolve this preset to a bibliography template.
+    pub fn bibliography_template(&self) -> Template {
+        match self {
+            TemplatePreset::Apa => embedded::apa_bibliography(),
+            TemplatePreset::ChicagoAuthorDate => embedded::chicago_author_date_bibliography(),
+            TemplatePreset::Vancouver => embedded::vancouver_bibliography(),
+            TemplatePreset::Ieee => embedded::ieee_bibliography(),
+            TemplatePreset::Harvard => embedded::harvard_bibliography(),
+        }
+    }
+}
+
 /// Citation specification.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct CitationSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Config>,
-    pub template: Template,
+    /// Reference to an embedded template preset.
+    /// If both `use_preset` and `template` are present, `template` takes precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_preset: Option<TemplatePreset>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub template: Option<Template>,
     /// Wrap the entire citation in punctuation. Preferred over prefix/suffix.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wrap: Option<template::WrapPunctuation>,
@@ -86,14 +134,31 @@ pub struct CitationSpec {
     pub _extra: HashMap<String, serde_json::Value>,
 }
 
+impl CitationSpec {
+    /// Resolve the effective template for this citation.
+    ///
+    /// Returns the explicit `template` if present, otherwise resolves `use_preset`.
+    /// Returns `None` if neither is specified.
+    pub fn resolve_template(&self) -> Option<Template> {
+        self.template
+            .clone()
+            .or_else(|| self.use_preset.as_ref().map(|p| p.citation_template()))
+    }
+}
+
 /// Bibliography specification.
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct BibliographySpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Config>,
+    /// Reference to an embedded template preset.
+    /// If both `use_preset` and `template` are present, `template` takes precedence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_preset: Option<TemplatePreset>,
     /// The default template for bibliography entries.
-    pub template: Template,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub template: Option<Template>,
     /// Type-specific template overrides. When present, replaces the default
     /// template for entries of the specified types. Keys are reference type
     /// names (e.g., "chapter", "article-journal").
@@ -102,6 +167,18 @@ pub struct BibliographySpec {
     /// Unknown fields captured for forward compatibility.
     #[serde(flatten)]
     pub _extra: HashMap<String, serde_json::Value>,
+}
+
+impl BibliographySpec {
+    /// Resolve the effective template for this bibliography.
+    ///
+    /// Returns the explicit `template` if present, otherwise resolves `use_preset`.
+    /// Returns `None` if neither is specified.
+    pub fn resolve_template(&self) -> Option<Template> {
+        self.template
+            .clone()
+            .or_else(|| self.use_preset.as_ref().map(|p| p.bibliography_template()))
+    }
 }
 
 /// Style metadata.
@@ -559,7 +636,7 @@ citation:
 "#;
         let style: Style = serde_yaml::from_str(yaml).unwrap();
         let citation = style.citation.unwrap();
-        assert_eq!(citation.template.len(), 2);
+        assert_eq!(citation.resolve_template().unwrap().len(), 2);
     }
 
     #[test]
@@ -626,14 +703,16 @@ bibliography:
 
         // Verify citation
         let citation = style.citation.unwrap();
-        assert_eq!(citation.template.len(), 2);
+        let citation_template = citation.resolve_template().unwrap();
+        assert_eq!(citation_template.len(), 2);
 
         // Verify bibliography
         let bib = style.bibliography.unwrap();
-        assert_eq!(bib.template.len(), 6);
+        let bib_template = bib.resolve_template().unwrap();
+        assert_eq!(bib_template.len(), 6);
 
         // Verify flattened rendering worked
-        match &bib.template[1] {
+        match &bib_template[1] {
             template::TemplateComponent::Date(d) => {
                 assert_eq!(
                     d.rendering.wrap,
@@ -643,7 +722,7 @@ bibliography:
             _ => panic!("Expected Date"),
         }
 
-        match &bib.template[3] {
+        match &bib_template[3] {
             template::TemplateComponent::Title(t) => {
                 assert_eq!(t.rendering.prefix, Some("In ".to_string()));
                 assert_eq!(t.rendering.emph, Some(true));
@@ -673,7 +752,8 @@ citation:
         );
 
         let citation = style.citation.as_ref().unwrap();
-        match &citation.template[0] {
+        let citation_template = citation.resolve_template().unwrap();
+        match &citation_template[0] {
             template::TemplateComponent::Contributor(c) => {
                 assert_eq!(
                     c._extra.get("future-modifier").unwrap(),
@@ -692,5 +772,76 @@ citation:
         );
         assert!(round_tripped.contains("future-option: true"));
         assert!(round_tripped.contains("future-modifier: bold"));
+    }
+
+    #[test]
+    fn test_style_with_preset() {
+        let yaml = r#"
+info:
+  title: Preset Test
+citation:
+  use-preset: apa
+bibliography:
+  use-preset: vancouver
+"#;
+        let style: Style = serde_yaml::from_str(yaml).unwrap();
+
+        // Test Citation Preset (APA)
+        let citation = style.citation.unwrap();
+        assert!(citation.use_preset.is_some());
+        assert!(citation.template.is_none());
+
+        let citation_template = citation.resolve_template().unwrap();
+        assert_eq!(citation_template.len(), 2); // APA citation is (Author, Year)
+
+        // precise check for APA structure
+        match &citation_template[0] {
+            template::TemplateComponent::Contributor(c) => {
+                assert_eq!(c.contributor, template::ContributorRole::Author)
+            }
+            _ => panic!("Expected Contributor"),
+        }
+
+        // Test Bibliography Preset (Vancouver)
+        let bib = style.bibliography.unwrap();
+        let bib_template = bib.resolve_template().unwrap();
+        // Vancouver bib has roughly 8 components
+        assert!(bib_template.len() >= 5);
+
+        // Verify first component is citation number
+        match &bib_template[0] {
+            template::TemplateComponent::Number(n) => {
+                assert_eq!(n.number, template::NumberVariable::CitationNumber)
+            }
+            _ => panic!("Expected Number"),
+        }
+    }
+
+    #[test]
+    fn test_preset_override_precedence() {
+        let yaml = r#"
+info:
+  title: Override Test
+citation:
+  use-preset: apa
+  template:
+    - variable: doi
+"#;
+        let style: Style = serde_yaml::from_str(yaml).unwrap();
+        let citation = style.citation.unwrap();
+
+        // Should have both
+        assert!(citation.use_preset.is_some());
+        assert!(citation.template.is_some());
+
+        // Template should win
+        let resolved = citation.resolve_template().unwrap();
+        assert_eq!(resolved.len(), 1);
+        match &resolved[0] {
+            template::TemplateComponent::Variable(v) => {
+                assert_eq!(v.variable, template::SimpleVariable::Doi)
+            }
+            _ => panic!("Expected Variable"),
+        }
     }
 }

--- a/crates/csln_migrate/src/main.rs
+++ b/crates/csln_migrate/src/main.rs
@@ -328,7 +328,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             CitationSpec {
                 options: None,
-                template: new_cit,
+                use_preset: None,
+                template: Some(new_cit),
                 wrap,
                 prefix,
                 suffix,
@@ -340,7 +341,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
         bibliography: Some(BibliographySpec {
             options: None,
-            template: new_bib,
+            use_preset: None,
+            template: Some(new_bib),
             // type_templates infrastructure exists but auto-generation is disabled.
             // Different styles have incompatible chapter formats (APA vs others),
             // so we can't apply a single template to all author-date styles.

--- a/crates/csln_processor/tests/oracle_comparison.rs
+++ b/crates/csln_processor/tests/oracle_comparison.rs
@@ -41,7 +41,7 @@ fn make_apa_style() -> Style {
         }),
         citation: Some(CitationSpec {
             options: None,
-            template: vec![
+            template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
                     contributor: ContributorRole::Author,
                     form: ContributorForm::Short,
@@ -56,13 +56,13 @@ fn make_apa_style() -> Style {
                     rendering: Rendering::default(),
                     ..Default::default()
                 }),
-            ],
+            ]),
             wrap: Some(WrapPunctuation::Parentheses),
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
             options: None,
-            template: vec![
+            template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
                     contributor: ContributorRole::Author,
                     form: ContributorForm::Long,
@@ -90,7 +90,7 @@ fn make_apa_style() -> Style {
                     overrides: None,
                     ..Default::default()
                 }),
-            ],
+            ]),
             ..Default::default()
         }),
         templates: None,

--- a/crates/csln_processor/tests/subsequent_author_substitute.rs
+++ b/crates/csln_processor/tests/subsequent_author_substitute.rs
@@ -35,7 +35,7 @@ fn make_style_with_substitute(substitute: Option<String>) -> Style {
         citation: None,
         bibliography: Some(BibliographySpec {
             options: None,
-            template: vec![
+            template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
                     contributor: ContributorRole::Author,
                     form: ContributorForm::Long,
@@ -50,7 +50,7 @@ fn make_style_with_substitute(substitute: Option<String>) -> Style {
                     rendering: Rendering::default(),
                     ..Default::default()
                 }),
-            ],
+            ]),
             ..Default::default()
         }),
         ..Default::default()


### PR DESCRIPTION
## Description
Exposes embedded templates (APA, Chicago, etc.) to style authors via a new \`use_preset\` field. This allows styles to reference standard templates without redefining them.

## Changes
- **Core**: Added \`TemplatePreset\` enum and \`use_preset\` to \`CitationSpec\`/\`BibliographySpec\`.
- **Core**: Added \`resolve_template()\` to handle precedence (template > preset).
- **Processor**: Updated to resolve templates using presets.
- **Migrate**: Updated for data structure changes.
- **Tests**: Added tests for preset resolution and override precedence.

Closes #39