### PR TITLE
feat(reference): support parent reference by ID

### DIFF
--- a/crates/csln_core/src/reference.rs
+++ b/crates/csln_core/src/reference.rs
@@ -84,7 +84,10 @@ impl InputReference {
     pub fn editor(&self) -> Option<Contributor> {
         match self {
             InputReference::Collection(r) => r.editor.clone(),
-            InputReference::CollectionComponent(r) => r.parent.editor.clone(),
+            InputReference::CollectionComponent(r) => match &r.parent {
+                Parent::Embedded(p) => p.editor.clone(),
+                Parent::Id(_) => None,
+            },
             _ => None,
         }
     }
@@ -105,7 +108,10 @@ impl InputReference {
     pub fn publisher(&self) -> Option<Contributor> {
         match self {
             InputReference::Monograph(r) => r.publisher.clone(),
-            InputReference::CollectionComponent(r) => r.parent.publisher.clone(),
+            InputReference::CollectionComponent(r) => match &r.parent {
+                Parent::Embedded(p) => p.publisher.clone(),
+                Parent::Id(_) => None,
+            },
             InputReference::Collection(r) => r.publisher.clone(),
             _ => None,
         }
@@ -222,7 +228,7 @@ pub struct SerialComponent {
     pub translator: Option<Contributor>,
     pub issued: EdtfString,
     /// The parent work, such as a magazine or journal.
-    pub parent: Serial,
+    pub parent: Parent<Serial>,
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,
     pub note: Option<String>,
@@ -230,6 +236,14 @@ pub struct SerialComponent {
     pub pages: Option<String>,
     pub volume: Option<NumOrStr>,
     pub issue: Option<NumOrStr>,
+}
+
+/// A parent reference (either embedded or by ID).
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
+#[serde(untagged)]
+pub enum Parent<T> {
+    Embedded(T),
+    Id(RefID),
 }
 
 /// A parent reference (either Monograph or Serial).
@@ -308,7 +322,7 @@ pub struct CollectionComponent {
     pub translator: Option<Contributor>,
     pub issued: EdtfString,
     /// The parent work, as either a Monograph.
-    pub parent: Collection,
+    pub parent: Parent<Collection>,
     pub pages: Option<NumOrStr>,
     pub url: Option<Url>,
     pub accessed: Option<EdtfString>,

--- a/crates/csln_core/tests/parent_reference.rs
+++ b/crates/csln_core/tests/parent_reference.rs
@@ -1,0 +1,54 @@
+use csln_core::reference::{
+    CollectionComponent, EdtfString, MonographComponentType, Parent, SerialComponent,
+    SerialComponentType, Title,
+};
+
+#[test]
+fn test_serial_component_with_parent_id() {
+    let parent_id = "journal-1".to_string();
+    let component = SerialComponent {
+        id: Some("article-1".to_string()),
+        r#type: SerialComponentType::Article,
+        title: Some(Title::Single("My Article".to_string())),
+        author: None,
+        translator: None,
+        issued: EdtfString("2023".to_string()),
+        parent: Parent::Id(parent_id.clone()),
+        url: None,
+        accessed: None,
+        note: None,
+        doi: None,
+        pages: None,
+        volume: None,
+        issue: None,
+    };
+
+    match component.parent {
+        Parent::Id(id) => assert_eq!(id, parent_id),
+        Parent::Embedded(_) => panic!("Expected Parent::Id"),
+    }
+}
+
+#[test]
+fn test_collection_component_with_parent_id() {
+    let parent_id = "book-1".to_string();
+    let component = CollectionComponent {
+        id: Some("chapter-1".to_string()),
+        r#type: MonographComponentType::Chapter,
+        title: Some(Title::Single("My Chapter".to_string())),
+        author: None,
+        translator: None,
+        issued: EdtfString("2023".to_string()),
+        parent: Parent::Id(parent_id.clone()),
+        pages: None,
+        url: None,
+        accessed: None,
+        note: None,
+        doi: None,
+    };
+
+    match component.parent {
+        Parent::Id(id) => assert_eq!(id, parent_id),
+        Parent::Embedded(_) => panic!("Expected Parent::Id"),
+    }
+}


### PR DESCRIPTION
Updates the input reference model to allow referencing parent items by ID instead of embedding them inline.

This reduces data duplication and enables proper relational modeling similar to biblatex's `crossref`.

### Summary of Changes

- **csln_core**:
    - Added `Parent<T>` enum with `Embedded(T)` and `Id(RefID)` variants.
    - Updated `SerialComponent` and `CollectionComponent` to use `Parent<T>` for their `parent` field.
    - Updated `InputReference` getters to handle ID references (returning `None` for metadata access).
- **tests**: Added `parent_reference.rs` to verify ID-based parent construction.

Closes: #64