### PR TITLE
chore(deps): replace serde_yaml with serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "strsim 0.10.0",
  "typst",
  "typst-kit",
@@ -395,7 +395,7 @@ dependencies = [
  "roxmltree",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "walkdir",
 ]
 
@@ -424,7 +424,7 @@ dependencies = [
  "roxmltree",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "thiserror 2.0.18",
  "url",
  "winnow",
@@ -440,7 +440,7 @@ dependencies = [
  "roxmltree",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "url",
 ]
 
@@ -468,7 +468,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -2289,6 +2289,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/crates/citum-analyze/Cargo.toml
+++ b/crates/citum-analyze/Cargo.toml
@@ -19,5 +19,5 @@ citum_schema = { package = "citum-schema", path = "../citum-schema" }
 roxmltree = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 walkdir = "2.4"

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.4", features = ["derive", "color"] }
 clap_complete = "4.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 strsim = "0.10"
 walkdir = "2.4"

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -15,7 +15,7 @@ citum_schema = { package = "citum-schema", path = "../citum-schema", features = 
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 thiserror = "2.0"
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }

--- a/crates/citum-migrate/Cargo.toml
+++ b/crates/citum-migrate/Cargo.toml
@@ -13,5 +13,5 @@ citum_schema = { package = "citum-schema", path = "../citum-schema" }
 indexmap = "2.13.0"
 roxmltree = "0.20"
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/citum-schema/Cargo.toml
+++ b/crates/citum-schema/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 schemars = { version = "0.8", features = ["derive", "url"], optional = true }
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }

--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -15,7 +15,7 @@ citum-engine = { package = "citum-engine", path = "../citum-engine" }
 citum-schema = { package = "citum-schema", path = "../citum-schema" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 thiserror = "2.0"
 clap = { version = "4.4", features = ["derive", "color"] }
 


### PR DESCRIPTION
## Summary

- Replaces `serde_yaml` 0.9 (deprecated, RUSTSEC-2024-0320 — ACE via unsafe tag resolution) with `serde_yaml_ng` 0.10
- `serde_yaml_ng` is the maintained community fork with an identical API — aliased via Cargo `package` key, no `.rs` changes needed

## Note on serde-saphyr

`serde-saphyr` was evaluated but has an incompatibility with this codebase: a bug in its enum variant deserialization causes sibling keys in nested YAML mappings to be misattributed to the parent struct, breaking ~100 styles that use `processing: { label: { ... } }` alongside other `options` keys. Filed for future consideration once resolved upstream.

## Test plan

- [x] `cargo build --all-targets --all-features` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 474/474 passed

Refs: csl26-5pu1