### PR TITLE
chore(skills): validate manifest frontmatter

### DIFF
--- a/.claude/skills/doc-standards/SKILL.md
+++ b/.claude/skills/doc-standards/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: doc-standards
+description: >
+  Documentation standards workflow for Citum specs, policies, architecture
+  snapshots, guides, and references. Use this skill when creating or updating
+  project documentation and choosing the correct docs directory/template.
+---
+
 # doc-standards Skill
 
 **Trigger phrases:** "create a spec", "write a design doc", "add a policy",

--- a/.claude/skills/git-advanced-workflows/SKILL.md
+++ b/.claude/skills/git-advanced-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-advanced-workflows
-description: Master advanced Git workflows including rebasing, cherry-picking, bisect, worktrees, and reflog to maintain clean history and recover from any situation. Use when managing complex Git histories, collaborating on feature branches, or troubleshooting repository issues.
+description: "Master advanced Git workflows including rebasing, cherry-picking, bisect, worktrees, and reflog to maintain clean history and recover from any situation. Use when managing complex Git histories, collaborating on feature branches, or troubleshooting repository issues."
 ---
 
 # Git Advanced Workflows

--- a/.claude/skills/pr-workflow-fast/SKILL.md
+++ b/.claude/skills/pr-workflow-fast/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: pr-workflow-fast
+description: >
+  Fast, consistent branch/PR workflow with explicit change-type quality gates
+  and concise evidence-first PR descriptions.
+---
+
 # PR Workflow Fast
 
 **Type:** User-Invocable, Agent-Invocable

--- a/.claude/skills/rust-pro/SKILL.md
+++ b/.claude/skills/rust-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-pro
-description: Master Rust 1.75+ with modern async patterns, advanced type system features, and production-ready systems programming. Expert in the latest Rust ecosystem including Tokio, axum, and cutting-edge crates. Use PROACTIVELY for Rust development, performance optimization, or systems programming.
+description: "Master Rust 1.75+ with modern async patterns, advanced type system features, and production-ready systems programming. Expert in the latest Rust ecosystem including Tokio, axum, and cutting-edge crates. Use PROACTIVELY for Rust development, performance optimization, or systems programming."
 model: opus
 ---
 

--- a/.claude/skills/style-maintain/SKILL.md
+++ b/.claude/skills/style-maintain/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: style-maintain
 type: agent-invocable
-description: Fast targeted maintenance for an existing Citum style. Use for punctuation/layout bugs, missing type overrides, or syntax modernization. Not for migrations or batch waves.
+description: "Fast targeted maintenance for an existing Citum style. Use for punctuation/layout bugs, missing type overrides, or syntax modernization. Not for migrations or batch waves."
 model: haiku
 ---
 

--- a/.claude/skills/style-qa/SKILL.md
+++ b/.claude/skills/style-qa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: style-qa
 type: agent-invocable
-description: Standardized QA gate for style work. Verifies fidelity (citations + bibliography), SQI drift, formatting defects, and regression surface. Produces approve/reject verdict with numbered findings.
+description: "Standardized QA gate for style work. Verifies fidelity (citations + bibliography), SQI drift, formatting defects, and regression surface. Produces approve/reject verdict with numbered findings."
 model: haiku
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
@@ -45,6 +50,9 @@ jobs:
 
       - name: Check docs and bean hygiene
         run: ./scripts/check-docs-beans-hygiene.sh
+
+      - name: Validate repo frontmatter manifests
+        run: ./scripts/validate-frontmatter.sh --repo-only --copilot-strict
 
       - name: Validate production styles
         run: ./scripts/validate-production-styles.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,18 @@ Fallback if nextest missing: `cargo test`. **DO NOT commit if any check fails.**
 
 Docs/styles (`.md`, `.yaml` in `styles/`) skip checks entirely.
 
+### Manifest Frontmatter Preflight
+
+Before relying on local skills/commands in Claude, Codex, or Copilot, run:
+```bash
+./scripts/validate-frontmatter.sh --copilot-strict
+```
+
+For CI/PR parity (repo-local manifests only), run:
+```bash
+./scripts/validate-frontmatter.sh --repo-only --copilot-strict
+```
+
 ### Documentation Rule
 
 **All new or modified public Rust items must have `///` doc comments.** This applies to structs, enums, traits, functions, and public fields. One clear sentence minimum — describe *what* it is/does. Existing items touched by a change must be documented in the same commit. Doc-only commits skip build checks.

--- a/scripts/validate-frontmatter.sh
+++ b/scripts/validate-frontmatter.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ONLY=false
+COPILOT_STRICT=false
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/validate-frontmatter.sh [--repo-only] [--copilot-strict]
+
+Validates YAML frontmatter for local Claude skills/commands.
+
+Options:
+  --repo-only      Validate repo-managed manifests only (.claude/skills/*/SKILL.md)
+  --copilot-strict Reject risky unquoted plain scalars that often break Copilot parsing
+  -h, --help       Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-only)
+      REPO_ONLY=true
+      shift
+      ;;
+    --copilot-strict)
+      COPILOT_STRICT=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "Error: Ruby is required for scripts/validate-frontmatter.sh." >&2
+  echo "Install Ruby or run in an environment with Ruby in PATH." >&2
+  exit 1
+fi
+
+files=()
+while IFS= read -r path; do
+  files+=("$path")
+done < <(find "$REPO_ROOT/.claude/skills" -mindepth 2 -maxdepth 2 -type f -name 'SKILL.md' 2>/dev/null | sort)
+
+if [[ "$REPO_ONLY" == false ]]; then
+  while IFS= read -r path; do
+    files+=("$path")
+  done < <(find "$HOME/.claude/skills" -mindepth 2 -maxdepth 2 -type f -name 'SKILL.md' 2>/dev/null | sort)
+
+  while IFS= read -r path; do
+    files+=("$path")
+  done < <(find "$HOME/.claude/commands" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort)
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No manifest files found."
+  exit 0
+fi
+
+ruby - "$COPILOT_STRICT" "${files[@]}" <<'RUBY'
+require 'yaml'
+
+copilot_strict = ARGV.shift == 'true'
+files = ARGV
+errors = []
+
+files.each do |file|
+  text = File.read(file, encoding: 'UTF-8')
+
+  unless text.start_with?("---\n")
+    errors << "#{file}:1 missing frontmatter start delimiter (---)"
+    next
+  end
+
+  match = text.match(/\A---\n(.*?)\n---\n?/m)
+  if match.nil?
+    errors << "#{file}:1 malformed frontmatter delimiters"
+    next
+  end
+
+  frontmatter = match[1]
+  begin
+    parsed = YAML.safe_load(frontmatter, permitted_classes: [], aliases: false)
+  rescue Psych::SyntaxError => e
+    line = e.line ? e.line + 1 : 1
+    errors << "#{file}:#{line} YAML parse error: #{e.problem}"
+    next
+  end
+
+  unless parsed.is_a?(Hash)
+    errors << "#{file}:1 frontmatter must be a YAML mapping"
+    next
+  end
+
+  %w[name description].each do |key|
+    value = parsed[key]
+    if !value.is_a?(String) || value.strip.empty?
+      errors << "#{file}:1 required key '#{key}' must be a non-empty string"
+    end
+  end
+
+  next unless copilot_strict
+
+  frontmatter.each_line.with_index(2) do |line, line_no|
+    stripped = line.strip
+    next if stripped.empty? || stripped.start_with?('#')
+
+    key_value = stripped.match(/^([A-Za-z0-9_-]+):\s*(.+)$/)
+    next unless key_value
+
+    value = key_value[2].strip
+    next if value.empty?
+    next if value.start_with?("'", '"', '[', '{', '|', '>', '&', '*', '!')
+
+    risky_characters = value.match?(/[:\[\]\(\)\|]/)
+    risky_options = value.match?(/\[[^\]]+\]/) || value.match?(/--[A-Za-z0-9_-]+/) || value.match?(/\s+or\s+/)
+
+    if risky_characters || risky_options
+      errors << "#{file}:#{line_no} copilot-strict: quote risky plain scalar for '#{key_value[1]}'"
+    end
+  end
+end
+
+if errors.empty?
+  puts "Frontmatter validation passed for #{files.length} file(s)."
+  exit 0
+end
+
+puts "Frontmatter validation failed (#{errors.length} issue#{errors.length == 1 ? '' : 's'}):"
+errors.each { |err| puts "- #{err}" }
+exit 1
+RUBY


### PR DESCRIPTION
## Summary
- add missing YAML frontmatter to repo skills that lacked it
- normalize risky unquoted frontmatter scalars in repo skill descriptions
- add `scripts/validate-frontmatter.sh` for cross-tool manifest validation
- enforce repo manifest validation in CI (`--repo-only --copilot-strict`)
- document local/CI preflight commands in `CLAUDE.md`

## Validation
- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict`
- `./scripts/validate-frontmatter.sh --copilot-strict`
- `./scripts/validate-frontmatter.sh`
- negative tests (temporary files) to confirm failure behavior:
  - missing `description` in a temp skill manifest
  - malformed YAML in a temp command manifest

## Notes
This PR contains repo-managed fixes only. I also applied matching fixes in
`~/.claude/skills` and `~/.claude/commands` locally so Copilot/Claude/Codex
loaders parse consistently, but those home-directory changes are outside git.
