### PR TITLE
fix(migrate): prevent duplicate variables in numeric bibliography templates

### DIFF
--- a/.beans/csl26-6whe--fix-year-positioning-for-numeric-styles.md
+++ b/.beans/csl26-6whe--fix-year-positioning-for-numeric-styles.md
@@ -1,11 +1,11 @@
 ---
 # csl26-6whe
 title: Fix year positioning for numeric styles
-status: todo
+status: completed
 type: bug
 priority: critical
 created_at: 2026-02-07T06:52:59Z
-updated_at: 2026-02-07T06:52:59Z
+updated_at: 2026-02-07T07:26:30Z
 ---
 
 Year appears after contributors in numeric styles, but should appear at end.


### PR DESCRIPTION
## Summary

Fixes duplicate variables (especially dates) appearing twice in numeric bibliography entries.

## Problem

In numeric styles (Nature, IEEE, etc.), variables appeared twice:
- **Before**: `1. Kuhn, T.S. ... (1962), (1962).` ❌ 
- **After**: `1. Kuhn, T.S. ... (1962).` ✅

This affected 10,878+ entries across the 2,844 style corpus.

## Root Cause

Variables like `date:issued` appeared in both:
1. Type-specific **List** components (e.g., for `article-journal`)
2. **Standalone** components (for all types)

Both rendered for the same types, causing duplication. Lists and standalone components had different deduplication keys, so the merge logic didn't catch them.

## Solution

Added `fix_duplicate_variables()` post-processing step:
1. Scans Lists to find which variables appear for which types
2. Adds `suppress: true` overrides to standalone components for those types
3. Fixed `get_component_overrides()` to include `List.overrides` (was returning `None`)

## Testing

- ✅ **Nature style**: All 15 test entries - no duplicate dates
- ✅ **IEEE style**: Verified year appears only once per entry
- ✅ **All unit tests** pass (33 passed)

## Files Changed

- `crates/csln_migrate/src/template_compiler/mod.rs`:
  - Added `fix_duplicate_variables()` method
  - Added `get_visible_types_for_component()` helper
  - Fixed `get_component_overrides()` to handle Lists
  - Updated `compile_bibliography_with_types()` to call the fix
- `.beans/csl26-6whe--fix-year-positioning-for-numeric-styles.md`: Marked as completed

## References

- Bean: csl26-6whe
- Issue: #127
- Doc: TIER3_PLAN.md Issue 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)