### PR TITLE
docs(reference): convert parent-by-id TODO to issue #64

### DIFF
--- a/crates/csln_core/src/reference.rs
+++ b/crates/csln_core/src/reference.rs
@@ -26,7 +26,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //!
 //! A reference can be a component of a larger work, such as a chapter in a book, or an article.
 //! The parent is represented inline as a Monograph or Serial.
-//! TODO: Add ability to reference a parent by ID.
+//!
+//! Future enhancement: support referencing a parent by ID to reduce duplication.
+//! See: https://github.com/bdarcus/csl26/issues/64
 
 use crate::locale::MonthList;
 use crate::options::{AndOptions, AndOtherOptions, Config, DisplayAsSort};


### PR DESCRIPTION
Replace bare TODO comment with issue reference for better tracking.

- Created issue #64 with full context and design proposal
- Updated doc comment to reference the issue

This keeps the codebase clean while preserving the enhancement request.