### PR TITLE
feat(beans): dependency-aware /beans next ranking

### DIFF
--- a/.beans/csl26-zt6c--improve-beans-next-dependency-aware-ranking.md
+++ b/.beans/csl26-zt6c--improve-beans-next-dependency-aware-ranking.md
@@ -1,0 +1,33 @@
+---
+# csl26-zt6c
+title: 'Improve /beans next: dependency-aware ranking'
+status: completed
+type: task
+priority: high
+created_at: 2026-03-06T13:47:09Z
+updated_at: 2026-03-06T13:50:10Z
+---
+
+Improve the citum-bean next script and beans SKILL.md so /beans next can be trusted without manual override.
+
+- [x] Rewrite citum-bean next to use beans query GraphQL for leverage scoring
+- [x] Rank by: priority → leverage (unblock count) desc → type → age
+- [x] Show in-progress beans as context header
+- [x] Display 'Unblocks N' in output when leverage > 0
+- [x] Drop redundant beans prime instruction from SKILL.md
+- [x] Add body-modification cheat sheet to SKILL.md
+- [x] Expand description trigger phrases in SKILL.md
+
+## Summary of Changes
+
+Rewrote citum-bean next to use a single GraphQL query (beans query) to fetch
+all non-terminal beans with blockingIds in one round trip. Leverage score
+is computed per bean as the count of its blockingIds that are still open.
+Ranking now uses: priority → leverage desc → type → age.
+
+Output now includes an in-progress context header showing what is already
+running, and a '· unblocks N' badge for high-leverage candidates.
+
+SKILL.md updated: dropped redundant beans prime call, added body-modification
+cheat sheet with exact syntax for checklist check-off, and expanded description
+trigger phrases.

--- a/.claude/skills/beans/SKILL.md
+++ b/.claude/skills/beans/SKILL.md
@@ -5,55 +5,92 @@ description: >
   Task tracking and issue management for this Citum project using the `beans`
   CLI. Always use this skill — never TodoWrite — when the user mentions tasks,
   todos, work items, what to work on next, creating/updating/closing issues, or
-  asks about project status. Trigger on: "what should I work on", "create a
-  task for", "mark that done", "what's in progress", "next task", "check my
-  tasks", "/beans next", "track this", "log a bug". Also trigger at the start
-  of any multi-step task to check for an existing bean before creating one.
+  asks about project status. Trigger on: "what should I work on", "what's next",
+  "create a task for", "mark that done", "I finished", "close this", "what's
+  in progress", "next task", "check my tasks", "/beans next", "track this",
+  "log a bug", "what's blocking me", "mark it complete", "I'm done with".
+  Also trigger at the start of any multi-step task to check for an existing
+  bean before creating one.
 ---
 
 # Beans (Citum)
 
-## Usage
-
-1. Treat `beans prime` output as authoritative for command syntax and workflow.
-2. Prefer `--json` for agent parsing and automation.
-3. Do not use TodoWrite or ad-hoc todo lists; track work in beans.
-
 ## Citum Overlay
 
-Use these project-specific rules on top of `beans prime`:
+The `beans prime` guide is already injected into every session — no need to
+call it again. Use these project-specific rules on top of it:
 
-- Start by checking existing work: `beans list --json --ready` and `beans show --json <id>`.
-- Always create beans with an explicit type (`-t`).
-- Keep bean checklists current while work is in progress.
+- Before starting work: check `beans list --json --ready` and `beans show --json <id>`.
+- Always create beans with an explicit type (`-t bug | feature | task | epic | milestone`).
+- Keep bean checklists current while work is in progress (`- [ ]` → `- [x]`).
 - Mark completed only when all checklist items are checked.
-- When completing, append a `## Summary of Changes`.
-- When scrapping, append a `## Reasons for Scrapping`.
+- When completing, append a `## Summary of Changes` section.
+- When scrapping, append a `## Reasons for Scrapping` section.
 
 ## Commit Rule
 
-**Always include the bean file in commits.** Use `git add -A` (not selective adds) so `.beans/` changes are never left out. Code changes and bean state must be committed together.
+**Always include the bean file in commits.** Use `git add -A` (not selective
+adds) so `.beans/` changes are never left out. Code changes and bean state must
+be committed together.
+
+## Common Patterns
+
+**Check off a checklist item** (exact match required — copy text verbatim):
+```bash
+beans update <id> \
+  --body-replace-old "- [ ] Do the thing" \
+  --body-replace-new "- [x] Do the thing"
+```
+
+**Append summary and mark complete in one shot:**
+```bash
+beans update <id> \
+  --body-replace-old "- [ ] Final step" --body-replace-new "- [x] Final step" \
+  --body-append "## Summary of Changes\n\nWhat was done and why." \
+  -s completed
+```
+
+**Multiple checkbox updates atomically** (use GraphQL to avoid multiple etag conflicts):
+```bash
+beans query 'mutation {
+  updateBean(id: "<id>", input: {
+    bodyMod: {
+      replace: [
+        { old: "- [ ] Step A", new: "- [x] Step A" }
+        { old: "- [ ] Step B", new: "- [x] Step B" }
+      ]
+    }
+  }) { id etag }
+}'
+```
 
 ## `/beans next` Helper
 
-`/beans next` is a local helper that ranks and presents multiple ready options.
+`/beans next` ranks ready options using the full dependency graph and shows
+what is currently in progress, so you can pick without manual analysis.
 
-- Default output: top 3 options.
-- Ranking: prioritize executable work first (`bug`/`feature`/`task`), then use priority (`critical` > `high` > `normal` > `low` > `deferred`), then oldest first. `milestone` and `epic` beans are fallback suggestions only when there are not enough concrete ready items.
-- Includes short rationale and parent title (when present).
+**Ranking:** priority → leverage (how many open beans this unblocks) desc →
+type (bug > feature > task) → oldest first. Epics/milestones appear only when
+concrete work is insufficient to fill the limit.
 
-**Implementation:** Always run via the wrapper script — never call `beans list --json --ready` directly, as that dumps raw JSON. The script handles ranking and formatting. After running, output the script result as plain text — no preamble, no commentary, nothing else.
+**Output includes:**
+- In-progress context header (what's already running)
+- `· unblocks N` badge when completing a bean would unblock other work
 
 ```bash
-bash .claude/skills/beans/bin/citum-bean next
+bash .claude/skills/beans/bin/citum-bean next           # top 3
 bash .claude/skills/beans/bin/citum-bean next --limit 5
 bash .claude/skills/beans/bin/citum-bean next --json
 ```
 
+Always run via the wrapper — never call `beans list --json --ready` directly,
+as that skips leverage scoring and the in-progress header. Output the script
+result as plain text with no preamble or commentary.
+
 ## Command Policy
 
-- Canonical command behavior comes from `beans` itself.
-- Do not duplicate CLI flag documentation here; use `beans prime` and `beans <cmd> --help`.
+- Canonical command behaviour comes from `beans` itself.
+- Do not duplicate CLI flag docs here; use `beans <cmd> --help`.
 - If this file conflicts with `beans prime`, `beans prime` wins.
 
 ## See Also

--- a/.claude/skills/beans/bin/citum-bean
+++ b/.claude/skills/beans/bin/citum-bean
@@ -55,19 +55,27 @@ case "$CMD" in
             exit 1
         fi
 
-        READY_JSON=$(beans list --json --ready)
-        # Defensive filter: keep only actionable statuses for /beans next.
-        # beans list --ready has a known bug where it leaks canceled beans;
-        # this filter is the authoritative gate.
-        READY_JSON=$(printf "%s\n" "$READY_JSON" | jq '
-            map(
-                select(
-                    (.status // "" | ascii_downcase) as $s |
-                    ($s == "todo" or $s == "in-progress")
-                )
-            )
+        # Single GraphQL query: fetch all non-terminal beans with relationship
+        # data. Resolving leverage and in-progress state in one round trip avoids
+        # multiple CLI calls and gives us the full dependency picture.
+        ALL_JSON=$(beans query --json '{
+            beans(filter: {
+                excludeStatus: ["completed", "scrapped", "draft", "canceled"]
+            }) {
+                id title status type priority parentId blockingIds blockedByIds
+            }
+        }' | jq '.beans')
+
+        # Separate in-progress from ready (unblocked todo beans).
+        IN_PROGRESS=$(printf "%s\n" "$ALL_JSON" | jq '[.[] | select(.status == "in-progress")]')
+        READY=$(printf "%s\n" "$ALL_JSON" | jq '
+            [.[] | select(
+                (.status == "todo") and
+                (.blockedByIds | length == 0)
+            )]
         ')
-        READY_COUNT=$(printf "%s\n" "$READY_JSON" | jq 'length')
+
+        READY_COUNT=$(printf "%s\n" "$READY" | jq 'length')
         if [[ "$READY_COUNT" -eq 0 ]]; then
             if [[ "$JSON_OUTPUT" -eq 1 ]]; then
                 echo "[]"
@@ -77,11 +85,23 @@ case "$CMD" in
             exit 0
         fi
 
-        # Prefer executable work over umbrella tracking beans. Epics and
-        # milestones remain visible only when there are not enough concrete
-        # bugs/features/tasks to fill the requested limit.
-        RANKED_JSON=$(printf "%s\n" "$READY_JSON" | jq --argjson limit "$LIMIT" '
-            map(.priority = (.priority // "normal")) as $items |
+        # Build a set of open IDs so leverage counts only beans still in play
+        # (not already completed or scrapped).
+        OPEN_IDS_JSON=$(printf "%s\n" "$ALL_JSON" | jq '[.[].id]')
+
+        # Rank candidates.
+        # Leverage = count of blockingIds whose targets are still open.
+        # Epics and milestones are fallback options shown only when concrete
+        # work (bug/feature/task) is insufficient to fill the limit.
+        # Sort key: priority asc, leverage desc, type rank asc, created_at asc.
+        RANKED_JSON=$(printf "%s\n" "$READY" | jq --argjson limit "$LIMIT" --argjson open_ids "$OPEN_IDS_JSON" '
+            (($open_ids) | map({key: ., value: true}) | from_entries) as $open |
+            map(
+                . + {
+                    leverage: ([.blockingIds[] | select($open[.] == true)] | length),
+                    priority: (.priority // "normal")
+                }
+            ) as $items |
             def priority_rank:
                 if .priority == "critical" then 0
                 elif .priority == "high" then 1
@@ -98,17 +118,18 @@ case "$CMD" in
             (
                 $items
                 | map(select((.type // "") != "epic" and (.type // "") != "milestone"))
-                | sort_by(priority_rank, type_rank, .created_at)
+                | sort_by(priority_rank, (-.leverage), type_rank, .created_at)
             ) as $concrete |
             (
                 $items
                 | map(select((.type // "") == "epic" or (.type // "") == "milestone"))
-                | sort_by(priority_rank, type_rank, .created_at)
+                | sort_by(priority_rank, (-.leverage), type_rank, .created_at)
             ) as $meta |
             ($concrete + $meta)[:$limit]
         ')
 
-        PARENT_IDS=$(printf "%s\n" "$RANKED_JSON" | jq -r '.[].parent // empty' | sort -u | tr '\n' ' ')
+        # Resolve parent titles for ranked candidates.
+        PARENT_IDS=$(printf "%s\n" "$RANKED_JSON" | jq -r '.[].parentId // empty' | sort -u | tr '\n' ' ')
         PARENT_MAP='{}'
         if [[ -n "${PARENT_IDS// /}" ]]; then
             PARENTS_JSON=$(beans show --json $PARENT_IDS)
@@ -124,14 +145,16 @@ case "$CMD" in
             --argjson parents "$PARENT_MAP" '
             $items | map(
                 . + {
-                    parent_title: (if (.parent != null and ($parents[.parent] != null)) then $parents[.parent] else null end),
+                    parent_title: (
+                        if (.parentId != null and ($parents[.parentId] != null))
+                        then $parents[.parentId]
+                        else null
+                        end
+                    ),
                     reason: (
-                        [
-                            "ready",
-                            ("priority=" + (.priority // "normal")),
-                            ("type=" + (.type // "task"))
-                        ] +
-                        (if (.parent != null and ($parents[.parent] != null)) then [("parent=" + $parents[.parent])] else [] end)
+                        ["priority=" + (.priority // "normal")] +
+                        (if .leverage > 0 then ["unblocks=" + (.leverage | tostring)] else [] end) +
+                        ["type=" + (.type // "task")]
                     ) | join(", ")
                 }
             )
@@ -142,9 +165,22 @@ case "$CMD" in
             exit 0
         fi
 
+        # Show in-progress context so the user can see what is already running
+        # before deciding what to start next.
+        IN_PROGRESS_COUNT=$(printf "%s\n" "$IN_PROGRESS" | jq 'length')
+        if [[ "$IN_PROGRESS_COUNT" -gt 0 ]]; then
+            echo "In progress:"
+            printf "%s\n" "$IN_PROGRESS" | jq -r '.[] | "  \(.id)  \(.type) · \(.priority // "normal")\n  \(.title)"'
+            echo ""
+        fi
+
+        # Print ranked candidates.
         printf "%s\n" "$CANDIDATES_JSON" | jq -r '
             to_entries[] |
-            "#\(.key + 1)  \(.value.id)  \(.value.type) · \(.value.priority)\n    \(.value.title)" +
+            (.value.leverage // 0) as $lev |
+            "#\(.key + 1)  \(.value.id)  \(.value.type) · \(.value.priority)" +
+            (if $lev > 0 then " · unblocks \($lev)" else "" end) +
+            "\n    \(.value.title)" +
             (if .value.parent_title then "\n    Parent: \(.value.parent_title)" else "" end)
         '
         FIRST_ID=$(printf "%s\n" "$CANDIDATES_JSON" | jq -r '.[0].id')
@@ -165,7 +201,8 @@ USAGE:
 
 COMMANDS:
     next [--limit N] [--json]
-        Show top ready bean options ranked by priority, type, and age.
+        Show top ready bean options ranked by priority, leverage (unblock
+        count), type, and age. Shows in-progress beans as context header.
 
     list ...
     show ...


### PR DESCRIPTION
## Summary

- `/beans next` now uses a single GraphQL query to fetch all non-terminal beans with relationship data in one round trip
- Adds **leverage scoring**: each ready bean is ranked by how many open beans it would unblock
- New ranking: `priority → leverage desc → type → age`
- Output shows an **in-progress context header** so you can see what's already running before picking the next task
- High-leverage candidates show a `· unblocks N` badge

## SKILL.md changes

- Dropped redundant `beans prime` call (already injected every session)
- Added body-modification cheat sheet with exact checklist check-off syntax
- Expanded description trigger phrases

## Test

```
bash .claude/skills/beans/bin/citum-bean next --limit 5
```