### PR TITLE
chore(beans): locator followup beans

### DIFF
--- a/.beans/csl26-j007--locator-ergonomics-compact-syntax-and-structured-v.md
+++ b/.beans/csl26-j007--locator-ergonomics-compact-syntax-and-structured-v.md
@@ -1,0 +1,69 @@
+---
+# csl26-j007
+title: 'Locator ergonomics: compact syntax and structured values'
+status: draft
+type: feature
+created_at: 2026-03-05T16:42:31Z
+updated_at: 2026-03-05T16:42:31Z
+---
+
+Two related improvements to compound locator input ergonomics, building on csl26-z4t6.
+
+## 1. Compact YAML syntax
+
+Current verbose form:
+```yaml
+locators:
+  - label: page
+    value: "23"
+  - label: line
+    value: "13"
+```
+
+Compact map form (CSLN prototype style):
+```yaml
+locators:
+  page: "23"
+  line: "13"
+```
+
+Implementation: `#[serde(untagged)]` enum on `locators` field accepting
+either `Map(IndexMap<LocatorType, LocatorValue>)` or `List(Vec<LocatorSegment>)`.
+Ordering preserved via IndexMap.
+
+## 2. Structured LocatorValue for deterministic plurality
+
+Current: `value: String` with heuristic plural detection (checks for `-`, `–`, `,`, `&`).
+Problem: false positives like "figure A-3" trigger plural ("pp." instead of "p.").
+
+Solution: hybrid `#[serde(untagged)]` enum:
+```rust
+enum LocatorValue {
+    Text(String),                          // heuristic (95% case)
+    Explicit { value: String, plural: bool }, // override
+}
+```
+
+YAML:
+```yaml
+# Normal (heuristic works):
+locators:
+  page: "42-45"
+
+# Explicit override:
+locators:
+  - label: page
+    value:
+      value: "figure A-3"
+      plural: false
+```
+
+## Prior art
+- CSLN prototype: `enum Locator { KeyValue((LocatorTerm, String)), String(String) }`
+- dplanner analysis recommended Option 3 (Hybrid) for zero-breakage + deterministic plurality
+
+## Dependencies
+- Requires csl26-z4t6 (compound locators) merged first
+- Orthogonal to csl26-zafv (numeric compound citations)
+
+Needs /dplan session to finalize exact serde strategy and test plan.


### PR DESCRIPTION
## Summary
- **csl26-zafv** (draft): Numeric compound citation styles — CSL schema [#437](https://github.com/citation-style-language/schema/issues/437). Chemistry journals group multiple refs under one citation number with sub-labels (`2. a) Zwart..., b) van der Klei...`). Needs `/dplan` for input model design.
- **csl26-j007** (draft): Locator ergonomics — compact YAML syntax (`locators: { page: "23", line: "13" }`) and structured `LocatorValue` enum for deterministic plurality override. Builds on csl26-z4t6 (PR #286).

Both are draft beans tracking future work identified during compound locator implementation.

## Test plan
- [x] Docs/beans only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)