### PR TITLE
feat: implement et-al-use-last and structured hyperlinking

### DIFF
--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -102,6 +102,18 @@ pub struct TitlesConfig {
     pub _extra: HashMap<String, serde_json::Value>,
 }
 
+/// Structured link options.
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct LinksConfig {
+    /// Link value to the item's DOI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doi: Option<bool>,
+    /// Link value to the item's URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<bool>,
+}
+
 /// Rendering options for titles.
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/csln_core/src/template.rs
+++ b/crates/csln_core/src/template.rs
@@ -311,6 +311,9 @@ pub struct TemplateTitle {
     pub form: Option<TitleForm>,
     #[serde(flatten, default)]
     pub rendering: Rendering,
+    /// Structured link options (DOI, URL).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<crate::options::LinksConfig>,
     /// Type-specific rendering overrides.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub overrides: Option<HashMap<String, Rendering>>,
@@ -393,6 +396,9 @@ pub struct TemplateVariable {
     pub variable: SimpleVariable,
     #[serde(flatten)]
     pub rendering: Rendering,
+    /// Structured link options (DOI, URL).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<crate::options::LinksConfig>,
     /// Type-specific rendering overrides. Use `suppress: true` to hide for certain types.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub overrides: Option<HashMap<String, Rendering>>,

--- a/crates/csln_processor/src/processor.rs
+++ b/crates/csln_processor/src/processor.rs
@@ -324,6 +324,7 @@ impl Processor {
                     value: values.value,
                     prefix: values.prefix,
                     suffix: values.suffix,
+                    url: values.url,
                     ref_type: Some(reference.ref_type.clone()),
                     config: Some(options.config.clone()),
                 })

--- a/crates/csln_processor/src/render.rs
+++ b/crates/csln_processor/src/render.rs
@@ -32,6 +32,8 @@ pub struct ProcTemplateComponent {
     pub prefix: Option<String>,
     /// Optional suffix from value extraction.
     pub suffix: Option<String>,
+    /// Optional URL for hyperlinking.
+    pub url: Option<String>,
     /// Reference type for type-specific overrides.
     pub ref_type: Option<String>,
     /// Optional global configuration.
@@ -381,6 +383,7 @@ mod tests {
                 suffix: None,
                 ref_type: None,
                 config: None,
+                url: None,
             },
             ProcTemplateComponent {
                 template_component: TemplateComponent::Date(TemplateDate {
@@ -394,6 +397,7 @@ mod tests {
                 suffix: None,
                 ref_type: None,
                 config: None,
+                url: None,
             },
         ];
 
@@ -424,6 +428,7 @@ mod tests {
                 suffix: None,
                 ref_type: None,
                 config: None,
+                url: None,
             },
             ProcTemplateComponent {
                 template_component: TemplateComponent::Date(TemplateDate {
@@ -437,6 +442,7 @@ mod tests {
                 suffix: None,
                 ref_type: None,
                 config: None,
+                url: None,
             },
         ];
 
@@ -461,6 +467,7 @@ mod tests {
             suffix: None,
             ref_type: None,
             config: None,
+            url: None,
         }];
 
         // Edge case: space before paren
@@ -485,6 +492,7 @@ mod tests {
             suffix: None,
             ref_type: None,
             config: None,
+            url: None,
         };
 
         let result = render_component(&component);
@@ -509,6 +517,7 @@ mod tests {
             suffix: None,
             ref_type: None,
             config: None,
+            url: None,
         };
 
         let result = render_component(&component);


### PR DESCRIPTION
## Summary

This PR implements two features to improve contributor list truncation and add declarative hyperlinking:

- `et-al-use-last`: Support for specifying the number of names to show after truncation (Refs: csln#156).
- **Structured Hyperlinking**: Logic to extract DOI or URL values into processed components via template configuration, enabling downstream format-specific linking (Refs: csln#125).

## Test Results

- All `csln_processor` tests passed.
- Added regression tests for `et-al-use-last` and URL extraction logic in `values.rs`.