### PR TITLE
feat(doc): add pandoc markdown citations

### DIFF
--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -4,7 +4,7 @@ use citum_engine::{
         AnnotationFormat, AnnotationStyle, LoadedBibliography, ParagraphBreak, load_annotations,
         load_bibliography, load_bibliography_with_sets, load_citations, validate_compound_sets,
     },
-    processor::document::djot::DjotParser,
+    processor::document::{djot::DjotParser, markdown::MarkdownParser},
     render::{djot::Djot, html::Html, latex::Latex, plain::PlainText, typst::Typst},
 };
 use citum_schema::locale::RawLocale;
@@ -205,7 +205,7 @@ enum Commands {
     about = "Render documents or references",
     long_about = "Render documents or references using a specified citation style.\n\n\
                   Citum supports two primary rendering modes:\n\
-                  - doc: Process a full document (Djot) with integrated citations.\n\
+                  - doc: Process a full document (Djot or Markdown) with integrated citations.\n\
                   - refs: Direct rendering of a bibliography file for debugging\n\
                     or inspection.\n\n\
                   Run 'citum render <COMMAND> --help' for specific examples."
@@ -221,6 +221,8 @@ enum RenderCommands {
                       EXAMPLES:\n  \
                       Render to HTML:\n    \
                       citum render doc manuscript.djot -b refs.json -s apa-7th -f html\n\n  \
+                      Render Markdown with Pandoc-style citations:\n    \
+                      citum render doc manuscript.md --input-format markdown -b refs.json -s apa-7th\n\n  \
                       Render to PDF (requires 'typst-pdf' feature):\n    \
                       citum render doc manuscript.djot -b refs.json -s apa-7th\n\
                       -f typst -o paper.pdf --pdf"
@@ -740,7 +742,7 @@ fn run_store_remove(name: &str) -> Result<(), Box<dyn Error>> {
 
 /// Execute the `render doc` subcommand.
 ///
-/// Reads a Djot document, resolves citations against the provided bibliography,
+/// Reads a document, resolves citations against the provided bibliography,
 /// and writes the rendered output to stdout or a file.
 fn run_render_doc(args: RenderDocArgs) -> Result<(), Box<dyn Error>> {
     if args.pdf && args.format != OutputFormat::Typst {
@@ -766,11 +768,12 @@ fn run_render_doc(args: RenderDocArgs) -> Result<(), Box<dyn Error>> {
             args.format,
             DocumentInput::Djot,
         )?,
-        InputFormat::Markdown => {
-            return Err(
-                "Input format `markdown` is not implemented yet. Use --input-format djot.".into(),
-            );
-        }
+        InputFormat::Markdown => render_doc_with_output_format(
+            &processor,
+            &doc_content,
+            args.format,
+            DocumentInput::Markdown,
+        )?,
     };
 
     if args.pdf {
@@ -1113,6 +1116,7 @@ fn run_convert(args: ConvertArgs) -> Result<(), Box<dyn Error>> {
 
 enum DocumentInput {
     Djot,
+    Markdown,
 }
 
 /// Render a full document through the processor using the given output format.
@@ -1129,6 +1133,26 @@ fn render_doc_with_output_format(
     match input_format {
         DocumentInput::Djot => {
             let parser = DjotParser;
+            match output_format {
+                OutputFormat::Plain => {
+                    Ok(processor.process_document::<_, PlainText>(content, &parser, doc_format))
+                }
+                OutputFormat::Html => {
+                    Ok(processor.process_document::<_, Html>(content, &parser, doc_format))
+                }
+                OutputFormat::Djot => {
+                    Ok(processor.process_document::<_, Djot>(content, &parser, doc_format))
+                }
+                OutputFormat::Latex => {
+                    Ok(processor.process_document::<_, Latex>(content, &parser, doc_format))
+                }
+                OutputFormat::Typst => {
+                    Ok(processor.process_document::<_, Typst>(content, &parser, doc_format))
+                }
+            }
+        }
+        DocumentInput::Markdown => {
+            let parser = MarkdownParser;
             match output_format {
                 OutputFormat::Plain => {
                     Ok(processor.process_document::<_, PlainText>(content, &parser, doc_format))

--- a/crates/citum-engine/src/processor/document/README.md
+++ b/crates/citum-engine/src/processor/document/README.md
@@ -1,6 +1,6 @@
 # Document Processor
 
-This module provides the infrastructure for document-level citation processing. It allows the CSLN processor to scan entire documents (currently Djot), identify citation markers, and replace them with rendered citations or generated footnotes depending on the active style.
+This module provides the infrastructure for document-level citation processing. It allows the CSLN processor to scan entire documents (currently Djot plus Markdown with Pandoc-style citations), identify citation markers, and replace them with rendered citations or generated footnotes depending on the active style.
 
 ## Architecture
 
@@ -14,6 +14,11 @@ Any new document format must implement the `CitationParser` trait:
 pub trait CitationParser {
     /// Parse the document into citation placements and note metadata.
     fn parse_document(&self, content: &str, locale: &Locale) -> ParsedDocument;
+
+    /// Finalize rendered document markup as HTML.
+    fn finalize_html_output(&self, rendered: &str) -> String {
+        djot::djot_to_html(rendered)
+    }
 }
 ```
 
@@ -23,7 +28,7 @@ pub trait CitationParser {
   - citation placement (`InlineProse` vs `ManualFootnote`)
   - manual footnote reference order
 
-`parse_citations()` remains available as a compatibility helper for callers that only need the flat citation list.
+`parse_citations()` remains available as a compatibility helper for callers that only need the flat citation list. `finalize_html_output()` has a default implementation so existing parser implementations remain source-compatible unless they need custom HTML post-processing.
 
 ## Note Styles
 
@@ -35,7 +40,7 @@ When the active style uses `options.processing: note`, `Processor::process_docum
 4. Manual and generated notes share one note-number sequence based on body reference order, not source-definition order.
 5. Punctuation and note-marker placement are configurable through `options.notes`. When omitted, the processor falls back to locale-based defaults modeled on org-cite note rules. In particular, `punctuation: adaptive` means punctuation stays inside a closing quote when it is already flush with that quote, and otherwise moves outside.
 
-This support is currently Djot-only.
+Generated/manual note handling is currently Djot-only. Markdown support in this first pass is limited to prose citations written with Pandoc-style citation markers.
 
 ## Adding a New Format
 
@@ -45,11 +50,12 @@ To add support for a new document format (e.g., Markdown):
 2.  **Implement the parser**: Use a parsing library to identify citation markers, note references, and note definitions.
 3.  **Register the module**: Add `pub mod markdown;` to `src/processor/document/mod.rs`.
 4.  **Update `DocumentFormat`**: Add your format to the `DocumentFormat` enum in `mod.rs`.
-5.  **Update `Processor::process_document`**: If your format requires specific post-processing (like Djot's HTML conversion), update the final conversion branch.
+5.  **Override `finalize_html_output()` if needed**: Formats that require custom HTML post-processing can override the default Djot-compatible conversion hook.
 
 ## Existing Implementations
 
-- **Djot (`djot.rs`)**: Uses `winnow` to parse citation markers, resolves locator labels with locale-aware normalization, tracks manual footnote references/definitions via `jotdown`, and converts final Djot output to HTML using `jotdown`.
+- **Djot (`djot.rs`)**: Uses `winnow` to parse citation markers, resolves locator labels with locale-aware normalization, tracks manual footnote references/definitions via `jotdown`, and relies on the default Djot HTML finalization hook.
+- **Markdown (`markdown.rs`)**: Parses Pandoc-style citation markers in prose and reuses the shared rendering pipeline, while leaving front matter, bibliography blocks, and Markdown footnote parsing for future work.
 
 ## Workflow
 
@@ -59,4 +65,4 @@ The `Processor::process_document` method follows these steps:
 3.  For note styles, assign note numbers from body note-reference order, annotate citation positions in that note order, replace prose citations with generated footnote references, and render citations inside manual footnotes in place.
 4.  Emit any generated footnote definitions.
 5.  Append the bibliography.
-6.  Optionally convert Djot output to HTML.
+6.  Optionally finalize the rendered markup as HTML.

--- a/crates/citum-engine/src/processor/document/markdown.rs
+++ b/crates/citum-engine/src/processor/document/markdown.rs
@@ -1,0 +1,350 @@
+/*
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Markdown document parsing for Pandoc-style citations.
+
+use super::{CitationParser, CitationPlacement, CitationStructure, ParsedCitation, ParsedDocument};
+use crate::{Citation, CitationItem};
+use citum_schema::citation::{CitationMode, normalize_locator_text};
+use citum_schema::locale::Locale;
+use std::collections::HashSet;
+
+/// A parser for Markdown documents with Pandoc-style citation syntax.
+///
+/// This parser currently supports inline prose citations and maps them into the
+/// shared document-processing pipeline. Markdown-specific footnotes, document
+/// metadata, and inline bibliography blocks remain future work.
+pub struct MarkdownParser;
+
+impl Default for MarkdownParser {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl CitationParser for MarkdownParser {
+    fn parse_document(&self, content: &str, locale: &Locale) -> ParsedDocument {
+        let citations = find_citations(content, locale)
+            .into_iter()
+            .map(|(start, end, citation)| ParsedCitation {
+                start,
+                end,
+                citation,
+                placement: CitationPlacement::InlineProse,
+                structure: CitationStructure::default(),
+            })
+            .collect();
+
+        ParsedDocument {
+            citations,
+            manual_note_order: Vec::new(),
+            manual_note_references: Vec::new(),
+            manual_note_labels: HashSet::new(),
+            bibliography_blocks: Vec::new(),
+            frontmatter_groups: None,
+            frontmatter_integral_names: None,
+            body_start: 0,
+        }
+    }
+}
+
+fn find_citations(content: &str, locale: &Locale) -> Vec<(usize, usize, Citation)> {
+    let mut results = Vec::new();
+    let mut offset = 0;
+
+    while offset < content.len() {
+        let remaining = &content[offset..];
+        let next_at = remaining.find('@');
+        let next_bracket = remaining.find('[');
+
+        let (relative_start, kind) = match (next_at, next_bracket) {
+            (Some(at), Some(bracket)) if bracket <= at => (bracket, ScanKind::Bracket),
+            (Some(at), Some(bracket)) if at < bracket => (at, ScanKind::Textual),
+            (Some(at), None) => (at, ScanKind::Textual),
+            (None, Some(bracket)) => (bracket, ScanKind::Bracket),
+            (None, None) => break,
+            _ => unreachable!(),
+        };
+
+        let start = offset + relative_start;
+        let candidate = &content[start..];
+
+        let parsed = match kind {
+            ScanKind::Bracket => parse_bracketed_citation(candidate, locale),
+            ScanKind::Textual => parse_textual_citation(content, start, locale),
+        };
+
+        if let Some((consumed, citation)) = parsed {
+            results.push((start, start + consumed, citation));
+            offset = start + consumed;
+        } else if matches!(kind, ScanKind::Bracket) {
+            offset = start + candidate.find(']').map_or(1, |idx| idx + 1);
+        } else {
+            offset = start + 1;
+        }
+    }
+
+    results
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ScanKind {
+    Bracket,
+    Textual,
+}
+
+fn parse_bracketed_citation(input: &str, locale: &Locale) -> Option<(usize, Citation)> {
+    if !input.starts_with('[') {
+        return None;
+    }
+
+    let closing = input.find(']')?;
+    let inner = input[1..closing].trim();
+    if inner.is_empty() || !inner.contains('@') {
+        return None;
+    }
+
+    let mut items = Vec::new();
+    let mut suppress_author = None;
+
+    for segment in inner.split(';') {
+        let (item, suppress) = parse_bracketed_item(segment, locale)?;
+        if let Some(existing) = suppress_author {
+            if existing != suppress {
+                return None;
+            }
+        } else {
+            suppress_author = Some(suppress);
+        }
+        items.push(item);
+    }
+
+    Some((
+        closing + 1,
+        Citation {
+            items,
+            suppress_author: suppress_author.unwrap_or(false),
+            ..Default::default()
+        },
+    ))
+}
+
+fn parse_bracketed_item(segment: &str, locale: &Locale) -> Option<(CitationItem, bool)> {
+    let segment = segment.trim();
+    let at_pos = segment.find('@')?;
+    let mut suppress_author = false;
+    let prefix_end = if at_pos > 0 && segment.as_bytes()[at_pos - 1] == b'-' {
+        suppress_author = true;
+        at_pos - 1
+    } else {
+        at_pos
+    };
+
+    let prefix = normalize_prefix(&segment[..prefix_end]);
+    let after_at = &segment[at_pos + 1..];
+    let key_end = cite_key_len(after_at)?;
+    let key = &after_at[..key_end];
+    let remainder = after_at[key_end..].trim_start();
+
+    let mut item = CitationItem {
+        id: key.to_string(),
+        prefix,
+        ..Default::default()
+    };
+
+    if let Some(rest) = remainder.strip_prefix(',') {
+        let rest = rest.trim();
+        if !rest.is_empty() {
+            item.locator = normalize_locator_text(rest, locale);
+            if item.locator.is_none() {
+                item.suffix = Some(rest.to_string());
+            }
+        }
+    } else if !remainder.is_empty() {
+        item.suffix = Some(remainder.trim().to_string());
+    }
+
+    Some((item, suppress_author))
+}
+
+fn parse_textual_citation(
+    content: &str,
+    start: usize,
+    locale: &Locale,
+) -> Option<(usize, Citation)> {
+    if !is_valid_textual_start(content, start) {
+        return None;
+    }
+
+    let after_at = &content[start + 1..];
+    let key_end = cite_key_len(after_at)?;
+    let key = &after_at[..key_end];
+    let mut consumed = 1 + key_end;
+
+    let mut item = CitationItem {
+        id: key.to_string(),
+        ..Default::default()
+    };
+
+    let trailing = &content[start + consumed..];
+    if let Some((locator_consumed, locator)) = parse_textual_locator_suffix(trailing, locale) {
+        item.locator = Some(locator);
+        consumed += locator_consumed;
+    }
+
+    Some((
+        consumed,
+        Citation {
+            mode: CitationMode::Integral,
+            items: vec![item],
+            ..Default::default()
+        },
+    ))
+}
+
+fn parse_textual_locator_suffix(
+    input: &str,
+    locale: &Locale,
+) -> Option<(usize, citum_schema::citation::CitationLocator)> {
+    let whitespace_len = input.len() - input.trim_start_matches(char::is_whitespace).len();
+    let rest = &input[whitespace_len..];
+    if !rest.starts_with('[') {
+        return None;
+    }
+
+    let closing = rest.find(']')?;
+    let inner = rest[1..closing].trim();
+    if inner.is_empty() || inner.contains('@') {
+        return None;
+    }
+
+    let locator = normalize_locator_text(inner, locale)?;
+    Some((whitespace_len + closing + 1, locator))
+}
+
+fn cite_key_len(input: &str) -> Option<usize> {
+    let len = input
+        .char_indices()
+        .take_while(
+            |(_, ch)| matches!(ch, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '-' | ':' | '.'),
+        )
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .last()
+        .unwrap_or(0);
+
+    if len == 0 { None } else { Some(len) }
+}
+
+fn normalize_prefix(prefix: &str) -> Option<String> {
+    let trimmed = prefix.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(format!("{trimmed} "))
+    }
+}
+
+fn is_valid_textual_start(content: &str, start: usize) -> bool {
+    let prev = content[..start].chars().next_back();
+    !matches!(prev, Some(ch) if ch.is_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | '@'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use citum_schema::citation::{CitationLocator, LocatorType};
+
+    #[test]
+    fn test_parse_bracketed_multi_cite() {
+        let parser = MarkdownParser;
+        let citations =
+            parser.parse_citations("See [@kuhn1962; @watson1953, ch. 2].", &Locale::en_us());
+
+        assert_eq!(citations.len(), 1);
+        let (_, _, citation) = &citations[0];
+        assert_eq!(citation.items.len(), 2);
+        assert_eq!(citation.items[0].id, "kuhn1962");
+        assert_eq!(
+            citation.items[1].locator,
+            Some(CitationLocator::single(LocatorType::Chapter, "2"))
+        );
+    }
+
+    #[test]
+    fn test_parse_bracketed_prefix_and_suppress_author() {
+        let parser = MarkdownParser;
+        let citations = parser.parse_citations("[see -@kuhn1962, p. 10]", &Locale::en_us());
+
+        assert_eq!(citations.len(), 1);
+        let (_, _, citation) = &citations[0];
+        assert!(citation.suppress_author);
+        assert_eq!(citation.items[0].prefix.as_deref(), Some("see "));
+        assert_eq!(
+            citation.items[0].locator,
+            Some(CitationLocator::single(LocatorType::Page, "10"))
+        );
+    }
+
+    #[test]
+    fn test_parse_textual_citation() {
+        let parser = MarkdownParser;
+        let citations = parser.parse_citations(
+            "Kuhn argued that @kuhn1962 changed science.",
+            &Locale::en_us(),
+        );
+
+        assert_eq!(citations.len(), 1);
+        let (_, _, citation) = &citations[0];
+        assert_eq!(citation.mode, CitationMode::Integral);
+        assert_eq!(citation.items[0].id, "kuhn1962");
+    }
+
+    #[test]
+    fn test_parse_textual_citation_with_locator_suffix() {
+        let parser = MarkdownParser;
+        let citations =
+            parser.parse_citations("@kuhn1962 [p. 10] argues this point.", &Locale::en_us());
+
+        assert_eq!(citations.len(), 1);
+        let (_, _, citation) = &citations[0];
+        assert_eq!(citation.mode, CitationMode::Integral);
+        assert_eq!(
+            citation.items[0].locator,
+            Some(CitationLocator::single(LocatorType::Page, "10"))
+        );
+    }
+
+    #[test]
+    fn test_parse_document_marks_citations_as_inline_prose() {
+        let parser = MarkdownParser;
+        let parsed = parser.parse_document("Text [@kuhn1962].", &Locale::en_us());
+
+        assert_eq!(parsed.citations.len(), 1);
+        assert_eq!(
+            parsed.citations[0].placement,
+            CitationPlacement::InlineProse
+        );
+        assert!(parsed.manual_note_order.is_empty());
+        assert!(parsed.bibliography_blocks.is_empty());
+    }
+
+    #[test]
+    fn test_does_not_parse_email_address() {
+        let parser = MarkdownParser;
+        let citations =
+            parser.parse_citations("Contact test@example.com for details.", &Locale::en_us());
+
+        assert!(citations.is_empty());
+    }
+
+    #[test]
+    fn test_unsupported_bracket_cluster_does_not_fall_back_to_textual_citations() {
+        let parser = MarkdownParser;
+        let citations =
+            parser.parse_citations("Mixed [@kuhn1962; -@watson1953] cluster.", &Locale::en_us());
+
+        assert!(citations.is_empty());
+    }
+}

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -6,6 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Document-level citation processing.
 
 pub mod djot;
+pub mod markdown;
 
 pub use djot::BibliographyBlock;
 
@@ -183,6 +184,14 @@ pub struct ParsedDocument {
 pub trait CitationParser {
     /// Parse the document into citation placements and note metadata.
     fn parse_document(&self, content: &str, locale: &Locale) -> ParsedDocument;
+
+    /// Finalize rendered document markup as HTML.
+    ///
+    /// The default implementation treats the rendered markup as Djot-compatible
+    /// content and converts it with the existing Djot HTML renderer.
+    fn finalize_html_output(&self, rendered: &str) -> String {
+        djot::djot_to_html(rendered)
+    }
 
     /// Find and extract citations from a document string.
     /// Returns a list of (start_index, end_index, citation_model) tuples.
@@ -384,7 +393,7 @@ impl Processor {
                 let mut result = rendered;
                 result.push_str(bib_heading);
                 result.push_str(&placeholders.push_block(bib_content));
-                let html = self::djot::djot_to_html(&result);
+                let html = parser.finalize_html_output(&result);
                 return placeholders.apply(html);
             } else if processor.is_note_style() {
                 processor.process_note_document::<F>(body, parsed)
@@ -409,7 +418,7 @@ impl Processor {
             result.push_str(&bib_content);
             let result = rewrite_document_markup_for_typst(result, format);
             return match format {
-                DocumentFormat::Html => self::djot::djot_to_html(&result),
+                DocumentFormat::Html => parser.finalize_html_output(&result),
                 DocumentFormat::Djot
                 | DocumentFormat::Plain
                 | DocumentFormat::Latex
@@ -459,7 +468,7 @@ impl Processor {
                     result = result.replace(&placeholder, &replacement);
                 }
 
-                let html = self::djot::djot_to_html(&result);
+                let html = parser.finalize_html_output(&result);
                 return placeholders.apply(html);
             } else if processor.is_note_style() {
                 processor.process_note_document::<F>(&staged, parsed_staged)
@@ -492,7 +501,7 @@ impl Processor {
 
             let result = rewrite_document_markup_for_typst(result, format);
             return match format {
-                DocumentFormat::Html => self::djot::djot_to_html(&result),
+                DocumentFormat::Html => parser.finalize_html_output(&result),
                 DocumentFormat::Djot
                 | DocumentFormat::Plain
                 | DocumentFormat::Latex
@@ -514,7 +523,7 @@ impl Processor {
             result.push_str(
                 &placeholders.push_block(processor.render_grouped_bibliography_with_format::<F>()),
             );
-            let html = self::djot::djot_to_html(&result);
+            let html = parser.finalize_html_output(&result);
             return placeholders.apply(html);
         } else if processor.is_note_style() {
             processor.process_note_document::<F>(body, parsed)
@@ -533,7 +542,7 @@ impl Processor {
         let result = rewrite_document_markup_for_typst(result, format);
 
         match format {
-            DocumentFormat::Html => self::djot::djot_to_html(&result),
+            DocumentFormat::Html => parser.finalize_html_output(&result),
             DocumentFormat::Djot
             | DocumentFormat::Plain
             | DocumentFormat::Latex

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -11,7 +11,7 @@ use std::{fs, path::PathBuf};
 use citum_engine::{
     Processor,
     io::load_bibliography,
-    processor::document::{DocumentFormat, djot::DjotParser},
+    processor::document::{DocumentFormat, djot::DjotParser, markdown::MarkdownParser},
 };
 use citum_schema::{
     BibliographySpec, Locale, Style, StyleInfo,
@@ -271,6 +271,69 @@ fn test_example_document_renders_note_style_integral_anchor_and_notes() {
     assert!(
         !output.contains("[+@smith2010]"),
         "raw citation leaked: {output}"
+    );
+}
+
+#[test]
+fn test_markdown_document_renders_pandoc_author_date_citations() {
+    let style = load_style("styles/apa-7th.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = MarkdownParser;
+    let document = concat!(
+        "Kuhn argued that @kuhn1962 [p. 10] changed science.\n\n",
+        "Later work supports this [see @smith2010, p. 12; @kuhn1962, ch. 3].",
+    );
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        document,
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    assert!(
+        output.contains("Kuhn (1962, p. 10) changed science."),
+        "integral markdown citation did not render: {output}"
+    );
+    assert!(
+        output.contains("Later work supports this ("),
+        "bracketed markdown cite cluster did not render: {output}"
+    );
+    assert!(
+        output.contains("Kuhn, 1962, ch. 3"),
+        "markdown locator cite missing from cluster: {output}"
+    );
+    assert!(
+        output.contains("see Smith, 2010, p. 12"),
+        "markdown prefix cite missing from cluster: {output}"
+    );
+}
+
+#[test]
+fn test_markdown_document_generates_notes_for_note_styles() {
+    let style = load_style("styles/chicago-shortened-notes-bibliography.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = MarkdownParser;
+    let document = "Narrative mention @smith2010 introduces the argument.";
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        document,
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    assert!(
+        output.contains("Narrative mention Smith[^citum-auto-1] introduces the argument."),
+        "note-style markdown integral citation did not anchor correctly: {output}"
+    );
+    assert!(
+        output.contains("[^citum-auto-1]: Smith, _A Great Book_."),
+        "generated note missing for markdown citation: {output}"
     );
 }
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -222,7 +222,8 @@
                     </h2>
                 </div>
                 <p class="text-slate-600 leading-relaxed mb-6">
-                    Citum processes full documents from checked-in Djot inputs. The current
+                    Citum processes full documents from checked-in Djot inputs, and also accepts
+                    Markdown documents that use Pandoc-style citation markers in prose. The current
                     Djot example demonstrates multi-cites, locators, integral citations, visibility modifiers,
                     footnotes, and in-document bibliography blocks.
                 </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -221,7 +221,7 @@
                     </div>
                     <h3 class="text-xl font-bold text-slate-900 mb-3">Document Processing</h3>
                     <p class="text-slate-500 leading-relaxed text-sm">
-                        Render full Djot documents with inline citations, bibliography blocks, and current CLI output targets.
+                        Render Djot documents end to end, or process Markdown documents with Pandoc-style citation markers through the same CLI output targets.
                     </p>
                 </a>
 

--- a/docs/specs/PANDOC_MARKDOWN_CITATIONS.md
+++ b/docs/specs/PANDOC_MARKDOWN_CITATIONS.md
@@ -1,6 +1,6 @@
 # Pandoc Markdown Citations Specification
 
-**Status:** Draft
+**Status:** Active
 **Version:** 1.0
 **Date:** 2026-03-09
 **Supersedes:** None


### PR DESCRIPTION
## Summary
- add a dedicated Markdown document parser for Pandoc-style citation markers
- wire `citum render doc --input-format markdown` through the shared document pipeline
- add parser and document rendering coverage for author-date and note styles

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- cargo run --bin citum -- render doc /tmp/citum-markdown-smoke.md --input-format markdown -b examples/document-refs.json -s apa-7th