### PR TITLE
feat(options): add substitute presets and style-aware contributor matching

### DIFF
--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod embedded;
 pub use citation::{Citation, CitationItem, CitationMode, Citations, LocatorType};
 pub use locale::Locale;
 pub use options::Config;
-pub use presets::{ContributorPreset, DatePreset, TitlePreset};
+pub use presets::{ContributorPreset, DatePreset, SubstitutePreset, TitlePreset};
 pub use template::TemplateComponent;
 
 /// A named template (reusable sequence of components).

--- a/crates/csln_migrate/src/options_extractor.rs
+++ b/crates/csln_migrate/src/options_extractor.rs
@@ -14,7 +14,7 @@ use csln_core::options::{
     AndOptions, BibliographyConfig, Config, ContributorConfig, DateConfig, DelimiterPrecedesLast,
     DemoteNonDroppingParticle, Disambiguation, DisplayAsSort, Group, PageRangeFormat, Processing,
     ProcessingCustom, ShortenListOptions, Sort, SortKey, SortSpec, SubsequentAuthorSubstituteRule,
-    Substitute as CslnSubstitute, SubstituteKey, TitlesConfig,
+    Substitute as CslnSubstitute, SubstituteConfig, SubstituteKey, TitlesConfig,
 };
 use csln_core::template::DelimiterPunctuation;
 
@@ -32,7 +32,7 @@ impl OptionsExtractor {
             contributors: Self::extract_contributor_config(style),
 
             // 3. Extract substitute patterns from the first <names> block with <substitute>
-            substitute: Self::extract_substitute_pattern(style),
+            substitute: Self::extract_substitute_pattern(style).map(SubstituteConfig::Explicit),
 
             // 4. Extract date configuration
             dates: Self::extract_date_config(style),
@@ -1213,7 +1213,7 @@ mod tests {
         let config = OptionsExtractor::extract(&style);
 
         assert!(config.substitute.is_some());
-        let sub = config.substitute.unwrap();
+        let sub = config.substitute.unwrap().resolve();
         assert_eq!(sub.template.len(), 2);
         assert_eq!(sub.template[0], SubstituteKey::Editor);
         assert_eq!(sub.template[1], SubstituteKey::Title);

--- a/crates/csln_processor/src/values.rs
+++ b/crates/csln_processor/src/values.rs
@@ -116,13 +116,13 @@ impl ComponentValues for TemplateContributor {
             && matches!(self.contributor, ContributorRole::Author)
         {
             // Use explicit substitute config, or fall back to default (editor → title → translator)
-            use csln_core::options::Substitute;
-            let default_substitute = Substitute::default();
-            let substitute = options
+            let default_substitute = csln_core::options::SubstituteConfig::default();
+            let substitute_config = options
                 .config
                 .substitute
                 .as_ref()
                 .unwrap_or(&default_substitute);
+            let substitute = substitute_config.resolve();
 
             for key in &substitute.template {
                 match key {


### PR DESCRIPTION
Add `SubstitutePreset` enum with three common patterns and make the processor use the style's substitute configuration.

## Changes

### New Presets
- **`standard`**: Editor → Title → Translator (most styles)
- **`editor-first`**: Editor → Translator → Title
- **`title-first`**: Title → Editor → Translator

### Flexible Configuration
`SubstituteConfig` accepts either a preset name or explicit configuration:

```yaml
# Using a preset:
substitute: standard

# Using explicit config:
substitute:
  template:
    - editor
    - title
```

### Processor Enhancement
The processor now uses the style's substitute configuration to determine primary contributor matching for `subsequent-author-substitute`, rather than hardcoding the fallback order.

## Notes
Naming is inspired by biblatex patterns where `/` indicates fallback order (e.g., `author/editor/translator`), but uses descriptive preset names for style author clarity.