### PR TITLE
feat(engine): implement title text-case semantics

### DIFF
--- a/.beans/csl26-qyrq--make-oracle-scoring-case-aware-and-roll-out-text-case.md
+++ b/.beans/csl26-qyrq--make-oracle-scoring-case-aware-and-roll-out-text-case.md
@@ -1,0 +1,58 @@
+---
+# csl26-qyrq
+title: Make oracle scoring case-aware and roll out text-case to all styles
+status: todo
+type: feature
+priority: high
+created_at: 2025-07-14T12:00:00Z
+updated_at: 2025-07-14T12:00:00Z
+---
+
+Follow-up to `csl26-zc4m` (title text-case semantics implementation).
+
+Context: PR #337 landed the text-case engine support. This bean tracks
+making the oracle scoring pipeline case-sensitive and rolling out
+`text_case` configuration to all styles.
+
+## Key Finding
+
+`oracle-utils.js` applies `.toLowerCase()` before all comparisons, so
+case differences have been invisible to fidelity scores. This means
+current baselines silently accept casing mismatches, masking the impact
+of missing `text_case` configuration in style YAML files.
+
+## Plan
+
+### Phase 1 — Oracle case-awareness
+
+- Add `--case-sensitive` flag to oracle scripts
+- Add case-mismatch counts as a separate metric in `report-core` output
+- Run baseline snapshot with the new metric to establish the current gap
+
+### Phase 2 — Migration text-case extraction
+
+- Wire CSL `text-case` extraction into `upsampler.rs` for variables
+  (currently discarded)
+- Emit `TitleRendering` config in migration output so styles carry
+  casing intent from their CSL sources
+
+### Phase 3 — Style audit and updates
+
+- Categorize 157 styles by expected text-case from CSL sources
+- Batch-add `text_case` to style YAML configs based on the audit
+
+### Phase 4 — Case-sensitive scoring gate
+
+- Make case-sensitive the default scoring mode
+- Regenerate baselines with case-sensitive comparisons
+- Add verification-policy divergences for intentional differences
+
+## Todos
+
+- [ ] Add `--case-sensitive` flag to oracle scripts
+- [ ] Add case-mismatch metric to `report-core`
+- [ ] Wire `text-case` extraction in `upsampler.rs`
+- [ ] Audit 157 styles for expected text-case
+- [ ] Batch-update style YAML configs with `text_case`
+- [ ] Regenerate baselines case-sensitively
+- [ ] Document verification-policy divergences

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -1380,7 +1380,9 @@ fn input_reference_to_csl_json(reference: &InputReference) -> csl_legacy::csl_js
         InputReference::SerialComponent(s) => {
             r.ref_type = "article-journal".to_string();
             r.container_title = match &s.parent {
-                citum_schema::reference::Parent::Embedded(parent) => Some(parent.title.to_string()),
+                citum_schema::reference::Parent::Embedded(parent) => {
+                    parent.title.as_ref().map(|t| t.to_string())
+                }
                 citum_schema::reference::Parent::Id(_) => None,
             };
             r.page = s.pages.as_ref().map(|p| p.to_string());

--- a/crates/citum-engine/src/ffi.rs
+++ b/crates/citum-engine/src/ffi.rs
@@ -263,9 +263,7 @@ fn input_reference_from_biblatex(entry: &biblatex::Entry) -> InputReference {
     };
     use url::Url;
 
-    let title = field_str("title")
-        .map(Title::Single)
-        .unwrap_or(Title::Single(String::new()));
+    let title = field_str("title").map(Title::Single);
     let issued = field_str("date")
         .map(EdtfString)
         .unwrap_or(EdtfString(String::new()));
@@ -344,20 +342,18 @@ fn input_reference_from_biblatex(entry: &biblatex::Entry) -> InputReference {
             }))
         }
         "inbook" | "incollection" | "inproceedings" => {
-            let parent_title = field_str("booktitle")
-                .map(Title::Single)
-                .unwrap_or(Title::Single(String::new()));
+            let parent_title = field_str("booktitle").map(Title::Single);
             InputReference::CollectionComponent(Box::new(CollectionComponent {
                 id,
                 r#type: MonographComponentType::Chapter,
-                title: Some(title),
+                title,
                 author,
                 translator: None,
                 issued,
                 parent: Parent::Embedded(Collection {
                     id: None,
                     r#type: CollectionType::EditedBook,
-                    title: Some(parent_title),
+                    title: parent_title,
                     short_title: None,
                     editor,
                     translator: None,
@@ -387,12 +383,11 @@ fn input_reference_from_biblatex(entry: &biblatex::Entry) -> InputReference {
         "article" => {
             let parent_title = field_str("journaltitle")
                 .or_else(|| field_str("journal"))
-                .map(Title::Single)
-                .unwrap_or(Title::Single(String::new()));
+                .map(Title::Single);
             InputReference::SerialComponent(Box::new(SerialComponent {
                 id,
                 r#type: SerialComponentType::Article,
-                title: Some(title),
+                title,
                 author,
                 translator: None,
                 issued,

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -62,7 +62,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! let reference = Reference::Monograph(Box::new(Monograph {
 //!     id: Some("kuhn1962".to_string()),
 //!     r#type: MonographType::Book,
-//!     title: Title::Single("The Structure of Scientific Revolutions".to_string()),
+//!     title: Some(Title::Single("The Structure of Scientific Revolutions".to_string())),
 //!     container_title: None,
 //!     author: Some(Contributor::ContributorList(ContributorList(vec![
 //!         Contributor::StructuredName(StructuredName {

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -545,7 +545,7 @@ mod tests {
         Reference::Monograph(Box::new(Monograph {
             id: Some(id.to_string()),
             r#type: MonographType::Book,
-            title: Title::Single(title.to_string()),
+            title: Some(Title::Single(title.to_string())),
             container_title: None,
             author: Some(Contributor::StructuredName(StructuredName {
                 family: MultilingualString::Simple(family.to_string()),

--- a/crates/citum-engine/src/render/rich_text.rs
+++ b/crates/citum-engine/src/render/rich_text.rs
@@ -15,6 +15,8 @@ struct DjotFrame {
     link_url: Option<String>,
     has_explicit_link: bool,
     last_char: Option<char>,
+    /// True when this frame (or an ancestor) carries `.nocase` protection.
+    case_protected: bool,
 }
 
 impl DjotFrame {
@@ -68,10 +70,14 @@ where
                 } else {
                     None
                 };
+                let classes = span_classes(Some(&attrs));
+                let parent_protected = stack.last().is_some_and(|f| f.case_protected);
+                let is_nocase = classes.iter().any(|c| c == "nocase");
                 stack.push(DjotFrame {
-                    classes: span_classes(Some(&attrs)),
+                    case_protected: parent_protected || is_nocase,
                     has_explicit_link: link_url.is_some(),
                     link_url,
+                    classes,
                     ..Default::default()
                 });
             }
@@ -109,8 +115,15 @@ where
             }
             Event::Str(s) => {
                 if let Some(frame) = stack.last_mut() {
+                    // Always call transform_text so stateful transforms (e.g., sentence-case)
+                    // can update their internal state, even for .nocase-protected spans.
                     let transformed = transform_text(s.as_ref());
-                    frame.push_rendered(fmt.text(&transformed), transformed.chars().last());
+                    let render_text = if frame.case_protected {
+                        s.to_string()
+                    } else {
+                        transformed
+                    };
+                    frame.push_rendered(fmt.text(&render_text), render_text.chars().last());
                 }
             }
             Event::Symbol(sym) => {

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -20,6 +20,8 @@ pub mod number;
 pub mod range;
 /// Locale term resolution helpers.
 pub mod term;
+/// Title text-case transform functions.
+pub mod text_case;
 /// Title extraction and title-formatting helpers.
 pub mod title;
 /// Generic variable extraction helpers.
@@ -204,9 +206,7 @@ pub fn effective_component_language(
                 },
                 TitleType::ParentSerial => match reference {
                     Reference::SerialComponent(component) => match &component.parent {
-                        citum_schema::reference::Parent::Embedded(parent) => {
-                            Some(parent.title.clone())
-                        }
+                        citum_schema::reference::Parent::Embedded(parent) => parent.title.clone(),
                         citum_schema::reference::Parent::Id(_) => None,
                     },
                     _ => None,

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -1944,3 +1944,359 @@ fn test_locator_label_selection_comprehensive() {
         &LocatorType::Page
     ));
 }
+
+// ── Title text-case tests ──────────────────────────────────────────────
+
+fn make_config_with_titles(titles: citum_schema::options::TitlesConfig) -> Config {
+    Config {
+        titles: Some(titles),
+        ..Default::default()
+    }
+}
+
+fn title_value_with_config(title_str: &str, ref_type: &str, config: &Config) -> String {
+    let locale = make_locale();
+    let options = RenderOptions {
+        config,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+    let reference = Reference::from(LegacyReference {
+        id: "tc".to_string(),
+        ref_type: ref_type.to_string(),
+        title: Some(title_str.to_string()),
+        ..Default::default()
+    });
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+    component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap()
+        .value
+}
+
+#[test]
+fn test_text_case_sentence_apa_basic() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceApa),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result =
+        title_value_with_config("The Structure of Scientific Revolutions", "book", &config);
+    assert_eq!(result, "The structure of scientific revolutions");
+}
+
+#[test]
+fn test_text_case_sentence_nlm_basic() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceNlm),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result =
+        title_value_with_config("The Structure of Scientific Revolutions", "book", &config);
+    assert_eq!(result, "The structure of scientific revolutions");
+}
+
+#[test]
+fn test_text_case_title_case() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::Title),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result = title_value_with_config("the quick brown fox", "book", &config);
+    assert_eq!(result, "The Quick Brown Fox");
+}
+
+#[test]
+fn test_text_case_as_is() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::AsIs),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result =
+        title_value_with_config("The Structure of Scientific Revolutions", "book", &config);
+    assert_eq!(result, "The Structure of Scientific Revolutions");
+}
+
+#[test]
+fn test_text_case_nocase_protection_in_djot() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceApa),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    // [mRNA]{.nocase} should be preserved even under sentence case
+    let result = title_value_with_config(
+        "The Role of [mRNA]{.nocase} in Modern Science",
+        "book",
+        &config,
+    );
+    assert_eq!(result, "The role of mRNA in modern science");
+}
+
+#[test]
+fn test_text_case_nocase_nested_in_emphasis() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceApa),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result = title_value_with_config(
+        "_Homo Sapiens_ and [DNA]{.nocase} Replication",
+        "book",
+        &config,
+    );
+    // Emphasis content gets sentence case (first word capitalized), DNA preserved
+    assert_eq!(result, "_Homo sapiens_ and DNA replication");
+}
+
+#[test]
+fn test_text_case_leading_nocase_advances_state() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceApa),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    // Leading .nocase span: the first-word state should still advance,
+    // so "replication" after the span is NOT capitalized.
+    let result = title_value_with_config(
+        "[DNA]{.nocase} Replication in Modern Science",
+        "book",
+        &config,
+    );
+    assert_eq!(result, "DNA replication in modern science");
+}
+
+#[test]
+fn test_text_case_structured_title_sentence_apa() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    use citum_schema::reference::types::{StructuredTitle, Subtitle, Title};
+
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceApa),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    // Build a native Citum structured title reference
+    let mut reference = Reference::from(LegacyReference {
+        id: "structured".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("placeholder".to_string()),
+        ..Default::default()
+    });
+    // Replace with structured title
+    if let Reference::Monograph(ref mut m) = reference {
+        m.title = Some(Title::Structured(StructuredTitle {
+            full: None,
+            main: "Understanding Citation Systems".to_string(),
+            sub: Subtitle::Vector(vec![
+                "History and Practice".to_string(),
+                "A Comparative View".to_string(),
+            ]),
+        }));
+    }
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+    // APA: first word of main + each subtitle capitalized
+    assert_eq!(
+        values.value,
+        "Understanding citation systems: History and practice: A comparative view"
+    );
+}
+
+#[test]
+fn test_text_case_structured_title_sentence_nlm() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+    use citum_schema::reference::types::{StructuredTitle, Subtitle, Title};
+
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceNlm),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let mut reference = Reference::from(LegacyReference {
+        id: "structured".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("placeholder".to_string()),
+        ..Default::default()
+    });
+    if let Reference::Monograph(ref mut m) = reference {
+        m.title = Some(Title::Structured(StructuredTitle {
+            full: None,
+            main: "Understanding Citation Systems".to_string(),
+            sub: Subtitle::String("History and Practice".to_string()),
+        }));
+    }
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+    // NLM: main sentence-cased, subtitle lowercased only
+    assert_eq!(
+        values.value,
+        "Understanding citation systems: history and practice"
+    );
+}
+
+#[test]
+fn test_text_case_non_english_falls_back_to_as_is() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::SentenceApa),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "german".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("Die Geschichte der Molekularbiologie".to_string()),
+        language: Some("de".to_string()),
+        ..Default::default()
+    });
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+    // German: should be as-is (no English sentence case applied)
+    assert_eq!(values.value, "Die Geschichte der Molekularbiologie");
+}
+
+#[test]
+fn test_text_case_template_level_override() {
+    use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
+
+    // Global config says as-is
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            text_case: Some(TextCase::AsIs),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator: None,
+        locator_label: None,
+    };
+    let hints = ProcHints::default();
+    let reference = Reference::from(LegacyReference {
+        id: "override".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("The Quick Brown Fox".to_string()),
+        ..Default::default()
+    });
+    // Template-level rendering overrides to lowercase
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        rendering: Rendering {
+            text_case: Some(TextCase::Lowercase),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+    assert_eq!(values.value, "the quick brown fox");
+}
+
+#[test]
+fn test_text_case_no_config_means_no_transform() {
+    let config = Config::default();
+    let result = title_value_with_config("The Quick Brown Fox", "book", &config);
+    // No text-case configured: title rendered as-is (just smart quotes)
+    assert_eq!(result, "The Quick Brown Fox");
+}

--- a/crates/citum-engine/src/values/text_case.rs
+++ b/crates/citum-engine/src/values/text_case.rs
@@ -1,0 +1,320 @@
+/*
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Title text-case transforms.
+//!
+//! Implements structured-title-aware casing for bibliography output.
+//! All transforms operate on Djot-markup-bearing strings and respect
+//! `.nocase` span protection via the rich-text renderer.
+
+use citum_schema::options::titles::TextCase;
+
+/// Apply a text-case transform to a single plain-text segment.
+///
+/// This function handles the core casing logic for a single string.
+/// For structured titles with subtitles, use [`apply_to_structured_parts`].
+///
+/// `.nocase`-protected spans are handled at the Djot rendering layer,
+/// not here — this function operates on already-resolved text segments.
+pub fn apply_text_case(text: &str, case: TextCase) -> String {
+    match case {
+        TextCase::AsIs => text.to_string(),
+        TextCase::Lowercase => text.to_lowercase(),
+        TextCase::Uppercase => text.to_uppercase(),
+        TextCase::CapitalizeFirst => capitalize_first_word(text),
+        TextCase::Sentence | TextCase::SentenceApa | TextCase::SentenceNlm => {
+            to_sentence_case(text)
+        }
+        TextCase::Title => to_title_case(text),
+    }
+}
+
+/// Apply text-case to a structured title (main + subtitles).
+///
+/// The key difference between sentence-case variants:
+/// - `SentenceApa`: capitalize first word of main title AND each subtitle
+/// - `SentenceNlm`: capitalize first word of main title only
+/// - Other variants: applied uniformly to each part
+pub fn apply_to_structured_parts(
+    main: &str,
+    subtitles: &[&str],
+    case: TextCase,
+) -> (String, Vec<String>) {
+    match case {
+        TextCase::SentenceApa => {
+            let main_cased = to_sentence_case(main);
+            let subs_cased = subtitles.iter().map(|s| to_sentence_case(s)).collect();
+            (main_cased, subs_cased)
+        }
+        TextCase::SentenceNlm => {
+            let main_cased = to_sentence_case(main);
+            // NLM: subtitles keep only explicit/protected capitals (lowercase the rest)
+            let subs_cased = subtitles.iter().map(|s| s.to_lowercase()).collect();
+            (main_cased, subs_cased)
+        }
+        _ => {
+            let main_cased = apply_text_case(main, case);
+            let subs_cased = subtitles.iter().map(|s| apply_text_case(s, case)).collect();
+            (main_cased, subs_cased)
+        }
+    }
+}
+
+/// Returns true if the given language tag indicates English.
+pub fn is_english_language(lang: Option<&str>) -> bool {
+    match lang {
+        Some(tag) => {
+            let primary = tag.split('-').next().unwrap_or(tag);
+            primary.eq_ignore_ascii_case("en")
+        }
+        // Default: assume English for backward compatibility
+        None => true,
+    }
+}
+
+/// Resolve the effective text-case, applying language fallback.
+///
+/// For non-English languages without defined transforms, returns `AsIs`.
+pub fn resolve_text_case(case: TextCase, language: Option<&str>) -> TextCase {
+    if !is_english_language(language) {
+        // Non-English: only explicit as-is, lowercase, uppercase pass through.
+        // All English-specific transforms fall back to as-is.
+        match case {
+            TextCase::AsIs | TextCase::Lowercase | TextCase::Uppercase => case,
+            _ => TextCase::AsIs,
+        }
+    } else {
+        case
+    }
+}
+
+/// Convert text to sentence case: lowercase everything, then capitalize the first word.
+fn to_sentence_case(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let lowered = text.to_lowercase();
+    capitalize_first_word(&lowered)
+}
+
+/// Capitalize the first alphabetic character of the string,
+/// preserving leading whitespace and punctuation.
+pub(crate) fn capitalize_first_word(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut found_first = false;
+    for ch in text.chars() {
+        if !found_first && ch.is_alphabetic() {
+            for upper in ch.to_uppercase() {
+                result.push(upper);
+            }
+            found_first = true;
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+// English title-case stop words (articles, short conjunctions, short prepositions).
+const TITLE_CASE_STOP_WORDS: &[&str] = &[
+    "a", "an", "and", "as", "at", "but", "by", "for", "in", "nor", "of", "on", "or", "so", "the",
+    "to", "up", "yet", "v", "vs",
+];
+
+/// Convert text to English headline-style title case.
+///
+/// Capitalizes the first and last word unconditionally.
+/// Interior stop words (articles, short prepositions, conjunctions) stay lowercase.
+fn to_title_case(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.is_empty() {
+        return text.to_string();
+    }
+
+    let last_idx = words.len() - 1;
+    let mut parts: Vec<String> = Vec::with_capacity(words.len());
+
+    for (i, word) in words.iter().enumerate() {
+        if i == 0 || i == last_idx {
+            parts.push(capitalize_first_word(&word.to_lowercase()));
+        } else {
+            let lower = word.to_lowercase();
+            if TITLE_CASE_STOP_WORDS.contains(&lower.as_str()) {
+                parts.push(lower);
+            } else {
+                parts.push(capitalize_first_word(&lower));
+            }
+        }
+    }
+
+    // Rebuild with original whitespace structure
+    let mut result = String::with_capacity(text.len());
+    let mut word_iter = parts.iter();
+    let mut in_word = false;
+    let mut current_word = word_iter.next();
+
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if in_word {
+                in_word = false;
+                current_word = word_iter.next();
+            }
+            result.push(ch);
+        } else if !in_word && let Some(word) = current_word {
+            result.push_str(word);
+            in_word = true;
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- capitalize_first_word ---
+
+    #[test]
+    fn test_capitalize_first_word_basic() {
+        assert_eq!(capitalize_first_word("hello world"), "Hello world");
+    }
+
+    #[test]
+    fn test_capitalize_first_word_leading_space() {
+        assert_eq!(capitalize_first_word("  hello"), "  Hello");
+    }
+
+    #[test]
+    fn test_capitalize_first_word_empty() {
+        assert_eq!(capitalize_first_word(""), "");
+    }
+
+    #[test]
+    fn test_capitalize_first_word_already_upper() {
+        assert_eq!(capitalize_first_word("Hello"), "Hello");
+    }
+
+    // --- to_sentence_case ---
+
+    #[test]
+    fn test_sentence_case_basic() {
+        assert_eq!(
+            to_sentence_case("The Quick Brown Fox"),
+            "The quick brown fox"
+        );
+    }
+
+    #[test]
+    fn test_sentence_case_all_caps() {
+        assert_eq!(to_sentence_case("DNA REPLICATION"), "Dna replication");
+    }
+
+    #[test]
+    fn test_sentence_case_empty() {
+        assert_eq!(to_sentence_case(""), "");
+    }
+
+    // --- to_title_case ---
+
+    #[test]
+    fn test_title_case_basic() {
+        assert_eq!(to_title_case("the quick brown fox"), "The Quick Brown Fox");
+    }
+
+    #[test]
+    fn test_title_case_stop_words() {
+        assert_eq!(
+            to_title_case("a tale of two cities"),
+            "A Tale of Two Cities"
+        );
+    }
+
+    #[test]
+    fn test_title_case_last_word_capitalized() {
+        assert_eq!(
+            to_title_case("the world we live in"),
+            "The World We Live In"
+        );
+    }
+
+    // --- apply_to_structured_parts ---
+
+    #[test]
+    fn test_sentence_apa_structured() {
+        let (main, subs) = apply_to_structured_parts(
+            "Understanding Citation Systems",
+            &["History and Practice", "A Comparative View"],
+            TextCase::SentenceApa,
+        );
+        assert_eq!(main, "Understanding citation systems");
+        assert_eq!(subs, vec!["History and practice", "A comparative view"]);
+    }
+
+    #[test]
+    fn test_sentence_nlm_structured() {
+        let (main, subs) = apply_to_structured_parts(
+            "Understanding Citation Systems",
+            &["History and Practice"],
+            TextCase::SentenceNlm,
+        );
+        assert_eq!(main, "Understanding citation systems");
+        // NLM: subtitles lowercased (no first-word capitalization)
+        assert_eq!(subs, vec!["history and practice"]);
+    }
+
+    #[test]
+    fn test_title_case_structured() {
+        let (main, subs) =
+            apply_to_structured_parts("the dna of empire", &["a new perspective"], TextCase::Title);
+        assert_eq!(main, "The Dna of Empire");
+        assert_eq!(subs, vec!["A New Perspective"]);
+    }
+
+    // --- resolve_text_case ---
+
+    #[test]
+    fn test_english_language_detection() {
+        assert!(is_english_language(Some("en")));
+        assert!(is_english_language(Some("en-US")));
+        assert!(is_english_language(Some("en-GB")));
+        assert!(is_english_language(None));
+        assert!(!is_english_language(Some("de")));
+        assert!(!is_english_language(Some("fr-FR")));
+    }
+
+    #[test]
+    fn test_resolve_non_english_falls_back() {
+        assert_eq!(
+            resolve_text_case(TextCase::SentenceApa, Some("de")),
+            TextCase::AsIs
+        );
+        assert_eq!(
+            resolve_text_case(TextCase::Title, Some("fr")),
+            TextCase::AsIs
+        );
+        // Explicit lowercase/uppercase pass through for any language
+        assert_eq!(
+            resolve_text_case(TextCase::Lowercase, Some("de")),
+            TextCase::Lowercase
+        );
+    }
+
+    #[test]
+    fn test_resolve_english_passes_through() {
+        assert_eq!(
+            resolve_text_case(TextCase::SentenceApa, Some("en")),
+            TextCase::SentenceApa
+        );
+        assert_eq!(
+            resolve_text_case(TextCase::Title, Some("en-US")),
+            TextCase::Title
+        );
+    }
+}

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -3,14 +3,15 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-//! Rendering logic for title fields with smartening and form selection.
-//!
-//! This module handles title component rendering, including main titles,
-//! container titles, and smart quote handling.
+//! Rendering logic for title fields with smartening, form selection,
+//! and text-case transforms.
 
 use crate::reference::Reference;
 use crate::render::rich_text::render_djot_inline_with_transform;
+use crate::values::text_case::{self, apply_text_case, capitalize_first_word};
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
+use citum_schema::options::titles::TextCase;
+use citum_schema::reference::types::{StructuredTitle, Subtitle};
 use citum_schema::reference::{Parent, types::Title};
 use citum_schema::template::{TemplateTitle, TitleForm, TitleType};
 
@@ -114,19 +115,126 @@ fn parent_short_title(reference: &Reference, title_type: &TitleType) -> Option<S
     }
 }
 
-fn render_title_inline<F: crate::render::format::OutputFormat<Output = String>>(
-    value: &str,
-    fmt: &F,
-) -> (String, bool) {
-    render_djot_inline_with_transform(value, fmt, smarten_title_quotes)
-}
-
 fn looks_like_djot_markup(value: &str) -> bool {
     value.contains('_')
         || value.contains('*')
         || value.contains("](")
         || value.contains("{.")
         || value.contains('`')
+}
+
+/// Build a text-transform closure that applies case transform then smart quotes.
+///
+/// The closure is used as the Djot text-leaf transform, so `.nocase` spans
+/// bypass it automatically via the rich-text renderer.
+fn make_case_transform(case: TextCase) -> impl FnMut(&str) -> String {
+    let mut seen_alpha = false;
+    move |text: &str| {
+        let cased = match case {
+            TextCase::Sentence | TextCase::SentenceApa | TextCase::SentenceNlm => {
+                let lowered = text.to_lowercase();
+                if !seen_alpha {
+                    // Capitalize the first alphabetic character we encounter
+                    let result = capitalize_first_word(&lowered);
+                    if result.chars().any(|c: char| c.is_alphabetic()) {
+                        seen_alpha = true;
+                    }
+                    result
+                } else {
+                    lowered
+                }
+            }
+            _ => apply_text_case(text, case),
+        };
+        smarten_title_quotes(&cased)
+    }
+}
+
+/// Render a single title part through Djot with case transform + smart quotes.
+/// Returns (rendered_value, has_explicit_link).
+fn render_part_with_case<F: crate::render::format::OutputFormat<Output = String>>(
+    value: &str,
+    fmt: &F,
+    case: Option<TextCase>,
+) -> (String, bool) {
+    if looks_like_djot_markup(value) {
+        match case {
+            Some(tc) => render_djot_inline_with_transform(value, fmt, make_case_transform(tc)),
+            None => render_djot_inline_with_transform(value, fmt, smarten_title_quotes),
+        }
+    } else {
+        let result = match case {
+            Some(tc) => smarten_title_quotes(&apply_text_case(value, tc)),
+            None => smarten_title_quotes(value),
+        };
+        (result, false)
+    }
+}
+
+/// Render a structured title with per-part case transforms.
+///
+/// For `SentenceApa`, each subtitle gets sentence-case (first word capitalized).
+/// For `SentenceNlm`, subtitles are lowercased (no first-word capitalization).
+fn render_structured_title<F: crate::render::format::OutputFormat<Output = String>>(
+    st: &StructuredTitle,
+    fmt: &F,
+    case: Option<TextCase>,
+) -> (String, bool) {
+    let subtitle_case = case.map(|c| match c {
+        TextCase::SentenceNlm => TextCase::Lowercase,
+        other => other,
+    });
+
+    let (main_rendered, mut has_link) = render_part_with_case(&st.main, fmt, case);
+    let mut parts = vec![main_rendered];
+
+    let subs: Vec<&str> = match &st.sub {
+        Subtitle::String(s) => vec![s.as_str()],
+        Subtitle::Vector(v) => v.iter().map(|s| s.as_str()).collect(),
+    };
+
+    for sub in subs {
+        let (sub_rendered, sub_link) = render_part_with_case(sub, fmt, subtitle_case);
+        has_link |= sub_link;
+        parts.push(sub_rendered);
+    }
+
+    (parts.join(": "), has_link)
+}
+
+/// Resolve the effective text-case for this title component.
+fn resolve_effective_text_case(
+    template: &TemplateTitle,
+    reference: &Reference,
+    options: &RenderOptions<'_>,
+) -> Option<TextCase> {
+    // 1. Template-level override takes precedence
+    if let Some(tc) = template.rendering.text_case {
+        return Some(apply_language_fallback(tc, reference));
+    }
+
+    // 2. Global title-category config
+    let ref_type = reference.ref_type();
+    let lang = reference.language();
+    let lang_str = lang.as_deref();
+
+    if let Some(rendering) = crate::render::component::get_title_category_rendering(
+        &template.title,
+        Some(&ref_type),
+        lang_str,
+        options.config,
+    ) && let Some(tc) = rendering.text_case
+    {
+        return Some(apply_language_fallback(tc, reference));
+    }
+
+    None
+}
+
+/// Apply language-aware fallback: non-English → as-is for English-specific transforms.
+fn apply_language_fallback(case: TextCase, reference: &Reference) -> TextCase {
+    let lang = reference.language();
+    text_case::resolve_text_case(case, lang.as_deref())
 }
 
 impl ComponentValues for TemplateTitle {
@@ -136,10 +244,6 @@ impl ComponentValues for TemplateTitle {
         hints: &ProcHints,
         options: &RenderOptions<'_>,
     ) -> Option<ProcValues<F::Output>> {
-        // Suppress title when disambiguate_only is set and only one work by
-        // this author appears in the document (no disambiguation needed).
-        // Used by author-class styles like MLA where the title in citations
-        // exists solely to resolve same-author ambiguity.
         if self.disambiguate_only == Some(true) && hints.group_length <= 1 {
             return None;
         }
@@ -149,7 +253,11 @@ impl ComponentValues for TemplateTitle {
             && !short_title.is_empty()
         {
             let (value, pre_formatted) = if looks_like_djot_markup(&short_title) {
-                let (value, _) = render_title_inline(&short_title, &F::default());
+                let (value, _) = render_djot_inline_with_transform(
+                    &short_title,
+                    &F::default(),
+                    smarten_title_quotes,
+                );
                 (value, true)
             } else {
                 (smarten_title_quotes(&short_title), false)
@@ -164,12 +272,11 @@ impl ComponentValues for TemplateTitle {
             });
         }
 
-        // Get the raw title based on type and template requirement
         let raw_title = match self.title {
             TitleType::Primary => reference.title(),
             TitleType::ParentSerial => match reference {
                 Reference::SerialComponent(r) => match &r.parent {
-                    Parent::Embedded(p) => Some(&p.title),
+                    Parent::Embedded(p) => p.title.as_ref(),
                     _ => None,
                 },
                 _ => None,
@@ -186,8 +293,17 @@ impl ComponentValues for TemplateTitle {
             _ => None,
         };
 
-        // Resolve multilingual title if configured
-        let value: Option<String> = raw_title.map(|title| match title {
+        let effective_case = resolve_effective_text_case(self, reference, options);
+        let fmt = F::default();
+
+        // Render title with structured-title-aware case transforms
+        let rendered: Option<(String, bool, bool)> = raw_title.map(|title| match &title {
+            Title::Structured(st) => {
+                let raw_text = title_text(&title, self.form.as_ref());
+                let (value, has_link) = render_structured_title(st, &fmt, effective_case);
+                let pre_formatted = looks_like_djot_markup(&raw_text);
+                (value, has_link, pre_formatted)
+            }
             Title::Multilingual(m) => {
                 let mode = options
                     .config
@@ -208,40 +324,43 @@ impl ComponentValues for TemplateTitle {
 
                 let complex =
                     citum_schema::reference::types::MultilingualString::Complex(m.clone());
-                crate::values::resolve_multilingual_string(
+                let value = crate::values::resolve_multilingual_string(
                     &complex,
                     mode,
                     preferred_transliteration,
                     preferred_script,
                     locale_str,
-                )
+                );
+                let (rendered, has_link) = render_part_with_case(&value, &fmt, effective_case);
+                let pre_formatted = looks_like_djot_markup(&value);
+                (rendered, has_link, pre_formatted)
             }
-            _ => title_text(&title, self.form.as_ref()),
+            _ => {
+                let value = title_text(&title, self.form.as_ref());
+                let (rendered, has_link) = render_part_with_case(&value, &fmt, effective_case);
+                let pre_formatted = looks_like_djot_markup(&value);
+                (rendered, has_link, pre_formatted)
+            }
         });
 
-        value.filter(|s: &String| !s.is_empty()).map(|value| {
-            use citum_schema::options::LinkAnchor;
-            let url = crate::values::resolve_effective_url(
-                self.links.as_ref(),
-                options.config.links.as_ref(),
-                reference,
-                LinkAnchor::Title,
-            );
-            let (value, has_explicit_link, pre_formatted) = if looks_like_djot_markup(&value) {
-                let fmt = F::default();
-                let (value, has_explicit_link) = render_title_inline(&value, &fmt);
-                (value, has_explicit_link, true)
-            } else {
-                (smarten_title_quotes(&value), false, false)
-            };
-            ProcValues {
-                value,
-                prefix: None,
-                suffix: None,
-                url: if has_explicit_link { None } else { url },
-                substituted_key: None,
-                pre_formatted,
-            }
-        })
+        rendered.filter(|(v, _, _)| !v.is_empty()).map(
+            |(value, has_explicit_link, pre_formatted)| {
+                use citum_schema::options::LinkAnchor;
+                let url = crate::values::resolve_effective_url(
+                    self.links.as_ref(),
+                    options.config.links.as_ref(),
+                    reference,
+                    LinkAnchor::Title,
+                );
+                ProcValues {
+                    value,
+                    prefix: None,
+                    suffix: None,
+                    url: if has_explicit_link { None } else { url },
+                    substituted_key: None,
+                    pre_formatted,
+                }
+            },
+        )
     }
 }

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -222,7 +222,7 @@ fn make_particle_book(
     InputReference::Monograph(Box::new(Monograph {
         id: Some(id.to_string()),
         r#type: MonographType::Book,
-        title: Title::Single(format!("Title {id}")),
+        title: Some(Title::Single(format!("Title {id}"))),
         container_title: None,
         author: Some(Contributor::StructuredName(StructuredName {
             family: family.into(),

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -46,7 +46,7 @@ pub fn make_book_multi_author(
     Reference::Monograph(Box::new(Monograph {
         id: Some(id.to_string()),
         r#type: MonographType::Book,
-        title: Title::Single(title.to_string()),
+        title: Some(Title::Single(title.to_string())),
         container_title: None,
         author: Some(Contributor::ContributorList(ContributorList(author_list))),
         editor: None,
@@ -110,7 +110,7 @@ pub fn make_article_multi_author(
         issued: EdtfString(year.to_string()),
         parent: Parent::Embedded(Serial {
             r#type: SerialType::AcademicJournal,
-            title: Title::Single(String::new()),
+            title: Some(Title::Single(String::new())),
             short_title: None,
             editor: None,
             publisher: None,
@@ -162,7 +162,7 @@ pub fn make_multilingual_book(
     Reference::Monograph(Box::new(Monograph {
         id: Some(id.to_string()),
         r#type: MonographType::Book,
-        title: Title::Single(title.to_string()),
+        title: Some(Title::Single(title.to_string())),
         container_title: None,
         author: Some(Contributor::Multilingual(MultilingualName {
             original: StructuredName {

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -512,7 +512,9 @@ fn test_multilingual_rendering_numeric_integral_translated() {
             citum_schema::reference::Monograph {
                 id: Some("item1".to_string()),
                 r#type: citum_schema::reference::MonographType::Book,
-                title: citum_schema::reference::Title::Single("War and Peace".to_string()),
+                title: Some(citum_schema::reference::Title::Single(
+                    "War and Peace".to_string(),
+                )),
                 container_title: None,
                 author: Some(Contributor::Multilingual(MultilingualName {
                     original: StructuredName {
@@ -569,12 +571,12 @@ fn test_effective_field_language_prefers_field_languages() {
     let reference = InputReference::Monograph(Box::new(Monograph {
         id: Some("item1".to_string()),
         r#type: MonographType::Book,
-        title: Title::Multilingual(MultilingualComplex {
+        title: Some(Title::Multilingual(MultilingualComplex {
             original: "Titel".to_string(),
             lang: Some("de".to_string()),
             transliterations: HashMap::new(),
             translations: HashMap::new(),
-        }),
+        })),
         container_title: None,
         author: None,
         editor: None,
@@ -614,12 +616,12 @@ fn test_effective_item_language_falls_back_to_multilingual_title_lang() {
     let reference = InputReference::Monograph(Box::new(Monograph {
         id: Some("item1".to_string()),
         r#type: MonographType::Book,
-        title: Title::Multilingual(MultilingualComplex {
+        title: Some(Title::Multilingual(MultilingualComplex {
             original: "東京".to_string(),
             lang: Some("ja".to_string()),
             transliterations: HashMap::new(),
             translations: HashMap::new(),
-        }),
+        })),
         container_title: None,
         author: None,
         editor: None,
@@ -683,7 +685,7 @@ fn test_citation_localized_template_selection_uses_item_language() {
         InputReference::Monograph(Box::new(Monograph {
             id: Some("de-item".to_string()),
             r#type: MonographType::Book,
-            title: Title::Single("Titel".to_string()),
+            title: Some(Title::Single("Titel".to_string())),
             container_title: None,
             author: None,
             editor: None,
@@ -722,7 +724,7 @@ fn test_citation_localized_template_selection_uses_item_language() {
         InputReference::Monograph(Box::new(Monograph {
             id: Some("fr-item".to_string()),
             r#type: MonographType::Book,
-            title: Title::Single("Titre".to_string()),
+            title: Some(Title::Single("Titre".to_string())),
             container_title: None,
             author: None,
             editor: None,
@@ -804,12 +806,12 @@ fn test_bibliography_localized_template_selection_uses_multilingual_title_lang()
         InputReference::Monograph(Box::new(Monograph {
             id: Some("item1".to_string()),
             r#type: MonographType::Book,
-            title: Title::Multilingual(MultilingualComplex {
+            title: Some(Title::Multilingual(MultilingualComplex {
                 original: "東京".to_string(),
                 lang: Some("ja".to_string()),
                 transliterations: HashMap::new(),
                 translations: HashMap::new(),
-            }),
+            })),
             container_title: None,
             author: None,
             editor: None,

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -38,15 +38,16 @@ fn test_apa_7th_sort_same_author_year_by_title() {
     let result = processor.render_bibliography();
 
     // All three Adams 2020 items should appear in title order: Academic, Digital, Ethics
+    // APA preset applies sentence-apa case transform to component titles.
     let academic_pos = result
-        .find("Academic Enterprise")
-        .expect("Academic Enterprise should be in output");
+        .find("academic enterprise")
+        .expect("academic enterprise should be in output");
     let digital_pos = result
-        .find("Digital Transformation")
-        .expect("Digital Transformation should be in output");
+        .find("Digital transformation")
+        .expect("Digital transformation should be in output");
     let ethics_pos = result
-        .find("Ethics in Research")
-        .expect("Ethics in Research should be in output");
+        .find("Ethics in research")
+        .expect("Ethics in research should be in output");
 
     assert!(
         academic_pos < digital_pos,

--- a/crates/citum-migrate/src/template_compiler/formatting.rs
+++ b/crates/citum-migrate/src/template_compiler/formatting.rs
@@ -36,6 +36,7 @@ impl TemplateCompiler {
         };
 
         Rendering {
+            text_case: None,
             emph: fmt
                 .font_style
                 .as_ref()

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -49,6 +49,7 @@ pub use legacy::{
 };
 pub use locale::Locale;
 pub use options::Config;
+pub use options::TextCase;
 pub use presets::{ContributorPreset, DatePreset, SortPreset, SubstitutePreset, TitlePreset};
 pub use template::{
     Rendering, TemplateComponent, TemplateContributor, TemplateDate, TemplateList, TemplateNumber,

--- a/crates/citum-schema-style/src/macros.rs
+++ b/crates/citum-schema-style/src/macros.rs
@@ -210,7 +210,7 @@ macro_rules! ref_book {
             $crate::reference::Monograph {
                 id: Some($id.to_string()),
                 r#type: $crate::reference::MonographType::Book,
-                title: $crate::reference::Title::Single($title.to_string()),
+                title: Some($crate::reference::Title::Single($title.to_string())),
                 container_title: None,
                 author: Some($crate::reference::Contributor::StructuredName(
                     $crate::reference::StructuredName {
@@ -274,7 +274,7 @@ macro_rules! ref_book_authors {
             $crate::reference::Monograph {
                 id: Some($id.to_string()),
                 r#type: $crate::reference::MonographType::Book,
-                title: $crate::reference::Title::Single($title.to_string()),
+                title: Some($crate::reference::Title::Single($title.to_string())),
                 container_title: None,
                 author: Some($crate::reference::Contributor::ContributorList(
                     $crate::reference::ContributorList(_authors),
@@ -333,7 +333,7 @@ macro_rules! ref_article {
                 issued: $crate::reference::EdtfString($year.to_string()),
                 parent: $crate::reference::Parent::Embedded($crate::reference::Serial {
                     r#type: $crate::reference::SerialType::AcademicJournal,
-                    title: $crate::reference::Title::Single(String::new()),
+                    title: Some($crate::reference::Title::Single(String::new())),
                     short_title: None,
                     editor: None,
                     publisher: None,
@@ -391,7 +391,7 @@ macro_rules! ref_article_authors {
                 issued: $crate::reference::EdtfString($year.to_string()),
                 parent: $crate::reference::Parent::Embedded($crate::reference::Serial {
                     r#type: $crate::reference::SerialType::AcademicJournal,
-                    title: $crate::reference::Title::Single(String::new()),
+                    title: Some($crate::reference::Title::Single(String::new())),
                     short_title: None,
                     editor: None,
                     publisher: None,

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -196,7 +196,7 @@ pub enum PageRangeFormat {
 
 pub mod titles;
 
-pub use titles::{TitleRendering, TitlesConfig, TitlesConfigEntry};
+pub use titles::{TextCase, TitleRendering, TitlesConfig, TitlesConfigEntry};
 
 /// Structured link options.
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]

--- a/crates/citum-schema-style/src/options/titles.rs
+++ b/crates/citum-schema-style/src/options/titles.rs
@@ -8,6 +8,34 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Text-case transform applied to title-like fields.
+///
+/// Styles select which transform applies to which field category.
+/// The engine provides the generic primitives; styles own the selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum TextCase {
+    /// English headline-style title case (capitalize principal words).
+    Title,
+    /// Generic sentence case (capitalize first word only).
+    Sentence,
+    /// APA-style sentence case: capitalize first word of main title
+    /// and first word after each subtitle boundary.
+    SentenceApa,
+    /// NLM-style sentence case: capitalize first word of main title only;
+    /// subtitles preserve only explicit/protected capitals.
+    SentenceNlm,
+    /// Capitalize the first letter of the value.
+    CapitalizeFirst,
+    /// Transform the entire value to lowercase.
+    Lowercase,
+    /// Transform the entire value to uppercase.
+    Uppercase,
+    /// No transformation; render the value exactly as stored.
+    AsIs,
+}
+
 /// Title config: either a preset name or explicit configuration.
 ///
 /// Allows styles to write `titles: apa` as shorthand, or provide
@@ -76,6 +104,9 @@ pub struct TitlesConfig {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TitleRendering {
+    /// Text-case transform to apply to this title category.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_case: Option<TextCase>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub emph: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -95,6 +126,7 @@ pub struct TitleRendering {
 impl TitleRendering {
     pub fn to_rendering(&self) -> crate::template::Rendering {
         crate::template::Rendering {
+            text_case: self.text_case,
             emph: self.emph,
             quote: self.quote,
             strong: self.strong,

--- a/crates/citum-schema-style/src/presets.rs
+++ b/crates/citum-schema-style/src/presets.rs
@@ -392,14 +392,22 @@ pub enum TitlePreset {
 impl TitlePreset {
     /// Convert this preset to a concrete `TitlesConfig`.
     pub fn config(&self) -> TitlesConfig {
+        use crate::options::titles::TextCase;
         let emph_rendering = TitleRendering {
             emph: Some(true),
             ..Default::default()
         };
         match self {
             TitlePreset::Apa => TitlesConfig {
-                component: Some(TitleRendering::default()),
-                monograph: Some(emph_rendering.clone()),
+                component: Some(TitleRendering {
+                    text_case: Some(TextCase::SentenceApa),
+                    ..Default::default()
+                }),
+                monograph: Some(TitleRendering {
+                    text_case: Some(TextCase::SentenceApa),
+                    emph: Some(true),
+                    ..Default::default()
+                }),
                 periodical: Some(emph_rendering),
                 ..Default::default()
             },
@@ -426,8 +434,14 @@ impl TitlePreset {
                 ..Default::default()
             },
             TitlePreset::Scientific => TitlesConfig {
-                component: Some(TitleRendering::default()),
-                monograph: Some(TitleRendering::default()),
+                component: Some(TitleRendering {
+                    text_case: Some(TextCase::SentenceNlm),
+                    ..Default::default()
+                }),
+                monograph: Some(TitleRendering {
+                    text_case: Some(TextCase::SentenceNlm),
+                    ..Default::default()
+                }),
                 periodical: Some(TitleRendering::default()),
                 ..Default::default()
             },

--- a/crates/citum-schema-style/src/reference/conversion.rs
+++ b/crates/citum-schema-style/src/reference/conversion.rs
@@ -51,10 +51,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
         let legacy_journal_abbreviation = short_title_from_legacy(&legacy, "journalAbbreviation");
         let id = Some(legacy.id);
         let language = legacy.language;
-        let title = legacy
-            .title
-            .map(Title::Single)
-            .unwrap_or(Title::Single(String::new()));
+        let title = legacy.title.map(Title::Single);
         let issued = legacy
             .issued
             .map(EdtfString::from)
@@ -172,10 +169,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
                 }))
             }
             "chapter" | "paper-conference" | "entry-dictionary" => {
-                let parent_title = legacy
-                    .container_title
-                    .map(Title::Single)
-                    .unwrap_or(Title::Single(String::new()));
+                let parent_title = legacy.container_title.map(Title::Single);
                 InputReference::CollectionComponent(Box::new(CollectionComponent {
                     id,
                     r#type: if legacy.ref_type == "paper-conference" {
@@ -183,14 +177,14 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
                     } else {
                         MonographComponentType::Chapter
                     },
-                    title: Some(title),
+                    title,
                     author: legacy.author.map(Contributor::from),
                     translator: legacy.translator.map(Contributor::from),
                     issued,
                     parent: Parent::Embedded(Collection {
                         id: None,
                         r#type: CollectionType::EditedBook,
-                        title: Some(parent_title),
+                        title: parent_title,
                         short_title: legacy_container_title_short,
                         editor: legacy.editor.map(Contributor::from),
                         translator: None,
@@ -241,14 +235,11 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
                     "broadcast" | "motion_picture" => SerialType::BroadcastProgram,
                     _ => SerialType::AcademicJournal,
                 };
-                let parent_title = legacy
-                    .container_title
-                    .map(Title::Single)
-                    .unwrap_or(Title::Single(String::new()));
+                let parent_title = legacy.container_title.map(Title::Single);
                 InputReference::SerialComponent(Box::new(SerialComponent {
                     id,
                     r#type: SerialComponentType::Article,
-                    title: Some(title),
+                    title,
                     author: legacy.author.map(Contributor::from),
                     translator: legacy.translator.map(Contributor::from),
                     issued,

--- a/crates/citum-schema-style/src/reference/mod.rs
+++ b/crates/citum-schema-style/src/reference/mod.rs
@@ -175,21 +175,21 @@ impl InputReference {
     /// Return the title.
     pub fn title(&self) -> Option<Title> {
         match self {
-            InputReference::Monograph(r) => Some(r.title.clone()),
+            InputReference::Monograph(r) => r.title.clone(),
             InputReference::CollectionComponent(r) => r.title.clone(),
             InputReference::SerialComponent(r) => r.title.clone(),
             InputReference::Collection(r) => r.title.clone(),
-            InputReference::LegalCase(r) => Some(r.title.clone()),
-            InputReference::Statute(r) => Some(r.title.clone()),
-            InputReference::Treaty(r) => Some(r.title.clone()),
-            InputReference::Hearing(r) => Some(r.title.clone()),
-            InputReference::Regulation(r) => Some(r.title.clone()),
-            InputReference::Brief(r) => Some(r.title.clone()),
-            InputReference::Classic(r) => Some(r.title.clone()),
-            InputReference::Patent(r) => Some(r.title.clone()),
-            InputReference::Dataset(r) => Some(r.title.clone()),
-            InputReference::Standard(r) => Some(r.title.clone()),
-            InputReference::Software(r) => Some(r.title.clone()),
+            InputReference::LegalCase(r) => r.title.clone(),
+            InputReference::Statute(r) => r.title.clone(),
+            InputReference::Treaty(r) => r.title.clone(),
+            InputReference::Hearing(r) => r.title.clone(),
+            InputReference::Regulation(r) => r.title.clone(),
+            InputReference::Brief(r) => r.title.clone(),
+            InputReference::Classic(r) => r.title.clone(),
+            InputReference::Patent(r) => r.title.clone(),
+            InputReference::Dataset(r) => r.title.clone(),
+            InputReference::Standard(r) => r.title.clone(),
+            InputReference::Software(r) => r.title.clone(),
         }
     }
 
@@ -376,7 +376,7 @@ impl InputReference {
             InputReference::SerialComponent(r) => {
                 let r = r.as_ref();
                 match &r.parent {
-                    Parent::Embedded(p) => Some(p.title.clone()),
+                    Parent::Embedded(p) => p.title.clone(),
                     Parent::Id(_) => None,
                 }
             }
@@ -673,7 +673,8 @@ impl InputReference {
                     SerialType::AcademicJournal => {
                         if r.genre.as_deref() == Some("entry-encyclopedia") {
                             "entry-encyclopedia".to_string()
-                        } else if matches!(s.title, Title::Single(ref title) if title == "arXiv") {
+                        } else if matches!(&s.title, Some(Title::Single(title)) if title == "arXiv")
+                        {
                             "article-journal+arxiv".to_string()
                         } else {
                             "article-journal".to_string()

--- a/crates/citum-schema-style/src/reference/types.rs
+++ b/crates/citum-schema-style/src/reference/types.rs
@@ -120,7 +120,7 @@ impl Default for MultilingualString {
 pub struct Monograph {
     pub id: Option<RefID>,
     pub r#type: MonographType,
-    pub title: Title,
+    pub title: Option<Title>,
     /// Parent or container title for monographic interviews and similar sources.
     pub container_title: Option<Title>,
     pub author: Option<Contributor>,
@@ -307,7 +307,7 @@ pub enum SerialComponentType {
 #[serde(rename_all = "kebab-case")]
 pub struct Serial {
     pub r#type: SerialType,
-    pub title: Title,
+    pub title: Option<Title>,
     /// Optional short form of the parent title for style-directed rendering.
     pub short_title: Option<String>,
     pub editor: Option<Contributor>,
@@ -422,7 +422,7 @@ pub enum RefDate {
 pub struct LegalCase {
     pub id: Option<RefID>,
     /// Case name (e.g., "Brown v. Board of Education")
-    pub title: Title,
+    pub title: Option<Title>,
     /// Court or authority (e.g., "U.S. Supreme Court")
     pub authority: String,
     /// Reporter volume
@@ -453,7 +453,7 @@ pub struct LegalCase {
 pub struct Statute {
     pub id: Option<RefID>,
     /// Statute name (e.g., "Civil Rights Act of 1964")
-    pub title: Title,
+    pub title: Option<Title>,
     /// Legislative body (e.g., "U.S. Congress")
     pub authority: Option<String>,
     /// Code volume
@@ -482,7 +482,7 @@ pub struct Statute {
 pub struct Treaty {
     pub id: Option<RefID>,
     /// Treaty name (e.g., "Treaty of Versailles")
-    pub title: Title,
+    pub title: Option<Title>,
     /// Parties to the treaty
     pub author: Option<Contributor>,
     /// Treaty series volume
@@ -511,7 +511,7 @@ pub struct Treaty {
 pub struct Hearing {
     pub id: Option<RefID>,
     /// Hearing title
-    pub title: Title,
+    pub title: Option<Title>,
     /// Legislative body conducting the hearing (e.g., "U.S. Senate Committee on Finance")
     pub authority: Option<String>,
     /// Session or congress number
@@ -536,7 +536,7 @@ pub struct Hearing {
 pub struct Regulation {
     pub id: Option<RefID>,
     /// Regulation title
-    pub title: Title,
+    pub title: Option<Title>,
     /// Regulatory authority (e.g., "EPA", "Federal Register")
     pub authority: Option<String>,
     /// Code volume
@@ -565,7 +565,7 @@ pub struct Regulation {
 pub struct Brief {
     pub id: Option<RefID>,
     /// Brief title or case name
-    pub title: Title,
+    pub title: Option<Title>,
     /// Court (e.g., "U.S. Supreme Court")
     pub authority: Option<String>,
     /// Author/filer of the brief
@@ -592,7 +592,7 @@ pub struct Brief {
 pub struct Classic {
     pub id: Option<RefID>,
     /// Work title (e.g., "Nicomachean Ethics")
-    pub title: Title,
+    pub title: Option<Title>,
     /// Author (e.g., "Aristotle")
     pub author: Option<Contributor>,
     /// Editor or translator
@@ -623,7 +623,7 @@ pub struct Classic {
 pub struct Patent {
     pub id: Option<RefID>,
     /// Patent title
-    pub title: Title,
+    pub title: Option<Title>,
     /// Inventor(s)
     pub author: Option<Contributor>,
     /// Assignee (patent holder)
@@ -658,7 +658,7 @@ pub struct Patent {
 pub struct Dataset {
     pub id: Option<RefID>,
     /// Dataset title
-    pub title: Title,
+    pub title: Option<Title>,
     /// Dataset author(s)/creator(s)
     pub author: Option<Contributor>,
     /// Publication/release date
@@ -693,7 +693,7 @@ pub struct Dataset {
 pub struct Standard {
     pub id: Option<RefID>,
     /// Standard title
-    pub title: Title,
+    pub title: Option<Title>,
     /// Standards organization (e.g., "ISO", "ANSI", "IEEE")
     pub authority: Option<String>,
     /// Standard number (e.g., "ISO 8601", "IEEE 754-2008")
@@ -722,7 +722,7 @@ pub struct Standard {
 pub struct Software {
     pub id: Option<RefID>,
     /// Software title
-    pub title: Title,
+    pub title: Option<Title>,
     /// Author(s)/developer(s)
     pub author: Option<Contributor>,
     /// Release date

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -52,6 +52,9 @@ use std::collections::HashMap;
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Rendering {
+    /// Text-case transform to apply to the rendered value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_case: Option<crate::options::titles::TextCase>,
     /// Render in italics/emphasis.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub emph: Option<bool>,
@@ -99,6 +102,7 @@ impl Rendering {
         crate::merge_options!(
             self,
             other,
+            text_case,
             emph,
             quote,
             strong,

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -240,7 +240,6 @@
           "required": [
             "class",
             "issued",
-            "title",
             "type"
           ],
           "properties": {
@@ -443,7 +442,14 @@
               ]
             },
             "title": {
-              "$ref": "#/definitions/Title"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "translator": {
               "anyOf": [
@@ -903,8 +909,7 @@
           "required": [
             "authority",
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -990,9 +995,12 @@
             },
             "title": {
               "description": "Case name (e.g., \"Brown v. Board of Education\")",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1017,8 +1025,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -1101,9 +1108,12 @@
             },
             "title": {
               "description": "Statute name (e.g., \"Civil Rights Act of 1964\")",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1128,8 +1138,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -1216,9 +1225,12 @@
             },
             "title": {
               "description": "Treaty name (e.g., \"Treaty of Versailles\")",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1243,8 +1255,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -1320,9 +1331,12 @@
             },
             "title": {
               "description": "Hearing title",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1340,8 +1354,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -1424,9 +1437,12 @@
             },
             "title": {
               "description": "Regulation title",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1451,8 +1467,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -1539,9 +1554,12 @@
             },
             "title": {
               "description": "Brief title or case name",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1559,8 +1577,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -1661,9 +1678,12 @@
             },
             "title": {
               "description": "Work title (e.g., \"Nicomachean Ethics\")",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1699,8 +1719,7 @@
           "required": [
             "class",
             "issued",
-            "patent-number",
-            "title"
+            "patent-number"
           ],
           "properties": {
             "accessed": {
@@ -1820,9 +1839,12 @@
             },
             "title": {
               "description": "Patent title",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1840,8 +1862,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -1952,9 +1973,12 @@
             },
             "title": {
               "description": "Dataset title",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -1980,8 +2004,7 @@
           "required": [
             "class",
             "issued",
-            "standard-number",
-            "title"
+            "standard-number"
           ],
           "properties": {
             "accessed": {
@@ -2072,9 +2095,12 @@
             },
             "title": {
               "description": "Standard title",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -2092,8 +2118,7 @@
           "type": "object",
           "required": [
             "class",
-            "issued",
-            "title"
+            "issued"
           ],
           "properties": {
             "accessed": {
@@ -2204,9 +2229,12 @@
             },
             "title": {
               "description": "Software title",
-              "allOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/Title"
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
@@ -2396,7 +2424,6 @@
       "description": "A serial publication (journal, magazine, etc.).",
       "type": "object",
       "required": [
-        "title",
         "type"
       ],
       "properties": {
@@ -2434,7 +2461,14 @@
           ]
         },
         "title": {
-          "$ref": "#/definitions/Title"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Title"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "type": {
           "$ref": "#/definitions/SerialType"

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -2950,6 +2950,17 @@
             "null"
           ]
         },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "wrap": {
           "description": "Punctuation to wrap the value in (e.g., parentheses).",
           "anyOf": [
@@ -3950,6 +3961,17 @@
             "null"
           ]
         },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "wrap": {
           "description": "Punctuation to wrap the value in (e.g., parentheses).",
           "anyOf": [
@@ -4094,6 +4116,17 @@
             "null"
           ]
         },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "wrap": {
           "description": "Punctuation to wrap the value in (e.g., parentheses).",
           "anyOf": [
@@ -4224,6 +4257,17 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "wrap": {
@@ -4374,6 +4418,17 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "wrap": {
@@ -4558,6 +4613,17 @@
             }
           ]
         },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "wrap": {
           "description": "Punctuation to wrap the value in (e.g., parentheses).",
           "anyOf": [
@@ -4700,6 +4766,17 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "title": {
@@ -4846,6 +4923,17 @@
             "null"
           ]
         },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "variable": {
           "$ref": "#/definitions/SimpleVariable"
         },
@@ -4899,6 +4987,67 @@
           "type": "string",
           "enum": [
             "symbol"
+          ]
+        }
+      ]
+    },
+    "TextCase": {
+      "description": "Text-case transform applied to title-like fields.\n\nStyles select which transform applies to which field category. The engine provides the generic primitives; styles own the selection.",
+      "oneOf": [
+        {
+          "description": "English headline-style title case (capitalize principal words).",
+          "type": "string",
+          "enum": [
+            "title"
+          ]
+        },
+        {
+          "description": "Generic sentence case (capitalize first word only).",
+          "type": "string",
+          "enum": [
+            "sentence"
+          ]
+        },
+        {
+          "description": "APA-style sentence case: capitalize first word of main title and first word after each subtitle boundary.",
+          "type": "string",
+          "enum": [
+            "sentence-apa"
+          ]
+        },
+        {
+          "description": "NLM-style sentence case: capitalize first word of main title only; subtitles preserve only explicit/protected capitals.",
+          "type": "string",
+          "enum": [
+            "sentence-nlm"
+          ]
+        },
+        {
+          "description": "Capitalize the first letter of the value.",
+          "type": "string",
+          "enum": [
+            "capitalize-first"
+          ]
+        },
+        {
+          "description": "Transform the entire value to lowercase.",
+          "type": "string",
+          "enum": [
+            "lowercase"
+          ]
+        },
+        {
+          "description": "Transform the entire value to uppercase.",
+          "type": "string",
+          "enum": [
+            "uppercase"
+          ]
+        },
+        {
+          "description": "No transformation; render the value exactly as stored.",
+          "type": "string",
+          "enum": [
+            "as-is"
           ]
         }
       ]
@@ -5024,6 +5173,17 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to this title category.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextCase"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },

--- a/docs/specs/TITLE_TEXT_CASE.md
+++ b/docs/specs/TITLE_TEXT_CASE.md
@@ -354,3 +354,21 @@ direction. The remaining disagreements or unresolved choices are:
 
 - v1.0 (2026-03-11): Initial draft synthesized from `perplexity.md` and
   `gem.md`.
+- v1.1 (2026-03-12): Implementation notes added.
+
+## Deferred Behavior
+
+The following are acknowledged in the spec but deferred from the initial
+implementation:
+
+- **Non-English sentence case**: Currently, non-English titles fall back to
+  `as-is` (no transform). Full language-specific casing rules (e.g., German
+  noun capitalization, French article casing) require per-language rulesets
+  and are tracked separately.
+- **`titlecase` crate evaluation**: The Rust `titlecase` crate was evaluated
+  but not adopted. Its CMOS-style rules don't match APA/Chicago variants
+  needed here. The built-in `to_title_case` uses a simple stop-word list
+  sufficient for the current scope.
+- **Semantic span roles**: `.nocase` is the only protected span class
+  recognized. Richer semantic spans (e.g., `.taxonomic`, `.chemical`) are
+  a future extension.


### PR DESCRIPTION
## Summary

Implements bean csl26-zc4m: style-owned, non-destructive, rich-text-aware title casing.

### Schema
- `TextCase` enum with 8 variants (title, sentence, sentence-apa, sentence-nlm, capitalize-first, lowercase, uppercase, as-is)
- `text_case` field on `TitleRendering` and `Rendering` structs
- APA preset → `sentence-apa`, Scientific preset → `sentence-nlm`
- **Breaking**: `title` field on all reference types is now `Option<Title>`

### Engine
- `.nocase` Djot span protection (frame-level propagation)
- Stateful sentence-case transform across Djot text events
- Structured title rendering with per-part case transforms
- Language-aware fallback (non-English → as-is)
- Template-level override of global title rendering config

### Tests
15 new tests covering all variants, nocase protection, structured titles, language fallback, and template overrides.

### Spec
Updated `docs/specs/TITLE_TEXT_CASE.md` with deferred behavior notes (non-English rules, titlecase crate evaluation, semantic spans).

Refs: csl26-zc4m