### PR TITLE
fix(styles): correct processing mode in gost-r-7-0-5-2008 styles

### DIFF
--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -29,6 +29,7 @@ const CUSTOM_TAG_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
 const LEGACY_SOURCE_OVERRIDES = {
   'apa-7th': 'apa',
   'din-alphanumeric': 'din-1505-2-alphanumeric',
+  'gost-r-7-0-5-2008-author-date': 'gost-r-7-0-5-2008',
 };
 
 const KNOWN_DEPENDENTS = {

--- a/styles/gost-r-7-0-5-2008-author-date.yaml
+++ b/styles/gost-r-7-0-5-2008-author-date.yaml
@@ -8,7 +8,7 @@ info:
   default-locale: ru-RU
 
 options:
-  processing: in-text
+  processing: author-date
 
 citation:
   template:

--- a/styles/gost-r-7-0-5-2008-numeric.yaml
+++ b/styles/gost-r-7-0-5-2008-numeric.yaml
@@ -8,11 +8,11 @@ info:
   default-locale: ru-RU
 
 options:
-  processing: in-text
+  processing: numeric
 
 citation:
   template:
-    - variable: citation-number
+    - number: citation-number
 
 bibliography:
   groups:
@@ -84,7 +84,7 @@ bibliography:
             - legislation
 
   template:
-    - variable: citation-number
+    - number: citation-number
       prefix: "["
       suffix: "] "
     - contributor: author


### PR DESCRIPTION
Both GOST styles used 'in-text' (CSL 1.0 class) instead of valid CSLN processing variants. Fixes CI failure.