### PR TITLE
fix(engine): compound numeric rendering bugs

### DIFF
--- a/.beans/csl26-8xjd--fix-compound-numeric-rendering-bugs.md
+++ b/.beans/csl26-8xjd--fix-compound-numeric-rendering-bugs.md
@@ -1,0 +1,32 @@
+---
+# csl26-8xjd
+title: Fix compound numeric rendering bugs
+status: completed
+type: bug
+priority: high
+created_at: 2026-03-06T18:56:42Z
+updated_at: 2026-03-06T19:08:48Z
+---
+
+Three rendering bugs in compound numeric styles:
+
+1. Integral citations show bare [1] instead of [1a]/[1b] — render_author_number_for_numeric_integral_with_format ignores citation_sub_label_for_ref
+2. Bibliography shows duplicate [1] entries instead of merged [1a]/[1b] — CLI's print_human uses process_references() bypassing merge_compound_entries
+3. Multi-item citations don't collapse [1a,1b] → [1a,b] (separate follow-up)
+
+Existing tests pass because test_compound_numeric_bibliography_rendering calls render_bibliography() directly, not the CLI code path.
+
+## Tasks
+- [x] Add failing test for Bug 2 (integral sub-labels)
+- [x] Fix Bug 2 in rendering.rs
+- [x] Fix Bug 3 in main.rs (CLI ungrouped bib path)
+- [x] Confirm tests pass
+
+## Summary of Changes
+
+- **rendering.rs**: `render_author_number_for_numeric_integral_with_format` now looks up sub-label via `citation_sub_label_for_ref` and includes it in the bracket.
+- **mod.rs**: `render_bibliography_with_format` now renders sub-entry content without the citation-number label component, uses `render_entry_body_with_format` for bibliography separators without outer wrappers, and keeps label components separate in the merged `ProcEntry`.
+- **main.rs**: CLI ungrouped bibliography path uses `render_selected_bibliography_with_format` for human output (handles compound merge while respecting keys); oracle/show_keys path unchanged.
+- **tests.rs**: two new regression tests added
+
+PR: https://github.com/citum/citum-core/pull/297

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -1655,36 +1655,32 @@ where
                 output.push_str(&grouped);
             }
         } else {
-            // Fall back to entry-by-entry rendering for ungrouped styles
             let _ = writeln!(output, "BIBLIOGRAPHY:");
-            let filter: HashSet<&str> = item_ids.iter().map(|id| id.as_str()).collect();
-            let processed = processor.process_references();
-            let mut rendered_entries = Vec::new();
-
-            for entry in processed.bibliography {
-                if filter.contains(entry.id.as_str()) {
-                    let text = citum_engine::render::refs_to_string_with_format::<F>(
-                        vec![entry.clone()],
-                        annotations,
-                        Some(annotation_style),
-                    );
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() {
-                        if show_keys {
-                            rendered_entries.push(format!("  [{}] {}", entry.id, trimmed));
-                        } else {
-                            rendered_entries.push(trimmed.to_string());
+            if show_keys {
+                // Oracle/show_keys path: render each entry individually so entries
+                // can be matched by reference ID. Compound merging is skipped here
+                // because the oracle addresses each ref independently.
+                let filter: HashSet<&str> = item_ids.iter().map(|id| id.as_str()).collect();
+                let processed = processor.process_references();
+                for entry in processed.bibliography {
+                    if filter.contains(entry.id.as_str()) {
+                        let text = citum_engine::render::refs_to_string_with_format::<F>(
+                            vec![entry.clone()],
+                            annotations,
+                            Some(annotation_style),
+                        );
+                        let trimmed = text.trim();
+                        if !trimmed.is_empty() {
+                            let _ = writeln!(output, "  [{}] {}", entry.id, trimmed);
                         }
                     }
                 }
-            }
-
-            if show_keys {
-                for entry in rendered_entries {
-                    let _ = writeln!(output, "{}", entry);
-                }
-            } else if !rendered_entries.is_empty() {
-                let _ = writeln!(output, "{}", rendered_entries.join("\n\n"));
+            } else {
+                // Human-readable path: use the engine bibliography renderer so
+                // compound numeric groups are merged while still honoring keys.
+                let bib =
+                    processor.render_selected_bibliography_with_format::<F, _>(item_ids.to_vec());
+                let _ = writeln!(output, "{}", bib);
             }
         }
     }

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -36,6 +36,7 @@ mod tests;
 
 use crate::error::ProcessorError;
 use crate::reference::{Bibliography, Citation, CitationItem, Reference};
+use crate::render::bibliography::render_entry_body_with_format;
 use crate::render::{ProcEntry, ProcTemplate};
 use crate::values::ProcHints;
 use citum_schema::Style;
@@ -773,12 +774,12 @@ impl Processor {
             None => return entries,
         };
 
-        // Build lookup: ref_id -> (group_number, index_within_group)
-        let mut ref_to_group: HashMap<String, (usize, usize)> = HashMap::new();
+        // Build lookup: ref_id -> group_number for all compound groups.
+        let mut ref_to_group: HashMap<String, usize> = HashMap::new();
         for (&num, ids) in compound_groups.iter() {
             if ids.len() > 1 {
-                for (i, id) in ids.iter().enumerate() {
-                    ref_to_group.insert(id.clone(), (num, i));
+                for id in ids {
+                    ref_to_group.insert(id.clone(), num);
                 }
             }
         }
@@ -787,30 +788,82 @@ impl Processor {
             return entries;
         }
 
-        // First pass: render each entry to string and collect by group
+        // Helper: is this component a citation-number label (e.g. `[1]`)?
+        let is_label_component = |comp: &crate::render::component::ProcTemplateComponent| -> bool {
+            matches!(
+                &comp.template_component,
+                citum_schema::template::TemplateComponent::Number(n)
+                    if n.number
+                        == citum_schema::template::NumberVariable::CitationNumber
+            )
+        };
+
+        // First pass: render each entry's content WITHOUT the citation-number label.
+        // This prevents the label from appearing inside each sub-entry when merged
+        // (e.g. "a) [1] Zwart..." is wrong; content should be "a) Zwart...").
+        // Use refs_to_string_with_format (not citation renderer) so bibliography
+        // separators are applied correctly between author/title/year etc.
         let mut rendered_strings: HashMap<String, String> = HashMap::new();
         for entry in &entries {
-            let rendered = crate::render::citation::citation_to_string_with_format::<F>(
-                &entry.template,
-                None,
-                None,
-                None,
-                None,
-            );
+            let content_components: Vec<_> = entry
+                .template
+                .iter()
+                .filter(|c| !is_label_component(c))
+                .cloned()
+                .collect();
+            let content_entry = ProcEntry {
+                id: entry.id.clone(),
+                template: content_components,
+                metadata: entry.metadata.clone(),
+            };
+            let rendered = render_entry_body_with_format::<F>(&content_entry);
             rendered_strings.insert(entry.id.clone(), rendered.trim().to_string());
         }
+
+        let entries_by_id: HashMap<String, ProcEntry> = entries
+            .iter()
+            .map(|entry| (entry.id.clone(), entry.clone()))
+            .collect();
+
+        let mut group_members_present: HashMap<usize, Vec<String>> = HashMap::new();
+        for entry in &entries {
+            if let Some(&group_num) = ref_to_group.get(&entry.id) {
+                group_members_present
+                    .entry(group_num)
+                    .or_default()
+                    .push(entry.id.clone());
+            }
+        }
+
+        let first_present_by_group: HashMap<usize, String> = group_members_present
+            .iter()
+            .filter_map(|(&group_num, ids)| ids.first().cloned().map(|id| (group_num, id)))
+            .collect();
 
         // Second pass: build merged output
         let mut result: Vec<ProcEntry> = Vec::new();
 
         for entry in entries {
-            if let Some(&(group_num, idx)) = ref_to_group.get(&entry.id) {
-                if idx == 0 {
+            if let Some(&group_num) = ref_to_group.get(&entry.id) {
+                let Some(present_ids) = group_members_present.get(&group_num) else {
+                    result.push(entry);
+                    continue;
+                };
+
+                if present_ids.len() == 1 {
+                    result.push(entry);
+                    continue;
+                }
+
+                if first_present_by_group.get(&group_num) == Some(&entry.id) {
                     // First in group — build merged entry
                     let group_ids = &compound_groups[&group_num];
                     let mut parts: Vec<String> = Vec::new();
 
                     for (i, id) in group_ids.iter().enumerate() {
+                        if !entries_by_id.contains_key(id) {
+                            continue;
+                        }
                         let sub_label = match compound_config.sub_label {
                             citum_schema::options::bibliography::SubLabelStyle::Alphabetic => {
                                 format!(
@@ -829,25 +882,30 @@ impl Processor {
                         }
                     }
 
-                    let merged_text = parts.join(&compound_config.sub_delimiter);
-                    let merged_component = entry
+                    let merged_content = parts.join(&compound_config.sub_delimiter);
+
+                    // Keep citation-number label components intact so the bibliography
+                    // renderer outputs the label (e.g. "[1] ") once, then appends the
+                    // merged sub-entries as a single pre-formatted content component.
+                    let mut merged_template: Vec<_> = entry
                         .template
-                        .first()
-                        .map(|c| c.template_component.clone())
-                        .unwrap_or_default();
+                        .iter()
+                        .filter(|c| is_label_component(c))
+                        .cloned()
+                        .collect();
+                    merged_template.push(crate::render::component::ProcTemplateComponent {
+                        template_component: citum_schema::template::TemplateComponent::default(),
+                        value: merged_content,
+                        pre_formatted: true,
+                        config: entry.template.first().and_then(|c| c.config.clone()),
+                        ..Default::default()
+                    });
 
-                    let merged_entry = ProcEntry {
+                    result.push(ProcEntry {
                         id: entry.id.clone(),
-                        template: vec![crate::render::component::ProcTemplateComponent {
-                            template_component: merged_component,
-                            value: merged_text,
-                            pre_formatted: true,
-                            ..Default::default()
-                        }],
+                        template: merged_template,
                         metadata: entry.metadata,
-                    };
-
-                    result.push(merged_entry);
+                    });
                 }
                 // else: skip non-first members of a group
             } else {
@@ -864,7 +922,19 @@ impl Processor {
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
+        self.render_selected_bibliography_with_format::<F, _>(
+            self.bibliography.keys().cloned().collect::<Vec<_>>(),
+        )
+    }
+
+    /// Render a selected bibliography subset to a string using a specific format.
+    pub fn render_selected_bibliography_with_format<F, I>(&self, item_ids: I) -> String
+    where
+        F: crate::render::format::OutputFormat<Output = String>,
+        I: IntoIterator<Item = String>,
+    {
         self.initialize_numeric_citation_numbers();
+        let selected: HashSet<String> = item_ids.into_iter().collect();
         let sorted_refs = self.sort_references(self.bibliography.values().collect());
         let mut bibliography: Vec<ProcEntry> = Vec::new();
         let mut prev_reference: Option<&Reference> = None;
@@ -874,6 +944,9 @@ impl Processor {
 
         for (index, reference) in sorted_refs.iter().enumerate() {
             let ref_id = reference.id().unwrap_or_default();
+            if !selected.contains(&ref_id) {
+                continue;
+            }
             let entry_number = self
                 .citation_numbers
                 .borrow()

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -7,6 +7,7 @@
 use crate::error::ProcessorError;
 use crate::reference::{Bibliography, Reference};
 use crate::render::{ProcTemplate, ProcTemplateComponent};
+use crate::values::range::{ConsecutiveSegment, consecutive_segments};
 use crate::values::{ComponentValues, ProcHints, RenderContext, RenderOptions};
 use citum_schema::citation::{LocatorSegment, LocatorType, ResolvedLocator};
 use citum_schema::locale::{Locale, TermForm};
@@ -211,6 +212,124 @@ impl<'a> Renderer<'a> {
         !has_explicit_integral
     }
 
+    fn should_collapse_compound_subentries(
+        &self,
+        mode: &citum_schema::citation::CitationMode,
+    ) -> bool {
+        if !matches!(mode, citum_schema::citation::CitationMode::NonIntegral) {
+            return false;
+        }
+
+        self.config
+            .bibliography
+            .as_ref()
+            .and_then(|b| b.compound_numeric.as_ref())
+            .is_some_and(|c| c.subentry && c.collapse_subentries)
+    }
+
+    fn collapse_compound_citation_chunks(
+        &self,
+        chunks: Vec<(Vec<String>, String)>,
+    ) -> Vec<(Vec<String>, String)> {
+        let Some(compound) = self
+            .config
+            .bibliography
+            .as_ref()
+            .and_then(|b| b.compound_numeric.as_ref())
+        else {
+            return chunks;
+        };
+
+        if !matches!(
+            compound.sub_label,
+            citum_schema::options::bibliography::SubLabelStyle::Alphabetic
+        ) {
+            return chunks;
+        }
+
+        let citation_numbers = self.citation_numbers.borrow();
+        let mut collapsed = Vec::new();
+        let mut i = 0;
+
+        while i < chunks.len() {
+            let Some(ref_id) = chunks[i].0.first() else {
+                collapsed.push(chunks[i].clone());
+                i += 1;
+                continue;
+            };
+            let Some(group_id) = self.compound_set_by_ref.get(ref_id) else {
+                collapsed.push(chunks[i].clone());
+                i += 1;
+                continue;
+            };
+            let Some(&citation_number) = citation_numbers.get(ref_id) else {
+                collapsed.push(chunks[i].clone());
+                i += 1;
+                continue;
+            };
+
+            let mut j = i;
+            let mut block_ids = Vec::new();
+            let mut member_ordinals = Vec::new();
+
+            while j < chunks.len() {
+                let Some(candidate_id) = chunks[j].0.first() else {
+                    break;
+                };
+                if chunks[j].0.len() != 1
+                    || self.compound_set_by_ref.get(candidate_id) != Some(group_id)
+                    || citation_numbers.get(candidate_id).copied() != Some(citation_number)
+                {
+                    break;
+                }
+
+                let Some(member_index) = self.compound_member_index.get(candidate_id).copied()
+                else {
+                    break;
+                };
+                let expected = format!(
+                    "{}{}",
+                    citation_number,
+                    self.citation_sub_label_for_ref(candidate_id)
+                        .unwrap_or_default()
+                );
+                if chunks[j].1 != expected {
+                    break;
+                }
+
+                block_ids.push(candidate_id.clone());
+                member_ordinals.push((member_index + 1) as u32);
+                j += 1;
+            }
+
+            if block_ids.len() < 2 {
+                collapsed.push(chunks[i].clone());
+                i += 1;
+                continue;
+            }
+
+            let labels = consecutive_segments(&member_ordinals)
+                .into_iter()
+                .map(|segment| match segment {
+                    ConsecutiveSegment::Single(value) => {
+                        crate::values::int_to_letter(value).unwrap_or_default()
+                    }
+                    ConsecutiveSegment::Range { start, end } => {
+                        let start_label = crate::values::int_to_letter(start).unwrap_or_default();
+                        let end_label = crate::values::int_to_letter(end).unwrap_or_default();
+                        format!("{start_label}-{end_label}")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+
+            collapsed.push((block_ids, format!("{citation_number}{labels}")));
+            i = j;
+        }
+
+        collapsed
+    }
+
     /// Ensure suffix has proper spacing (add space if suffix doesn't start with
     /// punctuation and isn't empty).
     fn ensure_suffix_spacing(&self, suffix: &str) -> String {
@@ -287,12 +406,16 @@ impl<'a> Renderer<'a> {
             String::new()
         };
 
-        // Format: "Author [N]"
+        // Include compound sub-label (e.g. "a", "b") when applicable.
+        let ref_id = reference.id().unwrap_or_default();
+        let sub_label = self.citation_sub_label_for_ref(&ref_id).unwrap_or_default();
+
+        // Format: "Author [Na]"
         if !author_part.is_empty() {
-            format!("{} [{}]", author_part, citation_number)
+            format!("{} [{}{}]", author_part, citation_number, sub_label)
         } else {
             // Fallback: just citation number if no author
-            format!("[{}]", citation_number)
+            format!("[{}{}]", citation_number, sub_label)
         }
     }
 
@@ -394,8 +517,8 @@ impl<'a> Renderer<'a> {
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
-        let mut rendered_items = Vec::new();
         let fmt = F::default();
+        let mut chunks: Vec<(Vec<String>, String)> = Vec::new();
 
         // For numeric styles with integral mode, render author + citation number instead.
         let use_author_number = self.should_render_author_number_for_numeric_integral(mode);
@@ -433,7 +556,7 @@ impl<'a> Renderer<'a> {
                     } else {
                         item_str
                     };
-                    rendered_items.push(fmt.citation(vec![item.id.clone()], content));
+                    chunks.push((vec![item.id.clone()], content));
                 }
             } else if use_label_author {
                 let item_str =
@@ -455,7 +578,7 @@ impl<'a> Renderer<'a> {
                     } else {
                         item_str
                     };
-                    rendered_items.push(fmt.citation(vec![item.id.clone()], content));
+                    chunks.push((vec![item.id.clone()], content));
                 }
             } else {
                 // Standard rendering: use template with citation number
@@ -501,13 +624,20 @@ impl<'a> Renderer<'a> {
                         } else {
                             item_str
                         };
-                        rendered_items.push(fmt.citation(vec![item.id.clone()], content));
+                        chunks.push((vec![item.id.clone()], content));
                     }
                 }
             }
         }
 
-        Ok(rendered_items)
+        if self.should_collapse_compound_subentries(mode) {
+            chunks = self.collapse_compound_citation_chunks(chunks);
+        }
+
+        Ok(chunks
+            .into_iter()
+            .map(|(ids, content)| fmt.citation(ids, content))
+            .collect())
     }
 
     /// Render citation items with author grouping for author-date styles.

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -2501,6 +2501,9 @@ options:
     separator: ". "
 bibliography:
   template:
+    - number: citation-number
+      wrap: brackets
+      suffix: " "
     - contributor: author
       form: long
     - title: primary
@@ -2550,7 +2553,12 @@ bibliography:
     let processor = Processor::with_compound_sets(style, bib, sets);
     let result = processor.render_bibliography();
 
-    // Compound group should have sub-labels
+    // Compound group should have one shared group label and sub-labels.
+    assert_eq!(
+        result.matches("[1]").count(),
+        1,
+        "Expected one group label: {result}"
+    );
     assert!(
         result.contains("a)"),
         "Should contain sub-label a): {}",
@@ -2652,6 +2660,525 @@ fn test_compound_numeric_citation_subentry_disabled() {
     };
     let rendered = processor.process_citation(&citation).unwrap();
     assert_eq!(rendered, "[1]");
+}
+
+/// Verifies integral (narrative) citations include sub-labels for compound groups.
+///
+/// Regression test: render_author_number_for_numeric_integral_with_format was
+/// using a bare citation number without consulting citation_sub_label_for_ref,
+/// so grouped refs rendered "Smith [1]" instead of "Smith [1a]".
+#[test]
+fn test_compound_numeric_integral_citation_sub_label() {
+    use citum_schema::options::bibliography::CompoundNumericConfig;
+    use citum_schema::options::{BibliographyConfig, Config, Processing};
+    use indexmap::IndexMap;
+
+    let style = Style {
+        options: Some(Config {
+            processing: Some(Processing::Numeric),
+            bibliography: Some(BibliographyConfig {
+                compound_numeric: Some(CompoundNumericConfig::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let refs_json = r#"[
+        {
+            "class": "monograph",
+            "id": "ref-a",
+            "type": "book",
+            "title": "Book A",
+            "author": [{"family": "Smith", "given": "A."}],
+            "issued": "2020"
+        },
+        {
+            "class": "monograph",
+            "id": "ref-b",
+            "type": "book",
+            "title": "Book B",
+            "author": [{"family": "Jones", "given": "B."}],
+            "issued": "2021"
+        }
+    ]"#;
+    let refs: Vec<Reference> = serde_json::from_str(refs_json).unwrap();
+    let mut bib = Bibliography::new();
+    for r in refs {
+        if let Some(id) = r.id() {
+            bib.insert(id, r);
+        }
+    }
+
+    let mut sets = IndexMap::new();
+    sets.insert(
+        "group-1".to_string(),
+        vec!["ref-a".to_string(), "ref-b".to_string()],
+    );
+
+    let processor = Processor::with_compound_sets(style, bib, sets);
+
+    // First member should render "Smith [1a]", not "Smith [1]"
+    let cite_a = Citation {
+        id: Some("c-a".to_string()),
+        items: vec![CitationItem {
+            id: "ref-a".to_string(),
+            ..Default::default()
+        }],
+        mode: citum_schema::citation::CitationMode::Integral,
+        ..Default::default()
+    };
+    let rendered_a = processor.process_citation(&cite_a).unwrap();
+    assert!(
+        rendered_a.contains("[1a]"),
+        "first compound member should show sub-label 'a': got '{}'",
+        rendered_a
+    );
+
+    // Second member should render "Jones [1b]", not "Jones [1]"
+    let cite_b = Citation {
+        id: Some("c-b".to_string()),
+        items: vec![CitationItem {
+            id: "ref-b".to_string(),
+            ..Default::default()
+        }],
+        mode: citum_schema::citation::CitationMode::Integral,
+        ..Default::default()
+    };
+    let rendered_b = processor.process_citation(&cite_b).unwrap();
+    assert!(
+        rendered_b.contains("[1b]"),
+        "second compound member should show sub-label 'b': got '{}'",
+        rendered_b
+    );
+}
+
+/// Verifies render_bibliography correctly merges compound groups when called
+/// through the standard public API (regression guard for Bug 3).
+///
+/// The CLI's non-show_keys bibliography path was calling process_references()
+/// directly and rendering entries one-by-one, bypassing merge_compound_entries.
+/// This test ensures render_bibliography (the correct path) produces a single
+/// merged entry — not two separate [1] entries.
+#[test]
+fn test_compound_numeric_bibliography_no_duplicate_labels() {
+    use indexmap::IndexMap;
+
+    let yaml = r#"
+info:
+  title: Test Compound Numeric Dedup
+  id: test-compound-dedup
+options:
+  processing: numeric
+  bibliography:
+    compound-numeric: {}
+    entry-suffix: .
+bibliography:
+  template:
+    - number: citation-number
+      wrap: brackets
+      suffix: " "
+    - contributor: author
+      form: long
+    - title: primary
+"#;
+    let style: Style = serde_yaml::from_str(yaml).unwrap();
+
+    let refs_json = r#"[
+        {
+            "id": "ref-a",
+            "class": "monograph",
+            "type": "book",
+            "title": "Article A",
+            "author": [{"family": "Smith", "given": "A."}],
+            "issued": "2020"
+        },
+        {
+            "id": "ref-b",
+            "class": "monograph",
+            "type": "book",
+            "title": "Article B",
+            "author": [{"family": "Jones", "given": "B."}],
+            "issued": "2021"
+        }
+    ]"#;
+    let refs: Vec<crate::reference::Reference> = serde_json::from_str(refs_json).unwrap();
+    let mut bib = crate::reference::Bibliography::new();
+    for r in refs {
+        if let Some(id) = r.id() {
+            bib.insert(id, r);
+        }
+    }
+
+    let mut sets = IndexMap::new();
+    sets.insert(
+        "group-1".to_string(),
+        vec!["ref-a".to_string(), "ref-b".to_string()],
+    );
+
+    let processor = Processor::with_compound_sets(style, bib, sets);
+    let result = processor.render_bibliography();
+
+    // Must have exactly one [1] label — compound group must be merged
+    let label_1_count = result.matches("[1]").count();
+    assert_eq!(
+        label_1_count, 1,
+        "expected exactly one [1] label for the merged group, got {}: {}",
+        label_1_count, result
+    );
+
+    // Should contain exactly one compound group entry
+    let entries: Vec<&str> = result.trim().split("\n\n").collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected 1 merged entry for the compound group, got {}: {:?}",
+        entries.len(),
+        entries
+    );
+}
+
+/// Verifies merged HTML bibliography output does not nest bibliography wrappers.
+#[test]
+fn test_compound_numeric_bibliography_html_has_no_nested_wrappers() {
+    use crate::render::html::Html;
+    use indexmap::IndexMap;
+
+    let yaml = r#"
+info:
+  title: Test Compound Numeric HTML
+  id: test-compound-html
+options:
+  processing: numeric
+  bibliography:
+    compound-numeric: {}
+    entry-suffix: .
+    separator: ". "
+bibliography:
+  template:
+    - number: citation-number
+      wrap: brackets
+      suffix: " "
+    - contributor: author
+      form: long
+    - title: primary
+"#;
+    let style: Style = serde_yaml::from_str(yaml).unwrap();
+
+    let refs_json = r#"[
+        {
+            "id": "ref-a",
+            "class": "monograph",
+            "type": "book",
+            "title": "Article A",
+            "author": [{"family": "Smith", "given": "A."}],
+            "issued": "2020"
+        },
+        {
+            "id": "ref-b",
+            "class": "monograph",
+            "type": "book",
+            "title": "Article B",
+            "author": [{"family": "Jones", "given": "B."}],
+            "issued": "2021"
+        }
+    ]"#;
+    let refs: Vec<Reference> = serde_json::from_str(refs_json).unwrap();
+    let mut bib = Bibliography::new();
+    for r in refs {
+        if let Some(id) = r.id() {
+            bib.insert(id, r);
+        }
+    }
+
+    let mut sets = IndexMap::new();
+    sets.insert(
+        "group-1".to_string(),
+        vec!["ref-a".to_string(), "ref-b".to_string()],
+    );
+
+    let processor = Processor::with_compound_sets(style, bib, sets);
+    let result = processor.render_bibliography_with_format::<Html>();
+
+    assert_eq!(
+        result.matches("csln-bibliography").count(),
+        1,
+        "merged HTML should have exactly one bibliography wrapper: {result}"
+    );
+    assert_eq!(
+        result.matches("csln-entry").count(),
+        1,
+        "merged HTML should have exactly one entry wrapper: {result}"
+    );
+}
+
+/// Verifies subset bibliography rendering honors keys and does not force a merge.
+#[test]
+fn test_compound_numeric_selected_bibliography_subset_respects_keys() {
+    use indexmap::IndexMap;
+
+    let yaml = r#"
+info:
+  title: Test Compound Numeric Selection
+  id: test-compound-selection
+options:
+  processing: numeric
+  bibliography:
+    compound-numeric:
+      sub-label: alphabetic
+      sub-label-suffix: ")"
+    entry-suffix: .
+    separator: ". "
+bibliography:
+  template:
+    - number: citation-number
+      wrap: brackets
+      suffix: " "
+    - contributor: author
+      form: long
+    - title: primary
+"#;
+    let style: Style = serde_yaml::from_str(yaml).unwrap();
+
+    let refs_json = r#"[
+        {
+            "id": "ref-a",
+            "class": "monograph",
+            "type": "book",
+            "title": "Article A",
+            "author": [{"family": "Smith", "given": "A."}],
+            "issued": "2020"
+        },
+        {
+            "id": "ref-b",
+            "class": "monograph",
+            "type": "book",
+            "title": "Article B",
+            "author": [{"family": "Jones", "given": "B."}],
+            "issued": "2021"
+        }
+    ]"#;
+    let refs: Vec<Reference> = serde_json::from_str(refs_json).unwrap();
+    let mut bib = Bibliography::new();
+    for r in refs {
+        if let Some(id) = r.id() {
+            bib.insert(id, r);
+        }
+    }
+
+    let mut sets = IndexMap::new();
+    sets.insert(
+        "group-1".to_string(),
+        vec!["ref-a".to_string(), "ref-b".to_string()],
+    );
+
+    let processor = Processor::with_compound_sets(style, bib, sets);
+    let result = processor
+        .render_selected_bibliography_with_format::<crate::render::plain::PlainText, _>(vec![
+            "ref-b".to_string(),
+        ]);
+
+    assert!(
+        result.contains("Jones"),
+        "selected entry should be rendered: {result}"
+    );
+    assert!(
+        !result.contains("Smith"),
+        "unselected entry should be omitted: {result}"
+    );
+    assert!(
+        result.contains("[1]"),
+        "selected entry should keep the group number: {result}"
+    );
+    assert!(
+        !result.contains("a)"),
+        "single selected member should not be merged: {result}"
+    );
+    assert!(
+        !result.contains("b)"),
+        "single selected member should not be merged: {result}"
+    );
+}
+
+/// Verifies compound numeric citations remain explicit when collapse is disabled.
+#[test]
+fn test_compound_numeric_citation_subentry_collapse_disabled() {
+    use citum_schema::CitationSpec;
+    use citum_schema::options::bibliography::CompoundNumericConfig;
+    use citum_schema::options::{BibliographyConfig, Config, Processing};
+    use citum_schema::template::{NumberVariable, TemplateNumber};
+    use indexmap::IndexMap;
+
+    let style = Style {
+        citation: Some(CitationSpec {
+            wrap: Some(WrapPunctuation::Brackets),
+            template: Some(vec![TemplateComponent::Number(TemplateNumber {
+                number: NumberVariable::CitationNumber,
+                ..Default::default()
+            })]),
+            delimiter: Some(",".to_string()),
+            multi_cite_delimiter: Some(",".to_string()),
+            ..Default::default()
+        }),
+        options: Some(Config {
+            processing: Some(Processing::Numeric),
+            bibliography: Some(BibliographyConfig {
+                compound_numeric: Some(CompoundNumericConfig {
+                    subentry: true,
+                    collapse_subentries: false,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let refs_json = r#"[
+        {"class": "monograph", "id": "ref-a", "type": "book", "title": "Book A", "issued": "2020"},
+        {"class": "monograph", "id": "ref-b", "type": "book", "title": "Book B", "issued": "2021"},
+        {"class": "monograph", "id": "ref-c", "type": "book", "title": "Book C", "issued": "2022"}
+    ]"#;
+    let refs: Vec<Reference> = serde_json::from_str(refs_json).unwrap();
+    let mut bib = Bibliography::new();
+    for r in refs {
+        if let Some(id) = r.id() {
+            bib.insert(id, r);
+        }
+    }
+
+    let mut sets = IndexMap::new();
+    sets.insert(
+        "group-1".to_string(),
+        vec![
+            "ref-a".to_string(),
+            "ref-b".to_string(),
+            "ref-c".to_string(),
+        ],
+    );
+
+    let processor = Processor::with_compound_sets(style, bib, sets);
+    let citation = Citation {
+        id: Some("c1".to_string()),
+        items: vec![
+            CitationItem {
+                id: "ref-a".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ref-b".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ref-c".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let rendered = processor.process_citation(&citation).unwrap();
+    assert_eq!(rendered, "[1a,1b,1c]");
+}
+
+/// Verifies compound numeric citations collapse adjacent grouped subentries.
+#[test]
+fn test_compound_numeric_citation_subentry_collapse_enabled() {
+    use citum_schema::CitationSpec;
+    use citum_schema::options::bibliography::CompoundNumericConfig;
+    use citum_schema::options::{BibliographyConfig, Config, Processing};
+    use citum_schema::template::{NumberVariable, TemplateNumber};
+    use indexmap::IndexMap;
+
+    let style = Style {
+        citation: Some(CitationSpec {
+            wrap: Some(WrapPunctuation::Brackets),
+            template: Some(vec![TemplateComponent::Number(TemplateNumber {
+                number: NumberVariable::CitationNumber,
+                ..Default::default()
+            })]),
+            delimiter: Some(",".to_string()),
+            multi_cite_delimiter: Some(",".to_string()),
+            ..Default::default()
+        }),
+        options: Some(Config {
+            processing: Some(Processing::Numeric),
+            bibliography: Some(BibliographyConfig {
+                compound_numeric: Some(CompoundNumericConfig {
+                    subentry: true,
+                    collapse_subentries: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let refs_json = r#"[
+        {"class": "monograph", "id": "ref-a", "type": "book", "title": "Book A", "issued": "2020"},
+        {"class": "monograph", "id": "ref-b", "type": "book", "title": "Book B", "issued": "2021"},
+        {"class": "monograph", "id": "ref-c", "type": "book", "title": "Book C", "issued": "2022"},
+        {"class": "monograph", "id": "ref-d", "type": "book", "title": "Book D", "issued": "2023"}
+    ]"#;
+    let refs: Vec<Reference> = serde_json::from_str(refs_json).unwrap();
+    let mut bib = Bibliography::new();
+    for r in refs {
+        if let Some(id) = r.id() {
+            bib.insert(id, r);
+        }
+    }
+
+    let mut sets = IndexMap::new();
+    sets.insert(
+        "group-1".to_string(),
+        vec![
+            "ref-a".to_string(),
+            "ref-b".to_string(),
+            "ref-c".to_string(),
+            "ref-d".to_string(),
+        ],
+    );
+
+    let processor = Processor::with_compound_sets(style, bib, sets);
+
+    let contiguous = Citation {
+        id: Some("c1".to_string()),
+        items: vec![
+            CitationItem {
+                id: "ref-a".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ref-b".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ref-c".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    assert_eq!(processor.process_citation(&contiguous).unwrap(), "[1a-c]");
+
+    let sparse = Citation {
+        id: Some("c2".to_string()),
+        items: vec![
+            CitationItem {
+                id: "ref-a".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ref-c".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    assert_eq!(processor.process_citation(&sparse).unwrap(), "[1a,c]");
 }
 
 /// Verifies checked constructors reject duplicate membership across sets.

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -50,6 +50,102 @@ pub fn refs_to_string(proc_entries: Vec<ProcEntry>) -> String {
     refs_to_string_with_format::<PlainText>(proc_entries, None, None)
 }
 
+/// Render one processed bibliography entry body without outer entry/bibliography wrappers.
+pub fn render_entry_body_with_format<F: OutputFormat<Output = String>>(
+    entry: &ProcEntry,
+) -> String {
+    let mut entry_output = String::new();
+    let proc_template = &entry.template;
+
+    // Check locale option for punctuation placement in quotes.
+    let punctuation_in_quote = proc_template
+        .first()
+        .and_then(|c| c.config.as_ref())
+        .is_some_and(|cfg| cfg.punctuation_in_quote);
+
+    // Get the bibliography separator from the config, defaulting to ". "
+    let default_separator = proc_template
+        .first()
+        .and_then(|c| c.config.as_ref())
+        .and_then(|cfg| cfg.bibliography.as_ref())
+        .and_then(|bib| bib.separator.as_deref())
+        .unwrap_or(". ");
+
+    for (j, component) in proc_template.iter().enumerate() {
+        let rendered = render_component_with_format::<F>(component);
+        if rendered.is_empty() {
+            continue;
+        }
+
+        if j > 0 && !entry_output.is_empty() {
+            let last_char = entry_output.chars().last().unwrap_or(' ');
+            let first_char = first_visible_char(&rendered).unwrap_or(' ');
+            let sep_first_char = default_separator.chars().next().unwrap_or('.');
+            let trimmed_last = last_visible_non_space_char(&entry_output).unwrap_or(' ');
+            let ends_with_punctuation = is_final_punctuation(trimmed_last);
+            let starts_with_separator = matches!(first_char, ',' | ';' | ':' | ' ' | '.' | '(');
+
+            if starts_with_separator {
+                if first_char == '(' && !last_char.is_whitespace() && last_char != '[' {
+                    entry_output.push(' ');
+                }
+            } else if ends_with_punctuation {
+                if !last_char.is_whitespace() {
+                    entry_output.push(' ');
+                }
+            } else if punctuation_in_quote
+                && (last_char == '"' || last_char == '\u{201D}')
+                && sep_first_char == '.'
+            {
+                entry_output.pop();
+                let quote_str = if last_char == '\u{201D}' {
+                    ".\u{201D} "
+                } else {
+                    ".\" "
+                };
+                entry_output.push_str(quote_str);
+            } else if !last_char.is_whitespace() && !first_char.is_whitespace() {
+                entry_output.push_str(default_separator);
+            } else if !last_char.is_whitespace()
+                && first_char.is_whitespace()
+                && default_separator.starts_with('.')
+                && !ends_with_punctuation
+            {
+                entry_output.push('.');
+            }
+        }
+
+        let _ = write!(&mut entry_output, "{}", rendered);
+    }
+
+    let bib_cfg = proc_template
+        .first()
+        .and_then(|c| c.config.as_ref())
+        .and_then(|cfg| cfg.bibliography.as_ref());
+    let entry_suffix = bib_cfg.and_then(|bib| bib.entry_suffix.as_deref());
+    match entry_suffix {
+        Some(suffix) if !suffix.is_empty() => {
+            let ends_with_url = ends_with_url_or_doi(&entry_output);
+            if !ends_with_url && !entry_output.ends_with(suffix.chars().next().unwrap_or('.')) {
+                if suffix == "."
+                    && punctuation_in_quote
+                    && (entry_output.ends_with('"') || entry_output.ends_with('\u{201D}'))
+                {
+                    let is_curly = entry_output.ends_with('\u{201D}');
+                    entry_output.pop();
+                    entry_output.push_str(if is_curly { ".\u{201D}" } else { ".\"" });
+                } else {
+                    entry_output.push_str(suffix);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    cleanup_dangling_punctuation(&mut entry_output);
+    entry_output
+}
+
 /// Render processed templates into a final bibliography string using a specific format.
 pub fn refs_to_string_with_format<F: OutputFormat<Output = String>>(
     proc_entries: Vec<ProcEntry>,
@@ -60,120 +156,8 @@ pub fn refs_to_string_with_format<F: OutputFormat<Output = String>>(
     let mut rendered_entries = Vec::new();
 
     for entry in &proc_entries {
-        let mut entry_output = String::new();
+        let mut entry_output = render_entry_body_with_format::<F>(entry);
         let proc_template = &entry.template;
-
-        // Check locale option for punctuation placement in quotes.
-        let punctuation_in_quote = proc_template
-            .first()
-            .and_then(|c| c.config.as_ref())
-            .is_some_and(|cfg| cfg.punctuation_in_quote);
-
-        // Get the bibliography separator from the config, defaulting to ". "
-        let default_separator = proc_template
-            .first()
-            .and_then(|c| c.config.as_ref())
-            .and_then(|cfg| cfg.bibliography.as_ref())
-            .and_then(|bib| bib.separator.as_deref())
-            .unwrap_or(". ");
-
-        for (j, component) in proc_template.iter().enumerate() {
-            let rendered = render_component_with_format::<F>(component);
-            if rendered.is_empty() {
-                continue;
-            }
-
-            // Add separator between components.
-            if j > 0 && !entry_output.is_empty() {
-                let last_char = entry_output.chars().last().unwrap_or(' ');
-                let first_char = first_visible_char(&rendered).unwrap_or(' ');
-
-                // Derive the first punctuation/char of the separator for comparison
-                let sep_first_char = default_separator.chars().next().unwrap_or('.');
-
-                // Check if last output ends with intentional punctuation (not just space).
-                // Component suffixes like ", " should be preserved and NOT followed by default separator.
-                // We only suppress the separator if the last non-space character is punctuation.
-                let trimmed_last = last_visible_non_space_char(&entry_output).unwrap_or(' ');
-                let ends_with_punctuation = is_final_punctuation(trimmed_last);
-
-                // Skip adding separator if:
-                // 1. The rendered component already starts with separator-like punctuation
-                // 2. Special handling for quotes with punctuation-in-quote locales
-                let starts_with_separator = matches!(first_char, ',' | ';' | ':' | ' ' | '.' | '(');
-
-                if starts_with_separator {
-                    // Component prefix already provides separation (or opens with paren)
-                    // If it starts with '(' and entry_output doesn't end with space, add one
-                    if first_char == '(' && !last_char.is_whitespace() && last_char != '[' {
-                        entry_output.push(' ');
-                    }
-                } else if ends_with_punctuation {
-                    // entry_output ends with punctuation (component suffix with punctuation).
-                    // This suffix is intentional formatting. Do NOT add default separator.
-                    // Just ensure there's space before the next component.
-                    if !last_char.is_whitespace() {
-                        entry_output.push(' ');
-                    }
-                    // If last_char is already whitespace, it's part of the component suffix,
-                    // so we preserve it as-is (e.g., ", " stays as ", ")
-                } else if punctuation_in_quote
-                    && (last_char == '"' || last_char == '\u{201D}')
-                    && sep_first_char == '.'
-                {
-                    // Special case: move period inside closing quote for locales that want it
-                    entry_output.pop();
-                    let quote_str = if last_char == '\u{201D}' {
-                        ".\u{201D} "
-                    } else {
-                        ".\" "
-                    };
-                    entry_output.push_str(quote_str);
-                } else {
-                    // Normal case: add the configured separator
-                    // Skip adding separator if we already have a space
-                    if !last_char.is_whitespace() && !first_char.is_whitespace() {
-                        entry_output.push_str(default_separator);
-                    } else if !last_char.is_whitespace() && first_char.is_whitespace() {
-                        // entry_output ends with content, component starts with space
-                        // don't add separator, but maybe ensure it has punctuation if separator is ". "
-                        if default_separator.starts_with('.') && !ends_with_punctuation {
-                            entry_output.push('.');
-                        }
-                    }
-                }
-            }
-            let _ = write!(&mut entry_output, "{}", rendered);
-        }
-
-        // Apply entry suffix
-        let bib_cfg = proc_template
-            .first()
-            .and_then(|c| c.config.as_ref())
-            .and_then(|cfg| cfg.bibliography.as_ref());
-        let entry_suffix = bib_cfg.and_then(|bib| bib.entry_suffix.as_deref());
-        match entry_suffix {
-            Some(suffix) if !suffix.is_empty() => {
-                let ends_with_url = ends_with_url_or_doi(&entry_output);
-                if ends_with_url {
-                    // Skip entry suffix for entries ending with URL/DOI
-                } else if !entry_output.ends_with(suffix.chars().next().unwrap_or('.')) {
-                    if suffix == "."
-                        && punctuation_in_quote
-                        && (entry_output.ends_with('"') || entry_output.ends_with('\u{201D}'))
-                    {
-                        let is_curly = entry_output.ends_with('\u{201D}');
-                        entry_output.pop();
-                        entry_output.push_str(if is_curly { ".\u{201D}" } else { ".\"" });
-                    } else {
-                        entry_output.push_str(suffix);
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        cleanup_dangling_punctuation(&mut entry_output);
 
         // Apply annotation if present
         if let Some(annotations) = annotations

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -16,6 +16,8 @@ pub mod date;
 pub mod list;
 /// Numeric variable extraction and page-range helpers.
 pub mod number;
+/// Shared helpers for collapsing consecutive numeric or ordinal sequences.
+pub mod range;
 /// Locale term resolution helpers.
 pub mod term;
 /// Title extraction and title-formatting helpers.

--- a/crates/citum-engine/src/values/range.rs
+++ b/crates/citum-engine/src/values/range.rs
@@ -1,0 +1,59 @@
+/*
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Shared helpers for collapsing ordered consecutive sequences into spans.
+
+/// One collapsed segment from an ordered numeric sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsecutiveSegment {
+    /// A single standalone value.
+    Single(u32),
+    /// A consecutive range from `start` to `end`, inclusive.
+    Range {
+        /// The first value in the consecutive range.
+        start: u32,
+        /// The last value in the consecutive range.
+        end: u32,
+    },
+}
+
+/// Collapse an ordered sequence into standalone values and consecutive ranges.
+///
+/// Duplicate values are coalesced, and descending steps start a new segment.
+pub fn consecutive_segments(values: &[u32]) -> Vec<ConsecutiveSegment> {
+    if values.is_empty() {
+        return Vec::new();
+    }
+
+    let mut segments = Vec::new();
+    let mut start = values[0];
+    let mut prev = values[0];
+
+    for &value in &values[1..] {
+        if value == prev {
+            continue;
+        }
+
+        if value == prev + 1 {
+            prev = value;
+            continue;
+        }
+
+        push_segment(&mut segments, start, prev);
+        start = value;
+        prev = value;
+    }
+
+    push_segment(&mut segments, start, prev);
+    segments
+}
+
+fn push_segment(segments: &mut Vec<ConsecutiveSegment>, start: u32, end: u32) {
+    if start == end {
+        segments.push(ConsecutiveSegment::Single(start));
+    } else {
+        segments.push(ConsecutiveSegment::Range { start, end });
+    }
+}

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -234,6 +234,33 @@ fn test_format_page_range_no_format() {
     assert_eq!(number::format_page_range("321-328", None), "321–328");
 }
 
+/// Tests the behavior of shared consecutive sequence collapsing.
+#[test]
+fn test_consecutive_segments() {
+    use crate::values::range::{ConsecutiveSegment, consecutive_segments};
+
+    assert_eq!(consecutive_segments(&[]), Vec::<ConsecutiveSegment>::new());
+    assert_eq!(
+        consecutive_segments(&[4]),
+        vec![ConsecutiveSegment::Single(4)]
+    );
+    assert_eq!(
+        consecutive_segments(&[1, 2, 3, 5, 7, 8]),
+        vec![
+            ConsecutiveSegment::Range { start: 1, end: 3 },
+            ConsecutiveSegment::Single(5),
+            ConsecutiveSegment::Range { start: 7, end: 8 },
+        ]
+    );
+    assert_eq!(
+        consecutive_segments(&[2, 2, 3, 6]),
+        vec![
+            ConsecutiveSegment::Range { start: 2, end: 3 },
+            ConsecutiveSegment::Single(6),
+        ]
+    );
+}
+
 /// Tests the behavior of test_et_al_delimiter_never.
 #[test]
 fn test_et_al_delimiter_never() {

--- a/crates/citum-schema/src/options/bibliography.rs
+++ b/crates/citum-schema/src/options/bibliography.rs
@@ -89,6 +89,11 @@ fn default_subentry() -> bool {
     true
 }
 
+/// Default compound subentry collapse behavior.
+fn default_collapse_subentries() -> bool {
+    false
+}
+
 /// Configuration for compound numeric bibliography entries.
 ///
 /// Groups multiple references under a single citation number with sub-labels.
@@ -102,6 +107,12 @@ pub struct CompoundNumericConfig {
     /// When false, grouped item citations render the whole-group number (`1`).
     #[serde(default = "default_subentry")]
     pub subentry: bool,
+    /// Whether adjacent grouped sub-entries collapse in citations.
+    ///
+    /// When true, adjacent members from the same group may render as
+    /// `1a,b` or `1a-c` instead of `1a,1b` or `1a,1b,1c`.
+    #[serde(default = "default_collapse_subentries")]
+    pub collapse_subentries: bool,
     /// Sub-label style: alphabetic (a, b, c) or numeric (1, 2, 3).
     #[serde(default)]
     pub sub_label: SubLabelStyle,
@@ -117,6 +128,7 @@ impl Default for CompoundNumericConfig {
     fn default() -> Self {
         Self {
             subentry: default_subentry(),
+            collapse_subentries: default_collapse_subentries(),
             sub_label: SubLabelStyle::default(),
             sub_label_suffix: default_sub_label_suffix(),
             sub_delimiter: default_sub_delimiter(),
@@ -132,6 +144,7 @@ mod tests {
     fn test_compound_numeric_config_defaults() {
         let config: CompoundNumericConfig = serde_json::from_str("{}").unwrap();
         assert!(config.subentry);
+        assert!(!config.collapse_subentries);
         assert_eq!(config.sub_label, SubLabelStyle::Alphabetic);
         assert_eq!(config.sub_label_suffix, ")");
         assert_eq!(config.sub_delimiter, ", ");
@@ -139,9 +152,10 @@ mod tests {
 
     #[test]
     fn test_compound_numeric_config_custom() {
-        let json = r#"{"subentry": false, "sub-label": "numeric", "sub-label-suffix": ".", "sub-delimiter": "; "}"#;
+        let json = r#"{"subentry": false, "collapse-subentries": true, "sub-label": "numeric", "sub-label-suffix": ".", "sub-delimiter": "; "}"#;
         let config: CompoundNumericConfig = serde_json::from_str(json).unwrap();
         assert!(!config.subentry);
+        assert!(config.collapse_subentries);
         assert_eq!(config.sub_label, SubLabelStyle::Numeric);
         assert_eq!(config.sub_label_suffix, ".");
         assert_eq!(config.sub_delimiter, "; ");

--- a/docs/architecture/CSL26_ZAFV_NUMERIC_COMPOUND_CITATIONS.md
+++ b/docs/architecture/CSL26_ZAFV_NUMERIC_COMPOUND_CITATIONS.md
@@ -42,6 +42,8 @@ Compound behavior only activates when style enables `options.bibliography.compou
 
 - `subentry: true` enables member addressing (`[2a]`, `[2b]`).
 - `subentry: false` keeps whole-group addressing (`[2]`).
+- `collapse-subentries: true` enables collapsing adjacent member cites from the
+  same group (`[2a,2b,2c]` → `[2a-c]`).
 - `sub-label`, `sub-label-suffix`, and `sub-delimiter` configure bibliography sub-item labels.
 
 ## Validation Rules
@@ -61,6 +63,8 @@ During bibliography loading:
 4. Citation output mode is style-controlled:
    - `subentry: true` → sub-item form (`[2a]`)
    - `subentry: false` → whole-group form (`[2]`)
+   - `collapse-subentries: true` → adjacent same-group member cites may collapse
+     (`[2a,2b]` → `[2a,b]`, `[2a,2b,2c]` → `[2a-c]`)
 
 ## Public API Surface
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -704,6 +704,11 @@
       "description": "Configuration for compound numeric bibliography entries.\n\nGroups multiple references under a single citation number with sub-labels. Used in chemistry journals (e.g., Angewandte Chemie).",
       "type": "object",
       "properties": {
+        "collapse-subentries": {
+          "description": "Whether adjacent grouped sub-entries collapse in citations.\n\nWhen true, adjacent members from the same group may render as `1a,b` or `1a-c` instead of `1a,1b` or `1a,1b,1c`.",
+          "default": false,
+          "type": "boolean"
+        },
         "sub-delimiter": {
           "description": "Delimiter between sub-items (default: \", \").",
           "default": ", ",

--- a/styles/angewandte-chemie.yaml
+++ b/styles/angewandte-chemie.yaml
@@ -30,7 +30,8 @@ options:
   bibliography:
     entry-suffix: .
     separator: ", "
-    compound-numeric: {}
+    compound-numeric:
+      collapse-subentries: true
 citation:
   use-preset: numeric-citation
   wrap: brackets

--- a/styles/chem-acs.yaml
+++ b/styles/chem-acs.yaml
@@ -32,7 +32,8 @@ options:
   bibliography:
     entry-suffix: .
     separator: ". "
-    compound-numeric: {}
+    compound-numeric:
+      collapse-subentries: true
   punctuation-in-quote: true
 citation:
   use-preset: numeric-citation

--- a/styles/chem-biochem.yaml
+++ b/styles/chem-biochem.yaml
@@ -29,6 +29,7 @@ options:
     entry-suffix: .
     separator: ". "
     compound-numeric:
+      collapse-subentries: true
       sub-label: alphabetic
       sub-label-suffix: ")"
       sub-delimiter: " "

--- a/styles/chem-rsc.yaml
+++ b/styles/chem-rsc.yaml
@@ -40,7 +40,8 @@ options:
   bibliography:
     entry-suffix: .
     separator: ", "
-    compound-numeric: {}
+    compound-numeric:
+      collapse-subentries: true
 citation:
   use-preset: numeric-citation
   wrap: brackets

--- a/styles/numeric-comp.yaml
+++ b/styles/numeric-comp.yaml
@@ -21,7 +21,8 @@ options:
   bibliography:
     entry-suffix: .
     separator: ". "
-    compound-numeric: {}
+    compound-numeric:
+      collapse-subentries: true
 citation:
   use-preset: numeric-citation
   wrap: brackets

--- a/tests/snapshots/compound/angewandte-chemie.txt
+++ b/tests/snapshots/compound/angewandte-chemie.txt
@@ -9,20 +9,15 @@ CITATIONS (Non-Integral):
   [3b]
 
 CITATIONS (Integral):
-  Zwart, Veenhuis, Harder [1]
-  van der Klei, Harder, Veenhuis [1]
+  Zwart, Veenhuis, Harder [1a]
+  van der Klei, Harder, Veenhuis [1b]
   Smith [2]
-  Jones [3]
-  Jones [3]
+  Jones [3a]
+  Jones [3b]
 
 BIBLIOGRAPHY:
-[1] Zwart, K. B., Veenhuis, M., Harder, W. An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae **1983**.
-
-[1] van der Klei, I. J., Harder, W., Veenhuis, M. A morphological view on the biogenesis of peroxisomes in intact cells **1991**.
+[1] a) Zwart, K. B., Veenhuis, M., Harder, W. An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae **1983**., b) van der Klei, I. J., Harder, W., Veenhuis, M. A morphological view on the biogenesis of peroxisomes in intact cells **1991**.
 
 [2] Smith, J. A standalone article not in any compound group **2020**.
 
-[3] Jones, A. Catalytic activity of transition metals **2019**.
-
-[3] Jones, A. Selectivity in heterogeneous catalysis **2019**.
-
+[3] a) Jones, A. Catalytic activity of transition metals **2019**., b) Jones, A. Selectivity in heterogeneous catalysis **2019**.

--- a/tests/snapshots/compound/chem-acs.txt
+++ b/tests/snapshots/compound/chem-acs.txt
@@ -9,20 +9,15 @@ CITATIONS (Non-Integral):
   [3b]
 
 CITATIONS (Integral):
-  Zwart; Veenhuis; Harder [1]
-  van der Klei; Harder; Veenhuis [1]
+  Zwart; Veenhuis; Harder [1a]
+  van der Klei; Harder; Veenhuis [1b]
   Smith [2]
-  Jones [3]
-  Jones [3]
+  Jones [3a]
+  Jones [3b]
 
 BIBLIOGRAPHY:
-Zwart, K. B.; Veenhuis, M.; Harder, W. _An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae_, 1983.
-
-van der Klei, I. J.; Harder, W.; Veenhuis, M. _A morphological view on the biogenesis of peroxisomes in intact cells_, 1991.
+a) Zwart, K. B.; Veenhuis, M.; Harder, W. _An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae_, 1983., b) van der Klei, I. J.; Harder, W.; Veenhuis, M. _A morphological view on the biogenesis of peroxisomes in intact cells_, 1991.
 
 Smith, J. _A standalone article not in any compound group_, 2020.
 
-Jones, A. _Catalytic activity of transition metals_, 2019.
-
-Jones, A. _Selectivity in heterogeneous catalysis_, 2019.
-
+a) Jones, A. _Catalytic activity of transition metals_, 2019., b) Jones, A. _Selectivity in heterogeneous catalysis_, 2019.

--- a/tests/snapshots/compound/chem-biochem.txt
+++ b/tests/snapshots/compound/chem-biochem.txt
@@ -9,20 +9,15 @@ CITATIONS (Non-Integral):
   (3b)
 
 CITATIONS (Integral):
-  Zwart, Veenhuis, Harder [1]
-  van der Klei, Harder, Veenhuis [1]
+  Zwart, Veenhuis, Harder [1a]
+  van der Klei, Harder, Veenhuis [1b]
   Smith [2]
-  Jones [3]
-  Jones [3]
+  Jones [3a]
+  Jones [3b]
 
 BIBLIOGRAPHY:
-(1) Zwart, K. B., Veenhuis, M., Harder, W. (1983) An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae.
-
-(1) van der Klei, I. J., Harder, W., Veenhuis, M. (1991) A morphological view on the biogenesis of peroxisomes in intact cells.
+(1) a) Zwart, K. B., Veenhuis, M., Harder, W. (1983) An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae. b) van der Klei, I. J., Harder, W., Veenhuis, M. (1991) A morphological view on the biogenesis of peroxisomes in intact cells.
 
 (2) Smith, J. (2020) A standalone article not in any compound group.
 
-(3) Jones, A. (2019) Catalytic activity of transition metals.
-
-(3) Jones, A. (2019) Selectivity in heterogeneous catalysis.
-
+(3) a) Jones, A. (2019) Catalytic activity of transition metals. b) Jones, A. (2019) Selectivity in heterogeneous catalysis.

--- a/tests/snapshots/compound/chem-rsc.txt
+++ b/tests/snapshots/compound/chem-rsc.txt
@@ -9,20 +9,15 @@ CITATIONS (Non-Integral):
   [3b]
 
 CITATIONS (Integral):
-  Zwart, Veenhuis, Harder [1]
-  van der Klei, Harder, Veenhuis [1]
+  Zwart, Veenhuis, Harder [1a]
+  van der Klei, Harder, Veenhuis [1b]
   Smith [2]
-  Jones [3]
-  Jones [3]
+  Jones [3a]
+  Jones [3b]
 
 BIBLIOGRAPHY:
-[1] Zwart, K. B., Veenhuis, M., Harder, W. 1983, _An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae_.
-
-[1] van der Klei, I. J., Harder, W., Veenhuis, M. 1991, _A morphological view on the biogenesis of peroxisomes in intact cells_.
+[1] a) Zwart, K. B., Veenhuis, M., Harder, W. 1983, _An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae_., b) van der Klei, I. J., Harder, W., Veenhuis, M. 1991, _A morphological view on the biogenesis of peroxisomes in intact cells_.
 
 [2] Smith, J. 2020, _A standalone article not in any compound group_.
 
-[3] Jones, A. 2019, _Catalytic activity of transition metals_.
-
-[3] Jones, A. 2019, _Selectivity in heterogeneous catalysis_.
-
+[3] a) Jones, A. 2019, _Catalytic activity of transition metals_., b) Jones, A. 2019, _Selectivity in heterogeneous catalysis_.

--- a/tests/snapshots/compound/numeric-comp.txt
+++ b/tests/snapshots/compound/numeric-comp.txt
@@ -9,20 +9,15 @@ CITATIONS (Non-Integral):
   [3b]
 
 CITATIONS (Integral):
-  Zwart, Veenhuis, Harder [1]
-  van der Klei, Harder, Veenhuis [1]
+  Zwart, Veenhuis, Harder [1a]
+  van der Klei, Harder, Veenhuis [1b]
   Smith [2]
-  Jones [3]
-  Jones [3]
+  Jones [3a]
+  Jones [3b]
 
 BIBLIOGRAPHY:
-[1] Zwart, K. B., Veenhuis, M., Harder, W. An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae. 1983.
-
-[1] van der Klei, I. J., Harder, W., Veenhuis, M. A morphological view on the biogenesis of peroxisomes in intact cells. 1991.
+[1] a) Zwart, K. B., Veenhuis, M., Harder, W. An immunochemical analysis of the biogenesis of peroxisomes in Saccharomyces cerevisiae. 1983., b) van der Klei, I. J., Harder, W., Veenhuis, M. A morphological view on the biogenesis of peroxisomes in intact cells. 1991.
 
 [2] Smith, J. A standalone article not in any compound group. 2020.
 
-[3] Jones, A. Catalytic activity of transition metals. 2019.
-
-[3] Jones, A. Selectivity in heterogeneous catalysis. 2019.
-
+[3] a) Jones, A. Catalytic activity of transition metals. 2019., b) Jones, A. Selectivity in heterogeneous catalysis. 2019.


### PR DESCRIPTION
## Summary

Finish the compound numeric fix end-to-end:

- fix compound bibliography merging so grouped entries render once with one label instead of nested or duplicated wrappers
- fix the CLI/engine divergence so `citum render refs --keys ...` uses the same compound merge behavior as the engine renderer
- preserve numeric integral sublabels in auto-rendered citations
- add explicit `collapse-subentries` style control for same-group sublabel collapse in numeric citations
- factor shared sequence-collapse logic into common code with dedicated tests
- refresh the native compound snapshots for the five biblatex-derived styles used by the core-quality gate

## What changed

- Added `Processor::render_selected_bibliography_with_format` and routed the CLI’s normal bibliography path through it.
- Refactored compound bibliography merging to render subentry bodies without nesting full bibliography containers.
- Added `collapse-subentries` to `CompoundNumericConfig` and enabled it in:
  - `angewandte-chemie`
  - `chem-acs`
  - `chem-biochem`
  - `chem-rsc`
  - `numeric-comp`
- Added shared range/sequence collapsing helpers and regression coverage for contiguous and sparse sublabel cases.
- Updated native snapshot benchmarks so the core gate measures the intended merged bibliography output.
- Incorporated the Copilot review follow-ups, including the missing function-name/documentation cleanup in the bean notes.

## Verification

- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `node scripts/report-core.js > /tmp/core-report-pr297.json`
- `node scripts/check-core-quality.js --report /tmp/core-report-pr297.json --baseline scripts/report-data/core-quality-baseline.json`

Refs: csl26-8xjd
