### PR TITLE
feat(styles): roll out note overrides

### DIFF
--- a/.beans/archive/csl26-3go0--unblock-mixed-condition-note-position-trees.md
+++ b/.beans/archive/csl26-3go0--unblock-mixed-condition-note-position-trees.md
@@ -1,7 +1,7 @@
 ---
 # csl26-3go0
 title: Unblock mixed-condition note position trees
-status: in-progress
+status: completed
 type: task
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - styles
     - citations
 created_at: 2026-03-10T22:20:45Z
-updated_at: 2026-03-10T22:54:30Z
+updated_at: 2026-03-11T11:29:52Z
 ---
 
 Follow-on from csl26-qfa3 and archive bean csl26-494i.
@@ -54,3 +54,11 @@ Deliverables:
   regenerated version only if it improves or preserves fidelity. If a specific
   style still needs manual cleanup after the shared migrate fix, split that into
   a narrow follow-on bean rather than widening this shared migration task.
+
+## Summary of Changes
+
+- Confirmed the mixed-condition migrate fix is already landed and treated this bean as a style rollout / repo-truth task rather than new Rust work.
+- Re-ran baseline and fresh XML-mode migrate comparisons for the eight scoped note parents; raw full-file re-migration still regressed fidelity, so shipped styles were updated selectively instead of replaced wholesale.
+- Added explicit repeated-position overrides to the shipped note styles that were still missing them: `chicago-notes-bibliography-17th-edition`, `mhra-notes`, `mhra-notes-publisher-place`, `mhra-notes-publisher-place-no-url`, `new-harts-rules-notes`, `new-harts-rules-notes-label-page`, and `new-harts-rules-notes-label-page-no-url`. `chicago-notes` remained the control case because it already shipped note-position overrides.
+- Verification: per-style oracle checks for all eight scoped parents, note/legal batch rerun via `oracle-batch-aggregate`, core-quality gate pass, and repo-truth doc update for the stale note-style status text.
+- Rendering lint still reports long-standing formatting defects in these note families, but the repeated-position rollout did not change the shipped oracle baselines or widen the scope into unrelated cleanup work.

--- a/.beans/archive/csl26-vnci--audit-repeated-note-position-coverage.md
+++ b/.beans/archive/csl26-vnci--audit-repeated-note-position-coverage.md
@@ -1,0 +1,22 @@
+---
+# csl26-vnci
+title: Audit repeated-note position coverage
+status: completed
+type: feature
+priority: high
+created_at: 2026-03-11T11:44:26Z
+updated_at: 2026-03-11T11:57:14Z
+---
+
+Add committed repeated-note fixtures, a note-style expectation manifest, verification/report plumbing, and gap reporting for first/subsequent/ibid behavior across note styles.
+
+
+Spec: `docs/specs/NOTE_POSITION_AUDIT.md`
+
+## Summary of Changes
+
+- Added dedicated repeated-note fixtures at `tests/fixtures/references-note-positions.json` and `tests/fixtures/citations-note-positions.json`.
+- Added per-style expectation coverage in `scripts/report-data/note-position-expectations.yaml`.
+- Added the repeat-note audit library, CLI, and focused tests.
+- Integrated repeated-note audit results into `scripts/report-core.js` and registered the fixtures in verification/report metadata.
+- Verified the audit now covers all 19 shipped `processing: note` styles and reports current configuration/rendering gaps explicitly.

--- a/.beans/csl26-t79d--spec-normative-note-shortening-policy.md
+++ b/.beans/csl26-t79d--spec-normative-note-shortening-policy.md
@@ -1,0 +1,26 @@
+---
+# csl26-t79d
+title: Spec normative note shortening policy
+status: todo
+type: feature
+priority: medium
+created_at: 2026-03-11T00:00:00Z
+updated_at: 2026-03-11T00:00:00Z
+---
+
+Follow-up to the repeated-note rollout PR.
+
+We need a normative spec for repeated-note and shortened-note behavior across
+note styles, separate from the current shipped-style audit and rollout work.
+
+Definition of done:
+
+- Draft and activate a spec under `docs/specs/` for note-shortening policy.
+- Paraphrase manual-derived rules without quoting copyrighted source text.
+- Classify note-style families such as lexical relative markers, shortened-note
+  preference, legal `id.` forms, and localized variants.
+- Define what belongs in style data versus processor logic.
+- Revisit the note-position audit manifest if the normative model differs from
+  current shipped behavior.
+- Tighten family-level tests only after the spec settles prose/integral
+  repeated-cite semantics.

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -301,7 +301,7 @@ fn test_mixed_manual_and_auto_notes_share_sequence() {
     assert!(result.contains("[^m1]: First"));
     assert!(result.contains("[^m2]: Second"));
     assert!(result.contains("[^citum-auto-2]:"));
-    assert!(result.contains("ibid"));
+    assert!(result.contains("Ibid"));
 }
 
 #[test]
@@ -415,7 +415,7 @@ fn test_note_order_uses_manual_reference_order_not_definition_order() {
 
     assert!(result.contains("[^m1]: See"));
     assert!(result.contains("[^citum-auto-2]:"));
-    assert!(result.contains("ibid"));
+    assert!(result.contains("Ibid"));
 }
 
 #[test]

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -58,6 +58,14 @@ fn effective_locator_string(item: &CitationItem) -> Option<String> {
         .map(|locator| locator.canonical_string())
 }
 
+fn capitalize_first(value: &str) -> String {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
 use self::disambiguation::Disambiguator;
 use self::matching::Matcher;
 use self::rendering::{CompoundRenderData, Renderer};
@@ -1172,7 +1180,22 @@ impl Processor {
             output
         };
 
-        Ok(fmt.finish(wrapped))
+        let mut rendered = fmt.finish(wrapped);
+        if matches!(
+            citation.position,
+            Some(citum_schema::citation::Position::Ibid)
+                | Some(citum_schema::citation::Position::IbidWithLocator)
+        ) && matches!(
+            citation.mode,
+            citum_schema::citation::CitationMode::NonIntegral
+        ) && citation.prefix.as_deref().unwrap_or("").is_empty()
+            && spec_prefix.is_empty()
+            && rendered.starts_with("ibid")
+        {
+            rendered = capitalize_first(&rendered);
+        }
+
+        Ok(rendered)
     }
 
     /// Render multiple citations in document order.

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -831,7 +831,7 @@ fn test_chicago_notes_ibid_renders_compact() {
         .expect("Failed to process ibid citation");
     assert!(
         ibid_result.contains("Ibid."),
-        "Ibid citation should contain 'Ibid.': got {}",
+        "Ibid citation should contain lexical ibid: got {}",
         ibid_result
     );
     // The ibid position is being respected - the citation should be shorter
@@ -881,12 +881,8 @@ fn test_chicago_notes_ibid_with_locator() {
         .process_citation(&ibid_with_locator)
         .expect("Failed to process ibid with locator citation");
     assert!(
-        result.contains("Ibid."),
-        "IbidWithLocator should contain 'Ibid.'"
-    );
-    assert!(
-        result.contains("45"),
-        "IbidWithLocator should contain locator value"
+        result.contains("Ibid., 45"),
+        "IbidWithLocator should contain lexical ibid: {result}"
     );
 }
 

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -260,8 +260,12 @@ fn test_example_document_renders_note_style_integral_anchor_and_notes() {
     assert!(output.contains("Later in the same chapter: Smith[^citum-auto-6] narrows"));
     assert!(output.contains("Integral with locator: Kuhn[^citum-auto-7] argues"));
     assert!(
-        output.contains("[^narrative-note]: Before the prose introduces him, Smith (_A Great Book_) already appears in a note."),
-        "manual note should render once with the citation resolved: {output}"
+        output.contains("[^narrative-note]: Before the prose introduces him, Smith ("),
+        "manual note should preserve the authored anchor: {output}"
+    );
+    assert!(
+        output.contains("_A Great Book_, 3"),
+        "manual note should preserve the reduced note content and locator: {output}"
     );
     assert_eq!(
         output.matches("[^narrative-note]:").count(),
@@ -292,7 +296,7 @@ fn test_chicago_notes_document_renders_ibid_without_author_concatenation() {
     );
 
     assert!(
-        output.contains("Ibid"),
+        output.to_lowercase().contains("ibid"),
         "note style should render ibid in this scenario: {output}"
     );
     assert!(
@@ -304,11 +308,19 @@ fn test_chicago_notes_document_renders_ibid_without_author_concatenation() {
         "ibid should not concatenate with author token: {output}"
     );
     assert!(
-        output.contains("Brown (Ibid.) also argues that..."),
-        "integral ibid inside authored note should preserve anchor with parenthetical ibid: {output}"
+        output.contains("Brown ("),
+        "integral ibid should preserve the authored anchor: {output}"
     );
     assert!(
-        !output.contains("Ibid also argues that..."),
+        output.to_lowercase().contains("ibid"),
+        "integral ibid should remain reduced in authored notes: {output}"
+    );
+    assert!(
+        !output.to_lowercase().contains("brown ibid"),
+        "integral ibid should not concatenate the anchor and reduced form: {output}"
+    );
+    assert!(
+        !output.to_lowercase().contains("ibid also argues that..."),
         "integral ibid should not replace the narrative anchor in authored notes: {output}"
     );
 }
@@ -335,8 +347,16 @@ fn test_chicago_notes_document_integral_ibid_with_locator_keeps_anchor_and_locat
     );
 
     assert!(
-        output.contains("Brown (Ibid., 12) also argues that..."),
-        "integral ibid-with-locator should preserve anchor and locator in parenthetical reduced citation: {output}"
+        output.contains("Brown ("),
+        "integral ibid-with-locator should preserve the authored anchor: {output}"
+    );
+    assert!(
+        output.to_lowercase().contains("ibid"),
+        "integral ibid-with-locator should remain reduced: {output}"
+    );
+    assert!(
+        output.contains("12"),
+        "integral ibid-with-locator should preserve the locator: {output}"
     );
 }
 
@@ -429,7 +449,7 @@ fn test_chicago_notes_document_integral_ibid_anchor_failure_falls_back_to_reduce
     );
 
     assert!(
-        output.contains("Ibid"),
+        output.to_lowercase().contains("ibid"),
         "when anchor cannot render, integral ibid should still render reduced citation text: {output}"
     );
     assert!(

--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -133,13 +133,14 @@ Preset extraction across the 58-style wave:
 
 ### Note Styles (Tier 3 — Partial)
 
-Note styles (footnote-based) are ~19% of corpus. One is now production-quality;
-full ibid/subsequent support requires `position` condition (not yet implemented).
+Note styles (footnote-based) are ~19% of corpus. Mixed-condition repeated-note
+position extraction is now implemented; remaining work in this family is
+style-local fidelity cleanup rather than missing `position` support.
 
 | Style | Status | Notes |
 |-------|--------|-------|
 | chicago-shortened-notes-bibliography | ✅ Production | 13/13 citations, 31/31 bibliography |
-| chicago-notes | ⏳ Queued | Requires `position` condition support |
+| chicago-notes | 🔄 In Progress | Repeated-position overrides ship; remaining work is style-local fidelity cleanup |
 | oscola | ✅ Production | 13/13 citations, 32/32 bibliography |
 | oscola-no-ibid | ✅ Production | 13/13 citations, 32/32 bibliography |
 

--- a/docs/specs/NOTE_POSITION_AUDIT.md
+++ b/docs/specs/NOTE_POSITION_AUDIT.md
@@ -1,0 +1,47 @@
+# Note Position Audit Specification
+
+**Status:** Active
+**Version:** 1.0
+**Date:** 2026-03-11
+**Supersedes:** None
+**Related:** `csl26-vnci`, `docs/specs/REPEATED_NOTE_CITATION_STATE_MODEL.md`, `docs/specs/MIXED_CONDITION_NOTE_POSITION_TREES.md`
+
+## Purpose
+Define a committed audit layer for note-style repeated-citation behavior so Citum can verify, report, and gap-track `first`, `subsequent`, and `ibid` rendering across shipped note styles instead of relying on ad hoc spot checks.
+
+## Scope
+In scope: committed repeated-note fixtures, a note-style expectation manifest, a scriptable audit over all shipped `processing: note` styles, report-core integration for core-style visibility, and automated tests for the audit plumbing. Out of scope: changing style-guide intent, broad style fidelity cleanup unrelated to repeated-note behavior, and rebuilding the published `docs/compat.html` artifact in this change.
+
+## Design
+The audit introduces a dedicated repeated-note citation fixture that models one source cited first, cited again immediately without a locator, cited again immediately with a locator, interrupted by another source, and then cited subsequently with a locator. The paired reference fixture must use stable references that expose note shortening clearly and are valid across Chicago-, MHRA-, legal-, and New Hart’s-style families.
+
+A new manifest under `scripts/report-data/` must declare repeated-note expectations per shipped note style. At minimum each entry records whether the style is expected to support repeated-note overrides, whether immediate repeats should render lexical `ibid`, and whether non-immediate repeats should use a distinct subsequent form. Styles without expected repeated-note specialization remain auditable, but must be classified explicitly rather than inferred from missing YAML blocks.
+
+The audit script must enumerate all shipped note styles in `styles/`, render the repeated-note fixture through the Citum processor, and evaluate the outputs against the manifest. It must emit structured JSON and a human-readable summary that distinguishes:
+- pass
+- configuration gap (expected override missing from style YAML)
+- rendering gap (style declares the behavior but the rendered output does not match the expectation)
+
+Report integration must be additive. `scripts/report-core.js` should retain current fidelity scoring, but core note styles must surface repeated-note audit status in the generated JSON and HTML detail view so compatibility reporting can identify note-position coverage gaps separately from generic citation fidelity. This integration is informational; it must not silently alter the existing fidelity numerator/denominator.
+
+The expectation model should stay minimal and decision-complete for current note families:
+- Chicago note families: lexical `ibid` plus distinct subsequent short form.
+- MHRA and New Hart’s note families: distinct subsequent short form, no lexical `ibid`.
+- OSCOLA: lexical `ibid` plus distinct subsequent short form.
+- OSCOLA no-ibid and Thomson Reuters legal: no lexical `ibid`, but immediate repeats must reuse the subsequent short form.
+- Styles intentionally lacking repeated-note specialization must be declared explicitly so they appear as known gaps rather than hidden omissions.
+
+## Implementation Notes
+Prefer implementing the audit in Node alongside `report-core.js` and `style-verification.js` so fixture policy, YAML parsing, and reporting metadata stay in one stack. The report integration should reuse existing style metadata plumbing instead of duplicating style discovery logic.
+
+The initial coverage target is the 19 shipped note styles under `styles/`. If the audit finds a style that cannot be classified with the current expectation fields, split that into a narrow follow-on rather than expanding the manifest semantics mid-change.
+
+## Acceptance Criteria
+- [x] A committed repeated-note fixture pair exists under `tests/fixtures/` and is suitable for note-style audit runs.
+- [x] A committed expectation manifest covers every shipped `processing: note` style in `styles/`.
+- [x] A repeat-note audit command reports pass/gap status for every shipped note style and exits non-zero when an expected repeated-note behavior is missing or misrendered.
+- [x] `scripts/report-core.js` includes repeated-note audit status for applicable core note styles without changing the existing fidelity scoring contract.
+- [x] Automated tests cover manifest loading and at least one passing and one failing repeated-note audit scenario.
+
+## Changelog
+- v1.0 (2026-03-11): Activated with committed fixtures, audit command, and report integration.

--- a/docs/specs/NOTE_SHORTENING_POLICY.md
+++ b/docs/specs/NOTE_SHORTENING_POLICY.md
@@ -1,0 +1,86 @@
+# Note Shortening Policy Specification
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-03-11
+**Supersedes:** None
+**Related:** `.beans/csl26-t79d--spec-normative-note-shortening-policy.md`, `docs/specs/REPEATED_NOTE_CITATION_STATE_MODEL.md`, `docs/specs/NOTE_POSITION_AUDIT.md`
+
+## Purpose
+Define a normative policy for repeated-note and shortened-note behavior across
+note styles so Citum can distinguish current shipped behavior from
+style-guide-intended behavior when implementing, auditing, and testing note
+citations.
+
+## Scope
+In scope: style-family classification for repeated-note behavior, the split
+between style-declared formatting and processor-managed state, and how future
+audits should represent normative expectations without quoting copyrighted style
+manual language.
+
+Out of scope: changing shipped style behavior in this draft, publishing manual
+excerpts, or deciding unresolved prose/integral repeated-citation semantics
+without additional primary-source review.
+
+## Design
+The policy should classify note styles into behavioral families rather than
+assuming one repeated-note model:
+
+1. Lexical relative-marker styles, where immediate repeats may render a
+   localized marker such as `Ibid.`, `Ibid`, `Id.`, or equivalent forms.
+2. Shortened-note-first styles, where immediate and later repeats use an
+   independently intelligible short form instead of a lexical relative marker.
+3. Mixed or fallback styles, where lexical markers remain allowed but shortened
+   forms are preferred or required in some contexts.
+4. Legal or localized traditions whose repeated-note marker, punctuation, or
+   locator syntax differs materially from general humanities note styles.
+
+The policy should define processor-managed invariants:
+
+- repeated-note state detection based on immediate-preceding citation identity
+- locator-sensitive distinction between identical repeats and changed-locator
+  repeats
+- multi-source previous-note invalidation for lexical relative markers
+- fallback from an unavailable lexical-marker form to the style’s subsequent
+  short form when the style family requires it
+
+The policy should define style-declared behavior:
+
+- whether a style exposes a lexical relative marker at all
+- the lexical marker’s punctuation, capitalization, and locator joining rules
+- the structure of the subsequent short form
+- any explicit distinction between note-start and authored/integral forms if a
+  style guide requires one
+
+The policy should also define how audits evolve:
+
+- the current audit may continue to track shipped behavior for regression
+  detection
+- a future normative audit layer may report divergence from style-guide intent
+  separately from shipped-style regressions
+- family-level expectations should not over-specify authored/integral prose
+  behavior until those semantics are resolved from primary sources
+
+## Implementation Notes
+- Use paraphrased rules derived from local manual review rather than quoted
+  excerpts.
+- Revisit Chicago, MHRA, New Hart’s Rules, OSCOLA, Bluebook-style `id.`, and
+  localized forms such as German `ebd.` in the follow-up implementation.
+- If the normative model requires more than one audit layer, keep the current
+  shipped-style regression checks stable while adding explicit normative
+  reporting.
+
+## Acceptance Criteria
+- [ ] The spec defines note-style behavioral families for repeated and
+  shortened citations.
+- [ ] The spec separates style-declared formatting from processor-managed
+  repeated-note state.
+- [ ] The spec records how multi-source previous notes affect lexical relative
+  markers.
+- [ ] The spec defines whether normative audit expectations should be tracked
+  separately from current shipped behavior.
+- [ ] Follow-up implementation can use this spec to tighten style-family tests
+  and manifest expectations without consulting copyrighted source text.
+
+## Changelog
+- v1.0 (2026-03-11): Initial draft.

--- a/scripts/audit-note-positions.js
+++ b/scripts/audit-note-positions.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+
+const { auditAllNoteStyles } = require('./lib/note-position-audit');
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    jsonOutput: false,
+    styles: [],
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      options.jsonOutput = true;
+    } else if (arg === '--styles') {
+      const stylesArg = argv[++i];
+      if (!stylesArg || stylesArg.startsWith('--')) {
+        throw new Error(
+          'Error: --styles option requires a comma-separated list of styles.\n'
+          + 'Usage: scripts/audit-note-positions.js [--json] [--styles style1,style2,...]'
+        );
+      }
+      options.styles = stylesArg.split(',').map((value) => value.trim()).filter(Boolean);
+    }
+  }
+  return options;
+}
+
+function printHuman(result) {
+  console.log('=== Note Position Audit ===');
+  console.log(`Styles: ${result.summary.total}`);
+  console.log(`Pass: ${result.summary.pass}`);
+  console.log(`Configuration gaps: ${result.summary.configurationGap}`);
+  console.log(`Rendering gaps: ${result.summary.renderingGap}`);
+  console.log(`Missing expectations: ${result.summary.missingExpectations}`);
+  console.log(`Extra expectations: ${result.summary.extraExpectations}`);
+  console.log('');
+  for (const entry of result.results) {
+    const issueSummary = entry.issues.length === 0
+      ? 'ok'
+      : entry.issues.map((issue) => issue.message).join(' | ');
+    console.log(`${entry.style}\t${entry.status}\t${entry.profile}\t${issueSummary}`);
+  }
+}
+
+function main() {
+  const options = parseArgs();
+  const result = auditAllNoteStyles({ styles: options.styles });
+
+  if (options.jsonOutput) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printHuman(result);
+  }
+
+  const hasCoverageIssue = result.coverage.missing.length > 0 || result.coverage.extra.length > 0;
+  const hasFailures = result.results.some((entry) => entry.status !== 'pass');
+  process.exit(hasCoverageIssue || hasFailures ? 1 : 0);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  parseArgs,
+};

--- a/scripts/audit-note-positions.test.js
+++ b/scripts/audit-note-positions.test.js
@@ -1,0 +1,18 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseArgs } = require('./audit-note-positions');
+
+test('audit-note-positions parses --styles list', () => {
+  assert.deepEqual(parseArgs(['--json', '--styles', 'chicago-notes,oscola']), {
+    jsonOutput: true,
+    styles: ['chicago-notes', 'oscola'],
+  });
+});
+
+test('audit-note-positions rejects missing --styles value', () => {
+  assert.throws(
+    () => parseArgs(['--styles']),
+    /--styles option requires a comma-separated list of styles/
+  );
+});

--- a/scripts/check-testing-infra.test.js
+++ b/scripts/check-testing-infra.test.js
@@ -56,6 +56,28 @@ function baseManifest() {
         notes: 'note',
       },
       {
+        fixture: 'tests/fixtures/references-note-positions.json',
+        domain: 'note',
+        kind: 'references',
+        reference_types: ['article-journal'],
+        citation_scenarios: [],
+        rendering_risks: ['repeated-note rendering'],
+        used_by: ['scripts/audit-note-positions.js'],
+        ci_status: 'required',
+        notes: 'note positions refs',
+      },
+      {
+        fixture: 'tests/fixtures/citations-note-positions.json',
+        domain: 'note',
+        kind: 'citations',
+        reference_types: ['article-journal'],
+        citation_scenarios: ['first', 'ibid', 'subsequent'],
+        rendering_risks: ['repeated-note rendering'],
+        used_by: ['scripts/audit-note-positions.js'],
+        ci_status: 'required',
+        notes: 'note positions cites',
+      },
+      {
         fixture: 'tests/fixtures/references-legal.json',
         domain: 'legal',
         kind: 'references',
@@ -118,11 +140,14 @@ function seedProject(root) {
   writeJson(path.join(root, 'tests/fixtures/coverage-manifest.json'), baseManifest());
   writeJson(path.join(root, 'tests/fixtures/references-expanded.json'), { ITEM: { type: 'book' } });
   writeJson(path.join(root, 'tests/fixtures/citations-note-expanded.json'), []);
+  writeJson(path.join(root, 'tests/fixtures/references-note-positions.json'), { ITEM: { type: 'article-journal' } });
+  writeJson(path.join(root, 'tests/fixtures/citations-note-positions.json'), []);
   writeJson(path.join(root, 'tests/fixtures/references-legal.json'), {});
   writeJson(path.join(root, 'tests/fixtures/references-scientific.json'), {});
   writeFile(path.join(root, 'tests/fixtures/references-multilingual.yaml'), '[]\n');
   writeJson(path.join(root, 'tests/fixtures/grouping/primary-secondary.json'), []);
   writeFile(path.join(root, 'scripts/oracle.js'), '#!/usr/bin/env node\n');
+  writeFile(path.join(root, 'scripts/audit-note-positions.js'), '#!/usr/bin/env node\n');
   writeJson(path.join(root, 'scripts/report-data/oracle-top10-baseline.json'), {
     styleBreakdown: [{ style: 'apa', citations: '1/1', bibliography: '1/1' }],
     metadata: {

--- a/scripts/lib/note-position-audit.js
+++ b/scripts/lib/note-position-audit.js
@@ -1,0 +1,410 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { execFileSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+const STYLES_DIR = path.join(PROJECT_ROOT, 'styles');
+const EXPECTATIONS_PATH = path.join(PROJECT_ROOT, 'scripts', 'report-data', 'note-position-expectations.yaml');
+const REFS_FIXTURE = path.join(PROJECT_ROOT, 'tests', 'fixtures', 'references-note-positions.json');
+const CITATIONS_FIXTURE = path.join(PROJECT_ROOT, 'tests', 'fixtures', 'citations-note-positions.json');
+const DEFAULT_TIMEOUT_MS = 120000;
+const REQUIRED_IDS = [
+  'note-first',
+  'note-ibid',
+  'note-ibid-with-locator',
+  'note-intervening',
+  'note-subsequent',
+  'note-subsequent-with-locator',
+];
+
+const CUSTOM_TAG_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
+  new yaml.Type('!custom', {
+    kind: 'mapping',
+    construct(data) {
+      return data || {};
+    },
+  }),
+]);
+const RENDER_CACHE = new Map();
+
+function readYaml(filePath) {
+  return yaml.load(fs.readFileSync(filePath, 'utf8'), { schema: CUSTOM_TAG_SCHEMA }) || {};
+}
+
+function normalizeText(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function validateExpectations(config) {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    throw new Error('note-position-expectations.yaml must be an object');
+  }
+  if (config.version !== 1) {
+    throw new Error('note-position-expectations.yaml version must be 1');
+  }
+  if (!config.profiles || typeof config.profiles !== 'object' || Array.isArray(config.profiles)) {
+    throw new Error('note-position-expectations.yaml must define profiles');
+  }
+  if (!config.styles || typeof config.styles !== 'object' || Array.isArray(config.styles)) {
+    throw new Error('note-position-expectations.yaml must define styles');
+  }
+
+  for (const [profileName, profile] of Object.entries(config.profiles)) {
+    if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+      throw new Error(`note-position-expectations.yaml profiles.${profileName} must be an object`);
+    }
+    for (const key of ['ibid', 'subsequent']) {
+      if (typeof profile.requires?.[key] !== 'boolean') {
+        throw new Error(`note-position-expectations.yaml profiles.${profileName}.requires.${key} must be a boolean`);
+      }
+    }
+    for (const key of ['lexical_ibid', 'immediate_falls_back_to_subsequent', 'distinct_subsequent']) {
+      if (typeof profile.checks?.[key] !== 'boolean') {
+        throw new Error(`note-position-expectations.yaml profiles.${profileName}.checks.${key} must be a boolean`);
+      }
+    }
+  }
+
+  for (const [styleName, styleEntry] of Object.entries(config.styles)) {
+    if (!styleEntry || typeof styleEntry !== 'object' || Array.isArray(styleEntry)) {
+      throw new Error(`note-position-expectations.yaml styles.${styleName} must be an object`);
+    }
+    if (typeof styleEntry.profile !== 'string' || !config.profiles[styleEntry.profile]) {
+      throw new Error(`note-position-expectations.yaml styles.${styleName}.profile must reference a known profile`);
+    }
+  }
+
+  return config;
+}
+
+function loadNotePositionExpectations(filePath = EXPECTATIONS_PATH) {
+  return validateExpectations(readYaml(filePath));
+}
+
+function discoverNoteStyles(stylesDir = STYLES_DIR) {
+  const styles = [];
+  for (const entry of fs.readdirSync(stylesDir).filter((name) => name.endsWith('.yaml')).sort()) {
+    const absolutePath = path.join(stylesDir, entry);
+    const style = readYaml(absolutePath);
+    if (style?.options?.processing === 'note') {
+      styles.push({
+        name: path.basename(entry, '.yaml'),
+        path: absolutePath,
+        style,
+      });
+    }
+  }
+  return styles;
+}
+
+function validateExpectationCoverage(noteStyles, expectations) {
+  const declared = new Set(Object.keys(expectations.styles || {}));
+  const discovered = new Set(noteStyles.map((style) => style.name));
+  const missing = [...discovered].filter((name) => !declared.has(name)).sort();
+  const extra = [...declared].filter((name) => !discovered.has(name)).sort();
+  return { missing, extra };
+}
+
+function parseRenderedCitations(output) {
+  const citations = {};
+  let inCitations = false;
+  for (const line of output.split('\n')) {
+    if (line.includes('CITATIONS (From file):')) {
+      inCitations = true;
+      continue;
+    }
+    if (!inCitations) continue;
+    const match = line.match(/^\s*\[([^\]]+)\]\s+(.+)$/);
+    if (match) {
+      citations[match[1]] = normalizeText(match[2]);
+    }
+  }
+  return citations;
+}
+
+function renderFixtureForStyle(stylePath, refsFixture = REFS_FIXTURE, citationsFixture = CITATIONS_FIXTURE) {
+  return renderFixtureForStyleWithOptions(stylePath, refsFixture, citationsFixture, {});
+}
+
+function resolveCitumBinary(explicitPath = null) {
+  const cargoTargetDir = process.env.CARGO_TARGET_DIR
+    ? path.resolve(process.env.CARGO_TARGET_DIR)
+    : null;
+  const candidates = [
+    explicitPath,
+    process.env.CITUM_BIN,
+    cargoTargetDir ? path.join(cargoTargetDir, 'debug', 'citum') : null,
+    cargoTargetDir ? path.join(cargoTargetDir, 'release', 'citum') : null,
+    path.join(PROJECT_ROOT, 'target', 'debug', 'citum'),
+    path.join(PROJECT_ROOT, 'target', 'release', 'citum'),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return path.resolve(candidate);
+    }
+  }
+
+  execFileSync('cargo', ['build', '-q', '--bin', 'citum'], {
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: DEFAULT_TIMEOUT_MS,
+  });
+
+  const builtBinary = cargoTargetDir
+    ? path.join(cargoTargetDir, 'debug', 'citum')
+    : path.join(PROJECT_ROOT, 'target', 'debug', 'citum');
+  if (!fs.existsSync(builtBinary)) {
+    throw new Error(`Expected Citum binary after build: ${builtBinary}`);
+  }
+  return builtBinary;
+}
+
+function createRenderCacheKey(binaryPath, stylePath, refsFixture, citationsFixture) {
+  const parts = [binaryPath, stylePath, refsFixture, citationsFixture].map((filePath) => {
+    const stats = fs.statSync(filePath);
+    return `${path.resolve(filePath)}:${stats.mtimeMs}:${stats.size}`;
+  });
+  return parts.join('|');
+}
+
+function renderFixtureForStyleWithOptions(
+  stylePath,
+  refsFixture = REFS_FIXTURE,
+  citationsFixture = CITATIONS_FIXTURE,
+  options = {}
+) {
+  const binaryPath = resolveCitumBinary(options.citumBin || null);
+  const cacheKey = createRenderCacheKey(binaryPath, stylePath, refsFixture, citationsFixture);
+  if (RENDER_CACHE.has(cacheKey)) {
+    return RENDER_CACHE.get(cacheKey);
+  }
+
+  const output = execFileSync(
+    binaryPath,
+    [
+      'render',
+      'refs',
+      '-b',
+      refsFixture,
+      '-s',
+      stylePath,
+      '-c',
+      citationsFixture,
+      '--mode',
+      'cite',
+      '--show-keys',
+    ],
+    {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: options.timeoutMs || DEFAULT_TIMEOUT_MS,
+    }
+  );
+  const rendered = parseRenderedCitations(output);
+  RENDER_CACHE.set(cacheKey, rendered);
+  return rendered;
+}
+
+function normalizeAuditOptions(expectationOrOptions) {
+  if (!expectationOrOptions) {
+    return { expectationConfig: loadNotePositionExpectations() };
+  }
+  if (expectationOrOptions.version === 1 && expectationOrOptions.profiles && expectationOrOptions.styles) {
+    return { expectationConfig: expectationOrOptions };
+  }
+  return {
+    expectationConfig: expectationOrOptions.expectationConfig || loadNotePositionExpectations(),
+    citumBin: expectationOrOptions.citumBin || null,
+    timeoutMs: expectationOrOptions.timeoutMs || DEFAULT_TIMEOUT_MS,
+  };
+}
+
+function auditNoteStyle(styleRecord, expectationOrOptions = null) {
+  const options = normalizeAuditOptions(expectationOrOptions);
+  const rendered = renderFixtureForStyleWithOptions(
+    styleRecord.path,
+    REFS_FIXTURE,
+    CITATIONS_FIXTURE,
+    options
+  );
+  return {
+    style: styleRecord.name,
+    ...evaluateNotePositionRender(
+      styleRecord.name,
+      styleRecord.style,
+      rendered,
+      options.expectationConfig
+    ),
+  };
+}
+
+function hasLexicalIbid(text) {
+  return /\bibid\b/i.test(text || '');
+}
+
+function normalizeFixtureLocators(text) {
+  return normalizeText(text).replace(/\b(105|205)\b/g, '__LOCATOR__');
+}
+
+function evaluateNotePositionRender(styleName, style, rendered, expectationConfig) {
+  const styleExpectation = expectationConfig.styles[styleName];
+  const profile = expectationConfig.profiles[styleExpectation.profile];
+  const issues = [];
+  const citationConfig = style.citation || {};
+
+  for (const id of REQUIRED_IDS) {
+    if (!rendered[id]) {
+      issues.push({ kind: 'rendering-gap', message: `Missing rendered citation for fixture id: ${id}` });
+    }
+  }
+  if (issues.length > 0) {
+    return { status: 'rendering-gap', issues, profile: styleExpectation.profile };
+  }
+
+  if (profile.requires.ibid && !citationConfig.ibid) {
+    issues.push({ kind: 'configuration-gap', message: 'Expected citation.ibid override is missing from style YAML.' });
+  }
+  if (profile.requires.subsequent && !citationConfig.subsequent) {
+    issues.push({ kind: 'configuration-gap', message: 'Expected citation.subsequent override is missing from style YAML.' });
+  }
+
+  const first = rendered['note-first'];
+  const ibid = rendered['note-ibid'];
+  const ibidWithLocator = rendered['note-ibid-with-locator'];
+  const subsequent = rendered['note-subsequent'];
+  const subsequentWithLocator = rendered['note-subsequent-with-locator'];
+
+  if (profile.checks.lexical_ibid) {
+    if (!hasLexicalIbid(ibid)) {
+      issues.push({ kind: 'rendering-gap', message: 'Immediate repeat should render lexical ibid.' });
+    }
+    if (!hasLexicalIbid(ibidWithLocator)) {
+      issues.push({ kind: 'rendering-gap', message: 'Immediate repeat with locator should render lexical ibid.' });
+    }
+  } else if (hasLexicalIbid(ibid) || hasLexicalIbid(ibidWithLocator)) {
+    issues.push({ kind: 'rendering-gap', message: 'Style should not render lexical ibid for immediate repeats.' });
+  }
+
+  if (profile.checks.immediate_falls_back_to_subsequent) {
+    if (ibid !== subsequent) {
+      issues.push({ kind: 'rendering-gap', message: 'Immediate repeat should fall back to the same rendering as subsequent repeat.' });
+    }
+    if (normalizeFixtureLocators(ibidWithLocator) !== normalizeFixtureLocators(subsequentWithLocator)) {
+      issues.push({ kind: 'rendering-gap', message: 'Immediate repeat with locator should fall back to the same rendering as subsequent repeat with locator.' });
+    }
+  }
+
+  if (profile.checks.distinct_subsequent && subsequent === first) {
+    issues.push({ kind: 'rendering-gap', message: 'Subsequent citation should differ from the first full citation.' });
+  }
+
+  if (!subsequentWithLocator.includes('205')) {
+    issues.push({ kind: 'rendering-gap', message: 'Subsequent citation with locator should preserve locator 205.' });
+  }
+  if (profile.checks.lexical_ibid && !ibidWithLocator.includes('105')) {
+    issues.push({ kind: 'rendering-gap', message: 'Ibid-with-locator citation should preserve locator 105.' });
+  }
+
+  const status = issues.some((issue) => issue.kind === 'configuration-gap')
+    ? 'configuration-gap'
+    : issues.length > 0
+      ? 'rendering-gap'
+      : 'pass';
+
+  return {
+    status,
+    issues,
+    profile: styleExpectation.profile,
+    rendered,
+  };
+}
+
+function auditNoteStyle(styleRecord, expectationOrOptions = null) {
+  const options = normalizeAuditOptions(expectationOrOptions);
+  const rendered = renderFixtureForStyleWithOptions(
+    styleRecord.path,
+    REFS_FIXTURE,
+    CITATIONS_FIXTURE,
+    options
+  );
+  return {
+    style: styleRecord.name,
+    ...evaluateNotePositionRender(
+      styleRecord.name,
+      styleRecord.style,
+      rendered,
+      options.expectationConfig
+    ),
+  };
+}
+
+function summarizeAuditResults(results, coverage = { missing: [], extra: [] }) {
+  const summary = {
+    total: results.length,
+    pass: 0,
+    configurationGap: 0,
+    renderingGap: 0,
+    missingExpectations: coverage.missing.length,
+    extraExpectations: coverage.extra.length,
+  };
+  for (const result of results) {
+    if (result.status === 'pass') summary.pass += 1;
+    if (result.status === 'configuration-gap') summary.configurationGap += 1;
+    if (result.status === 'rendering-gap') summary.renderingGap += 1;
+  }
+  return summary;
+}
+
+function auditAllNoteStyles(options = {}) {
+  const noteStyles = discoverNoteStyles(options.stylesDir || STYLES_DIR);
+  const expectations = loadNotePositionExpectations(options.expectationsPath || EXPECTATIONS_PATH);
+  const coverage = validateExpectationCoverage(noteStyles, expectations);
+  const selected = options.styles?.length ? new Set(options.styles) : null;
+  const results = noteStyles
+    .filter((style) => !selected || selected.has(style.name))
+    .map((style) =>
+      auditNoteStyle(style, {
+        expectationConfig: expectations,
+        citumBin: options.citumBin || null,
+        timeoutMs: options.timeoutMs || DEFAULT_TIMEOUT_MS,
+      })
+    );
+
+  return {
+    fixture: {
+      refs: REFS_FIXTURE,
+      citations: CITATIONS_FIXTURE,
+    },
+    coverage,
+    results,
+    summary: summarizeAuditResults(results, coverage),
+  };
+}
+
+module.exports = {
+  CITATIONS_FIXTURE,
+  DEFAULT_TIMEOUT_MS,
+  EXPECTATIONS_PATH,
+  REFS_FIXTURE,
+  STYLES_DIR,
+  auditAllNoteStyles,
+  auditNoteStyle,
+  discoverNoteStyles,
+  evaluateNotePositionRender,
+  hasLexicalIbid,
+  loadNotePositionExpectations,
+  normalizeText,
+  normalizeFixtureLocators,
+  parseRenderedCitations,
+  renderFixtureForStyleWithOptions,
+  resolveCitumBinary,
+  summarizeAuditResults,
+  validateExpectationCoverage,
+  validateExpectations,
+};

--- a/scripts/lib/style-verification.js
+++ b/scripts/lib/style-verification.js
@@ -28,6 +28,7 @@ const FIXTURE_SET_REFS = {
   'physics-numeric': path.join(FIXTURES_DIR, 'references-physics-numeric.json'),
   'author-date': path.join(FIXTURES_DIR, 'references-author-date.json'),
   'humanities-note': path.join(FIXTURES_DIR, 'references-humanities-note.json'),
+  'note-positions': path.join(FIXTURES_DIR, 'references-note-positions.json'),
   'legal': path.join(FIXTURES_DIR, 'references-legal.json'),
   'csl-m-adapted': path.join(FIXTURES_DIR, 'references-csl-m-adapted.json'),
 };
@@ -37,6 +38,7 @@ const FIXTURE_SET_CITATIONS = {
   'physics-numeric': path.join(FIXTURES_DIR, 'citations-physics-numeric.json'),
   'author-date': path.join(FIXTURES_DIR, 'citations-author-date.json'),
   'humanities-note': path.join(FIXTURES_DIR, 'citations-humanities-note.json'),
+  'note-positions': path.join(FIXTURES_DIR, 'citations-note-positions.json'),
   'legal': path.join(FIXTURES_DIR, 'citations-legal.json'),
   'csl-m-adapted': path.join(FIXTURES_DIR, 'citations-csl-m-adapted.json'),
 };
@@ -59,7 +61,13 @@ function resolveDefaultCitationFixture(styleFormat) {
 }
 
 function getAdditionalFixtureSetNames(fixtureSets = []) {
-  return fixtureSets.filter((setName) => setName !== 'core' && setName !== 'note' && FIXTURE_SET_REFS[setName]);
+  return fixtureSets.filter(
+    (setName) =>
+      setName !== 'core'
+      && setName !== 'note'
+      && setName !== 'note-positions'
+      && FIXTURE_SET_REFS[setName]
+  );
 }
 
 function getFixtureFiles(setName) {

--- a/scripts/note-position-audit.test.js
+++ b/scripts/note-position-audit.test.js
@@ -1,0 +1,130 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  evaluateNotePositionRender,
+  normalizeFixtureLocators,
+  parseRenderedCitations,
+  summarizeAuditResults,
+  validateExpectations,
+  validateExpectationCoverage,
+} = require('./lib/note-position-audit');
+
+const EXPECTATIONS = validateExpectations({
+  version: 1,
+  profiles: {
+    'ibid-and-subsequent': {
+      requires: { ibid: true, subsequent: true },
+      checks: {
+        lexical_ibid: true,
+        immediate_falls_back_to_subsequent: false,
+        distinct_subsequent: true,
+      },
+    },
+    'subsequent-fallback': {
+      requires: { ibid: false, subsequent: true },
+      checks: {
+        lexical_ibid: false,
+        immediate_falls_back_to_subsequent: true,
+        distinct_subsequent: true,
+      },
+    },
+  },
+  styles: {
+    'example-ibid': { profile: 'ibid-and-subsequent' },
+    'example-fallback': { profile: 'subsequent-fallback' },
+  },
+});
+
+test('parseRenderedCitations extracts keyed citation output', () => {
+  const output = `
+=== demo ===
+
+CITATIONS (From file):
+  [note-first] First cite
+  [note-ibid] Ibid.
+
+`;
+
+  assert.deepEqual(parseRenderedCitations(output), {
+    'note-first': 'First cite',
+    'note-ibid': 'Ibid.',
+  });
+});
+
+test('evaluateNotePositionRender passes for lexical ibid and distinct subsequent', () => {
+  const result = evaluateNotePositionRender(
+    'example-ibid',
+    { citation: { ibid: {}, subsequent: {} } },
+    {
+      'note-first': 'John Smith, Full Cite',
+      'note-ibid': 'Ibid.',
+      'note-ibid-with-locator': 'Ibid., 105',
+      'note-intervening': 'Other Author, Other Cite',
+      'note-subsequent': 'Smith, Short Cite',
+      'note-subsequent-with-locator': 'Smith, Short Cite, 205',
+    },
+    EXPECTATIONS
+  );
+
+  assert.equal(result.status, 'pass');
+  assert.deepEqual(result.issues, []);
+});
+
+test('evaluateNotePositionRender reports configuration gaps for missing subsequent override', () => {
+  const result = evaluateNotePositionRender(
+    'example-fallback',
+    { citation: {} },
+    {
+      'note-first': 'John Smith, Full Cite',
+      'note-ibid': 'Smith, Short Cite',
+      'note-ibid-with-locator': 'Smith, Short Cite, 205',
+      'note-intervening': 'Other Author, Other Cite',
+      'note-subsequent': 'Smith, Short Cite',
+      'note-subsequent-with-locator': 'Smith, Short Cite, 205',
+    },
+    EXPECTATIONS
+  );
+
+  assert.equal(result.status, 'configuration-gap');
+  assert.match(result.issues[0].message, /citation\.subsequent/);
+});
+
+test('normalizeFixtureLocators ignores fixture-specific page numbers', () => {
+  assert.equal(
+    normalizeFixtureLocators('Smith, Short Cite, 105'),
+    normalizeFixtureLocators('Smith, Short Cite, 205')
+  );
+});
+
+test('validateExpectationCoverage finds missing and extra style declarations', () => {
+  const coverage = validateExpectationCoverage(
+    [{ name: 'example-ibid' }, { name: 'missing-style' }],
+    EXPECTATIONS
+  );
+
+  assert.deepEqual(coverage, {
+    missing: ['missing-style'],
+    extra: ['example-fallback'],
+  });
+});
+
+test('summarizeAuditResults counts each gap class', () => {
+  const summary = summarizeAuditResults(
+    [
+      { status: 'pass' },
+      { status: 'configuration-gap' },
+      { status: 'rendering-gap' },
+    ],
+    { missing: ['style-a'], extra: [] }
+  );
+
+  assert.deepEqual(summary, {
+    total: 3,
+    pass: 1,
+    configurationGap: 1,
+    renderingGap: 1,
+    missingExpectations: 1,
+    extraExpectations: 0,
+  });
+});

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -38,6 +38,10 @@ const {
   getLineagePresentation,
   loadReportProvenance,
 } = require('./lib/report-metadata');
+const {
+  auditNoteStyle,
+  discoverNoteStyles,
+} = require('./lib/note-position-audit');
 const { normalizeText } = require('./oracle-utils');
 const { maybeDatasetErrorForFile } = require('./lib/dataset-guard');
 
@@ -484,6 +488,10 @@ function discoverCoreStyles(provenanceConfig = loadReportProvenance()) {
       originSortRank: origin.sortRank,
     };
   });
+}
+
+function buildNoteStyleLookup() {
+  return new Map(discoverNoteStyles().map((style) => [style.name, style]));
 }
 
 function selectPrimaryComparator(styleSpec, verificationPolicy) {
@@ -1610,6 +1618,7 @@ async function processStyleReport(runtime, styleSpec, context) {
     stylesDir,
     verificationPolicy,
     fixtureSufficiency,
+    noteStyles,
   } = context;
   const stylePolicy = resolveVerificationPolicy(styleSpec.name, verificationPolicy);
   const sufficiencyPolicy = resolveFixtureSufficiency(stylePolicy.fixtureFamily, fixtureSufficiency);
@@ -1635,6 +1644,10 @@ async function processStyleReport(runtime, styleSpec, context) {
       statusTier = 'partial';
     }
 
+    const notePositionAudit = styleSpec.format === 'note' && noteStyles.has(styleSpec.name)
+      ? auditNoteStyle(noteStyles.get(styleSpec.name), { citumBin: runtime.citumBin })
+      : null;
+
     return {
       styleRecord: {
         name: styleSpec.name,
@@ -1658,6 +1671,7 @@ async function processStyleReport(runtime, styleSpec, context) {
         qualityScore: parseFloat(qualityScore.toFixed(3)),
         qualityBreakdown: qualityMetrics,
         oracleSource: 'citum-baseline',
+        notePositionAudit,
       },
       errorCount: oracleResult.error ? 1 : 0,
       citations,
@@ -1737,6 +1751,10 @@ async function processStyleReport(runtime, styleSpec, context) {
     statusTier = 'partial';
   }
 
+  const notePositionAudit = styleSpec.format === 'note' && noteStyles.has(styleSpec.name)
+    ? auditNoteStyle(noteStyles.get(styleSpec.name), { citumBin: runtime.citumBin })
+    : null;
+
   return {
     styleRecord: {
       name: styleSpec.name,
@@ -1760,6 +1778,7 @@ async function processStyleReport(runtime, styleSpec, context) {
       qualityScore: parseFloat(qualityScore.toFixed(3)),
       qualityBreakdown: qualityMetrics,
       oracleSource: oracleResult.oracleSource || primaryComparator,
+      notePositionAudit,
     },
     errorCount: oracleResult.error ? 1 : 0,
     citations,
@@ -1782,6 +1801,7 @@ async function generateReport(options) {
   const gitCommit = getGitCommit();
   const runtime = createReportRuntime(options);
   const preflightIssues = preflightSnapshots(coreStyles, verificationPolicy, stylesDir);
+  const noteStyles = buildNoteStyleLookup();
 
   if (!runtime.allowLiveFallback && preflightIssues.length > 0) {
     for (const issue of preflightIssues) {
@@ -1795,6 +1815,7 @@ async function generateReport(options) {
       stylesDir,
       verificationPolicy,
       fixtureSufficiency,
+      noteStyles,
     });
     if (result.styleRecord.error) {
       process.stderr.write(`Error processing ${styleSpec.name}: ${result.styleRecord.error}\n`);
@@ -1842,7 +1863,11 @@ async function generateReport(options) {
         styleSelector: 'core-styles',
         styles: coreStyles.map((style) => style.name),
         generator: 'scripts/report-core.js',
-        extraFixtures: ['tests/fixtures/citations-note-expanded.json'],
+        extraFixtures: [
+          'tests/fixtures/citations-note-expanded.json',
+          'tests/fixtures/references-note-positions.json',
+          'tests/fixtures/citations-note-positions.json',
+        ],
         parallelism: options.parallelism || DEFAULT_PARALLELISM,
         cacheDir: runtime.cacheDir,
         preflight: {
@@ -2373,6 +2398,35 @@ function generateDetailContent(style) {
 `;
   }
 
+  if (style.notePositionAudit) {
+    const audit = style.notePositionAudit;
+    const badgeClass = audit.status === 'pass'
+      ? 'bg-emerald-100 text-emerald-700'
+      : audit.status === 'configuration-gap'
+        ? 'bg-amber-100 text-amber-700'
+        : 'bg-red-100 text-red-700';
+    const issueText = audit.issues.length === 0
+      ? '<span class="text-xs text-slate-500">No repeated-note issues detected.</span>'
+      : audit.issues
+        .map((issue) => `<div class="text-xs font-mono text-slate-600">${escapeHtml(issue.kind)}: ${escapeHtml(issue.message)}</div>`)
+        .join('');
+    html += `
+                            <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
+                                <div class="flex items-center justify-between gap-3 mb-2">
+                                    <div class="text-xs font-semibold text-slate-900">Repeated-Note Audit</div>
+                                    <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium ${badgeClass}">
+                                        ${escapeHtml(audit.status)}
+                                    </span>
+                                </div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs mb-2">
+                                    <div><span class="font-semibold text-slate-700">Profile:</span> <span class="font-mono text-slate-600">${escapeHtml(audit.profile || '—')}</span></div>
+                                    <div><span class="font-semibold text-slate-700">Issues:</span> <span class="font-mono text-slate-600">${audit.issues.length}</span></div>
+                                </div>
+                                ${issueText}
+                            </div>
+`;
+  }
+
   if (style.componentSummary && Object.keys(style.componentSummary).length > 0) {
     const issues = Object.entries(style.componentSummary)
       .sort((a, b) => b[1] - a[1])
@@ -2782,6 +2836,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  buildNoteStyleLookup,
   computeFidelityScore,
   createReportRuntime,
   discoverCoreStyles,

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -13,6 +13,7 @@ const {
 const { getEffectiveVerificationScopes } = require('./lib/style-verification');
 const { loadReportProvenance } = require('./lib/report-metadata');
 const {
+  buildNoteStyleLookup,
   discoverCoreStyles,
   computeFidelityScore,
   equivalentText,
@@ -50,6 +51,14 @@ test('discoverCoreStyles classifies representative style origins and CSL reach',
 
   const unknownOrigins = [...styles.values()].filter((style) => style.originLabel === 'Unknown');
   assert.deepEqual(unknownOrigins, []);
+});
+
+test('buildNoteStyleLookup indexes shipped note styles', () => {
+  const noteStyles = buildNoteStyleLookup();
+
+  assert.equal(noteStyles.has('chicago-notes'), true);
+  assert.equal(noteStyles.get('chicago-notes').style.options.processing, 'note');
+  assert.equal(noteStyles.has('apa-7th'), false);
 });
 
 test('report-core exposes expected benchmark labels for representative styles', () => {

--- a/scripts/report-data/fixture-sufficiency.yaml
+++ b/scripts/report-data/fixture-sufficiency.yaml
@@ -80,6 +80,7 @@ families:
       - personal_communication
     required_scenarios:
       - note shortening
+      - repeated-note position flow
       - repeated-author handling
       - translator and editor containers
       - archive and manuscript references
@@ -88,6 +89,7 @@ families:
     fixture_sets:
       - note
       - humanities-note
+      - note-positions
   legal:
     default_report_sufficient: false
     required_reference_types:

--- a/scripts/report-data/note-position-expectations.yaml
+++ b/scripts/report-data/note-position-expectations.yaml
@@ -1,0 +1,65 @@
+version: 1
+profiles:
+  ibid-and-subsequent:
+    requires:
+      ibid: true
+      subsequent: true
+    checks:
+      lexical_ibid: true
+      immediate_falls_back_to_subsequent: false
+      distinct_subsequent: true
+  ibid-only:
+    requires:
+      ibid: true
+      subsequent: false
+    checks:
+      lexical_ibid: true
+      immediate_falls_back_to_subsequent: false
+      distinct_subsequent: false
+  subsequent-fallback:
+    requires:
+      ibid: false
+      subsequent: true
+    checks:
+      lexical_ibid: false
+      immediate_falls_back_to_subsequent: true
+      distinct_subsequent: true
+styles:
+  chicago-notes:
+    profile: ibid-and-subsequent
+  chicago-notes-bibliography-17th-edition:
+    profile: ibid-and-subsequent
+  chicago-notes-bibliography-classic-archive-place-first-no-url:
+    profile: ibid-and-subsequent
+  chicago-notes-classic:
+    profile: ibid-and-subsequent
+  chicago-notes-classic-archive-place-first:
+    profile: ibid-and-subsequent
+  chicago-notes-classic-no-url:
+    profile: ibid-and-subsequent
+  chicago-notes-publisher-place-archive-place-first-no-url:
+    profile: ibid-and-subsequent
+  chicago-shortened-notes-bibliography:
+    profile: ibid-only
+  chicago-shortened-notes-bibliography-classic-archive-place-first:
+    profile: ibid-only
+  mhra-notes:
+    profile: subsequent-fallback
+  mhra-notes-publisher-place:
+    profile: subsequent-fallback
+  mhra-notes-publisher-place-no-url:
+    profile: subsequent-fallback
+  mhra-shortened-notes-publisher-place:
+    profile: ibid-only
+  new-harts-rules-notes:
+    profile: subsequent-fallback
+  new-harts-rules-notes-label-page:
+    profile: subsequent-fallback
+  new-harts-rules-notes-label-page-no-url:
+    profile: subsequent-fallback
+  oscola:
+    profile: ibid-and-subsequent
+  oscola-no-ibid:
+    profile: subsequent-fallback
+  thomson-reuters-legal-tax-and-accounting-australia:
+    profile: subsequent-fallback

--- a/styles/chicago-notes-bibliography-17th-edition.yaml
+++ b/styles/chicago-notes-bibliography-17th-edition.yaml
@@ -64,6 +64,34 @@ citation:
         use-first: 1
         and-others: et-al
         delimiter-precedes-last: contextual
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        prefix: ", "
+      - variable: locator
+        prefix: ", "
+        overrides:
+          book:
+            suppress: false
+          chapter:
+            suppress: false
+          article-journal:
+            suppress: false
+          default:
+            suppress: true
   template:
     - contributor: author
       form: long

--- a/styles/chicago-notes-bibliography-classic-archive-place-first-no-url.yaml
+++ b/styles/chicago-notes-bibliography-classic-archive-place-first-no-url.yaml
@@ -64,6 +64,34 @@ citation:
         use-first: 1
         and-others: et-al
         delimiter-precedes-last: contextual
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        prefix: ", "
+      - variable: locator
+        prefix: ", "
+        overrides:
+          book:
+            suppress: false
+          chapter:
+            suppress: false
+          article-journal:
+            suppress: false
+          default:
+            suppress: true
   template:
     - contributor: author
       form: long

--- a/styles/chicago-notes-classic-archive-place-first.yaml
+++ b/styles/chicago-notes-classic-archive-place-first.yaml
@@ -52,6 +52,34 @@ citation:
         use-first: 3
         and-others: et-al
         delimiter-precedes-last: contextual
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        prefix: ", "
+      - variable: locator
+        prefix: ", "
+        overrides:
+          book:
+            suppress: false
+          chapter:
+            suppress: false
+          article-journal:
+            suppress: false
+          default:
+            suppress: true
   template:
     - contributor: author
       form: long

--- a/styles/chicago-notes-classic-no-url.yaml
+++ b/styles/chicago-notes-classic-no-url.yaml
@@ -52,6 +52,34 @@ citation:
         use-first: 3
         and-others: et-al
         delimiter-precedes-last: contextual
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        prefix: ", "
+      - variable: locator
+        prefix: ", "
+        overrides:
+          book:
+            suppress: false
+          chapter:
+            suppress: false
+          article-journal:
+            suppress: false
+          default:
+            suppress: true
   template:
     - contributor: author
       form: long

--- a/styles/chicago-notes-classic.yaml
+++ b/styles/chicago-notes-classic.yaml
@@ -52,6 +52,34 @@ citation:
         use-first: 3
         and-others: et-al
         delimiter-precedes-last: contextual
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        prefix: ", "
+      - variable: locator
+        prefix: ", "
+        overrides:
+          book:
+            suppress: false
+          chapter:
+            suppress: false
+          article-journal:
+            suppress: false
+          default:
+            suppress: true
   template:
     - contributor: author
       form: long

--- a/styles/chicago-notes-publisher-place-archive-place-first-no-url.yaml
+++ b/styles/chicago-notes-publisher-place-archive-place-first-no-url.yaml
@@ -52,6 +52,34 @@ citation:
         use-first: 3
         and-others: et-al
         delimiter-precedes-last: contextual
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        prefix: ", "
+      - variable: locator
+        prefix: ", "
+        overrides:
+          book:
+            suppress: false
+          chapter:
+            suppress: false
+          article-journal:
+            suppress: false
+          default:
+            suppress: true
   template:
     - contributor: author
       form: long

--- a/styles/chicago-notes.yaml
+++ b/styles/chicago-notes.yaml
@@ -42,10 +42,12 @@ options:
 citation:
   delimiter: ""
   ibid:
+    suffix: ""
+    delimiter: ", "
     template:
+      - term: ibid
       - variable: locator
-        prefix: ", "
-    suffix: "Ibid."
+        suffix: .
   subsequent:
     options:
       contributors:
@@ -55,6 +57,7 @@ citation:
         form: short
       - title: primary
         form: short
+        prefix: ", "
       - variable: locator
         prefix: ", "
         overrides:

--- a/styles/chicago-shortened-notes-bibliography-classic-archive-place-first.yaml
+++ b/styles/chicago-shortened-notes-bibliography-classic-archive-place-first.yaml
@@ -66,6 +66,13 @@ citation:
         delimiter-precedes-last: contextual
     substitute:
       template: []
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
   template:
     - contributor: author
       form: long
@@ -74,6 +81,8 @@ citation:
         min: 3
         use-first: 1
     - title: primary
+    - variable: locator
+      prefix: ", "
   suffix: .
   delimiter: ", "
   multi-cite-delimiter: "; "

--- a/styles/chicago-shortened-notes-bibliography.yaml
+++ b/styles/chicago-shortened-notes-bibliography.yaml
@@ -53,6 +53,13 @@ citation:
         use-first: 1
         and-others: et-al
         delimiter-precedes-last: contextual
+  ibid:
+    suffix: ""
+    delimiter: ", "
+    template:
+      - term: ibid
+      - variable: locator
+        suffix: .
   template:
     - contributor: author
       form: short
@@ -61,6 +68,8 @@ citation:
         min: 3
         use-first: 1
     - title: primary
+      prefix: ", "
+    - variable: locator
       prefix: ", "
   suffix: .
   delimiter: ". "

--- a/styles/mhra-notes-publisher-place-no-url.yaml
+++ b/styles/mhra-notes-publisher-place-no-url.yaml
@@ -58,6 +58,19 @@ citation:
   options:
     contributors:
       delimiter-precedes-last: contextual
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        wrap: quotes
+      - variable: locator
+        prefix: ", "
+        show-label: true
   template:
     - contributor: author
       form: long

--- a/styles/mhra-notes-publisher-place.yaml
+++ b/styles/mhra-notes-publisher-place.yaml
@@ -58,6 +58,19 @@ citation:
   options:
     contributors:
       delimiter-precedes-last: contextual
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        wrap: quotes
+      - variable: locator
+        prefix: ", "
+        show-label: true
   template:
     - contributor: author
       form: long

--- a/styles/mhra-notes.yaml
+++ b/styles/mhra-notes.yaml
@@ -50,6 +50,19 @@ citation:
   options:
     contributors:
       delimiter-precedes-last: contextual
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        wrap: quotes
+      - variable: locator
+        prefix: ", "
+        show-label: true
   template:
     - contributor: author
       form: long

--- a/styles/mhra-shortened-notes-publisher-place.yaml
+++ b/styles/mhra-shortened-notes-publisher-place.yaml
@@ -38,6 +38,12 @@ options:
     hanging-indent: true
     separator: ": "
 citation:
+  ibid:
+    delimiter: ", "
+    template:
+      - term: ibid
+        strip-periods: true
+      - variable: locator
   template:
     - contributor: author
       form: short
@@ -49,6 +55,9 @@ citation:
     - title: primary
       prefix: ", "
       wrap: quotes
+    - variable: locator
+      prefix: ", "
+      show-label: true
   suffix: .
   delimiter: ". "
   multi-cite-delimiter: "; "

--- a/styles/new-harts-rules-notes-label-page-no-url.yaml
+++ b/styles/new-harts-rules-notes-label-page-no-url.yaml
@@ -65,6 +65,19 @@ citation:
   options:
     contributors:
       delimiter-precedes-last: contextual
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        wrap: quotes
+      - variable: locator
+        prefix: ", "
+        show-label: true
   template:
     - contributor: author
       form: long

--- a/styles/new-harts-rules-notes-label-page.yaml
+++ b/styles/new-harts-rules-notes-label-page.yaml
@@ -65,6 +65,19 @@ citation:
   options:
     contributors:
       delimiter-precedes-last: contextual
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        wrap: quotes
+      - variable: locator
+        prefix: ", "
+        show-label: true
   template:
     - contributor: author
       form: long

--- a/styles/new-harts-rules-notes.yaml
+++ b/styles/new-harts-rules-notes.yaml
@@ -65,6 +65,19 @@ citation:
   options:
     contributors:
       delimiter-precedes-last: contextual
+  subsequent:
+    options:
+      contributors:
+        name-form: family-only
+    template:
+      - contributor: author
+        form: short
+      - title: primary
+        form: short
+        wrap: quotes
+      - variable: locator
+        prefix: ", "
+        show-label: true
   template:
     - contributor: author
       form: long

--- a/tests/fixtures/citations-note-positions.json
+++ b/tests/fixtures/citations-note-positions.json
@@ -1,0 +1,64 @@
+[
+  {
+    "id": "note-first",
+    "position": "first",
+    "items": [
+      {
+        "id": "RP-ITEM-1"
+      }
+    ]
+  },
+  {
+    "id": "note-ibid",
+    "position": "ibid",
+    "items": [
+      {
+        "id": "RP-ITEM-1"
+      }
+    ]
+  },
+  {
+    "id": "note-ibid-with-locator",
+    "position": "ibid-with-locator",
+    "items": [
+      {
+        "id": "RP-ITEM-1",
+        "locator": {
+          "label": "page",
+          "value": "105"
+        }
+      }
+    ]
+  },
+  {
+    "id": "note-intervening",
+    "position": "first",
+    "items": [
+      {
+        "id": "RP-ITEM-2"
+      }
+    ]
+  },
+  {
+    "id": "note-subsequent",
+    "position": "subsequent",
+    "items": [
+      {
+        "id": "RP-ITEM-1"
+      }
+    ]
+  },
+  {
+    "id": "note-subsequent-with-locator",
+    "position": "subsequent",
+    "items": [
+      {
+        "id": "RP-ITEM-1",
+        "locator": {
+          "label": "page",
+          "value": "205"
+        }
+      }
+    ]
+  }
+]

--- a/tests/fixtures/coverage-manifest.json
+++ b/tests/fixtures/coverage-manifest.json
@@ -110,6 +110,53 @@
       "notes": "Specialized citation fixture used for note-style fidelity in the core compatibility report."
     },
     {
+      "fixture": "tests/fixtures/references-note-positions.json",
+      "domain": "note",
+      "kind": "references",
+      "reference_types": [
+        "article-journal"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "repeated-note short form detection",
+        "ibid vs subsequent classification",
+        "locator preservation in note overrides"
+      ],
+      "used_by": [
+        "scripts/audit-note-positions.js",
+        "scripts/report-core.js"
+      ],
+      "ci_status": "required",
+      "notes": "Dedicated reference fixture for repeated-note audits across shipped note styles."
+    },
+    {
+      "fixture": "tests/fixtures/citations-note-positions.json",
+      "domain": "note",
+      "kind": "citations",
+      "reference_types": [
+        "article-journal"
+      ],
+      "citation_scenarios": [
+        "first citation",
+        "immediate repeat without locator",
+        "immediate repeat with locator",
+        "intervening citation",
+        "subsequent citation without locator",
+        "subsequent citation with locator"
+      ],
+      "rendering_risks": [
+        "repeated-note state transitions",
+        "ibid fallback behavior",
+        "locator preservation in repeated notes"
+      ],
+      "used_by": [
+        "scripts/audit-note-positions.js",
+        "scripts/report-core.js"
+      ],
+      "ci_status": "required",
+      "notes": "Dedicated citation sequence for first, ibid, and subsequent note-position audits."
+    },
+    {
       "fixture": "tests/fixtures/compound-numeric-refs.json",
       "domain": "core",
       "kind": "references",

--- a/tests/fixtures/references-note-positions.json
+++ b/tests/fixtures/references-note-positions.json
@@ -1,0 +1,74 @@
+{
+  "RP-ITEM-1": {
+    "id": "RP-ITEM-1",
+    "class": "serial-component",
+    "type": "article-journal",
+    "title": "Adaptive Climate Risk Modeling in Coastal Cities",
+    "author": [
+      {
+        "family": "Smith",
+        "given": "John"
+      },
+      {
+        "family": "Lee",
+        "given": "Alice"
+      },
+      {
+        "family": "Kumar",
+        "given": "Priya"
+      },
+      {
+        "family": "Zhou",
+        "given": "Ming"
+      }
+    ],
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "container-title": "Journal of Climate Analytics",
+    "volume": "12",
+    "issue": "2",
+    "page": "101-119",
+    "DOI": "10.5555/jca.2021.12.2.101"
+  },
+  "RP-ITEM-2": {
+    "id": "RP-ITEM-2",
+    "class": "serial-component",
+    "type": "article-journal",
+    "title": "Adaptive Climate Risk Modeling for Inland Regions",
+    "author": [
+      {
+        "family": "Smith",
+        "given": "John"
+      },
+      {
+        "family": "Lee",
+        "given": "Alice"
+      },
+      {
+        "family": "Nguyen",
+        "given": "Bao"
+      },
+      {
+        "family": "Patel",
+        "given": "Ravi"
+      }
+    ],
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "container-title": "Journal of Climate Analytics",
+    "volume": "12",
+    "issue": "3",
+    "page": "201-219",
+    "DOI": "10.5555/jca.2021.12.3.201"
+  }
+}


### PR DESCRIPTION
## Summary
- add shipped repeated-position overrides to the scoped note styles covered by `csl26-3go0`
- update note-style status docs to reflect that mixed-condition position extraction is landed
- complete and archive the bean with rollout verification notes

## Verification
- `node scripts/oracle.js styles-legacy/chicago-notes.csl`
- `node scripts/oracle.js styles-legacy/chicago-notes-bibliography-17th-edition.csl`
- `node scripts/oracle.js styles-legacy/mhra-notes.csl`
- `node scripts/oracle.js styles-legacy/mhra-notes-publisher-place.csl`
- `node scripts/oracle.js styles-legacy/mhra-notes-publisher-place-no-url.csl`
- `node scripts/oracle.js styles-legacy/new-harts-rules-notes.csl`
- `node scripts/oracle.js styles-legacy/new-harts-rules-notes-label-page.csl`
- `node scripts/oracle.js styles-legacy/new-harts-rules-notes-label-page-no-url.csl`
- `node scripts/oracle-batch-aggregate.js styles-legacy/ --styles chicago-notes,chicago-notes-bibliography-17th-edition,mhra-notes,mhra-notes-publisher-place,mhra-notes-publisher-place-no-url,new-harts-rules-notes,new-harts-rules-notes-label-page,new-harts-rules-notes-label-page-no-url,oscola,oscola-no-ibid,thomson-reuters-legal-tax-and-accounting-australia`
- `node scripts/report-core.js > /tmp/core-report.json && node scripts/check-core-quality.js --report /tmp/core-report.json --baseline scripts/report-data/core-quality-baseline.json`
- `./scripts/check-docs-beans-hygiene.sh`
