### PR TITLE
fix(migrate): wave 3 baseline and disambiguation pass

### DIFF
--- a/docs/architecture/MIGRATE_ENHANCE_WAVE3_HANDOFF_2026-02-21.md
+++ b/docs/architecture/MIGRATE_ENHANCE_WAVE3_HANDOFF_2026-02-21.md
@@ -74,6 +74,70 @@ All 12 baseline outputs currently omit `options.processing`, which forces
 processor defaults instead of style-specific disambiguation settings. This is
 the first repeated migrate gap to promote in Rust for Wave 3 rerun.
 
+## Post-Promotion Checkpoint (`csln-migrate`)
+
+Promotion applied:
+- `crates/csln_migrate/src/options_extractor/processing.rs`
+  - recurse into citation macro trees when detecting author-date processing
+  - default extracted disambiguation to:
+    - `names: false`
+    - `add-givenname: false`
+    - `year-suffix: true`
+
+Wave rerun aggregate after promotion:
+- Citations: `129/156` (82.7%) `(+15)`
+- Bibliography: `344/385` (89.4%) `(no regression)`
+- Combined: `473/541` (87.4%) `(+15)`
+
+Per-style citation deltas:
+- `american-fisheries-society`: `9/13` -> `11/13`
+- `american-statistical-association`: `9/13` -> `11/13`
+- `nlm-name-year`: `8/13` -> `10/13`
+- `springer-basic-author-date-no-et-al`: `10/13` -> `13/13`
+- `springer-physics-author-date`: `10/13` -> `13/13`
+- `the-company-of-biologists`: `9/13` -> `12/13`
+
+Citation mismatch clusters after promotion:
+1. `suppress-author-with-locator` (9 styles)
+2. `et-al-with-locator` (6 styles)
+3. `with-locator` (3 styles)
+4. `et-al-single-long-list` (3 styles)
+5. `disambiguate-add-names-et-al` (3 styles)
+6. `locator-section-with-suffix` (2 styles)
+
+Interpretation:
+- The `et-al`/disambiguation cluster was materially reduced by migrate-side
+  processing extraction fixes.
+- The next repeated citation gap is now dominated by
+  `suppress-author-with-locator`, which should drive the next promotion.
+
+## Locator Preservation Checkpoint
+
+Second promotion applied:
+- `crates/csln_migrate/src/main.rs`
+  - inject `locator` into author-date citation templates when legacy citation
+    layout uses locator but inferred templates omit it
+- `scripts/merge-migration.js`
+  - preserve locator component from base migration output during merge when
+    inferred citation template has no locator
+
+Wave rerun aggregate after this pass:
+- Citations: `138/156` (88.5%) `(+9 from checkpoint 1, +24 from baseline)`
+- Bibliography: `344/385` (89.4%) `(no regression)`
+- Combined: `482/541` (89.1%) `(+9 from checkpoint 1, +24 from baseline)`
+
+Citation mismatch clusters after locator preservation:
+1. `et-al-with-locator` (4 styles)
+2. `suppress-author-with-locator` (3 styles)
+3. `et-al-single-long-list` (3 styles)
+4. `disambiguate-add-names-et-al` (3 styles)
+5. `with-locator` (2 styles)
+6. `locator-section-with-suffix` (2 styles)
+
+Interpretation:
+- The `suppress-author-with-locator` cluster dropped from 9 styles to 3.
+- Remaining misses are now primarily et-al/locator composition edge cases.
+
 ## Useful Commands
 ```bash
 styles=(

--- a/docs/architecture/MIGRATE_ENHANCE_WAVE_RUNBOOK_2026-02-21.md
+++ b/docs/architecture/MIGRATE_ENHANCE_WAVE_RUNBOOK_2026-02-21.md
@@ -25,11 +25,13 @@ Wave 2 citation status is now fully closed (`144/144`).
 
 ### Wave 3 (author-date + author/label diversity, 12 styles)
 - Baseline: `458/541` combined (citations `114/156`, bibliography `344/385`)
+- Rust checkpoint 1: `473/541` combined (citations `129/156`, bibliography `344/385`)
+- Rust+merge checkpoint 2: `482/541` combined (citations `138/156`, bibliography `344/385`)
 - Dominant citation mismatch clusters:
-  - `suppress-author-with-locator` (9)
-  - `et-al-with-locator` (9)
-  - `et-al-single-long-list` (9)
-  - `disambiguate-add-names-et-al` (9)
+  - `et-al-with-locator` (4)
+  - `suppress-author-with-locator` (3)
+  - `et-al-single-long-list` (3)
+  - `disambiguate-add-names-et-al` (3)
 
 ## Landed Enhancements
 
@@ -46,6 +48,16 @@ Wave 2 citation status is now fully closed (`144/144`).
   - emit extracted sort into generated `bibliography.sort`
 - `crates/csln_migrate/src/options_extractor/tests.rs`
   - coverage for new bibliography sort extraction
+- `crates/csln_migrate/src/options_extractor/processing.rs`
+  - recursively detect author-date signals through macro trees
+  - default extracted disambiguation to legacy-safe values
+    (`names=false`, `add-givenname=false`, `year-suffix=true`)
+- `crates/csln_migrate/src/main.rs`
+  - add author-date citation locator component when legacy layout uses
+    `citation-locator` and inferred templates omit it
+- `scripts/merge-migration.js`
+  - preserve base locator component when inferred citation template lacks
+    locator, preventing merge-time regression
 
 ### Processor sorting (`csln-processor`)
 - `crates/csln_processor/src/grouping/sorting.rs`
@@ -55,12 +67,16 @@ Wave 2 citation status is now fully closed (`144/144`).
 
 ## Remaining Gaps
 - Wave 2 bibliography remains `374/384` (10 unmatched entries).
-- Wave 3 migration/processor promotion pass and rerun are pending.
+- Wave 3 citation gap reduced but still open (`129/156`).
+- Wave 3 citation gap reduced further (`138/156`) but still open.
+- Wave 3 bibliography remains `344/385`, driven by style-specific outliers
+  (`springer-physics-author-date` is the largest gap at `10/33`).
 
 ## Next Execution Slice
-1. Apply migrate/processor promotion only for repeated (2+) Wave 3 mismatch
-   patterns.
-2. Re-run Wave 3 and record baseline vs post-enhancement deltas.
+1. Target remaining repeated citation gap:
+   `suppress-author-with-locator` (9 styles).
+2. Start focused bibliography pass for Wave 3 outliers, beginning with
+   `springer-physics-author-date`.
 3. Re-check core quality drift:
    - `node scripts/report-core.js > /tmp/core-report.json`
    - `node scripts/check-core-quality.js --report /tmp/core-report.json --baseline scripts/report-data/core-quality-baseline.json`

--- a/styles/american-fisheries-society.yaml
+++ b/styles/american-fisheries-society.yaml
@@ -19,6 +19,23 @@ options:
       - editor
       - translator
       - title
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: year
+          ascending: true
+        - key: author
+          ascending: true
+    group:
+      template:
+        - year
+        - author
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
   contributors:
     display-as-sort: first
     initialize-with: ". "
@@ -60,6 +77,9 @@ citation:
         use-first: 1
     - date: issued
       form: year
+      prefix: " "
+    - variable: locator
+      show-label: true
       prefix: " "
   wrap: parentheses
   delimiter: ". "

--- a/styles/american-marketing-association.yaml
+++ b/styles/american-marketing-association.yaml
@@ -19,6 +19,23 @@ options:
     template:
       - editor
       - translator
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: author
+          ascending: true
+        - key: year
+          ascending: true
+    group:
+      template:
+        - author
+        - year
+    disambiguate:
+      names: true
+      add-givenname: true
+      year-suffix: true
   contributors:
     display-as-sort: first
     initialize-with: ". "
@@ -68,6 +85,9 @@ citation:
         use-first: 1
     - date: issued
       form: year
+      prefix: " "
+    - variable: locator
+      show-label: true
       prefix: " "
   wrap: parentheses
   delimiter: ". "

--- a/styles/american-statistical-association.yaml
+++ b/styles/american-statistical-association.yaml
@@ -19,6 +19,23 @@ options:
     template:
       - editor
       - translator
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: author
+          ascending: true
+        - key: year
+          ascending: true
+    group:
+      template:
+        - author
+        - year
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
   contributors:
     display-as-sort: all
     initialize-with: ". "
@@ -69,6 +86,9 @@ citation:
     - date: issued
       form: year
       prefix: " "
+    - variable: locator
+      show-label: true
+      prefix: ","
   wrap: parentheses
   delimiter: ". "
   multi-cite-delimiter: "; "

--- a/styles/chicago-author-date-classic.yaml
+++ b/styles/chicago-author-date-classic.yaml
@@ -13,6 +13,11 @@ info:
   title: Chicago Manual of Style 18th edition (author-date, classic variants)
   id: http://www.zotero.org/styles/chicago-author-date-classic
 options:
+  processing:
+    disambiguate:
+      names: true
+      add-givenname: true
+      year-suffix: true
   contributors:
     shorten:
       min: 7

--- a/styles/harvard-cite-them-right.yaml
+++ b/styles/harvard-cite-them-right.yaml
@@ -20,6 +20,20 @@ options:
       - translator
     overrides:
       article-newspaper article-magazine article-journal: []
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: year
+          ascending: true
+    group:
+      template:
+        - year
+    disambiguate:
+      names: true
+      add-givenname: true
+      year-suffix: true
   contributors:
     display-as-sort: all
     initialize-with: .
@@ -68,6 +82,9 @@ citation:
     - date: issued
       form: year
       prefix: ", "
+    - variable: locator
+      show-label: true
+      prefix: " "
   wrap: parentheses
   delimiter: ". "
   multi-cite-delimiter: "; "

--- a/styles/modern-language-association.yaml
+++ b/styles/modern-language-association.yaml
@@ -69,6 +69,9 @@ citation:
     - title: primary
       wrap: quotes
       prefix: ", "
+    - variable: locator
+      show-label: true
+      prefix: " "
   wrap: parentheses
   delimiter: ". "
   multi-cite-delimiter: "; "

--- a/styles/new-harts-rules-author-date-space-publisher.yaml
+++ b/styles/new-harts-rules-author-date-space-publisher.yaml
@@ -21,9 +21,14 @@ options:
       manuscript: []
       classic: []
       song: []
-      webpage: []
-      event performance speech: []
       standard: []
+      event performance speech: []
+      webpage: []
+  processing:
+    disambiguate:
+      names: true
+      add-givenname: true
+      year-suffix: true
   contributors:
     initialize-with: ". "
     and: text

--- a/styles/nlm-name-year.yaml
+++ b/styles/nlm-name-year.yaml
@@ -18,6 +18,23 @@ options:
     template:
       - editor
       - title
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: year
+          ascending: true
+        - key: author
+          ascending: true
+    group:
+      template:
+        - year
+        - author
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
   contributors:
     display-as-sort: all
     initialize-with: ""

--- a/styles/sage-harvard.yaml
+++ b/styles/sage-harvard.yaml
@@ -19,6 +19,26 @@ options:
     template:
       - editor
       - translator
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: author
+          ascending: true
+        - key: year
+          ascending: true
+        - key: title
+          ascending: true
+    group:
+      template:
+        - author
+        - year
+        - title
+    disambiguate:
+      names: true
+      add-givenname: true
+      year-suffix: true
   contributors:
     display-as-sort: all
     initialize-with: ""
@@ -68,6 +88,9 @@ citation:
     - date: issued
       form: year
       prefix: ", "
+    - variable: locator
+      show-label: true
+      prefix: " "
   wrap: parentheses
   delimiter: ". "
   multi-cite-delimiter: "; "

--- a/styles/springer-basic-author-date-no-et-al.yaml
+++ b/styles/springer-basic-author-date-no-et-al.yaml
@@ -19,6 +19,23 @@ options:
     template:
       - editor
       - translator
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: year
+          ascending: true
+        - key: author
+          ascending: true
+    group:
+      template:
+        - year
+        - author
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
   contributors:
     display-as-sort: all
     initialize-with: ""

--- a/styles/springer-physics-author-date.yaml
+++ b/styles/springer-physics-author-date.yaml
@@ -19,6 +19,23 @@ options:
     template:
       - editor
       - translator
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: author
+          ascending: true
+        - key: year
+          ascending: false
+    group:
+      template:
+        - author
+        - year
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
   contributors:
     initialize-with: ". "
     shorten:

--- a/styles/the-company-of-biologists.yaml
+++ b/styles/the-company-of-biologists.yaml
@@ -19,6 +19,27 @@ options:
     template:
       - editor
       - title
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+        - key: author
+          ascending: true
+        - key: author
+          ascending: true
+        - key: author
+          ascending: true
+        - key: year
+          ascending: true
+    group:
+      template:
+        - author
+        - year
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
   contributors:
     display-as-sort: all
     initialize-with: ". "
@@ -66,6 +87,9 @@ citation:
     - date: issued
       form: year
       prefix: ", "
+    - variable: locator
+      show-label: true
+      prefix: " "
   wrap: parentheses
   delimiter: ". "
   multi-cite-delimiter: "; "


### PR DESCRIPTION
## Summary
- seed Wave 3 baseline for 12 planned styles and record baseline metrics/mismatch clusters
- promote repeated migrate gaps in csln-migrate and merge flow:
  - recurse citation macros for author-date processing detection
  - use legacy-safe disambiguation defaults (names=false, add-givenname=false, year-suffix=true)
  - inject locator components for in-text author-date templates when legacy styles use citation-locator
  - preserve base locator component during merge when inferred citation template omits locator
- rerun Wave 3 and update runbook/handoff with baseline vs checkpoint deltas

## Wave 3 Metrics
- baseline: citations 114/156, bibliography 344/385, combined 458/541
- final checkpoint: citations 138/156, bibliography 344/385, combined 482/541
- net delta: +24 citations with no bibliography regression

## Verification
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- node scripts/check-core-quality.js --report /tmp/core-report.json --baseline scripts/report-data/core-quality-baseline.json (pass with warning in the-geological-society-of-london oracle run)

Refs: csl26-w2n8