### PR TITLE
feat(presets): expand SQI preset extraction

### DIFF
--- a/crates/csln/generated_schemas/style.json
+++ b/crates/csln/generated_schemas/style.json
@@ -29,6 +29,14 @@
         }
       ]
     },
+    "custom": {
+      "description": "Custom user-defined fields for extensions.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    },
     "info": {
       "description": "Style metadata.",
       "allOf": [
@@ -67,7 +75,7 @@
       "type": "string"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "definitions": {
     "AndOptions": {
       "description": "Conjunction options between contributors.",
@@ -142,6 +150,14 @@
       "description": "Bibliography-specific configuration.",
       "type": "object",
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "entry-suffix": {
           "description": "Suffix appended to each bibliography entry (e.g., \".\"). Extracted from CSL 1.0 `<layout suffix=\".\">` attribute. If None, a trailing period is added by default unless entry ends with DOI/URL.",
           "type": [
@@ -186,16 +202,110 @@
           "type": "boolean"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "BibliographyGroup": {
+      "description": "A bibliography group with selector, optional heading, and per-group sorting.\n\nGroups allow styles to divide bibliographies into labeled sections with distinct sorting rules. Items match the first group whose selector evaluates to true (first-match semantics).\n\n# Examples\n\n```yaml groups: - id: vietnamese heading: localized: vi: \"Tài liệu tiếng Việt\" en-US: \"Vietnamese Sources\" selector: field: language: vi sort: template: - key: author sort-order: given-family ```",
+      "type": "object",
+      "required": [
+        "id",
+        "selector"
+      ],
+      "properties": {
+        "disambiguate": {
+          "description": "Optional disambiguation scope. - `globally` (default): Year suffixes are assigned across the whole bibliography. - `locally`: Year suffixes are assigned independently within this group.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DisambiguationScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "heading": {
+          "description": "Optional heading to display above this group. Omit for no heading (e.g., fallback group).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GroupHeading"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "description": "Unique identifier for this group.",
+          "type": "string"
+        },
+        "selector": {
+          "description": "Selector predicate to match references.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GroupSelector"
+            }
+          ]
+        },
+        "sort": {
+          "description": "Optional per-group sorting specification. Falls back to global bibliography sort if omitted.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GroupSort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "template": {
+          "description": "Optional per-group template override. Falls back to global bibliography template if omitted.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/TemplateComponent"
+          }
+        }
+      }
     },
     "BibliographySpec": {
       "description": "Bibliography specification.",
       "type": "object",
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "groups": {
+          "description": "Optional bibliography grouping specification.\n\nWhen present, divides the bibliography into labeled sections with optional per-group sorting. Items match the first group whose selector evaluates to true (first-match semantics). Omit for flat bibliography.\n\nSee `BibliographyGroup` for examples.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/BibliographyGroup"
+          }
+        },
         "options": {
           "anyOf": [
             {
               "$ref": "#/definitions/Config"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sort": {
+          "description": "Optional global bibliography sorting specification.\n\nWhen present, used for sorting the flat bibliography or as default for groups that don't specify their own sort.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GroupSort"
             },
             {
               "type": "null"
@@ -237,12 +347,20 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "CitationSpec": {
       "description": "Citation specification.",
       "type": "object",
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "delimiter": {
           "description": "Delimiter between components within a single citation item (e.g., \", \" or \" \"). Defaults to \", \".",
           "type": [
@@ -296,6 +414,17 @@
             "null"
           ]
         },
+        "sort": {
+          "description": "Optional citation sorting specification.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GroupSort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "suffix": {
           "description": "Suffix for the citation (use only when `wrap` doesn't suffice).",
           "type": [
@@ -335,7 +464,47 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "CitedStatus": {
+      "description": "Citation status filter.",
+      "oneOf": [
+        {
+          "description": "Match only references cited in the document.",
+          "type": "string",
+          "enum": [
+            "visible"
+          ]
+        },
+        {
+          "description": "Match all references regardless of citation status.",
+          "type": "string",
+          "enum": [
+            "any"
+          ]
+        }
+      ]
+    },
+    "ComponentOverride": {
+      "description": "Type-specific rendering overrides for components.",
+      "anyOf": [
+        {
+          "description": "A full component replacement for specific reference types.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TemplateComponent"
+            }
+          ]
+        },
+        {
+          "description": "Simple rendering options override.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Rendering"
+            }
+          ]
+        }
+      ]
     },
     "Config": {
       "description": "Top-level style configuration.",
@@ -353,21 +522,29 @@
           ]
         },
         "contributors": {
-          "description": "Contributor formatting defaults.",
+          "description": "Contributor formatting defaults. Accepts a preset name (e.g., \"apa\") or explicit configuration.",
           "anyOf": [
             {
-              "$ref": "#/definitions/ContributorConfig"
+              "$ref": "#/definitions/ContributorConfigEntry"
             },
             {
               "type": "null"
             }
           ]
         },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "dates": {
-          "description": "Date formatting defaults.",
+          "description": "Date formatting defaults. Accepts a preset name (e.g., \"long\") or explicit configuration.",
           "anyOf": [
             {
-              "$ref": "#/definitions/DateConfig"
+              "$ref": "#/definitions/DateConfigEntry"
             },
             {
               "type": "null"
@@ -441,6 +618,13 @@
             "null"
           ]
         },
+        "strip-periods": {
+          "description": "Strip trailing periods from terms, labels, and abbreviated dates.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "substitute": {
           "description": "Substitution rules for missing data.",
           "anyOf": [
@@ -453,10 +637,10 @@
           ]
         },
         "titles": {
-          "description": "Title formatting defaults.",
+          "description": "Title formatting defaults. Accepts a preset name (e.g., \"apa\") or explicit configuration.",
           "anyOf": [
             {
-              "$ref": "#/definitions/TitlesConfig"
+              "$ref": "#/definitions/TitlesConfigEntry"
             },
             {
               "type": "null"
@@ -475,7 +659,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "ContributorConfig": {
       "description": "Contributor formatting configuration.",
@@ -491,6 +675,14 @@
               "type": "null"
             }
           ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
         },
         "delimiter": {
           "description": "The delimiter between contributors.",
@@ -598,7 +790,28 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "ContributorConfigEntry": {
+      "description": "Contributor config: either a preset name or explicit configuration.\n\nAllows styles to write `contributors: apa` as shorthand, or provide full explicit configuration with field-level overrides.",
+      "anyOf": [
+        {
+          "description": "A named preset (e.g., \"apa\", \"chicago\", \"vancouver\", \"springer\").",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContributorPreset"
+            }
+          ]
+        },
+        {
+          "description": "Explicit contributor configuration.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ContributorConfig"
+            }
+          ]
+        }
+      ]
     },
     "ContributorForm": {
       "description": "How to render contributor names.",
@@ -608,6 +821,67 @@
         "short",
         "verb",
         "verb-short"
+      ]
+    },
+    "ContributorPreset": {
+      "description": "Contributor formatting presets.\n\nEach preset encodes the contributor formatting conventions for a major citation style or style family. Use doc comments to describe the visual behavior so style authors can choose the right preset without knowing style guide names.",
+      "oneOf": [
+        {
+          "description": "First author family-first, \"&\" symbol, et al. after 20 authors, initials with period-space, comma before \"&\". Example: \"Smith, J. D., & Jones, M. K.\"",
+          "type": "string",
+          "enum": [
+            "apa"
+          ]
+        },
+        {
+          "description": "First author family-first, \"and\" text, contextual serial comma, full given names (no initials). Example: \"Smith, John D., and Mary K. Jones\"",
+          "type": "string",
+          "enum": [
+            "chicago"
+          ]
+        },
+        {
+          "description": "All authors family-first, no conjunction, compact initials (no period/space), et al. after 6 of 7+. Example: \"Smith JD, Jones MK, Brown AB\"",
+          "type": "string",
+          "enum": [
+            "vancouver"
+          ]
+        },
+        {
+          "description": "Given-first format, \"and\" text, initials with period-space, comma before \"and\". Example: \"J. D. Smith, M. K. Jones, and A. B. Brown\"",
+          "type": "string",
+          "enum": [
+            "ieee"
+          ]
+        },
+        {
+          "description": "All authors family-first, \"and\" text, compact initials (period, no space), comma before \"and\". Example: \"Smith, J.D., Jones, M.K., and Brown, A.B.\"",
+          "type": "string",
+          "enum": [
+            "harvard"
+          ]
+        },
+        {
+          "description": "All authors family-first, no conjunction, compact initials (no period/space), space sort-separator, et al. after 3 of 5+. Example: \"Smith JD, Jones MK, Brown AB\"",
+          "type": "string",
+          "enum": [
+            "springer"
+          ]
+        },
+        {
+          "description": "Numeric compact author list for journal-heavy corpora: all family-first, no conjunction, sort-only particle demotion, space sort-separator, et al. after 6 of 7+.",
+          "type": "string",
+          "enum": [
+            "numeric-compact"
+          ]
+        },
+        {
+          "description": "Numeric medium author list variant: same as `numeric-compact`, but et al. after 3 of 4+.",
+          "type": "string",
+          "enum": [
+            "numeric-medium"
+          ]
+        }
       ]
     },
     "ContributorRole": {
@@ -647,6 +921,14 @@
             "null"
           ]
         },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "month": {
           "$ref": "#/definitions/MonthFormat"
         },
@@ -670,7 +952,28 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "DateConfigEntry": {
+      "description": "Date config: either a preset name or explicit configuration.\n\nAllows styles to write `dates: long` as shorthand, or provide full explicit configuration with field-level overrides.",
+      "anyOf": [
+        {
+          "description": "A named preset (e.g., \"long\", \"short\", \"numeric\", \"iso\").",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DatePreset"
+            }
+          ]
+        },
+        {
+          "description": "Explicit date configuration.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DateConfig"
+            }
+          ]
+        }
+      ]
     },
     "DateForm": {
       "description": "Date rendering forms.",
@@ -679,7 +982,41 @@
         "year",
         "year-month",
         "full",
-        "month-day"
+        "month-day",
+        "year-month-day"
+      ]
+    },
+    "DatePreset": {
+      "description": "Date formatting presets.\n\nEach preset defines how dates are displayed in citations and bibliographies, including month format, EDTF uncertainty/approximation markers, and range delimiters.",
+      "oneOf": [
+        {
+          "description": "Long month names, EDTF markers, en-dash ranges. Example: \"January 15, 2024\", \"ca. 2024\", \"2024?\"",
+          "type": "string",
+          "enum": [
+            "long"
+          ]
+        },
+        {
+          "description": "Short month names, EDTF markers, en-dash ranges. Example: \"Jan 15, 2024\"",
+          "type": "string",
+          "enum": [
+            "short"
+          ]
+        },
+        {
+          "description": "Numeric months, EDTF markers, en-dash ranges. Example: \"1/15/2024\"",
+          "type": "string",
+          "enum": [
+            "numeric"
+          ]
+        },
+        {
+          "description": "ISO 8601 numeric format, no EDTF markers. Example: \"2024-01-15\"",
+          "type": "string",
+          "enum": [
+            "iso"
+          ]
+        }
       ]
     },
     "DateVariable": {
@@ -735,6 +1072,25 @@
         }
       }
     },
+    "DisambiguationScope": {
+      "description": "Scope for disambiguation (e.g., year suffix assignment).",
+      "oneOf": [
+        {
+          "description": "Disambiguate across all items in the bibliography.",
+          "type": "string",
+          "enum": [
+            "globally"
+          ]
+        },
+        {
+          "description": "Disambiguate only within the current group.",
+          "type": "string",
+          "enum": [
+            "locally"
+          ]
+        }
+      ]
+    },
     "DisplayAsSort": {
       "description": "When to display names in sort order (family-first).",
       "type": "string",
@@ -770,6 +1126,22 @@
         }
       ]
     },
+    "FieldMatcher": {
+      "description": "Field value matcher.",
+      "anyOf": [
+        {
+          "description": "Match exact field value.",
+          "type": "string"
+        },
+        {
+          "description": "Match any of multiple values.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "GeneralTerm": {
       "description": "A list of general terms for citation formatting.",
       "type": "string",
@@ -791,7 +1163,14 @@
         "forthcoming",
         "online",
         "review-of",
-        "original-work-published"
+        "original-work-published",
+        "patent",
+        "volume",
+        "issue",
+        "page",
+        "chapter",
+        "edition",
+        "section"
       ]
     },
     "Group": {
@@ -809,6 +1188,234 @@
         }
       }
     },
+    "GroupHeading": {
+      "description": "Localizable heading source for bibliography groups.",
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "type": "object",
+          "required": [
+            "literal"
+          ],
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "type": "object",
+          "required": [
+            "term"
+          ],
+          "properties": {
+            "form": {
+              "description": "Optional term form (defaults to long).",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "term": {
+              "description": "Locale general term key.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/GeneralTerm"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "type": "object",
+          "required": [
+            "localized"
+          ],
+          "properties": {
+            "localized": {
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "GroupSelector": {
+      "description": "Selector predicate for matching references to groups.\n\nAll specified conditions must match (AND logic). Use the `not` field for negation-based fallback groups.",
+      "type": "object",
+      "properties": {
+        "cited": {
+          "description": "Match references by citation status.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CitedStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "field": {
+          "description": "Match references by field values (e.g., language, keywords).",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/FieldMatcher"
+          }
+        },
+        "not": {
+          "description": "Negation for fallback groups. Matches references that do NOT match the nested selector.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GroupSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "description": "Match references by type.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TypeSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "GroupSort": {
+      "description": "Per-group sorting specification.\n\nSorting follows a template of sort keys, applied in order. The first key is the primary sort, second is the tiebreaker, etc.",
+      "type": "object",
+      "required": [
+        "template"
+      ],
+      "properties": {
+        "template": {
+          "description": "Ordered list of sort keys to apply.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/GroupSortKey"
+          }
+        }
+      }
+    },
+    "GroupSortKey": {
+      "description": "A single sort key in a group sorting template.",
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "ascending": {
+          "description": "Sort order direction.",
+          "default": true,
+          "type": "boolean"
+        },
+        "key": {
+          "description": "The field or variable to sort by.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SortKey2"
+            }
+          ]
+        },
+        "order": {
+          "description": "For type-based ordering: explicit type sequence.\n\nExample: `[\"legal-case\", \"statute\", \"treaty\"]` for Bluebook hierarchy. Items appear in this order regardless of alphabetical content.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "sort-order": {
+          "description": "For name-based sorting: culturally appropriate name order.\n\nExample: `given-family` for Vietnamese, `family-given` for Western.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NameSortOrder"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "LabelConfig": {
+      "description": "Configuration for label citation mode.",
+      "type": "object",
+      "properties": {
+        "et-al-marker": {
+          "description": "Suffix appended when truncated. Alpha/Ams default: \"+\", Din default: \"\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "et-al-min": {
+          "description": "Max authors before truncation. Alpha/Ams default: 4, Din default: 3.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "multi-author-chars": {
+          "description": "Chars per author family name when 2+ authors. Preset default: 1.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "preset": {
+          "description": "Preset that determines default parameters.",
+          "default": "alpha",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LabelPreset"
+            }
+          ]
+        },
+        "single-author-chars": {
+          "description": "Chars taken from single author's family name. Preset default: 3 (Alpha/Ams), 4 (Din).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "year-digits": {
+          "description": "Year digits: 2 or 4. Preset default: 2.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        }
+      }
+    },
     "LabelForm": {
       "description": "Label rendering forms.",
       "type": "string",
@@ -816,6 +1423,40 @@
         "long",
         "short",
         "symbol"
+      ]
+    },
+    "LabelPlacement": {
+      "description": "Label placement relative to contributor names.",
+      "type": "string",
+      "enum": [
+        "prefix",
+        "suffix"
+      ]
+    },
+    "LabelPreset": {
+      "description": "Label style preset conventions.",
+      "oneOf": [
+        {
+          "description": "biblatex alphabetic / BibTeX alpha.bst: up to 4 authors, \"+\" marker, 2-digit year.",
+          "type": "string",
+          "enum": [
+            "alpha"
+          ]
+        },
+        {
+          "description": "DIN 1505-2: up to 3 authors, no et-al marker, 2-digit year.",
+          "type": "string",
+          "enum": [
+            "din"
+          ]
+        },
+        {
+          "description": "American Mathematical Society: same algorithm as Alpha, sorted by citation-number.",
+          "type": "string",
+          "enum": [
+            "ams"
+          ]
+        }
       ]
     },
     "LinkAnchor": {
@@ -1026,6 +1667,25 @@
         }
       ]
     },
+    "NameSortOrder": {
+      "description": "Name sorting order for culturally appropriate collation.",
+      "oneOf": [
+        {
+          "description": "Family name first (Western convention). Example: \"Smith, John\" → \"S\" sorts before \"T\"",
+          "type": "string",
+          "enum": [
+            "family-given"
+          ]
+        },
+        {
+          "description": "Given name first (Vietnamese convention). Example: \"Nguyễn Văn A\" → \"Nguyễn\" sorts before \"Trần\"",
+          "type": "string",
+          "enum": [
+            "given-family"
+          ]
+        }
+      ]
+    },
     "NumberForm": {
       "description": "Number rendering forms.",
       "type": "string",
@@ -1047,7 +1707,13 @@
         "collection-number",
         "number-of-pages",
         "number-of-volumes",
-        "citation-number"
+        "citation-number",
+        "citation-label",
+        "number",
+        "docket-number",
+        "patent-number",
+        "standard-number",
+        "report-number"
       ]
     },
     "PageRangeFormat": {
@@ -1091,7 +1757,7 @@
       ]
     },
     "Processing": {
-      "description": "Processing mode for citation/bibliography generation.",
+      "description": "Processing mode for citation/bibliography generation.\n\nCan be specified as: - A string: \"author-date\", \"numeric\", \"note\", or \"label\" - A label config map: { label: { preset: din } } - A custom config map: { sort: ..., group: ..., disambiguate: ... }",
       "oneOf": [
         {
           "type": "string",
@@ -1100,6 +1766,18 @@
             "numeric",
             "note"
           ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "label"
+          ],
+          "properties": {
+            "label": {
+              "$ref": "#/definitions/LabelConfig"
+            }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -1204,6 +1882,13 @@
             "null"
           ]
         },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "strong": {
           "description": "Render in bold/strong.",
           "type": [
@@ -1236,7 +1921,47 @@
             }
           ]
         }
+      },
+      "additionalProperties": false
+    },
+    "RoleLabel": {
+      "description": "Configuration for role labels (e.g., \"eds.\", \"trans.\").",
+      "type": "object",
+      "required": [
+        "term"
+      ],
+      "properties": {
+        "form": {
+          "description": "Term form: short (\"eds.\") or long (\"editors\").",
+          "default": "short",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RoleLabelForm"
+            }
+          ]
+        },
+        "placement": {
+          "description": "Where to place the label relative to names.",
+          "default": "suffix",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LabelPlacement"
+            }
+          ]
+        },
+        "term": {
+          "description": "Locale term key for the role (e.g., \"editor\", \"translator\").",
+          "type": "string"
+        }
       }
+    },
+    "RoleLabelForm": {
+      "description": "Term form for role labels.",
+      "type": "string",
+      "enum": [
+        "short",
+        "long"
+      ]
     },
     "RoleOptions": {
       "description": "Role display options.",
@@ -1429,7 +2154,16 @@
         "dimensions",
         "scale",
         "version",
-        "locator"
+        "locator",
+        "authority",
+        "reporter",
+        "page",
+        "volume",
+        "number",
+        "docket-number",
+        "patent-number",
+        "standard-number",
+        "report-number"
       ]
     },
     "Sort": {
@@ -1475,6 +2209,52 @@
           "enum": [
             "citation-number"
           ]
+        }
+      ]
+    },
+    "SortKey2": {
+      "description": "Sort key selector.",
+      "oneOf": [
+        {
+          "description": "Sort by reference type.",
+          "type": "string",
+          "enum": [
+            "type"
+          ]
+        },
+        {
+          "description": "Sort by author/contributor.",
+          "type": "string",
+          "enum": [
+            "author"
+          ]
+        },
+        {
+          "description": "Sort by title.",
+          "type": "string",
+          "enum": [
+            "title"
+          ]
+        },
+        {
+          "description": "Sort by issued date.",
+          "type": "string",
+          "enum": [
+            "issued"
+          ]
+        },
+        {
+          "description": "Sort by custom field.",
+          "type": "object",
+          "required": [
+            "field"
+          ],
+          "properties": {
+            "field": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -1587,7 +2367,8 @@
             "$ref": "#/definitions/SubstituteKey"
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "SubstituteConfig": {
       "description": "Substitution rules for missing author data.",
@@ -1641,6 +2422,62 @@
           "type": "string",
           "enum": [
             "title-first"
+          ]
+        },
+        {
+          "description": "Editor only with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-short"
+          ]
+        },
+        {
+          "description": "Editor only with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-long"
+          ]
+        },
+        {
+          "description": "Editor then translator with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-short"
+          ]
+        },
+        {
+          "description": "Editor then translator with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-long"
+          ]
+        },
+        {
+          "description": "Editor then title with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-title-short"
+          ]
+        },
+        {
+          "description": "Editor then title with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-title-long"
+          ]
+        },
+        {
+          "description": "Editor then translator then title with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-title-short"
+          ]
+        },
+        {
+          "description": "Editor then translator then title with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-title-long"
           ]
         }
       ]
@@ -1698,6 +2535,14 @@
             }
           ]
         },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "delimiter": {
           "description": "Custom delimiter between names (overrides global setting).",
           "type": [
@@ -1741,6 +2586,17 @@
             "null"
           ]
         },
+        "label": {
+          "description": "Optional role label configuration (e.g., \"eds.\" for editors).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "links": {
           "description": "Structured link options (DOI, URL).",
           "anyOf": [
@@ -1770,7 +2626,7 @@
             "null"
           ],
           "additionalProperties": {
-            "$ref": "#/definitions/Rendering"
+            "$ref": "#/definitions/ComponentOverride"
           }
         },
         "prefix": {
@@ -1812,6 +2668,13 @@
             "null"
           ]
         },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "strong": {
           "description": "Render in bold/strong.",
           "type": [
@@ -1845,7 +2708,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "TemplateDate": {
       "description": "A date component for rendering dates.",
@@ -1855,6 +2718,14 @@
         "form"
       ],
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "date": {
           "$ref": "#/definitions/DateVariable"
         },
@@ -1917,7 +2788,7 @@
             "null"
           ],
           "additionalProperties": {
-            "$ref": "#/definitions/Rendering"
+            "$ref": "#/definitions/ComponentOverride"
           }
         },
         "prefix": {
@@ -1936,6 +2807,13 @@
         },
         "small-caps": {
           "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
           "type": [
             "boolean",
             "null"
@@ -1974,7 +2852,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "TemplateList": {
       "description": "A list component for grouping multiple items with a delimiter.",
@@ -1983,6 +2861,14 @@
         "items"
       ],
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "delimiter": {
           "anyOf": [
             {
@@ -2034,7 +2920,7 @@
             "null"
           ],
           "additionalProperties": {
-            "$ref": "#/definitions/Rendering"
+            "$ref": "#/definitions/ComponentOverride"
           }
         },
         "prefix": {
@@ -2053,6 +2939,13 @@
         },
         "small-caps": {
           "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
           "type": [
             "boolean",
             "null"
@@ -2091,7 +2984,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "TemplateNumber": {
       "description": "A number component (volume, issue, pages, etc.).",
@@ -2100,6 +2993,14 @@
         "number"
       ],
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "emph": {
           "description": "Render in italics/emphasis.",
           "type": [
@@ -2169,7 +3070,7 @@
             "null"
           ],
           "additionalProperties": {
-            "$ref": "#/definitions/Rendering"
+            "$ref": "#/definitions/ComponentOverride"
           }
         },
         "prefix": {
@@ -2188,6 +3089,13 @@
         },
         "small-caps": {
           "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
           "type": [
             "boolean",
             "null"
@@ -2226,7 +3134,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "TemplatePreset": {
       "description": "Available embedded template presets.\n\nThese reference battle-tested templates for common citation styles. See `csln_core::embedded` for the actual template implementations.",
@@ -2265,6 +3173,13 @@
           "enum": [
             "harvard"
           ]
+        },
+        {
+          "description": "Numeric citation number only (citation-focused preset)",
+          "type": "string",
+          "enum": [
+            "numeric-citation"
+          ]
         }
       ]
     },
@@ -2275,6 +3190,14 @@
         "term"
       ],
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "emph": {
           "description": "Render in italics/emphasis.",
           "type": [
@@ -2321,7 +3244,7 @@
             "null"
           ],
           "additionalProperties": {
-            "$ref": "#/definitions/Rendering"
+            "$ref": "#/definitions/ComponentOverride"
           }
         },
         "prefix": {
@@ -2340,6 +3263,13 @@
         },
         "small-caps": {
           "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
           "type": [
             "boolean",
             "null"
@@ -2386,7 +3316,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "TemplateTitle": {
       "description": "A title component.",
@@ -2395,6 +3325,14 @@
         "title"
       ],
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "emph": {
           "description": "Render in italics/emphasis.",
           "type": [
@@ -2451,7 +3389,7 @@
             "null"
           ],
           "additionalProperties": {
-            "$ref": "#/definitions/Rendering"
+            "$ref": "#/definitions/ComponentOverride"
           }
         },
         "prefix": {
@@ -2470,6 +3408,13 @@
         },
         "small-caps": {
           "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
           "type": [
             "boolean",
             "null"
@@ -2511,7 +3456,7 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "TemplateVariable": {
       "description": "A simple variable component (DOI, ISBN, URL, etc.).",
@@ -2520,6 +3465,14 @@
         "variable"
       ],
       "properties": {
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "emph": {
           "description": "Render in italics/emphasis.",
           "type": [
@@ -2566,7 +3519,7 @@
             "null"
           ],
           "additionalProperties": {
-            "$ref": "#/definitions/Rendering"
+            "$ref": "#/definitions/ComponentOverride"
           }
         },
         "prefix": {
@@ -2583,8 +3536,29 @@
             "null"
           ]
         },
+        "show-label": {
+          "description": "Whether locator labels (e.g., \"p.\", \"sec.\") should be rendered when `variable: locator` is used. If omitted, processor defaults apply.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "small-caps": {
           "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-label-periods": {
+          "description": "Strip trailing periods from locator labels (e.g., \"p.\" -> \"p\"). Only applies to `variable: locator`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
           "type": [
             "boolean",
             "null"
@@ -2626,17 +3600,17 @@
           ]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "TermForm": {
       "description": "Form for term lookup.",
       "type": "string",
       "enum": [
-        "Long",
-        "Short",
-        "Verb",
-        "VerbShort",
-        "Symbol"
+        "long",
+        "short",
+        "verb",
+        "verb-short",
+        "symbol"
       ]
     },
     "TitleForm": {
@@ -2645,6 +3619,53 @@
       "enum": [
         "short",
         "long"
+      ]
+    },
+    "TitlePreset": {
+      "description": "Title formatting presets.\n\nEach preset defines how different types of titles (articles, books, journals) are formatted. Presets typically differ in whether titles are quoted, italicized, or plain.",
+      "oneOf": [
+        {
+          "description": "APA style: article titles plain, book/journal titles italic. Example: Article title. *Book Title*. *Journal Title*.",
+          "type": "string",
+          "enum": [
+            "apa"
+          ]
+        },
+        {
+          "description": "Chicago style: article titles quoted, book/journal titles italic. Example: \"Article Title.\" *Book Title*. *Journal Title*.",
+          "type": "string",
+          "enum": [
+            "chicago"
+          ]
+        },
+        {
+          "description": "IEEE style: article titles quoted, book/journal titles italic. Example: \"Article title,\" *Book Title*. *Journal Title*.",
+          "type": "string",
+          "enum": [
+            "ieee"
+          ]
+        },
+        {
+          "description": "Humanities style: monographs, periodicals, and serials all italic, articles plain. Common in geography, history, and social sciences. Example: Article title. *Book Title*. *Journal Title*. *Series Title*.",
+          "type": "string",
+          "enum": [
+            "humanities"
+          ]
+        },
+        {
+          "description": "Journal-focused emphasis: periodicals and serials italic, monographs plain.",
+          "type": "string",
+          "enum": [
+            "journal-emphasis"
+          ]
+        },
+        {
+          "description": "Scientific/Vancouver style: all titles plain (no formatting). Example: Article title. Book title. Journal title.",
+          "type": "string",
+          "enum": [
+            "scientific"
+          ]
+        }
       ]
     },
     "TitleRendering": {
@@ -2687,7 +3708,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "TitleType": {
       "description": "Types of titles.",
@@ -2741,6 +3763,14 @@
             }
           ]
         },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
         "default": {
           "description": "Default formatting for all titles.",
           "anyOf": [
@@ -2793,7 +3823,44 @@
           }
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
+    },
+    "TitlesConfigEntry": {
+      "description": "Title config: either a preset name or explicit configuration.\n\nAllows styles to write `titles: apa` as shorthand, or provide full explicit configuration with field-level overrides.",
+      "anyOf": [
+        {
+          "description": "A named preset (e.g., \"apa\", \"chicago\", \"humanities\", \"scientific\").",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TitlePreset"
+            }
+          ]
+        },
+        {
+          "description": "Explicit title configuration.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TitlesConfig"
+            }
+          ]
+        }
+      ]
+    },
+    "TypeSelector": {
+      "description": "Type-based selector.",
+      "anyOf": [
+        {
+          "description": "Match a single type.",
+          "type": "string"
+        },
+        {
+          "description": "Match any of multiple types.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "WrapPunctuation": {
       "description": "Punctuation to wrap a component in.",

--- a/crates/csln_core/src/embedded/mod.rs
+++ b/crates/csln_core/src/embedded/mod.rs
@@ -9,6 +9,7 @@ pub mod apa;
 pub mod chicago;
 pub mod harvard;
 pub mod ieee;
+pub mod numeric;
 pub mod vancouver;
 
 use crate::template::TemplateComponent;
@@ -23,6 +24,7 @@ pub use harvard::bibliography as harvard_bibliography;
 pub use harvard::citation as harvard_citation;
 pub use ieee::bibliography as ieee_bibliography;
 pub use ieee::citation as ieee_citation;
+pub use numeric::citation as numeric_citation;
 pub use vancouver::bibliography as vancouver_bibliography;
 pub use vancouver::citation as vancouver_citation;
 
@@ -34,6 +36,7 @@ pub fn citation_templates() -> HashMap<&'static str, Vec<TemplateComponent>> {
     map.insert("vancouver", vancouver_citation());
     map.insert("ieee", ieee_citation());
     map.insert("harvard", harvard_citation());
+    map.insert("numeric-citation", numeric_citation());
     map
 }
 
@@ -138,6 +141,7 @@ mod tests {
         assert!(templates.contains_key("vancouver"));
         assert!(templates.contains_key("ieee"));
         assert!(templates.contains_key("harvard"));
+        assert!(templates.contains_key("numeric-citation"));
     }
 
     #[test]

--- a/crates/csln_core/src/embedded/numeric.rs
+++ b/crates/csln_core/src/embedded/numeric.rs
@@ -1,0 +1,17 @@
+/*
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+use crate::template::{NumberVariable, TemplateComponent, TemplateNumber};
+
+/// Embedded citation template for plain numeric citation styles.
+///
+/// Renders as the citation number itself (wrapping is style-controlled):
+/// `1`, `(1)`, or `[1]` depending on the parent citation options.
+pub fn citation() -> Vec<TemplateComponent> {
+    vec![TemplateComponent::Number(TemplateNumber {
+        number: NumberVariable::CitationNumber,
+        ..Default::default()
+    })]
+}

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -117,6 +117,8 @@ pub enum TemplatePreset {
     Ieee,
     /// Harvard/Elsevier (author-date)
     Harvard,
+    /// Numeric citation number only (citation-focused preset)
+    NumericCitation,
 }
 
 impl TemplatePreset {
@@ -128,6 +130,7 @@ impl TemplatePreset {
             TemplatePreset::Vancouver => embedded::vancouver_citation(),
             TemplatePreset::Ieee => embedded::ieee_citation(),
             TemplatePreset::Harvard => embedded::harvard_citation(),
+            TemplatePreset::NumericCitation => embedded::numeric_citation(),
         }
     }
 
@@ -139,6 +142,8 @@ impl TemplatePreset {
             TemplatePreset::Vancouver => embedded::vancouver_bibliography(),
             TemplatePreset::Ieee => embedded::ieee_bibliography(),
             TemplatePreset::Harvard => embedded::harvard_bibliography(),
+            // Citation-focused preset; Vancouver bibliography is the closest numeric fallback.
+            TemplatePreset::NumericCitation => embedded::vancouver_bibliography(),
         }
     }
 }

--- a/crates/csln_core/src/presets.rs
+++ b/crates/csln_core/src/presets.rs
@@ -334,6 +334,14 @@ pub enum SubstitutePreset {
     EditorTranslatorShort,
     /// Editor then translator with long role labels.
     EditorTranslatorLong,
+    /// Editor then title with short role labels.
+    EditorTitleShort,
+    /// Editor then title with long role labels.
+    EditorTitleLong,
+    /// Editor then translator then title with short role labels.
+    EditorTranslatorTitleShort,
+    /// Editor then translator then title with long role labels.
+    EditorTranslatorTitleLong,
 }
 
 impl SubstitutePreset {
@@ -385,6 +393,34 @@ impl SubstitutePreset {
             SubstitutePreset::EditorTranslatorLong => Substitute {
                 contributor_role_form: Some("long".to_string()),
                 template: vec![SubstituteKey::Editor, SubstituteKey::Translator],
+                overrides: HashMap::new(),
+            },
+            SubstitutePreset::EditorTitleShort => Substitute {
+                contributor_role_form: Some("short".to_string()),
+                template: vec![SubstituteKey::Editor, SubstituteKey::Title],
+                overrides: HashMap::new(),
+            },
+            SubstitutePreset::EditorTitleLong => Substitute {
+                contributor_role_form: Some("long".to_string()),
+                template: vec![SubstituteKey::Editor, SubstituteKey::Title],
+                overrides: HashMap::new(),
+            },
+            SubstitutePreset::EditorTranslatorTitleShort => Substitute {
+                contributor_role_form: Some("short".to_string()),
+                template: vec![
+                    SubstituteKey::Editor,
+                    SubstituteKey::Translator,
+                    SubstituteKey::Title,
+                ],
+                overrides: HashMap::new(),
+            },
+            SubstitutePreset::EditorTranslatorTitleLong => Substitute {
+                contributor_role_form: Some("long".to_string()),
+                template: vec![
+                    SubstituteKey::Editor,
+                    SubstituteKey::Translator,
+                    SubstituteKey::Title,
+                ],
                 overrides: HashMap::new(),
             },
         }
@@ -543,6 +579,10 @@ mod tests {
             SubstitutePreset::EditorLong,
             SubstitutePreset::EditorTranslatorShort,
             SubstitutePreset::EditorTranslatorLong,
+            SubstitutePreset::EditorTitleShort,
+            SubstitutePreset::EditorTitleLong,
+            SubstitutePreset::EditorTranslatorTitleShort,
+            SubstitutePreset::EditorTranslatorTitleLong,
         ];
         for preset in substitute_presets {
             let yaml = serde_yaml::to_string(&preset).unwrap();

--- a/docs/compat.html
+++ b/docs/compat.html
@@ -123,10 +123,10 @@
                 </div>
             </div>
             <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
-                <div class="text-sm text-slate-500 font-mono">Generated: Fri, 20 Feb 2026 18:46:18 GMT</div>
+                <div class="text-sm text-slate-500 font-mono">Generated: Fri, 20 Feb 2026 19:06:23 GMT</div>
                 <div class="inline-flex items-center gap-2 px-3 py-1 rounded bg-slate-100 text-slate-700 text-xs font-mono border border-slate-200">
                     <span class="material-icons text-sm">code</span>
-                    <span>f1bb4a3</span>
+                    <span>eccc08b</span>
                 </div>
             </div>
         </div>
@@ -160,7 +160,7 @@
                 <!-- Quality Overall -->
                 <div class="bg-white rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Quality (SQI)</div>
-                    <div class="text-3xl font-bold text-slate-900">90.0%</div>
+                    <div class="text-3xl font-bold text-slate-900">91.9%</div>
                     <div class="text-xs text-slate-400 mt-2">Type coverage, fallback, concision, presets</div>
                 </div>
             </div>
@@ -643,7 +643,7 @@
                     data-bibliography-rate="0.875"
                     data-component-rate="0.994"
                     data-fidelity="0.909"
-                    data-quality="0.928"
+                    data-quality="0.943"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">african-online-scientific-information-systems-vancouver</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -662,7 +662,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">90.9%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -679,12 +679,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.3%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.2%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -1008,7 +1008,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="1"
                     data-fidelity="0.955"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">aims-press</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -1027,7 +1027,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -1044,12 +1044,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -1362,7 +1362,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-association-for-cancer-research</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -1381,7 +1381,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -1398,12 +1398,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -1716,7 +1716,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.9"
+                    data-quality="0.946"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-chemical-society</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -1735,7 +1735,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.0%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.6%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -1752,12 +1752,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.0%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.6%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.3%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -2464,7 +2464,7 @@
                     data-bibliography-rate="0.90625"
                     data-component-rate="0.997"
                     data-fidelity="0.932"
-                    data-quality="0.929"
+                    data-quality="0.945"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-institute-of-aeronautics-and-astronautics</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -2483,7 +2483,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">93.2%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.5%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -2500,12 +2500,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.8%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -2829,7 +2829,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.93"
+                    data-quality="0.945"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-institute-of-physics</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -2848,7 +2848,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.0%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.5%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -2865,12 +2865,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.0%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.9%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.2%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -3537,7 +3537,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="1"
                     data-fidelity="0.864"
-                    data-quality="0.871"
+                    data-quality="0.886"
                     data-sqi-tier-rank="3">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-meteorological-society</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
@@ -3556,7 +3556,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">86.4%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">87.1%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
                             B
@@ -3573,12 +3573,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 87.1%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.6%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 72.3%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -3934,7 +3934,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="1"
                     data-fidelity="0.955"
-                    data-quality="0.928"
+                    data-quality="0.944"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-physics-society</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -3953,7 +3953,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.4%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -3970,12 +3970,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.4%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.7%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -4288,7 +4288,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-physiological-society</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -4307,7 +4307,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -4324,12 +4324,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -4642,7 +4642,7 @@
                     data-bibliography-rate="0.90625"
                     data-component-rate="1"
                     data-fidelity="0.932"
-                    data-quality="0.918"
+                    data-quality="0.933"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-society-for-microbiology</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -4661,7 +4661,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">93.2%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -4678,12 +4678,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -4996,8 +4996,8 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.882"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.927"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-society-of-civil-engineers</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -5015,10 +5015,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.2%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.7%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -5032,12 +5032,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.2%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.7%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.7%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 60.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -5350,7 +5350,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">american-society-of-mechanical-engineers</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -5369,7 +5369,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -5386,12 +5386,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -6101,7 +6101,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="0.997"
                     data-fidelity="0.841"
-                    data-quality="0.869"
+                    data-quality="0.884"
                     data-sqi-tier-rank="3">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">annual-reviews-alphabetical</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -6120,7 +6120,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">84.1%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">86.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.4%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
                             B
@@ -6137,12 +6137,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 86.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.4%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 69.1%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 96.7%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 96.9%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -6939,7 +6939,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="0.997"
                     data-fidelity="0.955"
-                    data-quality="0.924"
+                    data-quality="0.94"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">annual-reviews</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -6958,7 +6958,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.4%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.0%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -6975,12 +6975,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.4%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.0%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 96.7%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 96.9%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -7650,7 +7650,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.903"
+                    data-quality="0.933"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">association-for-computing-machinery</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -7669,7 +7669,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -7686,12 +7686,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -8004,7 +8004,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.903"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">baishideng-publishing-group</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -8023,7 +8023,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -8040,12 +8040,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -8358,8 +8358,8 @@
                     data-bibliography-rate="0.90625"
                     data-component-rate="1"
                     data-fidelity="0.932"
-                    data-quality="0.885"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.915"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">begell-house-chicago-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -8377,10 +8377,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">93.2%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.5%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.5%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -8394,12 +8394,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.5%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 60.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
                                 </div>
                             </div>
 
@@ -8712,7 +8712,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.9"
+                    data-quality="0.945"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">biomed-central</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -8731,7 +8731,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.0%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.5%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -8748,12 +8748,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.0%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -9066,7 +9066,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.903"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">bmj</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -9085,7 +9085,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -9102,12 +9102,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -10240,7 +10240,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.903"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">cell</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -10259,7 +10259,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -10276,12 +10276,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -11122,7 +11122,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="1"
                     data-fidelity="0.955"
-                    data-quality="0.952"
+                    data-quality="0.982"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">chicago-shortened-notes-bibliography</td>
                     <td class="px-6 py-4 text-sm text-slate-600">note</td>
@@ -11141,7 +11141,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">95.2%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">98.2%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -11158,12 +11158,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 95.2%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 98.2%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 99.7%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -11558,8 +11558,8 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.885"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.915"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">copernicus-publications</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -11577,10 +11577,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.5%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.5%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -11594,12 +11594,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.5%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 60.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
                                 </div>
                             </div>
 
@@ -11912,8 +11912,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.886"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.901"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">cse-name-year</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -11931,10 +11931,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.1%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -11948,12 +11948,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.6%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.1%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 81.8%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.8%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
                                 </div>
                             </div>
 
@@ -12288,7 +12288,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">current-opinion</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -12307,7 +12307,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -12324,12 +12324,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -13440,7 +13440,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.886"
-                    data-quality="0.871"
+                    data-quality="0.886"
                     data-sqi-tier-rank="3">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">elsevier-vancouver-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
@@ -13459,7 +13459,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">87.1%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
                             B
@@ -13476,12 +13476,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 87.1%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.6%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 72.3%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.2%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -13837,8 +13837,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.887"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.917"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">elsevier-vancouver</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">502</td>
@@ -13856,10 +13856,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.7%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.7%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -13873,12 +13873,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.7%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.7%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 93.6%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -14545,7 +14545,7 @@
                     data-bibliography-rate="0.59375"
                     data-component-rate="0.947"
                     data-fidelity="0.705"
-                    data-quality="0.928"
+                    data-quality="0.944"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">elsevier-without-titles</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -14564,7 +14564,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">95%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">70.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.4%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -14581,12 +14581,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.4%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.7%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -14918,8 +14918,8 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="0.997"
                     data-fidelity="0.932"
-                    data-quality="0.89"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.905"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">entomological-society-of-america</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -14937,10 +14937,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">93.2%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.0%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.5%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -14954,12 +14954,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.0%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 78.6%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.9%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -15312,7 +15312,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">frontiers-medical-journals</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -15331,7 +15331,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -15348,12 +15348,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -15666,8 +15666,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.886"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.931"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">frontiers</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -15685,10 +15685,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.1%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -15702,12 +15702,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.6%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.1%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.3%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 60.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -16020,7 +16020,7 @@
                     data-bibliography-rate="0.8125"
                     data-component-rate="0.987"
                     data-fidelity="0.864"
-                    data-quality="0.926"
+                    data-quality="0.942"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">future-medicine</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -16039,7 +16039,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">86.4%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.6%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.2%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -16056,12 +16056,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.6%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.2%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.7%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -16389,7 +16389,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">future-science-group</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -16408,7 +16408,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -16425,12 +16425,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -16743,7 +16743,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="0.991"
                     data-fidelity="0.955"
-                    data-quality="0.928"
+                    data-quality="0.943"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">hainan-medical-university-journal-publisher</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -16762,7 +16762,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -16779,12 +16779,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.3%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -17116,7 +17116,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.9"
+                    data-quality="0.93"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">ieee</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -17135,7 +17135,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.0%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.0%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -17152,12 +17152,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.0%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.0%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -18236,8 +18236,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.895"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.94"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">institute-of-physics-numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">82</td>
@@ -18255,10 +18255,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.5%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.0%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -18272,12 +18272,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.5%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.0%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.2%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -18590,7 +18590,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.928"
+                    data-quality="0.944"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">integrated-science-publishing-journals</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -18609,7 +18609,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.4%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -18626,12 +18626,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.4%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.6%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -18944,7 +18944,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.886"
-                    data-quality="0.871"
+                    data-quality="0.886"
                     data-sqi-tier-rank="3">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">inter-research-science-center</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
@@ -18963,7 +18963,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">87.1%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
                             B
@@ -18980,12 +18980,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 87.1%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.6%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 72.3%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -19341,8 +19341,8 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.932"
-                    data-quality="0.89"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.905"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">international-journal-of-wildland-fire</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -19360,10 +19360,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">93.2%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.0%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.5%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -19377,12 +19377,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.0%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 78.6%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.8%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -20115,7 +20115,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="0.994"
                     data-fidelity="0.705"
-                    data-quality="0.671"
+                    data-quality="0.686"
                     data-sqi-tier-rank="1">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">karger-journals-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
@@ -20134,7 +20134,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">70.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">67.1%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">68.6%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-failing">
                             D
@@ -20151,12 +20151,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 67.1%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 68.6%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 15.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -20583,8 +20583,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.899"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.943"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">karger-journals</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">85</td>
@@ -20602,10 +20602,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -20619,12 +20619,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -20937,7 +20937,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="0.997"
                     data-fidelity="0.977"
-                    data-quality="0.903"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">landes-bioscience-journals</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -20956,7 +20956,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -20973,12 +20973,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -21699,8 +21699,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.896"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.941"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">mary-ann-liebert-vancouver</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">72</td>
@@ -21718,10 +21718,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.6%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.1%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -21735,12 +21735,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.6%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.1%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.4%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -22053,7 +22053,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.929"
+                    data-quality="0.945"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">medicina-clinica</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -22072,7 +22072,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.5%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -22089,12 +22089,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.6%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.9%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -22407,7 +22407,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="0.991"
                     data-fidelity="0.955"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">medicine-publishing</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -22426,7 +22426,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -22443,12 +22443,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -24099,8 +24099,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.897"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.943"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">multidisciplinary-digital-publishing-institute</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">180</td>
@@ -24118,10 +24118,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.7%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -24135,12 +24135,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.7%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.9%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.1%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -24818,7 +24818,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="0.991"
                     data-fidelity="0.977"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">nature-publishing-group-vancouver</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -24837,7 +24837,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -24854,12 +24854,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -25191,7 +25191,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="0.997"
                     data-fidelity="0.977"
-                    data-quality="0.903"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">nature</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -25210,7 +25210,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -25227,12 +25227,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -25556,7 +25556,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.928"
+                    data-quality="0.943"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">nlm-citation-sequence-brackets</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -25575,7 +25575,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -25592,12 +25592,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.3%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -25910,7 +25910,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.928"
+                    data-quality="0.943"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">nlm-citation-sequence-superscript-brackets-year-only</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -25929,7 +25929,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -25946,12 +25946,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.3%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -26264,8 +26264,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.898"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.943"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">nlm-citation-sequence-superscript</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">121</td>
@@ -26283,10 +26283,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -26300,12 +26300,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.3%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -26618,8 +26618,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.898"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.943"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">nlm-citation-sequence</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">116</td>
@@ -26637,10 +26637,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -26654,12 +26654,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.3%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -27792,7 +27792,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">plos</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -27811,7 +27811,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -27828,12 +27828,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -28146,7 +28146,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="0.997"
                     data-fidelity="0.955"
-                    data-quality="0.933"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">proceedings-of-the-royal-society-b</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -28165,7 +28165,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -28182,12 +28182,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -28511,8 +28511,8 @@
                     data-bibliography-rate="0.45454545454545453"
                     data-component-rate="0.917"
                     data-fidelity="0.6"
-                    data-quality="0.896"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.942"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">royal-society-of-chemistry</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -28530,10 +28530,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">92%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">60.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.6%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.2%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -28547,12 +28547,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.6%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.2%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.7%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -29281,7 +29281,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.918"
+                    data-quality="0.933"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">spandidos-publications</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -29300,7 +29300,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.3%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -29317,12 +29317,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -29635,7 +29635,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="1"
                     data-fidelity="0.955"
-                    data-quality="0.929"
+                    data-quality="0.945"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">spie-journals</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -29654,7 +29654,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.5%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -29671,12 +29671,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.7%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -29989,8 +29989,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.886"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.901"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-basic-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">460</td>
@@ -30008,10 +30008,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.6%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.1%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -30025,12 +30025,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.6%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.1%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 93.4%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
                                 </div>
                             </div>
 
@@ -30697,8 +30697,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.889"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.919"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-fachzeitschriften-medizin-psychologie</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -30716,10 +30716,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.9%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -30733,12 +30733,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.9%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 81.8%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.9%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -31073,8 +31073,8 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="1"
                     data-fidelity="0.955"
-                    data-quality="0.885"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.93"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-humanities-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -31092,10 +31092,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.5%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.0%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -31109,12 +31109,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.5%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 93.0%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.9%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 60.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -31427,8 +31427,8 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="0.994"
                     data-fidelity="0.977"
-                    data-quality="0.885"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.915"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-mathphys-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -31446,10 +31446,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.5%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.5%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -31463,12 +31463,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.5%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 99.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 60.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
                                 </div>
                             </div>
 
@@ -31796,8 +31796,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.898"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.943"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-mathphys-brackets</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">201</td>
@@ -31815,10 +31815,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -31832,12 +31832,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.1%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -32150,8 +32150,8 @@
                     data-bibliography-rate="0.34375"
                     data-component-rate="0.856"
                     data-fidelity="0.523"
-                    data-quality="0.899"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.945"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-physics-brackets</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -32169,10 +32169,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-amber-100 text-amber-700">86%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">52.3%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.5%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -32186,12 +32186,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.9%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -32527,8 +32527,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.895"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.925"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-socpsych-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">317</td>
@@ -32546,10 +32546,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.5%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.5%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -32563,12 +32563,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.5%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.5%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.2%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -32881,8 +32881,8 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.899"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.943"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">springer-socpsych-brackets</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -32900,10 +32900,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.3%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -32917,12 +32917,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.3%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.4%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -33986,8 +33986,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.897"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.927"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">taylor-and-francis-chicago-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">234</td>
@@ -34005,10 +34005,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.7%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.7%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -34022,12 +34022,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.7%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.7%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.6%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -34332,8 +34332,8 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.882"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.912"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">taylor-and-francis-council-of-science-editors-author-date</td>
                     <td class="px-6 py-4 text-sm text-slate-600">unknown</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -34351,10 +34351,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">88.2%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">91.2%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -34368,12 +34368,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 88.2%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 91.2%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 97.8%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 60.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
                                 </div>
                             </div>
 
@@ -34686,8 +34686,8 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.899"
-                    data-sqi-tier-rank="3">
+                    data-quality="0.929"
+                    data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">taylor-and-francis-national-library-of-medicine</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
                     <td class="px-6 py-4 text-sm text-slate-600">—</td>
@@ -34705,10 +34705,10 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">89.9%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.9%</td>
                     <td class="px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                            B
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
+                            A
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right">
@@ -34722,12 +34722,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.9%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.9%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.5%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
                                 </div>
                             </div>
 
@@ -35806,7 +35806,7 @@
                     data-bibliography-rate="0.9375"
                     data-component-rate="0.997"
                     data-fidelity="0.955"
-                    data-quality="0.928"
+                    data-quality="0.944"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">the-optical-society</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -35825,7 +35825,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">95.5%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.4%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -35842,12 +35842,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.4%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.2%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.5%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -36171,7 +36171,7 @@
                     data-bibliography-rate="1"
                     data-component-rate="1"
                     data-fidelity="1"
-                    data-quality="0.903"
+                    data-quality="0.948"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">thieme-german</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -36190,7 +36190,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">90.3%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.8%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -36207,12 +36207,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 90.3%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.8%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 70.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 
@@ -36685,7 +36685,7 @@
                     data-bibliography-rate="0.96875"
                     data-component-rate="1"
                     data-fidelity="0.977"
-                    data-quality="0.928"
+                    data-quality="0.944"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">trends-journals</td>
                     <td class="px-6 py-4 text-sm text-slate-600">numeric</td>
@@ -36704,7 +36704,7 @@
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
                     </td>
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">97.7%</td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">92.8%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">94.4%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
                             A
@@ -36721,12 +36721,12 @@
                         <div class="max-w-4xl">
 
                             <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
-                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 92.8%</div>
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 94.4%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 85.0%</div>
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.3%</div>
-                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 90.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 98.6%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 100.0%</div>
                                 </div>
                             </div>
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -772,9 +772,11 @@ Structured: [@kuhn1962, section: 5].</pre>
   <span class="text-primary">titles</span>: <span class="text-emerald-400">apa</span>             <span class="text-slate-500"># Preset shorthand</span>
 
 <span class="text-slate-500"># Available presets:</span>
-<span class="text-slate-500">#   contributors: apa | chicago | harvard | springer | vancouver</span>
+<span class="text-slate-500">#   contributors: apa | chicago | harvard | ieee | springer | vancouver | numeric-compact | numeric-medium</span>
 <span class="text-slate-500">#   dates:        long | short | numeric | iso</span>
-<span class="text-slate-500">#   titles:       apa | chicago | humanities | ieee | scientific</span></pre>
+<span class="text-slate-500">#   titles:       apa | chicago | humanities | ieee | journal-emphasis | scientific</span>
+<span class="text-slate-500">#   substitute:   standard | editor-* | editor-translator-* | editor-title-* | editor-translator-title-*</span>
+<span class="text-slate-500">#   citation:     use-preset: numeric-citation</span></pre>
                 </div>
             </article>
 

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -459,6 +459,14 @@
                                 <div class="font-mono text-sm text-primary mb-2">springer</div>
                                 <p class="text-slate-600 text-xs">All family-first, no conjunction, compact initials, et al. after 3 of 5+. Example: "Smith JD, Jones MK, Brown AB"</p>
                             </div>
+                            <div class="bg-white border border-slate-200 rounded-lg p-4">
+                                <div class="font-mono text-sm text-primary mb-2">numeric-compact</div>
+                                <p class="text-slate-600 text-xs">All family-first, no conjunction, sort-only particle demotion, et al. after 6 of 7+.</p>
+                            </div>
+                            <div class="bg-white border border-slate-200 rounded-lg p-4">
+                                <div class="font-mono text-sm text-primary mb-2">numeric-medium</div>
+                                <p class="text-slate-600 text-xs">Same as numeric-compact, but et al. after 3 of 4+.</p>
+                            </div>
                         </div>
                     </div>
 
@@ -535,6 +543,11 @@
                                         <td class="px-4 py-3 text-slate-600">Italic (incl. series)</td>
                                     </tr>
                                     <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">journal-emphasis</td>
+                                        <td class="px-4 py-3 text-slate-600">Plain</td>
+                                        <td class="px-4 py-3 text-slate-600">Journal + serial italic, monograph plain</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
                                         <td class="px-4 py-3 font-mono text-primary">scientific</td>
                                         <td class="px-4 py-3 text-slate-600">Plain</td>
                                         <td class="px-4 py-3 text-slate-600">Plain</td>
@@ -569,8 +582,53 @@
                                         <td class="px-4 py-3 font-mono text-primary">title-first</td>
                                         <td class="px-4 py-3 text-slate-600">Title → Editor → Translator (anonymous works)</td>
                                     </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-short</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor only (short role form)</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-long</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor only (long role form)</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-translator-short</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor → Translator (short role form)</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-translator-long</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor → Translator (long role form)</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-title-short</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor → Title (short role form)</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-title-long</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor → Title (long role form)</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-translator-title-short</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor → Translator → Title (short role form)</td>
+                                    </tr>
+                                    <tr class="hover:bg-slate-50">
+                                        <td class="px-4 py-3 font-mono text-primary">editor-translator-title-long</td>
+                                        <td class="px-4 py-3 text-slate-600">Editor → Translator → Title (long role form)</td>
+                                    </tr>
                                 </tbody>
                             </table>
+                        </div>
+                    </div>
+
+                    <div class="mb-10">
+                        <h3 class="text-lg font-semibold text-slate-900 mb-4">Template Preset</h3>
+                        <div class="border border-slate-200 rounded-lg p-4 bg-white">
+                            <p class="text-slate-600 text-sm mb-2">
+                                Use <code class="font-mono text-xs">citation.use-preset: numeric-citation</code>
+                                when the citation template is only a citation number and wrapping is controlled by style options.
+                            </p>
+                            <pre class="font-mono text-xs text-slate-700 bg-slate-50 rounded p-3 overflow-x-auto">citation:
+  use-preset: numeric-citation
+  wrap: brackets</pre>
                         </div>
                     </div>
 

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -29,6 +29,35 @@ Fidelity is the hard gate. SQI helps choose between equally correct solutions.
 5. Improve SQI only when output stays unchanged.
 6. Re-run checks before finishing.
 
+## Preset Catalog
+
+Use presets first, then override only what is style-specific.
+
+Option presets:
+
+- `contributors`: `apa`, `chicago`, `vancouver`, `ieee`, `harvard`, `springer`, `numeric-compact`, `numeric-medium`
+- `dates`: `long`, `short`, `numeric`, `iso`
+- `titles`: `apa`, `chicago`, `ieee`, `humanities`, `journal-emphasis`, `scientific`
+- `substitute`: `standard`, `editor-first`, `title-first`, `editor-short`, `editor-long`, `editor-translator-short`, `editor-translator-long`, `editor-title-short`, `editor-title-long`, `editor-translator-title-short`, `editor-translator-title-long`
+
+Template presets:
+
+- `citation.use-preset: numeric-citation` for numeric styles that render citation numbers via style-level wrapping (`[1]`, `(1)`, or superscript contexts).
+
+Example:
+
+```yaml
+options:
+  contributors: numeric-compact
+  dates: long
+  titles: humanities
+  substitute: editor-translator-title-short
+
+citation:
+  use-preset: numeric-citation
+  wrap: brackets
+```
+
 ## Verification Commands
 
 Run from repository root:

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
                     href="examples.html">Examples</a>
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="guides/style-author-guide.html">Style Guide</a>
+                    href="guides/style-author-guide.html">Style Author Guide</a>
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
                     href="compat.html">Compat</a>
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -867,6 +867,20 @@
           "enum": [
             "springer"
           ]
+        },
+        {
+          "description": "Numeric compact author list for journal-heavy corpora: all family-first, no conjunction, sort-only particle demotion, space sort-separator, et al. after 6 of 7+.",
+          "type": "string",
+          "enum": [
+            "numeric-compact"
+          ]
+        },
+        {
+          "description": "Numeric medium author list variant: same as `numeric-compact`, but et al. after 3 of 4+.",
+          "type": "string",
+          "enum": [
+            "numeric-medium"
+          ]
         }
       ]
     },
@@ -1344,6 +1358,64 @@
         }
       }
     },
+    "LabelConfig": {
+      "description": "Configuration for label citation mode.",
+      "type": "object",
+      "properties": {
+        "et-al-marker": {
+          "description": "Suffix appended when truncated. Alpha/Ams default: \"+\", Din default: \"\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "et-al-min": {
+          "description": "Max authors before truncation. Alpha/Ams default: 4, Din default: 3.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "multi-author-chars": {
+          "description": "Chars per author family name when 2+ authors. Preset default: 1.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "preset": {
+          "description": "Preset that determines default parameters.",
+          "default": "alpha",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LabelPreset"
+            }
+          ]
+        },
+        "single-author-chars": {
+          "description": "Chars taken from single author's family name. Preset default: 3 (Alpha/Ams), 4 (Din).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "year-digits": {
+          "description": "Year digits: 2 or 4. Preset default: 2.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        }
+      }
+    },
     "LabelForm": {
       "description": "Label rendering forms.",
       "type": "string",
@@ -1359,6 +1431,32 @@
       "enum": [
         "prefix",
         "suffix"
+      ]
+    },
+    "LabelPreset": {
+      "description": "Label style preset conventions.",
+      "oneOf": [
+        {
+          "description": "biblatex alphabetic / BibTeX alpha.bst: up to 4 authors, \"+\" marker, 2-digit year.",
+          "type": "string",
+          "enum": [
+            "alpha"
+          ]
+        },
+        {
+          "description": "DIN 1505-2: up to 3 authors, no et-al marker, 2-digit year.",
+          "type": "string",
+          "enum": [
+            "din"
+          ]
+        },
+        {
+          "description": "American Mathematical Society: same algorithm as Alpha, sorted by citation-number.",
+          "type": "string",
+          "enum": [
+            "ams"
+          ]
+        }
       ]
     },
     "LinkAnchor": {
@@ -1610,6 +1708,7 @@
         "number-of-pages",
         "number-of-volumes",
         "citation-number",
+        "citation-label",
         "number",
         "docket-number",
         "patent-number",
@@ -1658,7 +1757,7 @@
       ]
     },
     "Processing": {
-      "description": "Processing mode for citation/bibliography generation.",
+      "description": "Processing mode for citation/bibliography generation.\n\nCan be specified as: - A string: \"author-date\", \"numeric\", \"note\", or \"label\" - A label config map: { label: { preset: din } } - A custom config map: { sort: ..., group: ..., disambiguate: ... }",
       "oneOf": [
         {
           "type": "string",
@@ -1667,6 +1766,18 @@
             "numeric",
             "note"
           ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "label"
+          ],
+          "properties": {
+            "label": {
+              "$ref": "#/definitions/LabelConfig"
+            }
+          },
+          "additionalProperties": false
         },
         {
           "type": "object",
@@ -2311,6 +2422,62 @@
           "type": "string",
           "enum": [
             "title-first"
+          ]
+        },
+        {
+          "description": "Editor only with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-short"
+          ]
+        },
+        {
+          "description": "Editor only with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-long"
+          ]
+        },
+        {
+          "description": "Editor then translator with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-short"
+          ]
+        },
+        {
+          "description": "Editor then translator with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-long"
+          ]
+        },
+        {
+          "description": "Editor then title with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-title-short"
+          ]
+        },
+        {
+          "description": "Editor then title with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-title-long"
+          ]
+        },
+        {
+          "description": "Editor then translator then title with short role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-title-short"
+          ]
+        },
+        {
+          "description": "Editor then translator then title with long role labels.",
+          "type": "string",
+          "enum": [
+            "editor-translator-title-long"
           ]
         }
       ]
@@ -3006,6 +3173,13 @@
           "enum": [
             "harvard"
           ]
+        },
+        {
+          "description": "Numeric citation number only (citation-focused preset)",
+          "type": "string",
+          "enum": [
+            "numeric-citation"
+          ]
         }
       ]
     },
@@ -3476,6 +3650,13 @@
           "type": "string",
           "enum": [
             "humanities"
+          ]
+        },
+        {
+          "description": "Journal-focused emphasis: periodicals and serials italic, monographs plain.",
+          "type": "string",
+          "enum": [
+            "journal-emphasis"
           ]
         },
         {

--- a/styles/african-online-scientific-information-systems-vancouver.yaml
+++ b/styles/african-online-scientific-information-systems-vancouver.yaml
@@ -31,8 +31,7 @@ options:
   bibliography:
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/aims-press.yaml
+++ b/styles/aims-press.yaml
@@ -14,12 +14,7 @@ info:
   id: http://www.zotero.org/styles/aims-press
   default-locale: en-GB
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-short
   processing: numeric
   contributors: numeric-medium
   dates: long
@@ -29,8 +24,7 @@ options:
     entry-suffix: .
     separator: ", "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/american-association-for-cancer-research.yaml
+++ b/styles/american-association-for-cancer-research.yaml
@@ -24,8 +24,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/american-chemical-society.yaml
+++ b/styles/american-chemical-society.yaml
@@ -22,26 +22,15 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   page-range-format: expanded
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/american-institute-of-aeronautics-and-astronautics.yaml
+++ b/styles/american-institute-of-aeronautics-and-astronautics.yaml
@@ -28,8 +28,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/american-institute-of-physics.yaml
+++ b/styles/american-institute-of-physics.yaml
@@ -27,8 +27,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/american-medical-association.yaml
+++ b/styles/american-medical-association.yaml
@@ -15,10 +15,7 @@ info:
   id: http://www.zotero.org/styles/american-medical-association
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   processing: numeric
   contributors:
     initialize-with: ""

--- a/styles/american-meteorological-society.yaml
+++ b/styles/american-meteorological-society.yaml
@@ -14,12 +14,7 @@ info:
   id: http://www.zotero.org/styles/american-meteorological-society
   default-locale: en-GB
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-short
   contributors:
     display-as-sort: first
     initialize-with: ". "

--- a/styles/american-physics-society.yaml
+++ b/styles/american-physics-society.yaml
@@ -27,8 +27,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   prefix: "\_["
   suffix: "]"
   multi-cite-delimiter: ","

--- a/styles/american-physiological-society.yaml
+++ b/styles/american-physiological-society.yaml
@@ -30,8 +30,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/american-society-for-microbiology.yaml
+++ b/styles/american-society-for-microbiology.yaml
@@ -29,8 +29,7 @@ options:
   punctuation-in-quote: true
   volume-pages-delimiter: colon
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/american-society-of-civil-engineers.yaml
+++ b/styles/american-society-of-civil-engineers.yaml
@@ -25,10 +25,7 @@ options:
       names: false
       add-givenname: false
       year-suffix: true
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   contributors:
     display-as-sort: first
     initialize-with: ". "
@@ -40,18 +37,8 @@ options:
     delimiter: ", "
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     hanging-indent: true
     entry-suffix: .

--- a/styles/american-society-of-mechanical-engineers.yaml
+++ b/styles/american-society-of-mechanical-engineers.yaml
@@ -30,8 +30,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/annual-reviews-alphabetical.yaml
+++ b/styles/annual-reviews-alphabetical.yaml
@@ -34,8 +34,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/annual-reviews.yaml
+++ b/styles/annual-reviews.yaml
@@ -34,8 +34,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/association-for-computing-machinery.yaml
+++ b/styles/association-for-computing-machinery.yaml
@@ -14,27 +14,14 @@ info:
   id: http://www.zotero.org/styles/association-for-computing-machinery
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   processing: numeric
   contributors:
     delimiter: ", "
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     separator: ". "
   punctuation-in-quote: true

--- a/styles/baishideng-publishing-group.yaml
+++ b/styles/baishideng-publishing-group.yaml
@@ -14,10 +14,7 @@ info:
   id: http://www.zotero.org/styles/baishideng-publishing-group
   default-locale: en-GB
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   processing: numeric
   contributors:
     display-as-sort: all
@@ -31,21 +28,12 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: journal-emphasis
   bibliography:
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/begell-house-chicago-author-date.yaml
+++ b/styles/begell-house-chicago-author-date.yaml
@@ -41,18 +41,8 @@ options:
     delimiter-precedes-last: never
     demote-non-dropping-particle: display-and-sort
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   page-range-format: chicago
   bibliography:
     hanging-indent: true

--- a/styles/biomed-central.yaml
+++ b/styles/biomed-central.yaml
@@ -18,31 +18,15 @@ options:
     template:
       - editor
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 7
-      use-first: 6
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
-  dates:
-    month: numeric
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  contributors: numeric-compact
+  dates: numeric
   page-range-format: minimal
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/bmj.yaml
+++ b/styles/bmj.yaml
@@ -14,10 +14,7 @@ info:
   id: http://www.zotero.org/styles/bmj
   default-locale: en-GB
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
+  substitute: editor-long
   processing: numeric
   contributors:
     display-as-sort: all
@@ -31,24 +28,13 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   page-range-format: minimal
   bibliography:
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/cell.yaml
+++ b/styles/cell.yaml
@@ -14,11 +14,7 @@ info:
   id: http://www.zotero.org/styles/cell
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - title
+  substitute: editor-title-short
   processing: numeric
   contributors:
     display-as-sort: all
@@ -32,19 +28,14 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: long
   page-range-format: expanded
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/chicago-shortened-notes-bibliography.yaml
+++ b/styles/chicago-shortened-notes-bibliography.yaml
@@ -21,18 +21,8 @@ options:
       and-others: et-al
       delimiter-precedes-last: contextual
     demote-non-dropping-particle: display-and-sort
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   page-range-format: chicago16
   bibliography:
     hanging-indent: true

--- a/styles/copernicus-publications.yaml
+++ b/styles/copernicus-publications.yaml
@@ -25,10 +25,7 @@ options:
       names: false
       add-givenname: false
       year-suffix: true
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   contributors:
     display-as-sort: all
     initialize-with: ". "
@@ -39,11 +36,7 @@ options:
       delimiter-precedes-last: contextual
     delimiter: ", "
     demote-non-dropping-particle: sort-only
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: long
   bibliography:
     entry-suffix: .
     separator: ", "

--- a/styles/cse-name-year.yaml
+++ b/styles/cse-name-year.yaml
@@ -14,12 +14,7 @@ info:
   id: http://www.zotero.org/styles/cse-name-year
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-long
   contributors:
     display-as-sort: all
     initialize-with: ""

--- a/styles/current-opinion.yaml
+++ b/styles/current-opinion.yaml
@@ -35,8 +35,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/elsevier-vancouver-author-date.yaml
+++ b/styles/elsevier-vancouver-author-date.yaml
@@ -14,12 +14,7 @@ info:
   id: http://www.zotero.org/styles/elsevier-vancouver-author-date
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-long
   contributors: numeric-compact
   dates: long
   page-range-format: minimal

--- a/styles/elsevier-vancouver.yaml
+++ b/styles/elsevier-vancouver.yaml
@@ -31,8 +31,7 @@ options:
   punctuation-in-quote: true
 
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ','
   delimiter: ''

--- a/styles/elsevier-without-titles.yaml
+++ b/styles/elsevier-without-titles.yaml
@@ -27,8 +27,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/entomological-society-of-america.yaml
+++ b/styles/entomological-society-of-america.yaml
@@ -14,12 +14,7 @@ info:
   id: http://www.zotero.org/styles/entomological-society-of-america
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-long
   contributors: numeric-medium
   dates: numeric
   bibliography:

--- a/styles/frontiers-medical-journals.yaml
+++ b/styles/frontiers-medical-journals.yaml
@@ -14,11 +14,7 @@ info:
   id: http://www.zotero.org/styles/frontiers-medical-journals
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - title
+  substitute: editor-title-short
   processing: numeric
   contributors:
     display-as-sort: all
@@ -37,8 +33,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/frontiers.yaml
+++ b/styles/frontiers.yaml
@@ -25,11 +25,7 @@ options:
       names: false
       add-givenname: false
       year-suffix: true
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - title
+  substitute: editor-title-short
   contributors:
     display-as-sort: all
     initialize-with: ". "
@@ -42,18 +38,8 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: never
     sort-separator: ", "
-  dates:
-    month: numeric
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: numeric
+  titles: humanities
   bibliography:
     hanging-indent: true
     separator: ". "

--- a/styles/future-medicine.yaml
+++ b/styles/future-medicine.yaml
@@ -33,8 +33,7 @@ options:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/future-science-group.yaml
+++ b/styles/future-science-group.yaml
@@ -35,8 +35,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/hainan-medical-university-journal-publisher.yaml
+++ b/styles/hainan-medical-university-journal-publisher.yaml
@@ -34,8 +34,7 @@ options:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/ieee.yaml
+++ b/styles/ieee.yaml
@@ -13,27 +13,13 @@ info:
   title: IEEE Reference Guide version 11.29.2023
   id: http://www.zotero.org/styles/ieee
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
+  substitute: editor-translator-short
   processing: numeric
   contributors:
     initialize-with: ". "
     demote-non-dropping-particle: sort-only
-  dates:
-    month: short
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: short
+  titles: humanities
   bibliography:
     separator: ", "
   punctuation-in-quote: true

--- a/styles/institute-of-physics-numeric.yaml
+++ b/styles/institute-of-physics-numeric.yaml
@@ -30,25 +30,14 @@ options:
     delimiter-precedes-last: never
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   page-range-format: minimal
   bibliography:
     separator: " "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/integrated-science-publishing-journals.yaml
+++ b/styles/integrated-science-publishing-journals.yaml
@@ -32,8 +32,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/inter-research-science-center.yaml
+++ b/styles/inter-research-science-center.yaml
@@ -14,12 +14,7 @@ info:
   id: http://www.zotero.org/styles/inter-research-science-center
   default-locale: en-GB
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-short
   contributors:
     display-as-sort: all
     initialize-with: ""

--- a/styles/international-journal-of-wildland-fire.yaml
+++ b/styles/international-journal-of-wildland-fire.yaml
@@ -14,12 +14,7 @@ info:
   id: http://www.zotero.org/styles/international-journal-of-wildland-fire
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-short
   processing:
     sort:
       shorten-names: false

--- a/styles/karger-journals-author-date.yaml
+++ b/styles/karger-journals-author-date.yaml
@@ -14,11 +14,7 @@ info:
   id: http://www.zotero.org/styles/karger-journals-author-date
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
-      - title
+  substitute: editor-title-long
   contributors: numeric-compact
   dates: short
   bibliography:

--- a/styles/karger-journals.yaml
+++ b/styles/karger-journals.yaml
@@ -18,31 +18,15 @@ options:
     template:
       - editor
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 7
-      use-first: 6
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
-  dates:
-    month: short
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  contributors: numeric-compact
+  dates: short
   page-range-format: minimal
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/landes-bioscience-journals.yaml
+++ b/styles/landes-bioscience-journals.yaml
@@ -14,10 +14,7 @@ info:
   id: http://www.zotero.org/styles/landes-bioscience-journals
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
+  substitute: editor-long
   processing: numeric
   contributors:
     display-as-sort: all
@@ -31,19 +28,14 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: short
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: short
   page-range-format: minimal
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/mary-ann-liebert-vancouver.yaml
+++ b/styles/mary-ann-liebert-vancouver.yaml
@@ -14,10 +14,7 @@ info:
   id: http://www.zotero.org/styles/mary-ann-liebert-vancouver
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   processing: numeric
   contributors:
     display-as-sort: all
@@ -30,18 +27,13 @@ options:
     delimiter-precedes-last: never
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: numeric
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: numeric
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/medicina-clinica.yaml
+++ b/styles/medicina-clinica.yaml
@@ -23,8 +23,7 @@ options:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/medicine-publishing.yaml
+++ b/styles/medicine-publishing.yaml
@@ -35,8 +35,7 @@ options:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/multidisciplinary-digital-publishing-institute.yaml
+++ b/styles/multidisciplinary-digital-publishing-institute.yaml
@@ -22,26 +22,15 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   page-range-format: expanded
   bibliography:
     entry-suffix: .
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/nature-publishing-group-vancouver.yaml
+++ b/styles/nature-publishing-group-vancouver.yaml
@@ -35,8 +35,7 @@ options:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/nature.yaml
+++ b/styles/nature.yaml
@@ -27,24 +27,13 @@ options:
     delimiter-precedes-last: never
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/nlm-citation-sequence-brackets.yaml
+++ b/styles/nlm-citation-sequence-brackets.yaml
@@ -23,8 +23,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/nlm-citation-sequence-superscript-brackets-year-only.yaml
+++ b/styles/nlm-citation-sequence-superscript-brackets-year-only.yaml
@@ -23,8 +23,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/nlm-citation-sequence-superscript.yaml
+++ b/styles/nlm-citation-sequence-superscript.yaml
@@ -13,36 +13,17 @@ info:
   title: "NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence, superscript)"
   id: http://www.zotero.org/styles/nlm-citation-sequence-superscript
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
+  substitute: editor-long
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 7
-      use-first: 6
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  contributors: numeric-compact
+  dates: long
   page-range-format: minimal
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/nlm-citation-sequence.yaml
+++ b/styles/nlm-citation-sequence.yaml
@@ -13,36 +13,17 @@ info:
   title: "NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence)"
   id: http://www.zotero.org/styles/nlm-citation-sequence
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
+  substitute: editor-long
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 7
-      use-first: 6
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  contributors: numeric-compact
+  dates: long
   page-range-format: minimal
   bibliography:
     entry-suffix: .
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/plos.yaml
+++ b/styles/plos.yaml
@@ -22,8 +22,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/proceedings-of-the-royal-society-b.yaml
+++ b/styles/proceedings-of-the-royal-society-b.yaml
@@ -34,8 +34,7 @@ options:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/royal-society-of-chemistry.yaml
+++ b/styles/royal-society-of-chemistry.yaml
@@ -14,34 +14,20 @@ info:
   id: http://www.zotero.org/styles/royal-society-of-chemistry
   default-locale: en-GB
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   processing: numeric
   contributors:
     initialize-with: ". "
     delimiter: ", "
     delimiter-precedes-last: never
     demote-non-dropping-particle: sort-only
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     entry-suffix: .
     separator: ", "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/sage-vancouver.yaml
+++ b/styles/sage-vancouver.yaml
@@ -23,8 +23,7 @@ options:
     entry-suffix: .
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/spandidos-publications.yaml
+++ b/styles/spandidos-publications.yaml
@@ -36,8 +36,7 @@ options:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: parentheses
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/spie-journals.yaml
+++ b/styles/spie-journals.yaml
@@ -35,8 +35,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   multi-cite-delimiter: ","
 bibliography:
   options:

--- a/styles/springer-basic-author-date.yaml
+++ b/styles/springer-basic-author-date.yaml
@@ -17,11 +17,7 @@ options:
       add-givenname: false
       year-suffix: true
   strip-periods: true
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
+  substitute: editor-translator-short
   contributors:
     display-as-sort: all
     initialize-with: ""

--- a/styles/springer-fachzeitschriften-medizin-psychologie.yaml
+++ b/styles/springer-fachzeitschriften-medizin-psychologie.yaml
@@ -31,16 +31,11 @@ options:
     delimiter-precedes-et-al: never
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: long
   bibliography:
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/springer-humanities-author-date.yaml
+++ b/styles/springer-humanities-author-date.yaml
@@ -25,11 +25,7 @@ options:
       names: false
       add-givenname: false
       year-suffix: true
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
+  substitute: editor-translator-short
   contributors:
     display-as-sort: first
     initialize-with: ". "
@@ -42,18 +38,8 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     hanging-indent: true
     entry-suffix: .

--- a/styles/springer-mathphys-author-date.yaml
+++ b/styles/springer-mathphys-author-date.yaml
@@ -24,10 +24,7 @@ options:
       names: false
       add-givenname: false
       year-suffix: true
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   contributors:
     display-as-sort: all
     initialize-with: .
@@ -40,11 +37,7 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: long
   bibliography:
     separator: ". "
   punctuation-in-quote: true

--- a/styles/springer-mathphys-brackets.yaml
+++ b/styles/springer-mathphys-brackets.yaml
@@ -13,10 +13,7 @@ info:
   title: Springer - MathPhys (numeric, brackets)
   id: http://www.zotero.org/styles/springer-mathphys-brackets
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
+  substitute: editor-short
   processing: numeric
   contributors:
     display-as-sort: all
@@ -25,17 +22,12 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: long
   bibliography:
     separator: ". "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/springer-physics-brackets.yaml
+++ b/styles/springer-physics-brackets.yaml
@@ -14,35 +14,20 @@ info:
   id: http://www.zotero.org/styles/springer-physics-brackets
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
-      - translator
+  substitute: editor-translator-long
   processing: numeric
   contributors:
     initialize-with: ". "
     delimiter: ", "
     demote-non-dropping-particle: sort-only
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     entry-suffix: .
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/springer-socpsych-author-date.yaml
+++ b/styles/springer-socpsych-author-date.yaml
@@ -28,18 +28,8 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: never
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     hanging-indent: true
     separator: ": "

--- a/styles/springer-socpsych-brackets.yaml
+++ b/styles/springer-socpsych-brackets.yaml
@@ -33,25 +33,14 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: never
     sort-separator: ", "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   bibliography:
     separator: ". "
   punctuation-in-quote: true
   volume-pages-delimiter: comma
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ", "
 bibliography:

--- a/styles/taylor-and-francis-chicago-author-date.yaml
+++ b/styles/taylor-and-francis-chicago-author-date.yaml
@@ -19,18 +19,8 @@ options:
     and: text
     display-as-sort: first
     demote-non-dropping-particle: display-and-sort
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
-  titles:
-    monograph:
-      emph: true
-    periodical:
-      emph: true
-    serial:
-      emph: true
+  dates: long
+  titles: humanities
   page-range-format: expanded
   bibliography:
     hanging-indent: true

--- a/styles/taylor-and-francis-council-of-science-editors-author-date.yaml
+++ b/styles/taylor-and-francis-council-of-science-editors-author-date.yaml
@@ -25,12 +25,7 @@ options:
       names: false
       add-givenname: false
       year-suffix: true
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
-      - translator
-      - title
+  substitute: editor-translator-title-long
   contributors:
     display-as-sort: all
     initialize-with: ""
@@ -43,11 +38,7 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: short
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: short
   bibliography:
     hanging-indent: false
     separator: ". "

--- a/styles/taylor-and-francis-national-library-of-medicine.yaml
+++ b/styles/taylor-and-francis-national-library-of-medicine.yaml
@@ -14,10 +14,7 @@ info:
   id: http://www.zotero.org/styles/taylor-and-francis-national-library-of-medicine
   default-locale: en-US
 options:
-  substitute:
-    contributor-role-form: long
-    template:
-      - editor
+  substitute: editor-long
   processing: numeric
   contributors:
     display-as-sort: all
@@ -31,11 +28,7 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: long
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: long
   page-range-format: expanded
   bibliography:
     entry-suffix: .

--- a/styles/the-optical-society.yaml
+++ b/styles/the-optical-society.yaml
@@ -27,8 +27,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   prefix: "\_["
   suffix: "]"
   multi-cite-delimiter: ","

--- a/styles/thieme-german.yaml
+++ b/styles/thieme-german.yaml
@@ -14,11 +14,7 @@ info:
   id: http://www.zotero.org/styles/thieme-german
   default-locale: de-DE
 options:
-  substitute:
-    contributor-role-form: short
-    template:
-      - editor
-      - translator
+  substitute: editor-translator-short
   processing: numeric
   contributors:
     display-as-sort: all
@@ -31,17 +27,12 @@ options:
     delimiter-precedes-last: always
     demote-non-dropping-particle: sort-only
     sort-separator: " "
-  dates:
-    month: numeric
-    uncertainty-marker: "?"
-    approximation-marker: "ca. "
-    range-delimiter: –
+  dates: numeric
   page-range-format: expanded
   bibliography:
     separator: ". "
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:

--- a/styles/trends-journals.yaml
+++ b/styles/trends-journals.yaml
@@ -33,8 +33,7 @@ options:
     separator: ", "
   punctuation-in-quote: true
 citation:
-  template:
-    - number: citation-number
+  use-preset: numeric-citation
   wrap: brackets
   multi-cite-delimiter: ","
 bibliography:


### PR DESCRIPTION
## Summary
- add new core presets for substitution and numeric citation templates
- extract repeated preset patterns across the 100-style portfolio
- update style docs (guide + examples + index label) and regenerate compat/schema artifacts

## Presets Added
- substitute: editor-title-short, editor-title-long
- substitute: editor-translator-title-short, editor-translator-title-long
- template: numeric-citation

## Style/Application Scope
- applied deterministic preset rewrites across core styles where structure matched exactly
- introduced `citation.use-preset: numeric-citation` for numeric styles with citation-number-only templates

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- node scripts/report-core.js

## Results (100 styles)
- SQI improved in 70 styles, regressed in 0
- median SQI: 89.95 -> 93.3
- mean SQI: 89.99 -> 91.86
- preset usage mean: 80.1 -> 92.5
- fidelity regressions: none
