### PR TITLE
fix(migrate): handle Choose blocks in delimiter extraction

### DIFF
--- a/crates/csln_migrate/src/main.rs
+++ b/crates/csln_migrate/src/main.rs
@@ -321,6 +321,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // Extract delimiter from first group in CSL layout (author-year separator)
                 delimiter: analysis::citation::extract_citation_delimiter(
                     &legacy_style.citation.layout,
+                    &legacy_style.macros,
                 ),
                 multi_cite_delimiter: legacy_style.citation.layout.delimiter.clone(),
                 ..Default::default()


### PR DESCRIPTION
## Summary

PR #114 broke Chicago-style delimiter extraction by only checking Group nodes when recursing, missing groups nested inside Choose blocks. Additionally, the old logic could not handle macros that contain both author and date.

This PR restores Chicago delimiter extraction while preserving the Springer improvements from PR #114.

## Implementation

Implements a hybrid depth-first search approach that:

1. **Recursion through Choose blocks**: Previously only Group nodes were processed in the search loop, causing the algorithm to miss groups nested inside Choose branches
2. **Macro expansion**: When encountering a Text node with a macro name containing both "author" and "date" (e.g., `citation-author-date-item`), the algorithm now expands the macro and searches for delimiters inside
3. **Depth tracking**: Returns the deepest group containing both author and date, handling:
   - Flat structures: `<group><author/><date/></group>` (APA)
   - Nested groups: `<group><group><author/><date/></group></group>` (Springer)
   - Choose blocks: `<group><choose><author+date macros/></choose></group>` (Chicago)
   - Macro-based structures: Author and date inside a combined macro

## Results

### Delimiter Extraction
- **APA**: `, ` (comma-space) - maintained ✓
- **Springer**: ` ` (space) - PR #114 fix preserved ✓
- **Chicago**: ` ` (space) - restored from null ✓

### Oracle Test Results
- **APA citations**: 8/15 (maintained, no regression)
- **Springer citations**: 7/15 (maintained, PR #114 improvements preserved)
- **Chicago citations**: 0/15 (delimiter now correct, but failures due to separate template compilation issue where titles are extracted instead of dates)

## Test Plan

Pre-PR checklist completed:
- [x] `cargo fmt` (no formatting issues)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (zero warnings)
- [x] `cargo test` (all tests pass)
- [x] Oracle comparison tests for APA, Chicago, Springer

## Notes

Chicago citation test failures are unrelated to delimiter extraction. The delimiter is now correctly extracted as space, but the template compiler is extracting title components instead of date components. This is a separate issue that needs investigation in the template compilation pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)