### PR TITLE
fix: correct CI lint errors and model name mismatches

### DIFF
--- a/crates/csln/src/main.rs
+++ b/crates/csln/src/main.rs
@@ -390,7 +390,7 @@ fn main() {
                 if stem.contains("bib") || stem.contains("ref") {
                     DataType::Bib
                 } else if stem.contains("cite") || stem.contains("citation") {
-                    DataType::Citation
+                    DataType::Citations
                 } else if stem.len() == 5 && stem.contains('-') {
                     // e.g. en-US
                     DataType::Locale
@@ -422,7 +422,7 @@ fn main() {
                     let out_bytes = serialize_any(&locale, output_ext);
                     fs::write(&output, out_bytes).expect("Failed to write output");
                 }
-                DataType::Citation => {
+                DataType::Citations => {
                     let citations: csln_core::citation::Citations =
                         deserialize_any(&input_bytes, input_ext);
                     let out_bytes = serialize_any(&citations, output_ext);

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -1,5 +1,4 @@
 #[cfg(feature = "schema")]
-#[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;


### PR DESCRIPTION
This PR fixes the CI failures introduced by the previous commit to main.

- Removes duplicated cfg attribute in csln_core/src/lib.rs
- Updates Citation to Citations in csln Convert command to match the updated DataType enum
- Ensures all mandatory pre-commit checks (fmt, clippy, nextest) pass.