### PR TITLE
docs(workflow): strict message formatting rules

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -277,6 +277,8 @@ All changes must be made on feature branches. The user will handle merging via G
    - **50/72 Rule**: Limit the subject line to 50 characters and wrap the body at 72 characters.
    - **Explain What and Why**: The body should explain the rationale behind the change.
    - **Issue References**: Include GitHub issue references where relevant (e.g., `Refs: #123` or `csln#64`).
+   - **Plain Text Body**: Do NOT use Markdown in the commit body. Uses asterisks for bullet points is okay, but do not backtick code elements.
+   - **No Escaped Backticks**: Never escape backticks (e.g., write `code` not \`code\`).
    - **No Co-Authored-By**: Do NOT include `Co-Authored-By` footers in AI-authored commit messages.
 
    Example:

--- a/.agent/workflows/pr_workflow.md
+++ b/.agent/workflows/pr_workflow.md
@@ -80,6 +80,8 @@ git commit -m "<type>(<scope>): <description>
 **Commit rules**:
 - Use conventional commit format
 - Lowercase subject line
+- **Plain text body only**: No Markdown in the commit body (e.g., use `Result`, not `` `Result` ``).
+- **No escaped backticks**: Do not escape backticks in messages (use `code`, never \`code\`)
 - NO `Co-Authored-By` footer
 - Exclude debug files, `.env`, temp files
 
@@ -87,6 +89,11 @@ git commit -m "<type>(<scope>): <description>
 
 ```bash
 git push -u origin <branch-name>
+
+# NOTE: When generating the body, do NOT escape backticks.
+# Correct: "Added `MyStruct`"
+# Incorrect: "Added \`MyStruct\`"
+
 
 gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
 ## Summary


### PR DESCRIPTION
## Summary
- Prohibit markdown in git commit bodies to keep logs clean
- Explicitly forbid escaping backticks in PR descriptions and commit messages
- Update `pr_workflow.md` and `AGENTS.md` to reflect these rules

## Test Results
- N/A (Documentation changes only)
- `cargo test` passed successfully