### PR TITLE
Add task management section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,31 @@ If you want to contribute code directly, focus on:
 - **Schema Design**: Ensuring `csln_core` remains robust and extensible.
 - **Agent Tooling**: Developing new "skills" or scripts that enhance the autonomy and capabilities of the AI agents.
 
+## Task Management
+
+Active development uses [beans](https://github.com/jdx/beans) for local task tracking (see `.beans/` directory). GitHub Issues remain open for:
+
+- **Community bug reports**: Submit issues when you find rendering defects or incorrect output
+- **Feature requests**: Propose new capabilities or improvements
+- **Public discussion**: Comment on planned work and provide domain expertise
+
+### For Contributors
+
+Current development tasks are tracked locally as beans. If you see a GitHub issue marked with a migration note, the work is actively being tracked in the `.beans/` directory. The issue will be closed when the work is completed.
+
+### For Maintainers
+
+Use the `/bean` skill (see `.claude/skills/bean/SKILL.md`) for local task management:
+
+```bash
+/bean list              # Show all tasks
+/bean next              # Get recommended task
+/bean show BEAN_ID      # View details
+/bean update BEAN_ID --status completed
+```
+
+All beans are git-tracked markdown files with dependency relationships and priority levels.
+
 ## License
 
 MPL-2.0 - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

Document the beans-based task management workflow and clarify GitHub issue policy for contributors.

## Changes

- Add Task Management section to README
- Explain local beans workflow for active development
- Clarify that GitHub issues remain open for community contributions
- Document maintainer workflow with /bean skill
- Link to migration PR #151

## Context

Following the migration to beans (#151), contributors need to understand:
1. How development tasks are tracked (locally in .beans/)
2. What GitHub issues are for (community bug reports, features, discussion)
3. How the two systems relate (issues get migration notes linking to beans)

This helps set expectations and provides clear guidance for both contributors and maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)