### PR TITLE
feat(engine): support djot title markup

### DIFF
--- a/.beans/csl26-suz3--djot-as-default-markup-for-annotations-and-referen.md
+++ b/.beans/csl26-suz3--djot-as-default-markup-for-annotations-and-referen.md
@@ -20,58 +20,52 @@ Phase 1 (annotations) complete — commit `df059ae` on `feat/djot-rich-text`.
 - [x] Annotation render path in `bibliography.rs` uses djot
 - [x] CLI default updated
 - [x] Architecture doc at `docs/architecture/DJOT_RICH_TEXT.md`
-- [x] Fix link rendering (URL lost at End event — degrade to text currently)
-- [x] Phase 2: `RichText` type for `note`/`abstract` fields
-- [ ] Phase 3: `title` field (requires AST-aware case transformation)
+- [x] Fix link rendering (URL preserved through Djot inline rendering)
+- [ ] Phase 2: `RichText` type for `note`/`abstract` fields
+- [x] Phase 3: `title` field under the current rendering model
 
-## Phase 3 — Title Markup (AST-aware case transformation)
+2026-03-09 residual gap: this bean remains open only for `note`/`abstract`
+rich-text support. Broader title/text-case semantics were split out to
+`csl26-wv5o`.
 
-**Goal:** Allow djot inline markup in title fields so authors can protect spans from
-title-casing (e.g. `*Homo sapiens*` stays italicised and is not upper-cased by
-an APA/Chicago title-case pass).
+## Phase 3 — Title Markup (Current Rendering Model)
 
-**Current rendering pipeline** (`crates/citum-engine/src/values/title.rs`):
-1. `TemplateTitle::values()` calls `title_text()` — returns a plain `String`.
-2. `smarten_apostrophes()` is applied to that string.
-3. Result stored in `ProcValues { value, pre_formatted: false, ... }`.
-4. Downstream, the engine applies title-case / sentence-case to `value` based on
-   `TitleRendering` config.
+**Goal:** Allow djot inline markup in title fields without introducing a new
+title/sentence-case subsystem.
 
-**Problem:** Because casing is applied to the raw string, djot markup syntax
-would either survive into output verbatim or be cased incorrectly.
+**Implemented behavior:**
 
-**Required changes:**
-
-1. AST-split approach in `title_text` / `TemplateTitle::values`:
-   - Parse title string with jotdown into an inline event stream.
-   - Walk the AST; apply title-case / sentence-case only to `Event::Str` leaf
-     nodes (aware of first-word, after-colon, stop-word rules).
-   - Re-emit the event stream using `render_djot_inline` with the
-     case-transformed leaf strings.
-   - Return result with `pre_formatted: true` to skip the second casing pass.
-
-2. Case transformation helper needed:
-   - An `apply_title_case_to_word(word, position: WordPosition) -> String`
-     that knows about stop-words, first/last-word rules, etc.
-   - Currently casing lives outside the values layer; needs to be threaded in
-     or exposed as a shared helper.
-
-3. `rich_text.rs` extension:
-   - May need a `render_djot_inline_with_case_fn` variant that accepts a
-     `Fn(&str) -> String` applied to each `Str` leaf event.
-
-4. Casing bypass:
-   - Wherever the casing pass currently runs, it must skip when
-     `pre_formatted: true`.
+1. `TemplateTitle::values()` now routes resolved title strings through Djot
+   inline rendering before returning them to the component renderer.
+2. Smart apostrophe handling is applied to Djot `Event::Str` leaf text, so
+   inner markup remains intact.
+3. Title values are returned with `pre_formatted: true`, allowing outer title
+   rendering (quotes, italics, prefixes, suffixes) to wrap already-rendered
+   inline markup.
+4. Explicit inline Djot links inside titles suppress whole-title auto-linking,
+   so the authored inline link wins.
+5. This phase does **not** implement `.nocase`, sentence-case, title-case, or
+   other general text-case semantics.
 
 **Key files:**
 - `crates/citum-engine/src/values/title.rs` — main logic insertion point
-- `crates/citum-engine/src/render/rich_text.rs` — case-aware djot renderer
-- Wherever `TextCase` / `apply_text_case` runs in citum-engine/src/render/
+- `crates/citum-engine/src/render/rich_text.rs` — Djot inline renderer with
+  leaf-text transforms and explicit-link metadata
+- `crates/citum-engine/src/processor/tests.rs` — preset and autolink regressions
 
 **Definition of done:**
-- Fixture reference with `title: "Homo sapiens and the modern world"` (italics
-  on Homo sapiens via djot markup).
-- APA title-case config renders: "Homo sapiens and the Modern World"
-  (italicised span intact; stop-word "and" stays lower; first word capitalised).
-- All existing title oracle tests pass.
+- Djot inline markup in title strings survives through bibliography rendering.
+- Outer title rendering from presets/config still applies around inner Djot
+  markup.
+- Explicit inline title links take precedence over whole-title auto-linking.
+- General title/text-case semantics are tracked separately in `csl26-wv5o`.
+
+## Summary of Changes
+
+- refactored Djot inline rendering to preserve nested formatted child output and
+  use frame-local span metadata
+- added title-path Djot rendering with leaf-level smart apostrophe handling
+- suppressed outer title autolinks when the title already contains an explicit
+  inline link
+- added regressions for title value pre-formatting, inline-link precedence, and
+  title preset wrapping around Djot markup

--- a/.beans/csl26-wv5o--investigate-title-text-case-semantics-and-prior-ar.md
+++ b/.beans/csl26-wv5o--investigate-title-text-case-semantics-and-prior-ar.md
@@ -1,0 +1,31 @@
+---
+# csl26-wv5o
+title: Investigate title text-case semantics and prior art
+status: todo
+type: feature
+priority: normal
+created_at: 2026-03-09T21:07:35Z
+updated_at: 2026-03-09T21:07:35Z
+---
+
+Follow-up to `csl26-suz3`.
+
+Bounded Phase 3 for Djot title markup landed under the current rendering model,
+but the broader title/text-case problem remains open and should not be solved
+implicitly inside rich-text work.
+
+Requirements:
+- review CSL and biblatex prior art for title-case, sentence-case, and
+  `.nocase` / case-protection behavior
+- decide whether Citum should model general title/text-case semantics in the
+  engine, schema, presets, or a combination
+- revisit the existing assumption that input data should be normalized toward
+  sentence case before any title-case transformation
+- define how language-sensitive title formatting interacts with field language,
+  multilingual titles, and title/category presets
+- produce a spec before implementation if the result changes schema or engine
+  behavior materially
+
+Non-goals:
+- re-opening the bounded Djot title-markup work already landed in `csl26-suz3`
+- shipping `.nocase` or title-case logic without prior-art review and a spec

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -1570,6 +1570,96 @@ fn test_global_title_linking_html() {
     assert!(result.contains("Linked Title"));
 }
 
+/// Tests that inline Djot title links take precedence over whole-title autolinks.
+#[test]
+fn test_inline_title_link_takes_precedence_over_global_title_link_html() {
+    use crate::render::html::Html;
+    use citum_schema::options::{LinkAnchor, LinkTarget, LinksConfig};
+
+    let style = Style {
+        options: Some(Config {
+            links: Some(LinksConfig {
+                target: Some(LinkTarget::Doi),
+                anchor: Some(LinkAnchor::Title),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let mut bib = Bibliography::new();
+    bib.insert(
+        "doi-inline".to_string(),
+        Reference::from(LegacyReference {
+            id: "doi-inline".to_string(),
+            ref_type: "book".to_string(),
+            title: Some("[Linked title](https://example.com)".to_string()),
+            doi: Some("10.1001/test".to_string()),
+            issued: Some(DateVariable::year(2023)),
+            ..Default::default()
+        }),
+    );
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography_with_format::<Html>();
+
+    assert!(result.contains(r#"<a href="https://example.com">Linked title</a>"#));
+    assert!(!result.contains("https://doi.org/10.1001/test"));
+}
+
+/// Tests that title preset rendering still wraps Djot-marked title content correctly.
+#[test]
+fn test_chicago_title_preset_preserves_djot_markup_html() {
+    use crate::render::html::Html;
+    use citum_schema::TitlePreset;
+
+    let style = Style {
+        options: Some(Config {
+            titles: Some(TitlePreset::Chicago.config()),
+            ..Default::default()
+        }),
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let mut bib = Bibliography::new();
+    bib.insert(
+        "art1".to_string(),
+        Reference::from(LegacyReference {
+            id: "art1".to_string(),
+            ref_type: "article-journal".to_string(),
+            title: Some("_Homo sapiens_ and *modern* world".to_string()),
+            issued: Some(DateVariable::year(2023)),
+            ..Default::default()
+        }),
+    );
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography_with_format::<Html>();
+
+    assert!(
+        result.contains(
+            r#"<span class="csln-title">“<i>Homo sapiens</i> and <b>modern</b> world”</span>"#
+        ),
+        "Result: {}",
+        result
+    );
+}
+
 /// Tests the behavior of test_whole_entry_linking_typst.
 #[test]
 fn test_whole_entry_linking_typst() {

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -12,6 +12,27 @@ use citum_schema::template::WrapPunctuation;
 /// Renders processed citations and bibliography entries as HTML fragments.
 pub struct Html;
 
+impl Html {
+    fn sanitize_href(value: &str) -> String {
+        let mut escaped = String::with_capacity(value.len());
+        for ch in value.chars() {
+            if ch.is_ascii_control()
+                || ch.is_whitespace()
+                || matches!(ch, '"' | '\'' | '<' | '>' | '&')
+            {
+                let mut buf = [0u8; 4];
+                for byte in ch.encode_utf8(&mut buf).as_bytes() {
+                    escaped.push('%');
+                    escaped.push_str(&format!("{byte:02X}"));
+                }
+            } else {
+                escaped.push(ch);
+            }
+        }
+        escaped
+    }
+}
+
 impl OutputFormat for Html {
     type Output = String;
 
@@ -98,7 +119,7 @@ impl OutputFormat for Html {
         if content.is_empty() {
             return content;
         }
-        format!(r#"<a href="{}">{}</a>"#, url, content)
+        format!(r#"<a href="{}">{}</a>"#, Self::sanitize_href(url), content)
     }
 
     fn format_id(&self, id: &str) -> String {

--- a/crates/citum-engine/src/render/rich_text.rs
+++ b/crates/citum-engine/src/render/rich_text.rs
@@ -3,10 +3,166 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-//! Djot and org-mode inline markup rendering for annotation text.
+//! Djot and org-mode inline markup rendering for free-text fields.
 
 use super::format::OutputFormat;
 use jotdown::{Attributes, Container, Event, Parser};
+
+#[derive(Default)]
+struct DjotFrame {
+    children: Vec<String>,
+    classes: Vec<String>,
+    link_url: Option<String>,
+    has_explicit_link: bool,
+    last_char: Option<char>,
+}
+
+impl DjotFrame {
+    fn push_rendered(&mut self, rendered: String, logical_last_char: Option<char>) {
+        self.children.push(rendered);
+        if let Some(ch) = logical_last_char {
+            self.last_char = Some(ch);
+        }
+    }
+
+    fn prev_opens_quote(&self) -> bool {
+        self.last_char
+            .is_none_or(|c| c.is_whitespace() || "([{\u{2018}\u{201C}'\"".contains(c))
+    }
+}
+
+fn span_classes(attrs: Option<&Attributes>) -> Vec<String> {
+    attrs
+        .into_iter()
+        .flat_map(|attrs| attrs.iter())
+        .filter_map(|(kind, val)| {
+            use jotdown::AttributeKind;
+            if matches!(kind, AttributeKind::Class) {
+                Some(val.to_string())
+            } else {
+                None
+            }
+        })
+        .flat_map(|classes| {
+            classes
+                .split_whitespace()
+                .map(|class| class.to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn render_djot_inline_internal<F, G>(src: &str, fmt: &F, mut transform_text: G) -> (String, bool)
+where
+    F: OutputFormat<Output = String>,
+    G: FnMut(&str) -> String,
+{
+    let parser = Parser::new(src);
+    let mut stack = vec![DjotFrame::default()];
+
+    for event in parser {
+        match event {
+            Event::Start(container, attrs) => {
+                let link_url = if let Container::Link(url, _) = &container {
+                    Some(url.to_string())
+                } else {
+                    None
+                };
+                stack.push(DjotFrame {
+                    classes: span_classes(Some(&attrs)),
+                    has_explicit_link: link_url.is_some(),
+                    link_url,
+                    ..Default::default()
+                });
+            }
+            Event::End(container) => {
+                if let Some(frame) = stack.pop() {
+                    let inner_text = frame.children.join("");
+                    let formatted = match container {
+                        Container::Emphasis => fmt.emph(inner_text),
+                        Container::Strong => fmt.strong(inner_text),
+                        Container::Link(_, _) => {
+                            if let Some(url) = frame.link_url.as_deref() {
+                                fmt.link(url, inner_text)
+                            } else {
+                                inner_text
+                            }
+                        }
+                        Container::Span => {
+                            if frame
+                                .classes
+                                .iter()
+                                .any(|class| class == "smallcaps" || class == "small-caps")
+                            {
+                                fmt.small_caps(inner_text)
+                            } else {
+                                inner_text
+                            }
+                        }
+                        _ => inner_text,
+                    };
+                    if let Some(parent) = stack.last_mut() {
+                        parent.push_rendered(formatted, frame.last_char);
+                        parent.has_explicit_link |= frame.has_explicit_link;
+                    }
+                }
+            }
+            Event::Str(s) => {
+                if let Some(frame) = stack.last_mut() {
+                    let transformed = transform_text(s.as_ref());
+                    frame.push_rendered(fmt.text(&transformed), transformed.chars().last());
+                }
+            }
+            Event::Symbol(sym) => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.push_rendered(fmt.text(sym.as_ref()), sym.chars().last());
+                }
+            }
+            Event::LeftSingleQuote => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.push_rendered(fmt.text("\u{2018}"), Some('\u{2018}'));
+                }
+            }
+            Event::RightSingleQuote => {
+                if let Some(frame) = stack.last_mut() {
+                    let quote = if frame.prev_opens_quote() {
+                        '\u{2018}'
+                    } else {
+                        '\u{2019}'
+                    };
+                    frame.push_rendered(fmt.text(&quote.to_string()), Some(quote));
+                }
+            }
+            Event::LeftDoubleQuote => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.push_rendered(fmt.text("\u{201C}"), Some('\u{201C}'));
+                }
+            }
+            Event::RightDoubleQuote => {
+                if let Some(frame) = stack.last_mut() {
+                    let quote = if frame.prev_opens_quote() {
+                        '\u{201C}'
+                    } else {
+                        '\u{201D}'
+                    };
+                    frame.push_rendered(fmt.text(&quote.to_string()), Some(quote));
+                }
+            }
+            Event::Softbreak | Event::Hardbreak => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.push_rendered(fmt.text(" "), Some(' '));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    stack
+        .into_iter()
+        .next()
+        .map(|frame| (frame.children.join(""), frame.has_explicit_link))
+        .unwrap_or_default()
+}
 
 /// Render djot inline markup and map events to OutputFormat methods.
 ///
@@ -22,99 +178,20 @@ use jotdown::{Attributes, Container, Event, Parser};
 /// # Returns
 /// Formatted string with markup applied according to the OutputFormat's methods
 pub fn render_djot_inline<F: OutputFormat<Output = String>>(src: &str, fmt: &F) -> String {
-    let parser = Parser::new(src);
-    // Each entry is (collected_children, link_url). The root entry starts with no URL.
-    let mut stack: Vec<(Vec<String>, Option<String>)> = vec![(vec![], None)];
-    let mut current_attrs: Option<Attributes> = None;
+    render_djot_inline_internal(src, fmt, str::to_string).0
+}
 
-    for event in parser {
-        match event {
-            Event::Start(container, attrs) => {
-                current_attrs = Some(attrs.clone());
-                let url = if let Container::Link(url, _) = &container {
-                    Some(url.to_string())
-                } else {
-                    None
-                };
-                stack.push((vec![], url));
-            }
-            Event::End(container) => {
-                if let Some((inner, link_url)) = stack.pop() {
-                    let inner_text = inner.join("");
-                    let formatted = match container {
-                        Container::Emphasis => {
-                            let inner_output = fmt.text(&inner_text);
-                            fmt.emph(inner_output)
-                        }
-                        Container::Strong => {
-                            let inner_output = fmt.text(&inner_text);
-                            fmt.strong(inner_output)
-                        }
-                        Container::Link(_, _) => {
-                            if let Some(url) = link_url {
-                                let inner_output = fmt.text(&inner_text);
-                                fmt.link(&url, inner_output)
-                            } else {
-                                fmt.text(&inner_text)
-                            }
-                        }
-                        Container::Span => {
-                            // Check if span has smallcaps class in attributes from Event::Start
-                            if let Some(attrs) = &current_attrs {
-                                let classes: Vec<String> = attrs
-                                    .iter()
-                                    .filter_map(|(kind, val)| {
-                                        use jotdown::AttributeKind;
-                                        if matches!(kind, AttributeKind::Class) {
-                                            Some(val.to_string())
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .flat_map(|classes| {
-                                        classes
-                                            .split_whitespace()
-                                            .map(|s| s.to_string())
-                                            .collect::<Vec<_>>()
-                                    })
-                                    .collect();
-                                if classes.contains(&"smallcaps".to_string()) {
-                                    let inner_output = fmt.text(&inner_text);
-                                    fmt.small_caps(inner_output)
-                                } else {
-                                    fmt.text(&inner_text)
-                                }
-                            } else {
-                                fmt.text(&inner_text)
-                            }
-                        }
-                        _ => fmt.text(&inner_text),
-                    };
-                    if let Some((parent, _)) = stack.last_mut() {
-                        parent.push(formatted);
-                    }
-                }
-            }
-            Event::Str(s) => {
-                if let Some((parent, _)) = stack.last_mut() {
-                    parent.push(fmt.text(s.as_ref()));
-                }
-            }
-            Event::Softbreak | Event::Hardbreak => {
-                if let Some((parent, _)) = stack.last_mut() {
-                    parent.push(fmt.text(" "));
-                }
-            }
-            _ => {} // Ignore other events like Blankline, symbols, etc
-        }
-    }
-
-    // Collect root level content
-    stack
-        .into_iter()
-        .next()
-        .map(|(v, _)| v.join(""))
-        .unwrap_or_default()
+/// Render djot inline markup while transforming text leaves and returning link metadata.
+pub(crate) fn render_djot_inline_with_transform<F, G>(
+    src: &str,
+    fmt: &F,
+    transform_text: G,
+) -> (String, bool)
+where
+    F: OutputFormat<Output = String>,
+    G: FnMut(&str) -> String,
+{
+    render_djot_inline_internal(src, fmt, transform_text)
 }
 
 /// Render org-mode inline markup by walking the orgize event stream.
@@ -181,7 +258,9 @@ pub fn render_org_inline<F: OutputFormat<Output = String>>(src: &str, fmt: &F) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::render::html::Html;
     use crate::render::plain::PlainText;
+    use crate::render::typst::Typst;
 
     #[test]
     fn test_djot_emphasis_plain() {
@@ -230,6 +309,30 @@ mod tests {
         let result = render_djot_inline("[click here](https://example.com)", &fmt);
         // PlainText.link() just renders the link text (ignores URL)
         assert_eq!(result, "click here");
+    }
+
+    #[test]
+    fn test_djot_nested_formatting_preserves_typst_markup() {
+        let fmt = Typst;
+        let result = render_djot_inline("_emphasized *bold* text_", &fmt);
+        assert_eq!(result, "_emphasized *bold* text_");
+    }
+
+    #[test]
+    fn test_djot_nested_link_preserves_inner_markup_html() {
+        let fmt = Html;
+        let result = render_djot_inline("[_linked emphasis_](https://example.com)", &fmt);
+        assert_eq!(
+            result,
+            r#"<a href="https://example.com"><i>linked emphasis</i></a>"#
+        );
+    }
+
+    #[test]
+    fn test_djot_quotes_inside_emphasis_open_correctly() {
+        let fmt = PlainText;
+        let result = render_djot_inline("_\"Parmenides\" dialogue_", &fmt);
+        assert_eq!(result, "_“Parmenides” dialogue_");
     }
 
     #[test]

--- a/crates/citum-engine/src/render/test_formats.rs
+++ b/crates/citum-engine/src/render/test_formats.rs
@@ -79,6 +79,22 @@ mod tests {
     }
 
     #[test]
+    fn test_html_link_percent_encodes_href_breakout_chars() {
+        let component = ProcTemplateComponent {
+            template_component: tc_variable!(Url),
+            value: "label".to_string(),
+            url: Some(r#"" onmouseover="alert(1)"#.to_string()),
+            ..Default::default()
+        };
+
+        let result = render_component_with_format::<Html>(&component);
+        assert_eq!(
+            result,
+            r#"<span class="csln-url"><a href="%22%20onmouseover=%22alert(1)">label</a></span>"#
+        );
+    }
+
+    #[test]
     fn test_html_title_link_doi() {
         use citum_schema::{
             options::{LinkAnchor, LinkTarget, LinksConfig},

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -1040,6 +1040,290 @@ fn test_title_values_smarten_french_apostrophes() {
     );
 }
 
+/// Tests straight double quotes being smartened in plain title values.
+#[test]
+fn test_title_values_smarten_double_quotes() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "quoted-title".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("The \"Parmenides\" dialogue".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "The “Parmenides” dialogue");
+}
+
+/// Tests the behavior of mixed outer single and inner double title quotes.
+#[test]
+fn test_title_values_flip_flop_outer_single_inner_double_quotes() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "flip-flop-single-double".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("'Some Title \"with something\"'".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "‘Some Title “with something”’");
+}
+
+/// Tests the behavior of mixed outer double and inner single title quotes.
+#[test]
+fn test_title_values_flip_flop_outer_double_inner_single_quotes() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "flip-flop-double-single".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("\"Some title 'with something'\"".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "“Some title ‘with something’”");
+}
+
+/// Tests the behavior of preserving ambiguous double quotes in title values.
+#[test]
+fn test_title_values_preserve_ambiguous_double_quotes() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "record-title".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("The 12\" record".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "The 12\" record");
+}
+
+/// Tests the behavior of djot-marked title values.
+#[test]
+fn test_title_values_render_djot_markup_as_preformatted() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "djot-title".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("_Homo sapiens_ and *modern* world".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "_Homo sapiens_ and **modern** world");
+    assert!(values.pre_formatted);
+}
+
+/// Tests the behavior of djot-marked title smart apostrophes.
+#[test]
+fn test_title_values_smarten_djot_text_leaves() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "djot-apostrophe".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("_Plato's dialogue_".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "_Plato’s dialogue_");
+    assert!(values.pre_formatted);
+}
+
+/// Tests the behavior of djot-marked title smart double quotes.
+#[test]
+fn test_title_values_smarten_djot_double_quotes() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "djot-double-quotes".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("_\"Parmenides\" dialogue_".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "_“Parmenides” dialogue_");
+    assert!(values.pre_formatted);
+}
+
+/// Tests the behavior of inline title links suppressing whole-title autolinks.
+#[test]
+fn test_title_values_inline_link_suppresses_outer_title_link() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "djot-link".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("[Linked title](https://example.com)".to_string()),
+        doi: Some("10.1001/test".to_string()),
+        ..Default::default()
+    });
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        links: Some(LinksConfig {
+            doi: Some(true),
+            target: Some(LinkTarget::Doi),
+            anchor: Some(LinkAnchor::Title),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("title value should render");
+    assert_eq!(values.value, "Linked title");
+    assert!(values.pre_formatted);
+    assert_eq!(values.url, None);
+}
+
 /// Tests the behavior of test_variable_hyperlink.
 #[test]
 fn test_variable_hyperlink() {

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -6,45 +6,74 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Rendering logic for title fields with smartening and form selection.
 //!
 //! This module handles title component rendering, including main titles,
-//! container titles, and proper smart apostrophe handling.
+//! container titles, and smart quote handling.
 
 use crate::reference::Reference;
+use crate::render::rich_text::render_djot_inline_with_transform;
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
 use citum_schema::reference::{Parent, types::Title};
 use citum_schema::template::{TemplateTitle, TitleForm, TitleType};
 
-/// Converts straight apostrophes to smart apostrophes or quotes based on context.
+/// Converts straight apostrophes and double quotes to curly quotes when the
+/// surrounding context is unambiguous.
 ///
-/// Distinguishes between contractions/possessives (right single quotation mark)
-/// and opening quotes (left single quotation mark), preserving straight apostrophes
-/// in ambiguous contexts.
-fn smarten_apostrophes(input: &str) -> String {
+/// Ambiguous characters are preserved as straight quotes so titles containing
+/// measurements or other non-quotation uses do not get rewritten arbitrarily.
+fn smarten_title_quotes(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut it = input.char_indices().peekable();
     let mut prev: Option<char> = None;
-    while let Some((_, ch)) = it.next() {
-        if ch == '\'' {
-            let next = it.peek().map(|(_, c)| *c);
-            let prev_is_alpha = prev.is_some_and(|c| c.is_alphabetic());
-            let next_is_alpha = next.is_some_and(|c| c.is_alphabetic());
-            let next_is_digit = next.is_some_and(|c| c.is_ascii_digit());
-            let prev_opens_quote =
-                prev.is_none_or(|c| c.is_whitespace() || "([{\u{201C}\"".contains(c));
-            let next_closes_quote =
-                next.is_none_or(|c| c.is_whitespace() || ".,;:!?)]}\u{201D}\"".contains(c));
+    let mut open_single_quotes = 0usize;
+    let mut open_double_quotes = 0usize;
 
-            if prev_is_alpha && next_is_alpha {
-                out.push('\u{2019}');
-            } else if prev_opens_quote && next_is_alpha {
-                out.push('\u{2018}');
-            } else if (prev_opens_quote && next_is_digit) || (prev_is_alpha && next_closes_quote) {
-                out.push('\u{2019}');
-            } else {
-                out.push('\'');
+    while let Some((_, ch)) = it.next() {
+        let next = it.peek().map(|(_, c)| *c);
+        let prev_is_alpha = prev.is_some_and(|c| c.is_alphabetic());
+        let prev_is_digit = prev.is_some_and(|c| c.is_ascii_digit());
+        let prev_can_close_double_quote = prev.is_some_and(|c| {
+            c.is_alphanumeric() || matches!(c, '\'' | '"' | '\u{2019}' | '\u{201D}')
+        });
+        let next_is_alpha = next.is_some_and(|c| c.is_alphabetic());
+        let next_is_digit = next.is_some_and(|c| c.is_ascii_digit());
+        let next_is_alnum = next.is_some_and(|c| c.is_alphanumeric());
+        let prev_opens_quote =
+            prev.is_none_or(|c| c.is_whitespace() || "([{\u{2018}\u{201C}'\"".contains(c));
+        let next_closes_quote =
+            next.is_none_or(|c| c.is_whitespace() || ".,;:!?)]}\u{2019}\u{201D}'\"".contains(c));
+
+        match ch {
+            '\'' => {
+                if (prev_is_alpha && next_is_alpha) || (prev_opens_quote && next_is_digit) {
+                    out.push('\u{2019}');
+                } else if prev_opens_quote && next_is_alnum {
+                    out.push('\u{2018}');
+                    open_single_quotes += 1;
+                } else if (open_single_quotes > 0 || prev_is_alpha || prev_is_digit)
+                    && next_closes_quote
+                {
+                    out.push('\u{2019}');
+                    open_single_quotes = open_single_quotes.saturating_sub(1);
+                } else {
+                    out.push('\'');
+                }
             }
-        } else {
-            out.push(ch);
+            '"' => {
+                if prev_opens_quote && next_is_alnum {
+                    out.push('\u{201C}');
+                    open_double_quotes += 1;
+                } else if open_double_quotes > 0 && prev_can_close_double_quote && next_closes_quote
+                {
+                    out.push('\u{201D}');
+                    open_double_quotes -= 1;
+                } else if prev_is_alpha && next_closes_quote {
+                    out.push('\u{201D}');
+                } else {
+                    out.push('"');
+                }
+            }
+            _ => out.push(ch),
         }
+
         prev = Some(ch);
     }
     out
@@ -85,6 +114,21 @@ fn parent_short_title(reference: &Reference, title_type: &TitleType) -> Option<S
     }
 }
 
+fn render_title_inline<F: crate::render::format::OutputFormat<Output = String>>(
+    value: &str,
+    fmt: &F,
+) -> (String, bool) {
+    render_djot_inline_with_transform(value, fmt, smarten_title_quotes)
+}
+
+fn looks_like_djot_markup(value: &str) -> bool {
+    value.contains('_')
+        || value.contains('*')
+        || value.contains("](")
+        || value.contains("{.")
+        || value.contains('`')
+}
+
 impl ComponentValues for TemplateTitle {
     fn values<F: crate::render::format::OutputFormat<Output = String>>(
         &self,
@@ -104,13 +148,19 @@ impl ComponentValues for TemplateTitle {
             && let Some(short_title) = parent_short_title(reference, &self.title)
             && !short_title.is_empty()
         {
+            let (value, pre_formatted) = if looks_like_djot_markup(&short_title) {
+                let (value, _) = render_title_inline(&short_title, &F::default());
+                (value, true)
+            } else {
+                (smarten_title_quotes(&short_title), false)
+            };
             return Some(ProcValues {
-                value: smarten_apostrophes(&short_title),
+                value,
                 prefix: None,
                 suffix: None,
                 url: None,
                 substituted_key: None,
-                pre_formatted: false,
+                pre_formatted,
             });
         }
 
@@ -177,13 +227,20 @@ impl ComponentValues for TemplateTitle {
                 reference,
                 LinkAnchor::Title,
             );
+            let (value, has_explicit_link, pre_formatted) = if looks_like_djot_markup(&value) {
+                let fmt = F::default();
+                let (value, has_explicit_link) = render_title_inline(&value, &fmt);
+                (value, has_explicit_link, true)
+            } else {
+                (smarten_title_quotes(&value), false, false)
+            };
             ProcValues {
-                value: smarten_apostrophes(&value),
+                value,
                 prefix: None,
                 suffix: None,
-                url,
+                url: if has_explicit_link { None } else { url },
                 substituted_key: None,
-                pre_formatted: false,
+                pre_formatted,
             }
         })
     }

--- a/docs/architecture/DJOT_RICH_TEXT.md
+++ b/docs/architecture/DJOT_RICH_TEXT.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented (Phase 1) — bean `csl26-suz3`, branch `feat/djot-rich-text`, commit `df059ae`.
+Partially implemented (Phases 1 and 3) — bean `csl26-suz3`.
 
 ## Summary
 
@@ -34,15 +34,25 @@ annotation:
   paragraph_break: blank_line
 ```
 
-### Scope B — `note` and `abstract` fields (Phase 2)
+### Scope B — `note` and `abstract` fields (Phase 2, still open)
 
 Reference fields `note` and `abstract` are plain `Option<String>` today. A new `RichText` wrapper type will be introduced in `citum-schema` that serialises transparently from YAML strings but carries a format tag. At render time in the engine, field values pass through `render_djot_inline` before entering template rendering.
 
 `abstract` and `note` are safe to migrate first because neither undergoes case transformation. See the title section below.
 
-### Scope C — `title` and other case-transformed fields (future)
+### Scope C — `title` fields under the current rendering model (Phase 3)
 
-**Deferred.** `title` has a custom `Title` type and is subject to sentence-case and title-case transformation in the engine. Djot parsing must happen *after* case transformation is applied to leaf text nodes — not the raw string, where markers like `_foo_` would be uppercased. This requires making the case-transformation code AST-aware, which is a separate architectural change. See the title markup section below.
+Implemented for the current engine model. Resolved title strings are parsed as
+Djot inline, smart apostrophes are applied to `Event::Str` leaf text, and the
+result is returned as `pre_formatted` so outer title rendering can still apply
+quotes, italics, and affixes around the already-rendered inline markup.
+
+If an authored title contains an explicit inline Djot link, that link takes
+precedence over whole-title auto-linking.
+
+This does **not** implement general title-case or sentence-case semantics.
+`.nocase` and the broader text-case question remain deferred to follow-up bean
+`csl26-wv5o`.
 
 ## Title Markup: Known Cases
 
@@ -86,20 +96,21 @@ Implemented in `crates/citum-engine/src/render/rich_text.rs`:
 pub fn render_djot_inline<F: OutputFormat<Output = String>>(src: &str, fmt: &F) -> String
 ```
 
-Uses a stack-based approach over `jotdown::Parser::new(src)`. Each `Event::Start` pushes a new scope; `Event::End` pops the scope, applies the format method, and pushes the result to the parent scope.
+Uses a stack-based approach over `jotdown::Parser::new(src)`. Each frame stores
+its collected child output, any explicit link target, and frame-local span
+classes so nested markup can be rendered without escaping already-formatted
+children.
 
 | jotdown event | OutputFormat method |
 |---|---|
 | `Container::Emphasis` | `fmt.emph(…)` |
 | `Container::Strong` | `fmt.strong(…)` |
-| `Container::Link(…)` | `fmt.text(…)` (link URL not available at End; degrades to text — known limitation) |
+| `Container::Link(…)` | `fmt.link(…)` |
 | `Container::Verbatim` | `fmt.text(…)` (preserve as-is) |
-| `Container::Span` with class `smallcaps` | `fmt.small_caps(…)` |
+| `Container::Span` with class `smallcaps` / `small-caps` | `fmt.small_caps(…)` |
 | Block-level containers (`Heading`, `Paragraph`, `CodeBlock`, etc.) | Text content collected, block structure dropped |
-| `Event::Str(s)` | `fmt.text(s)` |
+| `Event::Str(s)` | `fmt.text(s)` or transformed text for title rendering |
 | `Event::Softbreak` / `Hardbreak` | `fmt.text(" ")` |
-
-**Known limitation:** Link URL is only accessible at `Event::Start(Container::Link(url, …))` but the formatted inner content is only available at `Event::End`. The current implementation degrades links to plain text. Fix requires stashing the URL on the stack alongside the content buffer.
 
 ### `AnnotationFormat` enum
 
@@ -130,9 +141,20 @@ Unit tests in `rich_text.rs`:
 - `test_djot_unicode_math` — `H₂O` passes through unchanged
 - `test_djot_plain_no_markup` — plain string passes through unchanged
 - `test_djot_combined_formatting` — nested emphasis + strong renders correctly
+- `test_djot_nested_formatting_preserves_typst_markup` — nested Djot markup is
+  not re-escaped when rendered to Typst
+- `test_djot_nested_link_preserves_inner_markup_html` — explicit links preserve
+  formatted child content in HTML output
+
+Title regressions in `values/tests.rs` and `processor/tests.rs` cover:
+
+- pre-formatted Djot title values
+- smart apostrophes applied to Djot title leaf text
+- inline title links suppressing whole-title auto-links
+- title preset wrapping around inner Djot markup
 
 ## Non-Goals
 
 - LaTeX or MathML interpretation
 - Full djot block-level rendering for field values
-- AST-level title markup (deferred to a follow-up)
+- General title/text-case semantics such as `.nocase`


### PR DESCRIPTION
## Summary
- support Djot inline markup inside title values under the current rendering model
- preserve explicit inline title links and avoid nested whole-title autolinks
- smarten straight title quotes across plain titles and Djot-marked title text, including flip-flop quote cases
- update the csl26-suz3 bean and architecture notes, and add a successor bean for broader title/text-case work

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run