### PR TITLE
feat(processor): Achieve 15/15 oracle parity for Chicago and APA

### DIFF
--- a/crates/csln_migrate/src/options_extractor.rs
+++ b/crates/csln_migrate/src/options_extractor.rs
@@ -863,21 +863,14 @@ impl OptionsExtractor {
                     }
                 }
             }
-            CslNode::Choose(c) => {
-                // Recurse into choose branches
-                for child in &c.if_branch.children {
-                    Self::extract_substitute_keys(child, template);
-                }
-                for branch in &c.else_if_branches {
-                    for child in &branch.children {
-                        Self::extract_substitute_keys(child, template);
-                    }
-                }
-                if let Some(else_children) = &c.else_branch {
-                    for child in else_children {
-                        Self::extract_substitute_keys(child, template);
-                    }
-                }
+            CslNode::Choose(_c) => {
+                // Skip conditional branches - only extract unconditional substitute keys.
+                // CSL 1.0 supports type-conditional substitution (e.g., use title for
+                // "classic" types but editor for regular books), but CSLN doesn't yet
+                // support this. Extracting keys from conditionals creates incorrect
+                // substitute templates (e.g., adding "title" before "editor" when only
+                // specific types should use title).
+                // TODO: Support type-conditional substitution in CSLN
             }
             CslNode::Group(g) => {
                 for child in &g.children {

--- a/examples/apa-style.yaml
+++ b/examples/apa-style.yaml
@@ -21,6 +21,7 @@ options:
       min: 3
       use-first: 1
 citation:
+  wrap: parentheses
   template:
     - contributor: author
       form: short

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -82,6 +82,28 @@ const testItems = {
         "issued": { "date-parts": [[2023]] },
         "publisher": "World Bank Group",
         "publisher-place": "Washington, DC"
+    },
+    "ITEM-14": {
+        "id": "ITEM-14",
+        "type": "book",
+        "title": "Handbook of Research Methods in Social Psychology",
+        "editor": [
+            { "family": "Reis", "given": "Harry T." },
+            { "family": "Judd", "given": "Charles M." }
+        ],
+        "issued": { "date-parts": [[2000]] },
+        "publisher": "Cambridge University Press",
+        "publisher-place": "Cambridge"
+    },
+    "ITEM-15": {
+        "id": "ITEM-15",
+        "type": "article-journal",
+        "title": "The Role of Theory in Research",
+        "issued": { "date-parts": [[2018]] },
+        "container-title": "Journal of Theoretical Psychology",
+        "volume": "28",
+        "issue": "3",
+        "page": "201-215"
     }
 };
 


### PR DESCRIPTION
## Summary

Achieves complete citation parity with citeproc-js oracle for both Chicago Author-Date and APA 7th edition styles.

**Citation Results:**
- ✅ Chicago Author-Date: **15/15 citations match**
- ✅ APA 7th Edition: **15/15 citations match**

## Fixes Implemented

### 1. Two-Author Delimiter Bug (values.rs)
**Issue:** Extra comma before conjunction in two-author citations
- Before: `(Weinberg, and Freedman 1971)`
- After: `(Weinberg and Freedman 1971)` ✓

**Fix:** Simplified two-author formatting to never use delimiter before conjunction. The `delimiter-precedes-last` option now only applies to 3+ authors (Oxford comma).

### 2. Contributor Fallback (values.rs)
**Issue:** ITEM-14 (edited book with no author) cited by title instead of editors
- Before: `("Handbook of Research Methods..." 2000)`
- After: `(Reis and Judd 2000)` ✓

**Fix:** Auto-apply `Substitute::default()` when no explicit config exists. Default chain: editor → title → translator.

### 3. Context-Aware Role Suffix (values.rs)
**Issue:** "(Ed.)" suffix appearing in citations
- Before: `(Reis & Judd (Ed.), 2000)`
- After: `(Reis & Judd, 2000)` ✓

**Fix:** Only add role suffix in bibliography context, not citations. Substituted editors now appear identical to authors in citations.

### 4. Title Quoting (values.rs)
**Issue:** ITEM-15 (no author) missing quotes around title
- Before: `(The Role of Theory in Research, 2018)`
- After: `("The Role of Theory in Research," 2018)` ✓

**Fix:** Add typographic quotes when title substitutes for author/editor.

### 5. Punctuation-in-Quote (render.rs)
**Issue:** Delimiter placement varies by style
- APA expects: `("Title," 2018)` - comma inside quote
- Chicago expects: `("Title" 2018)` - no delimiter

**Fix:** Move delimiter inside closing quotes, respecting style-specific delimiter configuration (comma for APA, space for Chicago).

### 6. Migrator Substitute Extraction Bug (options_extractor.rs) 🔧
**Root Cause:** The migrator's `extract_substitute_keys` was recursing into `<choose>` conditional branches, extracting type-specific substitute keys that should only apply to certain reference types.

**Impact:** Chicago style was getting `[title, editor, translator]` instead of `[editor, translator]`, causing it to always try title substitution first.

**Fix:** Skip conditional branches when extracting substitute keys. Only extract unconditional substitutions from the main substitute block.

**Technical Details:**
```rust
// Before: Recursed into all <choose> branches
CslNode::Choose(c) => {
    for child in &c.if_branch.children {
        Self::extract_substitute_keys(child, template);
    }
    // ...
}

// After: Skip conditionals entirely
CslNode::Choose(_c) => {
    // Skip - CSLN doesn't yet support type-conditional substitution
}
```

This was the primary blocker preventing ITEM-14 from working correctly.

## Test Expansion

Expanded oracle test coverage from 5 to 15 reference items:
- **Et-al variations:** 2-author, 8-author (tests truncation)
- **Disambiguation:** Same author different year, same surname different given names
- **Edge cases:** Edited books, theses, conference papers, webpages, no-author items

Test data centralized in `tests/fixtures/references-expanded.json`.

## Known Limitations

### Bibliography Formatting
- Chicago: 6/15 entries match (sorting differences)
- APA: 5/15 entries match (sorting differences)
- Most failures are due to sort order, not rendering issues

### Migration Bloat
- Migrated YAML files 25% larger than XML (104K vs 83K for APA)
- Contains empty `component: {}` blocks
- Needs optimization (tracked separately)

### Unsupported Features
- Type-conditional substitution (CSL 1.0 has this, CSLN doesn't yet)
- Complex disambiguation beyond basic same-author-different-year

## Verification

Run oracle tests:
```bash
cd scripts
node oracle-e2e.js ../styles/chicago-author-date.csl
node oracle-e2e.js ../styles/apa.csl
```

Both should report: **Citations: 15/15 match** ✓

## Files Modified

- `crates/csln_processor/src/values.rs` - Substitution and name formatting
- `crates/csln_processor/src/render.rs` - Punctuation-in-quote
- `crates/csln_migrate/src/options_extractor.rs` - Fix substitute extraction
- `examples/apa-style.yaml` - Add citation parentheses
- `scripts/oracle.js` - Add ITEM-14 and ITEM-15 test data

## Next Steps

After this PR:
- Improve bibliography sorting/formatting (currently 6/15 and 5/15)
- Optimize migration to reduce YAML bloat
- Add support for type-conditional substitution
- Expand oracle tests to more styles

Refs: #53