### PR TITLE
fix(server): enforce docs and invalid formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,10 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Enforce public API docs for citum-edtf
-        run: RUSTFLAGS='-D missing-docs' cargo check -p citum-edtf --lib --all-features
+        run: cargo rustc -p citum-edtf --lib --all-features -- -Dmissing-docs
+
+      - name: Enforce public API docs for citum-server
+        run: cargo rustc -p citum-server --lib --all-features -- -Dmissing-docs
 
       - name: Build
         run: cargo build --verbose

--- a/crates/citum-server/src/error.rs
+++ b/crates/citum-server/src/error.rs
@@ -10,33 +10,43 @@ use thiserror::Error;
 /// Server-level errors.
 #[derive(Error, Debug)]
 pub enum ServerError {
+    /// The style file loaded successfully but failed schema validation.
     #[error("style validation failed: {0}")]
     StyleValidation(String),
 
+    /// The requested style file could not be found on disk.
     #[error("style not found: {0}")]
     StyleNotFound(String),
 
+    /// Bibliography input could not be deserialized or rendered.
     #[error("bibliography processing failed: {0}")]
     BibliographyError(String),
 
+    /// Citation input could not be deserialized or rendered.
     #[error("citation processing failed: {0}")]
     CitationError(String),
 
+    /// An I/O operation failed while reading input or writing output.
     #[error("IO error: {0}")]
     IoError(#[from] io::Error),
 
+    /// JSON input or output failed to deserialize or serialize.
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
 
+    /// YAML style parsing failed.
     #[error("YAML error: {0}")]
     YamlError(#[from] serde_yaml::Error),
 
+    /// The underlying citation engine returned an error.
     #[error("engine error: {0}")]
     EngineError(#[from] ProcessorError),
 
+    /// A required JSON-RPC parameter was missing from the request.
     #[error("missing required field: {0}")]
     MissingField(String),
 
+    /// The request asked for an unsupported output format.
     #[error("unsupported output format: {0}")]
     UnsupportedOutputFormat(String),
 }

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -27,11 +27,15 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //!
 //! - `async`: Enable tokio runtime (required for HTTP)
 //! - `http`: Enable HTTP server (implies async)
+#![deny(missing_docs)]
 
+/// Server error types and conversions.
 pub mod error;
+/// JSON-RPC request handling and stdio transport.
 pub mod rpc;
 
 #[cfg(feature = "http")]
+/// Optional HTTP transport built on axum.
 pub mod http;
 
 pub use error::ServerError;

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -18,8 +18,11 @@ use std::path::Path;
 /// JSON-RPC request envelope.
 #[derive(Debug, Deserialize)]
 pub struct RpcRequest {
+    /// The request identifier echoed back in success and error responses.
     pub id: Value,
+    /// The JSON-RPC method name to dispatch.
     pub method: String,
+    /// The method-specific parameter object.
     pub params: Value,
 }
 
@@ -53,6 +56,10 @@ struct BibliographyResult {
 }
 
 /// Main RPC dispatcher that processes a single request.
+///
+/// On success, this returns a JSON object containing the original request ID
+/// and a method-specific `result` payload. On failure, it returns the request
+/// ID when available plus a human-readable error string.
 pub fn dispatch(req: RpcRequest) -> Result<Value, (Option<Value>, String)> {
     let id = req.id.clone();
 

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -231,6 +231,23 @@ fn missing_refs_returns_error() {
 }
 
 #[test]
+fn invalid_output_format_returns_error() {
+    let req = make_request(
+        12,
+        "render_bibliography",
+        json!({
+            "style_path": apa_style_path(),
+            "refs": hawking_refs(),
+            "output_format": "pdf"
+        }),
+    );
+    let err = dispatch(req).expect_err("invalid output format should error");
+    assert_eq!(err.0, Some(json!(12)));
+    assert!(err.1.contains("unsupported output format"));
+    assert!(err.1.contains("pdf"));
+}
+
+#[test]
 fn render_bibliography_typst_returns_labeled_markup() {
     let req = make_request(
         10,


### PR DESCRIPTION
## Summary
- add public API docs across `citum-server` and enable `#![deny(missing_docs)]`
- add CI enforcement for `citum-server` public docs
- add a regression test for unsupported `output_format` values so the JSON-RPC error contract stays explicit

## Verification
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- RUSTFLAGS="-D missing-docs" cargo check -p citum-server --lib --all-features

## Handoff context
Phase-1 public library hardening progress:
1. `citum-edtf` merged
2. `citum-server` (this PR)
3. `citum-engine` next
4. `citum-schema` after that

Remaining inventory from the earlier repo scan:
- `citum-engine`: 53 missing-doc warnings
- `citum-schema`: 798 missing-doc warnings

Execution strategy remains:
- keep PRs crate- or slice-scoped
- add failing tests first when docs expose real behavior gaps
- prefer observable output assertions over internal-state assertions
- only enable `missing_docs` when the audited unit is actually clean