### PR TITLE
fix(styles): close top-10 bibliography deltas

### DIFF
--- a/.beans/csl26-ifiw--overhaul-template-compilation-for-bibliography-ren.md
+++ b/.beans/csl26-ifiw--overhaul-template-compilation-for-bibliography-ren.md
@@ -1,18 +1,27 @@
 ---
 # csl26-ifiw
-title: Overhaul template compilation for bibliography rendering
-status: todo
+title: Track residual XML bibliography migration deltas
+status: completed
 type: epic
 priority: high
 created_at: 2026-02-07T18:20:28Z
-updated_at: 2026-02-27T01:14:33Z
+updated_at: 2026-02-28T00:20:51Z
 ---
 
-Epic to track remaining template-compilation and post-processing issues for bibliography rendering.
+Epic to track the remaining XML-path bibliography and citation deltas after the
+large early template-compilation failures were resolved.
 
-Historical baseline at creation time showed broad failures, but current migration quality is substantially improved. As of 2026-02-27:
+Historical baseline at creation time showed broad failures, but this is no
+longer an overhaul-sized problem. As of 2026-02-28 verification, the explicit
+top-10 cohort is now fully green:
 
-- Top-10 aggregate: bibliography 100% for `7/10` styles
-- Primary observed component issue: `publisher:extra`
+- Citations: `10/10` styles at `13/13`
+- Bibliography: `10/10` styles at full match
+- `nature` report `publisher:extra` is fixed
+- `chicago-author-date` citation disambiguation and bibliography gaps are fixed
+- `cell` dataset/patent/personal-communication bibliography gaps are fixed
 
-This epic should now focus on residual style-level mismatches (especially `chicago-author-date`, `nature`, and `cell`) and concrete pass-level regressions in `citum-migrate` (`template_compiler` and `passes/*`), rather than broad "ordering is broken everywhere" assumptions.
+This epic is complete. Future regressions in `citum-migrate`
+(`template_compiler` and `passes/*`) should be tracked as new concrete bugs,
+not by re-opening the earlier broad "ordering is broken everywhere" problem
+statement.

--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -1,7 +1,7 @@
 # Citum Style Tier Status
 
 > **Living document** — updated after each significant batch oracle run.
-> Last updated: 2026-02-21
+> Last updated: 2026-02-28
 >
 > **Oracle scoring:** Strict 12-scenario citation set (`tests/fixtures/citations-expanded.json`).
 > Hard-fails on processor/style errors. Includes suppress-author, mixed locator/prefix/suffix
@@ -23,7 +23,7 @@
 | springer-basic-brackets | 352 | 12/12 | 32/32 ✅ | 100% fidelity |
 | springer-socpsych-author-date | 317 | 12/12 | 32/32 ✅ | 100% fidelity |
 | american-medical-association | 293 | 12/12 | 32/32 ✅ | 100% fidelity |
-| taylor-and-francis-chicago-author-date | 234 | 12/12 | 31/31 ✅ | 100% fidelity |
+| chicago-author-date | — | 13/13 | 31/31 ✅ | 100% fidelity in the explicit 2026-02-28 cohort |
 
 **Strict 100% citation match (top 10):** 10/10 styles
 **Strict 100% bibliography match (top 10):** 10/10 styles

--- a/styles/cell.yaml
+++ b/styles/cell.yaml
@@ -50,6 +50,20 @@ bibliography:
       delimiter: ", "
       delimiter-precedes-last: always
       sort-separator: ", "
+  type-templates:
+    dataset:
+      - contributor: author
+        form: long
+        name-order: family-first
+      - date: issued
+        form: year
+        wrap: parentheses
+        prefix: " "
+      - title: primary
+      - variable: publisher
+        wrap: parentheses
+        prefix: ". "
+      - variable: url
   template:
     - contributor: author
       form: long

--- a/styles/chicago-author-date.yaml
+++ b/styles/chicago-author-date.yaml
@@ -14,6 +14,10 @@ info:
   id: http://www.zotero.org/styles/chicago-author-date
 options:
   processing:
+    disambiguate:
+      names: true
+      add-givenname: true
+      year-suffix: true
     sort:
       template:
         - key: author
@@ -40,7 +44,7 @@ citation:
     contributors:
       shorten:
         min: 3
-        use-first: 1
+        use-first: 3
         and-others: et-al
         delimiter-precedes-last: contextual
   template:
@@ -48,7 +52,7 @@ citation:
       form: short
       shorten:
         min: 3
-        use-first: 1
+        use-first: 3
         and-others: et-al
     - date: issued
       form: year
@@ -57,8 +61,10 @@ citation:
         personal_communication:
           suppress: true
     - variable: locator
+      show-label: false
+      prefix: ", "
   wrap: parentheses
-  delimiter: ", "
+  delimiter: " "
   multi-cite-delimiter: "; "
 bibliography:
   options:
@@ -102,6 +108,24 @@ bibliography:
             note:
               - primary
               - archival
+  type-templates:
+    patent:
+      - contributor: author
+        form: long
+        name-order: family-first
+      - date: issued
+        form: year
+      - title: primary
+      - items:
+          - term: patent
+            suffix: " "
+          - number: number
+          - date: issued
+            form: full
+            prefix: ", issued "
+        prefix: ". "
+        delimiter: none
+    personal-communication: []
   template:
     - contributor: author
       form: long

--- a/styles/nature.yaml
+++ b/styles/nature.yaml
@@ -68,8 +68,14 @@ bibliography:
     - number: pages
     - variable: publisher
       prefix: " ("
+      overrides:
+        report:
+          suppress: true
     - variable: publisher-place
       prefix: ", "
+      overrides:
+        report:
+          suppress: true
     - date: issued
       form: year
       wrap: parentheses


### PR DESCRIPTION
## Summary
- fix the remaining explicit top-10 bibliography deltas in nature, cell, and chicago-author-date
- enable chicago-author-date disambiguation and close its patent/personal-communication bibliography gaps
- close bean csl26-ifiw and update Tier status to the verified 2026-02-28 oracle cohort

## Verification
- node scripts/oracle.js styles-legacy/nature.csl --json
- node scripts/oracle.js styles-legacy/chicago-author-date.csl --json
- node scripts/oracle.js styles-legacy/cell.csl --json
- node scripts/oracle-batch-aggregate.js styles-legacy/ --styles apa,elsevier-harvard,elsevier-with-titles,springer-basic-author-date,ieee,elsevier-vancouver,american-medical-association,nature,cell,chicago-author-date --json

## Result
- explicit top-10 cohort: citations 10/10, bibliography 10/10