### PR TITLE
fix(migrate): extract bibliography delimiter from nested groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,6 @@ Code should be self-documenting with clear comments explaining:
 - **Key Features**: Variable-once rule, type-specific overrides, name_order control, initials formatting, volume(issue) grouping
 
 ### Known Gaps
-- Group delimiter extraction (colon vs period between components)
 - Page label extraction ("pp." from CSL Label nodes)
 - Volume-pages delimiter varies by style (comma vs colon)
 - DOI suppression for styles that don't output DOI


### PR DESCRIPTION
## Summary

Similar to the citation delimiter issue fixed in #115, bibliography separator extraction only looked at the first level of groups, missing delimiters in nested structures. This fix implements depth-first recursive search with macro expansion.

## Changes

- Refactored `extract_bibliography_separator_from_layout()` to use recursive search
- Added helper `find_deepest_group_delimiter()` with depth tracking
- Implemented macro expansion for Text nodes with `macro_name`
- Searches through Group, Choose, and macro-referenced nodes
- Returns delimiter from deepest group containing multiple variables

## Implementation Pattern

Follows the same approach as citation delimiter extraction in commit 65f2341:
- Depth-first search prioritizes innermost groups
- Choose blocks: searches all if/else branches
- Macro expansion: follows Text node references
- Fallback to layout-level delimiter if no group delimiter found

## Example Fix

For APA style with this nested structure:
```xml
<macro name="bibliography">
  <group delimiter=" ">
    <choose>
      <else>
        <group delimiter=". ">
          <text macro="author-and-contributors"/>
          <text macro="date"/>
        </group>
      </else>
    </choose>
  </group>
</macro>
```

Now correctly extracts `. ` (period-space) instead of space.

## Impact

- APA: separator extracted as `. ` (was missing)
- Nature: separator extracted as `, ` (was missing)
- All styles with nested bibliography structures benefit

## Testing

```bash
cargo fmt
cargo clippy --all-targets --all-features -- -D warnings
cargo test
node scripts/oracle.js styles/apa.csl
node scripts/oracle.js styles/nature.csl
```

All tests pass. APA and Nature now have correct separator extraction (though bibliography matches remain low due to other template compilation issues).

## Documentation

Updated CLAUDE.md to remove "Group delimiter extraction" from Known Gaps.

Refs: #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)