### PR TITLE
feat(processor): add citation grouping and year suffix ordering

### DIFF
--- a/crates/csln_processor/src/values.rs
+++ b/crates/csln_processor/src/values.rs
@@ -741,11 +741,25 @@ impl ComponentValues for TemplateDate {
     }
 }
 
-fn int_to_letter(n: u32) -> Option<String> {
+pub fn int_to_letter(n: u32) -> Option<String> {
     if n == 0 {
         return None;
     }
     char::from_u32(n + 96).map(|c| c.to_string())
+}
+
+/// Format contributors in short form for citation grouping.
+///
+/// Used when collapsing same-author citations to render "Author" part separately.
+pub fn format_contributors_short(names: &[Name], options: &RenderOptions<'_>) -> String {
+    format_names(
+        names,
+        &ContributorForm::Short,
+        options,
+        None,
+        None,
+        &ProcHints::default(),
+    )
 }
 
 impl ComponentValues for TemplateTitle {


### PR DESCRIPTION
## Summary

Implement two related features for author-date citation styles:

### 1. Year suffix ordering by title

Suffixes (a, b, c) are now assigned based on alphabetical title order within author-year groups, matching citeproc-js behavior:
- "A Function of Measurement..." → 1962a  
- "The Structure of Scientific Revolutions" → 1962b

### 2. Citation grouping

Adjacent same-author citations are collapsed:
- Before: `(Kuhn, 1962a; Kuhn, 1962b)`  
- After: `(Kuhn, 1962a, 1962b)`

### Design Decisions

- **Adjacent grouping only**: Only ADJACENT same-author items are grouped, respecting user-specified order
- **Prefix breaks grouping**: Item-level prefix breaks grouping to allow constructions like `(also see Doe 2022)`
- **Explicit over magic**: Styles can specify citation sorting if reordering is desired

### Changes

- `processor.rs`: Refactor `process_citation` into grouped/ungrouped paths
- `processor.rs`: Sort author-year groups by title in `apply_year_suffix`  
- `values.rs`: Make `int_to_letter` public, add `format_contributors_short`
- Add tests for both same-author grouping and different-author separation

### Testing

- All 108 existing tests pass
- Added 2 new tests: `test_citation_grouping_same_author`, `test_citation_grouping_different_authors`
- Oracle: 15/15 citations, 7/15 bibliography (unchanged from before)