### PR TITLE
chore(repo): add commit message guard hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+msg_file="${1:?missing commit message path}"
+header="$(sed -n '1p' "$msg_file")"
+
+# Allow Git-generated merge/squash/revert messages.
+if [[ "$header" =~ ^(Merge|Revert|fixup!|squash!) ]]; then
+  exit 0
+fi
+
+header_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?(!)?: [a-z].+$'
+
+if [[ ! "$header" =~ $header_regex ]]; then
+  cat <<'EOF' >&2
+Invalid commit header.
+Expected: type(scope): lowercase subject
+Allowed types: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+EOF
+  exit 1
+fi
+
+if (( ${#header} > 50 )); then
+  echo "Commit header must be 50 characters or fewer." >&2
+  exit 1
+fi
+
+line_count="$(wc -l < "$msg_file" | tr -d ' ')"
+if (( line_count > 1 )); then
+  second_line="$(sed -n '2p' "$msg_file")"
+  if [[ -n "$second_line" ]]; then
+    echo "Second line must be blank between header and body." >&2
+    exit 1
+  fi
+fi
+
+line_no=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+  line_no=$((line_no + 1))
+
+  # Header validated separately.
+  if (( line_no == 1 )); then
+    continue
+  fi
+
+  # Skip empty lines and URL lines.
+  if [[ -z "$line" || "$line" =~ ^https?:// ]]; then
+    continue
+  fi
+
+  if (( ${#line} > 72 )); then
+    echo "Commit body line $line_no exceeds 72 characters." >&2
+    exit 1
+  fi
+done < "$msg_file"
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,11 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/) format:
 - **References**: Include issue references (e.g., `Refs: csln#64`)
 - **No Co-Authored-By**: Do not include co-author footers
 
+Enable the repository commit hook to enforce this automatically:
+```bash
+git config core.hooksPath .githooks
+```
+
 Example:
 ```
 fix(processor): handle empty contributor list


### PR DESCRIPTION
## Summary
- add a tracked `.githooks/commit-msg` hook to enforce Conventional Commit formatting
- enforce: valid header type/scope, lowercase subject, <=50 char header
- enforce: blank separator line and <=72-char body wrapping
- document local setup in `CONTRIBUTING.md` (`git config core.hooksPath .githooks`)

## Validation
- local hook self-test with valid message: pass
- local hook self-test with malformed message: fail (expected)

## Notes
- this repository requires changes to `main` via PR, so this branch carries commit `daa75d0` for merge
