### PR TITLE
feat(presets): presetize numeric contributor variants

### DIFF
--- a/crates/csln_core/src/presets.rs
+++ b/crates/csln_core/src/presets.rs
@@ -86,6 +86,14 @@ pub enum ContributorPreset {
     /// For biomedical journals that show nearly all authors.
     /// Example: "Smith J, Jones M, Brown A, [10 authors], et al."
     NumericLarge,
+    /// Numeric all-authors: all family-first, no conjunction, compact initials,
+    /// no list shortening, particle demotion disabled.
+    /// Example: "Smith JD, Jones MK, Brown AB"
+    NumericAllAuthors,
+    /// Numeric given-first with period-only initials (no space), no conjunction,
+    /// and comma delimiters.
+    /// Example: "J.D. Smith, M.K. Jones, A.B. Brown"
+    NumericGivenDot,
     /// Annual Reviews style: all family-first, no initials, et al. after 5 of 7+,
     /// particle demotion never. Distinguishable by "never" demote policy.
     /// Example: "van der Berg J, Smith M, Jones A, Brown B, White C, et al."
@@ -231,6 +239,25 @@ impl ContributorPreset {
                     use_first: 10,
                     ..Default::default()
                 }),
+                ..Default::default()
+            },
+            ContributorPreset::NumericAllAuthors => ContributorConfig {
+                display_as_sort: Some(DisplayAsSort::All),
+                and: Some(AndOptions::None),
+                delimiter: Some(", ".to_string()),
+                delimiter_precedes_last: Some(DelimiterPrecedesLast::Always),
+                initialize_with: Some("".to_string()),
+                sort_separator: Some(" ".to_string()),
+                demote_non_dropping_particle: Some(DemoteNonDroppingParticle::Never),
+                ..Default::default()
+            },
+            ContributorPreset::NumericGivenDot => ContributorConfig {
+                display_as_sort: Some(DisplayAsSort::None),
+                and: Some(AndOptions::None),
+                delimiter: Some(", ".to_string()),
+                delimiter_precedes_last: Some(DelimiterPrecedesLast::Always),
+                initialize_with: Some(".".to_string()),
+                demote_non_dropping_particle: Some(DemoteNonDroppingParticle::SortOnly),
                 ..Default::default()
             },
             ContributorPreset::AnnualReviews => ContributorConfig {
@@ -582,6 +609,36 @@ mod tests {
     }
 
     #[test]
+    fn test_contributor_preset_numeric_all_authors() {
+        let config = ContributorPreset::NumericAllAuthors.config();
+        assert_eq!(config.and, Some(AndOptions::None));
+        assert_eq!(config.display_as_sort, Some(DisplayAsSort::All));
+        assert_eq!(config.sort_separator, Some(" ".to_string()));
+        assert_eq!(config.initialize_with, Some("".to_string()));
+        assert_eq!(
+            config.demote_non_dropping_particle,
+            Some(DemoteNonDroppingParticle::Never)
+        );
+        assert!(config.shorten.is_none());
+    }
+
+    #[test]
+    fn test_contributor_preset_numeric_given_dot() {
+        let config = ContributorPreset::NumericGivenDot.config();
+        assert_eq!(config.and, Some(AndOptions::None));
+        assert_eq!(config.display_as_sort, Some(DisplayAsSort::None));
+        assert_eq!(config.initialize_with, Some(".".to_string()));
+        assert_eq!(
+            config.demote_non_dropping_particle,
+            Some(DemoteNonDroppingParticle::SortOnly)
+        );
+        assert_eq!(
+            config.delimiter_precedes_last,
+            Some(DelimiterPrecedesLast::Always)
+        );
+    }
+
+    #[test]
     fn test_date_preset_long() {
         let config = DatePreset::Long.config();
         assert_eq!(config.month, MonthFormat::Long);
@@ -643,6 +700,8 @@ mod tests {
             ContributorPreset::NumericMedium,
             ContributorPreset::NumericTight,
             ContributorPreset::NumericLarge,
+            ContributorPreset::NumericAllAuthors,
+            ContributorPreset::NumericGivenDot,
             ContributorPreset::AnnualReviews,
             ContributorPreset::MathPhys,
             ContributorPreset::SocSciFirst,

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -49,6 +49,8 @@ Each preset encodes name formatting conventions for a style family. Pick the clo
 | `numeric-medium` | All family-first | none | none | 4/3 | `Smith J, Jones M` |
 | `numeric-tight` | All family-first | none | none | 7/3 | `Smith J, Jones M, Brown A, et al.` |
 | `numeric-large` | All family-first | none | none | 11/10 | `Smith J, … [10 authors], et al.` |
+| `numeric-all-authors` | All family-first | none | none | none | `Smith JD, Jones MK, Brown AB` |
+| `numeric-given-dot` | All given-first | `.` (period only) | none | none | `J.D. Smith, M.K. Jones, A.B. Brown` |
 | `annual-reviews` | All family-first | none | none | 7/5, demote-never | `van der Berg J, Smith M, Jones A, Brown B, White C, et al.` |
 | `math-phys` | All family-first | `.` (period only) | none | none (set separately) | `Smith, J., Jones, M., Brown, A.` |
 | `soc-sci-first` | First family-first, rest given-first | `. ` (period-space) | none | none (set separately) | `Smith, J. D., M. K. Jones` |
@@ -56,12 +58,12 @@ Each preset encodes name formatting conventions for a style family. Pick the clo
 
 **Choosing between similar presets:**
 
-- Compact initials (`""`): `vancouver`, `numeric-compact`, `numeric-medium`, `numeric-tight`, `numeric-large`, `annual-reviews`, `springer`
-- Period-only initials (`"."`): `harvard`, `math-phys`
+- Compact initials (`""`): `vancouver`, `numeric-compact`, `numeric-medium`, `numeric-tight`, `numeric-large`, `numeric-all-authors`, `annual-reviews`, `springer`
+- Period-only initials (`"."`): `harvard`, `math-phys`, `numeric-given-dot`
 - Period-space initials (`". "`): `apa`, `ieee`, `soc-sci-first`, `physics-numeric`
-- Given-first (no inversion): `ieee`, `physics-numeric`
+- Given-first (no inversion): `ieee`, `physics-numeric`, `numeric-given-dot`
 - First-author-only inversion: `apa`, `chicago`, `soc-sci-first`
-- All inverted: everything else
+- All inverted: everything except `ieee`, `physics-numeric`, `numeric-given-dot`
 
 When you need a different et al. threshold than the preset provides, use the preset and add a `shorten:` override at the context level:
 

--- a/styles/american-physics-society.yaml
+++ b/styles/american-physics-society.yaml
@@ -16,10 +16,7 @@ info:
 options:
   substitute: editor-translator-long
   processing: numeric
-  contributors:
-    initialize-with: ". "
-    delimiter: ", "
-    demote-non-dropping-particle: sort-only
+  contributors: physics-numeric
   dates: long
   titles: humanities
   bibliography:

--- a/styles/american-physiological-society.yaml
+++ b/styles/american-physiological-society.yaml
@@ -16,13 +16,7 @@ info:
 options:
   substitute: editor-translator-long
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: never
-    sort-separator: " "
+  contributors: numeric-all-authors
   dates: short
   titles: humanities
   bibliography:

--- a/styles/american-society-for-microbiology.yaml
+++ b/styles/american-society-for-microbiology.yaml
@@ -15,13 +15,7 @@ info:
   default-locale: en-US
 options:
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: never
-    sort-separator: " "
+  contributors: numeric-all-authors
   dates: long
   bibliography:
     entry-suffix: .

--- a/styles/bmj.yaml
+++ b/styles/bmj.yaml
@@ -16,18 +16,7 @@ info:
 options:
   substitute: editor-long
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 4
-      use-first: 3
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
+  contributors: numeric-medium
   dates: long
   titles: humanities
   page-range-format: minimal

--- a/styles/current-opinion.yaml
+++ b/styles/current-opinion.yaml
@@ -16,18 +16,7 @@ info:
 options:
   substitute: editor-translator-short
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 11
-      use-first: 10
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
+  contributors: numeric-large
   dates: long
   titles: journal-emphasis
   bibliography:

--- a/styles/elsevier-with-titles.yaml
+++ b/styles/elsevier-with-titles.yaml
@@ -12,11 +12,7 @@ options:
     - editor
     - translator
   processing: numeric
-  contributors:
-    initialize-with: .
-    delimiter: ', '
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
+  contributors: numeric-given-dot
   dates: long
   titles: scientific
   bibliography:

--- a/styles/elsevier-without-titles.yaml
+++ b/styles/elsevier-without-titles.yaml
@@ -16,11 +16,7 @@ info:
 options:
   substitute: editor-translator-short
   processing: numeric
-  contributors:
-    initialize-with: .
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
+  contributors: numeric-given-dot
   dates: long
   bibliography:
     entry-suffix: .

--- a/styles/future-science-group.yaml
+++ b/styles/future-science-group.yaml
@@ -16,18 +16,7 @@ info:
 options:
   substitute: editor-long
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 7
-      use-first: 3
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
+  contributors: numeric-tight
   dates: short
   titles: journal-emphasis
   bibliography:

--- a/styles/landes-bioscience-journals.yaml
+++ b/styles/landes-bioscience-journals.yaml
@@ -16,18 +16,7 @@ info:
 options:
   substitute: editor-long
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 11
-      use-first: 10
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
+  contributors: numeric-large
   dates: short
   page-range-format: minimal
   bibliography:

--- a/styles/medicine-publishing.yaml
+++ b/styles/medicine-publishing.yaml
@@ -16,18 +16,7 @@ info:
 options:
   substitute: editor-short
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 7
-      use-first: 3
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
+  contributors: numeric-tight
   dates: short
   titles: humanities
   page-range-format: minimal

--- a/styles/royal-society-of-chemistry.yaml
+++ b/styles/royal-society-of-chemistry.yaml
@@ -16,11 +16,7 @@ info:
 options:
   substitute: editor-translator-short
   processing: numeric
-  contributors:
-    initialize-with: .
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
+  contributors: numeric-given-dot
   dates: long
   bibliography:
     entry-suffix: .

--- a/styles/springer-basic-author-date.yaml
+++ b/styles/springer-basic-author-date.yaml
@@ -18,13 +18,7 @@ options:
       year-suffix: true
   strip-periods: true
   substitute: editor-translator-short
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: never
-    sort-separator: " "
+  contributors: numeric-all-authors
   dates: short
   bibliography:
     hanging-indent: true

--- a/styles/springer-physics-brackets.yaml
+++ b/styles/springer-physics-brackets.yaml
@@ -16,10 +16,7 @@ info:
 options:
   substitute: editor-translator-long
   processing: numeric
-  contributors:
-    initialize-with: ". "
-    delimiter: ", "
-    demote-non-dropping-particle: sort-only
+  contributors: physics-numeric
   dates: long
   titles: humanities
   bibliography:

--- a/styles/taylor-and-francis-national-library-of-medicine.yaml
+++ b/styles/taylor-and-francis-national-library-of-medicine.yaml
@@ -16,18 +16,7 @@ info:
 options:
   substitute: editor-long
   processing: numeric
-  contributors:
-    display-as-sort: all
-    initialize-with: ""
-    shorten:
-      min: 4
-      use-first: 3
-      and-others: et-al
-      delimiter-precedes-last: contextual
-    delimiter: ", "
-    delimiter-precedes-last: always
-    demote-non-dropping-particle: sort-only
-    sort-separator: " "
+  contributors: numeric-medium
   dates: long
   page-range-format: expanded
   bibliography:

--- a/styles/the-optical-society.yaml
+++ b/styles/the-optical-society.yaml
@@ -16,10 +16,7 @@ info:
 options:
   substitute: editor-translator-short
   processing: numeric
-  contributors:
-    initialize-with: ". "
-    delimiter: ", "
-    demote-non-dropping-particle: sort-only
+  contributors: physics-numeric
   dates: long
   titles: humanities
   bibliography:


### PR DESCRIPTION
## Summary
- add two contributor presets in core: numeric-all-authors and numeric-given-dot
- extend csln-migrate preset detection to recognize the new presets and refine detection for numeric tiers (numeric-compact, numeric-medium, numeric-tight, numeric-large) plus annual-reviews/math-phys branches
- apply presetization to 15 styles with matching contributor option patterns
- update the style author guide preset catalog

## Style wave changes (15 styles)
- numeric-all-authors: american-physiological-society, american-society-for-microbiology, springer-basic-author-date
- numeric-given-dot: elsevier-with-titles, elsevier-without-titles, royal-society-of-chemistry
- physics-numeric: american-physics-society, springer-physics-brackets, the-optical-society
- numeric-medium: bmj, taylor-and-francis-national-library-of-medicine
- numeric-large: current-opinion, landes-bioscience-journals
- numeric-tight: future-science-group, medicine-publishing

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- node scripts/report-core.js > /tmp/core-report-after.json
- node scripts/check-core-quality.js --report /tmp/core-report-after.json --baseline scripts/report-data/core-quality-baseline.json

## Metrics
- citations: 1278/1310 -> 1278/1310
- bibliography: 3028/3134 -> 3028/3134
- overall quality score: 92.9 -> 92.9
- core quality gate: pass (100 styles, fidelity 1.0 for all)
