### PR TITLE
fix(delimiter): normalize enum parsing across engine and migrate

### DIFF
--- a/.beans/csl26-6bak--refactor-delimiter-handling-with-hybrid-enum-appro.md
+++ b/.beans/csl26-6bak--refactor-delimiter-handling-with-hybrid-enum-appro.md
@@ -1,7 +1,7 @@
 ---
 # csl26-6bak
 title: Refactor delimiter handling with hybrid enum approach
-status: todo
+status: in_progress
 type: feature
 priority: high
 created_at: 2026-02-07T06:44:21Z
@@ -9,10 +9,26 @@ updated_at: 2026-02-07T12:11:38Z
 parent: csl26-u1in
 ---
 
-Current delimiter handling is scattered across the codebase.
+Current delimiter handling is scattered across the codebase. The hybrid enum
+exists in schema, but migrate/compiler and engine still contain duplicated
+or ad-hoc conversion logic.
 
-Propose hybrid enum approach that combines predefined delimiters (comma, period, space) with custom text variant.
+Implementation checklist:
+- [x] Centralize delimiter parsing/normalization usage around
+      `DelimiterPunctuation::from_csl_string` in schema consumers
+- [x] Replace migrate `map_delimiter` hand-written matcher with shared schema
+      conversion
+- [x] Refactor engine citation delimiter normalization to use enum parsing
+      (remove string-only `"none"` special-casing)
+- [x] Add targeted tests for delimiter normalization edge cases
+      (`none`, empty, trimmed values, custom)
+- [x] Run Rust verification suite:
+      `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`
 
-This will simplify the code and make delimiter logic more explicit.
+Acceptance criteria:
+- No duplicate delimiter mapping table remains in migrate compiler.
+- Citation processing handles `none`/empty delimiters via shared enum
+  semantics.
+- Existing tests pass and new delimiter-focused coverage is present.
 
 Refs: GitHub #126

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -38,7 +38,7 @@ use citum_schema::Style;
 use citum_schema::citation::Position;
 use citum_schema::locale::Locale;
 use citum_schema::options::Config;
-use citum_schema::template::WrapPunctuation;
+use citum_schema::template::{DelimiterPunctuation, WrapPunctuation};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
@@ -639,7 +639,10 @@ impl Processor {
         let sorted_items = self.sort_citation_items(citation.items.clone(), &effective_spec);
 
         let intra_delimiter = effective_spec.delimiter.as_deref().unwrap_or(", ");
-        let renderer_delimiter = if intra_delimiter == "none" || intra_delimiter.is_empty() {
+        let renderer_delimiter = if matches!(
+            DelimiterPunctuation::from_csl_string(intra_delimiter),
+            DelimiterPunctuation::None
+        ) {
             ""
         } else {
             intra_delimiter
@@ -649,6 +652,14 @@ impl Processor {
             .multi_cite_delimiter
             .as_deref()
             .unwrap_or("; ");
+        let renderer_inter_delimiter = if matches!(
+            DelimiterPunctuation::from_csl_string(inter_delimiter),
+            DelimiterPunctuation::None
+        ) {
+            ""
+        } else {
+            inter_delimiter
+        };
 
         let cite_config = self.get_citation_config();
         let processing = cite_config.processing.clone().unwrap_or_default();
@@ -686,7 +697,7 @@ impl Processor {
         };
 
         let fmt = F::default();
-        let content = fmt.join(rendered_groups, inter_delimiter);
+        let content = fmt.join(rendered_groups, renderer_inter_delimiter);
 
         // Apply citation-level prefix/suffix from input
         let citation_prefix = citation.prefix.as_deref().unwrap_or("");

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -211,6 +211,42 @@ fn test_process_citations_batch_api() {
 }
 
 #[test]
+fn test_process_citation_treats_trimmed_none_delimiter_as_empty() {
+    let mut style = make_style();
+    style.citation = Some(CitationSpec {
+        template: Some(vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                form: ContributorForm::Short,
+                ..Default::default()
+            }),
+            TemplateComponent::Date(TemplateDate {
+                date: TDateVar::Issued,
+                form: DateForm::Year,
+                ..Default::default()
+            }),
+        ]),
+        wrap: Some(WrapPunctuation::Parentheses),
+        delimiter: Some(" none ".to_string()),
+        ..Default::default()
+    });
+
+    let bib = make_bibliography();
+    let processor = Processor::new(style, bib);
+    let citation = Citation {
+        id: Some("c1".to_string()),
+        items: vec![crate::reference::CitationItem {
+            id: "kuhn1962".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let result = processor.process_citation(&citation).unwrap();
+    assert_eq!(result, "(Kuhn1962)");
+}
+
+#[test]
 fn test_citation_locator_label_renders_term() {
     let mut style = make_style();
     style.citation = Some(citum_schema::CitationSpec {

--- a/crates/citum-migrate/src/template_compiler/mod.rs
+++ b/crates/citum-migrate/src/template_compiler/mod.rs
@@ -1950,20 +1950,9 @@ impl TemplateCompiler {
     /// Map a String delimiter to DelimiterPunctuation.
     /// Preserves custom delimiters that don't match standard patterns.
     fn map_delimiter(&self, delimiter: &Option<String>) -> Option<DelimiterPunctuation> {
-        let d = delimiter.as_ref()?;
-        match d.as_str() {
-            ", " | "," => Some(DelimiterPunctuation::Comma),
-            "; " | ";" => Some(DelimiterPunctuation::Semicolon),
-            ". " | "." => Some(DelimiterPunctuation::Period),
-            ": " | ":" => Some(DelimiterPunctuation::Colon),
-            " & " | "&" => Some(DelimiterPunctuation::Ampersand),
-            " | " | "|" => Some(DelimiterPunctuation::VerticalLine),
-            " / " | "/" => Some(DelimiterPunctuation::Slash),
-            " - " | "-" => Some(DelimiterPunctuation::Hyphen),
-            " " => Some(DelimiterPunctuation::Space),
-            "" => Some(DelimiterPunctuation::None),
-            _ => Some(DelimiterPunctuation::Custom(d.clone())),
-        }
+        delimiter
+            .as_deref()
+            .map(DelimiterPunctuation::from_csl_string)
     }
 
     /// Get the rendering options from a component.

--- a/crates/citum-schema/src/template.rs
+++ b/crates/citum-schema/src/template.rs
@@ -665,33 +665,25 @@ impl DelimiterPunctuation {
     /// Handles common patterns like ", ", ": ", etc.
     /// Returns Custom variant for unrecognized delimiters.
     pub fn from_csl_string(s: &str) -> Self {
-        match s {
-            "," | ", " => Self::Comma,
-            ";" | "; " => Self::Semicolon,
-            "." | ". " => Self::Period,
-            ":" | ": " => Self::Colon,
-            "&" | " & " => Self::Ampersand,
-            "|" | " | " => Self::VerticalLine,
+        if s == " " {
+            return Self::Space;
+        }
+
+        let trimmed = s.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("none") {
+            return Self::None;
+        }
+
+        match trimmed {
+            "," => Self::Comma,
+            ";" => Self::Semicolon,
+            "." => Self::Period,
+            ":" => Self::Colon,
+            "&" => Self::Ampersand,
+            "|" => Self::VerticalLine,
             "/" => Self::Slash,
             "-" => Self::Hyphen,
-            " " => Self::Space,
-            "" => Self::None,
-            "none" => Self::None,
-            _ => {
-                let trimmed = s.trim();
-                match trimmed {
-                    "," => Self::Comma,
-                    ";" => Self::Semicolon,
-                    "." => Self::Period,
-                    ":" => Self::Colon,
-                    "&" => Self::Ampersand,
-                    "|" => Self::VerticalLine,
-                    "/" => Self::Slash,
-                    "-" => Self::Hyphen,
-                    "" => Self::None,
-                    _ => Self::Custom(s.to_string()),
-                }
-            }
+            _ => Self::Custom(s.to_string()),
         }
     }
 }
@@ -822,5 +814,25 @@ wrap: parentheses
         assert!(mixed.matches("default"));
         assert!(mixed.matches("chapter"));
         assert!(!mixed.matches("book"));
+    }
+
+    #[test]
+    fn test_delimiter_from_csl_string_normalizes_none_and_trimmed_values() {
+        assert_eq!(
+            DelimiterPunctuation::from_csl_string("none"),
+            DelimiterPunctuation::None
+        );
+        assert_eq!(
+            DelimiterPunctuation::from_csl_string(" none "),
+            DelimiterPunctuation::None
+        );
+        assert_eq!(
+            DelimiterPunctuation::from_csl_string(" "),
+            DelimiterPunctuation::Space
+        );
+        assert_eq!(
+            DelimiterPunctuation::from_csl_string(" : "),
+            DelimiterPunctuation::Colon
+        );
     }
 }


### PR DESCRIPTION
## Summary
- centralize delimiter string-to-enum normalization through the shared schema parser
- replace duplicate delimiter mapping logic in migrate template compiler with shared schema conversion
- normalize citation and multi-cite delimiter handling in engine so trimmed none resolves to an empty delimiter consistently
- add delimiter normalization regression tests in schema and processor test suites
- update bean csl26-6bak with plan and completed checklist

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run

## Refs
- csl26-6bak
- #126