### PR TITLE
feat(note): implement note-start conformance

### DIFF
--- a/.beans/archive/csl26-ns2i--implement-note-start-conformance-for-chicago-and-oscola.md
+++ b/.beans/archive/csl26-ns2i--implement-note-start-conformance-for-chicago-and-oscola.md
@@ -1,7 +1,7 @@
 ---
 # csl26-ns2i
 title: Implement note-start conformance for Chicago and OSCOLA
-status: todo
+status: completed
 type: feature
 priority: medium
 created_at: 2026-03-11T17:05:00Z

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -13,7 +13,7 @@ use citum_schema::template::{
     TemplateContributor, TemplateDate, TemplateList, TemplateTerm, TemplateTitle, TitleType,
     WrapPunctuation,
 };
-use citum_schema::{BibliographySpec, CitationSpec, Style};
+use citum_schema::{BibliographySpec, CitationSpec, NoteStartTextCase, Style};
 use csl_legacy::csl_json::{
     DateVariable as LegacyDateVariable, Name, Reference as LegacyReference,
 };
@@ -114,6 +114,7 @@ fn make_note_style() -> Style {
                 ..Default::default()
             })),
             ibid: Some(Box::new(CitationSpec {
+                note_start_text_case: Some(NoteStartTextCase::CapitalizeFirst),
                 template: Some(vec![TemplateComponent::Term(TemplateTerm {
                     term: citum_schema::locale::GeneralTerm::Ibid,
                     form: None,

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -39,6 +39,7 @@ use crate::reference::{Bibliography, Citation, CitationItem, Reference};
 use crate::render::bibliography::render_entry_body_with_format;
 use crate::render::{ProcEntry, ProcTemplate};
 use crate::values::ProcHints;
+use citum_schema::NoteStartTextCase;
 use citum_schema::Style;
 use citum_schema::citation::Position;
 use citum_schema::locale::Locale;
@@ -64,6 +65,51 @@ fn capitalize_first(value: &str) -> String {
         Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
         None => String::new(),
     }
+}
+
+fn apply_note_start_text_case(value: &str, text_case: NoteStartTextCase) -> String {
+    match text_case {
+        NoteStartTextCase::CapitalizeFirst => capitalize_first(value),
+        NoteStartTextCase::Lowercase => value.to_lowercase(),
+    }
+}
+
+fn apply_note_start_text_case_to_leading_text_node(
+    rendered: &str,
+    text_case: NoteStartTextCase,
+) -> String {
+    let mut in_tag = false;
+    let mut text_start = None;
+
+    for (index, ch) in rendered.char_indices() {
+        match ch {
+            '<' if !in_tag => in_tag = true,
+            '>' if in_tag => in_tag = false,
+            _ if !in_tag && !ch.is_whitespace() => {
+                text_start = Some(index);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let Some(text_start) = text_start else {
+        return rendered.to_string();
+    };
+
+    let text_end = rendered[text_start..]
+        .find('<')
+        .map(|offset| text_start + offset)
+        .unwrap_or(rendered.len());
+
+    let mut result = String::with_capacity(rendered.len());
+    result.push_str(&rendered[..text_start]);
+    result.push_str(&apply_note_start_text_case(
+        &rendered[text_start..text_end],
+        text_case,
+    ));
+    result.push_str(&rendered[text_end..]);
+    result
 }
 
 use self::disambiguation::Disambiguator;
@@ -1181,18 +1227,26 @@ impl Processor {
         };
 
         let mut rendered = fmt.finish(wrapped);
-        if matches!(
-            citation.position,
-            Some(citum_schema::citation::Position::Ibid)
-                | Some(citum_schema::citation::Position::IbidWithLocator)
-        ) && matches!(
-            citation.mode,
-            citum_schema::citation::CitationMode::NonIntegral
-        ) && citation.prefix.as_deref().unwrap_or("").is_empty()
+        if self
+            .style
+            .options
+            .as_ref()
+            .and_then(|options| options.processing.as_ref())
+            .is_some_and(|processing| matches!(processing, citum_schema::options::Processing::Note))
+            && matches!(
+                citation.position,
+                Some(citum_schema::citation::Position::Ibid)
+                    | Some(citum_schema::citation::Position::IbidWithLocator)
+            )
+            && matches!(
+                citation.mode,
+                citum_schema::citation::CitationMode::NonIntegral
+            )
+            && citation.prefix.as_deref().unwrap_or("").is_empty()
             && spec_prefix.is_empty()
-            && rendered.starts_with("ibid")
+            && let Some(text_case) = effective_spec.note_start_text_case
         {
-            rendered = capitalize_first(&rendered);
+            rendered = apply_note_start_text_case_to_leading_text_node(&rendered, text_case);
         }
 
         Ok(rendered)

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -94,6 +94,32 @@ fn make_style() -> Style {
     }
 }
 
+#[test]
+fn test_apply_note_start_text_case_to_leading_text_node_plain_text() {
+    assert_eq!(
+        super::apply_note_start_text_case_to_leading_text_node(
+            "Ibid., 105",
+            citum_schema::NoteStartTextCase::Lowercase
+        ),
+        "ibid., 105"
+    );
+}
+
+#[test]
+fn test_apply_note_start_text_case_to_leading_text_node_preserves_html_markup() {
+    let rendered = "<span class=\"csln-citation\" data-ref=\"ITEM-1\">Ibid.</span>";
+    let transformed = super::apply_note_start_text_case_to_leading_text_node(
+        rendered,
+        citum_schema::NoteStartTextCase::Lowercase,
+    );
+
+    assert_eq!(
+        transformed,
+        "<span class=\"csln-citation\" data-ref=\"ITEM-1\">ibid.</span>"
+    );
+    assert!(transformed.contains("data-ref=\"ITEM-1\""));
+}
+
 fn make_note_style() -> Style {
     let mut style = make_style();
     style.options = Some(Config {

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -1091,12 +1091,16 @@ fn test_oscola_ibid_and_subsequent_render_position_overrides() {
         "subsequent OSCOLA citation should use the short repeated-note form: {subsequent_rendered}"
     );
     assert!(
-        ibid_rendered.to_lowercase().contains("ibid"),
-        "OSCOLA ibid citation should render lexical ibid: {ibid_rendered}"
+        ibid_rendered.starts_with("ibid"),
+        "OSCOLA ibid citation should keep the note-start marker lowercase: {ibid_rendered}"
     );
     assert!(
         ibid_with_locator_rendered.contains("45"),
         "OSCOLA ibid-with-locator citation should keep the locator: {ibid_with_locator_rendered}"
+    );
+    assert!(
+        ibid_with_locator_rendered.starts_with("ibid"),
+        "OSCOLA ibid-with-locator citation should keep the note-start marker lowercase: {ibid_with_locator_rendered}"
     );
 }
 

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -213,6 +213,17 @@ pub enum CitationCollapse {
     CitationNumber,
 }
 
+/// Text-case transform applied when a citation renders at note start.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum NoteStartTextCase {
+    /// Uppercase the first character of the rendered citation.
+    CapitalizeFirst,
+    /// Lowercase the rendered citation text.
+    Lowercase,
+}
+
 /// Citation specification.
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -275,6 +286,12 @@ pub struct CitationSpec {
     /// Allows compact rendering like "ibid." or "ibid., p. 45".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ibid: Option<Box<CitationSpec>>,
+    /// Optional text-case transform for standalone note-start citation output.
+    ///
+    /// This is a style-owned rendering dimension layered on top of the
+    /// existing repeated-note state, not a new citation `Position`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note_start_text_case: Option<NoteStartTextCase>,
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
@@ -371,6 +388,9 @@ impl CitationSpec {
                 if spec.sort.is_some() {
                     merged.sort = spec.sort.clone();
                 }
+                if spec.note_start_text_case.is_some() {
+                    merged.note_start_text_case = spec.note_start_text_case;
+                }
 
                 std::borrow::Cow::Owned(merged)
             }
@@ -439,6 +459,9 @@ impl CitationSpec {
                 }
                 if spec.sort.is_some() {
                     merged.sort = spec.sort.clone();
+                }
+                if spec.note_start_text_case.is_some() {
+                    merged.note_start_text_case = spec.note_start_text_case;
                 }
 
                 std::borrow::Cow::Owned(merged)
@@ -757,6 +780,32 @@ options:
             .resolve_for_position(Some(&crate::citation::Position::Subsequent))
             .into_owned();
         assert_eq!(resolved_subsequent.suffix, Some("subseq".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_for_position_merges_note_start_text_case() {
+        let citation = CitationSpec {
+            note_start_text_case: Some(NoteStartTextCase::Lowercase),
+            ibid: Some(Box::new(CitationSpec {
+                note_start_text_case: Some(NoteStartTextCase::CapitalizeFirst),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let resolved = citation
+            .resolve_for_position(Some(&crate::citation::Position::Ibid))
+            .into_owned();
+        assert_eq!(
+            resolved.note_start_text_case,
+            Some(NoteStartTextCase::CapitalizeFirst)
+        );
+
+        let unresolved = citation.resolve_for_position(None).into_owned();
+        assert_eq!(
+            unresolved.note_start_text_case,
+            Some(NoteStartTextCase::Lowercase)
+        );
     }
 
     #[test]

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -601,6 +601,17 @@
             }
           ]
         },
+        "note-start-text-case": {
+          "description": "Optional text-case transform for standalone note-start citation output.\n\nThis is a style-owned rendering dimension layered on top of the existing repeated-note state, not a new citation `Position`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NoteStartTextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "options": {
           "description": "Citation-specific option overrides merged over the style config.",
           "anyOf": [
@@ -2671,6 +2682,25 @@
           "type": "string",
           "enum": [
             "adaptive"
+          ]
+        }
+      ]
+    },
+    "NoteStartTextCase": {
+      "description": "Text-case transform applied when a citation renders at note start.",
+      "oneOf": [
+        {
+          "description": "Uppercase the first character of the rendered citation.",
+          "type": "string",
+          "enum": [
+            "capitalize-first"
+          ]
+        },
+        {
+          "description": "Lowercase the rendered citation text.",
+          "type": "string",
+          "enum": [
+            "lowercase"
           ]
         }
       ]

--- a/scripts/lib/note-position-audit.js
+++ b/scripts/lib/note-position-audit.js
@@ -42,8 +42,8 @@ function validateExpectations(config) {
   if (!config || typeof config !== 'object' || Array.isArray(config)) {
     throw new Error('note-position-expectations.yaml must be an object');
   }
-  if (config.version !== 2) {
-    throw new Error('note-position-expectations.yaml version must be 2');
+  if (config.version !== 3) {
+    throw new Error('note-position-expectations.yaml version must be 3');
   }
   if (!config.regression_profiles || typeof config.regression_profiles !== 'object' || Array.isArray(config.regression_profiles)) {
     throw new Error('note-position-expectations.yaml must define regression_profiles');
@@ -88,6 +88,14 @@ function validateExpectations(config) {
     }
     if (typeof family.distinct_subsequent !== 'boolean') {
       throw new Error(`note-position-expectations.yaml conformance_families.${familyName}.distinct_subsequent must be a boolean`);
+    }
+    if (
+      family.note_start_text_case !== undefined
+      && !['capitalize-first', 'lowercase'].includes(family.note_start_text_case)
+    ) {
+      throw new Error(
+        `note-position-expectations.yaml conformance_families.${familyName}.note_start_text_case must be "capitalize-first" or "lowercase"`
+      );
     }
     if (!Array.isArray(family.unresolved)) {
       throw new Error(`note-position-expectations.yaml conformance_families.${familyName}.unresolved must be an array`);
@@ -251,7 +259,7 @@ function normalizeAuditOptions(expectationOrOptions) {
     return { expectationConfig: loadNotePositionExpectations() };
   }
   if (
-    expectationOrOptions.version === 2
+    expectationOrOptions.version === 3
     && expectationOrOptions.regression_profiles
     && expectationOrOptions.conformance_families
     && expectationOrOptions.styles
@@ -267,6 +275,29 @@ function normalizeAuditOptions(expectationOrOptions) {
 
 function hasLexicalIbid(text) {
   return /\bibid\b/i.test(text || '');
+}
+
+function matchesLeadingTextCase(text, expectedCase) {
+  const normalized = normalizeText(text);
+  const match = normalized.match(/\p{L}/u);
+  if (!match) {
+    return false;
+  }
+  const first = match[0];
+  if (expectedCase === 'capitalize-first') {
+    return first === first.toUpperCase() && first !== first.toLowerCase();
+  }
+  if (expectedCase === 'lowercase') {
+    return first === first.toLowerCase() && first !== first.toUpperCase();
+  }
+  return false;
+}
+
+function styleNoteStartTextCase(citationSpec) {
+  if (!citationSpec || typeof citationSpec !== 'object') {
+    return null;
+  }
+  return citationSpec.note_start_text_case || citationSpec['note-start-text-case'] || null;
 }
 
 function normalizeFixtureLocators(text) {
@@ -384,6 +415,26 @@ function evaluateConformanceLayer(styleName, style, rendered, expectationConfig)
     }
     if (!hasLexicalIbid(ibid) || !hasLexicalIbid(ibidWithLocator)) {
       issues.push({ kind: 'rendering-gap', message: 'Conformance family expects lexical ibid output for immediate repeats.' });
+    }
+    if (family.note_start_text_case) {
+      if (styleNoteStartTextCase(citationConfig.ibid) !== family.note_start_text_case) {
+        issues.push({
+          kind: 'style-gap',
+          message: `Conformance family expects citation.ibid.note_start_text_case=${family.note_start_text_case}.`,
+        });
+      }
+      if (!matchesLeadingTextCase(ibid, family.note_start_text_case)) {
+        issues.push({
+          kind: 'rendering-gap',
+          message: `Conformance family expects note-start ibid output with ${family.note_start_text_case} case.`,
+        });
+      }
+      if (!matchesLeadingTextCase(ibidWithLocator, family.note_start_text_case)) {
+        issues.push({
+          kind: 'rendering-gap',
+          message: `Conformance family expects note-start ibid-with-locator output with ${family.note_start_text_case} case.`,
+        });
+      }
     }
   } else if (hasLexicalIbid(ibid) || hasLexicalIbid(ibidWithLocator)) {
     issues.push({ kind: 'rendering-gap', message: 'Conformance family does not allow lexical ibid for immediate repeats.' });
@@ -537,8 +588,10 @@ module.exports = {
   normalizeText,
   normalizeFixtureLocators,
   parseRenderedCitations,
+  matchesLeadingTextCase,
   renderFixtureForStyle,
   renderFixtureForStyleWithOptions,
+  styleNoteStartTextCase,
   resolveCitumBinary,
   summarizeAuditResults,
   validateExpectationCoverage,

--- a/scripts/note-position-audit.test.js
+++ b/scripts/note-position-audit.test.js
@@ -5,6 +5,7 @@ const {
   evaluateConformanceLayer,
   evaluateNotePositionRender,
   evaluateRegressionLayer,
+  matchesLeadingTextCase,
   normalizeFixtureLocators,
   parseRenderedCitations,
   summarizeAuditResults,
@@ -13,7 +14,7 @@ const {
 } = require('./lib/note-position-audit');
 
 const EXPECTATIONS = validateExpectations({
-  version: 2,
+  version: 3,
   regression_profiles: {
     'ibid-and-subsequent': {
       requires: { ibid: true, subsequent: true },
@@ -35,11 +36,21 @@ const EXPECTATIONS = validateExpectations({
   conformance_families: {
     'chicago-full-note': {
       lexical_marker: 'ibid',
+      note_start_text_case: 'capitalize-first',
       immediate_repeat_form: 'marker',
       immediate_with_locator_form: 'marker',
       shortened_note_source: 'subsequent',
       distinct_subsequent: true,
-      unresolved: ['note-start', 'prose-integral'],
+      unresolved: ['prose-integral'],
+    },
+    oscola: {
+      lexical_marker: 'ibid',
+      note_start_text_case: 'lowercase',
+      immediate_repeat_form: 'marker',
+      immediate_with_locator_form: 'marker',
+      shortened_note_source: 'subsequent',
+      distinct_subsequent: true,
+      unresolved: ['prose-integral'],
     },
     'mhra-full-note': {
       lexical_marker: 'none',
@@ -58,6 +69,10 @@ const EXPECTATIONS = validateExpectations({
     'example-fallback': {
       regression_profile: 'subsequent-fallback',
       conformance_family: 'mhra-full-note',
+    },
+    'example-oscola': {
+      regression_profile: 'ibid-and-subsequent',
+      conformance_family: 'oscola',
     },
   },
 });
@@ -119,7 +134,7 @@ test('evaluateRegressionLayer reports configuration gaps for missing subsequent 
 test('evaluateConformanceLayer reports unresolved dimensions without failing a settled match', () => {
   const result = evaluateConformanceLayer(
     'example-ibid',
-    { citation: { ibid: {}, subsequent: {} } },
+    { citation: { ibid: { note_start_text_case: 'capitalize-first' }, subsequent: {} } },
     {
       'note-first': 'John Smith, Full Cite',
       'note-ibid': 'Ibid.',
@@ -133,7 +148,7 @@ test('evaluateConformanceLayer reports unresolved dimensions without failing a s
 
   assert.equal(result.status, 'pass');
   assert.deepEqual(result.issues, []);
-  assert.deepEqual(result.unresolved, ['note-start', 'prose-integral']);
+  assert.deepEqual(result.unresolved, ['prose-integral']);
 });
 
 test('evaluateNotePositionRender preserves regression aliases while exposing layered results', () => {
@@ -157,6 +172,25 @@ test('evaluateNotePositionRender preserves regression aliases while exposing lay
   assert.equal(result.conformance.status, 'pass');
 });
 
+test('evaluateConformanceLayer enforces lowercase note-start ibid for oscola', () => {
+  const result = evaluateConformanceLayer(
+    'example-oscola',
+    { citation: { ibid: { note_start_text_case: 'lowercase' }, subsequent: {} } },
+    {
+      'note-first': 'John Smith, Full Cite',
+      'note-ibid': 'ibid.',
+      'note-ibid-with-locator': 'ibid. 105',
+      'note-intervening': 'Other Author, Other Cite',
+      'note-subsequent': 'Smith, Short Cite',
+      'note-subsequent-with-locator': 'Smith, Short Cite, 205',
+    },
+    EXPECTATIONS
+  );
+
+  assert.equal(result.status, 'pass');
+  assert.deepEqual(result.unresolved, ['prose-integral']);
+});
+
 test('normalizeFixtureLocators ignores fixture-specific page numbers', () => {
   assert.equal(
     normalizeFixtureLocators('Smith, Short Cite, 105'),
@@ -172,7 +206,7 @@ test('validateExpectationCoverage finds missing and extra style declarations', (
 
   assert.deepEqual(coverage, {
     missing: ['missing-style'],
-    extra: ['example-fallback'],
+    extra: ['example-fallback', 'example-oscola'],
   });
 });
 
@@ -181,7 +215,7 @@ test('summarizeAuditResults counts each layer separately', () => {
     [
       {
         regression: { status: 'pass' },
-        conformance: { status: 'pass', unresolved: ['note-start'] },
+        conformance: { status: 'pass', unresolved: ['prose-integral'] },
       },
       {
         regression: { status: 'configuration-gap' },
@@ -210,4 +244,10 @@ test('summarizeAuditResults counts each layer separately', () => {
     missingExpectations: 1,
     extraExpectations: 0,
   });
+});
+
+test('matchesLeadingTextCase detects capitalized and lowercase note-start markers', () => {
+  assert.equal(matchesLeadingTextCase('Ibid., 105', 'capitalize-first'), true);
+  assert.equal(matchesLeadingTextCase('ibid. 105', 'lowercase'), true);
+  assert.equal(matchesLeadingTextCase('Ibid., 105', 'lowercase'), false);
 });

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -176,7 +176,7 @@ test('generateHtml renders repeated-note regression and conformance layers separ
             status: 'pass',
             family: 'chicago-full-note',
             issues: [],
-            unresolved: ['note-start', 'prose-integral'],
+            unresolved: ['prose-integral'],
           },
         },
       },
@@ -186,7 +186,7 @@ test('generateHtml renders repeated-note regression and conformance layers separ
   assert.match(html, /Regression Layer/);
   assert.match(html, /Normative Conformance/);
   assert.match(html, /chicago-full-note/);
-  assert.match(html, /Unresolved: note-start, prose-integral/);
+  assert.match(html, /Unresolved: prose-integral/);
 });
 
 test('generateHtml does not misreport missing conformance data as a pass', () => {

--- a/scripts/report-data/note-position-expectations.yaml
+++ b/scripts/report-data/note-position-expectations.yaml
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 regression_profiles:
   ibid-and-subsequent:
     requires:
@@ -27,21 +27,21 @@ regression_profiles:
 conformance_families:
   chicago-full-note:
     lexical_marker: ibid
+    note_start_text_case: capitalize-first
     immediate_repeat_form: marker
     immediate_with_locator_form: marker
     shortened_note_source: subsequent
     distinct_subsequent: true
     unresolved:
-      - note-start
       - prose-integral
   chicago-shortened-note:
     lexical_marker: ibid
+    note_start_text_case: capitalize-first
     immediate_repeat_form: marker
     immediate_with_locator_form: marker
     shortened_note_source: base
     distinct_subsequent: false
     unresolved:
-      - note-start
       - prose-integral
   mhra-full-note:
     lexical_marker: none
@@ -72,12 +72,12 @@ conformance_families:
       - prose-integral
   oscola:
     lexical_marker: ibid
+    note_start_text_case: lowercase
     immediate_repeat_form: marker
     immediate_with_locator_form: marker
     shortened_note_source: subsequent
     distinct_subsequent: true
     unresolved:
-      - note-start
       - prose-integral
   oscola-no-ibid:
     lexical_marker: none

--- a/styles/chicago-notes-bibliography-17th-edition.yaml
+++ b/styles/chicago-notes-bibliography-17th-edition.yaml
@@ -65,6 +65,7 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-notes-bibliography-classic-archive-place-first-no-url.yaml
+++ b/styles/chicago-notes-bibliography-classic-archive-place-first-no-url.yaml
@@ -65,6 +65,7 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-notes-classic-archive-place-first.yaml
+++ b/styles/chicago-notes-classic-archive-place-first.yaml
@@ -53,6 +53,7 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-notes-classic-no-url.yaml
+++ b/styles/chicago-notes-classic-no-url.yaml
@@ -53,6 +53,7 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-notes-classic.yaml
+++ b/styles/chicago-notes-classic.yaml
@@ -53,6 +53,7 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-notes-publisher-place-archive-place-first-no-url.yaml
+++ b/styles/chicago-notes-publisher-place-archive-place-first-no-url.yaml
@@ -53,6 +53,7 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-notes.yaml
+++ b/styles/chicago-notes.yaml
@@ -42,6 +42,7 @@ options:
 citation:
   delimiter: ""
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-shortened-notes-bibliography-classic-archive-place-first.yaml
+++ b/styles/chicago-shortened-notes-bibliography-classic-archive-place-first.yaml
@@ -67,6 +67,7 @@ citation:
     substitute:
       template: []
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/chicago-shortened-notes-bibliography.yaml
+++ b/styles/chicago-shortened-notes-bibliography.yaml
@@ -54,6 +54,7 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   ibid:
+    note-start-text-case: capitalize-first
     suffix: ""
     delimiter: ", "
     template:

--- a/styles/oscola.yaml
+++ b/styles/oscola.yaml
@@ -107,6 +107,7 @@ citation:
         show-label: true
         strip-label-periods: true
   ibid:
+    note-start-text-case: lowercase
     delimiter: " "
     template:
       - term: ibid


### PR DESCRIPTION
## Summary
- add a style-owned `note-start-text-case` citation setting instead of hardcoded ibid capitalization
- settle Chicago and OSCOLA repeated-note conformance expectations and shipped style declarations
- archive bean `csl26-ns2i` after implementation

## Testing
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- node scripts/audit-note-positions.js --json
- node scripts/report-core.js > /tmp/core-report.json && node scripts/check-core-quality.js --report /tmp/core-report.json --baseline scripts/report-data/core-quality-baseline.json
- ./scripts/check-docs-beans-hygiene.sh