### PR TITLE
feat(migrate): support type-conditional substitution extraction

### DIFF
--- a/crates/csln_core/src/options.rs
+++ b/crates/csln_core/src/options.rs
@@ -570,6 +570,9 @@ pub struct Substitute {
     /// Ordered list of fields to try as substitutes.
     #[serde(default)]
     pub template: Vec<SubstituteKey>,
+    /// Type-specific substitution overrides.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub overrides: HashMap<String, Vec<SubstituteKey>>,
 }
 
 impl Default for Substitute {
@@ -581,6 +584,7 @@ impl Default for Substitute {
                 SubstituteKey::Title,
                 SubstituteKey::Translator,
             ],
+            overrides: HashMap::new(),
         }
     }
 }

--- a/crates/csln_core/src/presets.rs
+++ b/crates/csln_core/src/presets.rs
@@ -267,6 +267,7 @@ impl SubstitutePreset {
                     SubstituteKey::Title,
                     SubstituteKey::Translator,
                 ],
+                overrides: HashMap::new(),
             },
             SubstitutePreset::EditorFirst => Substitute {
                 contributor_role_form: None,
@@ -275,6 +276,7 @@ impl SubstitutePreset {
                     SubstituteKey::Translator,
                     SubstituteKey::Title,
                 ],
+                overrides: HashMap::new(),
             },
             SubstitutePreset::TitleFirst => Substitute {
                 contributor_role_form: None,
@@ -283,6 +285,7 @@ impl SubstitutePreset {
                     SubstituteKey::Editor,
                     SubstituteKey::Translator,
                 ],
+                overrides: HashMap::new(),
             },
         }
     }

--- a/crates/csln_migrate/tests/substitute_extraction.rs
+++ b/crates/csln_migrate/tests/substitute_extraction.rs
@@ -1,0 +1,136 @@
+use csl_legacy::model::{
+    Choose, ChooseBranch, Citation, CslNode, Formatting, Info, Layout, Names, Style, Substitute,
+    Text,
+};
+use csln_core::options::SubstituteKey;
+use csln_migrate::options_extractor::OptionsExtractor;
+
+#[test]
+fn test_extract_type_conditional_substitute() {
+    // 1. Setup CSL with type-conditional substitute
+    // <names variable="author">
+    //   <substitute>
+    //     <choose>
+    //       <if type="classic">
+    //         <text variable="title"/>
+    //       </if>
+    //     </choose>
+    //     <names variable="editor"/>
+    //   </substitute>
+    // </names>
+
+    let if_branch = ChooseBranch {
+        type_: Some("classic".to_string()),
+        children: vec![CslNode::Text(Text {
+            variable: Some("title".to_string()),
+            value: None,
+            macro_name: None,
+            term: None,
+            form: None,
+            prefix: None,
+            suffix: None,
+            quotes: None,
+            text_case: None,
+            strip_periods: None,
+            plural: None,
+            formatting: Formatting::default(),
+        })],
+        match_mode: None,
+        variable: None,
+        is_numeric: None,
+        is_uncertain_date: None,
+        locator: None,
+        position: None,
+    };
+
+    let choose_node = CslNode::Choose(Choose {
+        if_branch,
+        else_if_branches: vec![],
+        else_branch: None,
+    });
+
+    let editor_names = CslNode::Names(Names {
+        variable: "editor".to_string(),
+        delimiter: None,
+        delimiter_precedes_et_al: None,
+        et_al_min: None,
+        et_al_use_first: None,
+        et_al_subsequent_min: None,
+        et_al_subsequent_use_first: None,
+        prefix: None,
+        suffix: None,
+        children: vec![],
+        formatting: Formatting::default(),
+    });
+
+    let substitute = Substitute {
+        children: vec![choose_node, editor_names],
+    };
+
+    let author_names = CslNode::Names(Names {
+        variable: "author".to_string(),
+        delimiter: None,
+        delimiter_precedes_et_al: None,
+        et_al_min: None,
+        et_al_use_first: None,
+        et_al_subsequent_min: None,
+        et_al_subsequent_use_first: None,
+        prefix: None,
+        suffix: None,
+        children: vec![CslNode::Substitute(substitute)],
+        formatting: Formatting::default(),
+    });
+
+    let style = Style {
+        version: "1.0".to_string(),
+        xmlns: "http://purl.org/net/xbiblio/csl".to_string(),
+        class: "in-text".to_string(),
+        default_locale: None,
+        initialize_with: None,
+        initialize_with_hyphen: None,
+        names_delimiter: None,
+        name_as_sort_order: None,
+        sort_separator: None,
+        delimiter_precedes_last: None,
+        delimiter_precedes_et_al: None,
+        demote_non_dropping_particle: None,
+        and: None,
+        page_range_format: None,
+        info: Info::default(),
+        locale: vec![],
+        macros: vec![],
+        citation: Citation {
+            layout: Layout {
+                prefix: None,
+                suffix: None,
+                delimiter: None,
+                children: vec![author_names],
+            },
+            sort: None,
+            et_al_min: None,
+            et_al_use_first: None,
+            disambiguate_add_year_suffix: None,
+            disambiguate_add_names: None,
+            disambiguate_add_givenname: None,
+        },
+        bibliography: None,
+    };
+
+    // 2. Extract config
+    let config = OptionsExtractor::extract(&style);
+
+    // 3. Verify
+    assert!(config.substitute.is_some());
+    let sub = config.substitute.unwrap().resolve();
+
+    // Default template should have editor (extracted from after choose)
+    assert!(sub.template.contains(&SubstituteKey::Editor));
+    assert!(!sub.template.contains(&SubstituteKey::Title)); // Title is conditional
+
+    // Overrides should have classic -> title
+    assert!(sub.overrides.contains_key("classic"));
+    assert_eq!(
+        sub.overrides.get("classic").unwrap(),
+        &vec![SubstituteKey::Title]
+    );
+}


### PR DESCRIPTION
Enables extraction of type-specific substitution rules from CSL 1.0 styles. Conditional branches within `<substitute>` are now mapped to CSLN's substitute overrides.

This ensures that styles with complex fallback logic (e.g., using title for classic works but editor for others) are correctly migrated.

### Summary of Changes

- **csln_core**:
    - Added `overrides` field to `Substitute` struct to support type-specific fallback rules.
    - Updated style presets (APA, Chicago, etc.) to initialize with empty overrides.
- **csln_migrate**:
    - Updated `extract_substitute_keys` to detect and parse `<choose>` blocks within `<substitute>`.
    - Maps `<if type="...">` and `<else-if type="...">` branches to CSLN's type override system.
    - Enhanced `extract_substitute_pattern` to search citation and bibliography layouts in addition to macros.
- **tests**: Added integration tests in `crates/csln_migrate/tests/substitute_extraction.rs` to verify correct extraction of conditional substitution rules.

Closes: #66