### PR TITLE
refactor(cli): make citum the only public binary name

### DIFF
--- a/.claude/contexts/processor-context.md
+++ b/.claude/contexts/processor-context.md
@@ -23,7 +23,7 @@ Working on the citation and bibliography **rendering engine**.
 - **Three-tier options**: Global → context-specific (citation/bibliography) → template-level overrides.
 
 ## Key Binaries & Scripts
-- `cargo run --bin citum-cli -- render refs -b references.json -s styles/apa-7th.yaml` — main rendering entry point
+- `cargo run --bin citum -- render refs -b references.json -s styles/apa-7th.yaml` — main rendering entry point
 - `node scripts/oracle.js styles-legacy/apa.csl` — verify against citeproc-js
 - `./scripts/workflow-test.sh styles-legacy/apa.csl` — end-to-end impact analysis
 

--- a/.claude/contexts/schema-context.md
+++ b/.claude/contexts/schema-context.md
@@ -35,7 +35,7 @@ Context-specific options override global for their context.
 
 ## Schema Generation
 ```bash
-cargo run --bin citum-cli -- schema > csln.schema.json
+cargo run --bin citum -- schema > csln.schema.json
 ```
 
 ## Reference Docs

--- a/.claude/skills/style-maintain/SKILL.md
+++ b/.claude/skills/style-maintain/SKILL.md
@@ -37,7 +37,7 @@ model: haiku
 
 ## Verification
 - `node scripts/oracle.js <legacy-style> --json`
-- `cargo run --bin citum-cli -- render refs -b tests/fixtures/references-expanded.json -s <style-path>`
+- `cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s <style-path>`
 - QA handoff to `../style-qa/SKILL.md`
 
 ## Related

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Transition citation management from CSL 1.0 (procedural XML) to CSLN (declarativ
 ```
 crates/
   csl-legacy/      # CSL 1.0 XML parser
-  citum-cli/            # Main CLI binary
+  citum-cli/            # CLI crate (binary: `citum`)
   citum_schema/       # Types: Style, Template, Options, Locale
   citum_migrate/    # CSL 1.0 → CSLN conversion
   citum_engine/  # Citation/bibliography rendering engine
@@ -137,8 +137,8 @@ node scripts/report-core.js > /tmp/core-report.json && \
   node scripts/check-core-quality.js \
   --report /tmp/core-report.json \
   --baseline scripts/report-data/core-quality-baseline.json
-cargo run --bin citum-cli -- render refs -b tests/fixtures/references-expanded.json -s styles/apa-7th.yaml
-cargo run --bin citum-cli -- schema > citum-cli.schema.json
+cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s styles/apa-7th.yaml
+cargo run --bin citum -- schema > citum.schema.json
 cargo bench --bench rendering                            # Hot path benchmarks
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,20 +132,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "citum-analyze"
-version = "0.6.0"
-dependencies = [
- "citum-schema",
- "csl-legacy",
- "roxmltree",
- "serde",
- "serde_json",
- "serde_yaml",
- "walkdir",
-]
-
-[[package]]
-name = "citum-cli"
+name = "citum"
 version = "0.6.0"
 dependencies = [
  "citum-engine",
@@ -159,6 +146,19 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "strsim 0.10.0",
+ "walkdir",
+]
+
+[[package]]
+name = "citum-analyze"
+version = "0.6.0"
+dependencies = [
+ "citum-schema",
+ "csl-legacy",
+ "roxmltree",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "walkdir",
 ]
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Do not treat hard-coded README percentages as canonical.
 - `citum_schema`: schema/types and shared models
 - `citum_engine`: citation and bibliography rendering engine
 - `citum_migrate`: CSL 1.0 -> CSLN migration pipeline (hybrid)
-- `citum-cli`: main CLI (`render`, `check`, `convert`)
+- `citum`: main CLI (`render`, `check`, `convert`)
 - `citum_analyze`: corpus analysis tooling
 
 ## Quick Start
@@ -37,7 +37,7 @@ cargo test --workspace
 Render references:
 
 ```bash
-cargo run --bin citum-cli -- render refs \
+cargo run --bin citum -- render refs \
   -b tests/fixtures/references-expanded.json \
   -s styles/apa-7th.yaml
 ```
@@ -45,7 +45,7 @@ cargo run --bin citum-cli -- render refs \
 Render a document:
 
 ```bash
-cargo run --bin citum-cli -- render doc \
+cargo run --bin citum -- render doc \
   -i examples/document.djot \
   -b examples/document-refs.json \
   -s styles/apa-7th.yaml \
@@ -55,7 +55,7 @@ cargo run --bin citum-cli -- render doc \
 Validate inputs:
 
 ```bash
-cargo run --bin citum-cli -- check \
+cargo run --bin citum -- check \
   -s styles/apa-7th.yaml \
   -b tests/fixtures/references-expanded.json \
   -c tests/fixtures/citations-expanded.json
@@ -64,12 +64,12 @@ cargo run --bin citum-cli -- check \
 Convert formats:
 
 ```bash
-cargo run --bin citum-cli -- convert styles/apa-7th.yaml --output /tmp/apa-7th.cbor
+cargo run --bin citum -- convert styles/apa-7th.yaml --output /tmp/apa-7th.cbor
 ```
 
 ## CLI Surface
 
-`citum-cli` currently exposes:
+`citum` currently exposes:
 
 - `render` (subcommands: `doc`, `refs`)
 - `check`
@@ -78,8 +78,8 @@ cargo run --bin citum-cli -- convert styles/apa-7th.yaml --output /tmp/apa-7th.c
 Schema generation is available with the feature-enabled build:
 
 ```bash
-cargo run --bin citum-cli --features schema -- schema style
-cargo run --bin citum-cli --features schema -- schema --out-dir ./schemas
+cargo run --bin citum --features schema -- schema style
+cargo run --bin citum --features schema -- schema --out-dir ./schemas
 ```
 
 ## Migration Workflow (Hybrid)

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "citum-cli"
+name = "citum"
 version.workspace = true
 edition.workspace = true
 
 [[bin]]
-name = "citum-cli"
+name = "citum"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -317,7 +317,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         }
         Commands::Doc(args) => {
             eprintln!(
-                "Warning: `csln doc` is deprecated. Use `csln render doc` with positional input."
+                "Warning: `citum doc` is deprecated. Use `citum render doc` with positional input."
             );
             let doc_args = RenderDocArgs {
                 input: args.document,
@@ -332,7 +332,7 @@ fn run() -> Result<(), Box<dyn Error>> {
             run_render_doc(doc_args)
         }
         Commands::Validate(args) => {
-            eprintln!("Warning: `csln validate` is deprecated. Use `csln check --style`.");
+            eprintln!("Warning: `citum validate` is deprecated. Use `citum check --style`.");
             run_check(CheckArgs {
                 style: Some(args.path.display().to_string()),
                 bibliography: Vec::new(),
@@ -404,8 +404,8 @@ fn run_styles_list() -> Result<(), Box<dyn Error>> {
 
     println!();
     println!("Usage:");
-    println!("  csln render refs -s <alias|name> -b refs.json");
-    println!("  csln render doc <doc.dj> -s <alias|name> -b refs.json");
+    println!("  citum render refs -s <alias|name> -b refs.json");
+    println!("  citum render doc <doc.dj> -s <alias|name> -b refs.json");
     Ok(())
 }
 
@@ -551,7 +551,7 @@ fn load_any_style(style_input: &str, no_semantics: bool) -> Result<Style, Box<dy
             msg.push_str(&format!("\n  - {}", s));
         }
     } else {
-        msg.push_str("\n\nUse `csln styles list` to see all available builtin styles.");
+        msg.push_str("\n\nUse `citum styles list` to see all available builtin styles.");
     }
 
     Err(msg.into())

--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -143,15 +143,15 @@ full ibid/subsequent support requires `position` condition (not yet implemented)
 
 ## Embedded Styles (Built into Binary)
 
-Twelve priority styles are compiled into the `citum-cli` binary via `include_bytes!`
+Twelve priority styles are compiled into the `citum` binary via `include_bytes!`
 and can be used without any style file on disk.
 
 ```bash
 # List all embedded styles
-citum-cli styles list
+citum styles list
 
 # Render using a builtin style
-citum-cli render refs --builtin apa-7th -b refs.json
+citum render refs --builtin apa-7th -b refs.json
 ```
 
 | Style | Format | Dependents | Corpus Impact |

--- a/docs/architecture/CITUM_FULL_MIGRATION_EXECUTION_PLAN_2026-02-26.md
+++ b/docs/architecture/CITUM_FULL_MIGRATION_EXECUTION_PLAN_2026-02-26.md
@@ -72,7 +72,7 @@ Core mappings:
 | `crates/csln_migrate` | `crates/citum-migrate` | path |
 | `crates/csln_analyze` | `crates/citum-analyze` | path |
 | `crates/csln` | `crates/citum-cli` | path |
-| `--bin csln` | `--bin citum-cli` | command token |
+| `--bin csln` | `--bin citum` | command token |
 | `bdarcus/csl26` | `citum/citum-core` | literal URL text |
 
 ### 5.2 Three-pass replacement model
@@ -125,7 +125,7 @@ Keep reviewable commits:
 ## 9. Open Decisions (Resolve Before Cutover)
 
 1. **Bean ID policy:** keep `csl26-*` IDs permanently vs introduce `citum-*` IDs for new tasks.
-2. **CLI compatibility policy:** temporary shim (`csln` alias) vs immediate hard rename to `citum-cli`.
+2. **CLI binary policy:** use `citum` as the single public command (no extra alias).
 3. **Frontend branding policy:** keep `.csln-*` CSS/API classes for compatibility vs rename in same window.
 4. **Server placement policy:** keep `citum-server` in `citum-core` until stabilization (default), then evaluate extraction later.
 

--- a/docs/architecture/CITUM_MODULARIZATION.md
+++ b/docs/architecture/CITUM_MODULARIZATION.md
@@ -68,7 +68,7 @@ citum-core repo:
        |
   citum-migrate ---> citum-schema, csl-legacy   [legacy stays internal]
        |
-  citum-cli     ---> citum-engine, citum-migrate
+  citum        ---> citum-engine, citum-migrate   [binary from `citum-cli` crate]
        |
   citum-bindings --> citum-engine [cdylib/wasm targets, thin wrapper only]
 ```
@@ -85,7 +85,7 @@ See [CITUM_SERVER_MODE.md](./CITUM_SERVER_MODE.md) for the full server mode plan
 | `csl-legacy`     | `csl-legacy`     | No         | Internal tooling               |
 | `csln-edtf`      | `csln-edtf`      | Yes        | Potentially standalone         |
 | `citum_analyze`   | `citum-analyze`  | No         | Internal tooling               |
-| `csln` (bin)     | `citum-cli`      | Yes (bin)  | CLI binary                     |
+| `csln` (bin)     | `citum`          | Yes (bin)  | CLI binary (from `citum-cli`) |
 | *(new)*          | `citum-server`   | Yes (bin)  | JSON-RPC + optional HTTP server; see [CITUM_SERVER_MODE.md](./CITUM_SERVER_MODE.md) |
 
 ### Target Workspace Layout
@@ -182,7 +182,7 @@ engine API surface is stable. Pin to the production readiness milestone
 
 `citum_schema` already has a `schema` feature flag using `schemars`. The JSON
 Schema generated from Rust types is the mechanism for keeping `citum-hub`
-and the public specification in sync. The existing `cargo run --bin citum-cli -- schema`
+and the public specification in sync. The existing `cargo run --bin citum -- schema`
 command exposes this.
 
 No new mechanism is needed. Stabilizing and publishing the schema crate

--- a/docs/architecture/CITUM_SERVER_MODE.md
+++ b/docs/architecture/CITUM_SERVER_MODE.md
@@ -8,7 +8,7 @@
 
 The Citum engine needs a server mode to support real-time citation formatting
 in word processors (Word, LibreOffice) and live preview in the citum-hub web
-app. The batch CLI (`citum-cli`) is synchronous and stdin/stdout-driven; adding
+app. The batch CLI (`citum`) is synchronous and stdin/stdout-driven; adding
 an HTTP server there conflates two fundamentally different runtime models.
 
 ---
@@ -16,7 +16,7 @@ an HTTP server there conflates two fundamentally different runtime models.
 ## Decision: Dedicated `citum-server` Binary Crate (In `citum-core`)
 
 The server mode belongs in a dedicated `citum-server` binary crate in the
-`citum-core` workspace. It should not be a subcommand on `citum-cli`, and it
+`citum-core` workspace. It should not be a subcommand on `citum`, and it
 should not live in `citum-hub` (`style-hub`).
 
 **Rationale:**
@@ -36,7 +36,7 @@ citum-schema    (no legacy deps)
 citum-engine    -> citum-schema
 citum-server    -> citum-engine, citum-schema   [new in citum-core]
 citum-migrate   -> citum-schema, csl-legacy
-citum-cli       -> citum-engine, citum-migrate
+citum          -> citum-engine, citum-migrate   [binary from `citum-cli` crate]
 citum-bindings  -> citum-engine                 [cdylib/wasm, Phase 2]
 ```
 
@@ -51,7 +51,7 @@ citum-bindings  -> citum-engine                 [cdylib/wasm, Phase 2]
 | `csl-legacy`     | No         | Internal tooling                           |
 | `csln-edtf`      | Yes        | Potentially standalone                     |
 | `citum-analyze`  | No         | Internal tooling                           |
-| `citum-cli`      | Yes (bin)  | CLI binary                                 |
+| `citum`          | Yes (bin)  | CLI binary (from `citum-cli` crate)       |
 
 ---
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -469,7 +469,7 @@ Structured: [@kuhn1962, section: 5].</pre>
                         Render a grouped bibliography with primary, archival, and secondary sources in English:
                     </p>
                     <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum-cli</span> render refs \
+                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
   -b examples/bib-grouping-refs.yaml \
   -s styles/chicago-author-date.yaml</pre>
                     </div>
@@ -503,7 +503,7 @@ Mayr, Ernst. 1991. "Darwin's Impact on Modern Thought." Proceedings of the Ameri
                         Switch to German headings by setting <code class="text-slate-600 bg-slate-100 px-1 rounded">default-locale: de-DE</code> in the style:
                     </p>
                     <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum-cli</span> render refs \
+                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
   -b examples/bib-grouping-refs.yaml \
   -s styles/chicago-author-date.yaml \
   --default-locale de-DE</pre>
@@ -673,7 +673,7 @@ Mayr, Ernst. 1991. "Darwin's Impact on Modern Thought." Proceedings of the Ameri
                         Render multilingual references with configurable title and name modes:
                     </p>
                     <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum-cli</span> render refs \
+                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
   -b examples/multilingual-refs.yaml \
   -s styles/experimental/multilingual-academic.yaml</pre>
                     </div>
@@ -1097,7 +1097,7 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                             Compilation
                         </h4>
                         <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300">
-                            <span class="text-primary">$</span> citum-cli convert
+                            <span class="text-primary">$</span> citum convert
                             styles/apa-7th.yaml --output /tmp/apa-7th.cbor
                         </div>
                         <p class="text-xs text-slate-500 mt-2 italic">
@@ -1110,7 +1110,7 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                             Processing
                         </h4>
                         <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300">
-                            <span class="text-primary">$</span> citum-cli render refs
+                            <span class="text-primary">$</span> citum render refs
                             -b data.cbor -s style.cbor
                         </div>
                         <p class="text-xs text-slate-500 mt-2 italic">
@@ -1143,8 +1143,8 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                         Generation Command (Optional Feature)
                     </h4>
                     <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300 overflow-x-auto">
-                        <span class="text-primary">$</span> cargo run --bin citum-cli --features schema -- schema &gt;
-                        citum-cli.schema.json
+                        <span class="text-primary">$</span> cargo run --bin citum --features schema -- schema &gt;
+                        citum.schema.json
                     </div>
                     <p class="text-xs text-slate-500 mt-2 italic">
                         Use this only when generating schemas locally; published schemas are already available on the

--- a/docs/guides/RENDERING_WORKFLOW.md
+++ b/docs/guides/RENDERING_WORKFLOW.md
@@ -6,16 +6,16 @@ This guide describes the standard workflow for debugging and fixing rendering is
 
 ```bash
 # Render references with a style (default plain text)
-citum-cli render refs -b references.json -s styles/apa-7th.yaml
+citum render refs -b references.json -s styles/apa-7th.yaml
 
 # Process with reference keys shown for debugging ([ITEM-1] ...)
-citum-cli render refs -b references.json -s styles/apa-7th.yaml --show-keys
+citum render refs -b references.json -s styles/apa-7th.yaml --show-keys
 
 # Convert a YAML style to binary CBOR for performance
-citum-cli convert styles/apa-7th.yaml --output styles/apa-7th.cbor
+citum convert styles/apa-7th.yaml --output styles/apa-7th.cbor
 
 # Generate semantic HTML
-citum-cli render refs -b references.json -s styles/apa-7th.yaml -O html
+citum render refs -b references.json -s styles/apa-7th.yaml -O html
 
 # Test a single style (default: structured diff)
 node ../scripts/oracle.js styles-legacy/apa.csl

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -171,7 +171,7 @@
                     <nav class="space-y-1">
                         <div class="toc-section">
                             <div class="toc-section-title">Getting Started</div>
-                            <a href="#how-citum-cli-differs" class="sidebar-link">
+                            <a href="#how-citum-differs" class="sidebar-link">
                                 <span class="material-icons text-sm">chevron_right</span>
                                 How CSLN Differs from CSL 1.0
                             </a>
@@ -236,7 +236,7 @@
             <main class="flex-1 min-w-0 space-y-16 pb-24">
 
                 <!-- How CSLN Differs from CSL 1.0 -->
-                <section id="how-citum-cli-differs" class="scroll-mt-24">
+                <section id="how-citum-differs" class="scroll-mt-24">
                     <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
                         <span class="material-icons text-primary">compare_arrows</span>
                         How CSLN Differs from CSL 1.0
@@ -1274,7 +1274,7 @@
                         <p class="text-slate-600 text-sm mb-4">Use these commands to test your style:</p>
                         <div class="space-y-3">
                             <div class="bg-slate-900 rounded-lg p-4 overflow-x-auto">
-                                <pre class="font-mono text-xs text-emerald-400"><span class="text-primary">$</span> cargo run --bin citum-cli -- render refs \
+                                <pre class="font-mono text-xs text-emerald-400"><span class="text-primary">$</span> cargo run --bin citum -- render refs \
   -b tests/fixtures/references-expanded.json \
   -s styles/my-style.yaml</pre>
                             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,9 +140,9 @@
                 <div
                     class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group cursor-text border border-slate-700 shadow-lg text-left">
                     <code
-                        class="font-mono text-emerald-400 text-sm">$ cargo install --git https://github.com/citum/citum-core citum-cli</code>
+                        class="font-mono text-emerald-400 text-sm">$ cargo install --git https://github.com/citum/citum-core --bin citum citum</code>
                     <button class="text-slate-500 hover:text-white transition-colors"
-                        onclick="navigator.clipboard.writeText('cargo install --git https://github.com/citum/citum-core citum-cli')"
+                        onclick="navigator.clipboard.writeText('cargo install --git https://github.com/citum/citum-core --bin citum citum')"
                         title="Copy to clipboard">
                         <span class="material-icons text-base">content_copy</span>
                     </button>
@@ -173,13 +173,13 @@
                     <div class="w-3 h-3 rounded-full bg-slate-300"></div>
                     <div class="w-3 h-3 rounded-full bg-slate-300"></div>
                 </div>
-                <div class="text-xs font-mono text-slate-400">citation_config.citum-cli.yaml</div>
+                <div class="text-xs font-mono text-slate-400">citation_config.citum.yaml</div>
                 <div class="w-12"></div>
             </div>
             <div class="p-8 overflow-x-auto bg-[#fafafa]">
                 <pre class="font-mono text-sm leading-relaxed"><span class="text-indigo-600">info</span>:
   <span class="text-primary">title</span>: <span class="text-emerald-600">"APA 7th Edition (CSLN)"</span>
-  <span class="text-primary">id</span>: <span class="text-emerald-600">"https://www.zotero.org/styles/apa-7th-citum-cli"</span>
+  <span class="text-primary">id</span>: <span class="text-emerald-600">"https://www.zotero.org/styles/apa-7th-citum"</span>
   <span class="text-primary">link</span>: <span class="text-emerald-600">"https://apastyle.apa.org/"</span>
 <span class="text-indigo-600">options</span>:
   <span class="text-primary">processing</span>: <span class="text-emerald-600">author-date</span>
@@ -407,10 +407,10 @@
                             <h4 class="font-bold text-slate-900 mb-2">Render references (HTML)</h4>
                             <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
                                 <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum-cli render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f html</span>
+                                    <span class="text-primary">$</span> citum render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f html</span>
                                 </code>
                                 <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum-cli render refs -b tests/fixtures/references-expanded.json -s mla -f html')"
+                                    onclick="navigator.clipboard.writeText('citum render refs -b tests/fixtures/references-expanded.json -s mla -f html')"
                                     title="Copy to clipboard">
                                     <span class="material-icons text-base">content_copy</span>
                                 </button>
@@ -422,10 +422,10 @@
                             <h4 class="font-bold text-slate-900 mb-2">Render for static sites (Djot)</h4>
                             <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
                                 <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum-cli render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f djot</span>
+                                    <span class="text-primary">$</span> citum render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f djot</span>
                                 </code>
                                 <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum-cli render refs -b tests/fixtures/references-expanded.json -s mla -f djot')"
+                                    onclick="navigator.clipboard.writeText('citum render refs -b tests/fixtures/references-expanded.json -s mla -f djot')"
                                     title="Copy to clipboard">
                                     <span class="material-icons text-base">content_copy</span>
                                 </button>
@@ -437,10 +437,10 @@
                             <h4 class="font-bold text-slate-900 mb-2">Render for LaTeX (Native Escaping)</h4>
                             <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
                                 <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum-cli render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f latex</span>
+                                    <span class="text-primary">$</span> citum render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f latex</span>
                                 </code>
                                 <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum-cli render refs -b tests/fixtures/references-expanded.json -s mla -f latex')"
+                                    onclick="navigator.clipboard.writeText('citum render refs -b tests/fixtures/references-expanded.json -s mla -f latex')"
                                     title="Copy to clipboard">
                                     <span class="material-icons text-base">content_copy</span>
                                 </button>
@@ -452,10 +452,10 @@
                             <h4 class="font-bold text-slate-900 mb-2">Render full document (Djot draft syntax)</h4>
                             <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
                                 <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum-cli render doc examples/document.djot -b examples/document-refs.json -s mla
+                                    <span class="text-primary">$</span> citum render doc examples/document.djot -b examples/document-refs.json -s mla
                                 </code>
                                 <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum-cli render doc examples/document.djot -b examples/document-refs.json -s mla')"
+                                    onclick="navigator.clipboard.writeText('citum render doc examples/document.djot -b examples/document-refs.json -s mla')"
                                     title="Copy to clipboard">
                                     <span class="material-icons text-base">content_copy</span>
                                 </button>
@@ -467,10 +467,10 @@
                             <h4 class="font-bold text-slate-900 mb-2">Use a builtin style (no file needed)</h4>
                             <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
                                 <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum-cli render refs -b refs.json <span class="text-emerald-400">-s apa</span>
+                                    <span class="text-primary">$</span> citum render refs -b refs.json <span class="text-emerald-400">-s apa</span>
                                 </code>
                                 <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum-cli render refs -b refs.json -s apa')"
+                                    onclick="navigator.clipboard.writeText('citum render refs -b refs.json -s apa')"
                                     title="Copy to clipboard">
                                     <span class="material-icons text-base">content_copy</span>
                                 </button>
@@ -482,10 +482,10 @@
                             <h4 class="font-bold text-slate-900 mb-2">List all embedded styles</h4>
                             <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
                                 <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum-cli styles list
+                                    <span class="text-primary">$</span> citum styles list
                                 </code>
                                 <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum-cli styles list')"
+                                    onclick="navigator.clipboard.writeText('citum styles list')"
                                     title="Copy to clipboard">
                                     <span class="material-icons text-base">content_copy</span>
                                 </button>
@@ -497,10 +497,10 @@
                             <h4 class="font-bold text-slate-900 mb-2">Convert to binary (Performance Mode)</h4>
                             <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
                                 <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum-cli convert styles/apa-7th.yaml --output /tmp/apa-7th.cbor
+                                    <span class="text-primary">$</span> citum convert styles/apa-7th.yaml --output /tmp/apa-7th.cbor
                                 </code>
                                 <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum-cli convert styles/apa-7th.yaml --output /tmp/apa-7th.cbor')"
+                                    onclick="navigator.clipboard.writeText('citum convert styles/apa-7th.yaml --output /tmp/apa-7th.cbor')"
                                     title="Copy to clipboard">
                                     <span class="material-icons text-base">content_copy</span>
                                 </button>

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -161,10 +161,10 @@ Users encounter versions in different contexts:
 
 ### CLI (Code Version)
 ```bash
-$ citum-cli --version
-citum-cli 0.2.3
+$ citum --version
+citum 0.2.3
 
-$ cargo run --bin citum-cli --features schema -- schema style
+$ cargo run --bin citum --features schema -- schema style
 # prints style JSON Schema to stdout
 ```
 
@@ -174,7 +174,7 @@ $ cargo run --bin citum-cli --features schema -- schema style
 version: "1.0.0"  # Schema version (optional, inherits default)
 info:
   title: APA 7th Edition (CSLN)
-  id: https://www.zotero.org/styles/apa-7th-citum-cli
+  id: https://www.zotero.org/styles/apa-7th-citum
 ```
 
 ### Documentation

--- a/scripts/batch-oracle.js
+++ b/scripts/batch-oracle.js
@@ -153,7 +153,7 @@ function renderWithCslnProcessor(stylePath) {
   let output;
   try {
     output = execSync(
-      `cargo run -q --bin citum-cli -- render refs -b tests/fixtures/references-expanded.json -s .migrated-temp.yaml -c .migrated-citations.json --mode both --show-keys`,
+      `cargo run -q --bin citum -- render refs -b tests/fixtures/references-expanded.json -s .migrated-temp.yaml -c .migrated-citations.json --mode both --show-keys`,
       { cwd: projectRoot, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     );
   } catch (e) {
@@ -301,7 +301,7 @@ console.log(`Testing ${styleFiles.length} styles...`);
 // Pre-build Rust binaries
 console.log('Building Rust binaries...');
 try {
-  execSync('cargo build --release --bin citum-migrate --bin citum-cli', {
+  execSync('cargo build --release --bin citum-migrate --bin citum', {
     cwd: projectRoot,
     stdio: 'inherit'
   });

--- a/scripts/lint-rendering.sh
+++ b/scripts/lint-rendering.sh
@@ -9,7 +9,7 @@ if [ -z "$STYLE_FILE" ]; then
 fi
 
 # Run the processor and capture output
-OUTPUT=$(cargo run --quiet --bin citum-cli -- render refs -b tests/fixtures/references-expanded.json -s "$STYLE_FILE" -c tests/fixtures/citations-expanded.json --mode both --show-keys 2>/dev/null)
+OUTPUT=$(cargo run --quiet --bin citum -- render refs -b tests/fixtures/references-expanded.json -s "$STYLE_FILE" -c tests/fixtures/citations-expanded.json --mode both --show-keys 2>/dev/null)
 
 echo "--- Rendering Lint Report for $(basename "$STYLE_FILE") ---"
 ERRORS=0

--- a/scripts/oracle-e2e.js
+++ b/scripts/oracle-e2e.js
@@ -88,7 +88,7 @@ function renderWithCslnProcessor(stylePath) {
   let output;
   try {
     output = execSync(
-      `cargo run -q --bin citum-cli -- render refs -b tests/fixtures/references-expanded.json -s .migrated-temp.yaml -c .migrated-citations.json --mode both --show-keys`,
+      `cargo run -q --bin citum -- render refs -b tests/fixtures/references-expanded.json -s .migrated-temp.yaml -c .migrated-citations.json --mode both --show-keys`,
       { cwd: projectRoot, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     );
   } catch (e) {

--- a/scripts/oracle-migration.js
+++ b/scripts/oracle-migration.js
@@ -199,7 +199,7 @@ function renderWithCsln(stylePath) {
 
     try {
         const output = execSync(
-            `cargo run -q --bin citum-cli -- render refs -b ${tmpFixture} -s ${cslnStylePath} -c ${tmpCitations} --mode both --show-keys`,
+            `cargo run -q --bin citum -- render refs -b ${tmpFixture} -s ${cslnStylePath} -c ${tmpCitations} --mode both --show-keys`,
             { encoding: 'utf8', cwd: path.join(__dirname, '..') }
         );
 

--- a/scripts/oracle-yaml.js
+++ b/scripts/oracle-yaml.js
@@ -45,7 +45,7 @@ function renderWithCslnYaml(yamlPath) {
   let output;
   try {
     output = execSync(
-      `cargo run -q --bin citum-cli -- render refs -b tests/fixtures/references-expanded.json -s "${absYamlPath}" -c .oracle-yaml-citations.json --mode both --show-keys`,
+      `cargo run -q --bin citum -- render refs -b tests/fixtures/references-expanded.json -s "${absYamlPath}" -c .oracle-yaml-citations.json --mode both --show-keys`,
       { cwd: projectRoot, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     );
   } catch (e) {

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -251,7 +251,7 @@ function renderWithCslnProcessor(stylePath, testItems, testCitations) {
   let output;
   try {
     output = execSync(
-      `cargo run -q --bin citum-cli -- render refs -b .migrated-refs.json -s "${cslnStylePath}" -c .migrated-citations.json --mode both --show-keys`,
+      `cargo run -q --bin citum -- render refs -b .migrated-refs.json -s "${cslnStylePath}" -c .migrated-citations.json --mode both --show-keys`,
       { cwd: projectRoot, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
     );
   } catch (e) {
@@ -522,7 +522,7 @@ if (!csln || csln.error) {
     console.error('Next Steps:');
     console.error('  1. Check migration output: cargo run --bin citum-migrate -- <csl-path>');
     console.error('  2. Validate YAML syntax: yamllint .migrated-temp.yaml');
-    console.error('  3. Check processor error: cargo run --bin citum-cli -- render refs -b <refs> -s <style> -c <citations> --mode both');
+    console.error('  3. Check processor error: cargo run --bin citum -- render refs -b <refs> -s <style> -c <citations> --mode both');
   }
   process.exit(2);
 }

--- a/scripts/validate-schema.sh
+++ b/scripts/validate-schema.sh
@@ -31,7 +31,7 @@ info "Found $STYLE_COUNT production style files"
 
 FAILED=0
 for style in "${STYLE_FILES[@]}"; do
-    if ! cargo run --quiet --bin citum-cli -- check -s "$style" >/dev/null 2>&1; then
+    if ! cargo run --quiet --bin citum -- check -s "$style" >/dev/null 2>&1; then
         error "Style failed schema validation: $style"
         FAILED=1
     fi


### PR DESCRIPTION
## Summary
- make the CLI package name  (binary remains )
- remove remaining user-facing  command text in CLI warnings/help
- align docs/examples/install snippets to the single public  binary name

## Verification
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run