### PR TITLE
feat(schema): locator ergonomics

### DIFF
--- a/.beans/csl26-j007--locator-ergonomics-compact-syntax-and-structured-v.md
+++ b/.beans/csl26-j007--locator-ergonomics-compact-syntax-and-structured-v.md
@@ -1,10 +1,11 @@
 ---
 # csl26-j007
 title: 'Locator ergonomics: compact syntax and structured values'
-status: draft
+status: in-progress
 type: feature
+priority: normal
 created_at: 2026-03-05T16:42:31Z
-updated_at: 2026-03-05T16:42:31Z
+updated_at: 2026-03-05T18:05:47Z
 ---
 
 Two related improvements to compound locator input ergonomics, building on csl26-z4t6.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "citum-edtf",
  "criterion",
  "csl-legacy",
+ "indexmap 2.13.0",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -53,11 +53,11 @@ use std::collections::{HashMap, HashSet};
 fn effective_locator_string(item: &CitationItem) -> Option<String> {
     use citum_schema::citation::ResolvedLocator;
     match item.resolved_locator() {
-        Some(ResolvedLocator::Flat { value, .. }) => Some(value.to_string()),
+        Some(ResolvedLocator::Flat { value, .. }) => Some(value),
         Some(ResolvedLocator::Compound(segments)) => {
             let parts: Vec<String> = segments
                 .iter()
-                .map(|s| format!("{:?}:{}", s.label, s.value))
+                .map(|s| format!("{:?}:{}", s.label, s.value.value_str()))
                 .collect();
             Some(parts.join(","))
         }

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -43,10 +43,7 @@ fn collapse_compound_locator(segments: &[LocatorSegment], locale: &Locale) -> St
     segments
         .iter()
         .map(|seg| {
-            let plural = seg.value.contains('\u{2013}')
-                || seg.value.contains('-')
-                || seg.value.contains(',')
-                || seg.value.contains('&');
+            let plural = seg.value.is_plural();
             let term = locale
                 .locator_term(&seg.label, plural, TermForm::Short)
                 .or_else(|| locale.locator_term(&seg.label, plural, TermForm::Symbol))
@@ -58,7 +55,7 @@ fn collapse_compound_locator(segments: &[LocatorSegment], locale: &Locale) -> St
                         .and_then(|v| v.as_str().map(String::from))
                         .unwrap_or_else(|| format!("{:?}", seg.label))
                 });
-            format!("{} {}", term, seg.value)
+            format!("{} {}", term, seg.value.value_str())
         })
         .collect::<Vec<_>>()
         .join(", ")
@@ -74,9 +71,9 @@ fn resolve_item_locator(
 ) -> (Option<String>, Option<LocatorType>) {
     match item.resolved_locator() {
         Some(ResolvedLocator::Compound(segments)) => {
-            (Some(collapse_compound_locator(segments, locale)), None)
+            (Some(collapse_compound_locator(&segments, locale)), None)
         }
-        Some(ResolvedLocator::Flat { label, value }) => (Some(value.to_string()), Some(label)),
+        Some(ResolvedLocator::Flat { label, value }) => (Some(value), Some(label)),
         None => (None, None),
     }
 }
@@ -1366,6 +1363,7 @@ fn resolve_component_for_ref_type(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use citum_schema::citation::{LocatorValue, LocatorsInput};
     use citum_schema::template::*;
 
     #[test]
@@ -1473,11 +1471,11 @@ mod tests {
         let segments = vec![
             LocatorSegment {
                 label: LocatorType::Chapter,
-                value: "3".to_string(),
+                value: LocatorValue::from("3"),
             },
             LocatorSegment {
                 label: LocatorType::Section,
-                value: "42".to_string(),
+                value: LocatorValue::from("42"),
             },
         ];
         let rendered = collapse_compound_locator(&segments, &locale);
@@ -1492,7 +1490,7 @@ mod tests {
         // Range with en-dash should trigger plural
         let segments = vec![LocatorSegment {
             label: LocatorType::Page,
-            value: "10\u{2013}12".to_string(),
+            value: LocatorValue::from("10\u{2013}12"),
         }];
         let rendered = collapse_compound_locator(&segments, &locale);
         assert!(rendered.contains("10\u{2013}12"));
@@ -1503,7 +1501,7 @@ mod tests {
         let locale = Locale::default();
         let segments = vec![LocatorSegment {
             label: LocatorType::SubVerbo,
-            value: "test".to_string(),
+            value: LocatorValue::from("test"),
         }];
         let rendered = collapse_compound_locator(&segments, &locale);
         // Should use kebab-case "sub-verbo", not PascalCase "SubVerbo"
@@ -1520,10 +1518,10 @@ mod tests {
             id: "test".to_string(),
             label: Some(LocatorType::Page),
             locator: Some("99".to_string()),
-            locators: Some(vec![LocatorSegment {
+            locators: Some(LocatorsInput::List(vec![LocatorSegment {
                 label: LocatorType::Chapter,
-                value: "5".to_string(),
-            }]),
+                value: LocatorValue::from("5"),
+            }])),
             ..Default::default()
         };
         let (value, label) = resolve_item_locator(&item, &locale);

--- a/crates/citum-schema/Cargo.toml
+++ b/crates/citum-schema/Cargo.toml
@@ -13,6 +13,7 @@ schemars = { version = "0.8", features = ["derive", "url"], optional = true }
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy", optional = true }
+indexmap = { version = "2", features = ["serde"] }
 
 [features]
 default = []

--- a/crates/citum-schema/src/citation.rs
+++ b/crates/citum-schema/src/citation.rs
@@ -9,6 +9,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! to the processor. Citations reference entries in the bibliography and
 //! can include locators, prefixes, suffixes, and mode information.
 
+use indexmap::IndexMap;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -193,6 +194,67 @@ pub enum LocatorType {
     Algorithm,
 }
 
+/// A locator value that supports both plain strings and explicit plurality.
+///
+/// Plain strings use heuristic plural detection (checking for `-`, `–`, `,`, `&`).
+/// Use the explicit form to override when the heuristic fails (e.g., "figure A-3"
+/// should be singular despite containing a hyphen).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum LocatorValue {
+    /// Plain string value with heuristic plural detection.
+    Text(String),
+    /// Explicit value with manual plural override.
+    Explicit {
+        /// The locator value string.
+        value: String,
+        /// Whether this locator is plural.
+        plural: bool,
+    },
+}
+
+impl LocatorValue {
+    /// Returns the raw value string.
+    pub fn value_str(&self) -> &str {
+        match self {
+            LocatorValue::Text(s) => s,
+            LocatorValue::Explicit { value, .. } => value,
+        }
+    }
+
+    /// Returns whether this locator value is plural.
+    ///
+    /// For `Text`, uses the heuristic (contains `-`, `–`, `,`, or `&`).
+    /// For `Explicit`, returns the specified `plural` field.
+    pub fn is_plural(&self) -> bool {
+        match self {
+            LocatorValue::Text(s) => {
+                s.contains('\u{2013}') || s.contains('-') || s.contains(',') || s.contains('&')
+            }
+            LocatorValue::Explicit { plural, .. } => *plural,
+        }
+    }
+}
+
+impl Default for LocatorValue {
+    fn default() -> Self {
+        LocatorValue::Text(String::new())
+    }
+}
+
+impl From<String> for LocatorValue {
+    fn from(s: String) -> Self {
+        LocatorValue::Text(s)
+    }
+}
+
+impl From<&str> for LocatorValue {
+    fn from(s: &str) -> Self {
+        LocatorValue::Text(s.to_string())
+    }
+}
+
 /// A single segment of a compound locator.
 ///
 /// Pairs a locator type with its value, e.g. `{ label: chapter, value: "3" }`.
@@ -203,21 +265,92 @@ pub struct LocatorSegment {
     /// The locator type for this segment.
     pub label: LocatorType,
     /// The locator value (e.g., "3", "42-45").
-    pub value: String,
+    pub value: LocatorValue,
+}
+
+/// Input form for compound locators, supporting both verbose and compact syntax.
+///
+/// The verbose form uses an explicit list of segments:
+/// ```yaml
+/// locators:
+///   - label: page
+///     value: "23"
+///   - label: line
+///     value: "13"
+/// ```
+///
+/// The compact form uses a map (order preserved via `IndexMap`):
+/// ```yaml
+/// locators:
+///   page: "23"
+///   line: "13"
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum LocatorsInput {
+    /// Verbose list of labeled segments.
+    List(Vec<LocatorSegment>),
+    /// Compact map form (locator type → value).
+    Map(IndexMap<LocatorType, LocatorValue>),
+}
+
+impl LocatorsInput {
+    /// Normalize to a list of segments regardless of input form.
+    pub fn segments(&self) -> Vec<LocatorSegment> {
+        match self {
+            LocatorsInput::List(list) => list.clone(),
+            LocatorsInput::Map(map) => map
+                .iter()
+                .map(|(label, value)| LocatorSegment {
+                    label: label.clone(),
+                    value: value.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Returns true if this contains no segments.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            LocatorsInput::List(list) => list.is_empty(),
+            LocatorsInput::Map(map) => map.is_empty(),
+        }
+    }
+}
+
+#[cfg(feature = "schema")]
+impl JsonSchema for LocatorsInput {
+    fn schema_name() -> String {
+        "LocatorsInput".to_string()
+    }
+
+    fn json_schema(
+        schema_generator: &mut schemars::r#gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        use schemars::schema::SchemaObject;
+
+        let list_schema = schema_generator.subschema_for::<Vec<LocatorSegment>>();
+        let map_schema =
+            schema_generator.subschema_for::<std::collections::BTreeMap<String, LocatorValue>>();
+
+        let mut schema = SchemaObject::default();
+        schema.subschemas().one_of = Some(vec![list_schema, map_schema]);
+        schema.into()
+    }
 }
 
 /// A resolved locator that abstracts over flat and compound forms.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ResolvedLocator<'a> {
+pub enum ResolvedLocator {
     /// A single label + value pair (the traditional flat form).
     Flat {
         /// The locator type.
         label: LocatorType,
         /// The locator value.
-        value: &'a str,
+        value: String,
     },
     /// Multiple label + value segments (compound locator).
-    Compound(&'a [LocatorSegment]),
+    Compound(Vec<LocatorSegment>),
 }
 
 /// A single citation item referencing a bibliography entry.
@@ -236,9 +369,11 @@ pub struct CitationItem {
     /// Compound locator segments for multi-part references.
     ///
     /// When present, takes priority over `label`/`locator`.
-    /// Example: `[{ label: chapter, value: "3" }, { label: section, value: "42" }]`
+    /// Supports both verbose list form and compact map form.
+    /// Example list: `[{ label: chapter, value: "3" }, { label: section, value: "42" }]`
+    /// Example map: `{ page: "23", line: "13" }`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub locators: Option<Vec<LocatorSegment>>,
+    pub locators: Option<LocatorsInput>,
     /// Prefix text before this item
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -249,20 +384,20 @@ pub struct CitationItem {
 
 impl CitationItem {
     /// Resolve the locator, preferring compound `locators` over flat `label`/`locator`.
-    pub fn resolved_locator(&self) -> Option<ResolvedLocator<'_>> {
-        if let Some(segments) = &self.locators
-            && !segments.is_empty()
+    pub fn resolved_locator(&self) -> Option<ResolvedLocator> {
+        if let Some(input) = &self.locators
+            && !input.is_empty()
         {
-            return Some(ResolvedLocator::Compound(segments));
+            return Some(ResolvedLocator::Compound(input.segments()));
         }
         match (&self.label, &self.locator) {
             (Some(label), Some(value)) => Some(ResolvedLocator::Flat {
                 label: label.clone(),
-                value,
+                value: value.clone(),
             }),
             (None, Some(value)) => Some(ResolvedLocator::Flat {
                 label: LocatorType::default(),
-                value,
+                value: value.clone(),
             }),
             _ => None,
         }
@@ -318,17 +453,12 @@ mod tests {
         }
         "#;
         let item: CitationItem = serde_json::from_str(json).unwrap();
-        assert_eq!(item.locators.as_ref().unwrap().len(), 2);
-        assert_eq!(
-            item.locators.as_ref().unwrap()[0].label,
-            LocatorType::Chapter
-        );
-        assert_eq!(item.locators.as_ref().unwrap()[0].value, "3");
-        assert_eq!(
-            item.locators.as_ref().unwrap()[1].label,
-            LocatorType::Section
-        );
-        assert_eq!(item.locators.as_ref().unwrap()[1].value, "42");
+        let segs = item.locators.as_ref().unwrap().segments();
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[0].label, LocatorType::Chapter);
+        assert_eq!(segs[0].value.value_str(), "3");
+        assert_eq!(segs[1].label, LocatorType::Section);
+        assert_eq!(segs[1].value.value_str(), "42");
 
         // Round-trip
         let serialized = serde_json::to_string(&item).unwrap();
@@ -342,16 +472,16 @@ mod tests {
             id: "test".to_string(),
             label: Some(LocatorType::Page),
             locator: Some("99".to_string()),
-            locators: Some(vec![
+            locators: Some(LocatorsInput::List(vec![
                 LocatorSegment {
                     label: LocatorType::Chapter,
-                    value: "3".to_string(),
+                    value: LocatorValue::from("3"),
                 },
                 LocatorSegment {
                     label: LocatorType::Section,
-                    value: "42".to_string(),
+                    value: LocatorValue::from("42"),
                 },
-            ]),
+            ])),
             ..Default::default()
         };
         let resolved = item.resolved_locator().unwrap();
@@ -389,5 +519,65 @@ mod tests {
         };
         let json = serde_json::to_value(&item).unwrap();
         assert!(!json.as_object().unwrap().contains_key("locators"));
+    }
+
+    #[test]
+    fn test_compact_map_form_deserialization() {
+        let json = r#"
+        {
+            "id": "smith2020",
+            "locators": {
+                "page": "23",
+                "line": "13"
+            }
+        }
+        "#;
+        let item: CitationItem = serde_json::from_str(json).unwrap();
+        let segs = item.locators.as_ref().unwrap().segments();
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[0].label, LocatorType::Page);
+        assert_eq!(segs[0].value.value_str(), "23");
+        assert_eq!(segs[1].label, LocatorType::Line);
+        assert_eq!(segs[1].value.value_str(), "13");
+    }
+
+    #[test]
+    fn test_locator_value_explicit_plural_override() {
+        let json = r#"
+        {
+            "id": "test",
+            "locators": [
+                {
+                    "label": "figure",
+                    "value": {
+                        "value": "A-3",
+                        "plural": false
+                    }
+                }
+            ]
+        }
+        "#;
+        let item: CitationItem = serde_json::from_str(json).unwrap();
+        let segs = item.locators.as_ref().unwrap().segments();
+        assert_eq!(segs[0].value.value_str(), "A-3");
+        assert!(!segs[0].value.is_plural());
+    }
+
+    #[test]
+    fn test_locator_value_heuristic_plural() {
+        let lv_range = LocatorValue::from("42-45");
+        assert!(lv_range.is_plural());
+
+        let lv_single = LocatorValue::from("42");
+        assert!(!lv_single.is_plural());
+
+        let lv_en_dash = LocatorValue::from("42–45");
+        assert!(lv_en_dash.is_plural());
+
+        let lv_comma = LocatorValue::from("1, 3, 5");
+        assert!(lv_comma.is_plural());
+
+        let lv_ampersand = LocatorValue::from("A & B");
+        assert!(lv_ampersand.is_plural());
     }
 }


### PR DESCRIPTION
## Summary
- Add `LocatorValue` untagged enum supporting plain strings (heuristic plurality) or explicit `{ value, plural }` override for cases like "figure A-3"
- Add `LocatorsInput` untagged enum accepting verbose list or compact map (`page: "23"`) syntax via `IndexMap`
- Change `ResolvedLocator` to fully owned (remove lifetime parameter)
- Update engine call sites to use `.value_str()` / `.is_plural()`

## Test plan
- [x] All 511 existing tests pass
- [x] Clippy clean, formatted
- [x] New unit tests for compact map deserialization, explicit plural override, and heuristic detection

Refs: csl26-j007

🤖 Generated with [Claude Code](https://claude.com/claude-code)