### PR TITLE
docs(engine): cover public support APIs

### DIFF
--- a/crates/citum-engine/src/error.rs
+++ b/crates/citum-engine/src/error.rs
@@ -5,23 +5,30 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use thiserror::Error;
 
+/// Errors produced while resolving or rendering citations and bibliographies.
 #[derive(Error, Debug)]
 pub enum ProcessorError {
+    /// A citation referenced an item ID that is not present in the bibliography.
     #[error("Reference not found: {0}")]
     ReferenceNotFound(String),
 
+    /// Date parsing or normalization failed for a reference field.
     #[error("Date parse error: {0}")]
     DateParseError(String),
 
+    /// Locale data could not be loaded or did not contain a required term.
     #[error("Locale error: {0}")]
     LocaleError(String),
 
+    /// Contributor or title substitution logic failed.
     #[error("Substitution error: {0}")]
     SubstitutionError(String),
 
+    /// Reading an input file from disk failed.
     #[error("File I/O error: {0}")]
     FileIO(#[from] std::io::Error),
 
+    /// Parsing a named input failed with a message describing the problem.
     #[error("Parse error ({0}): {1}")]
     ParseError(String, String),
 }

--- a/crates/citum-engine/src/grouping/sorting.rs
+++ b/crates/citum-engine/src/grouping/sorting.rs
@@ -24,11 +24,13 @@ fn compare_optional_years(a_year: Option<i32>, b_year: Option<i32>) -> std::cmp:
     }
 }
 
+/// Sorts grouped bibliography entries using group-specific sort rules.
 pub struct GroupSorter<'a> {
     locale: &'a Locale,
 }
 
 impl<'a> GroupSorter<'a> {
+    /// Create a sorter that uses `locale` for locale-sensitive comparisons.
     pub fn new(locale: &'a Locale) -> Self {
         Self { locale }
     }

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -103,14 +103,19 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! assert_eq!(result, "(Kuhn, 1962)");
 //! ```
 
+/// Error types returned by citation and bibliography processing.
 pub mod error;
 #[cfg(feature = "ffi")]
 pub mod ffi;
 pub mod grouping;
+/// File loading and deserialization helpers for processor inputs.
 pub mod io;
+/// Citation, bibliography, sorting, and document processing logic.
 pub mod processor;
 pub mod reference;
+/// Output-format renderers and string conversion helpers.
 pub mod render;
+/// Template value resolution and formatting helpers.
 pub mod values;
 
 pub use citum_schema::options::{Config, Processing};

--- a/crates/citum-engine/src/processor/matching.rs
+++ b/crates/citum-engine/src/processor/matching.rs
@@ -2,12 +2,14 @@ use crate::reference::Reference;
 use citum_schema::Style;
 use citum_schema::options::{Config, Substitute, SubstituteKey};
 
+/// Matches references using the processor's substitution configuration.
 pub struct Matcher<'a> {
     style: &'a Style,
     default_config: &'a Config,
 }
 
 impl<'a> Matcher<'a> {
+    /// Build a matcher from the active style and default configuration.
     pub fn new(style: &'a Style, default_config: &'a Config) -> Self {
         Self {
             style,

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -20,11 +20,15 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //!
 //! This is tracked via `rendered_vars` in `process_template()`.
 
+/// Author/date disambiguation and year-suffix assignment.
 pub mod disambiguation;
 pub mod document;
 pub mod labels;
+/// Matching helpers for substitution and repeated-contributor detection.
 pub mod matching;
+/// Template rendering orchestration and per-component state handling.
 pub mod rendering;
+/// Citation and bibliography sorting helpers.
 pub mod sorting;
 
 #[cfg(test)]

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -431,6 +431,11 @@ impl<'a> Renderer<'a> {
         )
     }
 
+    /// Render a grouped citation into one formatted string per citation item.
+    ///
+    /// This preserves per-item output when grouping rules require items to stay
+    /// separate, and otherwise applies the requested renderer format to the
+    /// grouped citation output.
     pub fn render_grouped_citation_with_format<F>(
         &self,
         items: &[crate::reference::CitationItem],

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -276,6 +276,10 @@ pub fn get_effective_rendering(component: &ProcTemplateComponent) -> Rendering {
     effective
 }
 
+/// Resolve title-category-specific rendering overrides for a title component.
+///
+/// The returned rendering reflects title type, mapped reference category, and
+/// optional language-specific overrides from the style configuration.
 pub fn get_title_category_rendering(
     title_type: &TitleType,
     ref_type: Option<&str>,

--- a/crates/citum-engine/src/render/djot.rs
+++ b/crates/citum-engine/src/render/djot.rs
@@ -9,6 +9,7 @@ use super::format::OutputFormat;
 use citum_schema::template::WrapPunctuation;
 
 #[derive(Default, Clone)]
+/// Renders processed citations and bibliography entries as Djot markup.
 pub struct Djot;
 
 impl OutputFormat for Djot {

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -9,6 +9,7 @@ use super::format::OutputFormat;
 use citum_schema::template::WrapPunctuation;
 
 #[derive(Default, Clone)]
+/// Renders processed citations and bibliography entries as HTML fragments.
 pub struct Html;
 
 impl OutputFormat for Html {

--- a/crates/citum-engine/src/render/mod.rs
+++ b/crates/citum-engine/src/render/mod.rs
@@ -16,8 +16,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! - [`citation`]: Logic for joining components into full citations.
 //! - [`bibliography`]: Logic for rendering bibliographies.
 
+/// Bibliography-level rendering and output assembly helpers.
 pub mod bibliography;
+/// Citation-level rendering and output assembly helpers.
 pub mod citation;
+/// Component-level rendering primitives shared by citations and bibliographies.
 pub mod component;
 pub mod djot;
 pub mod format;

--- a/crates/citum-engine/src/render/plain.rs
+++ b/crates/citum-engine/src/render/plain.rs
@@ -9,6 +9,7 @@ use super::format::OutputFormat;
 use citum_schema::template::WrapPunctuation;
 
 #[derive(Default, Clone)]
+/// Renders processed citations and bibliography entries as plain text.
 pub struct PlainText;
 
 impl OutputFormat for PlainText {

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -151,6 +151,11 @@ pub fn resolve_multilingual_string(
     }
 }
 
+/// Resolve the effective language for one logical field scope on a reference.
+///
+/// This prefers an explicit `field_languages` entry, then a multilingual title
+/// language tag for the provided title value, and finally the reference-level
+/// language.
 pub fn effective_field_language(
     reference: &Reference,
     scope: &str,
@@ -167,10 +172,12 @@ pub fn effective_field_language(
         .or_else(|| reference.language())
 }
 
+/// Resolve the effective language for the primary title of a reference.
 pub fn effective_item_language(reference: &Reference) -> Option<String> {
     effective_field_language(reference, "title", reference.title().as_ref())
 }
 
+/// Resolve the effective language for the specific template component being rendered.
 pub fn effective_component_language(
     reference: &Reference,
     component: &TemplateComponent,


### PR DESCRIPTION
## Summary
- document the first `citum-engine` public API slice across crate entrypoints
- add docs for `ProcessorError`, `GroupSorter`, `Matcher`, and public render marker types
- document grouped citation rendering and language/title rendering helpers

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- cargo rustc -p citum-engine --lib -- -Wmissing-docs
- git diff --check

## Remaining engine warning inventory
This PR deliberately leaves the remaining `citum-engine` missing-docs surface concentrated in:
- `processor/document/mod.rs`
- `values/mod.rs`
- `values/date.rs`
- `values/number.rs`

That is the next slice boundary, and it is where the more behavior-sensitive docs live.