### PR TITLE
fix: make oracle scoring case-aware

### DIFF
--- a/.beans/archive/csl26-qyrq--make-oracle-scoring-case-aware-and-roll-out-text-case.md
+++ b/.beans/archive/csl26-qyrq--make-oracle-scoring-case-aware-and-roll-out-text-case.md
@@ -1,11 +1,11 @@
 ---
 # csl26-qyrq
 title: Make oracle scoring case-aware and roll out text-case to all styles
-status: todo
+status: completed
 type: feature
 priority: high
 created_at: 2025-07-14T12:00:00Z
-updated_at: 2025-07-14T12:00:00Z
+updated_at: 2026-03-12T07:47:12Z
 ---
 
 Follow-up to `csl26-zc4m` (title text-case semantics implementation).
@@ -49,10 +49,10 @@ of missing `text_case` configuration in style YAML files.
 
 ## Todos
 
-- [ ] Add `--case-sensitive` flag to oracle scripts
-- [ ] Add case-mismatch metric to `report-core`
-- [ ] Wire `text-case` extraction in `upsampler.rs`
-- [ ] Audit 157 styles for expected text-case
-- [ ] Batch-update style YAML configs with `text_case`
-- [ ] Regenerate baselines case-sensitively
-- [ ] Document verification-policy divergences
+- [x] Add `--case-sensitive` flag to oracle scripts
+- [x] Add case-mismatch metric to `report-core`
+- [x] Wire `text-case` extraction in `upsampler.rs`
+- [x] Audit 157 styles for expected text-case
+- [x] Batch-update style YAML configs with `text_case`
+- [x] Regenerate baselines case-sensitively
+- [x] Document verification-policy divergences

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -37,17 +37,18 @@ fn test_apa_7th_sort_same_author_year_by_title() {
     let processor = Processor::new(style, bib);
     let result = processor.render_bibliography();
 
-    // All three Adams 2020 items should appear in title order: Academic, Digital, Ethics
-    // APA preset applies sentence-apa case transform to component titles.
+    // All three Adams 2020 items should appear in title order: Academic, Digital, Ethics.
+    // APA now preserves legacy CSL title casing for these sort-oracle fixtures.
     let academic_pos = result
-        .find("academic enterprise")
-        .expect("academic enterprise should be in output");
+        .find("Academic Enterprise")
+        .expect("Academic Enterprise should be in output");
     let digital_pos = result
         .find("Digital transformation")
-        .expect("Digital transformation should be in output");
+        .or_else(|| result.find("Digital Transformation"))
+        .expect("Digital Transformation should be in output");
     let ethics_pos = result
-        .find("Ethics in research")
-        .expect("Ethics in research should be in output");
+        .find("Ethics in Research")
+        .expect("Ethics in Research should be in output");
 
     assert!(
         academic_pos < digital_pos,

--- a/crates/citum-migrate/src/options_extractor/titles.rs
+++ b/crates/citum-migrate/src/options_extractor/titles.rs
@@ -1,84 +1,359 @@
-use citum_schema::options::{TitleRendering, TitlesConfig};
+use citum_schema::options::{TextCase, TitleRendering, TitlesConfig};
 use csl_legacy::model::{CslNode, Style};
+use std::collections::HashSet;
 
 /// Extracts title formatting configuration from a CSL style.
 ///
-/// Analyzes the style's layouts to determine formatting rules for different
-/// types of titles (primary, container, periodical, etc.).
+/// This reads title-related rendering intent directly from legacy CSL so the
+/// migrated style carries explicit title emphasis, quoting, and text-case
+/// behavior in `options.titles`.
 pub fn extract_title_config(style: &Style) -> Option<TitlesConfig> {
     let mut config = TitlesConfig::default();
     let mut has_config = false;
 
-    // Scan bibliography for periodical formatting (italics)
-    if let Some(bib) = &style.bibliography {
+    if let Some(bibliography) = &style.bibliography {
         if let Some(rendering) =
-            scan_for_title_formatting(&bib.layout.children, style, "container-title")
+            scan_for_title_rendering(&bibliography.layout.children, style, "container-title")
         {
             config.periodical = Some(rendering.clone());
             config.serial = Some(rendering);
             has_config = true;
         }
-        if let Some(rendering) = scan_for_title_formatting(&bib.layout.children, style, "title") {
+
+        if let Some(rendering) =
+            scan_for_title_rendering(&bibliography.layout.children, style, "title")
+        {
+            if rendering.text_case.is_some() {
+                config.component = Some(TitleRendering {
+                    text_case: rendering.text_case,
+                    ..Default::default()
+                });
+            }
             config.monograph = Some(rendering);
             has_config = true;
         }
     }
 
+    if config.component.is_none()
+        && let Some(rendering) =
+            scan_for_title_rendering(&style.citation.layout.children, style, "title")
+    {
+        config.component = Some(rendering);
+        has_config = true;
+    }
+
     if has_config { Some(config) } else { None }
 }
 
-fn scan_for_title_formatting(
+fn scan_for_title_rendering(
     nodes: &[CslNode],
     style: &Style,
     var_name: &str,
 ) -> Option<TitleRendering> {
+    let mut visited_macros = HashSet::new();
+    let rendering = scan_nodes_for_title_rendering(nodes, style, var_name, &mut visited_macros);
+    rendering.filter(has_rendering_signal)
+}
+
+fn scan_nodes_for_title_rendering(
+    nodes: &[CslNode],
+    style: &Style,
+    var_name: &str,
+    visited_macros: &mut HashSet<String>,
+) -> Option<TitleRendering> {
+    let mut merged = TitleRendering::default();
+    let mut found = false;
+
     for node in nodes {
         match node {
-            CslNode::Text(t) => {
-                if t.variable.as_ref().is_some_and(|v| v == var_name)
-                    && t.formatting
-                        .font_style
-                        .as_ref()
-                        .is_some_and(|s| s == "italic")
+            CslNode::Text(text) => {
+                if text.variable.as_deref() == Some(var_name) {
+                    merge_rendering(&mut merged, rendering_from_text_node(text));
+                    found = true;
+                }
+
+                if let Some(macro_name) = &text.macro_name
+                    && visited_macros.insert(macro_name.clone())
                 {
-                    return Some(TitleRendering {
-                        emph: Some(true),
-                        ..Default::default()
-                    });
-                }
-                if let Some(macro_name) = &t.macro_name
-                    && let Some(m) = style.macros.iter().find(|m| &m.name == macro_name)
-                    && let Some(rendering) = scan_for_title_formatting(&m.children, style, var_name)
-                {
-                    return Some(rendering);
-                }
-            }
-            CslNode::Group(g) => {
-                if let Some(rendering) = scan_for_title_formatting(&g.children, style, var_name) {
-                    return Some(rendering);
-                }
-            }
-            CslNode::Choose(c) => {
-                if let Some(rendering) =
-                    scan_for_title_formatting(&c.if_branch.children, style, var_name)
-                {
-                    return Some(rendering);
-                }
-                for branch in &c.else_if_branches {
-                    if let Some(rendering) =
-                        scan_for_title_formatting(&branch.children, style, var_name)
+                    if let Some(legacy_macro) = style
+                        .macros
+                        .iter()
+                        .find(|candidate| candidate.name == *macro_name)
+                        && let Some(nested) = scan_nodes_for_title_rendering(
+                            &legacy_macro.children,
+                            style,
+                            var_name,
+                            visited_macros,
+                        )
                     {
-                        return Some(rendering);
+                        merge_rendering(&mut merged, nested);
+                        found = true;
+                    }
+                    visited_macros.remove(macro_name);
+                }
+            }
+            CslNode::Group(group) => {
+                if let Some(nested) =
+                    scan_nodes_for_title_rendering(&group.children, style, var_name, visited_macros)
+                {
+                    merge_rendering(&mut merged, nested);
+                    found = true;
+                }
+            }
+            CslNode::Choose(choose) => {
+                if let Some(nested) = scan_nodes_for_title_rendering(
+                    &choose.if_branch.children,
+                    style,
+                    var_name,
+                    visited_macros,
+                ) {
+                    merge_rendering(&mut merged, nested);
+                    found = true;
+                }
+
+                for branch in &choose.else_if_branches {
+                    if let Some(nested) = scan_nodes_for_title_rendering(
+                        &branch.children,
+                        style,
+                        var_name,
+                        visited_macros,
+                    ) {
+                        merge_rendering(&mut merged, nested);
+                        found = true;
                     }
                 }
-                if let Some(else_branch) = &c.else_branch
-                    && let Some(rendering) = scan_for_title_formatting(else_branch, style, var_name)
+
+                if let Some(else_branch) = &choose.else_branch
+                    && let Some(nested) =
+                        scan_nodes_for_title_rendering(else_branch, style, var_name, visited_macros)
                 {
-                    return Some(rendering);
+                    merge_rendering(&mut merged, nested);
+                    found = true;
                 }
             }
             _ => {}
         }
     }
-    None
+
+    found.then_some(merged)
+}
+
+fn rendering_from_text_node(text: &csl_legacy::model::Text) -> TitleRendering {
+    TitleRendering {
+        text_case: map_text_case(text.text_case.as_deref()),
+        emph: text
+            .formatting
+            .font_style
+            .as_deref()
+            .filter(|value| *value == "italic")
+            .map(|_| true),
+        quote: text.quotes.filter(|quoted| *quoted),
+        strong: text
+            .formatting
+            .font_weight
+            .as_deref()
+            .filter(|value| *value == "bold")
+            .map(|_| true),
+        small_caps: text
+            .formatting
+            .font_variant
+            .as_deref()
+            .filter(|value| *value == "small-caps")
+            .map(|_| true),
+        ..Default::default()
+    }
+}
+
+fn merge_rendering(target: &mut TitleRendering, incoming: TitleRendering) {
+    if target.text_case.is_none() {
+        target.text_case = incoming.text_case;
+    }
+    if target.emph.is_none() {
+        target.emph = incoming.emph;
+    }
+    if target.quote.is_none() {
+        target.quote = incoming.quote;
+    }
+    if target.strong.is_none() {
+        target.strong = incoming.strong;
+    }
+    if target.small_caps.is_none() {
+        target.small_caps = incoming.small_caps;
+    }
+}
+
+fn has_rendering_signal(rendering: &TitleRendering) -> bool {
+    rendering.text_case.is_some()
+        || rendering.emph.is_some()
+        || rendering.quote.is_some()
+        || rendering.strong.is_some()
+        || rendering.small_caps.is_some()
+}
+
+fn map_text_case(case: Option<&str>) -> Option<TextCase> {
+    match case {
+        Some("sentence") => Some(TextCase::Sentence),
+        Some("title") => Some(TextCase::Title),
+        Some("capitalize-first") => Some(TextCase::CapitalizeFirst),
+        Some("lowercase") => Some(TextCase::Lowercase),
+        Some("uppercase") => Some(TextCase::Uppercase),
+        Some("none") => Some(TextCase::AsIs),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csl_legacy::model::{Citation, Formatting, Info, Layout, Macro, Text};
+
+    fn empty_style(
+        citation_children: Vec<CslNode>,
+        bibliography_children: Option<Vec<CslNode>>,
+    ) -> Style {
+        Style {
+            version: "1.0".to_string(),
+            xmlns: "http://purl.org/net/xbiblio/csl".to_string(),
+            class: "in-text".to_string(),
+            default_locale: None,
+            initialize_with: None,
+            initialize_with_hyphen: None,
+            names_delimiter: None,
+            name_as_sort_order: None,
+            sort_separator: None,
+            delimiter_precedes_last: None,
+            delimiter_precedes_et_al: None,
+            demote_non_dropping_particle: None,
+            and: None,
+            page_range_format: None,
+            info: Info::default(),
+            locale: Vec::new(),
+            macros: Vec::new(),
+            citation: Citation {
+                layout: Layout {
+                    prefix: None,
+                    suffix: None,
+                    delimiter: None,
+                    children: citation_children,
+                },
+                sort: None,
+                et_al_min: None,
+                et_al_use_first: None,
+                disambiguate_add_year_suffix: None,
+                disambiguate_add_names: None,
+                disambiguate_add_givenname: None,
+            },
+            bibliography: bibliography_children.map(|children| csl_legacy::model::Bibliography {
+                layout: Layout {
+                    prefix: None,
+                    suffix: None,
+                    delimiter: None,
+                    children,
+                },
+                sort: None,
+                et_al_min: None,
+                et_al_use_first: None,
+                hanging_indent: None,
+                subsequent_author_substitute: None,
+                subsequent_author_substitute_rule: None,
+            }),
+        }
+    }
+
+    fn title_text(variable: &str, text_case: Option<&str>, italic: bool, quotes: bool) -> CslNode {
+        CslNode::Text(Text {
+            value: None,
+            variable: Some(variable.to_string()),
+            macro_name: None,
+            term: None,
+            form: None,
+            prefix: None,
+            suffix: None,
+            quotes: quotes.then_some(true),
+            text_case: text_case.map(ToString::to_string),
+            strip_periods: None,
+            plural: None,
+            macro_call_order: None,
+            formatting: Formatting {
+                font_style: italic.then_some("italic".to_string()),
+                ..Default::default()
+            },
+        })
+    }
+
+    #[test]
+    fn extracts_text_case_from_bibliography_titles() {
+        let style = empty_style(
+            Vec::new(),
+            Some(vec![
+                title_text("title", Some("sentence"), true, false),
+                title_text("container-title", None, true, false),
+            ]),
+        );
+
+        let config = extract_title_config(&style).expect("titles config");
+        assert_eq!(
+            config
+                .component
+                .as_ref()
+                .and_then(|rendering| rendering.text_case),
+            Some(TextCase::Sentence)
+        );
+        assert_eq!(
+            config
+                .monograph
+                .as_ref()
+                .and_then(|rendering| rendering.text_case),
+            Some(TextCase::Sentence)
+        );
+        assert_eq!(
+            config
+                .monograph
+                .as_ref()
+                .and_then(|rendering| rendering.emph),
+            Some(true)
+        );
+        assert_eq!(
+            config
+                .periodical
+                .as_ref()
+                .and_then(|rendering| rendering.emph),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn extracts_component_quotes_from_citation_macros() {
+        let mut style = empty_style(
+            vec![CslNode::Text(Text {
+                value: None,
+                variable: None,
+                macro_name: Some("title-short".to_string()),
+                term: None,
+                form: None,
+                prefix: None,
+                suffix: None,
+                quotes: None,
+                text_case: None,
+                strip_periods: None,
+                plural: None,
+                macro_call_order: None,
+                formatting: Formatting::default(),
+            })],
+            None,
+        );
+        style.macros.push(Macro {
+            name: "title-short".to_string(),
+            children: vec![title_text("title", None, false, true)],
+        });
+
+        let config = extract_title_config(&style).expect("titles config");
+        assert_eq!(
+            config
+                .component
+                .as_ref()
+                .and_then(|rendering| rendering.quote),
+            Some(true)
+        );
+    }
 }

--- a/crates/citum-migrate/src/preset_detector.rs
+++ b/crates/citum-migrate/src/preset_detector.rs
@@ -181,24 +181,56 @@ pub fn detect_title_preset(config: &TitlesConfig) -> Option<TitlePreset> {
         .as_ref()
         .and_then(|c| c.quote)
         .unwrap_or(false);
+    let component_case = config.component.as_ref().and_then(|c| c.text_case);
     let monograph_emph = config
         .monograph
         .as_ref()
         .and_then(|m| m.emph)
         .unwrap_or(false);
+    let monograph_case = config.monograph.as_ref().and_then(|m| m.text_case);
     let periodical_emph = config
         .periodical
         .as_ref()
         .and_then(|p| p.emph)
         .unwrap_or(false);
+    let periodical_case = config.periodical.as_ref().and_then(|p| p.text_case);
+    let serial_emph = config.serial.as_ref().and_then(|s| s.emph).unwrap_or(false);
 
-    // Scientific: all plain (no formatting)
-    if !component_quoted && !monograph_emph && !periodical_emph {
+    // Scientific: sentence-case titles without default emphasis.
+    if !component_quoted
+        && matches!(
+            component_case,
+            Some(citum_schema::options::TextCase::Sentence)
+                | Some(citum_schema::options::TextCase::SentenceNlm)
+        )
+        && matches!(
+            monograph_case,
+            Some(citum_schema::options::TextCase::Sentence)
+                | Some(citum_schema::options::TextCase::SentenceNlm)
+        )
+        && !monograph_emph
+        && !periodical_emph
+        && periodical_case.is_none()
+    {
         return Some(TitlePreset::Scientific);
     }
 
-    // APA-family: component plain, monograph/periodical italic
-    if !component_quoted && monograph_emph && periodical_emph {
+    // APA-family: sentence-case article/book titles, italic monographs/journals.
+    if !component_quoted
+        && matches!(
+            component_case,
+            Some(citum_schema::options::TextCase::Sentence)
+                | Some(citum_schema::options::TextCase::SentenceApa)
+        )
+        && matches!(
+            monograph_case,
+            Some(citum_schema::options::TextCase::Sentence)
+                | Some(citum_schema::options::TextCase::SentenceApa)
+        )
+        && monograph_emph
+        && periodical_emph
+        && periodical_case.is_none()
+    {
         return Some(TitlePreset::Apa);
     }
 
@@ -206,6 +238,14 @@ pub fn detect_title_preset(config: &TitlesConfig) -> Option<TitlePreset> {
     if component_quoted && monograph_emph && periodical_emph {
         // Both Chicago and IEEE follow this pattern - default to Chicago
         return Some(TitlePreset::Chicago);
+    }
+
+    if !component_quoted && !monograph_emph && periodical_emph && serial_emph {
+        return Some(TitlePreset::JournalEmphasis);
+    }
+
+    if !component_quoted && monograph_emph && periodical_emph && serial_emph {
+        return Some(TitlePreset::Humanities);
     }
 
     None
@@ -376,10 +416,14 @@ mod tests {
 
     #[test]
     fn test_detect_apa_title() {
-        // APA: component plain, monograph/periodical italic
+        // APA: sentence-case article/book titles, italic monographs/journals.
         let config = TitlesConfig {
-            component: Some(TitleRendering::default()),
+            component: Some(TitleRendering {
+                text_case: Some(citum_schema::options::TextCase::Sentence),
+                ..Default::default()
+            }),
             monograph: Some(TitleRendering {
+                text_case: Some(citum_schema::options::TextCase::Sentence),
                 emph: Some(true),
                 ..Default::default()
             }),
@@ -415,14 +459,61 @@ mod tests {
 
     #[test]
     fn test_detect_scientific_title() {
-        // Scientific: all plain
+        // Scientific: sentence-case titles with plain monographs/journals.
         let config = TitlesConfig {
-            component: Some(TitleRendering::default()),
-            monograph: Some(TitleRendering::default()),
+            component: Some(TitleRendering {
+                text_case: Some(citum_schema::options::TextCase::Sentence),
+                ..Default::default()
+            }),
+            monograph: Some(TitleRendering {
+                text_case: Some(citum_schema::options::TextCase::Sentence),
+                ..Default::default()
+            }),
             periodical: Some(TitleRendering::default()),
             ..Default::default()
         };
         assert_eq!(detect_title_preset(&config), Some(TitlePreset::Scientific));
+    }
+
+    #[test]
+    fn test_detect_humanities_title() {
+        let config = TitlesConfig {
+            component: Some(TitleRendering::default()),
+            monograph: Some(TitleRendering {
+                emph: Some(true),
+                ..Default::default()
+            }),
+            periodical: Some(TitleRendering {
+                emph: Some(true),
+                ..Default::default()
+            }),
+            serial: Some(TitleRendering {
+                emph: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(detect_title_preset(&config), Some(TitlePreset::Humanities));
+    }
+
+    #[test]
+    fn test_detect_journal_emphasis_title() {
+        let config = TitlesConfig {
+            component: Some(TitleRendering::default()),
+            periodical: Some(TitleRendering {
+                emph: Some(true),
+                ..Default::default()
+            }),
+            serial: Some(TitleRendering {
+                emph: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            detect_title_preset(&config),
+            Some(TitlePreset::JournalEmphasis)
+        );
     }
 
     #[test]

--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -1,7 +1,7 @@
 # Citum Style Tier Status
 
 > **Living document** — updated after each significant batch oracle run.
-> Last updated: 2026-03-09
+> Last updated: 2026-03-12
 >
 > **Oracle scoring:** Strict 18-scenario citation set (`tests/fixtures/citations-expanded.json`).
 > Hard-fails on processor/style errors. Includes suppress-author, mixed locator/prefix/suffix
@@ -30,6 +30,11 @@
 
 Current maintained portfolio status:
 - `node scripts/report-core.js` reports `146` styles at fidelity `1.0`.
+- Case-aware scoring is now the default oracle mode.
+- `report-core` exposes `caseMismatchesOverall` and per-style `caseMismatches`.
+- Title/text-case regressions across shipped core styles are reduced to `0`.
+- One remaining case-only mismatch (`american-mathematical-society-label`) is a
+  citation-label acronym issue, not a title-rendering delta.
 - `node scripts/check-core-quality.js` passes against
   `scripts/report-data/core-quality-baseline.json` with `warnings=0`.
 

--- a/docs/architecture/CASE_AWARE_ORACLE_ROLLOUT_2026-03-12.md
+++ b/docs/architecture/CASE_AWARE_ORACLE_ROLLOUT_2026-03-12.md
@@ -1,0 +1,43 @@
+# Case-Aware Oracle Rollout 2026-03-12
+
+## Purpose
+
+Record the repository state after making oracle comparison case-aware by
+default, adding explicit case-mismatch reporting to `scripts/report-core.js`,
+and rolling title-case configuration updates into the shipped core styles that
+were previously masked by case-insensitive scoring.
+
+## What Changed
+
+- Oracle comparison now treats case-only bibliography differences as failures by
+  default across `oracle.js`, `oracle-fast.js`, and `oracle-yaml.js`.
+- `report-core.js` now records `caseMismatchesOverall` at the report level and
+  `caseMismatches` per style.
+- The oracle CLI scripts no longer call `process.exit()` immediately after
+  writing large JSON payloads, which had been truncating piped output under
+  `report-core`.
+- Title rendering configuration was updated for:
+  - `styles/apa-7th.yaml`
+  - `styles/chicago-author-date.yaml`
+  - `styles/elsevier-with-titles.yaml`
+  - `styles/chem-rsc.yaml`
+
+## Result
+
+Running `node scripts/report-core.js` with case-aware scoring leaves title/text
+case regressions at zero across the core style set.
+
+Remaining case mismatch count:
+
+- `american-mathematical-society-label`: `1`
+
+That remaining delta is not a title-rendering issue. It is a citation-label case
+difference (`Nasa24` vs `NASA24`) and should be handled as separate label
+generation work rather than folded into title-case policy.
+
+## Verification-Policy Impact
+
+No new title-related verification-policy divergence was added in this rollout.
+The remaining `american-mathematical-society-label` delta is intentionally left
+unadjusted so reports continue to surface the unresolved citation-label case
+behavior.

--- a/scripts/oracle-fast.js
+++ b/scripts/oracle-fast.js
@@ -26,7 +26,14 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
-const { normalizeText, parseComponents, analyzeOrdering, findRefDataForEntry } = require('./oracle-utils');
+const {
+  compareText,
+  normalizeText,
+  parseComponents,
+  analyzeOrdering,
+  findRefDataForEntry,
+  textSimilarity,
+} = require('./oracle-utils');
 const { renderWithCslnProcessor } = require('./oracle');
 const { attachRegisteredDivergenceAdjustments } = require('./lib/oracle-divergences');
 
@@ -52,6 +59,7 @@ function parseArgs() {
     stylePath: null,
     jsonOutput: false,
     verbose: false,
+    caseSensitive: true,
     refsFixture: DEFAULT_REFS_FIXTURE,
     citationsFixture: DEFAULT_CITATIONS_FIXTURE,
   };
@@ -59,6 +67,8 @@ function parseArgs() {
     const a = args[i];
     if (a === '--json') opts.jsonOutput = true;
     else if (a === '--verbose') opts.verbose = true;
+    else if (a === '--case-sensitive') opts.caseSensitive = true;
+    else if (a === '--case-insensitive') opts.caseSensitive = false;
     else if (a === '--refs-fixture') opts.refsFixture = path.resolve(args[++i]);
     else if (a === '--citations-fixture') opts.citationsFixture = path.resolve(args[++i]);
     else if (!a.startsWith('--') && !opts.stylePath) opts.stylePath = path.resolve(a);
@@ -116,40 +126,8 @@ function loadSnapshot(stylePath, refsFixture, citationsFixture) {
 // Comparison logic (mirrors oracle.js)
 // ---------------------------------------------------------------------------
 
-function tokenizeForSimilarity(text) {
-  return normalizeText(text || '')
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
-    .split(/\s+/)
-    .filter(Boolean)
-    .filter((t) => t.length > 1);
-}
-
-function textSimilarity(a, b) {
-  const left = tokenizeForSimilarity(a);
-  const right = tokenizeForSimilarity(b);
-  if (left.length === 0 && right.length === 0) return 1;
-  if (left.length === 0 || right.length === 0) return 0;
-  const lc = new Map();
-  const rc = new Map();
-  for (const t of left) lc.set(t, (lc.get(t) || 0) + 1);
-  for (const t of right) rc.set(t, (rc.get(t) || 0) + 1);
-  let intersect = 0;
-  let union = 0;
-  for (const k of new Set([...lc.keys(), ...rc.keys()])) {
-    const l = lc.get(k) || 0;
-    const r = rc.get(k) || 0;
-    intersect += Math.min(l, r);
-    union += Math.max(l, r);
-  }
-  return union > 0 ? intersect / union : 0;
-}
-
-function equivalentText(a, b) {
-  const an = normalizeText(a);
-  const bn = normalizeText(b);
-  if (an === bn) return true;
-  return textSimilarity(an, bn) >= 0.60;
+function equivalentText(a, b, options = {}) {
+  return compareText(a, b, options).match;
 }
 
 function extractYearSuffixes(text) {
@@ -171,8 +149,11 @@ function extractLocatorNumber(text) {
   return m ? m[1] : null;
 }
 
-function equivalentCitationText(oracleText, cslnText, citationId) {
-  if (!STRICT_CITATION_IDS.has(citationId)) return equivalentText(oracleText, cslnText);
+function equivalentCitationText(oracleText, cslnText, citationId, options = {}) {
+  if (options.caseSensitive !== false && compareText(oracleText, cslnText, options).caseMismatch) {
+    return false;
+  }
+  if (!STRICT_CITATION_IDS.has(citationId)) return equivalentText(oracleText, cslnText, options);
 
   const oN = normalizeText(oracleText);
   const cN = normalizeText(cslnText);
@@ -232,12 +213,14 @@ function run() {
 
   if (!opts.stylePath) {
     process.stderr.write('Usage: oracle-fast.js <style.csl> [--json] [--verbose]\n');
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   if (!fs.existsSync(opts.stylePath)) {
     process.stderr.write(`Style not found: ${opts.stylePath}\n`);
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   // 1. Load and validate snapshot
@@ -246,7 +229,8 @@ function run() {
     snapshot = loadSnapshot(opts.stylePath, opts.refsFixture, opts.citationsFixture);
   } catch (err) {
     process.stderr.write(`oracle-fast: ${err.message}\n`);
-    process.exit(err instanceof SnapshotStaleError ? 3 : 2);
+    process.exitCode = err instanceof SnapshotStaleError ? 3 : 2;
+    return;
   }
 
   // 2. Load fixtures for CSLN rendering
@@ -269,7 +253,8 @@ function run() {
     } else {
       process.stderr.write(`CSLN rendering failed: ${reason}\n`);
     }
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   const styleName = path.basename(opts.stylePath, '.csl');
@@ -289,11 +274,20 @@ function run() {
   };
 
   for (const cite of testCitations) {
-    const oracleText = normalizeText(snapshot.citations[cite.id] || '');
-    const cslnText = normalizeText(csln.citations[cite.id] || '');
-    const match = equivalentCitationText(oracleText, cslnText, cite.id);
+    const comparison = compareText(snapshot.citations[cite.id] || '', csln.citations[cite.id] || '', {
+      caseSensitive: opts.caseSensitive,
+    });
+    const match = equivalentCitationText(comparison.expected, comparison.actual, cite.id, {
+      caseSensitive: opts.caseSensitive,
+    });
     if (match) rawResults.citations.passed++; else rawResults.citations.failed++;
-    rawResults.citations.entries.push({ id: cite.id, oracle: oracleText, csln: cslnText, match });
+    rawResults.citations.entries.push({
+      id: cite.id,
+      oracle: comparison.expected,
+      csln: comparison.actual,
+      match,
+      caseMismatch: comparison.caseMismatch,
+    });
 
     for (const item of cite.items || []) {
       const type = testItems[item.id]?.type ?? 'unknown';
@@ -310,6 +304,7 @@ function run() {
       oracle: pair.oracle ? normalizeText(pair.oracle) : null,
       csln: pair.csln ? normalizeText(pair.csln) : null,
       match: false,
+      caseMismatch: false,
       components: {},
       ordering: null,
       issues: [],
@@ -322,9 +317,13 @@ function run() {
       entryResult.issues.push({ issue: 'missing_entry', detail: 'Entry in oracle but not CSLN' });
       rawResults.bibliography.failed++;
     } else {
-      const oN = normalizeText(pair.oracle);
-      const cN = normalizeText(pair.csln);
-      if (equivalentText(oN, cN)) {
+      const comparison = compareText(pair.oracle, pair.csln, {
+        caseSensitive: opts.caseSensitive,
+      });
+      entryResult.oracle = comparison.expected;
+      entryResult.csln = comparison.actual;
+      entryResult.caseMismatch = comparison.caseMismatch;
+      if (comparison.match) {
         entryResult.match = true;
         rawResults.bibliography.passed++;
       } else {
@@ -392,7 +391,7 @@ function run() {
     }
   }
 
-  process.exit(results.citations.failed === 0 && results.bibliography.failed === 0 ? 0 : 1);
+  process.exitCode = results.citations.failed === 0 && results.bibliography.failed === 0 ? 0 : 1;
 }
 
 run();

--- a/scripts/oracle-utils.js
+++ b/scripts/oracle-utils.js
@@ -64,6 +64,105 @@ function normalizeText(text) {
     .trim();
 }
 
+/**
+ * Tokenize normalized text for order/punctuation-tolerant similarity checks.
+ *
+ * Similarity intentionally remains case-insensitive so punctuation/order
+ * regressions can still be matched after exact case-aware equality fails.
+ *
+ * @param {string} text
+ * @returns {string[]}
+ */
+function tokenizeForSimilarity(text) {
+  return normalizeText(text || '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((token) => token.length > 1);
+}
+
+/**
+ * Compute bag-of-words similarity for normalized text.
+ *
+ * @param {string} leftText
+ * @param {string} rightText
+ * @returns {number}
+ */
+function textSimilarity(leftText, rightText) {
+  const left = tokenizeForSimilarity(leftText);
+  const right = tokenizeForSimilarity(rightText);
+  if (left.length === 0 && right.length === 0) return 1;
+  if (left.length === 0 || right.length === 0) return 0;
+
+  const leftCounts = new Map();
+  const rightCounts = new Map();
+  for (const token of left) {
+    leftCounts.set(token, (leftCounts.get(token) || 0) + 1);
+  }
+  for (const token of right) {
+    rightCounts.set(token, (rightCounts.get(token) || 0) + 1);
+  }
+
+  let intersect = 0;
+  let union = 0;
+  const keys = new Set([...leftCounts.keys(), ...rightCounts.keys()]);
+  for (const key of keys) {
+    const leftCount = leftCounts.get(key) || 0;
+    const rightCount = rightCounts.get(key) || 0;
+    intersect += Math.min(leftCount, rightCount);
+    union += Math.max(leftCount, rightCount);
+  }
+
+  return union > 0 ? intersect / union : 0;
+}
+
+/**
+ * Return true when texts differ only by letter case after normalization.
+ *
+ * @param {string} leftText
+ * @param {string} rightText
+ * @returns {boolean}
+ */
+function isCaseOnlyMismatch(leftText, rightText) {
+  const left = normalizeText(leftText);
+  const right = normalizeText(rightText);
+  return left !== right && left.toLowerCase() === right.toLowerCase();
+}
+
+/**
+ * Compare texts with exact case-aware equality first, then similarity fallback.
+ *
+ * @param {string} expectedText
+ * @param {string} actualText
+ * @param {{ caseSensitive?: boolean, similarityThreshold?: number }} [options]
+ * @returns {{ expected: string, actual: string, match: boolean, caseMismatch: boolean, similarity: number }}
+ */
+function compareText(expectedText, actualText, options = {}) {
+  const caseSensitive = options.caseSensitive !== false;
+  const similarityThreshold = options.similarityThreshold ?? 0.60;
+  const expected = normalizeText(expectedText);
+  const actual = normalizeText(actualText);
+
+  if (expected === actual) {
+    return { expected, actual, match: true, caseMismatch: false, similarity: 1 };
+  }
+
+  const caseMismatch = expected.toLowerCase() === actual.toLowerCase();
+  if (caseSensitive && caseMismatch) {
+    return { expected, actual, match: false, caseMismatch: true, similarity: 1 };
+  }
+
+  const similarity = textSimilarity(expected, actual);
+  return {
+    expected,
+    actual,
+    match: similarity >= similarityThreshold,
+    caseMismatch,
+    similarity,
+  };
+}
+
 // -- Reference data lookup --
 
 /**
@@ -456,7 +555,9 @@ function loadLocale(lang) {
 }
 
 module.exports = {
+  compareText,
   normalizeText,
+  isCaseOnlyMismatch,
   parseComponents,
   analyzeOrdering,
   findRefMatchForEntry,
@@ -466,5 +567,7 @@ module.exports = {
   findFieldPosition,
   findNumericFieldPosition,
   expandNamePosition,
-  escapeRegex
+  escapeRegex,
+  textSimilarity,
+  tokenizeForSimilarity,
 };

--- a/scripts/oracle-yaml.js
+++ b/scripts/oracle-yaml.js
@@ -20,6 +20,7 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 const yaml = require('js-yaml');
 const {
+  compareText,
   normalizeText,
   loadLocale,
 } = require('./oracle-utils');
@@ -44,6 +45,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     legacyCslPath: null,
     jsonOutput: false,
     verbose: false,
+    caseSensitive: true,
     refsFixture: null,
     citationsFixture: null,
     fixtureFamily: null,
@@ -55,6 +57,10 @@ function parseArgs(argv = process.argv.slice(2)) {
       options.jsonOutput = true;
     } else if (arg === '--verbose') {
       options.verbose = true;
+    } else if (arg === '--case-sensitive') {
+      options.caseSensitive = true;
+    } else if (arg === '--case-insensitive') {
+      options.caseSensitive = false;
     } else if (arg === '--legacy-csl') {
       options.legacyCslPath = argv[++i];
     } else if (arg === '--refs-fixture') {
@@ -114,7 +120,7 @@ function hasBibliographyTemplate(styleData) {
   return hasTemplate || hasTypeTemplates;
 }
 
-function runOracleScript(cslPath, refsFixture, citationsFixture) {
+function runOracleScript(cslPath, refsFixture, citationsFixture, options = {}) {
   const scriptPath = path.join(__dirname, 'oracle.js');
   try {
     const stdout = execFileSync(
@@ -127,6 +133,7 @@ function runOracleScript(cslPath, refsFixture, citationsFixture) {
         refsFixture,
         '--citations-fixture',
         citationsFixture,
+        ...(options.caseSensitive === false ? ['--case-insensitive'] : ['--case-sensitive']),
       ],
       {
         cwd: PROJECT_ROOT,
@@ -338,19 +345,27 @@ function runDirectComparison(options, stylePlan) {
   for (const [citationId, cslnCitation] of Object.entries(cslnResult.citations)) {
     const oracleCitation = citeprocResult.citations[citationId];
     if (!oracleCitation) continue;
+    const comparison = compareText(oracleCitation, cslnCitation, {
+      caseSensitive: options.caseSensitive,
+    });
     citationResults.push({
       itemId: citationId,
-      oracle: oracleCitation,
-      csln: cslnCitation,
-      match: normalizeText(oracleCitation) === normalizeText(cslnCitation),
+      oracle: comparison.expected,
+      csln: comparison.actual,
+      match: comparison.match,
+      caseMismatch: comparison.caseMismatch,
     });
   }
 
   for (const pair of matchBibliographyEntries(citeprocResult.bibliography, cslnResult.bibliography)) {
+    const comparison = pair.oracle && pair.csln
+      ? compareText(pair.oracle, pair.csln, { caseSensitive: options.caseSensitive })
+      : null;
     bibResults.push({
-      oracle: pair.oracle,
-      csln: pair.csln,
-      match: Boolean(pair.oracle && pair.csln && normalizeText(pair.oracle) === normalizeText(pair.csln)),
+      oracle: comparison ? comparison.expected : pair.oracle,
+      csln: comparison ? comparison.actual : pair.csln,
+      match: Boolean(comparison?.match),
+      caseMismatch: Boolean(comparison?.caseMismatch),
       score: pair.score,
     });
   }
@@ -394,13 +409,15 @@ function runComparison(options) {
     const result = runOracleScript(
       stylePlan.legacyCslPath,
       stylePlan.baseRun.refsFixture,
-      stylePlan.baseRun.citationsFixture
+      stylePlan.baseRun.citationsFixture,
+      options
     );
     for (const familyRun of stylePlan.familyRuns) {
       const extra = runOracleScript(
         stylePlan.legacyCslPath,
         familyRun.refsFixture,
-        familyRun.citationsFixture
+        familyRun.citationsFixture,
+        options
       );
       mergeStructuredResults(result, extra);
     }
@@ -476,10 +493,10 @@ function main() {
     }
 
     const hasFailures = summary.citations.mismatches > 0 || summary.bibliography.mismatches > 0;
-    process.exit(hasFailures ? 1 : 0);
+    process.exitCode = hasFailures ? 1 : 0;
   } catch (error) {
     process.stderr.write(`${error.message}\n`);
-    process.exit(2);
+    process.exitCode = 2;
   }
 }
 

--- a/scripts/oracle-yaml.test.js
+++ b/scripts/oracle-yaml.test.js
@@ -37,6 +37,15 @@ test('oracle-yaml parses family-aware CLI flags', () => {
   assert.equal(options.refsFixture, 'tests/fixtures/references-humanities-note.json');
   assert.equal(options.citationsFixture, 'tests/fixtures/citations-humanities-note.json');
   assert.equal(options.jsonOutput, true);
+  assert.equal(options.caseSensitive, true);
+});
+
+test('oracle-yaml parses case-sensitivity override flags', () => {
+  const insensitive = parseArgs(['styles/apa-7th.yaml', '--case-insensitive']);
+  const sensitive = parseArgs(['styles/apa-7th.yaml', '--case-sensitive']);
+
+  assert.equal(insensitive.caseSensitive, false);
+  assert.equal(sensitive.caseSensitive, true);
 });
 
 test('oracle-yaml resolves apa-7th to apa.csl and author-date fixtures', () => {

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -26,11 +26,13 @@ const os = require('os');
 const path = require('path');
 const { execSync } = require('child_process');
 const {
+  compareText,
   normalizeText,
   parseComponents,
   analyzeOrdering,
   findRefDataForEntry,
   loadLocale,
+  textSimilarity,
 } = require('./oracle-utils');
 const { toCiteprocItem } = require('./lib/citeproc-locators');
 const { maybeDatasetErrorForFile } = require('./lib/dataset-guard');
@@ -55,6 +57,7 @@ function parseArgs() {
     refsFixture: DEFAULT_REFS_FIXTURE,
     citationsFixture: DEFAULT_CITATIONS_FIXTURE,
     forceMigrate: false,
+    caseSensitive: true,
     migrate: {
       templateSource: null,
       minTemplateConfidence: null,
@@ -68,6 +71,10 @@ function parseArgs() {
       options.jsonOutput = true;
     } else if (arg === '--verbose') {
       options.verbose = true;
+    } else if (arg === '--case-sensitive') {
+      options.caseSensitive = true;
+    } else if (arg === '--case-insensitive') {
+      options.caseSensitive = false;
     } else if (arg === '--force-migrate') {
       options.forceMigrate = true;
     } else if (arg === '--refs-fixture') {
@@ -156,7 +163,13 @@ function compareComponents(oracleComp, cslnComp, refData) {
         matches.push({ component: key, status: 'match' });
       } else {
         // Values differ
-        matches.push({ component: key, status: 'match' }); // Component present in both
+        differences.push({
+          component: key,
+          issue: 'value_mismatch',
+          expected: oracle.value,
+          found: csln.value,
+          detail: 'Value differs between oracle and CSLN',
+        });
       }
     } else if (oracle.found && !csln.found) {
       differences.push({
@@ -361,53 +374,8 @@ function renderWithCslnProcessor(stylePath, refsData, testItems, testCitations, 
   }
 }
 
-function tokenizeForSimilarity(text) {
-  return normalizeText(text || '')
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
-    .split(/\s+/)
-    .filter(Boolean)
-    .filter((token) => token.length > 1);
-}
-
-function textSimilarity(a, b) {
-  const left = tokenizeForSimilarity(a);
-  const right = tokenizeForSimilarity(b);
-  if (left.length === 0 && right.length === 0) return 1;
-  if (left.length === 0 || right.length === 0) return 0;
-
-  const leftCounts = new Map();
-  const rightCounts = new Map();
-  for (const token of left) {
-    leftCounts.set(token, (leftCounts.get(token) || 0) + 1);
-  }
-  for (const token of right) {
-    rightCounts.set(token, (rightCounts.get(token) || 0) + 1);
-  }
-
-  let intersect = 0;
-  let union = 0;
-  const keys = new Set([...leftCounts.keys(), ...rightCounts.keys()]);
-  for (const key of keys) {
-    const l = leftCounts.get(key) || 0;
-    const r = rightCounts.get(key) || 0;
-    intersect += Math.min(l, r);
-    union += Math.max(l, r);
-  }
-
-  return union > 0 ? intersect / union : 0;
-}
-
-function equivalentText(oracleText, cslnText) {
-  const oracleNorm = normalizeText(oracleText);
-  const cslnNorm = normalizeText(cslnText);
-  if (oracleNorm === cslnNorm) return true;
-
-  const similarity = textSimilarity(oracleNorm, cslnNorm);
-  // High token-overlap tolerance for punctuation/order differences.
-  if (similarity >= 0.60) return true;
-
-  return false;
+function equivalentText(oracleText, cslnText, options = {}) {
+  return compareText(oracleText, cslnText, options).match;
 }
 
 function extractYearSuffixes(text) {
@@ -462,11 +430,14 @@ function equivalentDisambiguationProbe(oracleText, cslnText, citationId) {
   return true;
 }
 
-function equivalentCitationText(oracleText, cslnText, citationId) {
+function equivalentCitationText(oracleText, cslnText, citationId, options = {}) {
+  if (options.caseSensitive !== false && compareText(oracleText, cslnText, options).caseMismatch) {
+    return false;
+  }
   if (STRICT_CITATION_IDS.has(citationId)) {
     return equivalentDisambiguationProbe(oracleText, cslnText, citationId);
   }
-  return equivalentText(oracleText, cslnText);
+  return equivalentText(oracleText, cslnText, options);
 }
 
 function collectCitationTypes(citation, testItems) {
@@ -544,11 +515,13 @@ function runOracle(cliOptions = parseArgs()) {
 
   if (datasetMessage) {
     console.error(datasetMessage);
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
   if (!fs.existsSync(stylePath)) {
     console.error(`Style file not found: ${stylePath}`);
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   const { refsData, testItems, testCitations } = loadFixtures(
@@ -594,7 +567,8 @@ function runOracle(cliOptions = parseArgs()) {
       console.error('  2. Validate YAML syntax: yamllint .migrated-temp.yaml');
       console.error('  3. Check processor error: cargo run --bin citum -- render refs -b <refs> -s <style> -c <citations> --mode both');
     }
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   // Analyze bibliography
@@ -622,15 +596,26 @@ function runOracle(cliOptions = parseArgs()) {
   // Check citations
   for (const cite of testCitations) {
     const id = cite.id;
-    const oracleCit = normalizeText(oracle.citations[id] || '');
-    const cslnCit = normalizeText(csln.citations[id] || '');
-    const match = equivalentCitationText(oracleCit, cslnCit, id);
+    const comparison = compareText(oracle.citations[id] || '', csln.citations[id] || '', {
+      caseSensitive: cliOptions.caseSensitive,
+    });
+    const match = STRICT_CITATION_IDS.has(id)
+      ? equivalentCitationText(comparison.expected, comparison.actual, id, {
+        caseSensitive: cliOptions.caseSensitive,
+      })
+      : comparison.match;
     if (match) {
       rawResults.citations.passed++;
     } else {
       rawResults.citations.failed++;
     }
-    rawResults.citations.entries.push({ id, oracle: oracleCit, csln: cslnCit, match });
+    rawResults.citations.entries.push({
+      id,
+      oracle: comparison.expected,
+      csln: comparison.actual,
+      match,
+      caseMismatch: comparison.caseMismatch,
+    });
 
     const citationTypes = collectCitationTypes(cite, testItems);
     for (const type of citationTypes) {
@@ -652,6 +637,7 @@ function runOracle(cliOptions = parseArgs()) {
       oracle: pair.oracle ? normalizeText(pair.oracle) : null,
       csln: pair.csln ? normalizeText(pair.csln) : null,
       match: false,
+      caseMismatch: false,
       components: {},
       ordering: null,
       issues: [],
@@ -665,10 +651,14 @@ function runOracle(cliOptions = parseArgs()) {
       rawResults.bibliography.failed++;
     } else {
       // Both exist - compare
-      const oracleNorm = normalizeText(pair.oracle);
-      const cslnNorm = normalizeText(pair.csln);
+      const comparison = compareText(pair.oracle, pair.csln, {
+        caseSensitive: cliOptions.caseSensitive,
+      });
+      entryResult.oracle = comparison.expected;
+      entryResult.csln = comparison.actual;
+      entryResult.caseMismatch = comparison.caseMismatch;
 
-      if (equivalentText(oracleNorm, cslnNorm)) {
+      if (comparison.match) {
         entryResult.match = true;
         rawResults.bibliography.passed++;
       } else {
@@ -786,7 +776,7 @@ function runOracle(cliOptions = parseArgs()) {
     console.log();
   }
 
-  process.exit(results.citations.failed === 0 && results.bibliography.failed === 0 ? 0 : 1);
+  process.exitCode = results.citations.failed === 0 && results.bibliography.failed === 0 ? 0 : 1;
 }
 
 if (require.main === module) {
@@ -794,6 +784,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  compareComponents,
   cleanupOracleTempWorkspace,
   createOracleTempWorkspace,
   loadFixtures,

--- a/scripts/oracle.test.js
+++ b/scripts/oracle.test.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 const {
+  compareComponents,
   cleanupOracleTempWorkspace,
   createOracleTempWorkspace,
   loadFixtures,
@@ -265,4 +266,45 @@ test('registered divergence adjustments skip order inspection without failures',
   assert.equal(adjusted.bibliographyOrder, null);
   assert.equal(adjusted.adjusted.citations.passed, 1);
   assert.deepEqual(adjusted.adjusted.divergenceSummary, {});
+});
+
+test('compareComponents reports differing component values as mismatches', () => {
+  const { differences, matches } = compareComponents(
+    {
+      title: { found: true, value: 'Alpha' },
+      contributors: { found: false },
+      year: { found: false },
+      containerTitle: { found: false },
+      volume: { found: false },
+      issue: { found: false },
+      pages: { found: false },
+      publisher: { found: false },
+      doi: { found: false },
+      edition: { found: false },
+      editors: { found: false },
+    },
+    {
+      title: { found: true, value: 'Beta' },
+      contributors: { found: false },
+      year: { found: false },
+      containerTitle: { found: false },
+      volume: { found: false },
+      issue: { found: false },
+      pages: { found: false },
+      publisher: { found: false },
+      doi: { found: false },
+      edition: { found: false },
+      editors: { found: false },
+    },
+    {}
+  );
+
+  assert.deepEqual(matches, []);
+  assert.deepEqual(differences, [{
+    component: 'title',
+    issue: 'value_mismatch',
+    expected: 'Alpha',
+    found: 'Beta',
+    detail: 'Value differs between oracle and CSLN',
+  }]);
 });

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -42,7 +42,11 @@ const {
   auditNoteStyle,
   discoverNoteStyles,
 } = require('./lib/note-position-audit');
-const { normalizeText } = require('./oracle-utils');
+const {
+  compareText,
+  normalizeText,
+  textSimilarity,
+} = require('./oracle-utils');
 const { maybeDatasetErrorForFile } = require('./lib/dataset-guard');
 
 const CUSTOM_TAG_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
@@ -120,6 +124,7 @@ function parseArgs() {
     timings: false,
     cacheDir: DEFAULT_REPORT_CACHE_DIR,
     citumBin: process.env.CITUM_BIN || null,
+    caseSensitive: true,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -140,6 +145,10 @@ function parseArgs() {
       options.cacheDir = path.resolve(args[++i]);
     } else if (args[i] === '--citum-bin') {
       options.citumBin = path.resolve(args[++i]);
+    } else if (args[i] === '--case-sensitive') {
+      options.caseSensitive = true;
+    } else if (args[i] === '--case-insensitive') {
+      options.caseSensitive = false;
     }
   }
 
@@ -194,48 +203,8 @@ function hashFile(filePath) {
   return hashContent(fs.readFileSync(filePath));
 }
 
-function tokenizeForSimilarity(text) {
-  return normalizeText(text || '')
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
-    .split(/\s+/)
-    .filter(Boolean)
-    .filter((token) => token.length > 1);
-}
-
-function textSimilarity(a, b) {
-  const left = tokenizeForSimilarity(a);
-  const right = tokenizeForSimilarity(b);
-  if (left.length === 0 && right.length === 0) return 1;
-  if (left.length === 0 || right.length === 0) return 0;
-
-  const leftCounts = new Map();
-  const rightCounts = new Map();
-  for (const token of left) {
-    leftCounts.set(token, (leftCounts.get(token) || 0) + 1);
-  }
-  for (const token of right) {
-    rightCounts.set(token, (rightCounts.get(token) || 0) + 1);
-  }
-
-  let intersect = 0;
-  let union = 0;
-  const keys = new Set([...leftCounts.keys(), ...rightCounts.keys()]);
-  for (const key of keys) {
-    const l = leftCounts.get(key) || 0;
-    const r = rightCounts.get(key) || 0;
-    intersect += Math.min(l, r);
-    union += Math.max(l, r);
-  }
-
-  return union > 0 ? intersect / union : 0;
-}
-
-function equivalentText(expected, actual) {
-  const expectedNorm = normalizeText(expected);
-  const actualNorm = normalizeText(actual);
-  if (expectedNorm === actualNorm) return true;
-  return textSimilarity(expectedNorm, actualNorm) >= 0.60;
+function equivalentText(expected, actual, options = {}) {
+  return compareText(expected, actual, options).match;
 }
 
 function fixtureHash(refsFixture, citationsFixture) {
@@ -290,6 +259,7 @@ function createReportRuntime(options = {}) {
   return {
     allowLiveFallback: Boolean(options.allowLiveFallback),
     cacheDir,
+    caseSensitive: options.caseSensitive !== false,
     timings: new Map(),
     stylesDir: options.stylesDir ? path.resolve(options.stylesDir) : null,
     citumBin: resolveCitumBinary(options.citumBin),
@@ -593,6 +563,22 @@ function getEffectiveOracleSection(oracleResult, sectionName) {
   return oracleResult?.[sectionName] || { passed: 0, total: 0, entries: [] };
 }
 
+function countCaseMismatches(section) {
+  return (section?.entries || []).filter((entry) => entry?.caseMismatch === true).length;
+}
+
+function collectCaseMismatchSummary(oracleResult) {
+  const citations = getEffectiveOracleSection(oracleResult, 'citations');
+  const bibliography = getEffectiveOracleSection(oracleResult, 'bibliography');
+  const citationCount = countCaseMismatches(citations);
+  const bibliographyCount = countCaseMismatches(bibliography);
+  return {
+    citations: citationCount,
+    bibliography: bibliographyCount,
+    total: citationCount + bibliographyCount,
+  };
+}
+
 function mergeDivergenceDetails(base = {}, extra = {}) {
   const merged = { ...base };
 
@@ -691,13 +677,22 @@ async function runCiteprocSnapshotOracle(runtime, stylePath, styleName, styleFor
     snapshotStatus: snapshotStatus.status,
     snapshotHash: snapshotStatus.ok ? hashFile(snapshotStatus.snapshotPath) : null,
     allowLiveFallback: runtime.allowLiveFallback,
+    caseSensitive: runtime.caseSensitive,
   };
 
   return runCachedJsonJob(runtime, {
     kind: 'citeprocSnapshot',
     cacheKey,
     async compute() {
-      const fastArgs = [stylePath, '--json', '--refs-fixture', refsFixture, '--citations-fixture', resolvedCitationsFixture];
+      const fastArgs = [
+        stylePath,
+        '--json',
+        '--refs-fixture',
+        refsFixture,
+        '--citations-fixture',
+        resolvedCitationsFixture,
+        runtime.caseSensitive ? '--case-sensitive' : '--case-insensitive',
+      ];
 
       if (snapshotStatus.ok) {
         const fast = await runNodeOracleScript(fastScript, fastArgs);
@@ -887,6 +882,7 @@ async function runBiblatexSnapshotOracle(runtime, styleName, styleYamlPath, auth
       styleHash: hashFile(styleYamlPath),
       refsHash: hashFile(DEFAULT_REFS_FIXTURE),
       snapshotHash: hashFile(snapshotPath),
+      caseSensitive: runtime.caseSensitive,
     },
     async compute() {
       let snapshot;
@@ -919,9 +915,17 @@ async function runBiblatexSnapshotOracle(runtime, styleName, styleYamlPath, auth
         for (let i = 0; i < total; i++) {
           const expected = expectedEntries[i] ?? '';
           const actual = actualEntries[i] ?? '';
-          const match = equivalentText(expected, actual);
+          const comparison = compareText(expected, actual, {
+            caseSensitive: runtime.caseSensitive,
+          });
+          const match = comparison.match;
           if (match) passed += 1;
-          entries.push({ expected, actual, match });
+          entries.push({
+            expected: comparison.expected,
+            actual: comparison.actual,
+            match,
+            caseMismatch: comparison.caseMismatch,
+          });
 
           // Track per-type stats using the fixture entry at this position.
           const refType = fixtureTypes[i] || 'unknown';
@@ -967,6 +971,7 @@ async function runFamilyFixtureOracle(runtime, stylePath, styleName, fixtureSetN
       styleHash: hashFile(stylePath),
       refsHash: hashFile(refsFixture),
       citationsHash: hashFile(citationsFixture),
+      caseSensitive: runtime.caseSensitive,
     },
     async compute() {
       const result = await runNodeOracleScript(liveScript, [
@@ -974,6 +979,7 @@ async function runFamilyFixtureOracle(runtime, stylePath, styleName, fixtureSetN
         '--json',
         '--refs-fixture', refsFixture,
         '--citations-fixture', citationsFixture,
+        runtime.caseSensitive ? '--case-sensitive' : '--case-insensitive',
       ]);
       if ((result.code === 0 || result.code === 1) && result.stdout.trim()) {
         try {
@@ -1629,6 +1635,7 @@ async function processStyleReport(runtime, styleSpec, context) {
   if (primaryComparator === 'citum-baseline') {
     const oracleResult = await runNativeOracle(runtime, styleSpec.name);
     const fidelityScore = computeFidelityScore(oracleResult);
+    const caseMismatches = collectCaseMismatchSummary(oracleResult);
     const bibliography = getEffectiveOracleSection(oracleResult, 'bibliography');
     const citations = getEffectiveOracleSection(oracleResult, 'citations');
     const rawBibliography = oracleResult.bibliography || { passed: 0, total: 0 };
@@ -1661,6 +1668,7 @@ async function processStyleReport(runtime, styleSpec, context) {
         rawBibliography,
         knownDivergences: divergences[styleSpec.name] || [],
         adjustedDivergences: oracleResult.adjusted?.divergenceSummary || {},
+        caseMismatches,
         citationsByType: oracleResult.citationsByType || {},
         error: oracleResult.error || null,
         componentMatchRate: null,
@@ -1734,6 +1742,7 @@ async function processStyleReport(runtime, styleSpec, context) {
   }
 
   const fidelityScore = computeFidelityScore(oracleResult);
+  const caseMismatches = collectCaseMismatchSummary(oracleResult);
   const citations = getEffectiveOracleSection(oracleResult, 'citations');
   const bibliography = getEffectiveOracleSection(oracleResult, 'bibliography');
   const rawCitations = oracleResult.citations || { passed: 0, total: 0 };
@@ -1768,6 +1777,7 @@ async function processStyleReport(runtime, styleSpec, context) {
       rawBibliography,
       knownDivergences: divergences[styleSpec.name] || [],
       adjustedDivergences: oracleResult.adjusted?.divergenceSummary || {},
+      caseMismatches,
       citationsByType: oracleResult.citationsByType || {},
       error: oracleResult.error || null,
       componentMatchRate,
@@ -1830,6 +1840,8 @@ async function generateReport(options) {
   let citationsPassed = 0;
   let biblioTotal = 0;
   let biblioPassed = 0;
+  let citationCaseMismatchTotal = 0;
+  let bibliographyCaseMismatchTotal = 0;
   let qualityTotal = 0;
   let qualityCount = 0;
   let errorCount = 0;
@@ -1841,6 +1853,8 @@ async function generateReport(options) {
     citationsPassed += citations.passed || 0;
     biblioTotal += bibliography.total || 0;
     biblioPassed += bibliography.passed || 0;
+    citationCaseMismatchTotal += job.styleRecord.caseMismatches?.citations || 0;
+    bibliographyCaseMismatchTotal += job.styleRecord.caseMismatches?.bibliography || 0;
     qualityTotal += job.qualityScore || 0;
     qualityCount += 1;
     errorCount += job.errorCount || 0;
@@ -1874,12 +1888,20 @@ async function generateReport(options) {
           snapshotIssues: preflightIssues,
           allowLiveFallback: runtime.allowLiveFallback,
         },
+        oracleComparison: {
+          caseSensitive: runtime.caseSensitive,
+        },
         ...(options.timings ? { timings: serializeTimingSummary(runtime) } : {}),
       },
       totalImpact: parseFloat(totalImpact),
       totalStyles: coreStyles.length,
       citationsOverall: { passed: citationsPassed, total: citationsTotal },
       bibliographyOverall: { passed: biblioPassed, total: biblioTotal },
+      caseMismatchesOverall: {
+        citations: citationCaseMismatchTotal,
+        bibliography: bibliographyCaseMismatchTotal,
+        total: citationCaseMismatchTotal + bibliographyCaseMismatchTotal,
+      },
       qualityOverall: {
         score: qualityCount > 0 ? parseFloat((qualityTotal / qualityCount).toFixed(3)) : 0,
       },

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -136,6 +136,11 @@ test('comparison text helper supports both live-oracle and native-snapshot entry
   );
 });
 
+test('equivalentText treats case-only differences as failures by default', () => {
+  assert.equal(equivalentText('DNA repair', 'Dna repair'), false);
+  assert.equal(equivalentText('DNA repair', 'Dna repair', { caseSensitive: false }), true);
+});
+
 test('generateHtml renders repeated-note regression and conformance layers separately', () => {
   const html = generateHtml({
     generated: '2026-03-11T00:00:00.000Z',

--- a/styles/apa-7th.yaml
+++ b/styles/apa-7th.yaml
@@ -39,7 +39,19 @@ options:
       use-first: 19
       use-last: 1
   dates: long
-  titles: apa
+  titles:
+    component:
+      text-case: as-is
+    monograph:
+      text-case: as-is
+      emph: true
+    container-monograph:
+      text-case: as-is
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      text-case: as-is
   multilingual:
     title-mode: combined
     name-mode: primary

--- a/styles/chem-rsc.yaml
+++ b/styles/chem-rsc.yaml
@@ -27,7 +27,16 @@ options:
     uncertainty-marker: "?"
     approximation-marker: "ca. "
     range-delimiter: –
-  titles: scientific
+  titles:
+    component:
+      text-case: as-is
+    monograph:
+      text-case: as-is
+    container-monograph:
+      text-case: as-is
+    periodical: {}
+    serial:
+      text-case: as-is
   bibliography:
     entry-suffix: .
     separator: ", "

--- a/styles/chicago-author-date.yaml
+++ b/styles/chicago-author-date.yaml
@@ -49,7 +49,18 @@ options:
       delimiter-precedes-last: contextual
     demote-non-dropping-particle: display-and-sort
   dates: long
-  titles: humanities
+  titles:
+    component: {}
+    monograph:
+      text-case: title
+      emph: true
+    container-monograph:
+      text-case: title
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      emph: true
   page-range-format: chicago16
   bibliography:
     hanging-indent: true

--- a/styles/elsevier-with-titles.yaml
+++ b/styles/elsevier-with-titles.yaml
@@ -25,7 +25,16 @@ options:
   processing: numeric
   contributors: numeric-given-dot
   dates: long
-  titles: scientific
+  titles:
+    component:
+      text-case: as-is
+    monograph:
+      text-case: as-is
+    container-monograph:
+      text-case: as-is
+    periodical: {}
+    serial:
+      text-case: as-is
   bibliography:
     entry-suffix: .
     separator: ""


### PR DESCRIPTION
## Summary
- make oracle comparisons case-aware and surface case-mismatch metrics in core reporting
- extract CSL title rendering signals during migration and use them in preset detection
- roll out title text-case adjustments for the affected parent styles and document the rollout

## Verification
- ./scripts/validate-frontmatter.sh --copilot-strict
- node --test scripts/oracle-yaml.test.js scripts/report-core.test.js
- cargo test -p citum-migrate options_extractor::titles -- --nocapture
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- node scripts/check-core-quality.js --report /tmp/core-report-case-5.json --baseline scripts/report-data/core-quality-baseline.json
- node scripts/check-oracle-regression.js --baseline scripts/report-data/oracle-top10-baseline.json