### PR TITLE
feat: Implement declarative macros

### DIFF
--- a/crates/csln_core/src/embedded/apa.rs
+++ b/crates/csln_core/src/embedded/apa.rs
@@ -3,10 +3,9 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-use crate::template::{
-    ContributorForm, ContributorRole, DateForm, DateVariable, NumberVariable, Rendering,
-    SimpleVariable, TemplateComponent, TemplateContributor, TemplateDate, TemplateNumber,
-    TemplateTitle, TemplateVariable, TitleType, WrapPunctuation,
+use crate::{
+    tc_contributor, tc_date, tc_number, tc_title, tc_variable,
+    template::{TemplateComponent, WrapPunctuation},
 };
 
 /// Embedded citation template for APA style.
@@ -14,18 +13,7 @@ use crate::template::{
 /// Renders as: (Author, Year)
 /// Example: (Smith & Jones, 2024)
 pub fn citation() -> Vec<TemplateComponent> {
-    vec![
-        TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
-            form: ContributorForm::Short,
-            ..Default::default()
-        }),
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            ..Default::default()
-        }),
-    ]
+    vec![tc_contributor!(Author, Short), tc_date!(Issued, Year)]
 }
 
 /// Embedded bibliography template for APA style.
@@ -35,107 +23,29 @@ pub fn citation() -> Vec<TemplateComponent> {
 pub fn bibliography() -> Vec<TemplateComponent> {
     vec![
         // Author
-        TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
-            form: ContributorForm::Long,
-            rendering: Rendering {
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_contributor!(Author, Long, suffix = " "),
         // (Year).
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Parentheses),
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_date!(
+            Issued,
+            Year,
+            wrap = WrapPunctuation::Parentheses,
+            suffix = ". "
+        ),
         // Title (primary) - italicized for monographs, plain for articles
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::Primary,
-            form: None,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(Primary, suffix = ". "),
         // Container title (journal) - italicized
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::ParentSerial,
-            form: None,
-            rendering: Rendering {
-                emph: Some(true),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(ParentSerial, emph = true, suffix = ", "),
         // Container title (book) - italicized, with "In " prefix
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::ParentMonograph,
-            form: None,
-            rendering: Rendering {
-                prefix: Some("In ".to_string()),
-                emph: Some(true),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(ParentMonograph, prefix = "In ", emph = true, suffix = ", "),
         // Volume - italicized
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Volume,
-            form: None,
-            rendering: Rendering {
-                emph: Some(true),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Volume, emph = true),
         // (Issue)
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Issue,
-            form: None,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Parentheses),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Issue, wrap = WrapPunctuation::Parentheses, suffix = ", "),
         // Pages
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Pages,
-            form: None,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Pages, suffix = ". "),
         // Publisher
-        TemplateComponent::Variable(TemplateVariable {
-            variable: SimpleVariable::Publisher,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_variable!(Publisher, suffix = ". "),
         // DOI
-        TemplateComponent::Variable(TemplateVariable {
-            variable: SimpleVariable::Doi,
-            rendering: Rendering {
-                prefix: Some("https://doi.org/".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_variable!(Doi, prefix = "https://doi.org/"),
     ]
 }

--- a/crates/csln_core/src/embedded/chicago.rs
+++ b/crates/csln_core/src/embedded/chicago.rs
@@ -4,10 +4,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
 use crate::options::AndOptions;
-use crate::template::{
-    ContributorForm, ContributorRole, DateForm, DateVariable, NumberVariable, Rendering,
-    SimpleVariable, TemplateComponent, TemplateContributor, TemplateDate, TemplateNumber,
-    TemplateTitle, TemplateVariable, TitleType, WrapPunctuation,
+use crate::{
+    tc_contributor, tc_date, tc_number, tc_title, tc_variable,
+    template::{
+        ContributorForm, ContributorRole, TemplateComponent, TemplateContributor, WrapPunctuation,
+    },
 };
 
 /// Embedded citation template for Chicago author-date style.
@@ -22,15 +23,7 @@ pub fn author_date_citation() -> Vec<TemplateComponent> {
             and: Some(AndOptions::Text),
             ..Default::default()
         }),
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                prefix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_date!(Issued, Year, prefix = " "),
     ]
 }
 
@@ -41,83 +34,20 @@ pub fn author_date_citation() -> Vec<TemplateComponent> {
 pub fn author_date_bibliography() -> Vec<TemplateComponent> {
     vec![
         // Author
-        TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
-            form: ContributorForm::Long,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_contributor!(Author, Long, suffix = ". "),
         // Year.
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_date!(Issued, Year, suffix = ". "),
         // "Title" - quoted for articles
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::Primary,
-            form: None,
-            rendering: Rendering {
-                quote: Some(true),
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(Primary, quote = true, suffix = " "),
         // Journal Title - italicized
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::ParentSerial,
-            form: None,
-            rendering: Rendering {
-                emph: Some(true),
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(ParentSerial, emph = true, suffix = " "),
         // Volume
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Volume,
-            form: None,
-            rendering: Rendering::default(),
-            ..Default::default()
-        }),
+        tc_number!(Volume),
         // (Issue)
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Issue,
-            form: None,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Parentheses),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Issue, wrap = WrapPunctuation::Parentheses),
         // : Pages
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Pages,
-            form: None,
-            rendering: Rendering {
-                prefix: Some(": ".to_string()),
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Pages, prefix = ": ", suffix = ". "),
         // DOI
-        TemplateComponent::Variable(TemplateVariable {
-            variable: SimpleVariable::Doi,
-            rendering: Rendering {
-                prefix: Some("https://doi.org/".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_variable!(Doi, prefix = "https://doi.org/"),
     ]
 }

--- a/crates/csln_core/src/embedded/harvard.rs
+++ b/crates/csln_core/src/embedded/harvard.rs
@@ -4,10 +4,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
 use crate::options::AndOptions;
-use crate::template::{
-    ContributorForm, ContributorRole, DateForm, DateVariable, NumberVariable, Rendering,
-    TemplateComponent, TemplateContributor, TemplateDate, TemplateNumber, TemplateTitle, TitleType,
-    WrapPunctuation,
+use crate::{
+    tc_contributor, tc_date, tc_number, tc_title,
+    template::{
+        ContributorForm, ContributorRole, TemplateComponent, TemplateContributor, WrapPunctuation,
+    },
 };
 
 /// Embedded citation template for Harvard style.
@@ -22,15 +23,7 @@ pub fn citation() -> Vec<TemplateComponent> {
             and: Some(AndOptions::Text),
             ..Default::default()
         }),
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                prefix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_date!(Issued, Year, prefix = " "),
     ]
 }
 
@@ -40,73 +33,22 @@ pub fn citation() -> Vec<TemplateComponent> {
 pub fn bibliography() -> Vec<TemplateComponent> {
     vec![
         // Author
-        TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
-            form: ContributorForm::Long,
-            rendering: Rendering {
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_contributor!(Author, Long, suffix = " "),
         // (Year)
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Parentheses),
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_date!(
+            Issued,
+            Year,
+            wrap = WrapPunctuation::Parentheses,
+            suffix = " "
+        ),
         // Title.
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::Primary,
-            form: None,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(Primary, suffix = ". "),
         // *Journal*
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::ParentSerial,
-            form: None,
-            rendering: Rendering {
-                emph: Some(true),
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(ParentSerial, emph = true, suffix = " "),
         // Volume(Issue),
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Volume,
-            form: None,
-            rendering: Rendering::default(),
-            ..Default::default()
-        }),
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Issue,
-            form: None,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Parentheses),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Volume),
+        tc_number!(Issue, wrap = WrapPunctuation::Parentheses, suffix = ", "),
         // Pages.
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Pages,
-            form: None,
-            rendering: Rendering {
-                suffix: Some(".".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Pages, suffix = "."),
     ]
 }

--- a/crates/csln_core/src/embedded/ieee.rs
+++ b/crates/csln_core/src/embedded/ieee.rs
@@ -4,25 +4,18 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
 use crate::options::AndOptions;
-use crate::template::{
-    ContributorForm, ContributorRole, DateForm, DateVariable, NumberVariable, Rendering,
-    TemplateComponent, TemplateContributor, TemplateDate, TemplateNumber, TemplateTitle, TitleType,
-    WrapPunctuation,
+use crate::{
+    tc_date, tc_number, tc_title,
+    template::{
+        ContributorForm, ContributorRole, TemplateComponent, TemplateContributor, WrapPunctuation,
+    },
 };
 
 /// Embedded citation template for IEEE style.
 ///
 /// Renders as: [1]
 pub fn citation() -> Vec<TemplateComponent> {
-    vec![TemplateComponent::Number(TemplateNumber {
-        number: NumberVariable::CitationNumber,
-        form: None,
-        rendering: Rendering {
-            wrap: Some(WrapPunctuation::Brackets),
-            ..Default::default()
-        },
-        ..Default::default()
-    })]
+    vec![tc_number!(CitationNumber, wrap = WrapPunctuation::Brackets)]
 }
 
 /// Embedded bibliography template for IEEE style.
@@ -31,91 +24,33 @@ pub fn citation() -> Vec<TemplateComponent> {
 pub fn bibliography() -> Vec<TemplateComponent> {
     vec![
         // [Citation number]
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::CitationNumber,
-            form: None,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Brackets),
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(
+            CitationNumber,
+            wrap = WrapPunctuation::Brackets,
+            suffix = " "
+        ),
         // Author
         TemplateComponent::Contributor(TemplateContributor {
             contributor: ContributorRole::Author,
             form: ContributorForm::Long,
             and: Some(AndOptions::Text),
-            rendering: Rendering {
+            rendering: crate::template::Rendering {
                 suffix: Some(", ".to_string()),
                 ..Default::default()
             },
             ..Default::default()
         }),
         // "Title,"
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::Primary,
-            form: None,
-            rendering: Rendering {
-                quote: Some(true),
-                suffix: Some(" ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(Primary, quote = true, suffix = " "),
         // *Journal*,
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::ParentSerial,
-            form: None,
-            rendering: Rendering {
-                emph: Some(true),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(ParentSerial, emph = true, suffix = ", "),
         // vol. X,
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Volume,
-            form: None,
-            rendering: Rendering {
-                prefix: Some("vol. ".to_string()),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Volume, prefix = "vol. ", suffix = ", "),
         // no. Y,
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Issue,
-            form: None,
-            rendering: Rendering {
-                prefix: Some("no. ".to_string()),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Issue, prefix = "no. ", suffix = ", "),
         // pp. Z–W,
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Pages,
-            form: None,
-            rendering: Rendering {
-                prefix: Some("pp. ".to_string()),
-                suffix: Some(", ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Pages, prefix = "pp. ", suffix = ", "),
         // Year.
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                suffix: Some(".".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_date!(Issued, Year, suffix = "."),
     ]
 }

--- a/crates/csln_core/src/embedded/numeric.rs
+++ b/crates/csln_core/src/embedded/numeric.rs
@@ -3,15 +3,12 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-use crate::template::{NumberVariable, TemplateComponent, TemplateNumber};
+use crate::{tc_number, template::TemplateComponent};
 
 /// Embedded citation template for plain numeric citation styles.
 ///
 /// Renders as the citation number itself (wrapping is style-controlled):
 /// `1`, `(1)`, or `[1]` depending on the parent citation options.
 pub fn citation() -> Vec<TemplateComponent> {
-    vec![TemplateComponent::Number(TemplateNumber {
-        number: NumberVariable::CitationNumber,
-        ..Default::default()
-    })]
+    vec![tc_number!(CitationNumber)]
 }

--- a/crates/csln_core/src/embedded/vancouver.rs
+++ b/crates/csln_core/src/embedded/vancouver.rs
@@ -3,25 +3,16 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-use crate::template::{
-    ContributorForm, ContributorRole, DateForm, DateVariable, NumberVariable, Rendering,
-    TemplateComponent, TemplateContributor, TemplateDate, TemplateNumber, TemplateTitle, TitleType,
-    WrapPunctuation,
+use crate::{
+    tc_contributor, tc_date, tc_number, tc_title,
+    template::{TemplateComponent, WrapPunctuation},
 };
 
 /// Embedded citation template for Vancouver (numeric) style.
 ///
 /// Renders as: [1]
 pub fn citation() -> Vec<TemplateComponent> {
-    vec![TemplateComponent::Number(TemplateNumber {
-        number: NumberVariable::CitationNumber,
-        form: None,
-        rendering: Rendering {
-            wrap: Some(WrapPunctuation::Brackets),
-            ..Default::default()
-        },
-        ..Default::default()
-    })]
+    vec![tc_number!(CitationNumber, wrap = WrapPunctuation::Brackets)]
 }
 
 /// Embedded bibliography template for Vancouver style.
@@ -30,82 +21,20 @@ pub fn citation() -> Vec<TemplateComponent> {
 pub fn bibliography() -> Vec<TemplateComponent> {
     vec![
         // Citation number.
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::CitationNumber,
-            form: None,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(CitationNumber, suffix = ". "),
         // Author (Vancouver format - all initials, no periods)
-        TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
-            form: ContributorForm::Long,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_contributor!(Author, Long, suffix = ". "),
         // Title
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::Primary,
-            form: None,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(Primary, suffix = ". "),
         // Journal
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::ParentSerial,
-            form: None,
-            rendering: Rendering {
-                suffix: Some(". ".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_title!(ParentSerial, suffix = ". "),
         // Year;
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                suffix: Some(";".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_date!(Issued, Year, suffix = ";"),
         // Volume
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Volume,
-            form: None,
-            rendering: Rendering::default(),
-            ..Default::default()
-        }),
+        tc_number!(Volume),
         // (Issue)
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Issue,
-            form: None,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Parentheses),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Issue, wrap = WrapPunctuation::Parentheses),
         // :Pages
-        TemplateComponent::Number(TemplateNumber {
-            number: NumberVariable::Pages,
-            form: None,
-            rendering: Rendering {
-                prefix: Some(":".to_string()),
-                suffix: Some(".".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        tc_number!(Pages, prefix = ":", suffix = "."),
     ]
 }

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -19,6 +19,9 @@ pub mod template;
 // Embedded templates for priority styles (APA, Chicago, Vancouver, IEEE, Harvard)
 pub mod embedded;
 
+// Declarative macros for AST and configurations
+pub mod macros;
+
 pub use citation::{Citation, CitationItem, CitationMode, Citations, ItemVisibility, LocatorType};
 pub use grouping::{
     BibliographyGroup, CitedStatus, FieldMatcher, GroupHeading, GroupSelector, GroupSort,

--- a/crates/csln_core/src/macros.rs
+++ b/crates/csln_core/src/macros.rs
@@ -1,0 +1,187 @@
+/*
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Declarative macros for the CSLN ecosystem.
+
+/// Generates a string-backed enum and its `as_str` method.
+/// Preserves any doc comments and derive macros on the enum and its variants.
+#[macro_export]
+macro_rules! str_enum {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $(#[$vmeta:meta])*
+                $variant:ident = $val:expr
+            ),+ $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        #[non_exhaustive]
+        $vis enum $name {
+            $(
+                $(#[$vmeta])*
+                $variant,
+            )+
+        }
+
+        impl $name {
+            #[doc = "Returns the string value associated with this variant."]
+            pub fn as_str(&self) -> &'static str {
+                match self {
+                    $( Self::$variant => $val, )+
+                }
+            }
+        }
+    }
+}
+
+/// Dispatches an operation across all variants of `TemplateComponent`.
+/// Requires `$target` to be a `TemplateComponent` and provides `$inner`
+/// to the closure/expression provided in `$action`.
+#[macro_export]
+macro_rules! dispatch_component {
+    ($target:expr, |$inner:ident| $action:expr) => {
+        match $target {
+            $crate::template::TemplateComponent::Contributor($inner) => $action,
+            $crate::template::TemplateComponent::Date($inner) => $action,
+            $crate::template::TemplateComponent::Title($inner) => $action,
+            $crate::template::TemplateComponent::Number($inner) => $action,
+            $crate::template::TemplateComponent::Variable($inner) => $action,
+            $crate::template::TemplateComponent::List($inner) => $action,
+            $crate::template::TemplateComponent::Term($inner) => $action,
+        }
+    };
+}
+
+/// Merges fields from a target struct `source` into a mutable `target` if `source.field.is_some()`.
+/// This simplifies boilerplate in configuration merge implementations.
+#[macro_export]
+macro_rules! merge_options {
+    ($target:expr, $source:expr, $($field:ident),+ $(,)?) => {
+        $(
+            if $source.$field.is_some() {
+                $target.$field = $source.$field.clone();
+            }
+        )+
+    };
+}
+
+// AST Builder macros for tests and embedded styles.
+// These use a quasi-DSL to quickly stamp out TemplateComponents.
+
+#[macro_export]
+macro_rules! tc_contributor {
+    ($role:ident, $form:ident $(, $key:ident = $val:expr)*) => {
+        $crate::template::TemplateComponent::Contributor(
+            $crate::template::TemplateContributor {
+                contributor: $crate::template::ContributorRole::$role,
+                form: $crate::template::ContributorForm::$form,
+                rendering: $crate::template::Rendering {
+                    $( $key: Some($val.into()), )*
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! tc_date {
+    ($date_var:ident, $form:ident $(, $key:ident = $val:expr)*) => {
+        $crate::template::TemplateComponent::Date(
+            $crate::template::TemplateDate {
+                date: $crate::template::DateVariable::$date_var,
+                form: $crate::template::DateForm::$form,
+                rendering: $crate::template::Rendering {
+                    $( $key: Some($val.into()), )*
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! tc_title {
+    ($title_type:ident $(, $key:ident = $val:expr)*) => {
+        $crate::template::TemplateComponent::Title(
+            $crate::template::TemplateTitle {
+                title: $crate::template::TitleType::$title_type,
+                rendering: $crate::template::Rendering {
+                    $( $key: Some($val.into()), )*
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! tc_number {
+    ($num_var:ident $(, $key:ident = $val:expr)*) => {
+        $crate::template::TemplateComponent::Number(
+            $crate::template::TemplateNumber {
+                number: $crate::template::NumberVariable::$num_var,
+                rendering: $crate::template::Rendering {
+                    $( $key: Some($val.into()), )*
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! tc_variable {
+    ($var:ident $(, $key:ident = $val:expr)*) => {
+        $crate::template::TemplateComponent::Variable(
+            $crate::template::TemplateVariable {
+                variable: $crate::template::SimpleVariable::$var,
+                rendering: $crate::template::Rendering {
+                    $( $key: Some($val.into()), )*
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! tc_term {
+    ($term_var:ident $(, $key:ident = $val:expr)*) => {
+        $crate::template::TemplateComponent::Term(
+            $crate::template::TemplateTerm {
+                term: $crate::localization::GeneralTerm::$term_var,
+                rendering: $crate::template::Rendering {
+                    $( $key: Some($val.into()), )*
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! tc_list {
+    ([$($item:expr),* $(,)?] $(, $key:ident = $val:expr)*) => {
+        $crate::template::TemplateComponent::List(
+            $crate::template::TemplateList {
+                items: vec![$($item),*],
+                rendering: $crate::template::Rendering {
+                    $( $key: Some($val.into()), )*
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        )
+    };
+}

--- a/crates/csln_core/src/options/mod.rs
+++ b/crates/csln_core/src/options/mod.rs
@@ -186,18 +186,24 @@ impl Config {
     /// Used for combining global options with context-specific (citation/bibliography) options.
     /// Only non-None fields from `other` override fields in `self`.
     pub fn merge(&mut self, other: &Config) {
-        if other.substitute.is_some() {
-            self.substitute = other.substitute.clone();
-        }
-        if other.processing.is_some() {
-            self.processing = other.processing.clone();
-        }
-        if other.localize.is_some() {
-            self.localize = other.localize.clone();
-        }
-        if other.multilingual.is_some() {
-            self.multilingual = other.multilingual.clone();
-        }
+        crate::merge_options!(
+            self,
+            other,
+            substitute,
+            processing,
+            localize,
+            multilingual,
+            dates,
+            titles,
+            page_range_format,
+            bibliography,
+            links,
+            volume_pages_delimiter,
+            semantic_classes,
+            strip_periods,
+            custom,
+        );
+
         if let Some(other_contributors) = &other.contributors {
             if let Some(this_contributors) = &mut self.contributors {
                 this_contributors.merge(other_contributors);
@@ -205,32 +211,9 @@ impl Config {
                 self.contributors = Some(other_contributors.clone());
             }
         }
-        if other.dates.is_some() {
-            self.dates = other.dates.clone();
-        }
-        if other.titles.is_some() {
-            self.titles = other.titles.clone();
-        }
-        if other.page_range_format.is_some() {
-            self.page_range_format = other.page_range_format.clone();
-        }
-        if other.bibliography.is_some() {
-            self.bibliography = other.bibliography.clone();
-        }
-        if other.links.is_some() {
-            self.links = other.links.clone();
-        }
+
         if other.punctuation_in_quote {
             self.punctuation_in_quote = true;
-        }
-        if other.volume_pages_delimiter.is_some() {
-            self.volume_pages_delimiter = other.volume_pages_delimiter.clone();
-        }
-        if other.semantic_classes.is_some() {
-            self.semantic_classes = other.semantic_classes;
-        }
-        if other.strip_periods.is_some() {
-            self.strip_periods = other.strip_periods;
         }
     }
 

--- a/crates/csln_core/src/template.rs
+++ b/crates/csln_core/src/template.rs
@@ -94,42 +94,22 @@ pub struct Rendering {
 impl Rendering {
     /// Merge another rendering into this one, with the other taking precedence.
     pub fn merge(&mut self, other: &Rendering) {
-        if other.emph.is_some() {
-            self.emph = other.emph;
-        }
-        if other.quote.is_some() {
-            self.quote = other.quote;
-        }
-        if other.strong.is_some() {
-            self.strong = other.strong;
-        }
-        if other.small_caps.is_some() {
-            self.small_caps = other.small_caps;
-        }
-        if other.prefix.is_some() {
-            self.prefix = other.prefix.clone();
-        }
-        if other.suffix.is_some() {
-            self.suffix = other.suffix.clone();
-        }
-        if other.inner_prefix.is_some() {
-            self.inner_prefix = other.inner_prefix.clone();
-        }
-        if other.inner_suffix.is_some() {
-            self.inner_suffix = other.inner_suffix.clone();
-        }
-        if other.wrap.is_some() {
-            self.wrap = other.wrap.clone();
-        }
-        if other.suppress.is_some() {
-            self.suppress = other.suppress;
-        }
-        if other.initialize_with.is_some() {
-            self.initialize_with = other.initialize_with.clone();
-        }
-        if other.strip_periods.is_some() {
-            self.strip_periods = other.strip_periods;
-        }
+        crate::merge_options!(
+            self,
+            other,
+            emph,
+            quote,
+            strong,
+            small_caps,
+            prefix,
+            suffix,
+            inner_prefix,
+            inner_suffix,
+            wrap,
+            suppress,
+            initialize_with,
+            strip_periods,
+        );
     }
 }
 
@@ -205,28 +185,12 @@ impl Default for TemplateComponent {
 impl TemplateComponent {
     /// Get the rendering options for this component.
     pub fn rendering(&self) -> &Rendering {
-        match self {
-            TemplateComponent::Contributor(c) => &c.rendering,
-            TemplateComponent::Date(d) => &d.rendering,
-            TemplateComponent::Title(t) => &t.rendering,
-            TemplateComponent::Number(n) => &n.rendering,
-            TemplateComponent::Variable(v) => &v.rendering,
-            TemplateComponent::List(l) => &l.rendering,
-            TemplateComponent::Term(t) => &t.rendering,
-        }
+        crate::dispatch_component!(self, |inner| &inner.rendering)
     }
 
     /// Get the type-specific rendering overrides for this component.
     pub fn overrides(&self) -> Option<&HashMap<TypeSelector, ComponentOverride>> {
-        match self {
-            TemplateComponent::Contributor(c) => c.overrides.as_ref(),
-            TemplateComponent::Date(d) => d.overrides.as_ref(),
-            TemplateComponent::Title(t) => t.overrides.as_ref(),
-            TemplateComponent::Number(n) => n.overrides.as_ref(),
-            TemplateComponent::Variable(v) => v.overrides.as_ref(),
-            TemplateComponent::List(l) => l.overrides.as_ref(),
-            TemplateComponent::Term(t) => t.overrides.as_ref(),
-        }
+        crate::dispatch_component!(self, |inner| inner.overrides.as_ref())
     }
 }
 
@@ -331,53 +295,29 @@ pub enum ContributorForm {
     VerbShort,
 }
 
-/// Contributor roles.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-#[non_exhaustive]
-pub enum ContributorRole {
-    #[default]
-    Author,
-    Editor,
-    Translator,
-    Director,
-    Publisher,
-    Recipient,
-    Interviewer,
-    Interviewee,
-    Inventor,
-    Counsel,
-    Composer,
-    CollectionEditor,
-    ContainerAuthor,
-    EditorialDirector,
-    Illustrator,
-    OriginalAuthor,
-    ReviewedAuthor,
-}
-
-impl ContributorRole {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ContributorRole::Author => "author",
-            ContributorRole::Editor => "editor",
-            ContributorRole::Translator => "translator",
-            ContributorRole::Director => "director",
-            ContributorRole::Publisher => "publisher",
-            ContributorRole::Recipient => "recipient",
-            ContributorRole::Interviewer => "interviewer",
-            ContributorRole::Interviewee => "interviewee",
-            ContributorRole::Inventor => "inventor",
-            ContributorRole::Counsel => "counsel",
-            ContributorRole::Composer => "composer",
-            ContributorRole::CollectionEditor => "collection-editor",
-            ContributorRole::ContainerAuthor => "container-author",
-            ContributorRole::EditorialDirector => "editorial-director",
-            ContributorRole::Illustrator => "illustrator",
-            ContributorRole::OriginalAuthor => "original-author",
-            ContributorRole::ReviewedAuthor => "reviewed-author",
-        }
+crate::str_enum! {
+    /// Contributor roles.
+    #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "schema", derive(JsonSchema))]
+    #[serde(rename_all = "kebab-case")]
+    pub enum ContributorRole {
+        #[default] Author = "author",
+        Editor = "editor",
+        Translator = "translator",
+        Director = "director",
+        Publisher = "publisher",
+        Recipient = "recipient",
+        Interviewer = "interviewer",
+        Interviewee = "interviewee",
+        Inventor = "inventor",
+        Counsel = "counsel",
+        Composer = "composer",
+        CollectionEditor = "collection-editor",
+        ContainerAuthor = "container-author",
+        EditorialDirector = "editorial-director",
+        Illustrator = "illustrator",
+        OriginalAuthor = "original-author",
+        ReviewedAuthor = "reviewed-author"
     }
 }
 

--- a/crates/csln_processor/src/render/test_formats.rs
+++ b/crates/csln_processor/src/render/test_formats.rs
@@ -8,22 +8,12 @@ mod tests {
     use crate::render::component::{ProcTemplateComponent, render_component_with_format};
     use crate::render::djot::Djot;
     use crate::render::html::Html;
-    use csln_core::template::{
-        ContributorRole, Rendering, TemplateComponent, TemplateContributor, TemplateTitle,
-        TitleType,
-    };
+    use csln_core::{tc_contributor, tc_title, tc_variable};
 
     #[test]
     fn test_html_title() {
         let component = ProcTemplateComponent {
-            template_component: TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                rendering: Rendering {
-                    emph: Some(true),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }),
+            template_component: tc_title!(Primary, emph = true),
             value: "My Title".to_string(),
             ..Default::default()
         };
@@ -35,14 +25,7 @@ mod tests {
     #[test]
     fn test_html_contributor() {
         let component = ProcTemplateComponent {
-            template_component: TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
-                rendering: Rendering {
-                    small_caps: Some(true),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }),
+            template_component: tc_contributor!(Author, Long, small_caps = true),
             value: "Smith".to_string(),
             ..Default::default()
         };
@@ -57,14 +40,7 @@ mod tests {
     #[test]
     fn test_djot_title() {
         let component = ProcTemplateComponent {
-            template_component: TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                rendering: Rendering {
-                    emph: Some(true),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }),
+            template_component: tc_title!(Primary, emph = true),
             value: "My Title".to_string(),
             ..Default::default()
         };
@@ -76,14 +52,7 @@ mod tests {
     #[test]
     fn test_djot_contributor() {
         let component = ProcTemplateComponent {
-            template_component: TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
-                rendering: Rendering {
-                    small_caps: Some(true),
-                    ..Default::default()
-                },
-                ..Default::default()
-            }),
+            template_component: tc_contributor!(Author, Long, small_caps = true),
             value: "Smith".to_string(),
             ..Default::default()
         };
@@ -95,12 +64,7 @@ mod tests {
     #[test]
     fn test_html_link() {
         let component = ProcTemplateComponent {
-            template_component: TemplateComponent::Variable(
-                csln_core::template::TemplateVariable {
-                    variable: csln_core::template::SimpleVariable::Url,
-                    ..Default::default()
-                },
-            ),
+            template_component: tc_variable!(Url),
             value: "https://example.com".to_string(),
             url: Some("https://example.com".to_string()),
             ..Default::default()
@@ -115,9 +79,12 @@ mod tests {
 
     #[test]
     fn test_html_title_link_doi() {
-        use csln_core::options::{LinkAnchor, LinkTarget, LinksConfig};
+        use csln_core::{
+            options::{LinkAnchor, LinkTarget, LinksConfig},
+            template::{TemplateTitle, TitleType},
+        };
         let component = ProcTemplateComponent {
-            template_component: TemplateComponent::Title(TemplateTitle {
+            template_component: csln_core::template::TemplateComponent::Title(TemplateTitle {
                 title: TitleType::Primary,
                 links: Some(LinksConfig {
                     target: Some(LinkTarget::Doi),

--- a/crates/csln_processor/tests/bibliography.rs
+++ b/crates/csln_processor/tests/bibliography.rs
@@ -12,10 +12,6 @@ use csln_core::{
         BibliographyConfig, Config, ContributorConfig, DisplayAsSort, Processing, ProcessingCustom,
         Sort, SortKey, SortSpec,
     },
-    template::{
-        ContributorForm, ContributorRole, DateForm, DateVariable as TDateVar, NumberVariable,
-        Rendering, TemplateComponent, TemplateContributor, TemplateDate, TemplateNumber,
-    },
 };
 use csln_processor::Processor;
 
@@ -33,39 +29,15 @@ fn build_numeric_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![TemplateComponent::Number(TemplateNumber {
-                number: NumberVariable::CitationNumber,
-                rendering: Rendering::default(),
-                ..Default::default()
-            })]),
+            template: Some(vec![csln_core::tc_number!(CitationNumber)]),
             wrap: Some(csln_core::template::WrapPunctuation::Brackets),
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
             template: Some(vec![
-                TemplateComponent::Number(TemplateNumber {
-                    number: NumberVariable::CitationNumber,
-                    rendering: Rendering {
-                        suffix: Some(". ".to_string()),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some(" (".to_string()),
-                        suffix: Some(")".to_string()),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }),
+                csln_core::tc_number!(CitationNumber, suffix = ". "),
+                csln_core::tc_contributor!(Author, Long),
+                csln_core::tc_date!(Issued, Year, prefix = " (", suffix = ")"),
             ]),
             ..Default::default()
         }),
@@ -97,20 +69,8 @@ fn build_sorted_style(sort: Vec<SortSpec>) -> Style {
         }),
         bibliography: Some(BibliographySpec {
             template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some(" ".to_string()),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }),
+                csln_core::tc_contributor!(Author, Long),
+                csln_core::tc_date!(Issued, Year, prefix = " "),
             ]),
             ..Default::default()
         }),
@@ -143,17 +103,8 @@ fn make_style_with_substitute(substitute: Option<String>) -> Style {
         bibliography: Some(BibliographySpec {
             options: None,
             template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
+                csln_core::tc_contributor!(Author, Long),
+                csln_core::tc_date!(Issued, Year),
             ]),
             ..Default::default()
         }),

--- a/crates/csln_processor/tests/citations.rs
+++ b/crates/csln_processor/tests/citations.rs
@@ -9,7 +9,6 @@ use common::*;
 use csln_core::{
     CitationSpec, Style, StyleInfo,
     options::{Config, Processing},
-    template::{NumberVariable, Rendering, TemplateComponent, TemplateNumber},
 };
 use csln_processor::Processor;
 
@@ -27,11 +26,7 @@ fn build_numeric_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![TemplateComponent::Number(TemplateNumber {
-                number: NumberVariable::CitationNumber,
-                rendering: Rendering::default(),
-                ..Default::default()
-            })]),
+            template: Some(vec![csln_core::tc_number!(CitationNumber)]),
             wrap: Some(csln_core::template::WrapPunctuation::Brackets),
             ..Default::default()
         }),

--- a/crates/csln_processor/tests/common/mod.rs
+++ b/crates/csln_processor/tests/common/mod.rs
@@ -364,10 +364,7 @@ pub fn build_author_date_style(
     use csln_core::options::{
         Config, ContributorConfig, Disambiguation, Processing, ProcessingCustom, ShortenListOptions,
     };
-    use csln_core::template::{
-        ContributorForm, ContributorRole, DateForm, DateVariable, Rendering, TemplateComponent,
-        TemplateContributor, TemplateDate, WrapPunctuation,
-    };
+    use csln_core::template::WrapPunctuation;
 
     // Build disambiguation config
     let disambiguate = if disambiguate_year_suffix || disambiguate_names || disambiguate_givenname {
@@ -397,20 +394,8 @@ pub fn build_author_date_style(
 
     // Citation template: Author (Year)
     let citation_template = vec![
-        TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
-            form: ContributorForm::Short,
-            ..Default::default()
-        }),
-        TemplateComponent::Date(TemplateDate {
-            date: DateVariable::Issued,
-            form: DateForm::Year,
-            rendering: Rendering {
-                wrap: Some(WrapPunctuation::Parentheses),
-                ..Default::default()
-            },
-            ..Default::default()
-        }),
+        csln_core::tc_contributor!(Author, Short),
+        csln_core::tc_date!(Issued, Year, wrap = WrapPunctuation::Parentheses),
     ];
 
     Style {

--- a/crates/csln_processor/tests/document.rs
+++ b/crates/csln_processor/tests/document.rs
@@ -9,10 +9,6 @@ use common::*;
 use csln_core::{
     BibliographySpec, Style, StyleInfo,
     options::{BibliographyConfig, Config, Processing},
-    template::{
-        ContributorForm, ContributorRole, DateForm, DateVariable as TDateVar, Rendering,
-        TemplateComponent, TemplateContributor, TemplateDate,
-    },
 };
 use csln_processor::{
     Processor,
@@ -40,17 +36,8 @@ fn test_document_html_output_contains_heading() {
         citation: None,
         bibliography: Some(BibliographySpec {
             template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
+                csln_core::tc_contributor!(Author, Long),
+                csln_core::tc_date!(Issued, Year),
             ]),
             ..Default::default()
         }),
@@ -123,17 +110,8 @@ fn test_document_djot_output_unmodified() {
         citation: None,
         bibliography: Some(BibliographySpec {
             template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
+                csln_core::tc_contributor!(Author, Long),
+                csln_core::tc_date!(Issued, Year),
             ]),
             ..Default::default()
         }),

--- a/crates/csln_processor/tests/i18n.rs
+++ b/crates/csln_processor/tests/i18n.rs
@@ -11,10 +11,6 @@ use csln_core::{
     options::{Config, MultilingualConfig, MultilingualMode, Processing},
     reference::contributor::{Contributor, MultilingualName, StructuredName},
     reference::types::{MultilingualComplex, MultilingualString},
-    template::{
-        ContributorForm, ContributorRole, DateForm, DateVariable as TDateVar, Rendering,
-        TemplateComponent, TemplateContributor, TemplateDate,
-    },
 };
 use csln_processor::Processor;
 use csln_processor::values::resolve_multilingual_string;
@@ -40,17 +36,8 @@ fn build_ml_style(name_mode: MultilingualMode, preferred_script: Option<String>)
         }),
         citation: Some(CitationSpec {
             template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
-                    form: ContributorForm::Short,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
+                csln_core::tc_contributor!(Author, Short),
+                csln_core::tc_date!(Issued, Year),
             ]),
             delimiter: Some(", ".to_string()),
             ..Default::default()
@@ -493,11 +480,7 @@ fn test_multilingual_rendering_numeric_integral_translated() {
     let mut style = build_ml_style(MultilingualMode::Translated, None);
     style.options.as_mut().unwrap().processing = Some(Processing::Numeric);
     style.citation.as_mut().unwrap().template =
-        Some(vec![TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
-            form: ContributorForm::Short,
-            ..Default::default()
-        })]);
+        Some(vec![csln_core::tc_contributor!(Author, Short)]);
 
     let mut bib = indexmap::IndexMap::new();
     let mut translations = HashMap::new();


### PR DESCRIPTION
This PR introduces a suite of declarative macros across the CSLN Rust codebase to eliminate repetitive boilerplate logic and improve ergonomics for test writing and embedded style instantiation. 

Summary of Changes:
- tc_* AST Builder Macros: Introduced tc_contributor, tc_date, tc_title, tc_number, tc_variable, tc_list, and tc_term to instantiate TemplateComponents compactly without extensive Default verbosity.
- str_enum: Implemented a macro that generates an enum mapped to a str string, heavily used for serializing fields like ContributorRole.
- merge_options: Created a macro to automate merge options over optional Structs for configurations (like Config or Rendering).
- dispatch_component: Consolidated logic for TemplateComponent methods rendering and overrides by generically dispatching across arbitrary inner data types using a declarative closure syntax.

Tests:
- Embedded styles and test_formats.rs have been heavily refactored using these macros. All tests continue to pass.