### PR TITLE
feat(options): add configurable URL trailing period

### DIFF
--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -497,6 +497,11 @@ pub struct BibliographyConfig {
     /// Defaults to ". " if not specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub separator: Option<String>,
+    /// Whether to suppress the trailing period after URLs/DOIs.
+    /// Default behavior is to add a period (Chicago, MLA style).
+    /// Set to true to suppress the period (APA 7th, Bluebook style).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub suppress_period_after_url: bool,
     /// Unknown fields captured for forward compatibility.
     #[serde(flatten)]
     pub _extra: HashMap<String, serde_json::Value>,


### PR DESCRIPTION
## Summary

Add `suppress-period-after-url` option to BibliographyConfig to control trailing period after DOI/URL in bibliography entries.

### Style-Specific Behavior

Different style guides have different rules:
- **Chicago, MLA**: Add period after URL (bibliography entry is a sentence)
- **APA 7th, Bluebook**: No period after URL (avoid breaking links)

### The Solution

- Default behavior: add trailing period (most common)
- Styles that want to suppress can set `suppress-period-after-url: true`
- Migration detects DOI/URL without period suffix in CSL macros and sets the option automatically

### Example

```yaml
options:
  bibliography:
    suppress-period-after-url: true  # APA/Bluebook style
```

### Testing

- All 112 tests pass
- APA: 15/15 citations, 11/15 bibliography (up from 5/15)

### Remaining issues (4)

- Thesis bracket formatting
- Proceedings container-pages delimiter
- Edited book author/editor rendering
- Edition parentheses formatting