### PR TITLE
feat(latex): PDF tooltip interactivity for LuaLaTeX integration

### DIFF
--- a/bindings/latex/csln-example.tex
+++ b/bindings/latex/csln-example.tex
@@ -18,11 +18,20 @@
 
 \documentclass[12pt, a4paper]{article}
 
+% hyperref must be loaded before csln when tooltips=true: pdfcomment (loaded
+% by csln.sty) will reuse this already-loaded instance rather than loading
+% hyperref again with conflicting default options.
+\usepackage[hidelinks]{hyperref}   % clickable DOIs / URLs without coloured boxes
+
 % ---------------------------------------------------------------------------
 % CSLN citation package
-%   style   = path to a CSLN YAML style file (extension optional)
-%   bibfile = path to a CSLN YAML bibliography (extension optional)
-%             Use bibfile=refs.bib for a biblatex .bib file instead.
+%   style    = path to a CSLN YAML style file (extension optional)
+%   bibfile  = path to a CSLN YAML bibliography (extension optional)
+%              Use bibfile=refs.bib for a biblatex .bib file instead.
+%   tooltips = enable PDF tooltip annotations on bibliography entries.
+%              Hovering over an entry in a compatible PDF viewer reveals
+%              author, year, and title as a plain-text annotation.
+%              Loads pdfcomment automatically.
 % ---------------------------------------------------------------------------
 \usepackage[
   style   = ../../styles/apa-7th,
@@ -30,14 +39,8 @@
   tooltips
 ]{csln}
 
-% tooltips=true enables PDF tooltip annotations on bibliography entries.
-% Hovering over a bibliography entry in a compatible PDF viewer reveals
-% the author, year, and title as a plain-text annotation.
-% Requires the pdfcomment package (loaded automatically by csln.sty).
-
 % Standard LaTeX preamble
 \usepackage{fontspec}              % LuaLaTeX font support
-\usepackage[hidelinks]{hyperref}   % clickable DOIs / URLs without coloured boxes
 \usepackage{microtype}             % better typography
 \usepackage{geometry}
 \geometry{margin=2.5cm}

--- a/bindings/latex/csln-example.tex
+++ b/bindings/latex/csln-example.tex
@@ -26,8 +26,14 @@
 % ---------------------------------------------------------------------------
 \usepackage[
   style   = ../../styles/apa-7th,
-  bibfile = example-refs
+  bibfile = example-refs,
+  tooltips
 ]{csln}
+
+% tooltips=true enables PDF tooltip annotations on bibliography entries.
+% Hovering over a bibliography entry in a compatible PDF viewer reveals
+% the author, year, and title as a plain-text annotation.
+% Requires the pdfcomment package (loaded automatically by csln.sty).
 
 % Standard LaTeX preamble
 \usepackage{fontspec}              % LuaLaTeX font support

--- a/bindings/latex/csln-example.tex
+++ b/bindings/latex/csln-example.tex
@@ -18,9 +18,8 @@
 
 \documentclass[12pt, a4paper]{article}
 
-% hyperref must be loaded before csln when tooltips=true: pdfcomment (loaded
-% by csln.sty) will reuse this already-loaded instance rather than loading
-% hyperref again with conflicting default options.
+% hyperref should be loaded before csln so DOI \href links resolve correctly
+% and options are consistent across the document.
 \usepackage[hidelinks]{hyperref}   % clickable DOIs / URLs without coloured boxes
 
 % ---------------------------------------------------------------------------

--- a/bindings/latex/csln.lua
+++ b/bindings/latex/csln.lua
@@ -1,0 +1,568 @@
+-- CSLN LuaJIT Binding
+-- This module provides a high-level Lua interface to the CSLN Rust processor.
+
+local ffi = require("ffi")
+
+-- Define the C interface
+ffi.cdef[[
+    typedef struct Processor Processor;
+
+    /* Constructors (in-memory JSON data) */
+    Processor* csln_processor_new(const char* style_json, const char* bib_json);
+    Processor* csln_processor_new_with_locale(const char* style_json,
+                                              const char* bib_json,
+                                              const char* locale_json);
+
+    /* File-based constructors (preferred for LaTeX integration) */
+    Processor* csln_processor_new_from_yaml(const char* style_yaml_path,
+                                            const char* bib_yaml_path);
+    Processor* csln_processor_new_from_bib(const char* style_yaml_path,
+                                           const char* bib_path);
+
+    void csln_processor_free(Processor* processor);
+
+    /* Citation rendering */
+    char* csln_render_citation_latex(Processor* processor, const char* cite_json);
+    char* csln_render_citation_html(Processor* processor, const char* cite_json);
+    char* csln_render_citation_plain(Processor* processor, const char* cite_json);
+
+    /* Bibliography rendering */
+    char* csln_render_bibliography_latex(Processor* processor);
+    char* csln_render_bibliography_html(Processor* processor);
+    char* csln_render_bibliography_plain(Processor* processor);
+
+    void csln_string_free(char* s);
+
+    /* Metadata / tooltip */
+    char* csln_reference_tooltip(Processor* processor, const char* key);
+]]
+
+local CSLN = {}
+CSLN.__index = CSLN
+
+-- ---------------------------------------------------------------------------
+-- Library resolution
+-- ---------------------------------------------------------------------------
+
+--- Detect the current OS, compatible with both LuaJIT (jit.os) and
+--- LuaTeX standard Lua (os.uname).
+local function detect_os()
+    -- LuaJIT exposes jit.os
+    if jit then
+        return jit.os  -- "OSX", "Windows", "Linux", etc.
+    end
+    -- Standard LuaTeX exposes os.uname()
+    if os.uname then
+        local ok, info = pcall(os.uname)
+        if ok and type(info) == "table" then
+            local s = info.sysname or ""
+            if s == "Darwin" then return "OSX" end
+            if s == "Windows_NT" or s:find("MINGW") or s:find("MSYS") then
+                return "Windows"
+            end
+            return "Linux"
+        end
+    end
+    -- Last resort: path separator
+    if package.config:sub(1, 1) == "\\" then return "Windows" end
+    return "Linux"
+end
+
+local function shared_lib_name()
+    local os_name = detect_os()
+    if os_name == "Windows" then return "csln_processor.dll" end
+    if os_name == "OSX"     then return "libcsln_processor.dylib" end
+    return "libcsln_processor.so"
+end
+
+local function resolve_library()
+    local env_path = os.getenv("CSLN_LIB_PATH")
+    local lib_name = shared_lib_name()
+    local candidates = {}
+
+    if env_path and #env_path > 0 then
+        table.insert(candidates, env_path)
+    end
+    table.insert(candidates, "target/release/" .. lib_name)
+    table.insert(candidates, "target/debug/"   .. lib_name)
+    table.insert(candidates, lib_name)
+
+    local required_symbols = {
+        "csln_processor_new",
+        "csln_processor_free",
+        "csln_render_citation_latex",
+        "csln_render_bibliography_latex",
+        "csln_string_free",
+    }
+    local load_errors = {}
+
+    for _, candidate in ipairs(candidates) do
+        local ok, loaded = pcall(ffi.load, candidate)
+        if ok then
+            local symbols_ok = true
+            local missing = nil
+            for _, sym in ipairs(required_symbols) do
+                local has = pcall(function() return loaded[sym] end)
+                if not has then
+                    symbols_ok = false
+                    missing = sym
+                    break
+                end
+            end
+            if symbols_ok then return loaded, candidate end
+            table.insert(load_errors, candidate .. " (missing symbol: " .. tostring(missing) .. ")")
+        else
+            table.insert(load_errors, candidate .. " (" .. tostring(loaded) .. ")")
+        end
+    end
+
+    return nil, candidates, load_errors
+end
+
+local lib, loaded_path, load_errors = resolve_library()
+if lib == nil then
+    error(
+        "Failed to load csln_processor shared library. Tried: "
+            .. table.concat(loaded_path, ", ")
+            .. ". Details: "
+            .. table.concat(load_errors, " | ")
+            .. ". Ensure it is built with: cargo build --package csln_processor --release --features ffi"
+    )
+end
+
+-- ---------------------------------------------------------------------------
+-- Internal helpers
+-- ---------------------------------------------------------------------------
+
+--- Copy a C string returned by Rust, free it, return a Lua string.
+--- Note: a C NULL pointer is not Lua nil in FFI — it is a cdata that
+--- must be checked with ptr == ffi.cast("void*", 0) or ptr == nil (LuaJIT).
+local function consume_c_str(c_str)
+    if c_str == nil or c_str == ffi.cast("char*", 0) then return nil end
+    local s = ffi.string(c_str)
+    lib.csln_string_free(c_str)
+    return s
+end
+
+--- Escape a string for safe embedding inside a JSON string literal.
+local function json_escape(s)
+    s = tostring(s)
+    s = s:gsub('\\', '\\\\')
+    s = s:gsub('"',  '\\"')
+    s = s:gsub('\n', '\\n')
+    s = s:gsub('\r', '\\r')
+    s = s:gsub('\t', '\\t')
+    return s
+end
+
+--- Build a CSLN Citation JSON string from a Lua options table.
+--
+-- opts fields (all optional except items):
+--   mode            = "integral" | "non-integral"   (default: "non-integral")
+--   suppress_author = true | false
+--   prefix, suffix  = strings (citation-level affix)
+--   items           = list of { id, label, locator, prefix, suffix }
+--
+-- Single-key shorthand: if opts is a plain string it is treated as a bare key.
+local function build_citation_json(opts)
+    if type(opts) == "string" then
+        opts = { items = { { id = opts } } }
+    end
+
+    local parts = {}
+
+    if opts.mode and opts.mode ~= "non-integral" then
+        table.insert(parts, '"mode":"' .. json_escape(opts.mode) .. '"')
+    end
+    if opts.suppress_author then
+        table.insert(parts, '"suppress-author":true')
+    end
+    if opts.prefix then
+        table.insert(parts, '"prefix":"' .. json_escape(opts.prefix) .. '"')
+    end
+    if opts.suffix then
+        table.insert(parts, '"suffix":"' .. json_escape(opts.suffix) .. '"')
+    end
+
+    -- Build items array
+    local item_strs = {}
+    for _, item in ipairs(opts.items or {}) do
+        local ip = {}
+        table.insert(ip, '"id":"' .. json_escape(item.id) .. '"')
+        if item.label then
+            table.insert(ip, '"label":"' .. json_escape(item.label) .. '"')
+        end
+        if item.locator then
+            table.insert(ip, '"locator":"' .. json_escape(item.locator) .. '"')
+        end
+        if item.prefix then
+            table.insert(ip, '"prefix":"' .. json_escape(item.prefix) .. '"')
+        end
+        if item.suffix then
+            table.insert(ip, '"suffix":"' .. json_escape(item.suffix) .. '"')
+        end
+        table.insert(item_strs, "{" .. table.concat(ip, ",") .. "}")
+    end
+    table.insert(parts, '"items":[' .. table.concat(item_strs, ",") .. "]")
+
+    return "{" .. table.concat(parts, ",") .. "}"
+end
+
+-- ---------------------------------------------------------------------------
+-- Processor constructors
+-- ---------------------------------------------------------------------------
+
+--- Create a processor from in-memory JSON strings (low-level).
+function CSLN.new(style_json, bib_json)
+    local self = setmetatable({}, CSLN)
+    self.ptr = lib.csln_processor_new(style_json, bib_json)
+    if self.ptr == nil then return nil, "Failed to initialise CSLN processor" end
+    self.ptr      = ffi.gc(self.ptr, lib.csln_processor_free)
+    self.lib_path = loaded_path
+    return self
+end
+
+--- Create a processor from CSLN YAML files on disk (primary format).
+-- @param style_path  path to a CSLN YAML style file
+-- @param bib_path    path to a CSLN YAML bibliography file
+function CSLN.from_yaml(style_path, bib_path)
+    local self = setmetatable({}, CSLN)
+    self.ptr = lib.csln_processor_new_from_yaml(style_path, bib_path)
+    if self.ptr == nil then
+        return nil, "Failed to initialise CSLN processor from YAML files: "
+            .. tostring(style_path) .. ", " .. tostring(bib_path)
+    end
+    self.ptr      = ffi.gc(self.ptr, lib.csln_processor_free)
+    self.lib_path = loaded_path
+    return self
+end
+
+--- Create a processor from a CSLN YAML style and a biblatex .bib file.
+-- @param style_path  path to a CSLN YAML style file
+-- @param bib_path    path to a biblatex .bib file
+function CSLN.from_bib(style_path, bib_path)
+    local self = setmetatable({}, CSLN)
+    self.ptr = lib.csln_processor_new_from_bib(style_path, bib_path)
+    if self.ptr == nil then
+        return nil, "Failed to initialise CSLN processor from .bib file: "
+            .. tostring(bib_path)
+    end
+    self.ptr      = ffi.gc(self.ptr, lib.csln_processor_free)
+    self.lib_path = loaded_path
+    return self
+end
+
+-- ---------------------------------------------------------------------------
+-- Processor methods
+-- ---------------------------------------------------------------------------
+
+function CSLN:free()
+    if self.ptr then
+        local ptr = ffi.gc(self.ptr, nil)
+        lib.csln_processor_free(ptr)
+        self.ptr = nil
+    end
+end
+
+--- Render a citation to a LaTeX string.
+-- @param opts  string (bare key) or table — see build_citation_json above.
+function CSLN:render_citation(opts)
+    local cite_json = build_citation_json(opts)
+    local c_str = lib.csln_render_citation_latex(self.ptr, cite_json)
+    local result = consume_c_str(c_str)
+    if result == nil then
+        -- Provide diagnostic: show the JSON that Rust rejected
+        io.stderr:write("csln: render_citation returned NULL for JSON: "
+            .. cite_json .. "\n")
+    end
+    return result
+end
+
+--- Render a citation to an HTML string.
+function CSLN:render_citation_html(opts)
+    local cite_json = build_citation_json(opts)
+    local c_str = lib.csln_render_citation_html(self.ptr, cite_json)
+    return consume_c_str(c_str)
+end
+
+--- Render a citation to a plain-text string.
+function CSLN:render_citation_plain(opts)
+    local cite_json = build_citation_json(opts)
+    local c_str = lib.csln_render_citation_plain(self.ptr, cite_json)
+    return consume_c_str(c_str)
+end
+
+--- Render the full bibliography as a LaTeX string.
+function CSLN:render_bibliography()
+    local c_str = lib.csln_render_bibliography_latex(self.ptr)
+    return consume_c_str(c_str)
+end
+
+--- Render the full bibliography as an HTML string.
+function CSLN:render_bibliography_html()
+    local c_str = lib.csln_render_bibliography_html(self.ptr)
+    return consume_c_str(c_str)
+end
+
+--- Render the full bibliography as a plain-text string.
+function CSLN:render_bibliography_plain()
+    local c_str = lib.csln_render_bibliography_plain(self.ptr)
+    return consume_c_str(c_str)
+end
+
+-- ---------------------------------------------------------------------------
+-- Locator helpers (consumed by the LaTeX package)
+-- ---------------------------------------------------------------------------
+
+--- Map of biblatex optional-argument prefixes to CSLN LocatorType strings.
+CSLN.locator_labels = {
+    ["p."]    = "page",    ["pp."]   = "page",
+    ["ch."]   = "chapter", ["chap."] = "chapter",
+    ["sec."]  = "section", ["S"]     = "section", ["\xc2\xa7"] = "section",
+    ["vol."]  = "volume",  ["v."]    = "volume",
+    ["no."]   = "number",  ["n."]    = "number",
+    ["fig."]  = "figure",  ["f."]    = "figure",
+    ["l."]    = "line",
+    ["fn."]   = "note",    ["n"]     = "note",
+}
+
+--- Infer a CSLN locator label and value from a raw biblatex optional-arg string.
+-- E.g. "p. 23"  -> "page",  "23"
+--      "ch. 3"  -> "chapter", "3"
+--      "23"     -> "page",  "23"  (bare number defaults to page)
+-- Returns label, locator  (both nil if input is empty)
+function CSLN.parse_locator(s)
+    if not s or s == "" then return nil, nil end
+    for prefix, label in pairs(CSLN.locator_labels) do
+        local esc  = prefix:gsub("[%(%)%.%%%+%-%*%?%[%^%$]", "%%%1")
+        local rest = s:match("^" .. esc .. "%s*(.*)")
+        if rest then return label, rest end
+    end
+    if s:match("^%d") then return "page", s end
+    return "page", s
+end
+
+--- Render a citation and push it into the TeX output stream.
+-- proc     : a CSLN processor object
+-- cite_opts: string (bare key) or table — see build_citation_json
+-- When the global csln_tooltips is true, wraps the result in \cslntooltip
+-- so PDF viewers display author/year/title on hover over citation text.
+function CSLN.do_cite(proc, cite_opts)
+    if not proc then
+        tex.sprint("[csln: processor not initialised]")
+        return
+    end
+    local result = proc:render_citation(cite_opts)
+    if result then
+        if csln_tooltips then
+            -- Gather tooltip text for each cited item
+            local items = type(cite_opts) == "table" and (cite_opts.items or {})
+                          or {{id = tostring(cite_opts)}}
+            local tips = {}
+            for _, item in ipairs(items) do
+                local c_tip = lib.csln_reference_tooltip(proc.ptr, item.id)
+                local tip = consume_c_str(c_tip)
+                if tip and tip ~= "" then table.insert(tips, tip) end
+            end
+            if #tips > 0 then
+                result = "\\cslntooltip{" .. result .. "}{"
+                         .. table.concat(tips, "; ") .. "}"
+            end
+        end
+        tex.sprint(result)
+    else
+        local key = type(cite_opts) == "string" and cite_opts
+                    or (cite_opts.items and cite_opts.items[1] and cite_opts.items[1].id)
+                    or tostring(cite_opts)
+        tex.sprint("[csln: render error for " .. key .. "]")
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- High-level helpers for LaTeX commands (no Lua pattern chars in .sty)
+-- ---------------------------------------------------------------------------
+
+--- Split a comma-separated string into trimmed keys.
+function CSLN.split_keys(s)
+    local keys = {}
+    for k in s:gmatch("[^,]+") do
+        k = k:match("^%s*(.-)%s*$")  -- trim whitespace
+        if k ~= "" then table.insert(keys, k) end
+    end
+    return keys
+end
+
+--- Shared accumulator for multi-item citations.
+CSLN.cites_items = {}
+
+--- Reset the multi-item accumulator.
+function CSLN.cites_start()
+    CSLN.cites_items = {}
+end
+
+--- Add an item to the accumulator (with optional locator string).
+function CSLN.cites_add(raw_loc, key)
+    local label, locator = CSLN.parse_locator(raw_loc)
+    local item = { id = key }
+    if locator then item.label = label; item.locator = locator end
+    table.insert(CSLN.cites_items, item)
+end
+
+--- Flush the accumulator as a non-integral citation.
+function CSLN.cites_flush(proc)
+    CSLN.do_cite(proc, { items = CSLN.cites_items })
+end
+
+--- Flush the accumulator as an integral citation.
+function CSLN.cites_flush_integral(proc)
+    CSLN.do_cite(proc, { mode = "integral", items = CSLN.cites_items })
+end
+
+--- Render a single non-integral citation: \cite[loc]{key}
+function CSLN.cite_single(proc, raw_loc, key)
+    local label, locator = CSLN.parse_locator(raw_loc)
+    local item = { id = key }
+    if locator then item.label = label; item.locator = locator end
+    CSLN.do_cite(proc, { items = { item } })
+end
+
+--- Render a single integral citation: \textcite[loc]{key}
+function CSLN.textcite_single(proc, raw_loc, key)
+    local label, locator = CSLN.parse_locator(raw_loc)
+    local item = { id = key }
+    if locator then item.label = label; item.locator = locator end
+    CSLN.do_cite(proc, { mode = "integral", items = { item } })
+end
+
+--- Render a multi-key non-integral citation: \cites{k1, k2}
+function CSLN.cite_keys(proc, keys_str)
+    local items = {}
+    for _, k in ipairs(CSLN.split_keys(keys_str)) do
+        table.insert(items, { id = k })
+    end
+    CSLN.do_cite(proc, { items = items })
+end
+
+--- Render a multi-key integral citation: \textcites{k1, k2}
+function CSLN.textcite_keys(proc, keys_str)
+    local items = {}
+    for _, k in ipairs(CSLN.split_keys(keys_str)) do
+        table.insert(items, { id = k })
+    end
+    CSLN.do_cite(proc, { mode = "integral", items = items })
+end
+
+--- Initialise the processor from style + bibfile options.
+function CSLN.init_processor(style_opt, bibfile)
+    local function resolve_style(s)
+        local function try(p)
+            local f = io.open(p, "r")
+            if f then f:close(); return p end
+            return nil
+        end
+        return try(s)
+            or try(s .. ".yaml")
+            or (kpse and kpse.find_file(s, "tex"))
+            or (kpse and kpse.find_file(s .. ".yaml", "tex"))
+            or s
+    end
+
+    local style_path = resolve_style(style_opt)
+
+    local is_bib = bibfile:match("%.bib$")
+    local bib_path = bibfile
+    if not is_bib then
+        local function try(p)
+            local f = io.open(p, "r")
+            if f then f:close(); return p end
+            return nil
+        end
+        bib_path = try(bibfile)
+                or try(bibfile .. ".yaml")
+                or bibfile
+    end
+
+    local proc, err
+    if is_bib then
+        proc, err = CSLN.from_bib(style_path, bib_path)
+    else
+        proc, err = CSLN.from_yaml(style_path, bib_path)
+    end
+
+    if not proc then
+        error("csln: failed to init processor. "
+            .. tostring(err)
+            .. " | style=" .. tostring(style_path)
+            .. " | bib=" .. tostring(bib_path))
+    end
+    return proc
+end
+
+--- Create a PDF Widget annotation with tooltip text and a hover border colour.
+-- Emits \pdfextension obj and \pdfextension annot tokens into the TeX stream
+-- via tex.sprint.  Called from \cslntooltip in csln.sty during typesetting.
+--
+--   wid     : unique widget counter (integer, from \value{@csln@wid})
+--   boxnum  : TeX box register number that holds the citation text hbox
+--   tooltip : plain-text tooltip string, pre-escaped by \luaescapestring
+--
+-- Architecture:
+--   tex.sprint() queues tokens which TeX processes in order after \directlua
+--   returns.  \edef macros between \pdfextension obj calls capture the
+--   object numbers so the Widget's /AP entry can reference the XObjects.
+--   After TeX processes the queued tokens, \pdffeedback lastannot gives the
+--   Widget object number, which csln.sty accumulates for /AcroForm.
+function csln_emit_tooltip(wid, boxnum, tooltip)
+    local sp2bp = 72.0 / (72.27 * 65536)
+    local box   = tex.box[boxnum]
+    local w     = box.width  * sp2bp
+    local h     = box.height * sp2bp
+    local d     = box.depth  * sp2bp
+
+    -- Escape for embedding in a PDF literal string (...):
+    -- \ → \\, ( → \(, ) → \)
+    local safe = tooltip:gsub("\\", "\\\\")
+                        :gsub("%(", "\\(")
+                        :gsub("%)", "\\)")
+
+    local bbox  = string.format("0 %.4f %.4f %.4f", -d, w, h)
+    local hrect = string.format("0 %.4f %.4f %.4f re", -d, w, h + d)
+
+    -- 1. Normal appearance: empty Form XObject (text on page shows through)
+    tex.sprint(string.format(
+        [[\pdfextension obj stream attr{/Type /XObject /Subtype /Form /BBox [%s]}{}]],
+        bbox))
+    tex.sprint([[\edef\@csln@norm{\number\pdffeedback lastobj}]])
+
+    -- 2. Rollover appearance: steel-blue border outline shown on hover
+    --    Stroke-only rect — does not obscure the citation text beneath it.
+    tex.sprint(string.format(
+        [[\pdfextension obj stream attr{/Type /XObject /Subtype /Form /BBox [%s]}{q 0.20 0.47 0.78 RG 1 w %s S Q}]],
+        bbox, hrect))
+    tex.sprint([[\edef\@csln@roll{\number\pdffeedback lastobj}]])
+
+    -- 3. Transparent push-button Widget: carries /TU tooltip + /AP appearances
+    tex.sprint(string.format(
+        [[\pdfextension annot width %.4fbp height %.4fbp depth %.4fbp]],
+        w, h, d))
+    tex.sprint(string.format(
+        [[{/Subtype /Widget /FT /Btn /T (csln-%d) /TU (%s) /Ff 65536 /H /N /BS <</W 0>> /MK <<>> /AP <</N \@csln@norm\space 0 R /R \@csln@roll\space 0 R>>}]],
+        wid, safe))
+end
+
+--- Print the bibliography via tex.sprint.
+function CSLN.print_bibliography(proc)
+    if not proc then
+        tex.sprint("[csln: processor not initialised]")
+        return
+    end
+    local bbl = proc:render_bibliography()
+    if bbl then
+        tex.sprint(bbl)
+    else
+        tex.sprint("[csln: bibliography render error]")
+    end
+end
+
+return CSLN
+

--- a/bindings/latex/csln.lua
+++ b/bindings/latex/csln.lua
@@ -519,35 +519,16 @@ function csln_emit_tooltip(wid, boxnum, tooltip)
     local h     = box.height * sp2bp
     local d     = box.depth  * sp2bp
 
-    -- Escape for embedding in a PDF literal string (...):
-    -- \ → \\, ( → \(, ) → \)
-    local safe = tooltip:gsub("\\", "\\\\")
-                        :gsub("%(", "\\(")
-                        :gsub("%)", "\\)")
+    -- Build a PDF-safe string: strip parens (TeX reads \( as math-open command),
+    -- escape backslashes, then collapse any double spaces.
+    local safe = tooltip:gsub("%(", ""):gsub("%)", ""):gsub("\\", "\\\\")
 
-    local bbox  = string.format("0 %.4f %.4f %.4f", -d, w, h)
-    local hrect = string.format("0 %.4f %.4f %.4f re", -d, w, h + d)
-
-    -- 1. Normal appearance: empty Form XObject (text on page shows through)
+    -- Single Widget push-button annotation with /TU tooltip text.
+    -- No /AP needed for tooltip display; Acrobat shows /TU on hover.
     tex.sprint(string.format(
-        [[\pdfextension obj stream attr{/Type /XObject /Subtype /Form /BBox [%s]}{}]],
-        bbox))
-    tex.sprint([[\edef\@csln@norm{\number\pdffeedback lastobj}]])
-
-    -- 2. Rollover appearance: steel-blue border outline shown on hover
-    --    Stroke-only rect — does not obscure the citation text beneath it.
-    tex.sprint(string.format(
-        [[\pdfextension obj stream attr{/Type /XObject /Subtype /Form /BBox [%s]}{q 0.20 0.47 0.78 RG 1 w %s S Q}]],
-        bbox, hrect))
-    tex.sprint([[\edef\@csln@roll{\number\pdffeedback lastobj}]])
-
-    -- 3. Transparent push-button Widget: carries /TU tooltip + /AP appearances
-    tex.sprint(string.format(
-        [[\pdfextension annot width %.4fbp height %.4fbp depth %.4fbp]],
-        w, h, d))
-    tex.sprint(string.format(
-        [[{/Subtype /Widget /FT /Btn /T (csln-%d) /TU (%s) /Ff 65536 /H /N /BS <</W 0>> /MK <<>> /AP <</N \@csln@norm\space 0 R /R \@csln@roll\space 0 R>>}]],
-        wid, safe))
+        [[\pdfextension annot width %.4fbp height %.4fbp depth %.4fbp ]]
+        .. [[{/Subtype /Widget /FT /Btn /T (csln-%d) /TU (%s) /Ff 65536 /H /N /BS <</W 0>> /MK <<>>}]],
+        w, h, d, wid, safe))
 end
 
 --- Print the bibliography via tex.sprint.

--- a/bindings/latex/csln.sty
+++ b/bindings/latex/csln.sty
@@ -6,6 +6,7 @@
 % Usage:
 %   \usepackage[style=apa-7th, bibfile=refs]{csln}            % CSLN YAML bib
 %   \usepackage[style=apa-7th, bibfile=refs.bib]{csln}        % biblatex .bib
+%   \usepackage[style=apa-7th, bibfile=refs, tooltips]{csln}  % with PDF tooltips
 %
 % SPDX-License-Identifier: MPL-2.0
 % SPDX-FileCopyrightText: © 2023–2026 Bruce D'Arcus
@@ -36,7 +37,20 @@
 % Omit extension to default to CSLN YAML (.yaml).
 \DeclareStringOption[refs]{bibfile}
 
+% Enable PDF tooltip annotations on bibliography entries (requires pdfcomment).
+\DeclareBoolOption[false]{tooltips}
+
 \ProcessKeyvalOptions*
+
+% ---------------------------------------------------------------------------
+% PDF tooltip support
+% ---------------------------------------------------------------------------
+\if@csln@tooltips
+  \RequirePackage{pdfcomment}
+  \newcommand{\cslntooltip}[2]{\pdftooltip{#1}{#2}}
+\else
+  \newcommand{\cslntooltip}[2]{#1}
+\fi
 
 % ---------------------------------------------------------------------------
 % Lua-side initialisation (runs once at \begin{document})

--- a/bindings/latex/csln.sty
+++ b/bindings/latex/csln.sty
@@ -47,9 +47,26 @@
 % ---------------------------------------------------------------------------
 \ifcsln@tooltips
   \RequirePackage{pdfcomment}
-  \newcommand{\cslntooltip}[2]{\pdftooltip{#1}{#2}}
+  % \pdftooltip boxes its first argument as-is, so passing raw inline content
+  % prevents line-breaking and produces a malformed annotation.  Instead, wrap
+  % in a \parbox (a proper vbox at \linewidth) so the entry reflows correctly,
+  % then let \pdftooltip annotate that fixed-size box.  \hangindent is applied
+  % inside the parbox so it still takes visual effect.
+  \newcommand{\cslntooltip}[2]{%
+    \noindent
+    \pdftooltip{%
+      \parbox[t]{\linewidth}{%
+        \hangindent=2em\hangafter=1%
+        #1%
+      }%
+    }{#2}%
+  }
 \else
-  \newcommand{\cslntooltip}[2]{#1}
+  % Passthrough: replicate the hanging-indent layout used by latex.rs when
+  % no tooltip is emitted, so the output is identical whether tooltips=true/false.
+  \newcommand{\cslntooltip}[2]{%
+    \noindent\hangindent=2em\hangafter=1 #1%
+  }
 \fi
 
 % ---------------------------------------------------------------------------

--- a/bindings/latex/csln.sty
+++ b/bindings/latex/csln.sty
@@ -45,7 +45,7 @@
 % ---------------------------------------------------------------------------
 % PDF tooltip support
 % ---------------------------------------------------------------------------
-\if@csln@tooltips
+\ifcsln@tooltips
   \RequirePackage{pdfcomment}
   \newcommand{\cslntooltip}[2]{\pdftooltip{#1}{#2}}
 \else

--- a/bindings/latex/csln.sty
+++ b/bindings/latex/csln.sty
@@ -43,30 +43,46 @@
 \ProcessKeyvalOptions*
 
 % ---------------------------------------------------------------------------
-% PDF tooltip support
+% PDF tooltip support (native LuaLaTeX annotations, no external package)
 % ---------------------------------------------------------------------------
+% \cslntooltip{content}{tooltip-text} wraps inline citation text in a PDF
+% Widget push-button annotation.  In a compatible PDF viewer (Acrobat Reader)
+% hovering shows the tooltip text AND a subtle steel-blue border highlight.
+% Uses LuaTeX native primitives — same-pass positioning, no soulpos, no
+% pdfcomment required.  The csln_emit_tooltip() Lua function (in csln.lua)
+% creates two Form XObjects (normal: empty; rollover: coloured border) and
+% wires them into /AP so viewers change appearance on mouse-enter.
 \ifcsln@tooltips
-  \RequirePackage{pdfcomment}
-  % \pdftooltip boxes its first argument as-is, so passing raw inline content
-  % prevents line-breaking and produces a malformed annotation.  Instead, wrap
-  % in a \parbox (a proper vbox at \linewidth) so the entry reflows correctly,
-  % then let \pdftooltip annotate that fixed-size box.  \hangindent is applied
-  % inside the parbox so it still takes visual effect.
+  \newcounter{@csln@wid}
+  \newbox\@csln@tbox
+  \gdef\@csln@fields{}
+
   \newcommand{\cslntooltip}[2]{%
-    \noindent
-    \pdftooltip{%
-      \parbox[t]{\linewidth}{%
-        \hangindent=2em\hangafter=1%
-        #1%
+    \leavevmode
+    \stepcounter{@csln@wid}%
+    \setbox\@csln@tbox=\hbox{#1}%
+    % Lua reads box dimensions, emits XObjects + Widget annotation tokens.
+    % \luaescapestring ensures the tooltip string is safe inside the Lua call.
+    \directlua{csln_emit_tooltip(%
+      \the\value{@csln@wid}, \number\@csln@tbox,
+      "\luaescapestring{#2}")}%
+    \box\@csln@tbox
+    % Accumulate Widget annotation refs for AcroForm registration below.
+    \xdef\@csln@fields{%
+      \@csln@fields\number\pdffeedback lastannot\space 0 R\space}%
+  }%
+
+  % Register all widget annotations in /AcroForm so PDF viewers display
+  % the /TU tooltip text on hover over citation items.
+  \AtEndDocument{%
+    \ifx\@csln@fields\empty\else
+      \pdfextension catalog {%
+        /AcroForm << /Fields [\@csln@fields] >>%
       }%
-    }{#2}%
-  }
+    \fi
+  }%
 \else
-  % Passthrough: replicate the hanging-indent layout used by latex.rs when
-  % no tooltip is emitted, so the output is identical whether tooltips=true/false.
-  \newcommand{\cslntooltip}[2]{%
-    \noindent\hangindent=2em\hangafter=1 #1%
-  }
+  \newcommand{\cslntooltip}[2]{#1}
 \fi
 
 % ---------------------------------------------------------------------------
@@ -104,6 +120,7 @@
     csln_proc = csln_module.init_processor(
       "\csln@style", "\csln@bibfile"
     )
+    csln_tooltips = \ifcsln@tooltips true\else false\fi
   }%
 }
 

--- a/crates/csln_processor/src/ffi.rs
+++ b/crates/csln_processor/src/ffi.rs
@@ -388,6 +388,37 @@ pub unsafe extern "C" fn csln_render_bibliography_plain(processor: *mut Processo
     safe_c_string(rendered)
 }
 
+/// Return a plain-text tooltip string for a bibliography entry by key.
+///
+/// Produces a "Author (Year). Title" string suitable for PDF annotations.
+/// LaTeX special characters are replaced with spaces.
+/// Returns null if the key is not found or no metadata is available.
+///
+/// # Safety
+/// The caller must ensure that `processor` is a valid pointer and
+/// `key` is a valid null-terminated C string. The returned string
+/// must be freed with `csln_string_free`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn csln_reference_tooltip(
+    processor: *mut Processor,
+    key: *const c_char,
+) -> *mut c_char {
+    if processor.is_null() || key.is_null() {
+        return ptr::null_mut();
+    }
+
+    let processor = unsafe { &*processor };
+    let key_str = match unsafe { CStr::from_ptr(key) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+
+    match processor.reference_tooltip(key_str) {
+        Some(tooltip) => safe_c_string(tooltip),
+        None => ptr::null_mut(),
+    }
+}
+
 /// Free a string allocated by the processor.
 ///
 /// # Safety

--- a/crates/csln_processor/src/processor/mod.rs
+++ b/crates/csln_processor/src/processor/mod.rs
@@ -322,6 +322,13 @@ impl Processor {
         }
     }
 
+    /// Return a plain-text tooltip string for a reference by key, for PDF annotations.
+    /// Returns None if the key is not found or no metadata fields are available.
+    pub fn reference_tooltip(&self, key: &str) -> Option<String> {
+        let reference = self.bibliography.get(key)?;
+        self.extract_metadata(reference).tooltip_text()
+    }
+
     /// Process a single citation.
     pub fn process_citation(&self, citation: &Citation) -> Result<String, ProcessorError> {
         self.process_citation_with_format::<crate::render::plain::PlainText>(citation)

--- a/crates/csln_processor/src/render/format.rs
+++ b/crates/csln_processor/src/render/format.rs
@@ -108,3 +108,48 @@ pub struct ProcEntryMetadata {
     /// Rendered title string.
     pub title: Option<String>,
 }
+
+impl ProcEntryMetadata {
+    /// Build a plain-text tooltip string for PDF annotations.
+    /// Format: "Author (Year). Title" with parts omitted if None.
+    /// LaTeX special characters are replaced with spaces to keep the
+    /// annotation text clean and avoid PDF parsing issues.
+    pub fn tooltip_text(&self) -> Option<String> {
+        let has_content = self.author.is_some() || self.year.is_some() || self.title.is_some();
+        if !has_content {
+            return None;
+        }
+
+        let mut parts = Vec::new();
+        if let Some(author) = &self.author {
+            parts.push(escape_for_tooltip(author));
+        }
+        if let Some(year) = &self.year {
+            parts.push(format!("({})", escape_for_tooltip(year)));
+        }
+        if let Some(title) = &self.title {
+            parts.push(escape_for_tooltip(title));
+        }
+
+        let tooltip = parts.join(". ");
+        if tooltip.is_empty() {
+            None
+        } else {
+            Some(tooltip)
+        }
+    }
+}
+
+/// Replace LaTeX special characters with spaces for use in plain-text PDF annotations.
+fn escape_for_tooltip(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '{' | '}' | '\\' | '%' | '#' | '$' | '&' | '_' | '^' | '~' => {
+                result.push(' ');
+            }
+            _ => result.push(c),
+        }
+    }
+    result.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/crates/csln_processor/src/render/latex.rs
+++ b/crates/csln_processor/src/render/latex.rs
@@ -108,64 +108,8 @@ impl OutputFormat for Latex {
         _id: &str,
         content: Self::Output,
         _url: Option<&str>,
-        metadata: &super::format::ProcEntryMetadata,
+        _metadata: &super::format::ProcEntryMetadata,
     ) -> Self::Output {
-        // When metadata is available, delegate the full entry layout to
-        // \cslntooltip (defined in csln.sty).  With tooltips=true it wraps
-        // content in a \parbox so \pdftooltip gets a properly-sized box;
-        // with tooltips=false it is a passthrough that adds \hangindent itself.
-        // When metadata is absent, fall back to the plain hanging-indent format.
-        match build_pdf_tooltip(metadata) {
-            Some(tooltip_text) => format!("\\cslntooltip{{{}}}{{{}}}", content, tooltip_text),
-            None => format!("\\noindent\\hangindent=2em\\hangafter=1 {}", content),
-        }
+        format!("\\noindent\\hangindent=2em\\hangafter=1 {}", content)
     }
-}
-
-/// Build a PDF tooltip string from entry metadata.
-/// Format: "Author (Year). Title" with parts omitted if None.
-fn build_pdf_tooltip(metadata: &super::format::ProcEntryMetadata) -> Option<String> {
-    let has_content =
-        metadata.author.is_some() || metadata.year.is_some() || metadata.title.is_some();
-    if !has_content {
-        return None;
-    }
-
-    let mut parts = Vec::new();
-
-    if let Some(author) = &metadata.author {
-        parts.push(escape_tooltip_text(author));
-    }
-
-    if let Some(year) = &metadata.year {
-        let year_str = format!("({})", escape_tooltip_text(year));
-        parts.push(year_str);
-    }
-
-    if let Some(title) = &metadata.title {
-        parts.push(escape_tooltip_text(title));
-    }
-
-    let tooltip = parts.join(". ");
-    if tooltip.is_empty() {
-        None
-    } else {
-        Some(tooltip)
-    }
-}
-
-/// Escape plain-text metadata for use in LaTeX PDF annotations.
-/// Replaces special characters with spaces to avoid PDF/LaTeX parsing issues.
-fn escape_tooltip_text(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '{' | '}' | '\\' | '%' | '#' | '$' | '&' | '_' | '^' | '~' => {
-                result.push(' ');
-            }
-            _ => result.push(c),
-        }
-    }
-    // Collapse multiple spaces into one
-    result.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/crates/csln_processor/src/render/latex.rs
+++ b/crates/csln_processor/src/render/latex.rs
@@ -108,8 +108,60 @@ impl OutputFormat for Latex {
         _id: &str,
         content: Self::Output,
         _url: Option<&str>,
-        _metadata: &super::format::ProcEntryMetadata,
+        metadata: &super::format::ProcEntryMetadata,
     ) -> Self::Output {
-        format!("\\noindent\\hangindent=2em\\hangafter=1 {}", content)
+        let hanging = format!("\\noindent\\hangindent=2em\\hangafter=1 {}", content);
+        match build_pdf_tooltip(metadata) {
+            Some(tooltip_text) => format!("\\cslntooltip{{{}}}{{{}}}", hanging, tooltip_text),
+            None => hanging,
+        }
     }
+}
+
+/// Build a PDF tooltip string from entry metadata.
+/// Format: "Author (Year). Title" with parts omitted if None.
+fn build_pdf_tooltip(metadata: &super::format::ProcEntryMetadata) -> Option<String> {
+    let has_content =
+        metadata.author.is_some() || metadata.year.is_some() || metadata.title.is_some();
+    if !has_content {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+
+    if let Some(author) = &metadata.author {
+        parts.push(escape_tooltip_text(author));
+    }
+
+    if let Some(year) = &metadata.year {
+        let year_str = format!("({})", escape_tooltip_text(year));
+        parts.push(year_str);
+    }
+
+    if let Some(title) = &metadata.title {
+        parts.push(escape_tooltip_text(title));
+    }
+
+    let tooltip = parts.join(". ");
+    if tooltip.is_empty() {
+        None
+    } else {
+        Some(tooltip)
+    }
+}
+
+/// Escape plain-text metadata for use in LaTeX PDF annotations.
+/// Replaces special characters with spaces to avoid PDF/LaTeX parsing issues.
+fn escape_tooltip_text(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '{' | '}' | '\\' | '%' | '#' | '$' | '&' | '_' | '^' | '~' => {
+                result.push(' ');
+            }
+            _ => result.push(c),
+        }
+    }
+    // Collapse multiple spaces into one
+    result.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/crates/csln_processor/src/render/latex.rs
+++ b/crates/csln_processor/src/render/latex.rs
@@ -110,11 +110,13 @@ impl OutputFormat for Latex {
         _url: Option<&str>,
         metadata: &super::format::ProcEntryMetadata,
     ) -> Self::Output {
-        let hanging = format!("\\noindent\\hangindent=2em\\hangafter=1 {}", content);
-        match build_pdf_tooltip(metadata) {
-            Some(tooltip_text) => format!("\\cslntooltip{{{}}}{{{}}}", hanging, tooltip_text),
-            None => hanging,
-        }
+        // \pdftooltip boxes its content, so paragraph-level commands like
+        // \noindent\hangindent must sit outside the tooltip wrapper.
+        let inner = match build_pdf_tooltip(metadata) {
+            Some(tooltip_text) => format!("\\cslntooltip{{{}}}{{{}}}", content, tooltip_text),
+            None => content,
+        };
+        format!("\\noindent\\hangindent=2em\\hangafter=1 {}", inner)
     }
 }
 

--- a/crates/csln_processor/src/render/latex.rs
+++ b/crates/csln_processor/src/render/latex.rs
@@ -110,13 +110,15 @@ impl OutputFormat for Latex {
         _url: Option<&str>,
         metadata: &super::format::ProcEntryMetadata,
     ) -> Self::Output {
-        // \pdftooltip boxes its content, so paragraph-level commands like
-        // \noindent\hangindent must sit outside the tooltip wrapper.
-        let inner = match build_pdf_tooltip(metadata) {
+        // When metadata is available, delegate the full entry layout to
+        // \cslntooltip (defined in csln.sty).  With tooltips=true it wraps
+        // content in a \parbox so \pdftooltip gets a properly-sized box;
+        // with tooltips=false it is a passthrough that adds \hangindent itself.
+        // When metadata is absent, fall back to the plain hanging-indent format.
+        match build_pdf_tooltip(metadata) {
             Some(tooltip_text) => format!("\\cslntooltip{{{}}}{{{}}}", content, tooltip_text),
-            None => content,
-        };
-        format!("\\noindent\\hangindent=2em\\hangafter=1 {}", inner)
+            None => format!("\\noindent\\hangindent=2em\\hangafter=1 {}", content),
+        }
     }
 }
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -905,6 +905,37 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                 </div>
             </div>
 
+            <!-- PDF Interactivity -->
+            <div class="border-b border-slate-200" id="lualatex-pdf-tooltips">
+                <div class="px-8 py-4 bg-slate-100">
+                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+                        PDF Tooltip Interactivity
+                    </h3>
+                </div>
+                <div class="p-8 bg-white">
+                    <p class="text-slate-600 leading-relaxed text-sm mb-4">
+                        Similar to the HTML output's progressive enhancement (hover tooltips via
+                        <code class="text-xs bg-slate-200 px-1 rounded">data-*</code> attributes),
+                        the LuaLaTeX integration supports PDF annotation tooltips on bibliography entries.
+                        Enable with the <code class="text-xs bg-slate-200 px-1 rounded">tooltips</code>
+                        option — hovering over any bibliography entry in a compatible PDF viewer reveals
+                        the author, year, and title as a plain-text annotation.
+                    </p>
+                    <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300 leading-relaxed mb-4">
+                        <pre><span class="text-slate-500">% Enable PDF tooltip annotations</span>
+\usepackage[style=<span class="text-emerald-400">apa-7th</span>, bibfile=<span class="text-emerald-400">refs</span>, <span class="text-amber-400">tooltips</span>]{csln}
+
+<span class="text-slate-500">% Each bibliography entry is wrapped in \pdftooltip{entry}{Author (Year). Title}</span>
+<span class="text-slate-500">% The pdfcomment package is loaded automatically when tooltips=true</span></pre>
+                    </div>
+                    <p class="text-slate-500 text-xs">
+                        Compatible PDF viewers: Adobe Acrobat, Okular, and most desktop PDF readers
+                        that support PDF annotation tooltips (popup notes).
+                        The tooltip text is plain text: no LaTeX markup.
+                    </p>
+                </div>
+            </div>
+
             <div class="bg-slate-50 p-6 border-t border-slate-200">
                 <div class="flex items-start gap-3">
                     <div
@@ -913,11 +944,11 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                     </div>
                     <div class="text-sm text-slate-600 leading-relaxed">
                         <strong class="text-slate-900">Proof-of-concept status:</strong>
-                        Currently targets macOS and Linux. A full working example document is available in
-                        <a href="https://github.com/bdarcus/csl26/tree/main/bindings/latex"
-                            class="text-primary hover:underline">bindings/latex/</a>.
-                        The <code class="text-xs bg-slate-200 px-1 rounded">&amp;</code> conjunction in
-                        two-author citations is correctly escaped for LuaLaTeX output.
+                        Currently targets macOS and Linux. Full documentation is in
+                        <a href="#lualatex-integration"
+                            class="text-primary hover:underline">this section</a> above, with the
+                        working example file available in the repository's
+                        <code class="text-xs bg-slate-200 px-1 rounded">bindings/latex/</code> directory.
                     </div>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -338,7 +338,8 @@
                     <p class="text-slate-500 leading-relaxed text-sm">
                         Seamlessly integrate the Rust core into Python, Node.js, or Lua. A LuaLaTeX
                         proof-of-concept lets you use <code class="text-xs">\cite{key}</code> backed
-                        by the CSLN engine — no Biber required.
+                        by the CSLN engine — no Biber required. Supports PDF tooltip annotations on
+                        bibliography entries for interactive PDF output.
                     </p>
                 </a>
 


### PR DESCRIPTION
Turns out this is insanely difficult to implement. Planning to move this binding to a separate `labs` repo, and hoping `typst` will be a better fit for this functionality.

------

## Summary

Adds PDF tooltip annotations to **inline citation items** (e.g. `(Kuhn, 1962)`, `Kuhn (1962)`) via the `tooltips` package option.

## Status: WIP — PDF output is structurally damaged

The Lua/TeX implementation compiles without errors and the annotation code runs, but the resulting PDF has invalid AcroForm structure (\"Direct object in rootFields\" warnings from poppler). The Widget annotations are not rendering correctly in PDF viewers.

## What works

- Rust FFI: `csln_reference_tooltip` correctly returns "Author. Year. Title" text
- Lua `do_cite`: wraps citation output in `\cslntooltip{result}{tip}` when `tooltips` is enabled
- LaTeX `\cslntooltip`: boxes content, calls `csln_emit_tooltip`, accumulates annotation refs
- Compilation completes without errors

## What is broken

- The AcroForm /Fields structure in the output PDF is invalid
- Widget annotations are not displayed in PDF viewers
- Root cause: likely `\pdfextension catalog` adding AcroForm entries incorrectly, or `\pdffeedback lastannot` returning wrong object numbers when annotations are created via `tex.sprint`

## Approach

Uses native LuaTeX primitives (`\pdfextension annot`, `\pdffeedback lastannot`, `\pdfextension catalog`) — no external package required. Tooltip text is fetched from Rust via FFI and embedded as a PDF /TU Widget annotation on each citation item.

## To resume

The key open question is whether `\pdfextension annot` tokens inserted via `tex.sprint` produce valid indirect annotation objects that can be referenced in /AcroForm /Fields. May need to pre-allocate objects with `reserveobjnum` or use a different catalog-extension strategy.