### PR TITLE
docs(engine): enforce missing docs coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Enforce public API docs for citum-server
         run: cargo rustc -p citum-server --lib --all-features -- -Dmissing-docs
 
+      - name: Enforce public API docs for citum-engine
+        run: cargo rustc -p citum-engine --lib --all-features -- -Dmissing-docs
+
       - name: Build
         run: cargo build --verbose
 

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -3,6 +3,8 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
+#![deny(missing_docs)]
+
 //! CSLN Processor
 //!
 //! This crate provides the core citation and bibliography processing functionality

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -76,15 +76,22 @@ pub enum CitationPlacement {
     InlineProse,
     /// The citation marker appears inside a manually authored footnote
     /// definition and should render in place.
-    ManualFootnote { label: String },
+    ManualFootnote {
+        /// The source footnote label that identifies the manual note block.
+        label: String,
+    },
 }
 
 /// A citation marker parsed from a document.
 #[derive(Debug, Clone)]
 pub struct ParsedCitation {
+    /// Byte offset where the citation marker starts in the source document.
     pub start: usize,
+    /// Byte offset immediately after the citation marker in the source document.
     pub end: usize,
+    /// The parsed citation payload and its items.
     pub citation: Citation,
+    /// Where the citation was found in the source document.
     pub placement: CitationPlacement,
 }
 
@@ -97,7 +104,9 @@ pub(crate) struct ManualNoteReference {
 /// Structured output from a document parser.
 #[derive(Debug, Clone, Default)]
 pub struct ParsedDocument {
+    /// Citation markers discovered in source order.
     pub citations: Vec<ParsedCitation>,
+    /// Manual footnote labels in the order they appear in the document.
     pub manual_note_order: Vec<String>,
     pub(crate) manual_note_references: Vec<ManualNoteReference>,
     pub(crate) manual_note_labels: HashSet<String>,

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -351,6 +351,7 @@ impl ComponentValues for TemplateDate {
     }
 }
 
+/// Convert a 1-based index into an alphabetic suffix (`1 -> "a"`, `27 -> "aa"`).
 pub fn int_to_letter(n: u32) -> Option<String> {
     if n == 0 {
         return None;

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -8,12 +8,19 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! This module provides the logic to extract formatted values from references
 //! based on template component specifications.
 
+/// Contributor extraction and name-formatting helpers.
 pub mod contributor;
+/// Date extraction and date-formatting helpers.
 pub mod date;
+/// List-component value extraction helpers.
 pub mod list;
+/// Numeric variable extraction and page-range helpers.
 pub mod number;
+/// Locale term resolution helpers.
 pub mod term;
+/// Title extraction and title-formatting helpers.
 pub mod title;
+/// Generic variable extraction helpers.
 pub mod variable;
 
 #[cfg(test)]
@@ -454,6 +461,7 @@ pub struct ProcValues<T = String> {
     pub pre_formatted: bool,
 }
 
+/// Processing hints computed before rendering a reference or citation item.
 #[derive(Debug, Clone, Default)]
 pub struct ProcHints {
     /// Whether disambiguation is active (triggers year-suffix).
@@ -478,15 +486,21 @@ pub struct ProcHints {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RenderContext {
     #[default]
+    /// Render values for citation output.
     Citation,
+    /// Render values for bibliography output.
     Bibliography,
 }
 
 /// Options for rendering.
 pub struct RenderOptions<'a> {
+    /// Effective configuration after style and default resolution.
     pub config: &'a Config,
+    /// Locale used for term lookup and locale-sensitive formatting.
     pub locale: &'a Locale,
+    /// Whether the current render target is a citation or bibliography.
     pub context: RenderContext,
+    /// Citation mode for the current render operation.
     pub mode: citum_schema::citation::CitationMode,
     /// Whether to suppress the author name for this citation.
     /// Set from the citation-level `suppress_author` flag.
@@ -499,6 +513,7 @@ pub struct RenderOptions<'a> {
 
 /// Trait for extracting values from template components.
 pub trait ComponentValues {
+    /// Resolve the component into processed render values for one reference.
     fn values<F: crate::render::format::OutputFormat<Output = String>>(
         &self,
         reference: &Reference,

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -147,6 +147,7 @@ impl ComponentValues for TemplateNumber {
     }
 }
 
+/// Map a number variable to the nearest locator label used in citations.
 pub fn number_var_to_locator_type(
     var: &NumberVariable,
 ) -> Option<citum_schema::citation::LocatorType> {
@@ -167,6 +168,7 @@ pub fn number_var_to_locator_type(
     }
 }
 
+/// Heuristically detect whether a locator string should use plural labeling.
 pub fn check_plural(value: &str, _locator_type: &citum_schema::citation::LocatorType) -> bool {
     // Simple heuristic: if contains ranges or separators, it's plural.
     // "1-10", "1, 3", "1 & 3"


### PR DESCRIPTION
Complete the remaining public API docs in citum-engine's\ndocument and values modules.\n\nEnable crate-level missing-docs enforcement and add the\nmatching CI gate so future public items stay documented.
