### PR TITLE
fix: position year at end of bibliography for numeric styles

### DIFF
--- a/crates/csln_migrate/src/main.rs
+++ b/crates/csln_migrate/src/main.rs
@@ -96,8 +96,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 4. Template Compilation
     let template_compiler = TemplateCompiler;
+
+    // Detect if this is a numeric style
+    let is_numeric = match &options.processing {
+        Some(csln_core::options::Processing::Numeric) => true,
+        Some(csln_core::options::Processing::Custom(custom)) => {
+            // Check if sort key is CitationNumber
+            if let Some(sort) = &custom.sort {
+                sort.template
+                    .first()
+                    .is_some_and(|s| s.key == csln_core::options::SortKey::CitationNumber)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    };
+
     let (mut new_bib, type_templates) =
-        template_compiler.compile_bibliography_with_types(&csln_bib);
+        template_compiler.compile_bibliography_with_types(&csln_bib, is_numeric);
     let mut new_cit = template_compiler.compile_citation(&csln_cit);
 
     // Apply author suffix extracted from original CSL (lost during macro inlining)

--- a/crates/csln_migrate/src/template_compiler.rs
+++ b/crates/csln_migrate/src/template_compiler.rs
@@ -442,9 +442,13 @@ impl TemplateCompiler {
     }
 
     /// Compile and sort for bibliography output.
-    pub fn compile_bibliography(&self, nodes: &[CslnNode]) -> Vec<TemplateComponent> {
+    pub fn compile_bibliography(
+        &self,
+        nodes: &[CslnNode],
+        is_numeric: bool,
+    ) -> Vec<TemplateComponent> {
         let mut components = self.compile(nodes);
-        self.sort_bibliography_components(&mut components);
+        self.sort_bibliography_components(&mut components, is_numeric);
         components
     }
 
@@ -460,6 +464,7 @@ impl TemplateCompiler {
     pub fn compile_bibliography_with_types(
         &self,
         nodes: &[CslnNode],
+        is_numeric: bool,
     ) -> (
         Vec<TemplateComponent>,
         HashMap<String, Vec<TemplateComponent>>,
@@ -485,7 +490,7 @@ impl TemplateCompiler {
             }
         }
 
-        self.sort_bibliography_components(&mut default_template);
+        self.sort_bibliography_components(&mut default_template, is_numeric);
 
         // Type-specific template generation is disabled for now.
         // The compile_for_type approach produces malformed templates.
@@ -815,12 +820,18 @@ impl TemplateCompiler {
 
     /// Sort components for bibliography: citation-number first (for numeric styles),
     /// then author, date, title, then rest.
-    fn sort_bibliography_components(&self, components: &mut [TemplateComponent]) {
+    fn sort_bibliography_components(&self, components: &mut [TemplateComponent], is_numeric: bool) {
         components.sort_by_key(|c| match c {
             // Citation number goes first for numeric bibliography styles
             TemplateComponent::Number(n) if n.number == NumberVariable::CitationNumber => 0,
             TemplateComponent::Contributor(c) if c.contributor == ContributorRole::Author => 1,
-            TemplateComponent::Date(d) if d.date == DateVariable::Issued => 2,
+            TemplateComponent::Date(d) if d.date == DateVariable::Issued => {
+                if is_numeric {
+                    20
+                } else {
+                    2
+                }
+            }
             TemplateComponent::Title(t) if t.title == TitleType::Primary => 3,
             TemplateComponent::Title(t) if t.title == TitleType::ParentSerial => 4,
             TemplateComponent::Title(t) if t.title == TitleType::ParentMonograph => 5,

--- a/docs/TIER3_PLAN.md
+++ b/docs/TIER3_PLAN.md
@@ -249,9 +249,9 @@ CSLN:   [1]T. S. Kuhn, 1962. "The Structure..."
 **Root cause:** Migration uses author-date year positioning for all styles.
 
 **Fix:**
-- [ ] Detect numeric style class from CSL `<citation>` element
-- [ ] For numeric styles, move `date:issued` component to end of template
-- [ ] Preserve year position for author-date styles
+- [x] Detect numeric style class from CSL `<citation>` element
+- [x] For numeric styles, move `date:issued` component to end of template
+- [x] Preserve year position for author-date styles
 
 ### Issue 1.1: Superscript/Bracket Citation Format
 


### PR DESCRIPTION
## Summary
Moves the `date:issued` component to the end of the bibliography template for styles identified as numeric (e.g., IEEE, Nature).

## Changes
- **Migration Logic:** Modified `template_compiler.rs` to support `is_numeric` flag in `sort_bibliography_components`.
- **Sorter:** Assigns a high sort weight (20) to the issued date when `is_numeric` is true, ensuring it appears after titles and citation numbers explicitly.
- **Entry Point:** Updated `main.rs` to detect numeric processing mode (via `Processing::Numeric` or `CitationNumber` sort key) and pass the flag to the compiler.

## Verification
- **IEEE (Numeric):** Year moved to end. Matches oracle expectation. orderingIssues reduced (10 -> 5).
- **Nature (Numeric):** Year moved to end. Matches oracle.
- **APA (Author-Date):** No regression. orderingIssues: 0.

## Refs
Closes TIER3-1.0 (internal plan reference)