### PR TITLE
docs(schema): cover locale support docs

### DIFF
--- a/crates/citum-schema/src/embedded/mod.rs
+++ b/crates/citum-schema/src/embedded/mod.rs
@@ -5,13 +5,19 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Embedded priority templates for common citation styles.
 
+/// Embedded APA templates.
 pub mod apa;
+/// Embedded Chicago author-date templates.
 pub mod chicago;
+/// Embedded Harvard templates.
 pub mod harvard;
+/// Embedded IEEE templates.
 pub mod ieee;
 pub mod locales;
+/// Embedded numeric citation templates.
 pub mod numeric;
 pub mod styles;
+/// Embedded Vancouver templates.
 pub mod vancouver;
 
 use crate::template::TemplateComponent;

--- a/crates/citum-schema/src/locale/mod.rs
+++ b/crates/citum-schema/src/locale/mod.rs
@@ -8,7 +8,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Locales provide language-specific terms, date formats, and punctuation rules
 //! for citation formatting.
 
+/// Raw locale types used during locale file parsing.
 pub mod raw;
+/// Structured locale types used by the processor.
 pub mod types;
 
 use crate::citation::LocatorType;
@@ -700,6 +702,7 @@ impl Locale {
         }
     }
 
+    /// Parse a locale term key into a structured general-term identifier.
     pub fn parse_general_term(name: &str) -> Option<GeneralTerm> {
         match name {
             "in" => Some(GeneralTerm::In),

--- a/crates/citum-schema/src/locale/raw.rs
+++ b/crates/citum-schema/src/locale/raw.rs
@@ -32,18 +32,25 @@ pub struct RawLocale {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct RawDateTerms {
+    /// Localized month names.
     #[serde(default)]
     pub months: RawMonthNames,
+    /// Localized season names in display order.
     #[serde(default)]
     pub seasons: Vec<String>,
+    /// Localized term for uncertain dates.
     #[serde(default)]
     pub uncertainty_term: Option<String>,
+    /// Localized term for open-ended date ranges.
     #[serde(default)]
     pub open_ended_term: Option<String>,
+    /// Localized ante meridiem marker.
     #[serde(default)]
     pub am: Option<String>,
+    /// Localized post meridiem marker.
     #[serde(default)]
     pub pm: Option<String>,
+    /// Localized label for UTC.
     #[serde(default)]
     pub timezone_utc: Option<String>,
 }
@@ -52,8 +59,10 @@ pub struct RawDateTerms {
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct RawMonthNames {
+    /// Full month names.
     #[serde(default)]
     pub long: Vec<String>,
+    /// Abbreviated month names.
     #[serde(default)]
     pub short: Vec<String>,
 }
@@ -62,12 +71,16 @@ pub struct RawMonthNames {
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct RawRoleTerm {
+    /// Long-form role term.
     #[serde(default)]
     pub long: Option<RawTermValue>,
+    /// Short-form role term.
     #[serde(default)]
     pub short: Option<RawTermValue>,
+    /// Verb-form role term.
     #[serde(default)]
     pub verb: Option<RawTermValue>,
+    /// Short verb-form role term.
     #[serde(default, rename = "verb-short")]
     pub verb_short: Option<RawTermValue>,
 }
@@ -82,7 +95,12 @@ pub enum RawTermValue {
     /// Form-keyed value (for terms with long/short forms).
     Forms(HashMap<String, RawTermValue>),
     /// Singular/plural forms.
-    SingularPlural { singular: String, plural: String },
+    SingularPlural {
+        /// Singular form of the term.
+        singular: String,
+        /// Plural form of the term.
+        plural: String,
+    },
 }
 
 impl Default for RawTermValue {

--- a/crates/citum-schema/src/locale/types.rs
+++ b/crates/citum-schema/src/locale/types.rs
@@ -12,10 +12,15 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum TermForm {
+    /// Long form of a term.
     Long,
+    /// Short form of a term.
     Short,
+    /// Verb form of a term.
     Verb,
+    /// Short verb form of a term.
     VerbShort,
+    /// Symbol form of a term.
     Symbol,
 }
 
@@ -25,30 +30,55 @@ pub enum TermForm {
 #[serde(rename_all = "kebab-case")]
 pub enum GeneralTerm {
     #[default]
+    /// The preposition "in".
     In,
+    /// The term used for access dates.
     Accessed,
+    /// The term used for retrieval statements.
     Retrieved,
+    /// The preposition "at".
     At,
+    /// The preposition "from".
     From,
+    /// The preposition "by".
     By,
+    /// The term used when no date is available.
     NoDate,
+    /// The term used for anonymous authorship.
     Anonymous,
+    /// The term used for approximate dates.
     Circa,
+    /// The phrase used for availability statements.
     AvailableAt,
+    /// The term used for immediately repeated citations.
     Ibid,
+    /// The conjunction "and".
     And,
+    /// The abbreviation for omitted additional names.
     EtAl,
+    /// The phrase "and others".
     AndOthers,
+    /// The term used for forthcoming works.
     Forthcoming,
+    /// The term used for online resources.
     Online,
+    /// The phrase used to introduce reviewed works.
     ReviewOf,
+    /// The phrase used for original publication references.
     OriginalWorkPublished,
+    /// The term used for patents.
     Patent,
+    /// The general term for volume locators.
     Volume,
+    /// The general term for issue locators.
     Issue,
+    /// The general term for page locators.
     Page,
+    /// The general term for chapter locators.
     Chapter,
+    /// The general term for editions.
     Edition,
+    /// The general term for section locators.
     Section,
 }
 

--- a/crates/citum-schema/src/macros.rs
+++ b/crates/citum-schema/src/macros.rs
@@ -23,6 +23,7 @@ macro_rules! str_enum {
         $vis enum $name {
             $(
                 $(#[$vmeta])*
+                #[doc = "String-backed enum variant."]
                 $variant,
             )+
         }
@@ -72,6 +73,7 @@ macro_rules! merge_options {
 // AST Builder macros for tests and embedded styles.
 // These use a quasi-DSL to quickly stamp out TemplateComponents.
 
+/// Build a contributor `TemplateComponent` with optional rendering overrides.
 #[macro_export]
 macro_rules! tc_contributor {
     ($role:ident, $form:ident $(, $key:ident = $val:expr)*) => {
@@ -89,6 +91,7 @@ macro_rules! tc_contributor {
     };
 }
 
+/// Build a date `TemplateComponent` with optional rendering overrides.
 #[macro_export]
 macro_rules! tc_date {
     ($date_var:ident, $form:ident $(, $key:ident = $val:expr)*) => {
@@ -106,6 +109,7 @@ macro_rules! tc_date {
     };
 }
 
+/// Build a title `TemplateComponent` with optional rendering overrides.
 #[macro_export]
 macro_rules! tc_title {
     ($title_type:ident $(, $key:ident = $val:expr)*) => {
@@ -122,6 +126,7 @@ macro_rules! tc_title {
     };
 }
 
+/// Build a number `TemplateComponent` with optional rendering overrides.
 #[macro_export]
 macro_rules! tc_number {
     ($num_var:ident $(, $key:ident = $val:expr)*) => {
@@ -138,6 +143,7 @@ macro_rules! tc_number {
     };
 }
 
+/// Build a variable `TemplateComponent` with optional rendering overrides.
 #[macro_export]
 macro_rules! tc_variable {
     ($var:ident $(, $key:ident = $val:expr)*) => {
@@ -154,6 +160,7 @@ macro_rules! tc_variable {
     };
 }
 
+/// Build a term `TemplateComponent` with optional rendering overrides.
 #[macro_export]
 macro_rules! tc_term {
     ($term_var:ident $(, $key:ident = $val:expr)*) => {
@@ -170,6 +177,7 @@ macro_rules! tc_term {
     };
 }
 
+/// Build a list `TemplateComponent` with optional rendering overrides.
 #[macro_export]
 macro_rules! tc_list {
     ([$($item:expr),* $(,)?] $(, $key:ident = $val:expr)*) => {


### PR DESCRIPTION
## Summary

Document the remaining public support-surface items in `citum-schema` that were small enough to finish cleanly this week:
- `locale/mod.rs`
- `locale/raw.rs`
- `locale/types.rs`
- `embedded/mod.rs`
- `macros.rs`

This keeps the slice focused on locale parsing/lookup, embedded template module docs, and exported helper macros.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `cargo rustc -p citum-schema --lib --all-features -- -Wmissing-docs` (targeted sanity checks while slicing)
- `git diff --check`

## Handoff

This PR is intentionally not the end of `citum-schema` doc hardening. The next agent should continue from fresh `main` after this lands.

Recommended order:
1. `options/*`
2. `template.rs`
3. `reference/mod.rs` and `reference/contributor.rs`
4. `reference/types.rs`
5. `legacy.rs`
6. enable `#![deny(missing_docs)]` for `citum-schema` and add the CI gate only after the crate is clean under `cargo rustc -p citum-schema --lib --all-features -- -Dmissing-docs`

Remaining missing-doc warning surface from the latest scan:
- `crates/citum-schema/src/options/contributors.rs`: 19
- `crates/citum-schema/src/options/dates.rs`: 1
- `crates/citum-schema/src/options/localization.rs`: 6
- `crates/citum-schema/src/options/mod.rs`: 16
- `crates/citum-schema/src/options/processing.rs`: 18
- `crates/citum-schema/src/options/substitute.rs`: 3
- `crates/citum-schema/src/options/titles.rs`: 9
- `crates/citum-schema/src/template.rs`: 117
- `crates/citum-schema/src/reference/mod.rs`: 6
- `crates/citum-schema/src/reference/contributor.rs`: 21
- `crates/citum-schema/src/reference/types.rs`: 201
- `crates/citum-schema/src/legacy.rs`: 253

Operational notes for handoff:
- Keep using crate-scoped enforcement commands, not `RUSTFLAGS='-D missing-docs' cargo check ...`.
- For Rust-file changes, run the full gate before pushing.
- Prefer tight, reviewable commits by module or closely related module family.
