### PR TITLE
chore(release): bump to 0.10.0 and align schema versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "winnow",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -484,14 +484,14 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "citum-schema-style",
 ]
 
 [[package]]
 name = "citum-schema-style"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -721,7 +721,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "indexmap 2.13.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -96,6 +96,9 @@ pub struct InputBibliographyInfo {
 /// A named template (reusable sequence of components).
 pub type Template = Vec<TemplateComponent>;
 
+/// Canonical Citum style schema version used when `Style.version` is omitted.
+pub const STYLE_SCHEMA_VERSION: &str = "0.8.0";
+
 /// The new CSLN Style model.
 ///
 /// This is the target schema for CSLN, featuring declarative options
@@ -127,7 +130,7 @@ pub struct Style {
 }
 
 fn default_version() -> String {
-    "0.8.0".to_string()
+    STYLE_SCHEMA_VERSION.to_string()
 }
 
 /// Available embedded template presets.

--- a/crates/citum-schema/src/lib.rs
+++ b/crates/citum-schema/src/lib.rs
@@ -5,6 +5,9 @@
 
 pub use citum_schema_style::*;
 
+/// Canonical Citum style schema version for external consumers.
+pub const SCHEMA_VERSION: &str = citum_schema_style::STYLE_SCHEMA_VERSION;
+
 /// Data-oriented schema exports.
 pub mod data {
     pub use citum_schema_data::*;

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -9,7 +9,7 @@ Citum uses **independent versioning** for code and schema to maintain clarity an
 | Track | What | Version Source | Automation |
 |-------|------|----------------|------------|
 | **Code** | Rust crates (processor, core library, CLI) | `Cargo.toml` workspace version | Fully automated via release-plz |
-| **Schema** | Style YAML format specification | `Style.version` default in `citum_schema/src/lib.rs` | Semi-automated (manual bump + validation) |
+| **Schema** | Style YAML format specification | `citum_schema::SCHEMA_VERSION` (backed by `citum-schema-style`) | Semi-automated (manual bump + validation) |
 
 ### Why Two Tracks?
 
@@ -81,15 +81,16 @@ Tracks reach 1.0 independently based on their own stability criteria:
 
 ### Current Schema Version
 
-Check the default schema version in `../crates/citum-schema/src/lib.rs`:
+Check the public schema version constant in `../crates/citum-schema/src/lib.rs`:
 
 ```rust
-fn default_version() -> String {
-    "0.8.0".to_string()  // Current schema version
-}
+pub const SCHEMA_VERSION: &str = citum_schema_style::STYLE_SCHEMA_VERSION;
 ```
 
-All style files inherit this default unless explicitly overridden in YAML.
+This constant is the public source of truth and currently resolves to
+`STYLE_SCHEMA_VERSION` in `../crates/citum-schema-style/src/lib.rs`.
+
+All style files inherit this version as the `Style.version` default unless explicitly overridden in YAML.
 
 ### When to Bump Schema Version
 
@@ -123,14 +124,14 @@ Use the `../scripts/bump.sh` script to update the schema version:
 ../scripts/bump.sh schema minor --dry-run
 
 # What it does:
-# 1. Updates default_version() in citum_schema/src/lib.rs
+# 1. Updates STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/lib.rs
 # 2. Updates ./SCHEMA_VERSIONING.md with a schema changelog entry
 # 3. Validates with `cargo test --quiet --lib`
 # 4. Creates a schema-vX.Y.Z git tag
 ```
 
 **Manual process:**
-1. Update `default_version()` in `../crates/citum-schema/src/lib.rs`
+1. Update `STYLE_SCHEMA_VERSION` in `../crates/citum-schema-style/src/lib.rs`
 2. Run `cargo test --quiet --lib`
 3. Update this file with a schema changelog entry
 4. Commit the schema bump

--- a/scripts/bump.py
+++ b/scripts/bump.py
@@ -15,7 +15,7 @@ from typing import Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SCHEMA_LIB = REPO_ROOT / "crates/citum-schema/src/lib.rs"
+SCHEMA_STYLE_LIB = REPO_ROOT / "crates/citum-schema-style/src/lib.rs"
 SCHEMA_DOC = REPO_ROOT / "docs/reference/SCHEMA_VERSIONING.md"
 RELEASE_PLZ_WORKFLOW = REPO_ROOT / ".github/workflows/release-plz.yml"
 TRACK_CHOICES = ("schema", "code", "engine", "all")
@@ -89,13 +89,13 @@ def run_git(args: Sequence[str], check: bool = True) -> subprocess.CompletedProc
 
 
 def read_schema_version() -> str:
-    """Read the default schema version from citum-schema."""
+    """Read the canonical schema version from citum-schema-style."""
 
-    content = SCHEMA_LIB.read_text(encoding="utf-8")
-    match = re.search(r'fn default_version\(\) -> String \{\s*"([^"]+)"\.to_string\(\)\s*\}', content)
+    content = SCHEMA_STYLE_LIB.read_text(encoding="utf-8")
+    match = re.search(r'pub const STYLE_SCHEMA_VERSION: &str = "([^"]+)";', content)
     if match is None:
         raise BumpError(
-            "Could not find a string-returning default_version() in crates/citum-schema/src/lib.rs"
+            "Could not find STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/lib.rs"
         )
     return match.group(1)
 
@@ -138,7 +138,7 @@ def resolve_plan(track: str, bump_type: str, release_name: str) -> ReleasePlan:
     new_version = bump_version(old_version, bump_type)
 
     if track == "schema":
-        files_to_modify = [SCHEMA_LIB, SCHEMA_DOC]
+        files_to_modify = [SCHEMA_STYLE_LIB, SCHEMA_DOC]
         tags_to_create = (f"schema-v{new_version}",)
         changelog_tag_prefix = "schema-v"
     else:
@@ -218,7 +218,10 @@ def print_preview(plan: ReleasePlan) -> None:
         header(f"Schema release bump: {plan.old_version} -> {plan.new_version}")
         print("  Scope        : bump the default style schema version without changing code release versions")
         print(f"  Bump type    : {plan.bump_type}")
-        print(f"  Schema lib   : update default_version() in {SCHEMA_LIB.relative_to(REPO_ROOT)}")
+        print(
+            "  Schema lib   : update STYLE_SCHEMA_VERSION in "
+            f"{SCHEMA_STYLE_LIB.relative_to(REPO_ROOT)}"
+        )
         print(f"  Schema tag   : {plan.tags_to_create[0]}")
         print(f"  Schema doc   : add changelog entry in {SCHEMA_DOC.relative_to(REPO_ROOT)}")
     else:
@@ -243,14 +246,14 @@ def confirm_prompt() -> bool:
 
 
 def update_schema_version(plan: ReleasePlan) -> None:
-    """Replace the default schema version in citum-schema."""
+    """Replace STYLE_SCHEMA_VERSION in citum-schema-style."""
 
-    content = SCHEMA_LIB.read_text(encoding="utf-8")
-    pattern = r'(fn default_version\(\) -> String \{\s*")([^"]+)("\.to_string\(\)\s*\})'
+    content = SCHEMA_STYLE_LIB.read_text(encoding="utf-8")
+    pattern = r'(pub const STYLE_SCHEMA_VERSION: &str = ")([^"]+)(";)'
     updated, count = re.subn(pattern, rf"\g<1>{plan.new_version}\g<3>", content, count=1)
     if count != 1:
-        raise BumpError("Failed to update default_version() in crates/citum-schema/src/lib.rs")
-    SCHEMA_LIB.write_text(updated, encoding="utf-8")
+        raise BumpError("Failed to update STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/lib.rs")
+    SCHEMA_STYLE_LIB.write_text(updated, encoding="utf-8")
 
 
 def update_schema_doc(plan: ReleasePlan) -> None:


### PR DESCRIPTION
## Summary
- bump workspace version from 0.9.0 to 0.10.0
- expose `citum_schema::SCHEMA_VERSION` from the facade crate
- anchor style defaulting on `STYLE_SCHEMA_VERSION` in `citum-schema-style`
- update schema versioning docs and `scripts/bump.py` for the split crate layout

## Validation
- `./scripts/bump.sh schema minor --dry-run`
- `cargo run --bin citum --features schema -- schema style > /tmp/citum-style-schema.json`
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
