### PR TITLE
fix(core): switch InputReference from untagged to class-tagged dispatch

### DIFF
--- a/crates/csln_core/src/reference/mod.rs
+++ b/crates/csln_core/src/reference/mod.rs
@@ -30,7 +30,7 @@ pub use self::types::*;
 /// The Reference model.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(untagged)]
+#[serde(tag = "class", rename_all = "kebab-case")]
 pub enum InputReference {
     /// A monograph, such as a book or a report, is a monolithic work published or produced as a complete entity.
     Monograph(Box<Monograph>),

--- a/crates/csln_core/src/reference/types.rs
+++ b/crates/csln_core/src/reference/types.rs
@@ -90,7 +90,7 @@ impl Default for MultilingualString {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Monograph {
     pub id: Option<RefID>,
     pub r#type: MonographType,
@@ -137,7 +137,7 @@ pub enum MonographType {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Collection {
     pub id: Option<RefID>,
     pub r#type: CollectionType,
@@ -173,7 +173,7 @@ pub enum CollectionType {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct CollectionComponent {
     pub id: Option<RefID>,
     pub r#type: MonographComponentType,
@@ -210,7 +210,7 @@ pub enum MonographComponentType {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct SerialComponent {
     pub id: Option<RefID>,
     pub r#type: SerialComponentType,
@@ -360,7 +360,7 @@ pub enum RefDate {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct LegalCase {
     pub id: Option<RefID>,
     /// Case name (e.g., "Brown v. Board of Education")
@@ -389,7 +389,7 @@ pub struct LegalCase {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Statute {
     pub id: Option<RefID>,
     /// Statute name (e.g., "Civil Rights Act of 1964")
@@ -416,7 +416,7 @@ pub struct Statute {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Treaty {
     pub id: Option<RefID>,
     /// Treaty name (e.g., "Treaty of Versailles")
@@ -443,7 +443,7 @@ pub struct Treaty {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Hearing {
     pub id: Option<RefID>,
     /// Hearing title
@@ -466,7 +466,7 @@ pub struct Hearing {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Regulation {
     pub id: Option<RefID>,
     /// Regulation title
@@ -493,7 +493,7 @@ pub struct Regulation {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Brief {
     pub id: Option<RefID>,
     /// Brief title or case name
@@ -518,7 +518,7 @@ pub struct Brief {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Classic {
     pub id: Option<RefID>,
     /// Work title (e.g., "Nicomachean Ethics")
@@ -547,7 +547,7 @@ pub struct Classic {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Patent {
     pub id: Option<RefID>,
     /// Patent title
@@ -580,7 +580,7 @@ pub struct Patent {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Dataset {
     pub id: Option<RefID>,
     /// Dataset title
@@ -613,7 +613,7 @@ pub struct Dataset {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Standard {
     pub id: Option<RefID>,
     /// Standard title
@@ -640,7 +640,7 @@ pub struct Standard {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
-#[serde(deny_unknown_fields)]
+// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Software {
     pub id: Option<RefID>,
     /// Software title

--- a/crates/csln_core/tests/json_deserialization.rs
+++ b/crates/csln_core/tests/json_deserialization.rs
@@ -15,6 +15,7 @@ fn test_monograph_doi_alias() {
 #[test]
 fn test_input_reference_doi_alias() {
     let json = r#"{
+        "class": "monograph",
         "type": "book",
         "title": "Test Book",
         "issued": "2023",
@@ -31,6 +32,7 @@ fn test_input_reference_doi_alias() {
 #[test]
 fn test_input_reference_url_alias() {
     let json = r#"{
+        "class": "monograph",
         "type": "book",
         "title": "Test Book",
         "issued": "2023",

--- a/examples/comprehensive.yaml
+++ b/examples/comprehensive.yaml
@@ -6,6 +6,7 @@ info:
 references:
   # 1. Monograph (Book)
   - id: kuhn1962
+    class: monograph
     type: book
     title: The Structure of Scientific Revolutions
     author:
@@ -17,6 +18,7 @@ references:
 
   # 2. SerialComponent (Journal Article)
   - id: watson1953
+    class: serial-component
     type: article
     title: Molecular Structure of Nucleic Acids
     author:
@@ -35,6 +37,7 @@ references:
 
   # 3. CollectionComponent (Book Chapter)
   - id: smith2010
+    class: collection-component
     type: chapter
     title: The Future of CSLN
     author:
@@ -54,6 +57,7 @@ references:
 
   # 4. Monograph with original-date and keywords
   - id: foucault_discipline
+    class: monograph
     type: book
     title: Discipline and Punish
     author:
@@ -73,6 +77,7 @@ references:
 
   # 5. Missing references from complex-citations.yaml
   - id: brown1954
+    class: monograph
     type: book
     title: Another Book
     author:
@@ -83,6 +88,7 @@ references:
       name: Oxford University Press
 
   - id: who2020
+    class: monograph
     type: book
     title: Global Status Report
     author:
@@ -92,6 +98,7 @@ references:
       name: World Health Organization
 
   - id: goethe1808
+    class: monograph
     type: book
     title: Faust
     author:
@@ -102,6 +109,7 @@ references:
       name: Cotta
 
   - id: king1963
+    class: monograph
     type: book
     title: Letter from Birmingham Jail
     author:

--- a/tests/fixtures/references-expanded.json
+++ b/tests/fixtures/references-expanded.json
@@ -2,6 +2,7 @@
   "comment": "Expanded test data covering common reference types and citation mechanics",
   "ITEM-1": {
     "id": "ITEM-1",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "The Structure of Scientific Revolutions",
     "author": [{ "family": "Kuhn", "given": "Thomas S." }],
@@ -15,6 +16,7 @@
   },
   "ITEM-2": {
     "id": "ITEM-2",
+    "class": "monograph",
     "type": "book",
     "title": "A Brief History of Time",
     "author": [{ "family": "Hawking", "given": "Stephen" }],
@@ -24,6 +26,7 @@
   },
   "ITEM-3": {
     "id": "ITEM-3",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Deep Learning",
     "author": [
@@ -39,6 +42,7 @@
   },
   "ITEM-4": {
     "id": "ITEM-4",
+    "class": "collection-component",
     "type": "chapter",
     "title": "The Role of Deliberate Practice",
     "author": [{ "family": "Ericsson", "given": "K. Anders" }],
@@ -55,6 +59,7 @@
   },
   "ITEM-5": {
     "id": "ITEM-5",
+    "class": "monograph",
     "type": "report",
     "title": "World Development Report 2023",
     "author": [{ "literal": "World Bank" }],
@@ -64,6 +69,7 @@
   },
   "ITEM-6": {
     "id": "ITEM-6",
+    "class": "monograph",
     "type": "book",
     "title": "The Psychology of Computer Programming",
     "author": [
@@ -77,6 +83,7 @@
   },
   "ITEM-7": {
     "id": "ITEM-7",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Attention Is All You Need",
     "author": [
@@ -96,6 +103,7 @@
   },
   "ITEM-8": {
     "id": "ITEM-8",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Scientific Paradigms and Normal Science",
     "author": [{ "family": "Kuhn", "given": "Thomas S." }],
@@ -108,6 +116,7 @@
   },
   "ITEM-9": {
     "id": "ITEM-9",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Climate Change and Extreme Weather Events",
     "author": [
@@ -122,6 +131,7 @@
   },
   "ITEM-10": {
     "id": "ITEM-10",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Machine Learning for Climate Prediction",
     "author": [
@@ -137,6 +147,7 @@
   },
   "ITEM-11": {
     "id": "ITEM-11",
+    "class": "monograph",
     "type": "thesis",
     "title": "Neural Networks for Natural Language Understanding",
     "author": [{ "family": "Chen", "given": "Wei" }],
@@ -146,6 +157,7 @@
   },
   "ITEM-12": {
     "id": "ITEM-12",
+    "class": "collection-component",
     "type": "paper-conference",
     "title": "Distributed Representations of Words and Phrases",
     "author": [
@@ -162,6 +174,7 @@
   },
   "ITEM-13": {
     "id": "ITEM-13",
+    "class": "monograph",
     "type": "webpage",
     "title": "The State of JavaScript 2023",
     "author": [{ "literal": "State of JS Team" }],
@@ -171,6 +184,7 @@
   },
   "ITEM-14": {
     "id": "ITEM-14",
+    "class": "collection",
     "type": "book",
     "title": "Handbook of Research Methods in Social Psychology",
     "editor": [
@@ -183,6 +197,7 @@
   },
   "ITEM-15": {
     "id": "ITEM-15",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "The Role of Theory in Research",
     "issued": { "date-parts": [[2018]] },
@@ -194,6 +209,7 @@
   },
   "ITEM-16": {
     "id": "ITEM-16",
+    "class": "serial-component",
     "type": "article-newspaper",
     "title": "Major Breakthrough in Quantum Computing Announced",
     "author": [{ "family": "Rodriguez", "given": "Maria" }],
@@ -203,6 +219,7 @@
   },
   "ITEM-17": {
     "id": "ITEM-17",
+    "class": "serial-component",
     "type": "article-magazine",
     "title": "The Art of Minimalism in Modern Design",
     "author": [{ "family": "Thompson", "given": "Alexander" }],
@@ -214,6 +231,7 @@
   },
   "ITEM-18": {
     "id": "ITEM-18",
+    "class": "serial-component",
     "type": "entry-encyclopedia",
     "title": "Renaissance Art and Culture",
     "author": [{ "family": "Vasari", "given": "Giorgio" }],
@@ -225,6 +243,7 @@
   },
   "ITEM-19": {
     "id": "ITEM-19",
+    "class": "dataset",
     "type": "dataset",
     "title": "Global Temperature Anomalies 1880-2023",
     "author": [{ "literal": "NASA Goddard Institute for Space Studies" }],
@@ -235,6 +254,7 @@
   },
   "ITEM-20": {
     "id": "ITEM-20",
+    "class": "legal-case",
     "type": "legal_case",
     "title": "Brown v. Board of Education",
     "issued": { "date-parts": [[1954, 5, 17]] },
@@ -245,6 +265,7 @@
   },
   "ITEM-21": {
     "id": "ITEM-21",
+    "class": "patent",
     "type": "patent",
     "title": "Method for Efficient Data Compression",
     "author": [
@@ -257,6 +278,7 @@
   },
   "ITEM-22": {
     "id": "ITEM-22",
+    "class": "monograph",
     "type": "motion_picture",
     "title": "The Arrival of a Train at La Ciotat Station",
     "author": [{ "family": "Lumière", "given": "Louis" }],
@@ -267,6 +289,7 @@
   },
   "ITEM-23": {
     "id": "ITEM-23",
+    "class": "serial-component",
     "type": "broadcast",
     "title": "The Universe in a Nutshell",
     "author": [{ "family": "Sagan", "given": "Carl" }],
@@ -277,6 +300,7 @@
   },
   "ITEM-24": {
     "id": "ITEM-24",
+    "class": "monograph",
     "type": "interview",
     "title": "The Future of Artificial Intelligence",
     "author": [{ "family": "Bengio", "given": "Yoshua" }],
@@ -287,6 +311,7 @@
   },
   "ITEM-25": {
     "id": "ITEM-25",
+    "class": "monograph",
     "type": "book",
     "title": "Metamorphosis",
     "author": [{ "family": "Kafka", "given": "Franz" }],
@@ -298,6 +323,7 @@
   },
   "ITEM-26": {
     "id": "ITEM-26",
+    "class": "monograph",
     "type": "book",
     "title": "Éthique",
     "author": [{ "family": "Spinoza", "given": "Baruch" }],
@@ -308,6 +334,7 @@
   },
   "ITEM-27": {
     "id": "ITEM-27",
+    "class": "monograph",
     "type": "report",
     "title": "State of the World's Biodiversity",
     "author": [{ "literal": "United Nations Environment Programme" }],
@@ -319,6 +346,7 @@
   },
   "ITEM-28": {
     "id": "ITEM-28",
+    "class": "monograph",
     "type": "personal_communication",
     "title": "Discussion on CSLN Schema Design",
     "author": [{ "family": "Smith", "given": "Patricia" }],
@@ -328,6 +356,7 @@
   },
   "ITEM-29": {
     "id": "ITEM-29",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Adaptive Climate Risk Modeling in Coastal Cities",
     "author": [
@@ -345,6 +374,7 @@
   },
   "ITEM-30": {
     "id": "ITEM-30",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Adaptive Climate Risk Modeling for Inland Regions",
     "author": [
@@ -362,6 +392,7 @@
   },
   "ITEM-31": {
     "id": "ITEM-31",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Methods for Robust Climate Attribution",
     "author": [{ "family": "Garcia", "given": "Maria" }],
@@ -373,6 +404,7 @@
   },
   "ITEM-32": {
     "id": "ITEM-32",
+    "class": "serial-component",
     "type": "article-journal",
     "title": "Methods for Probabilistic Climate Attribution",
     "author": [{ "family": "Garcia", "given": "Maria" }],

--- a/tests/fixtures/references-legal.json
+++ b/tests/fixtures/references-legal.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "brown1954",
+    "class": "legal-case",
     "type": "legal_case",
     "title": "Brown v. Board of Education",
     "authority": "U.S. Supreme Court",
@@ -11,6 +12,7 @@
   },
   {
     "id": "civilrights1964",
+    "class": "statute",
     "type": "legislation",
     "title": "Civil Rights Act of 1964",
     "authority": "U.S. Congress",
@@ -21,6 +23,7 @@
   },
   {
     "id": "versailles1919",
+    "class": "treaty",
     "type": "treaty",
     "title": "Treaty of Versailles",
     "author": [{ "literal": "Allied Powers" }],

--- a/tests/fixtures/references-legal.yaml
+++ b/tests/fixtures/references-legal.yaml
@@ -1,6 +1,7 @@
 references:
   # Legal case - has authority (required), reporter, page
   - id: brown1954
+    class: legal-case
     title: Brown v. Board of Education
     authority: U.S. Supreme Court
     volume: "347"
@@ -10,6 +11,7 @@ references:
 
   # Statute - has code and section (distinguishing from legal-case)
   - id: civilrights1964
+    class: statute
     title: Civil Rights Act of 1964
     authority: U.S. Congress
     volume: "78"
@@ -19,6 +21,7 @@ references:
 
   # Treaty - has author field (distinguishing from legal-case)
   - id: versailles1919
+    class: treaty
     title: Treaty of Versailles
     author:
       - literal: Allied Powers

--- a/tests/fixtures/references-multilingual.yaml
+++ b/tests/fixtures/references-multilingual.yaml
@@ -4,6 +4,7 @@ references:
   # Sorting should be by given name in Vietnamese convention
 
   - id: nguyen2020
+    class: monograph
     type: book  # MonographType::Book
     title: Lịch sử Việt Nam
     author:
@@ -15,6 +16,7 @@ references:
     language: vi
 
   - id: tran2019
+    class: monograph
     type: book  # MonographType::Book
     title: Văn hóa truyền thống
     author:
@@ -26,6 +28,7 @@ references:
     language: vi
 
   - id: le2021
+    class: monograph
     type: book  # MonographType::Book
     title: Kinh tế Việt Nam
     author:
@@ -40,6 +43,7 @@ references:
   # Sorting should be by family name (Smith, Jones)
 
   - id: smith2020
+    class: monograph
     type: book  # MonographType::Book
     title: Vietnamese History
     author:
@@ -51,6 +55,7 @@ references:
     language: en
 
   - id: jones2019
+    class: monograph
     type: book  # MonographType::Book
     title: Southeast Asian Culture
     author:
@@ -62,6 +67,7 @@ references:
     language: en
 
   - id: brown2021
+    class: monograph
     type: book  # MonographType::Book
     title: Economic Development
     author:

--- a/tests/fixtures/references-scientific.json
+++ b/tests/fixtures/references-scientific.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "pavlovic2008",
+    "class": "patent",
     "type": "patent",
     "title": "Bicycle with adjustable suspension",
     "author": [{ "family": "Pavlovic", "given": "Nebojša" }],
@@ -12,6 +13,7 @@
   },
   {
     "id": "irino2009",
+    "class": "dataset",
     "type": "dataset",
     "title": "Chemical and mineral compositions of sediments from ODP Site 127-797",
     "author": [{ "family": "Irino", "given": "Tomohisa" }, { "family": "Tada", "given": "Ryuji" }],
@@ -23,6 +25,7 @@
   },
   {
     "id": "ieee754-2008",
+    "class": "standard",
     "type": "standard",
     "title": "IEEE Standard for Floating-Point Arithmetic",
     "authority": "IEEE",
@@ -33,6 +36,7 @@
   },
   {
     "id": "rcore2021",
+    "class": "software",
     "type": "software",
     "title": "R: A language and environment for statistical computing",
     "author": [{ "literal": "R Core Team" }],


### PR DESCRIPTION
## Summary

- Replaces serde untagged on InputReference with serde tag class rename_all kebab-case
- Eliminates silent misparse bugs where serde order-dependent structural matching could select the wrong variant
- All 9 fixture files and examples/comprehensive.yaml updated to include the explicit class field

## Trade-off

deny_unknown_fields removed from all 15 concrete reference structs due to a serde limitation: internally-tagged enums replay the tag field into the inner struct deserializer, causing deny_unknown_fields to reject class as unknown. A typo in a reference field name now silently produces None rather than a parse error -- but this surfaces visibly at render time rather than as silent wrong-type selection.

## Class values

monograph, collection, collection-component, serial-component, legal-case, statute, treaty, hearing, regulation, brief, classic, patent, dataset, standard, software

## Test plan

- 304 tests pass
- cargo fmt and cargo clippy clean

Refs: csl26-m102