### PR TITLE
feat(citations): add integral name memory

### DIFF
--- a/crates/citum-cli/generated_schemas/bib.json
+++ b/crates/citum-cli/generated_schemas/bib.json
@@ -32,6 +32,19 @@
       "items": {
         "$ref": "#/definitions/InputReference"
       }
+    },
+    "sets": {
+      "description": "Optional compound entry sets keyed by set id.\n\nEach set id maps to an ordered list of reference ids that should be treated as one compound numeric group when `compound-numeric` is enabled by style.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
     }
   },
   "definitions": {
@@ -203,12 +216,14 @@
       "type": "object",
       "properties": {
         "author": {
+          "description": "Creator or maintainer of the bibliography dataset.",
           "type": [
             "string",
             "null"
           ]
         },
         "title": {
+          "description": "Human-readable title for the bibliography dataset.",
           "type": [
             "string",
             "null"
@@ -239,6 +254,27 @@
                 }
               ]
             },
+            "ads-bibcode": {
+              "description": "ADS bibcode identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive": {
+              "description": "Archive or repository name for unpublished material.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive-location": {
+              "description": "Archive location, shelfmark, or call number for unpublished material.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "author": {
               "anyOf": [
                 {
@@ -259,6 +295,17 @@
               "type": [
                 "string",
                 "null"
+              ]
+            },
+            "container-title": {
+              "description": "Parent or container title for monographic interviews and similar sources.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "doi": {
@@ -299,6 +346,17 @@
               "type": [
                 "string",
                 "null"
+              ]
+            },
+            "interviewer": {
+              "description": "Interviewer for interview-style references.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Contributor"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "isbn": {
@@ -358,6 +416,17 @@
               ]
             },
             "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recipient": {
+              "description": "Recipient for personal communications such as letters or emails.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/Contributor"
@@ -551,6 +620,13 @@
                 {
                   "type": "null"
                 }
+              ]
+            },
+            "ads-bibcode": {
+              "description": "ADS bibcode identifier.",
+              "type": [
+                "string",
+                "null"
               ]
             },
             "author": {
@@ -2161,19 +2237,38 @@
       ]
     },
     "MonographType": {
-      "type": "string",
-      "enum": [
-        "book",
-        "report",
-        "thesis",
-        "webpage",
-        "post",
-        "personal-communication",
-        "document"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "book",
+            "manual",
+            "report",
+            "thesis",
+            "webpage",
+            "post",
+            "personal-communication",
+            "document"
+          ]
+        },
+        {
+          "description": "An interview treated as a standalone monographic source.",
+          "type": "string",
+          "enum": [
+            "interview"
+          ]
+        },
+        {
+          "description": "An unpublished manuscript or archival document.",
+          "type": "string",
+          "enum": [
+            "manuscript"
+          ]
+        }
       ]
     },
     "MultilingualComplex": {
-      "description": "Complex multilingual representation with original, transliterations, and translations.",
+      "description": "Complex multilingual representation with original, transliterations, and translations.\n\nAllows capturing the original text in its native script, along with transliterations (phonetic representations in different scripts) and translations (semantic equivalents in different languages). This is essential for accurately rendering bibliographies in multilingual and non-Latin-script contexts.",
       "type": "object",
       "required": [
         "original"
@@ -2187,18 +2282,18 @@
           ]
         },
         "original": {
-          "description": "The text in its original script.",
+          "description": "The text in its original script and language.",
           "type": "string"
         },
         "translations": {
-          "description": "Translations of the text into other languages. Keys are ISO 639/BCP 47 language codes.",
+          "description": "Translations of the text into other languages.\n\nKeys are ISO 639/BCP 47 language codes (e.g., \"en\" for English, \"fr\" for French). Values are the translated text.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
         "transliterations": {
-          "description": "Transliterations/Transcriptions of the original text. Keys are script codes or full BCP 47 tags.",
+          "description": "Transliterations/Transcriptions of the original text into other scripts.\n\nKeys are typically script codes (e.g., \"Latn\" for Latin) or full BCP 47 tags. Values are the transliterated or transcribed text.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -2245,26 +2340,32 @@
       }
     },
     "MultilingualString": {
-      "description": "A string that can be represented in multiple languages and scripts.",
+      "description": "A string that can be represented in multiple languages and scripts.\n\nThis is an enum that supports both simple strings and complex multilingual representations. Use `Simple` for basic strings and `Complex` when you need to track original language, transliterations, and translations.",
       "anyOf": [
         {
+          "description": "A simple string in a single language.",
           "type": "string"
         },
         {
-          "$ref": "#/definitions/MultilingualComplex"
+          "description": "A complex multilingual string with original, transliterations, and translations.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MultilingualComplex"
+            }
+          ]
         }
       ]
     },
     "NumOrStr": {
-      "description": "A value that could be either a number or a string.",
+      "description": "A value that could be either a number or a string.\n\nUsed for fields that may contain numeric or string values, such as issue numbers, volume numbers, or similar identifiers that can be formatted as either type. The `Display` implementation shows the value in its appropriate form.",
       "anyOf": [
         {
-          "description": "It's a number!",
+          "description": "A numeric value.",
           "type": "integer",
           "format": "int64"
         },
         {
-          "description": "It's a string!",
+          "description": "A string value.",
           "type": "string"
         }
       ]

--- a/crates/citum-cli/generated_schemas/citation.json
+++ b/crates/citum-cli/generated_schemas/citation.json
@@ -86,6 +86,17 @@
           "description": "The reference ID (citekey).",
           "type": "string"
         },
+        "integral-name-state": {
+          "description": "Explicit integral name-memory state override for this item.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameState"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "locator": {
           "description": "Canonical locator value for pinpoint citations.",
           "anyOf": [
@@ -149,6 +160,25 @@
           "type": "string",
           "enum": [
             "non-integral"
+          ]
+        }
+      ]
+    },
+    "IntegralNameState": {
+      "description": "Explicit integral citation name-memory state for one citation item.",
+      "oneOf": [
+        {
+          "description": "Render this item as the first integral mention in scope.",
+          "type": "string",
+          "enum": [
+            "first"
+          ]
+        },
+        {
+          "description": "Render this item as a subsequent integral mention in scope.",
+          "type": "string",
+          "enum": [
+            "subsequent"
           ]
         }
       ]

--- a/crates/citum-cli/generated_schemas/locale.json
+++ b/crates/citum-cli/generated_schemas/locale.json
@@ -54,6 +54,7 @@
       "type": "object",
       "properties": {
         "am": {
+          "description": "Localized ante meridiem marker.",
           "default": null,
           "type": [
             "string",
@@ -61,6 +62,7 @@
           ]
         },
         "months": {
+          "description": "Localized month names.",
           "default": {
             "long": [],
             "short": []
@@ -72,6 +74,7 @@
           ]
         },
         "open-ended-term": {
+          "description": "Localized term for open-ended date ranges.",
           "default": null,
           "type": [
             "string",
@@ -79,6 +82,7 @@
           ]
         },
         "pm": {
+          "description": "Localized post meridiem marker.",
           "default": null,
           "type": [
             "string",
@@ -86,6 +90,7 @@
           ]
         },
         "seasons": {
+          "description": "Localized season names in display order.",
           "default": [],
           "type": "array",
           "items": {
@@ -93,6 +98,7 @@
           }
         },
         "timezone-utc": {
+          "description": "Localized label for UTC.",
           "default": null,
           "type": [
             "string",
@@ -100,6 +106,7 @@
           ]
         },
         "uncertainty-term": {
+          "description": "Localized term for uncertain dates.",
           "default": null,
           "type": [
             "string",
@@ -113,6 +120,7 @@
       "type": "object",
       "properties": {
         "long": {
+          "description": "Full month names.",
           "default": [],
           "type": "array",
           "items": {
@@ -120,6 +128,7 @@
           }
         },
         "short": {
+          "description": "Abbreviated month names.",
           "default": [],
           "type": "array",
           "items": {
@@ -133,6 +142,7 @@
       "type": "object",
       "properties": {
         "long": {
+          "description": "Long-form role term.",
           "default": null,
           "anyOf": [
             {
@@ -144,6 +154,7 @@
           ]
         },
         "short": {
+          "description": "Short-form role term.",
           "default": null,
           "anyOf": [
             {
@@ -155,6 +166,7 @@
           ]
         },
         "verb": {
+          "description": "Verb-form role term.",
           "default": null,
           "anyOf": [
             {
@@ -166,6 +178,7 @@
           ]
         },
         "verb-short": {
+          "description": "Short verb-form role term.",
           "default": null,
           "anyOf": [
             {
@@ -201,9 +214,11 @@
           ],
           "properties": {
             "plural": {
+              "description": "Plural form of the term.",
               "type": "string"
             },
             "singular": {
+              "description": "Singular form of the term.",
               "type": "string"
             }
           }

--- a/crates/citum-cli/generated_schemas/style.json
+++ b/crates/citum-cli/generated_schemas/style.json
@@ -71,7 +71,7 @@
     },
     "version": {
       "description": "Style schema version.",
-      "default": "1.0",
+      "default": "0.8.0",
       "type": "string"
     }
   },
@@ -100,41 +100,6 @@
           "enum": [
             "none"
           ]
-        },
-        {
-          "description": "Context-sensitive conjunction based on the citation mode.\n\nThis allows styles like APA 7th to use \"and\" in narrative (integral) citations but \"&\" in parenthetical (non-integral) ones.",
-          "type": "object",
-          "required": [
-            "mode-dependent"
-          ],
-          "properties": {
-            "mode-dependent": {
-              "type": "object",
-              "required": [
-                "integral",
-                "non-integral"
-              ],
-              "properties": {
-                "integral": {
-                  "description": "The option to use for integral/narrative citations (e.g., \"Smith and Jones\").",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/AndOptions"
-                    }
-                  ]
-                },
-                "non-integral": {
-                  "description": "The option to use for non-integral/parenthetical citations (e.g., \"(Smith & Jones)\"). Also typically serves as the default for bibliographies.",
-                  "allOf": [
-                    {
-                      "$ref": "#/definitions/AndOptions"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "additionalProperties": false
         }
       ]
     },
@@ -150,6 +115,17 @@
       "description": "Bibliography-specific configuration.",
       "type": "object",
       "properties": {
+        "compound-numeric": {
+          "description": "Configuration for compound numeric bibliography entries. When present, enables grouping of references by input bibliography `sets`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CompoundNumericConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "custom": {
           "description": "Custom user-defined fields for extensions.",
           "type": [
@@ -292,6 +268,7 @@
           }
         },
         "locales": {
+          "description": "Locale-specific template overrides checked before the default template.",
           "type": [
             "array",
             "null"
@@ -301,6 +278,7 @@
           }
         },
         "options": {
+          "description": "Bibliography-specific option overrides merged over the style config.",
           "anyOf": [
             {
               "$ref": "#/definitions/Config"
@@ -322,7 +300,7 @@
           ]
         },
         "template": {
-          "description": "The default template for bibliography entries.",
+          "description": "The default template for bibliography entries. Default template for entries when no localized override is selected.",
           "type": [
             "array",
             "null"
@@ -358,40 +336,206 @@
       },
       "additionalProperties": false
     },
+    "CitationCollapse": {
+      "description": "Citation collapse behavior for multi-item citations.",
+      "oneOf": [
+        {
+          "description": "Collapse adjacent citation numbers into a numeric range such as `1–3`.",
+          "type": "string",
+          "enum": [
+            "citation-number"
+          ]
+        }
+      ]
+    },
     "CitationField": {
       "description": "Discipline/field classification for a citation style.\n\nValues correspond to the CSL 1.0 `<category field=\"...\"/>` attribute, `generic-base` is silently ignored during migration.",
-      "type": "string",
-      "enum": [
-        "anthropology",
-        "biology",
-        "botany",
-        "chemistry",
-        "communications",
-        "engineering",
-        "geography",
-        "geology",
-        "history",
-        "humanities",
-        "law",
-        "linguistics",
-        "literature",
-        "math",
-        "medicine",
-        "philosophy",
-        "physics",
-        "political-science",
-        "psychology",
-        "science",
-        "social-science",
-        "sociology",
-        "theology",
-        "zoology"
+      "oneOf": [
+        {
+          "description": "Anthropology styles.",
+          "type": "string",
+          "enum": [
+            "anthropology"
+          ]
+        },
+        {
+          "description": "Biology styles.",
+          "type": "string",
+          "enum": [
+            "biology"
+          ]
+        },
+        {
+          "description": "Botany styles.",
+          "type": "string",
+          "enum": [
+            "botany"
+          ]
+        },
+        {
+          "description": "Chemistry styles.",
+          "type": "string",
+          "enum": [
+            "chemistry"
+          ]
+        },
+        {
+          "description": "Communications studies styles.",
+          "type": "string",
+          "enum": [
+            "communications"
+          ]
+        },
+        {
+          "description": "Engineering styles.",
+          "type": "string",
+          "enum": [
+            "engineering"
+          ]
+        },
+        {
+          "description": "Geography styles.",
+          "type": "string",
+          "enum": [
+            "geography"
+          ]
+        },
+        {
+          "description": "Geology styles.",
+          "type": "string",
+          "enum": [
+            "geology"
+          ]
+        },
+        {
+          "description": "History styles.",
+          "type": "string",
+          "enum": [
+            "history"
+          ]
+        },
+        {
+          "description": "Humanities styles.",
+          "type": "string",
+          "enum": [
+            "humanities"
+          ]
+        },
+        {
+          "description": "Law styles.",
+          "type": "string",
+          "enum": [
+            "law"
+          ]
+        },
+        {
+          "description": "Linguistics styles.",
+          "type": "string",
+          "enum": [
+            "linguistics"
+          ]
+        },
+        {
+          "description": "Literature styles.",
+          "type": "string",
+          "enum": [
+            "literature"
+          ]
+        },
+        {
+          "description": "Mathematics styles.",
+          "type": "string",
+          "enum": [
+            "math"
+          ]
+        },
+        {
+          "description": "Medicine styles.",
+          "type": "string",
+          "enum": [
+            "medicine"
+          ]
+        },
+        {
+          "description": "Philosophy styles.",
+          "type": "string",
+          "enum": [
+            "philosophy"
+          ]
+        },
+        {
+          "description": "Physics styles.",
+          "type": "string",
+          "enum": [
+            "physics"
+          ]
+        },
+        {
+          "description": "Political science styles.",
+          "type": "string",
+          "enum": [
+            "political-science"
+          ]
+        },
+        {
+          "description": "Psychology styles.",
+          "type": "string",
+          "enum": [
+            "psychology"
+          ]
+        },
+        {
+          "description": "General science styles.",
+          "type": "string",
+          "enum": [
+            "science"
+          ]
+        },
+        {
+          "description": "Social science styles.",
+          "type": "string",
+          "enum": [
+            "social-science"
+          ]
+        },
+        {
+          "description": "Sociology styles.",
+          "type": "string",
+          "enum": [
+            "sociology"
+          ]
+        },
+        {
+          "description": "Theology styles.",
+          "type": "string",
+          "enum": [
+            "theology"
+          ]
+        },
+        {
+          "description": "Zoology styles.",
+          "type": "string",
+          "enum": [
+            "zoology"
+          ]
+        }
       ]
     },
     "CitationSpec": {
       "description": "Citation specification.",
       "type": "object",
       "properties": {
+        "collapse": {
+          "description": "Optional collapse behavior for adjacent multi-item citations.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CitationCollapse"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "custom": {
           "description": "Custom user-defined fields for extensions.",
           "type": [
@@ -430,6 +574,7 @@
           ]
         },
         "locales": {
+          "description": "Locale-specific template overrides checked before the default template.",
           "type": [
             "array",
             "null"
@@ -457,6 +602,7 @@
           ]
         },
         "options": {
+          "description": "Citation-specific option overrides merged over the style config.",
           "anyOf": [
             {
               "$ref": "#/definitions/Config"
@@ -503,6 +649,7 @@
           ]
         },
         "template": {
+          "description": "Default template when no localized override is selected.",
           "type": [
             "array",
             "null"
@@ -576,6 +723,42 @@
         }
       ]
     },
+    "CompoundNumericConfig": {
+      "description": "Configuration for compound numeric bibliography entries.\n\nGroups multiple references under a single citation number with sub-labels. Used in chemistry journals (e.g., Angewandte Chemie).",
+      "type": "object",
+      "properties": {
+        "collapse-subentries": {
+          "description": "Whether adjacent grouped sub-entries collapse in citations.\n\nWhen true, adjacent members from the same group may render as `1a,b` or `1a-c` instead of `1a,1b` or `1a,1b,1c`.",
+          "default": false,
+          "type": "boolean"
+        },
+        "sub-delimiter": {
+          "description": "Delimiter between sub-items (default: \", \").",
+          "default": ", ",
+          "type": "string"
+        },
+        "sub-label": {
+          "description": "Sub-label style: alphabetic (a, b, c) or numeric (1, 2, 3).",
+          "default": "alphabetic",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SubLabelStyle"
+            }
+          ]
+        },
+        "sub-label-suffix": {
+          "description": "Suffix after sub-label (e.g., \")\" → \"a)\", \".\" → \"a.\").",
+          "default": ")",
+          "type": "string"
+        },
+        "subentry": {
+          "description": "Whether grouped item citations render sub-entry labels (`1a`, `1b`).\n\nWhen false, grouped item citations render the whole-group number (`1`).",
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "Config": {
       "description": "Top-level style configuration.",
       "type": "object",
@@ -615,6 +798,17 @@
           "anyOf": [
             {
               "$ref": "#/definitions/DateConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "integral-names": {
+          "description": "Integral citation name-memory behavior.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameConfig"
             },
             {
               "type": "null"
@@ -841,6 +1035,17 @@
             "null"
           ]
         },
+        "name-form": {
+          "description": "How to render given names. See `NameForm` for variants. Per-scope overrides (per-mode, per-position) are expressed by setting this field in the appropriate scope's contributor config block.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "role": {
           "description": "When and how to display contributor roles.",
           "anyOf": [
@@ -1024,25 +1229,133 @@
     },
     "ContributorRole": {
       "description": "Contributor roles.",
-      "type": "string",
-      "enum": [
-        "author",
-        "editor",
-        "translator",
-        "director",
-        "publisher",
-        "recipient",
-        "interviewer",
-        "interviewee",
-        "inventor",
-        "counsel",
-        "composer",
-        "collection-editor",
-        "container-author",
-        "editorial-director",
-        "illustrator",
-        "original-author",
-        "reviewed-author"
+      "oneOf": [
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "author"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "editor"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "translator"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "director"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "publisher"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "recipient"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "interviewer"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "interviewee"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "inventor"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "counsel"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "composer"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "collection-editor"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "container-author"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "editorial-director"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "textual-editor"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "illustrator"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "original-author"
+          ]
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "enum": [
+            "reviewed-author"
+          ]
+        }
       ]
     },
     "DateConfig": {
@@ -1213,7 +1526,7 @@
       ]
     },
     "Disambiguation": {
-      "description": "Disambiguation settings.",
+      "description": "Disambiguation settings.\n\nControls how ambiguous citations are disambiguated in the output.",
       "type": "object",
       "required": [
         "names",
@@ -1221,13 +1534,16 @@
       ],
       "properties": {
         "add-givenname": {
+          "description": "Whether to add given names to disambiguate similarly-named authors.",
           "default": false,
           "type": "boolean"
         },
         "names": {
+          "description": "Whether to attempt disambiguation by expanding author names.",
           "type": "boolean"
         },
         "year-suffix": {
+          "description": "Whether to append year suffixes (a, b, c, ...) for multiple works from the same author-year.",
           "type": "boolean"
         }
       }
@@ -1303,44 +1619,222 @@
       ]
     },
     "GeneralTerm": {
-      "description": "A list of general terms for citation formatting.",
-      "type": "string",
-      "enum": [
-        "in",
-        "accessed",
-        "retrieved",
-        "at",
-        "from",
-        "by",
-        "no-date",
-        "anonymous",
-        "circa",
-        "available-at",
-        "ibid",
-        "and",
-        "et-al",
-        "and-others",
-        "forthcoming",
-        "online",
-        "review-of",
-        "original-work-published",
-        "patent",
-        "volume",
-        "issue",
-        "page",
-        "chapter",
-        "edition",
-        "section"
+      "description": "A list of general terms for citation formatting.\n\nThese are the standard terms that appear in bibliographies and citations, including prepositions (in, at, from, by), punctuation terms (and, et al), date-related terms (accessed, no-date, circa), locator terms (page, chapter, volume), and special phrases (ibid, forthcoming, available-at).",
+      "oneOf": [
+        {
+          "description": "The preposition \"in\" (e.g., \"in Smith, 2020\").",
+          "type": "string",
+          "enum": [
+            "in"
+          ]
+        },
+        {
+          "description": "The term used for access dates (e.g., \"accessed May 1\").",
+          "type": "string",
+          "enum": [
+            "accessed"
+          ]
+        },
+        {
+          "description": "The term used for retrieval statements (e.g., \"retrieved from URL\").",
+          "type": "string",
+          "enum": [
+            "retrieved"
+          ]
+        },
+        {
+          "description": "The preposition \"at\" (e.g., \"at the conference\").",
+          "type": "string",
+          "enum": [
+            "at"
+          ]
+        },
+        {
+          "description": "The preposition \"from\" (e.g., \"from the publisher\").",
+          "type": "string",
+          "enum": [
+            "from"
+          ]
+        },
+        {
+          "description": "The preposition \"of\" (e.g., \"special issue of\").",
+          "type": "string",
+          "enum": [
+            "of"
+          ]
+        },
+        {
+          "description": "The preposition \"to\" (e.g., \"from x to y\").",
+          "type": "string",
+          "enum": [
+            "to"
+          ]
+        },
+        {
+          "description": "The preposition \"by\" (e.g., \"by John Smith\").",
+          "type": "string",
+          "enum": [
+            "by"
+          ]
+        },
+        {
+          "description": "The term used when no date is available (e.g., \"n.d.\").",
+          "type": "string",
+          "enum": [
+            "no-date"
+          ]
+        },
+        {
+          "description": "The term used for anonymous authorship (e.g., \"anonymous\").",
+          "type": "string",
+          "enum": [
+            "anonymous"
+          ]
+        },
+        {
+          "description": "The term used for approximate dates (e.g., \"circa\").",
+          "type": "string",
+          "enum": [
+            "circa"
+          ]
+        },
+        {
+          "description": "The phrase used for availability statements (e.g., \"available at URL\").",
+          "type": "string",
+          "enum": [
+            "available-at"
+          ]
+        },
+        {
+          "description": "The term used for immediately repeated citations (e.g., \"ibid.\").",
+          "type": "string",
+          "enum": [
+            "ibid"
+          ]
+        },
+        {
+          "description": "The conjunction \"and\" (e.g., \"Smith and Jones\").",
+          "type": "string",
+          "enum": [
+            "and"
+          ]
+        },
+        {
+          "description": "The abbreviation for omitted additional names (e.g., \"et al.\").",
+          "type": "string",
+          "enum": [
+            "et-al"
+          ]
+        },
+        {
+          "description": "The phrase \"and others\" (generic use).",
+          "type": "string",
+          "enum": [
+            "and-others"
+          ]
+        },
+        {
+          "description": "The term used for forthcoming works (e.g., \"forthcoming\").",
+          "type": "string",
+          "enum": [
+            "forthcoming"
+          ]
+        },
+        {
+          "description": "The term used for online resources (e.g., \"online\").",
+          "type": "string",
+          "enum": [
+            "online"
+          ]
+        },
+        {
+          "description": "The adverb \"here\".",
+          "type": "string",
+          "enum": [
+            "here"
+          ]
+        },
+        {
+          "description": "The term used for deposited materials.",
+          "type": "string",
+          "enum": [
+            "deposited"
+          ]
+        },
+        {
+          "description": "The phrase used to introduce reviewed works (e.g., \"review of\").",
+          "type": "string",
+          "enum": [
+            "review-of"
+          ]
+        },
+        {
+          "description": "The phrase used for original publication references (e.g., \"originally published\").",
+          "type": "string",
+          "enum": [
+            "original-work-published"
+          ]
+        },
+        {
+          "description": "The term used for patents (e.g., \"patent\").",
+          "type": "string",
+          "enum": [
+            "patent"
+          ]
+        },
+        {
+          "description": "The general term for volume locators (e.g., \"volume\", \"vol.\").",
+          "type": "string",
+          "enum": [
+            "volume"
+          ]
+        },
+        {
+          "description": "The general term for issue locators (e.g., \"issue\", \"no.\").",
+          "type": "string",
+          "enum": [
+            "issue"
+          ]
+        },
+        {
+          "description": "The general term for page locators (e.g., \"page\", \"p.\", \"pp.\").",
+          "type": "string",
+          "enum": [
+            "page"
+          ]
+        },
+        {
+          "description": "The general term for chapter locators (e.g., \"chapter\", \"ch.\").",
+          "type": "string",
+          "enum": [
+            "chapter"
+          ]
+        },
+        {
+          "description": "The general term for editions (e.g., \"edition\", \"ed.\").",
+          "type": "string",
+          "enum": [
+            "edition"
+          ]
+        },
+        {
+          "description": "The general term for section locators (e.g., \"section\", \"§\").",
+          "type": "string",
+          "enum": [
+            "section"
+          ]
+        }
       ]
     },
     "Group": {
-      "description": "Grouping configuration for bibliography.",
+      "description": "Grouping configuration for bibliography.\n\nSpecifies how bibliography entries should be grouped in the output.",
       "type": "object",
       "required": [
         "template"
       ],
       "properties": {
         "template": {
+          "description": "Sort keys used to define group boundaries (e.g., [Author, Year]).",
           "type": "array",
           "items": {
             "$ref": "#/definitions/SortKey"
@@ -1538,6 +2032,133 @@
           ]
         }
       }
+    },
+    "IntegralNameConfig": {
+      "description": "Integral citation name-memory configuration.",
+      "type": "object",
+      "properties": {
+        "contexts": {
+          "description": "Which document contexts participate in name-memory tracking.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameContexts"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rule": {
+          "description": "The name-memory rule to apply to integral citations.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameRule"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Where the first-mention memory resets.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subsequent-form": {
+          "description": "The contributor form to use after the first mention in scope.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "IntegralNameContexts": {
+      "description": "Which document contexts participate in integral citation name memory.",
+      "oneOf": [
+        {
+          "description": "Only body-text integral citations participate.",
+          "type": "string",
+          "enum": [
+            "body-only"
+          ]
+        },
+        {
+          "description": "Body text and note citations both participate.",
+          "type": "string",
+          "enum": [
+            "body-and-notes"
+          ]
+        }
+      ]
+    },
+    "IntegralNameForm": {
+      "description": "The contributor form used after the first integral mention in scope.",
+      "oneOf": [
+        {
+          "description": "Use the short contributor form for subsequent mentions.",
+          "type": "string",
+          "enum": [
+            "short"
+          ]
+        },
+        {
+          "description": "Use family name only for subsequent mentions.",
+          "type": "string",
+          "enum": [
+            "family-only"
+          ]
+        }
+      ]
+    },
+    "IntegralNameRule": {
+      "description": "The supported integral citation name-memory rule.",
+      "oneOf": [
+        {
+          "description": "Render the first integral mention in scope in full, then shorten later mentions.",
+          "type": "string",
+          "enum": [
+            "full-then-short"
+          ]
+        }
+      ]
+    },
+    "IntegralNameScope": {
+      "description": "The scope where integral citation name-memory resets.",
+      "oneOf": [
+        {
+          "description": "Keep one name-memory scope for the whole document.",
+          "type": "string",
+          "enum": [
+            "document"
+          ]
+        },
+        {
+          "description": "Reset name memory at chapter boundaries.",
+          "type": "string",
+          "enum": [
+            "chapter"
+          ]
+        },
+        {
+          "description": "Reset name memory at section boundaries.",
+          "type": "string",
+          "enum": [
+            "section"
+          ]
+        }
+      ]
     },
     "LabelConfig": {
       "description": "Configuration for label citation mode.",
@@ -1755,18 +2376,21 @@
       }
     },
     "LocalizedTemplateSpec": {
+      "description": "Locale-scoped template override with optional fallback behavior.",
       "type": "object",
       "required": [
         "template"
       ],
       "properties": {
         "default": {
+          "description": "Whether this override is the fallback when no locale matches.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "locale": {
+          "description": "Language tags that should select this template override.",
           "type": [
             "array",
             "null"
@@ -1776,6 +2400,7 @@
           }
         },
         "template": {
+          "description": "Template used when this localized override is selected.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/TemplateComponent"
@@ -1874,6 +2499,32 @@
           "type": "string",
           "enum": [
             "combined"
+          ]
+        }
+      ]
+    },
+    "NameForm": {
+      "description": "How to render the given-name component of a contributor name.\n\nControls whether full given names, family name only, or initialized given names are rendered. Used to express first/subsequent mention differences (Chicago) and integral/non-integral differences.\n\nInitialization formatting details (`initialize_with`, `initialize_with_hyphen`) are separate fields and only take effect when `NameForm::Initials` is active.",
+      "oneOf": [
+        {
+          "description": "Render full given names: \"John D. Smith\".",
+          "type": "string",
+          "enum": [
+            "full"
+          ]
+        },
+        {
+          "description": "Render family name only, suppressing given names: \"Smith\". Used for subsequent mentions in Chicago/Turabian note styles.",
+          "type": "string",
+          "enum": [
+            "family-only"
+          ]
+        },
+        {
+          "description": "Render initialized given names using `initialize_with` separator. If `initialize_with` is None, defaults to \". \" (e.g., \"J. Smith\"). Empty string gives compact initials: \"JD Smith\".",
+          "type": "string",
+          "enum": [
+            "initials"
           ]
         }
       ]
@@ -2051,7 +2702,10 @@
         "docket-number",
         "patent-number",
         "standard-number",
-        "report-number"
+        "report-number",
+        "part-number",
+        "supplement-number",
+        "printing-number"
       ]
     },
     "PageRangeFormat": {
@@ -2095,31 +2749,31 @@
       ]
     },
     "Processing": {
-      "description": "Processing mode for citation/bibliography generation.\n\nCan be specified as: - A string: \"author-date\", \"numeric\", \"note\", or \"label\" - A label config map: { label: { preset: din } } - A custom config map: { sort: ..., group: ..., disambiguate: ... }",
+      "description": "Processing mode for citation/bibliography generation.\n\nDetermines how citations and bibliographies are sorted, grouped, and disambiguated. Can be specified as a simple string or with complex configuration maps: - A string: `\"author-date\"`, `\"numeric\"`, `\"note\"`, or `\"label\"` - A label config map: `{ label: { preset: din } }` - A custom config map: `{ sort: ..., group: ..., disambiguate: ... }`",
       "oneOf": [
         {
-          "description": "Author-date styles default bibliography ordering to author, year, title.",
+          "description": "Author-date styles (e.g., APA, Chicago). Default bibliography ordering: author, year, title.",
           "type": "string",
           "enum": [
             "author-date"
           ]
         },
         {
-          "description": "Numeric styles do not imply a bibliography sort.",
+          "description": "Numeric styles (e.g., IEEE, Nature). Do not imply a bibliography sort; citations are numbered in order of appearance.",
           "type": "string",
           "enum": [
             "numeric"
           ]
         },
         {
-          "description": "Note styles with a bibliography default to author, title, year ordering.",
+          "description": "Note styles (e.g., Chicago Notes-Bibliography). With a bibliography default to author, title, year ordering.",
           "type": "string",
           "enum": [
             "note"
           ]
         },
         {
-          "description": "Label styles default bibliography ordering to author, year, title.",
+          "description": "Label styles (e.g., Alpha, DIN 1505-2). Default bibliography ordering: author, year, title.",
           "type": "object",
           "required": [
             "label"
@@ -2132,7 +2786,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Fully custom processing behavior; explicit `sort` remains authoritative.",
+          "description": "Fully custom processing behavior. Explicit `sort` configuration remains authoritative.",
           "type": "object",
           "required": [
             "custom"
@@ -2147,10 +2801,11 @@
       ]
     },
     "ProcessingCustom": {
-      "description": "Custom processing configuration.",
+      "description": "Custom processing configuration.\n\nAllows explicit specification of sorting, grouping, and disambiguation rules without relying on preset defaults.",
       "type": "object",
       "properties": {
         "disambiguate": {
+          "description": "Disambiguation settings (optional).",
           "anyOf": [
             {
               "$ref": "#/definitions/Disambiguation"
@@ -2161,6 +2816,7 @@
           ]
         },
         "group": {
+          "description": "Bibliography grouping configuration (optional).",
           "anyOf": [
             {
               "$ref": "#/definitions/Group"
@@ -2171,6 +2827,7 @@
           ]
         },
         "sort": {
+          "description": "Bibliography sorting configuration (optional).",
           "anyOf": [
             {
               "$ref": "#/definitions/SortEntry"
@@ -2464,6 +3121,24 @@
           "format": "uint8",
           "minimum": 0.0
         },
+        "subsequent-min": {
+          "description": "Minimum number of names to trigger shortening on subsequent cites. Defaults to `min` if not set.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "subsequent-use-first": {
+          "description": "Number of names to show when shortened on subsequent cites. Defaults to `use_first` if not set.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
         "use-first": {
           "description": "Number of names to show when shortened.",
           "type": "integer",
@@ -2517,28 +3192,29 @@
         "docket-number",
         "patent-number",
         "standard-number",
-        "report-number"
+        "report-number",
+        "ads-bibcode"
       ]
     },
     "Sort": {
-      "description": "Sorting configuration.",
+      "description": "Sorting configuration.\n\nSpecifies how bibliography entries are ordered.",
       "type": "object",
       "required": [
         "template"
       ],
       "properties": {
         "render-substitutions": {
-          "description": "Use same substitutions for sorting as for rendering.",
+          "description": "Whether to apply the same name substitutions during sorting as during rendering.",
           "default": false,
           "type": "boolean"
         },
         "shorten-names": {
-          "description": "Shorten name lists for sorting the same as for display.",
+          "description": "Whether to shorten name lists for sorting the same as for display.",
           "default": false,
           "type": "boolean"
         },
         "template": {
-          "description": "Sort keys in order.",
+          "description": "Sort keys in order of application.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/SortSpec"
@@ -2547,10 +3223,10 @@
       }
     },
     "SortEntry": {
-      "description": "Sort configuration: either a preset name or explicit configuration.",
+      "description": "Sort configuration: either a preset name or explicit configuration.\n\nCan be a preset name like `author-date-title` or a full `Sort` struct with explicit settings.",
       "anyOf": [
         {
-          "description": "A named sort preset (e.g., \"author-date-title\").",
+          "description": "A named sort preset (e.g., `author-date-title`, `author-title-date`).",
           "allOf": [
             {
               "$ref": "#/definitions/SortPreset"
@@ -2558,7 +3234,7 @@
           ]
         },
         {
-          "description": "Explicit sort configuration.",
+          "description": "Explicit sort configuration with custom keys and order.",
           "allOf": [
             {
               "$ref": "#/definitions/Sort"
@@ -2568,18 +3244,31 @@
       ]
     },
     "SortKey": {
-      "description": "Available sort keys.",
+      "description": "Available sort keys.\n\nSpecifies what field to sort bibliography entries by.",
       "oneOf": [
         {
+          "description": "Sort by the work's author(s).",
           "type": "string",
           "enum": [
-            "author",
-            "year",
+            "author"
+          ]
+        },
+        {
+          "description": "Sort by publication year.",
+          "type": "string",
+          "enum": [
+            "year"
+          ]
+        },
+        {
+          "description": "Sort by the work's title.",
+          "type": "string",
+          "enum": [
             "title"
           ]
         },
         {
-          "description": "Sort by citation order (for numeric styles).",
+          "description": "Sort by citation order (typically used for numeric styles).",
           "type": "string",
           "enum": [
             "citation-number"
@@ -2660,18 +3349,24 @@
       ]
     },
     "SortSpec": {
-      "description": "A single sort specification.",
+      "description": "A single sort specification.\n\nDefines one sort dimension with its key and direction.",
       "type": "object",
       "required": [
         "key"
       ],
       "properties": {
         "ascending": {
+          "description": "Whether to sort in ascending order (default: true).",
           "default": true,
           "type": "boolean"
         },
         "key": {
-          "$ref": "#/definitions/SortKey"
+          "description": "The field to sort by.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SortKey"
+            }
+          ]
         }
       }
     },
@@ -2687,6 +3382,7 @@
           ]
         },
         "description": {
+          "description": "Short summary of the style's intended use or provenance.",
           "type": [
             "string",
             "null"
@@ -2700,6 +3396,7 @@
           }
         },
         "id": {
+          "description": "Stable identifier for the style, usually a URI or slug.",
           "type": [
             "string",
             "null"
@@ -2717,6 +3414,7 @@
           ]
         },
         "title": {
+          "description": "Human-readable title of the style.",
           "type": [
             "string",
             "null"
@@ -2732,9 +3430,11 @@
       ],
       "properties": {
         "href": {
+          "description": "Link target for related style metadata.",
           "type": "string"
         },
         "rel": {
+          "description": "Relationship type for the link, such as `self` or `documentation`.",
           "type": [
             "string",
             "null"
@@ -2747,18 +3447,21 @@
       "type": "object",
       "properties": {
         "email": {
+          "description": "Contact email for the credited person.",
           "type": [
             "string",
             "null"
           ]
         },
         "name": {
+          "description": "Display name for the credited person.",
           "type": [
             "string",
             "null"
           ]
         },
         "uri": {
+          "description": "URI identifying the credited person.",
           "type": [
             "string",
             "null"
@@ -2806,6 +3509,25 @@
           }
         }
       }
+    },
+    "SubLabelStyle": {
+      "description": "Sub-label style for compound numeric bibliography entries.",
+      "oneOf": [
+        {
+          "description": "Alphabetic sub-labels: a, b, c, ...",
+          "type": "string",
+          "enum": [
+            "alphabetic"
+          ]
+        },
+        {
+          "description": "Numeric sub-labels: 1, 2, 3, ...",
+          "type": "string",
+          "enum": [
+            "numeric"
+          ]
+        }
+      ]
     },
     "SubsequentAuthorSubstituteRule": {
       "description": "Rules for subsequent author substitution.",
@@ -4112,14 +4834,43 @@
       "additionalProperties": false
     },
     "TermForm": {
-      "description": "Form for term lookup.",
-      "type": "string",
-      "enum": [
-        "long",
-        "short",
-        "verb",
-        "verb-short",
-        "symbol"
+      "description": "Form for term lookup.\n\nSpecifies which form variant of a term should be used in citation output.",
+      "oneOf": [
+        {
+          "description": "Long form of a term (e.g., \"page\" vs \"p.\").",
+          "type": "string",
+          "enum": [
+            "long"
+          ]
+        },
+        {
+          "description": "Short form of a term (e.g., \"p.\" vs \"page\").",
+          "type": "string",
+          "enum": [
+            "short"
+          ]
+        },
+        {
+          "description": "Verb form of a term (e.g., \"edited by\").",
+          "type": "string",
+          "enum": [
+            "verb"
+          ]
+        },
+        {
+          "description": "Short verb form of a term (e.g., \"ed.\" vs \"edited by\").",
+          "type": "string",
+          "enum": [
+            "verb-short"
+          ]
+        },
+        {
+          "description": "Symbol form of a term (e.g., \"§\" for section).",
+          "type": "string",
+          "enum": [
+            "symbol"
+          ]
+        }
       ]
     },
     "TimeFormat": {

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -28,6 +28,7 @@ fn main() {
             locator: None,
             prefix: None,
             suffix: None,
+            integral_name_state: None,
         }],
     };
 

--- a/crates/citum-engine/src/processor/document/djot.rs
+++ b/crates/citum-engine/src/processor/document/djot.rs
@@ -6,13 +6,15 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Djot document parsing and HTML conversion.
 
 use super::{
-    CitationParser, CitationPlacement, ManualNoteReference, ParsedCitation, ParsedDocument,
+    CitationParser, CitationPlacement, CitationStructure, DocumentIntegralNameOverride,
+    ManualNoteReference, ParsedCitation, ParsedDocument,
 };
 use crate::{Citation, CitationItem};
 use citum_schema::citation::{CitationMode, normalize_locator_text};
 use citum_schema::grouping::BibliographyGroup;
 use citum_schema::locale::Locale;
 use jotdown::{Attributes, Container, Event, Parser};
+use serde::Deserialize;
 use std::collections::HashSet;
 use std::ops::Range;
 use winnow::Parser as WinnowParser;
@@ -25,6 +27,27 @@ use winnow::token::{take_until, take_while};
 struct FootnoteDefinitionRange {
     label: String,
     content: Range<usize>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct DocumentFrontmatter {
+    bibliography: Option<Vec<BibliographyGroup>>,
+    integral_names: Option<DocumentIntegralNameOverride>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ScopeChange {
+    offset: usize,
+    structure: CitationStructure,
+}
+
+#[derive(Debug, Default)]
+struct ScopeTracker {
+    current_chapter: Option<String>,
+    current_section: Option<String>,
+    chapter_stack: Vec<(Option<String>, Option<String>)>,
+    section_stack: Vec<Option<String>>,
 }
 
 /// A bibliography block parsed from djot source.
@@ -61,7 +84,7 @@ fn parse_integral_modifier(input: &mut &str) -> winnow::Result<bool, ContextErro
 impl CitationParser for DjotParser {
     fn parse_document(&self, content: &str, locale: &Locale) -> ParsedDocument {
         // Try to parse frontmatter and get remaining content
-        let (frontmatter_groups, remaining_content) = parse_frontmatter(content);
+        let (frontmatter, remaining_content) = parse_frontmatter(content);
         let body_start = content.len() - remaining_content.len();
 
         let (manual_note_references, manual_note_labels, footnote_definitions) =
@@ -75,15 +98,17 @@ impl CitationParser for DjotParser {
             }
         }
 
-        let citations = find_citations(remaining_content, locale)
+        let mut citations: Vec<_> = find_citations(remaining_content, locale)
             .into_iter()
             .map(|(start, end, citation)| ParsedCitation {
                 start,
                 end,
                 citation,
                 placement: citation_placement(start, end, &footnote_definitions),
+                structure: CitationStructure::default(),
             })
             .collect();
+        annotate_citation_structures(remaining_content, &mut citations);
 
         // Scan for inline bibliography blocks in remaining content
         let bibliography_blocks = scan_bibliography_blocks(remaining_content);
@@ -94,7 +119,11 @@ impl CitationParser for DjotParser {
             manual_note_references,
             manual_note_labels,
             bibliography_blocks,
-            frontmatter_groups,
+            frontmatter_groups: frontmatter
+                .as_ref()
+                .and_then(|frontmatter| frontmatter.bibliography.clone()),
+            frontmatter_integral_names: frontmatter
+                .and_then(|frontmatter| frontmatter.integral_names),
             body_start,
         }
     }
@@ -159,6 +188,88 @@ fn citation_placement(
             label: definition.label.clone(),
         })
         .unwrap_or(CitationPlacement::InlineProse)
+}
+
+fn annotate_citation_structures(content: &str, citations: &mut [ParsedCitation]) {
+    if citations.is_empty() {
+        return;
+    }
+
+    let changes = collect_scope_changes(content);
+    for citation in citations {
+        citation.structure = scope_for_offset(&changes, citation.start);
+    }
+}
+
+fn collect_scope_changes(content: &str) -> Vec<ScopeChange> {
+    let mut tracker = ScopeTracker::default();
+    let mut changes = vec![ScopeChange {
+        offset: 0,
+        structure: tracker.current_structure(),
+    }];
+
+    for (event, range) in Parser::new(content).into_offset_iter() {
+        match event {
+            Event::Start(Container::Div { class }, _) => {
+                let classes: Vec<&str> = class.split_whitespace().collect();
+                if classes.contains(&"chapter") {
+                    tracker.enter_chapter(format!("chapter-div-{}", range.start));
+                    push_scope_change(&mut changes, range.start, tracker.current_structure());
+                }
+                if classes.contains(&"section") {
+                    tracker.enter_section(format!("section-div-{}", range.start));
+                    push_scope_change(&mut changes, range.start, tracker.current_structure());
+                }
+            }
+            Event::End(Container::Div { class }) => {
+                let classes: Vec<&str> = class.split_whitespace().collect();
+                if classes.contains(&"section") {
+                    tracker.exit_section();
+                    push_scope_change(&mut changes, range.end, tracker.current_structure());
+                }
+                if classes.contains(&"chapter") {
+                    tracker.exit_chapter();
+                    push_scope_change(&mut changes, range.end, tracker.current_structure());
+                }
+            }
+            Event::Start(
+                Container::Heading {
+                    level,
+                    id,
+                    has_section: _,
+                },
+                _,
+            ) => {
+                let scope_id = if id.is_empty() {
+                    format!("heading-{level}-{}", range.start)
+                } else {
+                    id.to_string()
+                };
+                tracker.enter_heading(level, scope_id);
+                push_scope_change(&mut changes, range.start, tracker.current_structure());
+            }
+            _ => {}
+        }
+    }
+
+    changes
+}
+
+fn push_scope_change(changes: &mut Vec<ScopeChange>, offset: usize, structure: CitationStructure) {
+    if changes
+        .last()
+        .is_none_or(|change| change.structure != structure)
+    {
+        changes.push(ScopeChange { offset, structure });
+    }
+}
+
+fn scope_for_offset(changes: &[ScopeChange], offset: usize) -> CitationStructure {
+    let index = changes.partition_point(|change| change.offset <= offset);
+    changes
+        .get(index.saturating_sub(1))
+        .map(|change| change.structure.clone())
+        .unwrap_or_default()
 }
 
 fn find_citations(content: &str, locale: &Locale) -> Vec<(usize, usize, Citation)> {
@@ -270,9 +381,64 @@ fn parse_citation_item_no_integral(
     Ok(item)
 }
 
+impl ScopeTracker {
+    fn current_structure(&self) -> CitationStructure {
+        let chapter_scope = self
+            .current_chapter
+            .clone()
+            .unwrap_or_else(|| "document".to_string());
+        let section_scope = self
+            .current_section
+            .clone()
+            .unwrap_or_else(|| chapter_scope.clone());
+        CitationStructure {
+            chapter_scope,
+            section_scope,
+        }
+    }
+
+    fn enter_chapter(&mut self, scope_id: String) {
+        self.chapter_stack
+            .push((self.current_chapter.clone(), self.current_section.clone()));
+        self.current_chapter = Some(scope_id);
+        self.current_section = None;
+    }
+
+    fn exit_chapter(&mut self) {
+        if let Some((chapter, section)) = self.chapter_stack.pop() {
+            self.current_chapter = chapter;
+            self.current_section = section;
+        }
+    }
+
+    fn enter_section(&mut self, scope_id: String) {
+        self.section_stack.push(self.current_section.clone());
+        self.current_section = Some(scope_id);
+    }
+
+    fn exit_section(&mut self) {
+        if let Some(section) = self.section_stack.pop() {
+            self.current_section = section;
+        }
+    }
+
+    fn enter_heading(&mut self, level: u16, scope_id: String) {
+        if level == 1 {
+            if self.chapter_stack.is_empty() {
+                self.current_chapter = Some(scope_id);
+                self.current_section = None;
+            } else {
+                self.current_section = Some(scope_id);
+            }
+        } else {
+            self.current_section = Some(scope_id);
+        }
+    }
+}
+
 /// Parse YAML frontmatter from content.
-/// Returns (Option<groups>, remaining_content).
-fn parse_frontmatter(content: &str) -> (Option<Vec<BibliographyGroup>>, &str) {
+/// Returns (frontmatter, remaining_content).
+fn parse_frontmatter(content: &str) -> (Option<DocumentFrontmatter>, &str) {
     let trimmed = content.trim_start();
     if !trimmed.starts_with("---") {
         return (None, content);
@@ -283,18 +449,10 @@ fn parse_frontmatter(content: &str) -> (Option<Vec<BibliographyGroup>>, &str) {
         let frontmatter_content = &after_opening[..closing_pos];
         let remaining = &after_opening[closing_pos + 3..].trim_start();
 
-        match serde_yaml::from_str::<serde_yaml::Value>(frontmatter_content) {
-            Ok(value) => {
-                if let Some(bib_value) = value.get("bibliography")
-                    && let Ok(groups) =
-                        serde_yaml::from_value::<Vec<BibliographyGroup>>(bib_value.clone())
-                {
-                    return (Some(groups), remaining);
-                }
-                (None, remaining)
-            }
-            Err(_) => (None, remaining),
-        }
+        (
+            serde_yaml::from_str::<DocumentFrontmatter>(frontmatter_content).ok(),
+            remaining,
+        )
     } else {
         (None, content)
     }

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -14,10 +14,13 @@ mod tests;
 
 use crate::Citation;
 use crate::processor::Processor;
+use crate::processor::rendering::{CompoundRenderData, Renderer};
 use citum_schema::locale::Locale;
 use citum_schema::options::{
+    IntegralNameConfig, IntegralNameContexts, IntegralNameRule, IntegralNameScope,
     NoteConfig as StyleNoteConfig, NoteMarkerOrder, NoteNumberPlacement, NoteQuotePlacement,
 };
+use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 
 const GENERATED_NOTE_LABEL_PREFIX: &str = "citum-auto-";
@@ -83,6 +86,59 @@ pub enum CitationPlacement {
     },
 }
 
+/// Structural citation scope metadata derived from the source document.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CitationStructure {
+    /// The resolved chapter-level scope key for this citation location.
+    pub chapter_scope: String,
+    /// The resolved section-level scope key for this citation location.
+    pub section_scope: String,
+}
+
+/// Document-level integral-name override parsed from frontmatter.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DocumentIntegralNameOverride {
+    /// Whether the integral-name policy is enabled for this document.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// The name-memory rule to apply.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule: Option<citum_schema::options::IntegralNameRule>,
+    /// Where name-memory resets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<citum_schema::options::IntegralNameScope>,
+    /// Which document contexts participate in the policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<citum_schema::options::IntegralNameContexts>,
+    /// The contributor form used after the first mention.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subsequent_form: Option<citum_schema::options::IntegralNameForm>,
+}
+
+impl DocumentIntegralNameOverride {
+    fn apply_to(&self, base: Option<&IntegralNameConfig>) -> Option<IntegralNameConfig> {
+        if self.enabled == Some(false) {
+            return None;
+        }
+
+        let mut result = base.cloned().unwrap_or_default();
+        if self.rule.is_some() {
+            result.rule = self.rule;
+        }
+        if self.scope.is_some() {
+            result.scope = self.scope;
+        }
+        if self.contexts.is_some() {
+            result.contexts = self.contexts;
+        }
+        if self.subsequent_form.is_some() {
+            result.subsequent_form = self.subsequent_form;
+        }
+        Some(result)
+    }
+}
+
 /// A citation marker parsed from a document.
 #[derive(Debug, Clone)]
 pub struct ParsedCitation {
@@ -94,6 +150,8 @@ pub struct ParsedCitation {
     pub citation: Citation,
     /// Where the citation was found in the source document.
     pub placement: CitationPlacement,
+    /// Structural scope metadata for this citation location.
+    pub structure: CitationStructure,
 }
 
 #[derive(Debug, Clone)]
@@ -115,6 +173,8 @@ pub struct ParsedDocument {
     pub bibliography_blocks: Vec<djot::BibliographyBlock>,
     /// Bibliography groups from YAML frontmatter.
     pub frontmatter_groups: Option<Vec<citum_schema::grouping::BibliographyGroup>>,
+    /// Integral-name override from YAML frontmatter.
+    pub frontmatter_integral_names: Option<DocumentIntegralNameOverride>,
     /// Byte offset where the document body starts (past any frontmatter).
     pub body_start: usize,
 }
@@ -157,6 +217,49 @@ struct GeneratedNote {
     note_number: u32,
 }
 
+#[derive(Debug, Default)]
+struct HtmlPlaceholderRegistry {
+    next_index: usize,
+    inline_replacements: Vec<(String, String)>,
+    block_replacements: Vec<(String, String)>,
+}
+
+impl HtmlPlaceholderRegistry {
+    fn push_inline(&mut self, html: String) -> String {
+        let token = self.next_token("INLINE");
+        self.inline_replacements.push((token.clone(), html));
+        token
+    }
+
+    fn push_block(&mut self, html: String) -> String {
+        let token = self.next_token("BLOCK");
+        self.block_replacements.push((token.clone(), html));
+        token
+    }
+
+    fn apply(self, rendered: String) -> String {
+        let mut output = rendered;
+
+        for (token, html) in self.block_replacements {
+            let paragraph = format!("<p>{token}</p>");
+            output = output.replace(&paragraph, &html);
+            output = output.replace(&token, &html);
+        }
+
+        for (token, html) in self.inline_replacements {
+            output = output.replace(&token, &html);
+        }
+
+        output
+    }
+
+    fn next_token(&mut self, kind: &str) -> String {
+        let token = format!("CITUMHTML{kind}TOKEN{}", self.next_index);
+        self.next_index = self.next_index.saturating_add(1);
+        token
+    }
+}
+
 #[derive(Debug, Clone)]
 enum NoteOccurrence {
     Manual { label: String, start: usize },
@@ -171,7 +274,71 @@ impl NoteOccurrence {
     }
 }
 
+#[derive(Debug, Clone)]
+struct IntegralNameContext {
+    placement: CitationPlacement,
+    structure: CitationStructure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeenIntegralNameState {
+    Unseen,
+    NoteOnlySeen,
+    BodySeen,
+}
+
 impl Processor {
+    fn normalize_inline_document_citations(&self, parsed: &ParsedDocument) -> Vec<Citation> {
+        let mut normalized: Vec<Citation> = parsed
+            .citations
+            .iter()
+            .map(|parsed| parsed.citation.clone())
+            .collect();
+        let ordered_indices = build_integral_name_order_indices(parsed);
+        let mut ordered_citations: Vec<Citation> = ordered_indices
+            .iter()
+            .map(|index| normalized[*index].clone())
+            .collect();
+        let ordered_contexts: Vec<_> = ordered_indices
+            .iter()
+            .map(|index| IntegralNameContext {
+                placement: parsed.citations[*index].placement.clone(),
+                structure: parsed.citations[*index].structure.clone(),
+            })
+            .collect();
+        self.annotate_integral_name_states(&mut ordered_citations, &ordered_contexts);
+        for (citation, index) in ordered_citations
+            .into_iter()
+            .zip(ordered_indices.into_iter())
+        {
+            normalized[index] = citation;
+        }
+        self.normalize_note_context(&normalized)
+    }
+
+    fn processor_with_document_integral_name_override(
+        &self,
+        override_config: Option<&DocumentIntegralNameOverride>,
+    ) -> Option<Self> {
+        let override_config = override_config?;
+        let mut style = self.style.clone();
+        let base = style
+            .options
+            .as_ref()
+            .and_then(|options| options.integral_names.as_ref());
+        let applied = override_config.apply_to(base);
+        style
+            .options
+            .get_or_insert_with(Default::default)
+            .integral_names = applied;
+        Some(Self::with_locale_and_compound_sets(
+            style,
+            self.bibliography.clone(),
+            self.locale.clone(),
+            self.compound_sets.clone(),
+        ))
+    }
+
     /// Process citations in a document and append a bibliography.
     pub fn process_document<P, F>(
         &self,
@@ -184,6 +351,10 @@ impl Processor {
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let parsed = parser.parse_document(content, &self.locale);
+        let owned_processor = self.processor_with_document_integral_name_override(
+            parsed.frontmatter_integral_names.as_ref(),
+        );
+        let processor = owned_processor.as_ref().unwrap_or(self);
 
         // Strip any frontmatter from the content passed to rendering.
         let body = &content[parsed.body_start..];
@@ -195,15 +366,35 @@ impl Processor {
         // Handle frontmatter groups if present (check before inline blocks)
         if has_frontmatter {
             let groups = parsed.frontmatter_groups.as_ref().unwrap().clone();
-            let rendered = if self.is_note_style() {
-                self.process_note_document::<F>(body, parsed)
+            let rendered = if matches!(format, DocumentFormat::Html) {
+                let mut placeholders = HtmlPlaceholderRegistry::default();
+                let rendered = if processor.is_note_style() {
+                    processor.process_note_document_html(body, parsed, &mut placeholders)
+                } else {
+                    processor.process_inline_document_html(body, parsed, &mut placeholders)
+                };
+                let bib_content = rewrite_group_headings_for_document(
+                    processor.render_with_custom_groups::<F>(
+                        &processor.process_references().bibliography,
+                        &groups,
+                    ),
+                    format,
+                );
+                let bib_heading = "\n\n# Bibliography\n\n";
+                let mut result = rendered;
+                result.push_str(bib_heading);
+                result.push_str(&placeholders.push_block(bib_content));
+                let html = self::djot::djot_to_html(&result);
+                return placeholders.apply(html);
+            } else if processor.is_note_style() {
+                processor.process_note_document::<F>(body, parsed)
             } else {
-                self.process_inline_document::<F>(body, parsed)
+                processor.process_inline_document::<F>(body, parsed)
             };
 
             let bib_content = rewrite_group_headings_for_document(
-                self.render_with_custom_groups::<F>(
-                    &self.process_references().bibliography,
+                processor.render_with_custom_groups::<F>(
+                    &processor.process_references().bibliography,
                     &groups,
                 ),
                 format,
@@ -240,10 +431,40 @@ impl Processor {
 
             // Re-parse on the placeholder content so citation offsets are correct.
             let parsed_staged = parser.parse_document(&staged, &self.locale);
-            let rendered = if self.is_note_style() {
-                self.process_note_document::<F>(&staged, parsed_staged)
+            let rendered = if matches!(format, DocumentFormat::Html) {
+                let mut placeholders = HtmlPlaceholderRegistry::default();
+                let rendered = if processor.is_note_style() {
+                    processor.process_note_document_html(&staged, parsed_staged, &mut placeholders)
+                } else {
+                    processor.process_inline_document_html(
+                        &staged,
+                        parsed_staged,
+                        &mut placeholders,
+                    )
+                };
+
+                let mut result = rendered;
+                for (i, block) in blocks.iter().enumerate() {
+                    let placeholder = format!("\x00BIBBLOCK{i}\x00");
+                    let mut headingless = block.group.clone();
+                    let heading = headingless.heading.take();
+                    let bib_content = processor.render_bibliography_for_group::<F>(&headingless);
+                    let bib_token = placeholders.push_block(bib_content);
+                    let replacement = if let Some(h) = heading {
+                        let heading_text = processor.resolve_group_heading(&h).unwrap_or_default();
+                        format!("## {heading_text}\n\n{bib_token}\n")
+                    } else {
+                        format!("{bib_token}\n")
+                    };
+                    result = result.replace(&placeholder, &replacement);
+                }
+
+                let html = self::djot::djot_to_html(&result);
+                return placeholders.apply(html);
+            } else if processor.is_note_style() {
+                processor.process_note_document::<F>(&staged, parsed_staged)
             } else {
-                self.process_inline_document::<F>(&staged, parsed_staged)
+                processor.process_inline_document::<F>(&staged, parsed_staged)
             };
 
             // Swap placeholders for rendered bibliographies.
@@ -254,9 +475,9 @@ impl Processor {
                 // we emit the heading ourselves at the correct document level (##).
                 let mut headingless = block.group.clone();
                 let heading = headingless.heading.take();
-                let bib_content = self.render_bibliography_for_group::<F>(&headingless);
+                let bib_content = processor.render_bibliography_for_group::<F>(&headingless);
                 let replacement = if let Some(h) = heading {
-                    let heading_text = self.resolve_group_heading(&h).unwrap_or_default();
+                    let heading_text = processor.resolve_group_heading(&h).unwrap_or_default();
                     let prefix = match format {
                         DocumentFormat::Latex => format!("\\subsection*{{{heading_text}}}\n\n"),
                         DocumentFormat::Typst => format!("== {heading_text}\n\n"),
@@ -280,10 +501,25 @@ impl Processor {
         }
 
         // Default behavior: append bibliography with heading
-        let rendered = if self.is_note_style() {
-            self.process_note_document::<F>(body, parsed)
+        let rendered = if matches!(format, DocumentFormat::Html) {
+            let mut placeholders = HtmlPlaceholderRegistry::default();
+            let rendered = if processor.is_note_style() {
+                processor.process_note_document_html(body, parsed, &mut placeholders)
+            } else {
+                processor.process_inline_document_html(body, parsed, &mut placeholders)
+            };
+
+            let mut result = rendered;
+            result.push_str("\n\n# Bibliography\n\n");
+            result.push_str(
+                &placeholders.push_block(processor.render_grouped_bibliography_with_format::<F>()),
+            );
+            let html = self::djot::djot_to_html(&result);
+            return placeholders.apply(html);
+        } else if processor.is_note_style() {
+            processor.process_note_document::<F>(body, parsed)
         } else {
-            self.process_inline_document::<F>(body, parsed)
+            processor.process_inline_document::<F>(body, parsed)
         };
 
         let bib_heading = match format {
@@ -293,7 +529,7 @@ impl Processor {
         };
         let mut result = rendered;
         result.push_str(bib_heading);
-        result.push_str(&self.render_grouped_bibliography_with_format::<F>());
+        result.push_str(&processor.render_grouped_bibliography_with_format::<F>());
         let result = rewrite_document_markup_for_typst(result, format);
 
         match format {
@@ -305,23 +541,128 @@ impl Processor {
         }
     }
 
+    fn annotate_integral_name_states(
+        &self,
+        citations: &mut [Citation],
+        contexts: &[IntegralNameContext],
+    ) {
+        let citation_config = self.get_citation_config();
+        let Some(config) = citation_config
+            .integral_names
+            .as_ref()
+            .map(|cfg| cfg.resolve())
+        else {
+            return;
+        };
+        if !matches!(config.rule, IntegralNameRule::FullThenShort) {
+            return;
+        }
+
+        let mut seen: HashMap<(String, String), SeenIntegralNameState> = HashMap::new();
+        for (citation, context) in citations.iter_mut().zip(contexts.iter()) {
+            if !matches!(
+                citation.mode,
+                citum_schema::citation::CitationMode::Integral
+            ) {
+                continue;
+            }
+
+            let is_body = matches!(context.placement, CitationPlacement::InlineProse);
+            if matches!(config.contexts, IntegralNameContexts::BodyOnly) && !is_body {
+                continue;
+            }
+
+            let scope_key = match config.scope {
+                IntegralNameScope::Document => "document".to_string(),
+                IntegralNameScope::Chapter => context.structure.chapter_scope.clone(),
+                IntegralNameScope::Section => context.structure.section_scope.clone(),
+            };
+
+            for item in &mut citation.items {
+                if item.integral_name_state.is_some() {
+                    continue;
+                }
+
+                let key = (scope_key.clone(), item.id.clone());
+                let state = seen
+                    .get(&key)
+                    .copied()
+                    .unwrap_or(SeenIntegralNameState::Unseen);
+                let derived = match config.contexts {
+                    IntegralNameContexts::BodyOnly => {
+                        if matches!(state, SeenIntegralNameState::BodySeen) {
+                            citum_schema::citation::IntegralNameState::Subsequent
+                        } else {
+                            seen.insert(key, SeenIntegralNameState::BodySeen);
+                            citum_schema::citation::IntegralNameState::First
+                        }
+                    }
+                    IntegralNameContexts::BodyAndNotes => {
+                        if is_body {
+                            match state {
+                                SeenIntegralNameState::BodySeen => {
+                                    citum_schema::citation::IntegralNameState::Subsequent
+                                }
+                                SeenIntegralNameState::Unseen
+                                | SeenIntegralNameState::NoteOnlySeen => {
+                                    seen.insert(key, SeenIntegralNameState::BodySeen);
+                                    citum_schema::citation::IntegralNameState::First
+                                }
+                            }
+                        } else {
+                            match state {
+                                SeenIntegralNameState::Unseen => {
+                                    seen.insert(key, SeenIntegralNameState::NoteOnlySeen);
+                                    citum_schema::citation::IntegralNameState::First
+                                }
+                                SeenIntegralNameState::NoteOnlySeen
+                                | SeenIntegralNameState::BodySeen => {
+                                    citum_schema::citation::IntegralNameState::Subsequent
+                                }
+                            }
+                        }
+                    }
+                };
+                item.integral_name_state = Some(derived);
+            }
+        }
+    }
+
     fn process_inline_document<F>(&self, content: &str, parsed: ParsedDocument) -> String
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let mut result = String::new();
         let mut last_idx = 0;
-        let citation_models: Vec<Citation> = parsed
-            .citations
-            .iter()
-            .map(|parsed| parsed.citation.clone())
-            .collect();
-        let normalized = self.normalize_note_context(&citation_models);
+        let normalized = self.normalize_inline_document_citations(&parsed);
 
         for (parsed, citation) in parsed.citations.iter().zip(normalized.into_iter()) {
             result.push_str(&content[last_idx..parsed.start]);
             match self.process_citation_with_format::<F>(&citation) {
                 Ok(rendered) => result.push_str(&rendered),
+                Err(_) => result.push_str(&content[parsed.start..parsed.end]),
+            }
+            last_idx = parsed.end;
+        }
+
+        result.push_str(&content[last_idx..]);
+        result
+    }
+
+    fn process_inline_document_html(
+        &self,
+        content: &str,
+        parsed: ParsedDocument,
+        placeholders: &mut HtmlPlaceholderRegistry,
+    ) -> String {
+        let mut result = String::new();
+        let mut last_idx = 0;
+        let normalized = self.normalize_inline_document_citations(&parsed);
+
+        for (parsed, citation) in parsed.citations.iter().zip(normalized.into_iter()) {
+            result.push_str(&content[last_idx..parsed.start]);
+            match self.process_citation_with_format::<crate::render::html::Html>(&citation) {
+                Ok(rendered) => result.push_str(&placeholders.push_inline(rendered)),
                 Err(_) => result.push_str(&content[parsed.start..parsed.end]),
             }
             last_idx = parsed.end;
@@ -350,12 +691,21 @@ impl Processor {
                     } else {
                         result.push_str(&content[parsed_citation.start..parsed_citation.end]);
                     }
+                    last_idx = parsed_citation.end;
                 }
                 CitationPlacement::InlineProse => {
                     if let Some(note) = generated_notes
                         .iter()
                         .find(|note| note.citation_index == index)
                     {
+                        if matches!(
+                            parsed_citation.citation.mode,
+                            citum_schema::citation::CitationMode::Integral
+                        ) && let Ok(anchor) = self
+                            .render_note_integral_anchor_with_format::<F>(&parsed_citation.citation)
+                        {
+                            result.push_str(&anchor);
+                        }
                         let consumed_right = render_note_reference_in_prose(
                             &mut result,
                             &content[parsed_citation.end..],
@@ -388,14 +738,10 @@ impl Processor {
         result
     }
 
-    fn prepare_note_citations<F>(
+    fn prepare_note_citation_state(
         &self,
-        content: &str,
         parsed: &mut ParsedDocument,
-    ) -> (Vec<GeneratedNote>, HashMap<usize, String>)
-    where
-        F: crate::render::format::OutputFormat<Output = String>,
-    {
+    ) -> (Vec<GeneratedNote>, HashMap<String, Vec<usize>>) {
         let mut used_labels = parsed.manual_note_labels.clone();
         let mut manual_numbers: HashMap<String, u32> = HashMap::new();
         let mut manual_citations: HashMap<String, Vec<usize>> = HashMap::new();
@@ -433,7 +779,6 @@ impl Processor {
 
         let mut next_note = 1_u32;
         let mut generated_notes = Vec::new();
-        let mut rendered_notes = HashMap::new();
         for occurrence in &note_occurrences {
             match occurrence {
                 NoteOccurrence::Manual { label, .. } => {
@@ -490,6 +835,14 @@ impl Processor {
             .iter()
             .map(|index| parsed.citations[*index].citation.clone())
             .collect();
+        let ordered_contexts: Vec<_> = ordered_indices
+            .iter()
+            .map(|index| IntegralNameContext {
+                placement: parsed.citations[*index].placement.clone(),
+                structure: parsed.citations[*index].structure.clone(),
+            })
+            .collect();
+        self.annotate_integral_name_states(&mut ordered_citations, &ordered_contexts);
         ordered_citations = self.normalize_note_context(&ordered_citations);
         self.annotate_positions(&mut ordered_citations);
 
@@ -501,11 +854,26 @@ impl Processor {
         }
 
         generated_notes.sort_by_key(|note| note.note_number);
+        (generated_notes, manual_citations)
+    }
+
+    fn prepare_note_citations<F>(
+        &self,
+        content: &str,
+        parsed: &mut ParsedDocument,
+    ) -> (Vec<GeneratedNote>, HashMap<usize, String>)
+    where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        let (generated_notes, manual_citations) = self.prepare_note_citation_state(parsed);
+        let mut rendered_notes: HashMap<usize, String> = HashMap::new();
+
         for generated in &generated_notes {
+            let note_citation = self.note_render_citation_for_generated(
+                &parsed.citations[generated.citation_index].citation,
+            );
             let rendered = self
-                .process_citation_with_format::<F>(
-                    &parsed.citations[generated.citation_index].citation,
-                )
+                .process_citation_with_format::<F>(&note_citation)
                 .unwrap_or_else(|_| {
                     content[parsed.citations[generated.citation_index].start
                         ..parsed.citations[generated.citation_index].end]
@@ -523,15 +891,198 @@ impl Processor {
                         content[parsed.citations[index].start..parsed.citations[index].end]
                             .to_string()
                     });
-                rendered_notes.insert(index, rendered);
+                rendered_notes.insert(
+                    index,
+                    adjust_manual_note_citation_rendering(
+                        &rendered,
+                        &content[parsed.citations[index].end..],
+                    ),
+                );
             }
         }
 
         (generated_notes, rendered_notes)
     }
+
+    fn prepare_note_citations_html(
+        &self,
+        content: &str,
+        parsed: &mut ParsedDocument,
+        placeholders: &mut HtmlPlaceholderRegistry,
+    ) -> (Vec<GeneratedNote>, HashMap<usize, String>) {
+        let (generated_notes, manual_citations) = self.prepare_note_citation_state(parsed);
+        let mut rendered_notes = HashMap::new();
+
+        for generated in &generated_notes {
+            let note_citation = self.note_render_citation_for_generated(
+                &parsed.citations[generated.citation_index].citation,
+            );
+            let rendered = self
+                .process_citation_with_format::<crate::render::html::Html>(&note_citation)
+                .unwrap_or_else(|_| {
+                    content[parsed.citations[generated.citation_index].start
+                        ..parsed.citations[generated.citation_index].end]
+                        .to_string()
+                });
+            rendered_notes.insert(generated.citation_index, placeholders.push_inline(rendered));
+        }
+
+        for indices in manual_citations.values() {
+            for index in indices {
+                let rendered = self
+                    .process_citation_with_format::<crate::render::html::Html>(
+                        &parsed.citations[*index].citation,
+                    )
+                    .unwrap_or_else(|_| {
+                        content[parsed.citations[*index].start..parsed.citations[*index].end]
+                            .to_string()
+                    });
+                rendered_notes.insert(
+                    *index,
+                    placeholders.push_inline(adjust_manual_note_citation_rendering(
+                        &rendered,
+                        &content[parsed.citations[*index].end..],
+                    )),
+                );
+            }
+        }
+
+        (generated_notes, rendered_notes)
+    }
+
+    fn process_note_document_html(
+        &self,
+        content: &str,
+        mut parsed: ParsedDocument,
+        placeholders: &mut HtmlPlaceholderRegistry,
+    ) -> String {
+        let (generated_notes, rendered_notes) =
+            self.prepare_note_citations_html(content, &mut parsed, placeholders);
+        let note_rule = self.note_rule();
+
+        let mut result = String::new();
+        let mut last_idx = 0;
+        for (index, parsed_citation) in parsed.citations.iter().enumerate() {
+            result.push_str(&content[last_idx..parsed_citation.start]);
+            match &parsed_citation.placement {
+                CitationPlacement::ManualFootnote { .. } => {
+                    if let Some(rendered) = rendered_notes.get(&index) {
+                        result.push_str(rendered);
+                    } else {
+                        result.push_str(&content[parsed_citation.start..parsed_citation.end]);
+                    }
+                    last_idx = parsed_citation.end;
+                }
+                CitationPlacement::InlineProse => {
+                    if let Some(note) = generated_notes
+                        .iter()
+                        .find(|note| note.citation_index == index)
+                    {
+                        if matches!(
+                            parsed_citation.citation.mode,
+                            citum_schema::citation::CitationMode::Integral
+                        ) && let Ok(anchor) = self
+                            .render_note_integral_anchor_with_format::<crate::render::html::Html>(
+                                &parsed_citation.citation,
+                            )
+                        {
+                            result.push_str(&placeholders.push_inline(anchor));
+                        }
+                        let consumed_right = render_note_reference_in_prose(
+                            &mut result,
+                            &content[parsed_citation.end..],
+                            &format!("[^{}]", note.label),
+                            note_rule,
+                        );
+                        last_idx = parsed_citation.end + consumed_right;
+                    } else {
+                        result.push_str(&content[parsed_citation.start..parsed_citation.end]);
+                        last_idx = parsed_citation.end;
+                    }
+                }
+            }
+        }
+        result.push_str(&content[last_idx..]);
+
+        if !generated_notes.is_empty() {
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            result.push('\n');
+
+            for note in &generated_notes {
+                if let Some(rendered) = rendered_notes.get(&note.citation_index) {
+                    result.push_str(&format!("[^{}]: {}\n", note.label, rendered));
+                }
+            }
+        }
+
+        result
+    }
 }
 
 impl Processor {
+    fn note_render_citation_for_generated(&self, citation: &Citation) -> Citation {
+        let mut note_citation = citation.clone();
+        if matches!(
+            note_citation.mode,
+            citum_schema::citation::CitationMode::Integral
+        ) {
+            note_citation.mode = citum_schema::citation::CitationMode::NonIntegral;
+        }
+        note_citation
+    }
+
+    fn render_note_integral_anchor_with_format<F>(
+        &self,
+        citation: &Citation,
+    ) -> Result<String, crate::error::ProcessorError>
+    where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        let default_spec = citum_schema::CitationSpec::default();
+        let effective_spec = self.style.citation.as_ref().map_or_else(
+            || std::borrow::Cow::Borrowed(&default_spec),
+            |cs| {
+                let position_resolved = cs.resolve_for_position(citation.position.as_ref());
+                let spec_for_mode = position_resolved.into_owned();
+                std::borrow::Cow::Owned(
+                    spec_for_mode
+                        .resolve_for_mode(&citum_schema::citation::CitationMode::Integral)
+                        .into_owned(),
+                )
+            },
+        );
+
+        let sorted_items = self.sort_citation_items(citation.items.clone(), &effective_spec);
+        let inter_delimiter = effective_spec
+            .multi_cite_delimiter
+            .as_deref()
+            .unwrap_or("; ");
+
+        let renderer = Renderer::new(
+            &self.style,
+            &self.bibliography,
+            &self.locale,
+            self.get_config(),
+            &self.hints,
+            &self.citation_numbers,
+            CompoundRenderData {
+                set_by_ref: &self.compound_set_by_ref,
+                member_index: &self.compound_member_index,
+                sets: &self.compound_sets,
+            },
+        );
+
+        renderer.render_integral_anchor_with_format::<F>(
+            &sorted_items,
+            &effective_spec,
+            inter_delimiter,
+            citation.suppress_author,
+            citation.position.as_ref(),
+        )
+    }
+
     fn note_rule(&self) -> NoteRule {
         if let Some(notes) = self.get_config().notes.as_ref() {
             return merge_note_rule(self.locale_note_rule(), notes);
@@ -852,6 +1403,40 @@ fn build_note_order_indices(
     ordered
 }
 
+fn build_integral_name_order_indices(parsed: &ParsedDocument) -> Vec<usize> {
+    let mut manual_citations: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut note_occurrences: Vec<NoteOccurrence> = parsed
+        .manual_note_references
+        .iter()
+        .map(|note| NoteOccurrence::Manual {
+            label: note.label.clone(),
+            start: note.start,
+        })
+        .collect();
+
+    for (index, parsed_citation) in parsed.citations.iter().enumerate() {
+        match &parsed_citation.placement {
+            CitationPlacement::InlineProse => note_occurrences.push(NoteOccurrence::Generated {
+                citation_index: index,
+                start: parsed_citation.start,
+            }),
+            CitationPlacement::ManualFootnote { label } => {
+                manual_citations
+                    .entry(label.clone())
+                    .or_default()
+                    .push(index);
+            }
+        }
+    }
+
+    for indices in manual_citations.values_mut() {
+        indices.sort_by_key(|index| parsed.citations[*index].start);
+    }
+
+    note_occurrences.sort_by_key(NoteOccurrence::start);
+    build_note_order_indices(&note_occurrences, &manual_citations)
+}
+
 fn next_generated_note_label(used_labels: &mut HashSet<String>, note_number: u32) -> String {
     let mut candidate = note_number;
     loop {
@@ -861,4 +1446,40 @@ fn next_generated_note_label(used_labels: &mut HashSet<String>, note_number: u32
         }
         candidate = candidate.saturating_add(1);
     }
+}
+
+fn adjust_manual_note_citation_rendering(rendered: &str, right: &str) -> String {
+    let trimmed_right = right.trim_start_matches([' ', '\t']);
+    if trimmed_right.is_empty() || trimmed_right.starts_with('\n') {
+        return rendered.to_string();
+    }
+
+    trim_visible_terminal_period(rendered)
+}
+
+fn trim_visible_terminal_period(rendered: &str) -> String {
+    let mut cut = rendered.len();
+    loop {
+        cut = rendered[..cut].trim_end().len();
+
+        if !rendered[..cut].ends_with('>') {
+            break;
+        }
+
+        let Some(tag_start) = rendered[..cut].rfind("</") else {
+            break;
+        };
+        let tag = &rendered[tag_start..cut];
+        if tag.ends_with('>') && !tag[2..tag.len() - 1].contains('<') {
+            cut = tag_start;
+            continue;
+        }
+        break;
+    }
+
+    let Some((period_idx, '.')) = rendered[..cut].char_indices().next_back() else {
+        return rendered.to_string();
+    };
+
+    format!("{}{}", &rendered[..period_idx], &rendered[cut..])
 }

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -4,7 +4,9 @@ use crate::reference::{Bibliography, Reference};
 use crate::render::plain::PlainText;
 use crate::render::typst::Typst;
 use citum_schema::options::{
-    Config, NoteConfig, NoteMarkerOrder, NoteNumberPlacement, NoteQuotePlacement, Processing,
+    Config, IntegralNameConfig, IntegralNameContexts, IntegralNameForm, IntegralNameRule,
+    IntegralNameScope, NoteConfig, NoteMarkerOrder, NoteNumberPlacement, NoteQuotePlacement,
+    Processing,
 };
 use citum_schema::template::{
     ContributorForm, ContributorRole, DateForm, DateVariable, Rendering, TemplateComponent,
@@ -156,6 +158,67 @@ fn make_note_style_with_rules(notes: NoteConfig) -> Style {
     style
 }
 
+fn make_integral_name_style(scope: IntegralNameScope, contexts: IntegralNameContexts) -> Style {
+    Style {
+        options: Some(Config {
+            processing: Some(Processing::AuthorDate),
+            integral_names: Some(IntegralNameConfig {
+                rule: Some(IntegralNameRule::FullThenShort),
+                scope: Some(scope),
+                contexts: Some(contexts),
+                subsequent_form: Some(IntegralNameForm::Short),
+            }),
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            template: Some(vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author,
+                    form: ContributorForm::Short,
+                    ..Default::default()
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::Issued,
+                    form: DateForm::Year,
+                    rendering: Rendering::default(),
+                    ..Default::default()
+                }),
+            ]),
+            integral: Some(Box::new(CitationSpec {
+                template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author,
+                    form: ContributorForm::Long,
+                    ..Default::default()
+                })]),
+                ..Default::default()
+            })),
+            wrap: Some(WrapPunctuation::Parentheses),
+            ..Default::default()
+        }),
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author,
+                    form: ContributorForm::Long,
+                    ..Default::default()
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::Issued,
+                    form: DateForm::Year,
+                    rendering: Rendering {
+                        prefix: Some(" (".to_string()),
+                        suffix: Some(")".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
 #[test]
 fn test_author_date_documents_still_render_inline() {
     let bib = make_test_bib();
@@ -201,6 +264,27 @@ fn test_manual_footnote_citations_render_in_place() {
     assert!(result.contains("[^m1]: See"));
     assert!(result.contains("Book One"));
     assert!(!result.contains("citum-auto-"));
+}
+
+#[test]
+fn test_manual_footnote_definition_is_not_duplicated() {
+    let bib = make_test_bib();
+    let processor = Processor::new(make_note_style(), bib);
+    let parser = DjotParser;
+
+    let content = "Text[^m1].\n\n[^m1]: See [@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert_eq!(
+        result.matches("[^m1]:").count(),
+        1,
+        "manual note duplicated: {result}"
+    );
+    assert!(
+        !result.contains("[@item1]"),
+        "raw citation leaked: {result}"
+    );
 }
 
 #[test]
@@ -349,6 +433,25 @@ fn test_note_style_html_output_contains_footnotes() {
 
     assert!(result.contains("role=\"doc-noteref\""));
     assert!(result.contains("role=\"doc-endnotes\""));
+}
+
+#[test]
+fn test_note_style_integral_citation_keeps_prose_anchor() {
+    let style: Style = serde_yaml::from_str(include_str!(
+        "../../../../../styles/chicago-shortened-notes-bibliography.yaml"
+    ))
+    .unwrap();
+    let bib = make_test_bib();
+    let processor = Processor::new(style, bib);
+    let parser = DjotParser;
+
+    let content = "Narrative [+@item1] continues.";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("Narrative Doe[^citum-auto-1] continues."));
+    assert!(result.contains("[^citum-auto-1]: Doe,"));
+    assert!(result.contains("Book One"));
 }
 
 #[test]
@@ -548,4 +651,214 @@ Some text [@item1]."#;
     assert!(result.contains("== Primary Sources"));
     assert!(result.contains("== Secondary Sources"));
     assert!(!result.contains("## Primary Sources"));
+}
+
+#[test]
+fn test_integral_name_memory_full_then_short_in_one_document() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Document,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = "First [+@item1]. Later [+@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("First John Doe. Later Doe."));
+}
+
+#[test]
+fn test_integral_name_memory_chapter_reset_uses_full_name_again() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Chapter,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = "# One\n\n[+@item1]. [+@item1].\n\n# Two\n\n[+@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("John Doe. Doe."));
+    assert!(result.contains("# Two\n\nJohn Doe."));
+}
+
+#[test]
+fn test_integral_name_memory_section_reset_uses_full_name_again() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Section,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = "## One\n\n[+@item1]. [+@item1].\n\n## Two\n\n[+@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("John Doe. Doe."));
+    assert!(result.contains("## Two\n\nJohn Doe."));
+}
+
+#[test]
+fn test_integral_name_memory_body_only_ignores_note_mentions() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(IntegralNameScope::Document, IntegralNameContexts::BodyOnly),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content =
+        "Lead[^n1]. First body [+@item1]. Later body [+@item1].\n\n[^n1]: Note [+@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("[^n1]: Note John Doe."));
+    assert!(result.contains("First body John Doe. Later body Doe."));
+}
+
+#[test]
+fn test_integral_name_memory_body_and_notes_keeps_body_first_after_note_first() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Document,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = "Lead[^n1]. First body [+@item1].\n\n[^n1]: First note [+@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("[^n1]: First note John Doe."));
+    assert!(result.contains("First body John Doe."));
+}
+
+#[test]
+fn test_integral_name_memory_repeated_note_then_body_transitions_correctly() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Document,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = "Lead[^n1] and again[^n2]. First body [+@item1]. Later[^n3].\n\n[^n1]: One [+@item1].\n\n[^n2]: Two [+@item1].\n\n[^n3]: Three [+@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("[^n1]: One John Doe."));
+    assert!(result.contains("[^n2]: Two Doe."));
+    assert!(result.contains("First body John Doe."));
+    assert!(result.contains("[^n3]: Three Doe."));
+}
+
+#[test]
+fn test_document_frontmatter_can_disable_integral_name_memory() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Document,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = r#"---
+integral-names:
+  enabled: false
+---
+
+First [+@item1]. Later [+@item1]."#;
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("First John Doe. Later John Doe."));
+}
+
+#[test]
+fn test_document_frontmatter_can_override_integral_name_scope_for_typst() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Document,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = r#"---
+integral-names:
+  enabled: true
+  scope: chapter
+---
+
+# One
+
+[+@item1]. [+@item1].
+
+# Two
+
+[+@item1]."#;
+    let result = processor.process_document::<_, Typst>(content, &parser, DocumentFormat::Typst);
+
+    assert!(result.contains("#link(<ref-item1>)[John Doe]. #link(<ref-item1>)[Doe]."));
+    assert!(result.contains("= Two\n\n#link(<ref-item1>)[John Doe]."));
+}
+
+#[test]
+fn test_document_frontmatter_ignores_unknown_keys() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Document,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = r#"---
+title: Sample Essay
+author: Example Author
+bibliography:
+  - id: cited
+    heading:
+      literal: "Cited Works"
+    selector:
+      cited: visible
+integral-names:
+  enabled: true
+  scope: document
+  contexts: body-and-notes
+---
+
+First [+@item1]. Later [+@item1]."#;
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert!(result.contains("First John Doe. Later Doe."));
+    assert!(result.contains("# Bibliography"));
+    assert!(result.contains("Cited Works"));
 }

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -694,6 +694,7 @@ impl<'a> Renderer<'a> {
                     loc_value.as_deref(),
                     loc_label,
                     position,
+                    item.integral_name_state,
                 ) {
                     let item_str = crate::render::citation::citation_to_string_with_format::<F>(
                         &proc,
@@ -847,6 +848,7 @@ impl<'a> Renderer<'a> {
                     loc_value.as_deref(),
                     loc_label,
                     position,
+                    first_item.integral_name_state,
                 ) {
                     // Use integral-specific delimiter, defaulting to space for narrative
                     let integral_delimiter = spec.delimiter.as_deref().unwrap_or(" ");
@@ -909,6 +911,7 @@ impl<'a> Renderer<'a> {
                         loc_value.as_deref(),
                         loc_label,
                         position,
+                        item.integral_name_state,
                     ) {
                         let item_str = crate::render::citation::citation_to_string_with_format::<F>(
                             &proc,
@@ -940,8 +943,14 @@ impl<'a> Renderer<'a> {
             }
 
             // Fallback to default hardcoded grouping (or if no integral template)
-            let author_part = self
-                .render_author_for_grouping_with_format::<F>(first_ref, template, mode, position);
+            let author_part = self.render_author_for_grouping_with_format::<F>(
+                first_ref,
+                first_item,
+                template,
+                mode,
+                suppress_author,
+                position,
+            );
 
             let mut item_parts = Vec::new();
             let mut group_delimiter: Option<String> = None;
@@ -979,6 +988,7 @@ impl<'a> Renderer<'a> {
                     loc_value.as_deref(),
                     loc_label,
                     position,
+                    item.integral_name_state,
                 ) {
                     let item_str = crate::render::citation::citation_to_string_with_format::<F>(
                         &proc,
@@ -1090,11 +1100,13 @@ impl<'a> Renderer<'a> {
     }
 
     /// Render just the author part for citation grouping.
-    fn render_author_for_grouping_with_format<F>(
+    pub(crate) fn render_author_for_grouping_with_format<F>(
         &self,
         reference: &Reference,
+        item: &crate::reference::CitationItem,
         template: &[TemplateComponent],
         mode: &citum_schema::citation::CitationMode,
+        suppress_author: bool,
         position: Option<&citum_schema::citation::Position>,
     ) -> String
     where
@@ -1105,7 +1117,7 @@ impl<'a> Renderer<'a> {
             locale: self.locale,
             context: RenderContext::Citation,
             mode: mode.clone(),
-            suppress_author: false,
+            suppress_author,
             locator: None,
             locator_label: None,
         };
@@ -1122,6 +1134,7 @@ impl<'a> Renderer<'a> {
             // Inject citation position so subsequent et-al thresholds are applied.
             let hints = ProcHints {
                 position: position.cloned(),
+                integral_name_state: item.integral_name_state,
                 ..base_hints
             };
             if let Some(vals) = comp.values::<F>(reference, &hints, &options)
@@ -1164,6 +1177,74 @@ impl<'a> Renderer<'a> {
             String::new()
         }
     }
+
+    /// Render the prose anchor for an integral citation without any trailing note text.
+    pub(crate) fn render_integral_anchor_with_format<F>(
+        &self,
+        items: &[crate::reference::CitationItem],
+        spec: &citum_schema::CitationSpec,
+        inter_delimiter: &str,
+        suppress_author: bool,
+        position: Option<&citum_schema::citation::Position>,
+    ) -> Result<String, ProcessorError>
+    where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        use crate::reference::CitationItem;
+
+        let preserve_individual_citations = items.iter().any(|item| {
+            self.hints
+                .get(&item.id)
+                .is_some_and(|hints| hints.min_names_to_show.is_some() || hints.expand_given_names)
+        });
+
+        let mut groups: Vec<(String, Vec<&CitationItem>)> = Vec::new();
+        for item in items {
+            let reference = self.bibliography.get(&item.id);
+            let author_key = if preserve_individual_citations {
+                item.id.clone()
+            } else {
+                reference
+                    .map(|r| self.get_author_grouping_key(r))
+                    .unwrap_or_default()
+            };
+
+            match groups.last_mut() {
+                Some(group) if !author_key.is_empty() && group.0 == author_key => {
+                    group.1.push(item);
+                }
+                _ => {
+                    groups.push((author_key, vec![item]));
+                }
+            }
+        }
+
+        let mut rendered_groups = Vec::new();
+        let fmt = F::default();
+        for (_author_key, group) in groups {
+            let first_item = group[0];
+            let reference = self
+                .bibliography
+                .get(&first_item.id)
+                .ok_or_else(|| ProcessorError::ReferenceNotFound(first_item.id.clone()))?;
+            let item_language = crate::values::effective_item_language(reference);
+            let template = spec.resolve_template_for_language(item_language.as_deref());
+            let effective_template = template.as_deref().unwrap_or(&[]);
+            let author_part = self.render_author_for_grouping_with_format::<F>(
+                reference,
+                first_item,
+                effective_template,
+                &citum_schema::citation::CitationMode::Integral,
+                suppress_author,
+                position,
+            );
+            if !author_part.is_empty() {
+                rendered_groups.push(author_part);
+            }
+        }
+
+        Ok(fmt.join(rendered_groups, inter_delimiter))
+    }
     #[allow(dead_code)]
     fn render_author_for_grouping(
         &self,
@@ -1172,8 +1253,9 @@ impl<'a> Renderer<'a> {
         mode: &citum_schema::citation::CitationMode,
         position: Option<&citum_schema::citation::Position>,
     ) -> String {
+        let item = crate::reference::CitationItem::default();
         self.render_author_for_grouping_with_format::<crate::render::plain::PlainText>(
-            reference, template, mode, position,
+            reference, &item, template, mode, false, position,
         )
     }
 
@@ -1319,6 +1401,7 @@ impl<'a> Renderer<'a> {
             options,
             entry_number,
             None,
+            None,
         )
     }
 
@@ -1335,6 +1418,7 @@ impl<'a> Renderer<'a> {
         locator: Option<&str>,
         locator_label: Option<citum_schema::citation::LocatorType>,
         position: Option<&citum_schema::citation::Position>,
+        integral_name_state: Option<citum_schema::citation::IntegralNameState>,
     ) -> Option<ProcTemplate> {
         self.process_template_with_number_with_format::<crate::render::plain::PlainText>(
             reference,
@@ -1346,6 +1430,7 @@ impl<'a> Renderer<'a> {
             locator,
             locator_label,
             position,
+            integral_name_state,
         )
     }
 
@@ -1362,6 +1447,7 @@ impl<'a> Renderer<'a> {
         locator: Option<&str>,
         locator_label: Option<citum_schema::citation::LocatorType>,
         position: Option<&citum_schema::citation::Position>,
+        integral_name_state: Option<citum_schema::citation::IntegralNameState>,
     ) -> Option<ProcTemplate>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -1381,6 +1467,7 @@ impl<'a> Renderer<'a> {
             options,
             citation_number,
             position,
+            integral_name_state,
         )
     }
 
@@ -1392,6 +1479,7 @@ impl<'a> Renderer<'a> {
         options: RenderOptions<'_>,
         citation_number: usize,
         position: Option<&citum_schema::citation::Position>,
+        integral_name_state: Option<citum_schema::citation::IntegralNameState>,
     ) -> Option<ProcTemplate> {
         self.process_template_with_number_internal_with_format::<crate::render::plain::PlainText>(
             reference,
@@ -1399,6 +1487,7 @@ impl<'a> Renderer<'a> {
             options,
             citation_number,
             position,
+            integral_name_state,
         )
     }
 
@@ -1409,6 +1498,7 @@ impl<'a> Renderer<'a> {
         options: RenderOptions<'_>,
         citation_number: usize,
         position: Option<&citum_schema::citation::Position>,
+        integral_name_state: Option<citum_schema::citation::IntegralNameState>,
     ) -> Option<ProcTemplate>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -1435,6 +1525,7 @@ impl<'a> Renderer<'a> {
                 None
             },
             position: position.cloned(),
+            integral_name_state,
             ..base_hint.clone()
         };
 

--- a/crates/citum-engine/src/values/contributor.rs
+++ b/crates/citum-engine/src/values/contributor.rs
@@ -11,6 +11,7 @@ use citum_schema::options::{
     AndOptions, AndOtherOptions, DemoteNonDroppingParticle, DisplayAsSort, EditorLabelFormat,
     ShortenListOptions, SubstituteKey,
 };
+use citum_schema::options::{IntegralNameForm, IntegralNameRule};
 use citum_schema::template::{ContributorForm, ContributorRole, NameOrder, TemplateContributor};
 
 /// Checks if a contributor role label should be omitted for a given reference.
@@ -83,6 +84,31 @@ impl ComponentValues for TemplateContributor {
                     }
                 }
             }
+        }
+
+        if options.context == RenderContext::Citation
+            && matches!(options.mode, citum_schema::citation::CitationMode::Integral)
+            && matches!(component.contributor, ContributorRole::Author)
+            && matches!(
+                hints.integral_name_state,
+                Some(citum_schema::citation::IntegralNameState::Subsequent)
+            )
+            && options
+                .config
+                .integral_names
+                .as_ref()
+                .is_some_and(|cfg| matches!(cfg.resolve().rule, IntegralNameRule::FullThenShort))
+        {
+            let subsequent_form = options
+                .config
+                .integral_names
+                .as_ref()
+                .map(|cfg| cfg.resolve().subsequent_form)
+                .unwrap_or(IntegralNameForm::Short);
+            component.form = match subsequent_form {
+                IntegralNameForm::Short => ContributorForm::Short,
+                IntegralNameForm::FamilyOnly => ContributorForm::FamilyOnly,
+            };
         }
 
         // Respect explicit suppression before any contributor substitution logic.

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -484,6 +484,8 @@ pub struct ProcHints {
     pub citation_sub_label: Option<String>,
     /// Citation position (first, subsequent, ibid, etc.).
     pub position: Option<citum_schema::citation::Position>,
+    /// Explicit integral citation name-memory state for this rendered item.
+    pub integral_name_state: Option<citum_schema::citation::IntegralNameState>,
 }
 
 /// Context for rendering (citation vs bibliography).

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -9,11 +9,12 @@ use common::*;
 use citum_engine::Processor;
 use citum_schema::{
     CitationSpec, Style, StyleInfo,
-    citation::{Citation, CitationItem, CitationMode},
+    citation::{Citation, CitationItem, CitationMode, IntegralNameState},
     grouping::{GroupSort, GroupSortEntry, GroupSortKey, SortKey as GroupSortKeyType},
     options::{
-        AndOptions, Config, ContributorConfig, DelimiterPrecedesLast, DisplayAsSort, Processing,
-        ProcessingCustom, ShortenListOptions,
+        AndOptions, Config, ContributorConfig, DelimiterPrecedesLast, DisplayAsSort,
+        IntegralNameConfig, IntegralNameContexts, IntegralNameForm, IntegralNameRule,
+        IntegralNameScope, Processing, ProcessingCustom, ShortenListOptions,
     },
     reference::InputReference,
 };
@@ -63,6 +64,106 @@ fn build_title_year_citation_style(sort: Vec<GroupSortKey>) -> Style {
         }),
         ..Default::default()
     }
+}
+
+fn build_integral_name_style() -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("Integral Name Memory".to_string()),
+            id: Some("integral-name-memory".to_string()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            processing: Some(Processing::AuthorDate),
+            integral_names: Some(IntegralNameConfig {
+                rule: Some(IntegralNameRule::FullThenShort),
+                scope: Some(IntegralNameScope::Document),
+                contexts: Some(IntegralNameContexts::BodyAndNotes),
+                subsequent_form: Some(IntegralNameForm::Short),
+            }),
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            integral: Some(Box::new(CitationSpec {
+                template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+                ..Default::default()
+            })),
+            template: Some(vec![
+                citum_schema::tc_contributor!(Author, Short),
+                citum_schema::tc_date!(
+                    Issued,
+                    Year,
+                    wrap = citum_schema::template::WrapPunctuation::Parentheses
+                ),
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_citation_item_explicit_integral_name_state_override() {
+    let mut bibliography = indexmap::IndexMap::new();
+    bibliography.insert(
+        "item1".to_string(),
+        make_book("item1", "Smith", "John", 2020, "Book A"),
+    );
+    let processor = Processor::new(build_integral_name_style(), bibliography);
+
+    let first = Citation {
+        mode: CitationMode::Integral,
+        items: vec![CitationItem {
+            id: "item1".to_string(),
+            integral_name_state: Some(IntegralNameState::First),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let subsequent = Citation {
+        mode: CitationMode::Integral,
+        items: vec![CitationItem {
+            id: "item1".to_string(),
+            integral_name_state: Some(IntegralNameState::Subsequent),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    assert_eq!(
+        processor
+            .process_citation(&first)
+            .expect("first should render"),
+        "John Smith"
+    );
+    assert_eq!(
+        processor
+            .process_citation(&subsequent)
+            .expect("subsequent should render"),
+        "Smith"
+    );
+}
+
+#[test]
+fn test_builtin_mla_enables_integral_name_memory() {
+    let style = citum_schema::embedded::get_embedded_style("mla")
+        .expect("mla style should be embedded")
+        .expect("mla style should parse");
+    let integral_names = style
+        .options
+        .and_then(|options| options.integral_names)
+        .expect("mla should enable integral-names");
+
+    assert_eq!(integral_names.rule, Some(IntegralNameRule::FullThenShort));
+    assert_eq!(integral_names.scope, Some(IntegralNameScope::Document));
+    assert_eq!(
+        integral_names.contexts,
+        Some(IntegralNameContexts::BodyAndNotes)
+    );
+    assert_eq!(
+        integral_names.subsequent_form,
+        Some(IntegralNameForm::Short)
+    );
 }
 
 // --- Disambiguation Tests ---

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -150,6 +150,130 @@ fn test_document_djot_output_unmodified() {
     );
 }
 
+#[test]
+fn test_document_html_output_renders_raw_markup() {
+    let style = load_style("styles/modern-language-association.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = DjotParser;
+    let document = fs::read_to_string(project_root().join("examples/document.djot"))
+        .expect("example document should be readable");
+
+    let html_output = processor.process_document::<_, citum_engine::render::html::Html>(
+        &document,
+        &parser,
+        DocumentFormat::Html,
+    );
+
+    assert!(
+        html_output.contains(r#"<span class="csln-citation" data-ref="smith2010">"#),
+        "citation markup should be real HTML: {html_output}"
+    );
+    assert!(
+        html_output.contains(r#"<div class="csln-bibliography">"#),
+        "bibliography markup should be real HTML: {html_output}"
+    );
+    assert!(
+        !html_output.contains("&lt;span class="),
+        "citation markup should not be escaped: {html_output}"
+    );
+    assert!(
+        !html_output.contains("&lt;div class="),
+        "bibliography markup should not be escaped: {html_output}"
+    );
+}
+
+#[test]
+fn test_example_document_renders_integral_name_memory() {
+    let style = load_style("styles/modern-language-association.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = DjotParser;
+    let document = fs::read_to_string(project_root().join("examples/document.djot"))
+        .expect("example document should be readable");
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        &document,
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    assert!(output.contains("First narrative mention: John Smith (10)"));
+    assert!(output.contains("Later in the same chapter: Smith (12) narrows"));
+    assert!(output.contains("Integral with locator: Thomas S. Kuhn (10) argues"));
+    assert!(output.contains(
+        "[^narrative-note]: Before the prose introduces him, John Smith (3) already appears in a note."
+    ));
+    assert!(output.contains("Suppress author with locator: (10)."));
+    assert!(output.contains("# Chapter Two"));
+    assert!(output.contains("so John Smith (14)"));
+}
+
+#[test]
+fn test_example_document_renders_author_date_integral_citations() {
+    let style = load_style("styles/apa-7th.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = DjotParser;
+    let document = fs::read_to_string(project_root().join("examples/document.djot"))
+        .expect("example document should be readable");
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        &document,
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    assert!(output.contains("First narrative mention: Smith (2010, p. 10)"));
+    assert!(output.contains("Later in the same chapter: Smith (2010, p. 12)"));
+    assert!(output.contains("Integral with locator: Kuhn (1962, p. 10) argues"));
+    assert!(output.contains(
+        "[^narrative-note]: Before the prose introduces him, Smith (2010, p. 3) already appears in a note."
+    ));
+    assert!(output.contains("Suppress author with locator: (1962, p. 10)."));
+}
+
+#[test]
+fn test_example_document_renders_note_style_integral_anchor_and_notes() {
+    let style = load_style("styles/chicago-shortened-notes-bibliography.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = DjotParser;
+    let document = fs::read_to_string(project_root().join("examples/document.djot"))
+        .expect("example document should be readable");
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        &document,
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    assert!(output.contains("First narrative mention: Smith[^citum-auto-5] surveys"));
+    assert!(output.contains("Later in the same chapter: Smith[^citum-auto-6] narrows"));
+    assert!(output.contains("Integral with locator: Kuhn[^citum-auto-7] argues"));
+    assert!(
+        output.contains("[^narrative-note]: Before the prose introduces him, Smith (_A Great Book_) already appears in a note."),
+        "manual note should render once with the citation resolved: {output}"
+    );
+    assert_eq!(
+        output.matches("[^narrative-note]:").count(),
+        1,
+        "manual note should not be duplicated: {output}"
+    );
+    assert!(
+        !output.contains("[+@smith2010]"),
+        "raw citation leaked: {output}"
+    );
+}
+
 fn project_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }

--- a/crates/citum-schema/src/citation.rs
+++ b/crates/citum-schema/src/citation.rs
@@ -33,6 +33,17 @@ pub enum CitationMode {
     NonIntegral,
 }
 
+/// Explicit integral citation name-memory state for one citation item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum IntegralNameState {
+    /// Render this item as the first integral mention in scope.
+    First,
+    /// Render this item as a subsequent integral mention in scope.
+    Subsequent,
+}
+
 /// Position of a citation in the document flow.
 ///
 /// Indicates where this citation appears relative to previous citations
@@ -402,6 +413,9 @@ pub struct CitationItem {
     /// Suffix text after this item
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suffix: Option<String>,
+    /// Explicit integral name-memory state override for this item.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integral_name_state: Option<IntegralNameState>,
 }
 
 impl CitationItem {

--- a/crates/citum-schema/src/lib.rs
+++ b/crates/citum-schema/src/lib.rs
@@ -33,7 +33,9 @@ pub mod embedded;
 /// Declarative macros for AST and configurations.
 pub mod macros;
 
-pub use citation::{Citation, CitationItem, CitationMode, Citations, LocatorType, Position};
+pub use citation::{
+    Citation, CitationItem, CitationMode, Citations, IntegralNameState, LocatorType, Position,
+};
 pub use grouping::{
     BibliographyGroup, CitedStatus, FieldMatcher, GroupHeading, GroupSelector, GroupSort,
     GroupSortEntry, GroupSortKey, NameSortOrder, SortKey, TypeSelector,

--- a/crates/citum-schema/src/options/integral_names.rs
+++ b/crates/citum-schema/src/options/integral_names.rs
@@ -1,0 +1,116 @@
+/*
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Integral citation name-memory configuration.
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct IntegralNameConfig {
+    /// The name-memory rule to apply to integral citations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule: Option<IntegralNameRule>,
+    /// Where the first-mention memory resets.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<IntegralNameScope>,
+    /// Which document contexts participate in name-memory tracking.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<IntegralNameContexts>,
+    /// The contributor form to use after the first mention in scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subsequent_form: Option<IntegralNameForm>,
+}
+
+impl IntegralNameConfig {
+    /// Merge another integral-name config into this one.
+    pub fn merge(&mut self, other: &IntegralNameConfig) {
+        if other.rule.is_some() {
+            self.rule = other.rule;
+        }
+        if other.scope.is_some() {
+            self.scope = other.scope;
+        }
+        if other.contexts.is_some() {
+            self.contexts = other.contexts;
+        }
+        if other.subsequent_form.is_some() {
+            self.subsequent_form = other.subsequent_form;
+        }
+    }
+
+    /// Resolve the effective integral-name config with defaults filled in.
+    pub fn resolve(&self) -> ResolvedIntegralNameConfig {
+        ResolvedIntegralNameConfig {
+            rule: self.rule.unwrap_or_default(),
+            scope: self.scope.unwrap_or_default(),
+            contexts: self.contexts.unwrap_or_default(),
+            subsequent_form: self.subsequent_form.unwrap_or_default(),
+        }
+    }
+}
+
+/// The supported integral citation name-memory rule.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum IntegralNameRule {
+    /// Render the first integral mention in scope in full, then shorten later mentions.
+    #[default]
+    FullThenShort,
+}
+
+/// The scope where integral citation name-memory resets.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum IntegralNameScope {
+    /// Keep one name-memory scope for the whole document.
+    #[default]
+    Document,
+    /// Reset name memory at chapter boundaries.
+    Chapter,
+    /// Reset name memory at section boundaries.
+    Section,
+}
+
+/// Which document contexts participate in integral citation name memory.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum IntegralNameContexts {
+    /// Only body-text integral citations participate.
+    #[default]
+    BodyOnly,
+    /// Body text and note citations both participate.
+    BodyAndNotes,
+}
+
+/// The contributor form used after the first integral mention in scope.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum IntegralNameForm {
+    /// Use the short contributor form for subsequent mentions.
+    #[default]
+    Short,
+    /// Use family name only for subsequent mentions.
+    FamilyOnly,
+}
+
+/// Integral-name configuration with defaults resolved.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct ResolvedIntegralNameConfig {
+    /// The active integral name-memory rule.
+    pub rule: IntegralNameRule,
+    /// The active scope boundary.
+    pub scope: IntegralNameScope,
+    /// The active context participation mode.
+    pub contexts: IntegralNameContexts,
+    /// The contributor form used after the first mention.
+    pub subsequent_form: IntegralNameForm,
+}

--- a/crates/citum-schema/src/options/mod.rs
+++ b/crates/citum-schema/src/options/mod.rs
@@ -8,6 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 pub mod bibliography;
 pub mod contributors;
 pub mod dates;
+pub mod integral_names;
 pub mod localization;
 pub mod multilingual;
 pub mod processing;
@@ -20,6 +21,10 @@ pub use contributors::{
     ShortenListOptions,
 };
 pub use dates::{DateConfig, DateConfigEntry};
+pub use integral_names::{
+    IntegralNameConfig, IntegralNameContexts, IntegralNameForm, IntegralNameRule,
+    IntegralNameScope, ResolvedIntegralNameConfig,
+};
 pub use localization::{Localize, MonthFormat, Scope};
 pub use multilingual::{MultilingualConfig, MultilingualMode, ScriptConfig};
 pub use processing::{
@@ -107,6 +112,9 @@ pub struct Config {
     /// Document-level note marker placement and punctuation movement rules.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<NoteConfig>,
+    /// Integral citation name-memory behavior.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integral_names: Option<IntegralNameConfig>,
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
@@ -260,6 +268,7 @@ impl Config {
             semantic_classes,
             strip_periods,
             notes,
+            integral_names,
             custom,
         );
 

--- a/crates/citum-schema/tests/json_deserialization.rs
+++ b/crates/citum-schema/tests/json_deserialization.rs
@@ -1,5 +1,7 @@
-use citum_schema::InputBibliography;
+use citum_schema::citation::{CitationItem, IntegralNameState};
+use citum_schema::options::{IntegralNameContexts, IntegralNameRule, IntegralNameScope};
 use citum_schema::reference::{InputReference, Monograph};
+use citum_schema::{InputBibliography, Style};
 
 #[test]
 fn test_monograph_doi_alias() {
@@ -83,4 +85,61 @@ fn test_input_bibliography_sets_round_trip() {
     let reparsed: InputBibliography =
         serde_json::from_str(&serialized).expect("round-trip parse should work");
     assert_eq!(reparsed.sets, bibliography.sets);
+}
+
+#[test]
+fn test_style_integral_names_round_trip() {
+    let json = r#"{
+        "version": "0.8.0",
+        "info": { "title": "Test Style" },
+        "options": {
+            "integral-names": {
+                "rule": "full-then-short",
+                "scope": "chapter",
+                "contexts": "body-and-notes",
+                "subsequent-form": "short"
+            }
+        }
+    }"#;
+
+    let style: Style = serde_json::from_str(json).expect("style should parse");
+    let config = style
+        .options
+        .as_ref()
+        .and_then(|options| options.integral_names.as_ref())
+        .expect("integral-names should exist");
+    assert_eq!(config.rule, Some(IntegralNameRule::FullThenShort));
+    assert_eq!(config.scope, Some(IntegralNameScope::Chapter));
+    assert_eq!(config.contexts, Some(IntegralNameContexts::BodyAndNotes));
+
+    let serialized = serde_json::to_string(&style).expect("style should serialize");
+    let reparsed: Style = serde_json::from_str(&serialized).expect("style should round-trip");
+    assert!(
+        reparsed
+            .options
+            .and_then(|options| options.integral_names)
+            .is_some()
+    );
+}
+
+#[test]
+fn test_citation_item_integral_name_state_round_trip() {
+    let json = r#"{
+        "id": "item1",
+        "integral-name-state": "subsequent"
+    }"#;
+
+    let item: CitationItem = serde_json::from_str(json).expect("citation item should parse");
+    assert_eq!(
+        item.integral_name_state,
+        Some(IntegralNameState::Subsequent)
+    );
+
+    let serialized = serde_json::to_string(&item).expect("citation item should serialize");
+    let reparsed: CitationItem =
+        serde_json::from_str(&serialized).expect("citation item should round-trip");
+    assert_eq!(
+        reparsed.integral_name_state,
+        Some(IntegralNameState::Subsequent)
+    );
 }

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -314,6 +314,32 @@ Structured: [@kuhn1962, section: 5].</pre>
                 </div>
             </div>
 
+            <div class="border-b border-slate-200">
+                <div class="px-8 py-4 bg-slate-100">
+                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+                        Integral Name Memory (MLA Author-Page)
+                    </h3>
+                </div>
+                <div class="bg-slate-900 p-6 overflow-x-auto">
+                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
+<span class="text-indigo-400">options</span>:
+  <span class="text-primary">integral-names</span>:
+    <span class="text-primary">rule</span>: <span class="text-emerald-400">full-then-short</span>
+    <span class="text-primary">scope</span>: <span class="text-emerald-400">document</span>
+    <span class="text-primary">contexts</span>: <span class="text-emerald-400">body-and-notes</span>
+    <span class="text-primary">subsequent-form</span>: <span class="text-emerald-400">short</span>
+
+<span class="text-indigo-400">citation</span>:
+  <span class="text-primary">integral</span>:
+    <span class="text-primary">template</span>:
+      - <span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>
+      - <span class="text-primary">variable</span>: <span class="text-emerald-400">locator</span>
+        <span class="text-primary">show-label</span>: <span class="text-emerald-400">false</span>
+        <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span></pre>
+                </div>
+            </div>
+
             <!-- Visual Output -->
             <div>
                 <div class="px-8 py-4 bg-slate-100">
@@ -334,6 +360,11 @@ Structured: [@kuhn1962, section: 5].</pre>
                                 Authors)</div>
                             <div class="font-mono text-xs text-slate-400 mb-1">Source: @weinberg1971</div>
                             <div class="font-mono text-sm text-slate-900">Weinberg and Freedman (1971)</div>
+                        </div>
+                        <div class="border-l-4 border-amber-500 pl-4">
+                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Narrative Name Memory</div>
+                            <div class="font-mono text-xs text-slate-400 mb-1">MLA default: document scope.<br />Example override: Chapter 1 [+@smith2010, p. 10] ... later [+@smith2010, p. 12] ...<br />Chapter 2: [+@smith2010, p. 14] ...</div>
+                            <div class="font-mono text-sm text-slate-900">John Smith (10) ... later Smith (12) ... then John Smith (14) again</div>
                         </div>
                         <div class="border-l-4 border-indigo-500 pl-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Parenthetical (APA

--- a/docs/schemas/citation.json
+++ b/docs/schemas/citation.json
@@ -86,6 +86,17 @@
           "description": "The reference ID (citekey).",
           "type": "string"
         },
+        "integral-name-state": {
+          "description": "Explicit integral name-memory state override for this item.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameState"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "locator": {
           "description": "Canonical locator value for pinpoint citations.",
           "anyOf": [
@@ -149,6 +160,25 @@
           "type": "string",
           "enum": [
             "non-integral"
+          ]
+        }
+      ]
+    },
+    "IntegralNameState": {
+      "description": "Explicit integral citation name-memory state for one citation item.",
+      "oneOf": [
+        {
+          "description": "Render this item as the first integral mention in scope.",
+          "type": "string",
+          "enum": [
+            "first"
+          ]
+        },
+        {
+          "description": "Render this item as a subsequent integral mention in scope.",
+          "type": "string",
+          "enum": [
+            "subsequent"
           ]
         }
       ]

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -804,6 +804,17 @@
             }
           ]
         },
+        "integral-names": {
+          "description": "Integral citation name-memory behavior.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "links": {
           "description": "Hyperlink configuration.",
           "anyOf": [
@@ -2021,6 +2032,133 @@
           ]
         }
       }
+    },
+    "IntegralNameConfig": {
+      "description": "Integral citation name-memory configuration.",
+      "type": "object",
+      "properties": {
+        "contexts": {
+          "description": "Which document contexts participate in name-memory tracking.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameContexts"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rule": {
+          "description": "The name-memory rule to apply to integral citations.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameRule"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Where the first-mention memory resets.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subsequent-form": {
+          "description": "The contributor form to use after the first mention in scope.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IntegralNameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "IntegralNameContexts": {
+      "description": "Which document contexts participate in integral citation name memory.",
+      "oneOf": [
+        {
+          "description": "Only body-text integral citations participate.",
+          "type": "string",
+          "enum": [
+            "body-only"
+          ]
+        },
+        {
+          "description": "Body text and note citations both participate.",
+          "type": "string",
+          "enum": [
+            "body-and-notes"
+          ]
+        }
+      ]
+    },
+    "IntegralNameForm": {
+      "description": "The contributor form used after the first integral mention in scope.",
+      "oneOf": [
+        {
+          "description": "Use the short contributor form for subsequent mentions.",
+          "type": "string",
+          "enum": [
+            "short"
+          ]
+        },
+        {
+          "description": "Use family name only for subsequent mentions.",
+          "type": "string",
+          "enum": [
+            "family-only"
+          ]
+        }
+      ]
+    },
+    "IntegralNameRule": {
+      "description": "The supported integral citation name-memory rule.",
+      "oneOf": [
+        {
+          "description": "Render the first integral mention in scope in full, then shorten later mentions.",
+          "type": "string",
+          "enum": [
+            "full-then-short"
+          ]
+        }
+      ]
+    },
+    "IntegralNameScope": {
+      "description": "The scope where integral citation name-memory resets.",
+      "oneOf": [
+        {
+          "description": "Keep one name-memory scope for the whole document.",
+          "type": "string",
+          "enum": [
+            "document"
+          ]
+        },
+        {
+          "description": "Reset name memory at chapter boundaries.",
+          "type": "string",
+          "enum": [
+            "chapter"
+          ]
+        },
+        {
+          "description": "Reset name memory at section boundaries.",
+          "type": "string",
+          "enum": [
+            "section"
+          ]
+        }
+      ]
     },
     "LabelConfig": {
       "description": "Configuration for label citation mode.",

--- a/examples/document.djot
+++ b/examples/document.djot
@@ -1,6 +1,15 @@
-# Testing Citum Document Processing
+---
+integral-names:
+  enabled: true
+  scope: chapter
+  contexts: body-and-notes
+---
+
+# Chapter One
 
 This is a test document using the proposed Djot citation syntax.
+This example overrides the MLA default `document` scope to `chapter`
+so the narrative-name reset is visible in one short sample.
 
 ## Parenthetical Citations
 
@@ -12,13 +21,24 @@ Simple parenthetical: [@watson1953].
 
 ## Integral Citations
 
-Basic integral: [+@kuhn1962] argues ..., [+@watson1953] that ...
+Introductory note[^narrative-note].
+
+First narrative mention: [+@smith2010, p. 10] surveys the broader literature.
+
+Later in the same chapter: [+@smith2010, p. 12] narrows the argument.
 
 Integral with locator: [+@kuhn1962, p. 10] argues...
 
 ## Visibility Modifiers
 
-Suppress author: [-@kuhn1962].
+Suppress author with locator: [-@kuhn1962, p. 10].
+
+[^narrative-note]: Before the prose introduces him, [+@smith2010, p. 3] already appears in a note.
+
+# Chapter Two
+
+The chapter boundary resets the narrative name memory, so [+@smith2010, p. 14]
+appears in full again here.
 
 ## In-Document Bibliography Grouping
 

--- a/styles/modern-language-association.yaml
+++ b/styles/modern-language-association.yaml
@@ -21,6 +21,11 @@ info:
 options:
   processing: author-date
   substitute: standard
+  integral-names:
+    rule: full-then-short
+    scope: document
+    contexts: body-and-notes
+    subsequent-form: short
   contributors: chicago
   dates: long
   titles: chicago
@@ -53,7 +58,14 @@ citation:
           prefix: ", "
     - variable: locator
       show-label: false
-      prefix: " "
+  integral:
+    template:
+      - contributor: author
+        form: long
+        name-order: given-first
+      - variable: locator
+        show-label: false
+        wrap: parentheses
   wrap: parentheses
   multi-cite-delimiter: "; "
 bibliography:


### PR DESCRIPTION
## Summary
- add style-level integral citation name memory with `scope`, `contexts`, and `subsequent-form`
- derive first/subsequent integral-name state across body text and notes during document processing
- enable the behavior for built-in MLA and update docs, examples, generated schemas, and tests

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run

## Reviewer Instructions
1. Start in `crates/citum-schema` and `styles/modern-language-association.yaml` to verify the new public model and MLA defaults.
2. Then review `crates/citum-engine/src/processor/document/mod.rs` and `crates/citum-engine/src/processor/document/djot.rs` for scope detection, note ordering, and the `body-only` vs `body-and-notes` state machine.
3. Finish with `crates/citum-engine/src/values/contributor.rs`, `crates/citum-engine/src/processor/rendering.rs`, and the updated examples/docs to confirm the derived state only affects integral narrative author rendering.

## Notes
- `document` is the article/essay-wide scope and is the built-in MLA default.
- `chapter` and `section` are additional source-structural scopes; this does not attempt rendered page-awareness.
- `examples/document.djot` deliberately overrides to `chapter` so the docs visibly demonstrate a reset, but that is only an example override, not the default behavior.
- explicit `CitationItem.integral_name_state` still lets non-document callers override document-derived behavior per item.
