### PR TITLE
feat(schema): compound locator support

### DIFF
--- a/.beans/csl26-z4t6--support-numeric-compound-citations-in-native-model.md
+++ b/.beans/csl26-z4t6--support-numeric-compound-citations-in-native-model.md
@@ -1,11 +1,11 @@
 ---
 # csl26-z4t6
 title: Support numeric compound citations in native model
-status: todo
+status: completed
 type: feature
 priority: high
 created_at: 2026-03-05T15:22:32Z
-updated_at: 2026-03-05T15:24:36Z
+updated_at: 2026-03-05T15:57:47Z
 ---
 
 Tentative conclusion from PR #285 analysis:
@@ -29,3 +29,18 @@ Definition of done (tentative):
 - Processor and renderers handle compound locators deterministically.
 - Backward compatibility tests confirm unchanged output for existing
   non-compound styles.
+
+
+## Summary of Changes
+
+Added compound locator support as an additive, backward-compatible schema extension:
+
+- `LocatorSegment` struct (`label` + `value`) in `citum-schema`
+- `ResolvedLocator` enum (Flat | Compound) with `CitationItem::resolved_locator()`
+- `locators: Option<Vec<LocatorSegment>>` on `CitationItem` (takes priority when present)
+- `collapse_compound_locator()` and `resolve_item_locator()` in rendering engine
+- 6 call sites updated to use resolver; variable.rs and templates unchanged
+- 6 new unit tests (serde roundtrip, priority, flat fallback, none, skip-serializing)
+- All 504 tests pass, no regressions
+
+Branch: `feat/compound-locators`

--- a/.beans/csl26-zafv--support-numeric-compound-citation-styles.md
+++ b/.beans/csl26-zafv--support-numeric-compound-citation-styles.md
@@ -1,0 +1,23 @@
+---
+# csl26-zafv
+title: Support numeric compound citation styles
+status: draft
+type: feature
+created_at: 2026-03-05T15:58:00Z
+updated_at: 2026-03-05T15:58:00Z
+---
+
+CSL schema issue #437: numeric compound styles group multiple references under a single citation number with sub-labels (a, b, c...).
+
+Example: "2. a) Zwart KB, et al. (1983) ..., b) van der Klei IJ, et al. (1991) ..."
+
+This is prevalent in chemistry journals and was never supported in CSL 1.0.
+
+Design questions to resolve:
+- How does input signal compound grouping? Style-level `processing: numeric-compound`? Explicit field on `Citation`?
+- Sub-label rendering: alphabetic (a, b, c) per locale? Configurable?
+- Delimiter between sub-items within a compound citation
+- Interaction with existing numeric citation numbering
+
+Orthogonal to compound locators (csl26-z4t6, completed).
+Needs a /dplan session before implementation.

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -27,6 +27,7 @@ fn main() {
             id: "weinberg1971".to_string(),
             label: None,
             locator: None,
+            locators: None,
             prefix: None,
             suffix: None,
         }],

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -46,6 +46,25 @@ use citum_schema::template::{DelimiterPunctuation, WrapPunctuation};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
+/// Get a canonical locator string for ibid comparison.
+///
+/// Accounts for both flat (`label`/`locator`) and compound (`locators`) forms.
+/// Returns `None` when no locator is present.
+fn effective_locator_string(item: &CitationItem) -> Option<String> {
+    use citum_schema::citation::ResolvedLocator;
+    match item.resolved_locator() {
+        Some(ResolvedLocator::Flat { value, .. }) => Some(value.to_string()),
+        Some(ResolvedLocator::Compound(segments)) => {
+            let parts: Vec<String> = segments
+                .iter()
+                .map(|s| format!("{:?}:{}", s.label, s.value))
+                .collect();
+            Some(parts.join(","))
+        }
+        None => None,
+    }
+}
+
 use self::disambiguation::Disambiguator;
 use self::matching::Matcher;
 use self::rendering::Renderer;
@@ -145,13 +164,13 @@ impl Processor {
                     .items
                     .iter()
                     .map(|item| {
-                        let locator = item.locator.clone();
+                        let locator = effective_locator_string(item);
                         (item.id.clone(), locator)
                     })
                     .collect();
                 previous_items = Some(current_items);
                 for item in &citation.items {
-                    seen_items.insert(item.id.clone(), item.locator.clone());
+                    seen_items.insert(item.id.clone(), effective_locator_string(item));
                 }
                 continue;
             }
@@ -159,7 +178,7 @@ impl Processor {
             // Single-item citation: check for ibid cases
             if citation.items.len() == 1 {
                 let current_id = &citation.items[0].id;
-                let current_locator = &citation.items[0].locator;
+                let current_locator = effective_locator_string(&citation.items[0]);
 
                 // Check if this is immediately after the previous citation with same item
                 if let Some(ref prev_items) = previous_items
@@ -171,7 +190,7 @@ impl Processor {
                     if prev_locator.is_none() && current_locator.is_none() {
                         // No locators on either: plain ibid
                         citation.position = Some(Position::Ibid);
-                    } else if prev_locator != current_locator {
+                    } else if *prev_locator != current_locator {
                         // Different locators: ibid with locator
                         citation.position = Some(Position::IbidWithLocator);
                     }
@@ -187,7 +206,7 @@ impl Processor {
                     }
                 }
 
-                seen_items.insert(current_id.clone(), current_locator.clone());
+                seen_items.insert(current_id.clone(), current_locator);
             } else {
                 // Multi-item citation: never ibid, just First or Subsequent
                 let all_seen = citation
@@ -202,7 +221,7 @@ impl Processor {
                 };
 
                 for item in &citation.items {
-                    seen_items.insert(item.id.clone(), item.locator.clone());
+                    seen_items.insert(item.id.clone(), effective_locator_string(item));
                 }
             }
 
@@ -211,7 +230,7 @@ impl Processor {
                 .items
                 .iter()
                 .map(|item| {
-                    let locator = item.locator.clone();
+                    let locator = effective_locator_string(item);
                     (item.id.clone(), locator)
                 })
                 .collect();

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -8,7 +8,8 @@ use crate::error::ProcessorError;
 use crate::reference::{Bibliography, Reference};
 use crate::render::{ProcTemplate, ProcTemplateComponent};
 use crate::values::{ComponentValues, ProcHints, RenderContext, RenderOptions};
-use citum_schema::locale::Locale;
+use citum_schema::citation::{LocatorSegment, LocatorType, ResolvedLocator};
+use citum_schema::locale::{Locale, TermForm};
 use citum_schema::options::Config;
 use citum_schema::template::ComponentOverride;
 use citum_schema::template::TemplateComponent;
@@ -32,6 +33,52 @@ pub struct Renderer<'a> {
     pub hints: &'a HashMap<String, ProcHints>,
     /// Shared state for citation numbers (used in numeric styles).
     pub citation_numbers: &'a RefCell<HashMap<String, usize>>,
+}
+
+/// Collapse compound locator segments into a pre-labelled string.
+///
+/// Each segment is rendered as `"term value"` using the locale's short-form term,
+/// then joined with `", "`. Falls back to the label name if no locale term exists.
+fn collapse_compound_locator(segments: &[LocatorSegment], locale: &Locale) -> String {
+    segments
+        .iter()
+        .map(|seg| {
+            let plural = seg.value.contains('\u{2013}')
+                || seg.value.contains('-')
+                || seg.value.contains(',')
+                || seg.value.contains('&');
+            let term = locale
+                .locator_term(&seg.label, plural, TermForm::Short)
+                .or_else(|| locale.locator_term(&seg.label, plural, TermForm::Symbol))
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| {
+                    // Fall back to serde kebab-case name for user-facing output
+                    serde_json::to_value(&seg.label)
+                        .ok()
+                        .and_then(|v| v.as_str().map(String::from))
+                        .unwrap_or_else(|| format!("{:?}", seg.label))
+                });
+            format!("{} {}", term, seg.value)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Resolve a citation item's locator into a `(value, label)` pair for `RenderOptions`.
+///
+/// Compound locators are collapsed to a pre-labelled string with no separate label
+/// (since labels are embedded per-segment). Flat locators pass through unchanged.
+fn resolve_item_locator(
+    item: &citum_schema::citation::CitationItem,
+    locale: &Locale,
+) -> (Option<String>, Option<LocatorType>) {
+    match item.resolved_locator() {
+        Some(ResolvedLocator::Compound(segments)) => {
+            (Some(collapse_compound_locator(segments, locale)), None)
+        }
+        Some(ResolvedLocator::Flat { label, value }) => (Some(value.to_string()), Some(label)),
+        None => (None, None),
+    }
 }
 
 impl<'a> Renderer<'a> {
@@ -153,14 +200,15 @@ impl<'a> Renderer<'a> {
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let fmt = F::default();
+        let (loc_value, loc_label) = resolve_item_locator(item, self.locale);
         let options = RenderOptions {
             config: self.config,
             locale: self.locale,
             context: RenderContext::Citation,
             mode: citum_schema::citation::CitationMode::Integral,
             suppress_author: false,
-            locator: item.locator.as_deref(),
-            locator_label: item.label.clone(),
+            locator: loc_value.as_deref(),
+            locator_label: loc_label,
         };
 
         // Render author in short form
@@ -217,14 +265,15 @@ impl<'a> Renderer<'a> {
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let fmt = F::default();
+        let (loc_value, loc_label) = resolve_item_locator(item, self.locale);
         let options = RenderOptions {
             config: self.config,
             locale: self.locale,
             context: RenderContext::Citation,
             mode: citum_schema::citation::CitationMode::Integral,
             suppress_author: false,
-            locator: item.locator.as_deref(),
-            locator_label: item.label.clone(),
+            locator: loc_value.as_deref(),
+            locator_label: loc_label,
         };
 
         if let Some(contributor) = reference.author().or_else(|| reference.editor()) {
@@ -373,6 +422,7 @@ impl<'a> Renderer<'a> {
                 let effective_template = template.as_deref().unwrap_or(&[]);
                 let effective_delim = spec.delimiter.as_deref().unwrap_or(intra_delimiter);
 
+                let (loc_value, loc_label) = resolve_item_locator(item, self.locale);
                 if let Some(proc) = self.process_template_with_number_with_format::<F>(
                     reference,
                     effective_template,
@@ -380,8 +430,8 @@ impl<'a> Renderer<'a> {
                     mode.clone(),
                     suppress_author,
                     citation_number,
-                    item.locator.as_deref(),
-                    item.label.clone(),
+                    loc_value.as_deref(),
+                    loc_label,
                     position,
                 ) {
                     let item_str = crate::render::citation::citation_to_string_with_format::<F>(
@@ -515,6 +565,7 @@ impl<'a> Renderer<'a> {
             {
                 // Narrative mode with explicit template (e.g., APA 7th)
                 let citation_number = self.get_or_assign_citation_number(&first_item.id);
+                let (loc_value, loc_label) = resolve_item_locator(first_item, self.locale);
                 if let Some(proc) = self.process_template_with_number_with_format::<F>(
                     first_ref,
                     template,
@@ -522,8 +573,8 @@ impl<'a> Renderer<'a> {
                     mode.clone(),
                     suppress_author,
                     citation_number,
-                    first_item.locator.as_deref(),
-                    first_item.label.clone(),
+                    loc_value.as_deref(),
+                    loc_label,
                     position,
                 ) {
                     // Use integral-specific delimiter, defaulting to space for narrative
@@ -576,6 +627,7 @@ impl<'a> Renderer<'a> {
                     let template = spec.resolve_template_for_language(item_language.as_deref());
                     let effective_template = template.as_deref().unwrap_or(&[]);
                     let citation_number = self.get_or_assign_citation_number(&item.id);
+                    let (loc_value, loc_label) = resolve_item_locator(item, self.locale);
                     if let Some(proc) = self.process_template_with_number_with_format::<F>(
                         reference,
                         effective_template,
@@ -583,8 +635,8 @@ impl<'a> Renderer<'a> {
                         mode.clone(),
                         suppress_author,
                         citation_number,
-                        item.locator.as_deref(),
-                        item.label.clone(),
+                        loc_value.as_deref(),
+                        loc_label,
                         position,
                     ) {
                         let item_str = crate::render::citation::citation_to_string_with_format::<F>(
@@ -632,6 +684,7 @@ impl<'a> Renderer<'a> {
                 let filtered_template = self.filter_author_from_template(effective_template);
 
                 let citation_number = self.get_or_assign_citation_number(&item.id);
+                let (loc_value, loc_label) = resolve_item_locator(item, self.locale);
                 if let Some(proc) = self.process_template_with_number_with_format::<F>(
                     reference,
                     &filtered_template,
@@ -639,8 +692,8 @@ impl<'a> Renderer<'a> {
                     mode.clone(),
                     suppress_author,
                     citation_number,
-                    item.locator.as_deref(),
-                    item.label.clone(),
+                    loc_value.as_deref(),
+                    loc_label,
                     position,
                 ) {
                     let item_str = crate::render::citation::citation_to_string_with_format::<F>(
@@ -1412,5 +1465,72 @@ mod tests {
 
         assert_eq!(filtered_list.items.len(), 1);
         assert!(matches!(filtered_list.items[0], TemplateComponent::Date(_)));
+    }
+
+    #[test]
+    fn compound_locator_joins_segments_with_separator() {
+        let locale = Locale::default();
+        let segments = vec![
+            LocatorSegment {
+                label: LocatorType::Chapter,
+                value: "3".to_string(),
+            },
+            LocatorSegment {
+                label: LocatorType::Section,
+                value: "42".to_string(),
+            },
+        ];
+        let rendered = collapse_compound_locator(&segments, &locale);
+        assert!(rendered.contains("3"), "should contain first value");
+        assert!(rendered.contains("42"), "should contain second value");
+        assert!(rendered.contains(", "), "should join with comma-space");
+    }
+
+    #[test]
+    fn compound_locator_plural_detection() {
+        let locale = Locale::default();
+        // Range with en-dash should trigger plural
+        let segments = vec![LocatorSegment {
+            label: LocatorType::Page,
+            value: "10\u{2013}12".to_string(),
+        }];
+        let rendered = collapse_compound_locator(&segments, &locale);
+        assert!(rendered.contains("10\u{2013}12"));
+    }
+
+    #[test]
+    fn compound_locator_fallback_uses_kebab_case() {
+        let locale = Locale::default();
+        let segments = vec![LocatorSegment {
+            label: LocatorType::SubVerbo,
+            value: "test".to_string(),
+        }];
+        let rendered = collapse_compound_locator(&segments, &locale);
+        // Should use kebab-case "sub-verbo", not PascalCase "SubVerbo"
+        assert!(
+            rendered.contains("sub-verbo"),
+            "expected kebab-case fallback, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn resolve_item_locator_prefers_compound() {
+        let locale = Locale::default();
+        let item = citum_schema::citation::CitationItem {
+            id: "test".to_string(),
+            label: Some(LocatorType::Page),
+            locator: Some("99".to_string()),
+            locators: Some(vec![LocatorSegment {
+                label: LocatorType::Chapter,
+                value: "5".to_string(),
+            }]),
+            ..Default::default()
+        };
+        let (value, label) = resolve_item_locator(&item, &locale);
+        assert!(value.unwrap().contains("5"));
+        assert!(
+            label.is_none(),
+            "compound locators embed labels per-segment"
+        );
     }
 }

--- a/crates/citum-schema/src/citation.rs
+++ b/crates/citum-schema/src/citation.rs
@@ -193,6 +193,33 @@ pub enum LocatorType {
     Algorithm,
 }
 
+/// A single segment of a compound locator.
+///
+/// Pairs a locator type with its value, e.g. `{ label: chapter, value: "3" }`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct LocatorSegment {
+    /// The locator type for this segment.
+    pub label: LocatorType,
+    /// The locator value (e.g., "3", "42-45").
+    pub value: String,
+}
+
+/// A resolved locator that abstracts over flat and compound forms.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedLocator<'a> {
+    /// A single label + value pair (the traditional flat form).
+    Flat {
+        /// The locator type.
+        label: LocatorType,
+        /// The locator value.
+        value: &'a str,
+    },
+    /// Multiple label + value segments (compound locator).
+    Compound(&'a [LocatorSegment]),
+}
+
 /// A single citation item referencing a bibliography entry.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -206,12 +233,40 @@ pub struct CitationItem {
     /// Locator value (e.g., "42-45" for pages)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locator: Option<String>,
+    /// Compound locator segments for multi-part references.
+    ///
+    /// When present, takes priority over `label`/`locator`.
+    /// Example: `[{ label: chapter, value: "3" }, { label: section, value: "42" }]`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locators: Option<Vec<LocatorSegment>>,
     /// Prefix text before this item
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
     /// Suffix text after this item
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suffix: Option<String>,
+}
+
+impl CitationItem {
+    /// Resolve the locator, preferring compound `locators` over flat `label`/`locator`.
+    pub fn resolved_locator(&self) -> Option<ResolvedLocator<'_>> {
+        if let Some(segments) = &self.locators
+            && !segments.is_empty()
+        {
+            return Some(ResolvedLocator::Compound(segments));
+        }
+        match (&self.label, &self.locator) {
+            (Some(label), Some(value)) => Some(ResolvedLocator::Flat {
+                label: label.clone(),
+                value,
+            }),
+            (None, Some(value)) => Some(ResolvedLocator::Flat {
+                label: LocatorType::default(),
+                value,
+            }),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -249,5 +304,90 @@ mod tests {
         assert_eq!(item.id, "kuhn1962");
         assert_eq!(item.label, Some(LocatorType::Page));
         assert_eq!(item.locator, Some("42-45".to_string()));
+    }
+
+    #[test]
+    fn test_compound_locator_serde_roundtrip() {
+        let json = r#"
+        {
+            "id": "smith2020",
+            "locators": [
+                { "label": "chapter", "value": "3" },
+                { "label": "section", "value": "42" }
+            ]
+        }
+        "#;
+        let item: CitationItem = serde_json::from_str(json).unwrap();
+        assert_eq!(item.locators.as_ref().unwrap().len(), 2);
+        assert_eq!(
+            item.locators.as_ref().unwrap()[0].label,
+            LocatorType::Chapter
+        );
+        assert_eq!(item.locators.as_ref().unwrap()[0].value, "3");
+        assert_eq!(
+            item.locators.as_ref().unwrap()[1].label,
+            LocatorType::Section
+        );
+        assert_eq!(item.locators.as_ref().unwrap()[1].value, "42");
+
+        // Round-trip
+        let serialized = serde_json::to_string(&item).unwrap();
+        let deserialized: CitationItem = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.locators, item.locators);
+    }
+
+    #[test]
+    fn test_resolved_locator_compound_priority() {
+        let item = CitationItem {
+            id: "test".to_string(),
+            label: Some(LocatorType::Page),
+            locator: Some("99".to_string()),
+            locators: Some(vec![
+                LocatorSegment {
+                    label: LocatorType::Chapter,
+                    value: "3".to_string(),
+                },
+                LocatorSegment {
+                    label: LocatorType::Section,
+                    value: "42".to_string(),
+                },
+            ]),
+            ..Default::default()
+        };
+        let resolved = item.resolved_locator().unwrap();
+        assert!(matches!(resolved, ResolvedLocator::Compound(_)));
+    }
+
+    #[test]
+    fn test_resolved_locator_flat_fallback() {
+        let item = CitationItem {
+            id: "test".to_string(),
+            label: Some(LocatorType::Page),
+            locator: Some("42".to_string()),
+            ..Default::default()
+        };
+        let resolved = item.resolved_locator().unwrap();
+        assert!(matches!(resolved, ResolvedLocator::Flat { .. }));
+    }
+
+    #[test]
+    fn test_resolved_locator_none() {
+        let item = CitationItem {
+            id: "test".to_string(),
+            ..Default::default()
+        };
+        assert!(item.resolved_locator().is_none());
+    }
+
+    #[test]
+    fn test_flat_locator_skips_serializing_locators() {
+        let item = CitationItem {
+            id: "test".to_string(),
+            label: Some(LocatorType::Page),
+            locator: Some("42".to_string()),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&item).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("locators"));
     }
 }

--- a/docs/schemas/citation.json
+++ b/docs/schemas/citation.json
@@ -104,6 +104,16 @@
             "null"
           ]
         },
+        "locators": {
+          "description": "Compound locator segments for multi-part references.\n\nWhen present, takes priority over `label`/`locator`. Example: `[{ label: chapter, value: \"3\" }, { label: section, value: \"42\" }]`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/LocatorSegment"
+          }
+        },
         "prefix": {
           "description": "Prefix text before this item",
           "type": [
@@ -138,6 +148,28 @@
           ]
         }
       ]
+    },
+    "LocatorSegment": {
+      "description": "A single segment of a compound locator.\n\nPairs a locator type with its value, e.g. `{ label: chapter, value: \"3\" }`.",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "properties": {
+        "label": {
+          "description": "The locator type for this segment.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LocatorType"
+            }
+          ]
+        },
+        "value": {
+          "description": "The locator value (e.g., \"3\", \"42-45\").",
+          "type": "string"
+        }
+      }
     },
     "LocatorType": {
       "description": "Locator types for pinpoint citations.",


### PR DESCRIPTION
## Summary
- Adds `LocatorSegment` struct and `ResolvedLocator` enum to represent compound locators (e.g., "ch. 3, § 42")
- New `locators: Option<Vec<LocatorSegment>>` field on `CitationItem` — when present, takes priority over flat `label`/`locator`
- Engine collapses compound segments to pre-labelled string via locale term lookup; `variable.rs` and templates unchanged

## Test plan
- [x] Serde round-trip test for compound locator YAML/JSON
- [x] `resolved_locator()` priority: compound > flat > none
- [x] `skip_serializing_if` confirms `locators` absent when `None`
- [x] All 504 existing tests pass (no regressions)

Refs: csl26-z4t6

🤖 Generated with [Claude Code](https://claude.com/claude-code)