### PR TITLE
chore(testing): consolidate testing infrastructure contracts

### DIFF
--- a/.beans/csl26-r6fn--testing-infrastructure.md
+++ b/.beans/csl26-r6fn--testing-infrastructure.md
@@ -5,9 +5,23 @@ status: todo
 type: epic
 priority: high
 created_at: 2026-02-07T07:40:14Z
-updated_at: 2026-02-07T07:40:14Z
+updated_at: 2026-02-27T19:40:29Z
 blocking:
     - csl26-li63
 ---
 
-Build comprehensive testing infrastructure with baseline tracking, regression detection, test data generation, and expanded coverage.
+Consolidate and harden the testing infrastructure already built.
+
+Remaining umbrella scope:
+- testing contract consolidation
+- fixture-family coverage and governance
+- deterministic baseline/reporting metadata policy
+- documentation and workflow coherence
+
+Delivered slices now tracked as complete elsewhere:
+- `csl26-iek4` baseline tracking and CI oracle regression gate
+- `csl26-qb6h` oracle component parser hardening
+- `csl26-gczk` component coverage tracking
+- `csl26-6ijy` top-10 reporting
+
+This epic now covers the integration layer between those pieces rather than re-implementing them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install script dependencies
         run: npm install --prefix scripts
 
+      - name: Check testing infrastructure contracts
+        run: node scripts/check-testing-infra.js
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 

--- a/baselines/README.md
+++ b/baselines/README.md
@@ -1,6 +1,15 @@
 # Regression Detection Baselines
 
-This directory stores baseline test results for regression detection in the rendering fidelity workflow.
+This directory stores local baseline snapshots for regression detection in the
+rendering fidelity workflow.
+
+These files are distinct from the canonical committed CI baselines:
+
+- `scripts/report-data/oracle-top10-baseline.json`
+- `scripts/report-data/core-quality-baseline.json`
+
+Use `baselines/` for local milestone snapshots, refactor safety checks, and
+ad hoc comparison runs. Do not treat it as the source of truth for CI.
 
 ## Usage
 
@@ -65,10 +74,23 @@ Baseline files are JSON with the structure:
   ],
   "metadata": {
     "timestamp": "2026-02-06T12:00:00.000Z",
+    "gitCommit": "abcdef0",
+    "generator": "scripts/oracle-batch-aggregate.js",
+    "fixture": "tests/fixtures/citations-expanded.json",
+    "styleSelector": "top:20",
+    "styles": ["apa", "ieee"],
     "duration": "45.2s"
   }
 }
 ```
+
+Committed baseline/report artifacts should always carry:
+
+- `metadata.timestamp`
+- `metadata.gitCommit`
+- `metadata.fixture`
+- `metadata.generator`
+- `metadata.styles` or `metadata.styleSelector`
 
 ## Best Practices
 
@@ -99,17 +121,28 @@ Baseline JSON files are gitignored by default (`baselines/*.json`) to avoid repo
 
 ## Integration with Workflow
 
-See [docs/RENDERING_WORKFLOW.md](../docs/RENDERING_WORKFLOW.md) and [docs/WORKFLOW_ANALYSIS.md](../docs/WORKFLOW_ANALYSIS.md) for how regression detection integrates into the overall rendering fidelity workflow.
+See [docs/guides/RENDERING_WORKFLOW.md](../docs/guides/RENDERING_WORKFLOW.md) and [docs/guides/WORKFLOW_ANALYSIS.md](../docs/guides/WORKFLOW_ANALYSIS.md) for how regression detection integrates into the overall rendering fidelity workflow.
 
-## CI Canonical Baseline
+## CI Canonical Baselines
 
-The committed CI oracle baseline lives at:
+The committed CI baselines live at:
 
 - `scripts/report-data/oracle-top10-baseline.json`
+- `scripts/report-data/core-quality-baseline.json`
 
-CI checks this file via:
+CI checks these files via:
 
 ```bash
+node scripts/check-testing-infra.js
+
 node scripts/check-oracle-regression.js \
   --baseline scripts/report-data/oracle-top10-baseline.json
+
+node scripts/report-core.js > /tmp/core-report.json
+node scripts/check-core-quality.js \
+  --report /tmp/core-report.json \
+  --baseline scripts/report-data/core-quality-baseline.json
 ```
+
+Refresh committed baselines only in dedicated baseline PRs with a short
+before/after summary and justification for the reset.

--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -6,6 +6,9 @@
 > **Oracle scoring:** Strict 12-scenario citation set (`tests/fixtures/citations-expanded.json`).
 > Hard-fails on processor/style errors. Includes suppress-author, mixed locator/prefix/suffix
 > edge cases. Run `node scripts/oracle-batch-aggregate.js styles-legacy/ --top 10` to refresh.
+> Testing contract and fixture governance are defined in
+> `docs/architecture/CSL26_R6FN_TESTING_INFRASTRUCTURE_CONSOLIDATION_PLAN_2026-02-27.md`
+> and `tests/fixtures/coverage-manifest.json`.
 
 ## Top-10 Parent Styles
 
@@ -192,6 +195,9 @@ node scripts/check-core-quality.js \
 node scripts/check-oracle-regression.js \
   --baseline scripts/report-data/oracle-top10-baseline.json
 
+# Check testing-infrastructure contracts and fixture governance
+node scripts/check-testing-infra.js
+
 # Refresh pinned top-10 oracle baseline (dedicated baseline PR only)
 node scripts/oracle-batch-aggregate.js styles-legacy/ \
   --styles apa,elsevier-with-titles,elsevier-harvard,elsevier-vancouver,springer-vancouver-brackets,springer-basic-author-date,springer-basic-brackets,springer-socpsych-author-date,american-medical-association,taylor-and-francis-chicago-author-date \
@@ -201,5 +207,6 @@ node scripts/oracle-batch-aggregate.js styles-legacy/ \
 ## Related
 
 - **beans:** `csl26-heqm` (top 10 at 100% fidelity), `csl26-gidg` (90% corpus match), `csl26-l2hg` (numeric triage)
-- **docs:** `docs/architecture/SQI_REFINEMENT_PLAN.md`, `docs/reference/STYLE_PRIORITY.md`
-- **CI:** `.github/workflows/ci.yml` — core fidelity gate (`check-core-quality.js`) + oracle regression gate (`check-oracle-regression.js`)
+- **docs:** `docs/architecture/SQI_REFINEMENT_PLAN.md`, `docs/reference/STYLE_PRIORITY.md`, `docs/architecture/CSL26_R6FN_TESTING_INFRASTRUCTURE_CONSOLIDATION_PLAN_2026-02-27.md`
+- **fixtures:** `tests/fixtures/coverage-manifest.json`
+- **CI:** `.github/workflows/ci.yml` — testing contract gate (`check-testing-infra.js`) + core fidelity gate (`check-core-quality.js`) + oracle regression gate (`check-oracle-regression.js`)

--- a/docs/architecture/CSL26_R6FN_TESTING_INFRASTRUCTURE_CONSOLIDATION_PLAN_2026-02-27.md
+++ b/docs/architecture/CSL26_R6FN_TESTING_INFRASTRUCTURE_CONSOLIDATION_PLAN_2026-02-27.md
@@ -1,0 +1,137 @@
+# CSL26-R6FN Testing Infrastructure Consolidation Plan
+
+## Summary
+
+`csl26-r6fn` no longer represents greenfield testing work. The repo already has
+working oracle baselines, core-quality reporting, specialty fixtures, and
+component-coverage tracking. The remaining need is to define the testing stack
+as one coherent contract so CI, docs, and beans describe the same system.
+
+This document is the canonical testing-layer map for that consolidation.
+
+## Layer 1: Rust Correctness
+
+- Purpose: validate processor, schema, parser, and integration semantics.
+- Source files:
+  - `crates/**`
+  - `tests/**`
+- Commands:
+  - `cargo nextest run`
+  - Fallback where needed: `cargo test`
+- Failure meaning:
+  - Core engine behavior, parsing, or integration semantics have regressed.
+- Gate status:
+  - CI required.
+
+## Layer 2: Oracle Fidelity
+
+- Purpose: compare Citum rendering against citeproc-js for canonical style
+  fidelity.
+- Source files:
+  - `scripts/oracle.js`
+  - `scripts/oracle-batch-aggregate.js`
+  - `scripts/check-oracle-regression.js`
+  - `scripts/report-data/oracle-top10-baseline.json`
+- Commands:
+  - `node scripts/oracle.js styles-legacy/apa.csl --json`
+  - `node scripts/oracle-batch-aggregate.js styles-legacy/ --top 10`
+  - `node scripts/check-oracle-regression.js --baseline scripts/report-data/oracle-top10-baseline.json`
+- Failure meaning:
+  - Rendered citation or bibliography output regressed relative to the pinned
+    oracle baseline.
+- Gate status:
+  - CI required for the top-10 baseline set.
+
+## Layer 3: Portfolio Quality
+
+- Purpose: measure fidelity and SQI-style quality across production core styles.
+- Source files:
+  - `scripts/report-core.js`
+  - `scripts/check-core-quality.js`
+  - `scripts/report-data/core-quality-baseline.json`
+- Commands:
+  - `node scripts/report-core.js > /tmp/core-report.json`
+  - `node scripts/check-core-quality.js --report /tmp/core-report.json --baseline scripts/report-data/core-quality-baseline.json`
+- Failure meaning:
+  - A production core style dropped below the hard fidelity gate, or quality
+    drift exceeded baseline tolerances.
+- Gate status:
+  - CI required.
+
+## Layer 4: Fixture-Family Specialty Coverage
+
+- Purpose: protect rendering domains that are not fully represented by the
+  canonical top-10 oracle baseline.
+- Coverage manifest:
+  - `tests/fixtures/coverage-manifest.json`
+- Fixture families:
+  - Note: `tests/fixtures/citations-note-expanded.json`
+  - Legal: `tests/fixtures/references-legal.json`
+  - Scientific: `tests/fixtures/references-scientific.json`
+  - Multilingual: `tests/fixtures/references-multilingual.yaml` and
+    `tests/fixtures/multilingual/*.json`
+  - Grouping: `tests/fixtures/grouping/*.json`
+- Commands:
+  - `node scripts/check-testing-infra.js`
+  - Domain/runtime tests remain in `cargo nextest run`
+- Failure meaning:
+  - Fixture ownership, metadata contracts, or specialty coverage declarations
+    drifted out of sync with the repo.
+- Gate status:
+  - CI required for manifest and metadata validation.
+  - Individual specialty fixtures remain covered by targeted Rust tests and
+    docs-driven workflows rather than a heavyweight oracle gate.
+
+## Canonical Policies
+
+### Canonical CI Baselines
+
+- Oracle regression baseline:
+  - `scripts/report-data/oracle-top10-baseline.json`
+- Core-quality baseline:
+  - `scripts/report-data/core-quality-baseline.json`
+
+These are the only committed baseline artifacts used as CI gate inputs.
+
+### Ad Hoc Local Baselines
+
+Files under `baselines/` are for local milestone snapshots, refactor safety
+checks, and pre/post comparison work. They are not authoritative CI inputs.
+
+### Metadata Contract
+
+Committed baseline/report artifacts must include:
+
+- `metadata.timestamp`
+- `metadata.gitCommit`
+- `metadata.fixture`
+- `metadata.generator`
+- `metadata.styles` or `metadata.styleSelector`
+
+### Fixture Governance
+
+The manifest in `tests/fixtures/coverage-manifest.json` is the source of truth
+for:
+
+- which fixture files are canonical
+- which risk classes they cover
+- which scripts/tests own them
+- whether they are CI-required or advisory
+
+## Operational Workflow
+
+1. Run Rust tests for semantic correctness.
+2. Run oracle regression checks for pinned top-10 style fidelity.
+3. Run core-quality reporting for production-style fidelity + SQI drift.
+4. Run `node scripts/check-testing-infra.js` to verify fixture governance and
+   metadata contracts.
+5. Refresh committed baselines only in dedicated baseline PRs with explicit
+   justification.
+
+## Related Files
+
+- `baselines/README.md`
+- `docs/TIER_STATUS.md`
+- `docs/guides/RENDERING_WORKFLOW.md`
+- `tests/fixtures/coverage-manifest.json`
+- `scripts/check-testing-infra.js`

--- a/docs/guides/RENDERING_WORKFLOW.md
+++ b/docs/guides/RENDERING_WORKFLOW.md
@@ -2,6 +2,20 @@
 
 This guide describes the standard workflow for debugging and fixing rendering issues in Citum. It assumes you have basic familiarity with the project structure and oracle comparison tools.
 
+## Testing Contract
+
+The rendering workflow now sits inside four explicit testing layers:
+
+1. Rust correctness: `cargo nextest run`
+2. Oracle fidelity: `scripts/oracle.js`, `scripts/oracle-batch-aggregate.js`, `scripts/check-oracle-regression.js`
+3. Portfolio quality: `scripts/report-core.js`, `scripts/check-core-quality.js`
+4. Fixture governance: `tests/fixtures/coverage-manifest.json`, `scripts/check-testing-infra.js`
+
+Use the canonical CI baselines in `scripts/report-data/`, and use `baselines/`
+only for local comparison snapshots. The authoritative layer map is:
+
+- `docs/architecture/CSL26_R6FN_TESTING_INFRASTRUCTURE_CONSOLIDATION_PLAN_2026-02-27.md`
+
 ## Quick Reference
 
 ```bash
@@ -19,6 +33,9 @@ citum render refs -b references.json -s styles/apa-7th.yaml -O html
 
 # Test a single style (default: structured diff)
 node ../scripts/oracle.js styles-legacy/apa.csl
+
+# Validate fixture ownership and committed baseline metadata contracts
+node ../scripts/check-testing-infra.js
 ```
 
 ## Style Catalog Scope

--- a/scripts/check-testing-infra.js
+++ b/scripts/check-testing-infra.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const REQUIRED_DOMAINS = new Set([
+  'core',
+  'note',
+  'legal',
+  'scientific',
+  'multilingual',
+  'grouping',
+]);
+const ALLOWED_CI_STATUS = new Set(['required', 'advisory', 'manual']);
+const REQUIRED_METADATA_FIELDS = ['timestamp', 'gitCommit', 'generator', 'fixture'];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function ensureStringArray(value, label) {
+  assert(Array.isArray(value), `${label} must be an array`);
+  assert(value.length > 0, `${label} must not be empty`);
+  for (const entry of value) {
+    assert(isNonEmptyString(entry), `${label} entries must be non-empty strings`);
+  }
+}
+
+function validateManifestEntry(entry, seenFixtures, seenDomains, projectRoot) {
+  assert(entry && typeof entry === 'object' && !Array.isArray(entry), 'Fixture entries must be objects');
+  assert(isNonEmptyString(entry.fixture), 'Fixture entry is missing fixture path');
+  assert(!seenFixtures.has(entry.fixture), `Duplicate fixture entry: ${entry.fixture}`);
+  seenFixtures.add(entry.fixture);
+
+  assert(isNonEmptyString(entry.domain), `Fixture ${entry.fixture} is missing domain`);
+  assert(REQUIRED_DOMAINS.has(entry.domain), `Fixture ${entry.fixture} has invalid domain: ${entry.domain}`);
+  seenDomains.add(entry.domain);
+
+  assert(isNonEmptyString(entry.kind), `Fixture ${entry.fixture} is missing kind`);
+  ensureStringArray(entry.reference_types, `${entry.fixture} reference_types`);
+  assert(Array.isArray(entry.citation_scenarios), `${entry.fixture} citation_scenarios must be an array`);
+  ensureStringArray(entry.rendering_risks, `${entry.fixture} rendering_risks`);
+  ensureStringArray(entry.used_by, `${entry.fixture} used_by`);
+  assert(ALLOWED_CI_STATUS.has(entry.ci_status), `Fixture ${entry.fixture} has invalid ci_status: ${entry.ci_status}`);
+  assert(isNonEmptyString(entry.notes), `Fixture ${entry.fixture} is missing notes`);
+
+  const fixturePath = path.resolve(projectRoot, entry.fixture);
+  assert(fs.existsSync(fixturePath), `Fixture path does not exist: ${entry.fixture}`);
+
+  for (const scriptPath of entry.used_by) {
+    const resolved = path.resolve(projectRoot, scriptPath);
+    assert(fs.existsSync(resolved), `Referenced owner path does not exist for ${entry.fixture}: ${scriptPath}`);
+  }
+}
+
+function validateCoverageManifest(projectRoot = PROJECT_ROOT) {
+  const manifestPath = path.join(projectRoot, 'tests', 'fixtures', 'coverage-manifest.json');
+  const manifest = readJson(manifestPath);
+
+  assert(manifest && typeof manifest === 'object' && !Array.isArray(manifest), 'coverage-manifest.json must be an object');
+  assert(manifest.version === 1, 'coverage-manifest.json version must be 1');
+  assert(Array.isArray(manifest.fixtures), 'coverage-manifest.json fixtures must be an array');
+  assert(manifest.fixtures.length > 0, 'coverage-manifest.json fixtures must not be empty');
+
+  const seenFixtures = new Set();
+  const seenDomains = new Set();
+
+  for (const entry of manifest.fixtures) {
+    validateManifestEntry(entry, seenFixtures, seenDomains, projectRoot);
+  }
+
+  for (const domain of REQUIRED_DOMAINS) {
+    assert(seenDomains.has(domain), `coverage-manifest.json is missing required domain: ${domain}`);
+  }
+
+  return manifest;
+}
+
+function validateMetadataFields(metadata, label) {
+  assert(metadata && typeof metadata === 'object' && !Array.isArray(metadata), `${label} is missing metadata object`);
+  for (const field of REQUIRED_METADATA_FIELDS) {
+    assert(isNonEmptyString(metadata[field]), `${label} metadata is missing ${field}`);
+  }
+  const hasStyleList = Array.isArray(metadata.styles) && metadata.styles.length > 0;
+  const hasStyleSelector = isNonEmptyString(metadata.styleSelector);
+  assert(hasStyleList || hasStyleSelector, `${label} metadata requires styles or styleSelector`);
+}
+
+function validateOracleBaseline(projectRoot = PROJECT_ROOT) {
+  const baselinePath = path.join(projectRoot, 'scripts', 'report-data', 'oracle-top10-baseline.json');
+  const baseline = readJson(baselinePath);
+
+  assert(Array.isArray(baseline.styleBreakdown), 'oracle-top10-baseline.json is missing styleBreakdown');
+  assert(baseline.styleBreakdown.length > 0, 'oracle-top10-baseline.json styleBreakdown must not be empty');
+  validateMetadataFields(baseline.metadata, 'oracle-top10-baseline.json');
+  return baseline;
+}
+
+function validateCoreQualityBaseline(projectRoot = PROJECT_ROOT) {
+  const baselinePath = path.join(projectRoot, 'scripts', 'report-data', 'core-quality-baseline.json');
+  const baseline = readJson(baselinePath);
+
+  assert(baseline.styles && typeof baseline.styles === 'object', 'core-quality-baseline.json is missing styles');
+  assert(Object.keys(baseline.styles).length > 0, 'core-quality-baseline.json styles must not be empty');
+  validateMetadataFields(baseline.metadata, 'core-quality-baseline.json');
+  return baseline;
+}
+
+function runChecks(projectRoot = PROJECT_ROOT) {
+  validateCoverageManifest(projectRoot);
+  validateOracleBaseline(projectRoot);
+  validateCoreQualityBaseline(projectRoot);
+}
+
+function main() {
+  try {
+    runChecks();
+    console.log('Testing infrastructure contracts are valid.');
+  } catch (error) {
+    console.error(`check-testing-infra failed: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  ALLOWED_CI_STATUS,
+  PROJECT_ROOT,
+  REQUIRED_DOMAINS,
+  REQUIRED_METADATA_FIELDS,
+  runChecks,
+  validateCoreQualityBaseline,
+  validateCoverageManifest,
+  validateMetadataFields,
+  validateOracleBaseline,
+};

--- a/scripts/check-testing-infra.test.js
+++ b/scripts/check-testing-infra.test.js
@@ -1,0 +1,182 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  validateCoreQualityBaseline,
+  validateCoverageManifest,
+  validateOracleBaseline,
+} = require('./check-testing-infra');
+
+function makeTempProject() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'citum-testing-infra-'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeFile(filePath, contents = '') {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents, 'utf8');
+}
+
+function baseManifest() {
+  return {
+    version: 1,
+    fixtures: [
+      {
+        fixture: 'tests/fixtures/references-expanded.json',
+        domain: 'core',
+        kind: 'references',
+        reference_types: ['book'],
+        citation_scenarios: [],
+        rendering_risks: ['core rendering'],
+        used_by: ['scripts/oracle.js'],
+        ci_status: 'required',
+        notes: 'core',
+      },
+      {
+        fixture: 'tests/fixtures/citations-note-expanded.json',
+        domain: 'note',
+        kind: 'citations',
+        reference_types: ['book'],
+        citation_scenarios: ['single item'],
+        rendering_risks: ['note rendering'],
+        used_by: ['scripts/oracle.js'],
+        ci_status: 'required',
+        notes: 'note',
+      },
+      {
+        fixture: 'tests/fixtures/references-legal.json',
+        domain: 'legal',
+        kind: 'references',
+        reference_types: ['legal_case'],
+        citation_scenarios: [],
+        rendering_risks: ['legal rendering'],
+        used_by: ['scripts/oracle.js'],
+        ci_status: 'required',
+        notes: 'legal',
+      },
+      {
+        fixture: 'tests/fixtures/references-scientific.json',
+        domain: 'scientific',
+        kind: 'references',
+        reference_types: ['dataset'],
+        citation_scenarios: [],
+        rendering_risks: ['scientific rendering'],
+        used_by: ['scripts/oracle.js'],
+        ci_status: 'required',
+        notes: 'scientific',
+      },
+      {
+        fixture: 'tests/fixtures/references-multilingual.yaml',
+        domain: 'multilingual',
+        kind: 'references',
+        reference_types: ['book'],
+        citation_scenarios: [],
+        rendering_risks: ['multilingual rendering'],
+        used_by: ['scripts/oracle.js'],
+        ci_status: 'required',
+        notes: 'multilingual',
+      },
+      {
+        fixture: 'tests/fixtures/grouping/primary-secondary.json',
+        domain: 'grouping',
+        kind: 'references',
+        reference_types: ['manuscript'],
+        citation_scenarios: [],
+        rendering_risks: ['grouping rendering'],
+        used_by: ['scripts/oracle.js'],
+        ci_status: 'required',
+        notes: 'grouping',
+      },
+    ],
+  };
+}
+
+function baselineMetadata() {
+  return {
+    timestamp: '2026-02-27T00:00:00.000Z',
+    gitCommit: 'abcdef0',
+    generator: 'scripts/report-core.js',
+    fixture: 'tests/fixtures/references-expanded.json',
+    styleSelector: 'core-styles',
+    styles: ['apa-7th'],
+  };
+}
+
+function seedProject(root) {
+  writeJson(path.join(root, 'tests/fixtures/coverage-manifest.json'), baseManifest());
+  writeJson(path.join(root, 'tests/fixtures/references-expanded.json'), { ITEM: { type: 'book' } });
+  writeJson(path.join(root, 'tests/fixtures/citations-note-expanded.json'), []);
+  writeJson(path.join(root, 'tests/fixtures/references-legal.json'), {});
+  writeJson(path.join(root, 'tests/fixtures/references-scientific.json'), {});
+  writeFile(path.join(root, 'tests/fixtures/references-multilingual.yaml'), '[]\n');
+  writeJson(path.join(root, 'tests/fixtures/grouping/primary-secondary.json'), []);
+  writeFile(path.join(root, 'scripts/oracle.js'), '#!/usr/bin/env node\n');
+  writeJson(path.join(root, 'scripts/report-data/oracle-top10-baseline.json'), {
+    styleBreakdown: [{ style: 'apa', citations: '1/1', bibliography: '1/1' }],
+    metadata: {
+      ...baselineMetadata(),
+      generator: 'scripts/oracle-batch-aggregate.js',
+    },
+  });
+  writeJson(path.join(root, 'scripts/report-data/core-quality-baseline.json'), {
+    generated: '2026-02-27',
+    commit: 'abcdef0',
+    source: 'scripts/report-core.js',
+    styles: { 'apa-7th': { fidelityScore: 1, quality: 90, concision: 90, presetUsage: 90 } },
+    metadata: baselineMetadata(),
+  });
+}
+
+test('validation passes for a complete testing-infra fixture set', () => {
+  const root = makeTempProject();
+  seedProject(root);
+
+  assert.doesNotThrow(() => validateCoverageManifest(root));
+  assert.doesNotThrow(() => validateOracleBaseline(root));
+  assert.doesNotThrow(() => validateCoreQualityBaseline(root));
+});
+
+test('coverage manifest fails when a fixture path is missing', () => {
+  const root = makeTempProject();
+  seedProject(root);
+  fs.rmSync(path.join(root, 'tests/fixtures/references-scientific.json'));
+
+  assert.throws(() => validateCoverageManifest(root), /Fixture path does not exist/);
+});
+
+test('coverage manifest fails when a used_by path is missing', () => {
+  const root = makeTempProject();
+  seedProject(root);
+  const manifestPath = path.join(root, 'tests/fixtures/coverage-manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  manifest.fixtures[0].used_by = ['scripts/missing.js'];
+  writeJson(manifestPath, manifest);
+
+  assert.throws(() => validateCoverageManifest(root), /Referenced owner path does not exist/);
+});
+
+test('baseline validation fails when metadata fields are missing', () => {
+  const root = makeTempProject();
+  seedProject(root);
+  const baselinePath = path.join(root, 'scripts/report-data/core-quality-baseline.json');
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+  delete baseline.metadata.generator;
+  writeJson(baselinePath, baseline);
+
+  assert.throws(() => validateCoreQualityBaseline(root), /missing generator/);
+});
+
+test('coverage manifest fails when structure is malformed', () => {
+  const root = makeTempProject();
+  seedProject(root);
+  writeJson(path.join(root, 'tests/fixtures/coverage-manifest.json'), { version: 1, fixtures: {} });
+
+  assert.throws(() => validateCoverageManifest(root), /fixtures must be an array/);
+});

--- a/scripts/oracle-batch-aggregate.js
+++ b/scripts/oracle-batch-aggregate.js
@@ -24,6 +24,7 @@ const path = require('path');
 const os = require('os');
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_CITATIONS_FIXTURE = 'tests/fixtures/citations-expanded.json';
 
 // Priority parent styles (from STYLE_PRIORITY.md)
 const PRIORITY_STYLES = [
@@ -61,6 +62,18 @@ function detectTemplateSource(styleName) {
   if (fs.existsSync(cachePath)) return 'inferred';
 
   return 'xml';
+}
+
+function getGitCommit() {
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      cwd: WORKSPACE_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
 }
 
 /**
@@ -416,10 +429,20 @@ async function main() {
   const summary = aggregateResults(results);
   
   // Add metadata
+  const styleSelector = specificStyles
+    ? 'explicit'
+    : runAll
+      ? 'all'
+      : `top:${topN}`;
   summary.metadata = {
     timestamp: new Date().toISOString(),
+    gitCommit: getGitCommit(),
+    generator: 'scripts/oracle-batch-aggregate.js',
     duration: ((Date.now() - startTime) / 1000).toFixed(1) + 's',
     concurrency: runAll ? concurrency : 1,
+    fixture: DEFAULT_CITATIONS_FIXTURE,
+    styleSelector,
+    styles: stylesToTest.map((stylePath) => path.basename(stylePath, '.csl')),
   };
 
   // Compare against baseline if requested

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -727,6 +727,8 @@ function generateReport(options) {
   const stylesDir = getStylesDir(options.stylesDir);
   const coreStyles = discoverCoreStyles();
   const divergences = loadDivergences();
+  const generated = getTimestamp();
+  const gitCommit = getGitCommit();
 
   const styles = [];
   let citationsTotal = 0;
@@ -824,8 +826,18 @@ function generateReport(options) {
 
   return {
     report: {
-      generated: getTimestamp(),
-      commit: getGitCommit(),
+      generated,
+      commit: gitCommit,
+      source: 'scripts/report-core.js',
+      metadata: {
+        timestamp: generated,
+        gitCommit,
+        fixture: 'tests/fixtures/references-expanded.json',
+        styleSelector: 'core-styles',
+        styles: coreStyles.map((style) => style.name),
+        generator: 'scripts/report-core.js',
+        extraFixtures: ['tests/fixtures/citations-note-expanded.json'],
+      },
       totalImpact: parseFloat(totalImpact),
       totalStyles: coreStyles.length,
       citationsOverall: { passed: citationsPassed, total: citationsTotal },

--- a/scripts/report-data/core-quality-baseline.json
+++ b/scripts/report-data/core-quality-baseline.json
@@ -2,6 +2,29 @@
   "generated": "2026-02-19",
   "commit": "eb4dbad",
   "source": "scripts/report-core.js",
+  "metadata": {
+    "timestamp": "2026-02-19",
+    "gitCommit": "eb4dbad",
+    "fixture": "tests/fixtures/references-expanded.json",
+    "styleSelector": "core-styles",
+    "styles": [
+      "american-medical-association",
+      "apa-7th",
+      "chicago-notes",
+      "elsevier-harvard",
+      "elsevier-vancouver",
+      "elsevier-with-titles",
+      "springer-basic-author-date",
+      "springer-basic-brackets",
+      "springer-socpsych-author-date",
+      "springer-vancouver-brackets",
+      "taylor-and-francis-chicago-author-date"
+    ],
+    "generator": "scripts/report-core.js",
+    "extraFixtures": [
+      "tests/fixtures/citations-note-expanded.json"
+    ]
+  },
   "styles": {
     "american-medical-association": {
       "fidelityScore": 1,

--- a/scripts/report-data/oracle-top10-baseline.json
+++ b/scripts/report-data/oracle-top10-baseline.json
@@ -91,9 +91,12 @@
   "errors": [],
   "metadata": {
     "timestamp": "2026-02-27T01:52:20.419Z",
+    "gitCommit": "f61026f",
+    "generator": "scripts/oracle-batch-aggregate.js",
     "duration": "21.2s",
     "concurrency": 1,
     "fixture": "tests/fixtures/citations-expanded.json",
+    "styleSelector": "top:10",
     "styles": [
       "apa",
       "elsevier-with-titles",

--- a/tests/fixtures/coverage-manifest.json
+++ b/tests/fixtures/coverage-manifest.json
@@ -1,0 +1,306 @@
+{
+  "version": 1,
+  "fixtures": [
+    {
+      "fixture": "tests/fixtures/references-expanded.json",
+      "domain": "core",
+      "kind": "references",
+      "reference_types": [
+        "article-journal",
+        "article-magazine",
+        "article-newspaper",
+        "book",
+        "broadcast",
+        "chapter",
+        "dataset",
+        "entry-encyclopedia",
+        "interview",
+        "legal_case",
+        "motion_picture",
+        "paper-conference",
+        "patent",
+        "personal_communication",
+        "report",
+        "thesis",
+        "webpage"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "reference-type coverage",
+        "bibliography template structure",
+        "title/container formatting",
+        "core citation fixture pairing"
+      ],
+      "used_by": [
+        "scripts/oracle.js",
+        "scripts/oracle-yaml.js",
+        "scripts/oracle-e2e.js",
+        "scripts/report-core.js",
+        "scripts/generate-test-item.js",
+        "crates/citum-engine/src/processor/tests.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Canonical bibliography fixture for oracle fidelity and core-style reporting."
+    },
+    {
+      "fixture": "tests/fixtures/citations-expanded.json",
+      "domain": "core",
+      "kind": "citations",
+      "reference_types": [
+        "article-journal",
+        "book",
+        "paper-conference"
+      ],
+      "citation_scenarios": [
+        "single item",
+        "multi-item cluster",
+        "locator",
+        "mixed locators",
+        "suppress-author",
+        "prefix and suffix",
+        "et-al shortening",
+        "add-names disambiguation",
+        "year-suffix disambiguation"
+      ],
+      "rendering_risks": [
+        "citation punctuation",
+        "cite grouping",
+        "locator rendering",
+        "suppress-author handling",
+        "disambiguation"
+      ],
+      "used_by": [
+        "scripts/oracle.js",
+        "scripts/oracle-batch-aggregate.js",
+        "scripts/generate-test-item.js",
+        "scripts/lint-rendering.sh",
+        "crates/citum-engine/src/processor/tests.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Canonical strict citation regression surface used by the top-10 oracle baseline."
+    },
+    {
+      "fixture": "tests/fixtures/citations-note-expanded.json",
+      "domain": "note",
+      "kind": "citations",
+      "reference_types": [
+        "all core references paired with note citation scenarios"
+      ],
+      "citation_scenarios": [
+        "32 single-item note citations",
+        "add-names et-al note disambiguation",
+        "year-suffix note disambiguation"
+      ],
+      "rendering_risks": [
+        "note citation punctuation",
+        "note disambiguation",
+        "note-style citation coverage"
+      ],
+      "used_by": [
+        "scripts/report-core.js",
+        "scripts/oracle.js"
+      ],
+      "ci_status": "required",
+      "notes": "Specialized citation fixture used for note-style fidelity in the core compatibility report."
+    },
+    {
+      "fixture": "tests/fixtures/references-legal.json",
+      "domain": "legal",
+      "kind": "references",
+      "reference_types": [
+        "legal_case",
+        "legislation",
+        "treaty"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "legal type parsing",
+        "legal bibliography rendering",
+        "legal citation labels"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/domain_fixtures.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Processor-domain fixture for legal references."
+    },
+    {
+      "fixture": "tests/fixtures/references-legal.yaml",
+      "domain": "legal",
+      "kind": "references",
+      "reference_types": [
+        "legal_case",
+        "legislation",
+        "treaty"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "YAML bibliography parsing parity"
+      ],
+      "used_by": [
+        "docs/architecture/design/LEGAL_CITATIONS.md"
+      ],
+      "ci_status": "advisory",
+      "notes": "YAML companion fixture retained for schema/examples and manual parity checks."
+    },
+    {
+      "fixture": "tests/fixtures/references-scientific.json",
+      "domain": "scientific",
+      "kind": "references",
+      "reference_types": [
+        "dataset",
+        "patent",
+        "software",
+        "standard"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "scientific domain parsing",
+        "scientific labels",
+        "dataset and patent bibliography output"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/domain_fixtures.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Processor-domain fixture for scientific and technical reference classes."
+    },
+    {
+      "fixture": "tests/fixtures/references-multilingual.yaml",
+      "domain": "multilingual",
+      "kind": "references",
+      "reference_types": [
+        "book",
+        "article-journal"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "multilingual bibliography rendering",
+        "script preservation",
+        "locale-sensitive output"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/domain_fixtures.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Canonical processor fixture for multilingual bibliography rendering."
+    },
+    {
+      "fixture": "tests/fixtures/multilingual/multilingual-cjk.json",
+      "domain": "multilingual",
+      "kind": "references",
+      "reference_types": [
+        "article-journal",
+        "book"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "CJK transliteration coverage",
+        "script fallback behavior"
+      ],
+      "used_by": [
+        "docs/architecture/MULTILINGUAL_GROUPING_STYLE_TARGETS.md"
+      ],
+      "ci_status": "advisory",
+      "notes": "Specialized multilingual planning fixture for CJK references."
+    },
+    {
+      "fixture": "tests/fixtures/multilingual/multilingual-cyrillic.json",
+      "domain": "multilingual",
+      "kind": "references",
+      "reference_types": [
+        "article-journal",
+        "book"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "Cyrillic transliteration coverage",
+        "script fallback behavior"
+      ],
+      "used_by": [
+        "docs/architecture/MULTILINGUAL_GROUPING_STYLE_TARGETS.md"
+      ],
+      "ci_status": "advisory",
+      "notes": "Specialized multilingual planning fixture for Cyrillic references."
+    },
+    {
+      "fixture": "tests/fixtures/multilingual/multilingual-mixed.json",
+      "domain": "multilingual",
+      "kind": "references",
+      "reference_types": [
+        "article-journal",
+        "book"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "romanization collision handling",
+        "multilingual disambiguation"
+      ],
+      "used_by": [
+        "docs/architecture/MULTILINGUAL_GROUPING_STYLE_TARGETS.md"
+      ],
+      "ci_status": "advisory",
+      "notes": "Specialized multilingual fixture for disambiguation edge cases."
+    },
+    {
+      "fixture": "tests/fixtures/grouping/primary-secondary.json",
+      "domain": "grouping",
+      "kind": "references",
+      "reference_types": [
+        "article-journal",
+        "interview",
+        "manuscript"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "sectional bibliography headings",
+        "group assignment",
+        "document rendering integration"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/document.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Primary grouping fixture for document-level bibliography sections."
+    },
+    {
+      "fixture": "tests/fixtures/grouping/legal-hierarchy.json",
+      "domain": "grouping",
+      "kind": "references",
+      "reference_types": [
+        "book",
+        "legal-case",
+        "statute",
+        "treaty"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "legal grouping hierarchy",
+        "section ordering"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/document.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Legal grouping fixture used for Juris-M style hierarchy checks."
+    },
+    {
+      "fixture": "tests/fixtures/grouping/multilingual-groups.json",
+      "domain": "grouping",
+      "kind": "references",
+      "reference_types": [
+        "book"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "per-group disambiguation restart",
+        "multilingual group sorting"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/document.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Grouping fixture for local year-suffix resets across multilingual sections."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- rescope csl26-r6fn around testing-contract consolidation rather than greenfield infrastructure work
- add a fixture coverage manifest and check-testing-infra validator, then wire that contract check into CI
- standardize report and baseline metadata and align baseline and rendering workflow docs with the committed CI baselines

## Validation
- node scripts/check-testing-infra.js
- node --test scripts/check-testing-infra.test.js
- node --check scripts/oracle-batch-aggregate.js
- node --check scripts/report-core.js
- node --check scripts/check-testing-infra.js
- node --check scripts/check-testing-infra.test.js

## Notes
- Existing broader oracle and report commands still surface pre-existing workspace issues outside this change set, including a springer-vancouver-brackets file I/O failure in scripts/oracle.js.