### PR TITLE
docs: add comprehensive JSON schemas section to index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
                     href="examples.html">Examples</a>
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="schemas/style.json">Schemas</a>
+                    href="#schemas">Schemas</a>
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
                     href="https://github.com/bdarcus/csl26">GitHub</a>
                 <a class="bg-primary hover:bg-primary/90 text-white px-4 py-2 rounded font-medium text-sm flex items-center gap-2 transition-all"
@@ -518,6 +518,50 @@
                     <p class="text-[10px] font-mono text-slate-400 mt-2 text-right">100% Complete</p>
                 </div>
 
+            </div>
+        </div>
+    </section>
+
+    <!-- JSON Schemas Section -->
+    <section class="py-24 px-6 border-t border-slate-200" id="schemas">
+        <div class="max-w-7xl mx-auto">
+            <div class="text-center mb-16">
+                <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">JSON Schemas</h2>
+                <p class="text-slate-500">Validation tools for developers and style authors. Use these in your IDE for autocomplete and real-time validation.</p>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+                <!-- Style Schema -->
+                <a href="schemas/style.json" class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
+                        <span class="material-icons text-sm">architecture</span>
+                    </div>
+                    <h4 class="font-bold text-slate-900 mb-2">Style</h4>
+                    <p class="text-xs text-slate-500">Core CSLN style definition.</p>
+                </a>
+                <!-- Bib Schema -->
+                <a href="schemas/bib.json" class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
+                        <span class="material-icons text-sm">inventory_2</span>
+                    </div>
+                    <h4 class="font-bold text-slate-900 mb-2">Bibliography</h4>
+                    <p class="text-xs text-slate-500">Input reference format.</p>
+                </a>
+                <!-- Locale Schema -->
+                <a href="schemas/locale.json" class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
+                        <span class="material-icons text-sm">language</span>
+                    </div>
+                    <h4 class="font-bold text-slate-900 mb-2">Locale</h4>
+                    <p class="text-xs text-slate-500">Terms and date patterns.</p>
+                </a>
+                <!-- Citations Schema -->
+                <a href="schemas/citations.json" class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
+                        <span class="material-icons text-sm">format_quote</span>
+                    </div>
+                    <h4 class="font-bold text-slate-900 mb-2">Citations</h4>
+                    <p class="text-xs text-slate-500">Citation list format.</p>
+                </a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
This PR adds a dedicated 'JSON Schemas' section to docs/index.html.

- Replaces the single direct nav link with an anchor to the new section.
- Lists all four schemas (Style, Bibliography, Locale, Citations) with descriptions and icons.
- Improves discoverability for developer validation tools.