### PR TITLE
docs: link to new style-editor repository

### DIFF
--- a/.agent/design/STYLE_EDITOR_VISION.md
+++ b/.agent/design/STYLE_EDITOR_VISION.md
@@ -95,6 +95,7 @@ GET  /examples/:field       # Field-specific references
 ## Relevant Links
 
 - [Issue #28: MakeCSL Vision](https://github.com/bdarcus/csln/issues/28)
+- [Style Editor Repository](https://github.com/bdarcus/style-editor) - The web platform companion to this repository
 - [PERSONAS.md](.agent/PERSONAS.md) - stakeholder alignment
 - [options.rs](crates/csln_core/src/options.rs) - configuration model
 


### PR DESCRIPTION
This PR updates the `STYLE_EDITOR_VISION.md` document to include a link to the newly created `style-editor` repository, which now hosts the web platform companion and Rust server backend.

This establishes the link between the core library (this repo) and the application platform.