### PR TITLE
feat(migrate): infer month format from CSL date-parts

### DIFF
--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -257,7 +257,7 @@ impl Default for DateConfig {
 }
 
 /// Month display format.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum MonthFormat {
     #[default]

--- a/crates/csln_migrate/tests/date_inference.rs
+++ b/crates/csln_migrate/tests/date_inference.rs
@@ -1,0 +1,95 @@
+use csl_legacy::model::{Citation, CslNode, Date, DatePart, Formatting, Info, Layout, Style};
+use csln_core::options::MonthFormat;
+use csln_migrate::options_extractor::OptionsExtractor;
+
+fn make_style_with_date(form: Option<String>) -> Style {
+    let date_part = DatePart {
+        name: "month".to_string(),
+        form,
+        prefix: None,
+        suffix: None,
+    };
+
+    let date_node = CslNode::Date(Date {
+        variable: "issued".to_string(),
+        form: None,
+        prefix: None,
+        suffix: None,
+        delimiter: None,
+        date_parts: None,
+        text_case: None,
+        parts: vec![date_part],
+        formatting: Formatting::default(),
+    });
+
+    Style {
+        version: "1.0".to_string(),
+        xmlns: "http://purl.org/net/xbiblio/csl".to_string(),
+        class: "in-text".to_string(),
+        default_locale: None,
+        initialize_with: None,
+        initialize_with_hyphen: None,
+        names_delimiter: None,
+        name_as_sort_order: None,
+        sort_separator: None,
+        delimiter_precedes_last: None,
+        delimiter_precedes_et_al: None,
+        demote_non_dropping_particle: None,
+        and: None,
+        page_range_format: None,
+        info: Info::default(),
+        locale: vec![],
+        macros: vec![],
+        citation: Citation {
+            layout: Layout {
+                prefix: None,
+                suffix: None,
+                delimiter: None,
+                children: vec![date_node],
+            },
+            sort: None,
+            et_al_min: None,
+            et_al_use_first: None,
+            disambiguate_add_year_suffix: None,
+            disambiguate_add_names: None,
+            disambiguate_add_givenname: None,
+        },
+        bibliography: None,
+    }
+}
+
+#[test]
+fn test_infer_short_month() {
+    let style = make_style_with_date(Some("short".to_string()));
+    let config = OptionsExtractor::extract(&style);
+
+    assert!(config.dates.is_some());
+    assert_eq!(config.dates.unwrap().month, MonthFormat::Short);
+}
+
+#[test]
+fn test_infer_long_month() {
+    let style = make_style_with_date(Some("long".to_string()));
+    let config = OptionsExtractor::extract(&style);
+
+    assert!(config.dates.is_some());
+    assert_eq!(config.dates.unwrap().month, MonthFormat::Long);
+}
+
+#[test]
+fn test_infer_numeric_month() {
+    let style = make_style_with_date(Some("numeric".to_string()));
+    let config = OptionsExtractor::extract(&style);
+
+    assert!(config.dates.is_some());
+    assert_eq!(config.dates.unwrap().month, MonthFormat::Numeric);
+}
+
+#[test]
+fn test_infer_default_month() {
+    let style = make_style_with_date(None); // Default is usually long
+    let config = OptionsExtractor::extract(&style);
+
+    assert!(config.dates.is_some());
+    assert_eq!(config.dates.unwrap().month, MonthFormat::Long);
+}


### PR DESCRIPTION
Analyzes CSL 1.0 date macros to infer the preferred month format (long, short, numeric) for the CSLN style configuration.

The extractor scans citation layouts, bibliography layouts, and macros for date-part elements, counting the frequency of each month form. The most frequent form is used to set `dates.month` in the migrated style.

### Summary of Changes

- **csln_core**: Added `Eq` and `Hash` derives to `MonthFormat` enum to allow its use as a hash map key.
- **csln_migrate**:
    - Implemented `extract_date_config` in `OptionsExtractor`.
    - Added `scan_for_month_format` helper to recursively traverse CSL node structures (macros, groups, choose branches).
    - Correctly handled the `Date` node structure, which uses a `parts` vector of `DatePart` structs rather than generic children nodes.
- **tests**: Added integration tests in `crates/csln_migrate/tests/date_inference.rs` to verify correct inference from various CSL 1.0 month forms.

This ensures that styles migrating from CSL 1.0 retain their preferred date formatting (e.g., "Jan." vs "January") without manual intervention.

Closes: #67