### PR TITLE
feat(ci): add oracle top-10 regression baseline gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,8 @@ jobs:
           node scripts/check-core-quality.js \
             --report /tmp/core-report.json \
             --baseline scripts/report-data/core-quality-baseline.json
+
+      - name: Check oracle top-10 regression baseline
+        run: |
+          node scripts/check-oracle-regression.js \
+            --baseline scripts/report-data/oracle-top10-baseline.json

--- a/baselines/README.md
+++ b/baselines/README.md
@@ -100,3 +100,16 @@ Baseline JSON files are gitignored by default (`baselines/*.json`) to avoid repo
 ## Integration with Workflow
 
 See [docs/RENDERING_WORKFLOW.md](../docs/RENDERING_WORKFLOW.md) and [docs/WORKFLOW_ANALYSIS.md](../docs/WORKFLOW_ANALYSIS.md) for how regression detection integrates into the overall rendering fidelity workflow.
+
+## CI Canonical Baseline
+
+The committed CI oracle baseline lives at:
+
+- `scripts/report-data/oracle-top10-baseline.json`
+
+CI checks this file via:
+
+```bash
+node scripts/check-oracle-regression.js \
+  --baseline scripts/report-data/oracle-top10-baseline.json
+```

--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -187,10 +187,19 @@ node scripts/report-core.js > /tmp/core-report.json
 node scripts/check-core-quality.js \
   --report /tmp/core-report.json \
   --baseline scripts/report-data/core-quality-baseline.json
+
+# Check oracle regression gate against pinned top-10 baseline
+node scripts/check-oracle-regression.js \
+  --baseline scripts/report-data/oracle-top10-baseline.json
+
+# Refresh pinned top-10 oracle baseline (dedicated baseline PR only)
+node scripts/oracle-batch-aggregate.js styles-legacy/ \
+  --styles apa,elsevier-with-titles,elsevier-harvard,elsevier-vancouver,springer-vancouver-brackets,springer-basic-author-date,springer-basic-brackets,springer-socpsych-author-date,american-medical-association,taylor-and-francis-chicago-author-date \
+  --json > scripts/report-data/oracle-top10-baseline.json
 ```
 
 ## Related
 
 - **beans:** `csl26-heqm` (top 10 at 100% fidelity), `csl26-gidg` (90% corpus match), `csl26-l2hg` (numeric triage)
 - **docs:** `docs/architecture/SQI_REFINEMENT_PLAN.md`, `docs/reference/STYLE_PRIORITY.md`
-- **CI:** `.github/workflows/ci.yml` — core fidelity gate (`check-core-quality.js`)
+- **CI:** `.github/workflows/ci.yml` — core fidelity gate (`check-core-quality.js`) + oracle regression gate (`check-oracle-regression.js`)

--- a/docs/architecture/CSL26_IEK4_BASELINE_TRACKING_PLAN_2026-02-27.md
+++ b/docs/architecture/CSL26_IEK4_BASELINE_TRACKING_PLAN_2026-02-27.md
@@ -1,0 +1,88 @@
+# CSL26-IEK4 Plan: Baseline Tracking for Regression Detection (2026-02-27)
+
+## Bean
+- ID: `csl26-iek4`
+- Title: Add baseline tracking for regression detection
+- Current status: `todo`
+- Dependency listed in bean: `csl26-r6fn` (Testing Infrastructure)
+
+## Evaluation Summary
+`csl26-iek4` should remain open and needs addressing.
+
+What is already implemented:
+- `scripts/oracle-batch-aggregate.js` supports `--save` and `--compare` and reports regressions.
+- `baselines/README.md` documents baseline capture and comparison workflow.
+- CI already enforces `scripts/check-core-quality.js` against `scripts/report-data/core-quality-baseline.json`.
+
+What is still missing relative to bean intent:
+- No committed oracle baseline artifact used as a canonical CI regression reference.
+- No CI gate that compares current oracle results against a pinned oracle baseline and fails on regression.
+- No explicit policy for baseline scope/versioning tied to fixtures/style set changes.
+
+## Goal
+Create a deterministic, CI-enforced oracle baseline gate that detects rendering regressions automatically for the project’s priority style set.
+
+## Scope
+In scope:
+- Oracle baseline artifact format and storage location.
+- CI regression gate for oracle-based style fidelity.
+- Maintenance workflow for baseline refreshes with review visibility.
+
+Out of scope:
+- Expanding citation fixture coverage beyond the current strict 12-scenario set.
+- Replacing `check-core-quality.js`; this remains a complementary gate.
+
+## Implementation Plan
+1. Define canonical baseline target
+- Baseline set: top-priority parent styles currently used for strict tracking (start with top 10 in `docs/TIER_STATUS.md`).
+- Fixture set: strict 12-scenario fixture (`tests/fixtures/citations-expanded.json`) as canonical input.
+- Determinism: fix sort/stable output order in saved JSON if needed.
+
+2. Add committed oracle baseline artifact
+- Add a tracked file under `scripts/report-data/`, for example:
+  - `scripts/report-data/oracle-top10-baseline.json`
+- Generate it via:
+  - `node scripts/oracle-batch-aggregate.js styles-legacy/ --top 10 --json > scripts/report-data/oracle-top10-baseline.json`
+- Include metadata fields for baseline provenance:
+  - date/time, fixture path, style count, script version hash (or commit SHA).
+
+3. Add CI regression check for oracle baseline
+- Add a small checker script (for example `scripts/check-oracle-regression.js`) that:
+  - loads baseline JSON,
+  - runs current oracle aggregate for same style set,
+  - fails on any citation or bibliography pass-count regression per style,
+  - prints clear per-style deltas.
+- Wire script into `.github/workflows/ci.yml` after existing Rust/tests and core-quality checks.
+
+4. Add local workflow commands and docs
+- Update `docs/TIER_STATUS.md` and/or `docs/guides/RENDERING_WORKFLOW.md` with:
+  - gate command,
+  - baseline refresh command,
+  - policy: refresh baseline only in dedicated PRs with justification.
+
+5. Add maintenance guardrails
+- Require PR note when updating baseline artifact:
+  - reason for refresh,
+  - before/after summary,
+  - explicit statement whether changes are expected improvements or accepted deltas.
+
+## Acceptance Criteria
+- CI fails when any tracked top-style citation/bibliography score drops below baseline.
+- CI passes when scores are equal or improved.
+- Baseline file is committed, reproducible, and documented.
+- Developer docs include a baseline refresh protocol and rationale requirements.
+
+## Risks and Mitigations
+- Risk: baseline churn from fixture/style-set changes.
+  - Mitigation: pin fixture/style-set in metadata and require explicit baseline-refresh PR.
+- Risk: flaky/non-deterministic oracle output.
+  - Mitigation: enforce stable ordering and deterministic JSON serialization.
+- Risk: duplicated gates with core-quality check.
+  - Mitigation: keep responsibilities separate (portfolio SQI/concision vs per-style oracle fidelity).
+
+## Suggested Execution Order
+1. Implement checker script + deterministic output contract.
+2. Generate and commit initial oracle baseline file.
+3. Wire CI gate.
+4. Document refresh policy and commands.
+5. Run full validation and open follow-up bean updates (`csl26-r6fn` linkage) if needed.

--- a/scripts/check-oracle-regression.js
+++ b/scripts/check-oracle-regression.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function usage() {
+  console.error('Usage: node scripts/check-oracle-regression.js --baseline <path> [--styles-dir <path>]');
+}
+
+function parseArgs(argv) {
+  const args = {
+    baseline: null,
+    stylesDir: 'styles-legacy',
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--baseline') {
+      args.baseline = argv[++i] || null;
+    } else if (arg === '--styles-dir') {
+      args.stylesDir = argv[++i] || 'styles-legacy';
+    }
+  }
+
+  return args;
+}
+
+function parseScore(score, label) {
+  const match = /^(\d+)\/(\d+)$/.exec(String(score || ''));
+  if (!match) {
+    throw new Error(`Invalid ${label} score format: ${score}`);
+  }
+  return {
+    passed: Number(match[1]),
+    total: Number(match[2]),
+  };
+}
+
+function styleMapFromBreakdown(styleBreakdown) {
+  const map = new Map();
+  for (const style of styleBreakdown || []) {
+    map.set(style.style, style);
+  }
+  return map;
+}
+
+function runAggregate(stylesDir, styles) {
+  const scriptPath = path.resolve(__dirname, 'oracle-batch-aggregate.js');
+  const styleArg = styles.join(',');
+  const cmd = `node "${scriptPath}" "${stylesDir}" --styles "${styleArg}" --json`;
+  const output = execSync(cmd, {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  return JSON.parse(output);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.baseline) {
+    usage();
+    process.exit(2);
+  }
+
+  const baselinePath = path.resolve(args.baseline);
+  if (!fs.existsSync(baselinePath)) {
+    console.error(`Baseline file not found: ${baselinePath}`);
+    process.exit(2);
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+  const baselineBreakdown = baseline.styleBreakdown;
+  if (!Array.isArray(baselineBreakdown) || baselineBreakdown.length === 0) {
+    console.error('Baseline file is missing styleBreakdown entries.');
+    process.exit(2);
+  }
+
+  const baselineStyles = Array.isArray(baseline.metadata?.styles)
+    ? baseline.metadata.styles
+    : baselineBreakdown.map((s) => s.style);
+
+  if (!baselineStyles.length) {
+    console.error('Baseline does not define any styles to check.');
+    process.exit(2);
+  }
+
+  console.log(`Running oracle regression check for ${baselineStyles.length} styles...`);
+  const current = runAggregate(args.stylesDir, baselineStyles);
+
+  const baselineMap = styleMapFromBreakdown(baselineBreakdown);
+  const currentMap = styleMapFromBreakdown(current.styleBreakdown);
+
+  const regressions = [];
+  const improvements = [];
+
+  for (const styleName of baselineStyles) {
+    const baselineStyle = baselineMap.get(styleName);
+    const currentStyle = currentMap.get(styleName);
+
+    if (!baselineStyle) {
+      regressions.push({
+        style: styleName,
+        reason: 'Style missing from baseline styleBreakdown',
+      });
+      continue;
+    }
+
+    if (!currentStyle) {
+      regressions.push({
+        style: styleName,
+        reason: 'Style missing from current aggregate output',
+      });
+      continue;
+    }
+
+    const baselineCit = parseScore(baselineStyle.citations, `${styleName} citations (baseline)`);
+    const baselineBib = parseScore(baselineStyle.bibliography, `${styleName} bibliography (baseline)`);
+    const currentCit = parseScore(currentStyle.citations, `${styleName} citations (current)`);
+    const currentBib = parseScore(currentStyle.bibliography, `${styleName} bibliography (current)`);
+
+    if (baselineCit.total !== currentCit.total || baselineBib.total !== currentBib.total) {
+      regressions.push({
+        style: styleName,
+        reason: `Fixture totals changed (C ${baselineCit.total}->${currentCit.total}, B ${baselineBib.total}->${currentBib.total})`,
+      });
+      continue;
+    }
+
+    const citationsDelta = currentCit.passed - baselineCit.passed;
+    const bibliographyDelta = currentBib.passed - baselineBib.passed;
+
+    if (citationsDelta < 0 || bibliographyDelta < 0) {
+      regressions.push({
+        style: styleName,
+        reason: [
+          citationsDelta < 0 ? `citations ${baselineStyle.citations} -> ${currentStyle.citations}` : null,
+          bibliographyDelta < 0 ? `bibliography ${baselineStyle.bibliography} -> ${currentStyle.bibliography}` : null,
+        ].filter(Boolean).join(', '),
+      });
+    } else if (citationsDelta > 0 || bibliographyDelta > 0) {
+      improvements.push({
+        style: styleName,
+        reason: [
+          citationsDelta > 0 ? `citations ${baselineStyle.citations} -> ${currentStyle.citations}` : null,
+          bibliographyDelta > 0 ? `bibliography ${baselineStyle.bibliography} -> ${currentStyle.bibliography}` : null,
+        ].filter(Boolean).join(', '),
+      });
+    }
+  }
+
+  if (regressions.length > 0) {
+    console.error('\nOracle regressions detected:');
+    for (const regression of regressions) {
+      console.error(`- ${regression.style}: ${regression.reason}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('No oracle regressions detected.');
+  if (improvements.length > 0) {
+    console.log(`Improvements detected in ${improvements.length} style(s):`);
+    for (const improvement of improvements) {
+      console.log(`- ${improvement.style}: ${improvement.reason}`);
+    }
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`check-oracle-regression failed: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/report-data/oracle-top10-baseline.json
+++ b/scripts/report-data/oracle-top10-baseline.json
@@ -1,0 +1,110 @@
+{
+  "totalStyles": 10,
+  "citationsPerfect": 10,
+  "bibliographyPerfect": 10,
+  "citationsPartial": 0,
+  "bibliographyPartial": 0,
+  "componentIssues": {},
+  "orderingIssues": 0,
+  "styleBreakdown": [
+    {
+      "style": "apa",
+      "citations": "13/13",
+      "bibliography": "31/31",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "elsevier-with-titles",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "elsevier-harvard",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "elsevier-vancouver",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "springer-vancouver-brackets",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "springer-basic-author-date",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "springer-basic-brackets",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "springer-socpsych-author-date",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "american-medical-association",
+      "citations": "13/13",
+      "bibliography": "32/32",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    },
+    {
+      "style": "taylor-and-francis-chicago-author-date",
+      "citations": "13/13",
+      "bibliography": "31/31",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "templateSource": "xml"
+    }
+  ],
+  "errors": [],
+  "metadata": {
+    "timestamp": "2026-02-27T01:52:20.419Z",
+    "duration": "21.2s",
+    "concurrency": 1,
+    "fixture": "tests/fixtures/citations-expanded.json",
+    "styles": [
+      "apa",
+      "elsevier-with-titles",
+      "elsevier-harvard",
+      "elsevier-vancouver",
+      "springer-vancouver-brackets",
+      "springer-basic-author-date",
+      "springer-basic-brackets",
+      "springer-socpsych-author-date",
+      "american-medical-association",
+      "taylor-and-francis-chicago-author-date"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add scripts/check-oracle-regression.js to compare current oracle results against a pinned baseline and fail on per-style citation/bibliography regressions
- add committed oracle baseline artifact at scripts/report-data/oracle-top10-baseline.json (top-10 style set, fixture metadata included)
- wire new gate into CI workflow
- document local check + baseline refresh commands in docs/TIER_STATUS.md and baselines/README.md
- include the implementation plan document for csl26-iek4

## Verification
- node scripts/check-oracle-regression.js --baseline scripts/report-data/oracle-top10-baseline.json

## Refs
- csl26-iek4
- #125