### PR TITLE
fix(sort): strip leading articles and fix anonymous work formatting

### DIFF
--- a/crates/csln_processor/src/values.rs
+++ b/crates/csln_processor/src/values.rs
@@ -174,10 +174,16 @@ impl ComponentValues for TemplateContributor {
                     }
                     SubstituteKey::Title => {
                         if let Some(title) = &reference.title {
-                            // When title is used as citation key (substitute for author),
-                            // it should be quoted per CSL conventions
+                            // When title substitutes for author:
+                            // - In CITATIONS: quote the title per CSL conventions
+                            // - In BIBLIOGRAPHY: use title as-is (it will be styled normally)
+                            let value = if options.context == RenderContext::Citation {
+                                format!("\u{201C}{}\u{201D}", title) // Curly quotes
+                            } else {
+                                title.clone()
+                            };
                             return Some(ProcValues {
-                                value: format!("\u{201C}{}\u{201D}", title), // U+201C (") and U+201D (")
+                                value,
                                 prefix: None,
                                 suffix: None,
                                 url: None,


### PR DESCRIPTION
## Summary

Two related fixes that improve bibliography sorting accuracy from **7/15 → 10/15** for APA.

### 1. Locale-based article stripping for sorting

Leading articles are now stripped when using title as a sort key:
- English: the, a, an
- German: der, die, das, ein, eine  
- French: le, la, les, l', un, une
- Spanish: el, la, los, las, un, una
- Italian: il, lo, la, i, gli, le, un, una
- Portuguese: o, a, os, as, um, uma
- Dutch: de, het, een

This ensures "The Role of Theory" sorts under "R", not "T".

### 2. Context-aware title substitution

When title substitutes for a missing author (anonymous works):
- **Citation**: `("The Role of Theory," 2018)` — quoted ✓
- **Bibliography**: `The Role of Theory. (2018)...` — not quoted ✓

Previously, the title was quoted in BOTH contexts, which caused the bibliography entry to start with a quote character and sort incorrectly.

### Changes

- `locale.rs`: Add `sort_articles` field and `strip_sort_articles()` method
- `locale.rs`: Add `default_articles_for_locale()` for 7 languages
- `processor.rs`: Use `locale.strip_sort_articles()` in `sort_references()`
- `processor.rs`: Add test for anonymous work sorting
- `values.rs`: Only quote substituted titles in citation context

### Testing

- All 111 tests pass
- APA: 15/15 citations ✅, 10/15 bibliography (up from 7/15)

### Remaining bibliography issues (for future PRs)

- Thesis: `[PhD thesis]` vs `. PhD thesis.`
- Proceedings: `, 3111–3119` vs `. 3111–3119` (delimiter)
- Edited books: Editor rendering when editors ARE the authors
- URL: Trailing period after URL
- Edition: `(Silver Anniversary Edition)` vs `. Silver Anniversary Edition.`