### PR TITLE
chore(deps): replace serde_yaml with serde-saphyr

### DIFF
--- a/.beans/csl26-5pu1--replace-serde-yaml-with-serde-saphyr.md
+++ b/.beans/csl26-5pu1--replace-serde-yaml-with-serde-saphyr.md
@@ -1,0 +1,13 @@
+---
+# csl26-5pu1
+title: Replace serde_yaml with serde-saphyr
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-02T21:19:23Z
+updated_at: 2026-03-02T21:51:03Z
+---
+
+serde_yaml 0.9 is deprecated with RUSTSEC-2024-0320 (ACE via unsafe tag resolution). serde-saphyr is the maintained successor with identical API. Use Cargo package alias to avoid touching .rs files.
+
+## Summary of Changes\n\nReplaced serde_yaml with serde-saphyr 0.0.21 on branch deps/yaml-serde-saphyr. Required fixing Value/from_value usages in io.rs and djot.rs to use direct typed deserialization. 474/474 tests pass. Commit: d04c69b

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +35,17 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
 
 [[package]]
 name = "anstream"
@@ -90,6 +114,12 @@ checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayref"
@@ -377,8 +407,8 @@ dependencies = [
  "indexmap",
  "schemars",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "strsim 0.10.0",
  "typst",
  "typst-kit",
@@ -394,8 +424,8 @@ dependencies = [
  "csl-legacy",
  "roxmltree",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "walkdir",
 ]
 
@@ -423,8 +453,8 @@ dependencies = [
  "regex",
  "roxmltree",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.18",
  "url",
  "winnow",
@@ -439,8 +469,8 @@ dependencies = [
  "indexmap",
  "roxmltree",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
 ]
 
 [[package]]
@@ -453,8 +483,8 @@ dependencies = [
  "csl-legacy",
  "schemars",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "url",
 ]
 
@@ -467,8 +497,8 @@ dependencies = [
  "citum-schema",
  "clap",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -754,6 +784,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +978,20 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1607,6 +1669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2050,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser-bw"
+version = "0.0.608"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55ae5ea09894b6d5382621db78f586df37ef18ab581bf32c754e75076b124b1"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2291,26 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6fc4aa0da972ba0f51cf5c1bb16e9dba35334adc6831b09b3ffb0ec20bb264"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom",
+ "nohash-hasher",
+ "num-traits",
+ "regex",
+ "saphyr-parser-bw",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -3234,6 +3339,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,6 +3429,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3613,6 +3733,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "write-fonts"

--- a/crates/citum-analyze/Cargo.toml
+++ b/crates/citum-analyze/Cargo.toml
@@ -19,5 +19,5 @@ citum_schema = { package = "citum-schema", path = "../citum-schema" }
 roxmltree = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde-saphyr", version = "0.0.21" }
 walkdir = "2.4"

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.4", features = ["derive", "color"] }
 clap_complete = "4.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde-saphyr", version = "0.0.21" }
 ciborium = "0.2"
 strsim = "0.10"
 walkdir = "2.4"

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -15,7 +15,7 @@ citum_schema = { package = "citum-schema", path = "../citum-schema", features = 
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde-saphyr", version = "0.0.21" }
 ciborium = "0.2"
 thiserror = "2.0"
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }

--- a/crates/citum-engine/src/io.rs
+++ b/crates/citum-engine/src/io.rs
@@ -91,9 +91,6 @@ pub fn load_citations(path: &Path) -> Result<Vec<Citation>, ProcessorError> {
         }
         _ => {
             let content = String::from_utf8_lossy(&bytes);
-            // Check for syntax errors first
-            let _: serde_yaml::Value = serde_yaml::from_str(&content)
-                .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
 
             if let Ok(citations) = serde_yaml::from_str::<Vec<Citation>>(&content) {
                 return Ok(citations);
@@ -125,9 +122,6 @@ pub fn load_annotations(path: &Path) -> Result<HashMap<String, String>, Processo
         }
         _ => {
             let content = String::from_utf8_lossy(&bytes);
-            let _: serde_yaml::Value = serde_yaml::from_str(&content)
-                .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
-
             serde_yaml::from_str::<HashMap<String, String>>(&content)
                 .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))
         }
@@ -215,10 +209,6 @@ pub fn load_bibliography(path: &Path) -> Result<Bibliography, ProcessorError> {
             // YAML/Fallback
             let content = String::from_utf8_lossy(&bytes);
 
-            // Check for syntax errors first
-            let _: serde_yaml::Value = serde_yaml::from_str(&content)
-                .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
-
             if let Ok(input_bib) = serde_yaml::from_str::<InputBibliography>(&content) {
                 for r in input_bib.references {
                     if let Some(id) = r.id() {
@@ -228,30 +218,31 @@ pub fn load_bibliography(path: &Path) -> Result<Bibliography, ProcessorError> {
                 return Ok(bib);
             }
 
-            // Try parsing as IndexMap<String, serde_yaml::Value> (YAML/JSON, preserves order)
+            // Try parsing as IndexMap<String, InputReference> (key-keyed YAML map, preserves order)
             if let Ok(map) =
-                serde_yaml::from_str::<indexmap::IndexMap<String, serde_yaml::Value>>(&content)
+                serde_yaml::from_str::<indexmap::IndexMap<String, InputReference>>(&content)
             {
-                let mut found = false;
-                for (key, val) in map {
-                    if let Ok(mut r) = serde_yaml::from_value::<InputReference>(val.clone()) {
-                        if r.id().is_none() {
-                            r.set_id(key.clone());
-                        }
-                        bib.insert(key, r);
-                        found = true;
-                    } else if let Ok(ref_item) = serde_yaml::from_value::<LegacyReference>(val) {
-                        let mut r = Reference::from(ref_item);
-                        if r.id().is_none() {
-                            r.set_id(key.clone());
-                        }
-                        bib.insert(key, r);
-                        found = true;
+                for (key, mut r) in map {
+                    if r.id().is_none() {
+                        r.set_id(key.clone());
                     }
+                    bib.insert(key, r);
                 }
-                if found {
-                    return Ok(bib);
+                return Ok(bib);
+            }
+
+            // Try parsing as IndexMap<String, LegacyReference> (CSL-JSON key-keyed map)
+            if let Ok(map) =
+                serde_yaml::from_str::<indexmap::IndexMap<String, LegacyReference>>(&content)
+            {
+                for (key, ref_item) in map {
+                    let mut r = Reference::from(ref_item);
+                    if r.id().is_none() {
+                        r.set_id(key.clone());
+                    }
+                    bib.insert(key, r);
                 }
+                return Ok(bib);
             }
 
             // Try parsing as Vec<InputReference> (YAML/JSON)

--- a/crates/citum-engine/src/processor/document/djot.rs
+++ b/crates/citum-engine/src/processor/document/djot.rs
@@ -324,16 +324,12 @@ fn parse_frontmatter(content: &str) -> (Option<Vec<BibliographyGroup>>, &str) {
         let frontmatter_content = &after_opening[..closing_pos];
         let remaining = &after_opening[closing_pos + 3..].trim_start();
 
-        match serde_yaml::from_str::<serde_yaml::Value>(frontmatter_content) {
-            Ok(value) => {
-                if let Some(bib_value) = value.get("bibliography")
-                    && let Ok(groups) =
-                        serde_yaml::from_value::<Vec<BibliographyGroup>>(bib_value.clone())
-                {
-                    return (Some(groups), remaining);
-                }
-                (None, remaining)
-            }
+        #[derive(serde::Deserialize)]
+        struct Frontmatter {
+            bibliography: Option<Vec<BibliographyGroup>>,
+        }
+        match serde_yaml::from_str::<Frontmatter>(frontmatter_content) {
+            Ok(fm) => (fm.bibliography, remaining),
             Err(_) => (None, remaining),
         }
     } else {

--- a/crates/citum-migrate/Cargo.toml
+++ b/crates/citum-migrate/Cargo.toml
@@ -13,5 +13,5 @@ citum_schema = { package = "citum-schema", path = "../citum-schema" }
 indexmap = "2.13.0"
 roxmltree = "0.20"
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde-saphyr", version = "0.0.21" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/citum-schema/Cargo.toml
+++ b/crates/citum-schema/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde-saphyr", version = "0.0.21" }
 ciborium = "0.2"
 schemars = { version = "0.8", features = ["derive", "url"], optional = true }
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }

--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -15,7 +15,7 @@ citum-engine = { package = "citum-engine", path = "../citum-engine" }
 citum-schema = { package = "citum-schema", path = "../citum-schema" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde-saphyr", version = "0.0.21" }
 thiserror = "2.0"
 clap = { version = "4.4", features = ["derive", "color"] }
 


### PR DESCRIPTION
## Summary

- Replaces `serde_yaml` 0.9 (deprecated, RUSTSEC-2024-0320 — ACE via unsafe tag resolution) with `serde-saphyr` 0.0.21
- serde-saphyr is type-driven: no `Value`/`from_value`, no dynamic "any" objects — the class of exploits in RUSTSEC-2024-0320 is not applicable by construction
- Updated `io.rs` and `djot.rs` to use direct typed deserialization instead of the old two-pass `Value` map pattern

## Changes

- 6× `Cargo.toml`: swap dependency via `package` alias
- `citum-engine/src/io.rs`: remove redundant YAML syntax-check `Value` parses; replace `IndexMap<String, Value>` + `from_value` with typed `IndexMap<String, InputReference>` / `IndexMap<String, LegacyReference>` passes
- `citum-engine/src/processor/document/djot.rs`: replace `Value`-based frontmatter parse with a small typed `Frontmatter` struct

## Test plan

- [x] `cargo build --all-targets --all-features` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 474/474 passed

Refs: csl26-5pu1