### PR TITLE
Add pull request convention to Git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,17 @@ All changes must be made on feature branches. The user will handle merging via G
 
 4. **Stop here.** Do NOT attempt to merge. The user will review and merge when ready.
 
+## Pull Request Convention
+
+**Draft vs Ready PRs:**
+- **Draft PR** = Work in progress, more commits expected
+- **Regular PR** = Complete and ready for immediate merge
+
+When opening a PR:
+- Use **draft** if you plan to add more commits to the same branch
+- Use **regular** (non-draft) only when all work is complete and tested
+- The user will merge regular PRs without waiting for confirmation
+
 Branch naming conventions:
 - `feat/` - New features
 - `fix/` - Bug fixes


### PR DESCRIPTION
## Summary

Documents the draft vs regular PR convention in CLAUDE.md to clarify expectations and streamline workflow.

## Convention Added

**Draft vs Ready PRs:**
- **Draft PR** = Work in progress, more commits expected
- **Regular PR** = Complete and ready for immediate merge

When opening a PR:
- Use **draft** if planning to add more commits to the same branch
- Use **regular** (non-draft) only when all work is complete and tested
- User will merge regular PRs without waiting for confirmation

## Location

Added to Git Workflow section in CLAUDE.md, right after commit guidelines and before branch naming conventions.

## Why

This establishes clear expectations about PR readiness. Regular PRs signal they're safe to merge immediately, while drafts indicate more work is coming.

---

Generated with Claude Code