### PR TITLE
feat(locale): expose locator terms for page labels

### DIFF
--- a/crates/csln_core/src/citation.rs
+++ b/crates/csln_core/src/citation.rs
@@ -61,7 +61,7 @@ fn is_default_mode(mode: &CitationMode) -> bool {
 }
 
 /// Locator types for pinpoint citations.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, JsonSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum LocatorType {
     Book,
@@ -81,6 +81,7 @@ pub enum LocatorType {
     SubVerbo,
     Verse,
     Volume,
+    Issue,
 }
 
 /// A single citation item referencing a bibliography entry.

--- a/crates/csln_core/src/template.rs
+++ b/crates/csln_core/src/template.rs
@@ -353,6 +353,8 @@ pub struct TemplateNumber {
     pub number: NumberVariable,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form: Option<NumberForm>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_form: Option<LabelForm>,
     #[serde(flatten)]
     pub rendering: Rendering,
     /// Type-specific rendering overrides.
@@ -388,6 +390,16 @@ pub enum NumberForm {
     Numeric,
     Ordinal,
     Roman,
+}
+
+/// Label rendering forms.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum LabelForm {
+    Long,
+    #[default]
+    Short,
+    Symbol,
 }
 
 /// A simple variable component (DOI, ISBN, URL, etc.).


### PR DESCRIPTION
Exposes locator terms (like "p."/"pp.", "Vol.", etc.) in the `Locale` struct and enables declarative label rendering in the processor.

This allows style authors to specify `label-form: short` (or long/symbol) on number components, moving label logic from hardcoded processor rules to data-driven locale files.

### Summary of Changes

- **csln_core**:
    - Added `LocatorTerm` and `SingularPlural` structs to `locale.rs`.
    - Exposed `locators` (a `HashMap<LocatorType, LocatorTerm>`) in the `Locale` struct.
    - Implemented parsing for locator terms from YAML locale files in `Locale::from_raw`.
    - Added `LabelForm` enum and `label_form` field to `TemplateNumber` in `template.rs`.
    - Added `Issue` to `LocatorType` in `citation.rs` and implemented `Eq`, `Hash`, and `PartialEq` for it.
- **csln_processor**:
    - Updated `TemplateNumber` value extraction in `values.rs` to support declarative labels.
    - Implemented heuristic pluralization logic for locator labels.
    - Mapped `NumberVariable` to `LocatorType` for automatic label lookup.

These changes allow style authors to declaratively specify locator labels (e.g., `label-form: short`) in their YAML styles, which will then be correctly pluralized and localized by the processor using the project's locale data.

The implementation follows the project's core principle of "explicit over magic" by moving label rendering from hardcoded processor logic into the declarative style and locale systems.

Closes: #69