### PR TITLE
fix(engine): correct note-style ibid rendering

### DIFF
--- a/crates/citum-engine/src/processor/document/README.md
+++ b/crates/citum-engine/src/processor/document/README.md
@@ -64,5 +64,5 @@ The `Processor::process_document` method follows these steps:
 2.  For non-note styles, render each parsed citation inline.
 3.  For note styles, assign note numbers from body note-reference order, annotate citation positions in that note order, replace prose citations with generated footnote references, and render citations inside manual footnotes in place.
 4.  Emit any generated footnote definitions.
-5.  Append the bibliography.
+5.  Append the bibliography only when rendered bibliography content is non-empty.
 6.  Optionally finalize the rendered markup as HTML.

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -389,10 +389,12 @@ impl Processor {
                     ),
                     format,
                 );
-                let bib_heading = "\n\n# Bibliography\n\n";
                 let mut result = rendered;
-                result.push_str(bib_heading);
-                result.push_str(&placeholders.push_block(bib_content));
+                if !bib_content.trim().is_empty() {
+                    let bib_heading = "\n\n# Bibliography\n\n";
+                    result.push_str(bib_heading);
+                    result.push_str(&placeholders.push_block(bib_content));
+                }
                 let html = parser.finalize_html_output(&result);
                 return placeholders.apply(html);
             } else if processor.is_note_style() {
@@ -408,14 +410,16 @@ impl Processor {
                 ),
                 format,
             );
-            let bib_heading = match format {
-                DocumentFormat::Latex => "\n\n\\section*{Bibliography}\n\n",
-                DocumentFormat::Typst => "\n\n= Bibliography\n\n",
-                _ => "\n\n# Bibliography\n\n",
-            };
             let mut result = rendered;
-            result.push_str(bib_heading);
-            result.push_str(&bib_content);
+            if !bib_content.trim().is_empty() {
+                let bib_heading = match format {
+                    DocumentFormat::Latex => "\n\n\\section*{Bibliography}\n\n",
+                    DocumentFormat::Typst => "\n\n= Bibliography\n\n",
+                    _ => "\n\n# Bibliography\n\n",
+                };
+                result.push_str(bib_heading);
+                result.push_str(&bib_content);
+            }
             let result = rewrite_document_markup_for_typst(result, format);
             return match format {
                 DocumentFormat::Html => parser.finalize_html_output(&result),
@@ -518,11 +522,12 @@ impl Processor {
                 processor.process_inline_document_html(body, parsed, &mut placeholders)
             };
 
+            let bib_content = processor.render_grouped_bibliography_with_format::<F>();
             let mut result = rendered;
-            result.push_str("\n\n# Bibliography\n\n");
-            result.push_str(
-                &placeholders.push_block(processor.render_grouped_bibliography_with_format::<F>()),
-            );
+            if !bib_content.trim().is_empty() {
+                result.push_str("\n\n# Bibliography\n\n");
+                result.push_str(&placeholders.push_block(bib_content));
+            }
             let html = parser.finalize_html_output(&result);
             return placeholders.apply(html);
         } else if processor.is_note_style() {
@@ -531,14 +536,17 @@ impl Processor {
             processor.process_inline_document::<F>(body, parsed)
         };
 
-        let bib_heading = match format {
-            DocumentFormat::Latex => "\n\n\\section*{Bibliography}\n\n",
-            DocumentFormat::Typst => "\n\n= Bibliography\n\n",
-            _ => "\n\n# Bibliography\n\n",
-        };
+        let bib_content = processor.render_grouped_bibliography_with_format::<F>();
         let mut result = rendered;
-        result.push_str(bib_heading);
-        result.push_str(&processor.render_grouped_bibliography_with_format::<F>());
+        if !bib_content.trim().is_empty() {
+            let bib_heading = match format {
+                DocumentFormat::Latex => "\n\n\\section*{Bibliography}\n\n",
+                DocumentFormat::Typst => "\n\n= Bibliography\n\n",
+                _ => "\n\n# Bibliography\n\n",
+            };
+            result.push_str(bib_heading);
+            result.push_str(&bib_content);
+        }
         let result = rewrite_document_markup_for_typst(result, format);
 
         match format {
@@ -1082,13 +1090,18 @@ impl Processor {
                 sets: &self.compound_sets,
             },
         );
+        let anchor_position = match citation.position.as_ref() {
+            Some(citum_schema::citation::Position::Ibid)
+            | Some(citum_schema::citation::Position::IbidWithLocator) => None,
+            other => other,
+        };
 
         renderer.render_integral_anchor_with_format::<F>(
             &sorted_items,
             &effective_spec,
             inter_delimiter,
             citation.suppress_author,
-            citation.position.as_ref(),
+            anchor_position,
         )
     }
 

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -1112,6 +1112,19 @@ impl<'a> Renderer<'a> {
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
+        let is_note_processing = self.config.processing.as_ref().is_some_and(|processing| {
+            matches!(processing, citum_schema::options::Processing::Note)
+        });
+        if is_note_processing
+            && matches!(
+                position,
+                Some(citum_schema::citation::Position::Ibid)
+                    | Some(citum_schema::citation::Position::IbidWithLocator)
+            )
+        {
+            return String::new();
+        }
+
         let options = RenderOptions {
             config: self.config,
             locale: self.locale,

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -275,6 +275,98 @@ fn test_example_document_renders_note_style_integral_anchor_and_notes() {
 }
 
 #[test]
+fn test_chicago_notes_document_renders_ibid_without_author_concatenation() {
+    let style = load_style("styles/chicago-notes.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = DjotParser;
+    let document = fs::read_to_string(project_root().join("examples/document-citation-flow.djot"))
+        .expect("citation flow example should be readable");
+
+    let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
+        &document,
+        &parser,
+        DocumentFormat::Djot,
+    );
+
+    assert!(
+        output.contains("Ibid"),
+        "note style should render ibid in this scenario: {output}"
+    );
+    assert!(
+        !output.contains("KuhnIbid"),
+        "ibid should not concatenate with author token: {output}"
+    );
+    assert!(
+        !output.contains("SmithIbid"),
+        "ibid should not concatenate with author token: {output}"
+    );
+}
+
+#[test]
+fn test_chicago_notes_document_omits_empty_bibliography_heading() {
+    let style = load_style("styles/chicago-notes.yaml");
+    let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+        .expect("example bibliography should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let parser = DjotParser;
+    let document = fs::read_to_string(project_root().join("examples/document-citation-flow.djot"))
+        .expect("citation flow example should be readable");
+
+    let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
+        &document,
+        &parser,
+        DocumentFormat::Djot,
+    );
+
+    assert!(
+        !output.contains("# Bibliography"),
+        "empty bibliography should not emit heading: {output}"
+    );
+
+    let html_output = processor.process_document::<_, citum_engine::render::html::Html>(
+        &document,
+        &parser,
+        DocumentFormat::Html,
+    );
+    assert!(
+        !html_output.contains("<h1>Bibliography</h1>"),
+        "empty bibliography should not emit HTML heading: {html_output}"
+    );
+}
+
+#[test]
+fn test_document_citation_flow_non_note_styles_do_not_render_ibid() {
+    let parser = DjotParser;
+    let document = fs::read_to_string(project_root().join("examples/document-citation-flow.djot"))
+        .expect("citation flow example should be readable");
+
+    for style_path in [
+        "styles/apa-7th.yaml",
+        "styles/ieee.yaml",
+        "styles/alpha.yaml",
+    ] {
+        let style = load_style(style_path);
+        let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))
+            .expect("example bibliography should parse");
+        let processor = Processor::new(style, bibliography);
+
+        let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
+            &document,
+            &parser,
+            DocumentFormat::Djot,
+        );
+        assert!(
+            !output.contains("Ibid"),
+            "non-note style unexpectedly rendered ibid for {style_path}: {output}"
+        );
+    }
+}
+
+#[test]
 fn test_markdown_document_renders_pandoc_author_date_citations() {
     let style = load_style("styles/apa-7th.yaml");
     let bibliography = load_bibliography(&project_root().join("examples/document-refs.json"))

--- a/docs/specs/NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md
+++ b/docs/specs/NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md
@@ -1,6 +1,6 @@
 # Document Note Stream Specification
 
-**Status:** Draft
+**Status:** Active
 **Version:** 1.0
 **Date:** 2026-03-10
 **Supersedes:** N/A
@@ -30,6 +30,14 @@ Out of scope:
 6. A footnote definition is one note slot in the shared stream even when it contains multiple citations and non-citation content.
 7. Position-aware rendering uses the shared stream and the style’s position templates (`first`, `subsequent`, `ibid`).
 
+## Note Ordering and Position Rules
+1. The note sequence is linear and derived from document order, not page layout.
+2. Generated note references and authored footnote references share this same linear sequence.
+3. Position resolution (`first`, `subsequent`, `ibid`) is computed against that shared sequence.
+4. `Ibid` eligibility is determined by the immediately preceding note context in that sequence.
+5. `Ibid` applies only when the immediately preceding note context resolves to a single source.
+6. When a footnote contains multiple citations, they share one note slot while still resolving per-citation position in source order within that slot.
+
 ## Implementation Notes
 - Citation position logic for document rendering must remain independent of page
   layout or pagination.
@@ -44,4 +52,4 @@ Out of scope:
 - [ ] Manual and generated note sequencing is page-agnostic.
 
 ## Changelog
-- v1.0 (2026-03-10): Initial version.
+- v1.0 (2026-03-10): Initial active version.

--- a/examples/document-citation-flow.djot
+++ b/examples/document-citation-flow.djot
@@ -1,0 +1,30 @@
+Some citations in the main text flow:
+
+- Normal citation.[^c1]
+- Author suppression.[^c2]
+- Integral: [+@kuhn1962] argues that...
+
+Some text.[^note]
+
+Some more citations in the main text flow, but without explicit notes:
+
+- Normal citation.[@smith2010]
+- Author suppression.[-@smith2010]
+- Integral: [+@smith2010] argues that...
+
+Some other text.[^note2]
+
+[^c1]: [@kuhn1962].
+
+[^c2]: [-@kuhn1962].
+
+[^note]: Some citations in a note...
+
+   - [@kuhn1962].
+   - [-@kuhn1962].
+   - [+@kuhn1962] argues that...
+
+[^note2]: Some more citations in a note...
+
+   - [+@brown1954] argues that...
+   - [+@brown1954] also argues that...


### PR DESCRIPTION
## Summary
- Fix note-style `ibid` rendering so it is emitted cleanly (no concatenated author tokens like `SmithIbid`).
- Preserve integral prose anchors while keeping note-position resolution correct across generated and manual notes.
- Add regression coverage with a Djot document fixture and cross-style checks (Chicago notes, APA, numeric/label styles).
- Define and narrow the note-stream spec to document-order, page-agnostic note sequencing and `ibid` eligibility rules.
- Incorporate review follow-up optimization that removes redundant PlainText bibliography render passes.

## What Changed
- Updated note-style rendering flow for integral citations so anchor handling and position templates stay coherent.
- Kept the non-integral `ibid` guard in rendering where it remains semantically required.
- Document processor now renders bibliography content once in target format and checks emptiness on that output directly.
- Expanded/updated document tests for mixed manual/generated notes and style comparisons.
- Refined `docs/specs/NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md` to focus only on note-stream behavior and rules.

## Key Files
- crates/citum-engine/src/processor/document/mod.rs
- crates/citum-engine/src/processor/mod.rs
- crates/citum-engine/src/processor/rendering.rs
- crates/citum-engine/tests/document.rs
- examples/document-citation-flow.djot
- docs/specs/NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- cargo run --bin citum -- render doc examples/document-citation-flow.djot -b examples/document-refs.json -s styles/chicago-notes.yaml -I djot -f djot
