### PR TITLE
docs: populate high priority features table

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -155,6 +155,11 @@ Run `cargo run --bin csln_analyze -- styles/` to regenerate these statistics.
 ### High Priority (Not Yet Implemented)
 | Feature | Usage | Notes |
 |---------|-------|-------|
+| Group delimiters | - | Colon vs period between components |
+| Page labels | - | "pp." extraction from CSL Label nodes |
+| Volume-pages delimiter | - | Varies by style (comma vs colon) |
+| DOI suppression | - | Some styles don't output DOI |
+| Editor name-order | - | given-first vs family-first varies by style |
 
 ### Medium Priority (Note Styles)
 | Feature | Usage | Notes |


### PR DESCRIPTION
Move known gaps from the prose list into the High Priority table for better visibility and tracking.

## Changes

Populated the empty "High Priority (Not Yet Implemented)" table with:
- Group delimiters (colon vs period)
- Page labels ("pp." extraction)
- Volume-pages delimiter
- DOI suppression
- Editor name-order

This makes it easier to see at a glance what features need implementation.