### PR TITLE
feat: prove locale-specific bibliography layouts

### DIFF
--- a/.beans/csl26-24pu--locale-specific-template-layouts-for-multilingual.md
+++ b/.beans/csl26-24pu--locale-specific-template-layouts-for-multilingual.md
@@ -1,18 +1,21 @@
 ---
 # csl26-24pu
 title: Locale-specific template layouts for multilingual bibliography
-status: todo
+status: completed
 type: feature
 priority: low
 created_at: 2026-02-25T12:21:02Z
-updated_at: 2026-02-25T12:21:02Z
+updated_at: 2026-03-08T00:00:00Z
 ---
 
 ## Background
 
 PRIOR_ART.md proposes `bibliography.locales[].template` as the Citum pattern for locale-specific bibliography layouts. This allows a style to render the same reference differently depending on the locale — for example, Japanese/CJK mixed-language bibliographies where the component order and punctuation differ from the Latin-script default.
 
-This is not yet implemented. Currently a style has one template per reference type; locale overrides apply only to terms and date formats, not to template structure.
+This is implemented on `main`. The schema supports `bibliography.locales[]`,
+the processor selects the bibliography template branch from the effective item
+language, and localized branches can replace the full entry structure rather
+than only locale terms or date formatting.
 
 ## Motivation
 
@@ -20,25 +23,40 @@ Real use case: a style that renders Latin-script references as `Author. Title. P
 
 CSL-M (the multilingual CSL fork) addresses this with `cs:layout` locale conditions. The Citum approach is cleaner: declare alternate templates per locale directly in the style YAML.
 
-## Design sketch (from PRIOR_ART.md)
+## Implemented shape
 
 ```yaml
 bibliography:
   template:
-    - type: article-journal
-      components: [...]   # default (Latin-script)
+    - contributor: author
+    - title: primary
   locales:
-    ja:
+    - locale: [ja, zh, ko]
       template:
-        - type: article-journal
-          components: [...]   # Japanese layout
+        - contributor: author
+        - variable: publisher
+        - date: issued
+        - title: primary
+    - default: true
+      template:
+        - contributor: author
+        - title: primary
 ```
 
-## Scope
+## Completion proof
 
-- Schema: add `locales` map to `Bibliography` struct, keyed by BCP 47 language tag
-- Processor: detect reference locale from `InputReference.language`, fall back to style default
-- Test: at least one style with a Japanese/CJK template variant
+- Experimental proof style:
+  `styles/experimental/locale-specific-bibliography-layouts.yaml`
+- Integration coverage:
+  `crates/citum-engine/tests/multilingual.rs`
+- Fixture reused:
+  `tests/fixtures/multilingual/multilingual-cjk.json`
+
+The proof covers both branches:
+
+- CJK items select the localized bibliography layout
+- items without a matching locale fall back to the default layout
+- output differences demonstrate full-entry structural switching, not just term localization
 
 ## References
 

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -111,3 +111,37 @@ fn test_arabic_transliterated_forms() {
         "Citation should handle transliterated Arabic"
     );
 }
+
+#[test]
+fn test_bibliography_locales_switch_full_entry_layouts() {
+    let root = project_root();
+    let style =
+        load_style(&root.join("styles/experimental/locale-specific-bibliography-layouts.yaml"));
+    let bibliography =
+        load_bibliography(&root.join("tests/fixtures/multilingual/multilingual-cjk.json"))
+            .expect("CJK fixture should parse");
+
+    let processor = Processor::new(style, bibliography);
+
+    let japanese_entry = processor
+        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+            vec!["CJK-JAPANESE-LANGUAGE-TAGGED".to_string()],
+        );
+    let default_entry = processor
+        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+            vec!["CSL-ET-AL-KANJI".to_string()],
+        );
+
+    assert!(
+        japanese_entry.contains("Tokyo Academic Press, 2018. 日本語の書誌"),
+        "Japanese entry should use localized publisher-year-title order: {japanese_entry}"
+    );
+    assert!(
+        !japanese_entry.contains("日本語の書誌. Tokyo Academic Press"),
+        "Japanese entry should not use default title-publisher order: {japanese_entry}"
+    );
+    assert!(
+        default_entry.contains("Test Book. Test Publisher, 2020"),
+        "Default entry should use title-publisher-year order: {default_entry}"
+    );
+}

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -157,6 +157,30 @@ That means:
 - template selection is per item
 - title formatting can still vary per field inside that item
 
+Bibliography branches work the same way and can change the full entry layout:
+
+```yaml
+bibliography:
+  template:
+    - contributor: author
+    - title: primary
+      prefix: ". "
+  locales:
+    - locale: [ja, zh, ko]
+      template:
+        - contributor: author
+        - variable: publisher
+          prefix: ". "
+        - date: issued
+          form: year
+          prefix: ", "
+        - title: primary
+          prefix: ". "
+```
+
+See `styles/experimental/locale-specific-bibliography-layouts.yaml` for a
+complete end-to-end example that uses `tests/fixtures/multilingual/multilingual-cjk.json`.
+
 ## Practical Workflow
 
 1. Start from a nearby style in `/styles`.

--- a/styles/experimental/locale-specific-bibliography-layouts.yaml
+++ b/styles/experimental/locale-specific-bibliography-layouts.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://bdarcus.github.io/csl26/schemas/style.json
+info:
+  id: locale-specific-bibliography-layouts
+  title: Locale-Specific Bibliography Layouts
+  description: >
+    Demonstrates bibliography.locales[] selecting a different full-entry layout
+    for CJK items than for the default Latin-script branch.
+  default-locale: en-US
+
+options:
+  processing: author-date
+  bibliography:
+    entry-suffix: .
+    separator: ""
+
+citation:
+  template:
+    - contributor: author
+      form: short
+    - date: issued
+      form: year
+      prefix: ", "
+  wrap: parentheses
+
+bibliography:
+  template:
+    - contributor: author
+      form: long
+    - title: primary
+      prefix: ". "
+    - variable: publisher
+      prefix: ". "
+    - date: issued
+      form: year
+      prefix: ", "
+  locales:
+    - locale: [ja, zh, ko]
+      template:
+        - contributor: author
+          form: long
+        - variable: publisher
+          prefix: ". "
+        - date: issued
+          form: year
+          prefix: ", "
+        - title: primary
+          prefix: ". "
+    - default: true
+      template:
+        - contributor: author
+          form: long
+        - title: primary
+          prefix: ". "
+        - variable: publisher
+          prefix: ". "
+        - date: issued
+          form: year
+          prefix: ", "

--- a/tests/fixtures/multilingual/multilingual-cjk.json
+++ b/tests/fixtures/multilingual/multilingual-cjk.json
@@ -120,6 +120,22 @@
     "issued": { "date-parts": [[1960]] },
     "publisher": "有斐閣"
   },
+  "CJK-JAPANESE-LANGUAGE-TAGGED": {
+    "id": "CJK-JAPANESE-LANGUAGE-TAGGED",
+    "class": "monograph",
+    "type": "book",
+    "title": "日本語の書誌",
+    "author": [
+      {
+        "family": "佐藤",
+        "given": "花子"
+      }
+    ],
+    "issued": { "date-parts": [[2018]] },
+    "publisher": "Tokyo Academic Press",
+    "publisher-place": "Tokyo",
+    "language": "ja"
+  },
   "CSL-ET-AL-KANJI": {
     "id": "CSL-ET-AL-KANJI",
     "class": "monograph",


### PR DESCRIPTION
## Summary
- add an experimental style proving bibliography.locales[] can switch full entry layouts
- add multilingual bibliography coverage using the existing CJK fixture plus a language-tagged Japanese item
- update the style author guide and mark csl26-24pu completed

## Verification
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run