### PR TITLE
feat(processor): position-based citation variants (ibid, subsequent)

### DIFF
--- a/crates/csln_core/src/citation.rs
+++ b/crates/csln_core/src/citation.rs
@@ -32,6 +32,26 @@ pub enum CitationMode {
     NonIntegral,
 }
 
+/// Position of a citation in the document flow.
+///
+/// Indicates where this citation appears relative to previous citations
+/// of the same item(s). Used for note-based styles to detect ibid and
+/// subsequent citations, and for author-date styles to apply position-specific
+/// formatting rules (e.g., short forms after first citation).
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum Position {
+    /// First citation of an item.
+    First,
+    /// Subsequent citation of an item (non-consecutive).
+    Subsequent,
+    /// Same item cited immediately before, no locator on either.
+    Ibid,
+    /// Same item cited immediately before, with different locator.
+    IbidWithLocator,
+}
+
 /// A citation containing one or more references.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -48,6 +68,10 @@ pub struct Citation {
     /// Only relevant for author-date styles.
     #[serde(default, skip_serializing_if = "is_default_mode")]
     pub mode: CitationMode,
+    /// Position of this citation in the document flow.
+    /// Detected automatically by the processor or set explicitly by the caller.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<Position>,
     /// Suppress the author name across all items in this citation.
     /// Used when the author is already named in the prose: "Smith argues (2020)".
     /// Applies uniformly to all items — per-item suppression is not supported

--- a/crates/csln_core/src/lib.rs
+++ b/crates/csln_core/src/lib.rs
@@ -22,7 +22,7 @@ pub mod embedded;
 // Declarative macros for AST and configurations
 pub mod macros;
 
-pub use citation::{Citation, CitationItem, CitationMode, Citations, LocatorType};
+pub use citation::{Citation, CitationItem, CitationMode, Citations, LocatorType, Position};
 pub use grouping::{
     BibliographyGroup, CitedStatus, FieldMatcher, GroupHeading, GroupSelector, GroupSort,
     GroupSortKey, NameSortOrder, SortKey, TypeSelector,
@@ -193,6 +193,18 @@ pub struct CitationSpec {
     /// Overrides fields from the main citation spec when mode is NonIntegral.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub non_integral: Option<Box<CitationSpec>>,
+    /// Configuration for subsequent citations.
+    /// Overrides fields from the main citation spec when position is Subsequent.
+    /// Useful for short-form citations in note-based styles or author-date styles
+    /// that show abbreviated citations after the first mention.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subsequent: Option<Box<CitationSpec>>,
+    /// Configuration for ibid citations (ibid or ibid with locator).
+    /// Overrides fields from the main citation spec when position is Ibid or IbidWithLocator.
+    /// If present, takes precedence over `subsequent` for these positions.
+    /// Allows compact rendering like "ibid." or "ibid., p. 45".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ibid: Option<Box<CitationSpec>>,
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
@@ -230,6 +242,67 @@ impl CitationSpec {
                 // We don't want to recurse infinitely or keep the mode specs in the merged result
                 merged.integral = None;
                 merged.non_integral = None;
+
+                if spec.options.is_some() {
+                    merged.options = spec.options.clone();
+                }
+                if spec.use_preset.is_some() {
+                    merged.use_preset = spec.use_preset.clone();
+                }
+                if spec.template.is_some() {
+                    merged.template = spec.template.clone();
+                }
+                if spec.wrap.is_some() {
+                    merged.wrap = spec.wrap.clone();
+                }
+                if spec.prefix.is_some() {
+                    merged.prefix = spec.prefix.clone();
+                }
+                if spec.suffix.is_some() {
+                    merged.suffix = spec.suffix.clone();
+                }
+                if spec.delimiter.is_some() {
+                    merged.delimiter = spec.delimiter.clone();
+                }
+                if spec.multi_cite_delimiter.is_some() {
+                    merged.multi_cite_delimiter = spec.multi_cite_delimiter.clone();
+                }
+                if spec.sort.is_some() {
+                    merged.sort = spec.sort.clone();
+                }
+
+                std::borrow::Cow::Owned(merged)
+            }
+            None => std::borrow::Cow::Borrowed(self),
+        }
+    }
+
+    /// Resolve the effective spec for a given citation position.
+    ///
+    /// If a position-specific spec exists (e.g., `ibid` for Ibid position),
+    /// it merges with and overrides the base spec. Position resolution should
+    /// be applied before mode resolution to allow position-specific modes.
+    ///
+    /// Priority: ibid > subsequent > base
+    pub fn resolve_for_position(
+        &self,
+        position: Option<&crate::citation::Position>,
+    ) -> std::borrow::Cow<'_, CitationSpec> {
+        use crate::citation::Position;
+
+        let position_spec = match position {
+            Some(Position::Ibid) | Some(Position::IbidWithLocator) => self.ibid.as_ref(),
+            Some(Position::Subsequent) => self.subsequent.as_ref(),
+            Some(Position::First) | None => None,
+        };
+
+        match position_spec {
+            Some(spec) => {
+                // Merge logic: position specific > base
+                let mut merged = self.clone();
+                // Don't recurse infinitely or keep position specs in merged result
+                merged.subsequent = None;
+                merged.ibid = None;
 
                 if spec.options.is_some() {
                     merged.options = spec.options.clone();

--- a/crates/csln_processor/examples/test_cite.rs
+++ b/crates/csln_processor/examples/test_cite.rs
@@ -18,6 +18,7 @@ fn main() {
     let cite = Citation {
         id: Some("cite1".to_string()),
         mode: CitationMode::NonIntegral,
+        position: None,
         suppress_author: false,
         prefix: None,
         suffix: None,

--- a/crates/csln_processor/src/processor/mod.rs
+++ b/crates/csln_processor/src/processor/mod.rs
@@ -35,6 +35,7 @@ use crate::reference::{Bibliography, Citation, CitationItem, Reference};
 use crate::render::{ProcEntry, ProcTemplate};
 use crate::values::ProcHints;
 use csln_core::Style;
+use csln_core::citation::Position;
 use csln_core::locale::Locale;
 use csln_core::options::Config;
 use csln_core::template::WrapPunctuation;
@@ -96,6 +97,103 @@ impl Processor {
             .processing
             .as_ref()
             .is_some_and(|p| matches!(p, csln_core::options::Processing::Note))
+    }
+
+    /// Detect and annotate citation positions.
+    ///
+    /// Analyzes citations in order and assigns positions based on whether an item
+    /// has been cited before:
+    /// - First: Item not cited before
+    /// - Subsequent: Item cited before but not immediately preceding
+    /// - Ibid: Same single item as immediately preceding citation, no locators
+    /// - IbidWithLocator: Same single item as preceding, different locators
+    ///
+    /// Multi-item citations are never marked as Ibid (only First or Subsequent).
+    /// Only sets position if currently None (respects explicit caller values).
+    fn annotate_positions(&self, citations: &mut [Citation]) {
+        let mut seen_items: HashMap<String, Option<String>> = HashMap::new(); // item_id -> last_locator
+        let mut previous_items: Option<Vec<(String, Option<String>)>> = None;
+
+        for citation in citations.iter_mut() {
+            // Skip if position already explicitly set
+            if citation.position.is_some() {
+                // Update history even if position was explicit
+                let current_items: Vec<(String, Option<String>)> = citation
+                    .items
+                    .iter()
+                    .map(|item| {
+                        let locator = item.locator.clone();
+                        (item.id.clone(), locator)
+                    })
+                    .collect();
+                previous_items = Some(current_items);
+                for item in &citation.items {
+                    seen_items.insert(item.id.clone(), item.locator.clone());
+                }
+                continue;
+            }
+
+            // Single-item citation: check for ibid cases
+            if citation.items.len() == 1 {
+                let current_id = &citation.items[0].id;
+                let current_locator = &citation.items[0].locator;
+
+                // Check if this is immediately after the previous citation with same item
+                if let Some(ref prev_items) = previous_items
+                    && prev_items.len() == 1
+                    && prev_items[0].0 == *current_id
+                {
+                    // Same item as immediately preceding
+                    let prev_locator = &prev_items[0].1;
+                    if prev_locator.is_none() && current_locator.is_none() {
+                        // No locators on either: plain ibid
+                        citation.position = Some(Position::Ibid);
+                    } else if prev_locator != current_locator {
+                        // Different locators: ibid with locator
+                        citation.position = Some(Position::IbidWithLocator);
+                    }
+                    // else: same locator, treat as subsequent
+                }
+
+                // If not ibid, check if item was ever cited before
+                if citation.position.is_none() {
+                    if seen_items.contains_key(current_id) {
+                        citation.position = Some(Position::Subsequent);
+                    } else {
+                        citation.position = Some(Position::First);
+                    }
+                }
+
+                seen_items.insert(current_id.clone(), current_locator.clone());
+            } else {
+                // Multi-item citation: never ibid, just First or Subsequent
+                let all_seen = citation
+                    .items
+                    .iter()
+                    .all(|item| seen_items.contains_key(&item.id));
+
+                citation.position = if all_seen {
+                    Some(Position::Subsequent)
+                } else {
+                    Some(Position::First)
+                };
+
+                for item in &citation.items {
+                    seen_items.insert(item.id.clone(), item.locator.clone());
+                }
+            }
+
+            // Update history for next iteration
+            let current_items: Vec<(String, Option<String>)> = citation
+                .items
+                .iter()
+                .map(|item| {
+                    let locator = item.locator.clone();
+                    (item.id.clone(), locator)
+                })
+                .collect();
+            previous_items = Some(current_items);
+        }
     }
 
     /// Normalize citation note context for note styles.
@@ -522,14 +620,17 @@ impl Processor {
             self.cited_ids.borrow_mut().insert(item.id.clone());
         }
 
-        // Resolve the effective citation spec
+        // Resolve the effective citation spec (position first, then mode)
         let default_spec = csln_core::CitationSpec::default();
-        let effective_spec = self
-            .style
-            .citation
-            .as_ref()
-            .map(|cs| cs.resolve_for_mode(&citation.mode))
-            .unwrap_or(std::borrow::Cow::Borrowed(&default_spec));
+        let effective_spec = self.style.citation.as_ref().map_or_else(
+            || std::borrow::Cow::Borrowed(&default_spec),
+            |cs| {
+                // Resolve position first (owned), then mode on the owned spec
+                let position_resolved = cs.resolve_for_position(citation.position.as_ref());
+                let spec_for_mode = position_resolved.into_owned();
+                std::borrow::Cow::Owned(spec_for_mode.resolve_for_mode(&citation.mode).into_owned())
+            },
+        );
 
         let template_vec = effective_spec.resolve_template().unwrap_or_default();
         let template = template_vec.as_slice();
@@ -653,7 +754,8 @@ impl Processor {
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
-        let normalized = self.normalize_note_context(citations);
+        let mut normalized = self.normalize_note_context(citations);
+        self.annotate_positions(&mut normalized);
         normalized
             .iter()
             .map(|c| self.process_citation_with_format::<F>(c))

--- a/crates/csln_processor/src/processor/tests.rs
+++ b/crates/csln_processor/src/processor/tests.rs
@@ -1799,3 +1799,189 @@ fn test_group_heading_term_resolves_from_locale() {
 
     assert!(output.contains("# and"));
 }
+
+#[test]
+fn test_position_detection_first() {
+    use crate::reference::CitationItem;
+    use csln_core::Citation;
+
+    let processor = Processor::new(make_style(), make_bibliography());
+    let mut citations = vec![Citation {
+        items: vec![CitationItem {
+            id: "smith2020".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }];
+
+    processor.annotate_positions(&mut citations);
+
+    assert_eq!(citations[0].position, Some(csln_core::Position::First));
+}
+
+#[test]
+fn test_position_detection_subsequent() {
+    use crate::reference::CitationItem;
+    use csln_core::Citation;
+
+    let processor = Processor::new(make_style(), make_bibliography());
+    let mut citations = vec![
+        Citation {
+            items: vec![CitationItem {
+                id: "smith2020".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        Citation {
+            items: vec![CitationItem {
+                id: "jones2021".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        Citation {
+            items: vec![CitationItem {
+                id: "smith2020".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+    ];
+
+    processor.annotate_positions(&mut citations);
+
+    assert_eq!(citations[0].position, Some(csln_core::Position::First));
+    assert_eq!(citations[1].position, Some(csln_core::Position::First));
+    assert_eq!(citations[2].position, Some(csln_core::Position::Subsequent));
+}
+
+#[test]
+fn test_position_detection_ibid() {
+    use crate::reference::CitationItem;
+    use csln_core::Citation;
+
+    let processor = Processor::new(make_style(), make_bibliography());
+    let mut citations = vec![
+        Citation {
+            items: vec![CitationItem {
+                id: "smith2020".to_string(),
+                locator: None,
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        Citation {
+            items: vec![CitationItem {
+                id: "smith2020".to_string(),
+                locator: None,
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+    ];
+
+    processor.annotate_positions(&mut citations);
+
+    assert_eq!(citations[0].position, Some(csln_core::Position::First));
+    assert_eq!(citations[1].position, Some(csln_core::Position::Ibid));
+}
+
+#[test]
+fn test_position_detection_ibid_with_locator() {
+    use crate::reference::CitationItem;
+    use csln_core::Citation;
+
+    let processor = Processor::new(make_style(), make_bibliography());
+    let mut citations = vec![
+        Citation {
+            items: vec![CitationItem {
+                id: "smith2020".to_string(),
+                locator: Some("42".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        Citation {
+            items: vec![CitationItem {
+                id: "smith2020".to_string(),
+                locator: Some("45".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+    ];
+
+    processor.annotate_positions(&mut citations);
+
+    assert_eq!(citations[0].position, Some(csln_core::Position::First));
+    assert_eq!(
+        citations[1].position,
+        Some(csln_core::Position::IbidWithLocator)
+    );
+}
+
+#[test]
+fn test_position_detection_multi_item_no_ibid() {
+    use crate::reference::CitationItem;
+    use csln_core::Citation;
+
+    let processor = Processor::new(make_style(), make_bibliography());
+    let mut citations = vec![
+        Citation {
+            items: vec![CitationItem {
+                id: "smith2020".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        Citation {
+            items: vec![CitationItem {
+                id: "jones2021".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        Citation {
+            items: vec![
+                CitationItem {
+                    id: "smith2020".to_string(),
+                    ..Default::default()
+                },
+                CitationItem {
+                    id: "jones2021".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        },
+    ];
+
+    processor.annotate_positions(&mut citations);
+
+    assert_eq!(citations[0].position, Some(csln_core::Position::First));
+    assert_eq!(citations[1].position, Some(csln_core::Position::First));
+    // Multi-item citations should never be ibid, even if all items appeared before
+    assert_eq!(citations[2].position, Some(csln_core::Position::Subsequent));
+}
+
+#[test]
+fn test_position_detection_explicit_position_respected() {
+    use crate::reference::CitationItem;
+    use csln_core::Citation;
+
+    let processor = Processor::new(make_style(), make_bibliography());
+    let mut citations = vec![Citation {
+        items: vec![CitationItem {
+            id: "smith2020".to_string(),
+            ..Default::default()
+        }],
+        position: Some(csln_core::Position::Ibid),
+        ..Default::default()
+    }];
+
+    processor.annotate_positions(&mut citations);
+
+    // Explicit position should be preserved
+    assert_eq!(citations[0].position, Some(csln_core::Position::Ibid));
+}


### PR DESCRIPTION
## Summary

- Add `Position` enum (`First`, `Subsequent`, `Ibid`, `IbidWithLocator`) to `csln_core::citation`, re-exported from crate root
- Extend `CitationSpec` with `subsequent` and `ibid` sub-spec fields (parallel to `integral`/`non_integral`)
- Add `annotate_positions` to processor — auto-detects position from citation sequence, respects explicit caller-supplied values
- Chain position resolution before mode resolution in `process_citation_with_format`

## Test plan

- [x] Unit tests for `first`, `subsequent`, `ibid`, `ibid-with-locator`, multi-item (never ibid), and explicit position (respected, not overwritten)
- [x] 304/304 tests pass (`cargo nextest run`)
- [x] `cargo fmt` + `cargo clippy -- -D warnings` clean

## Notes

Tier 1 (first/subsequent) and Tier 2 (ibid/ibid-with-locator) per csl26-b76h.
Tier 3 (page-aware ibid) is an integration-side enhancement; not in scope.
No changes to bibliography rendering or style YAML files.

Closes csl26-b76h (partial — compat fixture/oracle updates tracked separately).