### PR TITLE
test(engine): expand behavior report to metadata, multilingual, sort_oracle

### DIFF
--- a/.beans/archive/csl26-8g5m--expand-behavior-report-metadata-multilingual-sort.md
+++ b/.beans/archive/csl26-8g5m--expand-behavior-report-metadata-multilingual-sort.md
@@ -1,0 +1,19 @@
+---
+# csl26-8g5m
+title: 'Expand behavior report: metadata, multilingual, sort_oracle'
+status: completed
+type: task
+priority: normal
+created_at: 2026-03-12T19:01:29Z
+updated_at: 2026-03-12T19:06:26Z
+---
+
+Add announce_behavior calls to metadata.rs, multilingual.rs, and sort_oracle.rs engine integration suites. Register all three in PILOT_SOURCES and the default test-report.sh target list. Regenerate the report to confirm useful human-readable output.\n\nRef skill: .claude/skills/engine-behavior-reporting/SKILL.md
+
+## Summary of Changes
+
+- Added `announce_behavior` calls to `metadata.rs` (12 tests), `multilingual.rs` (5 tests), and `sort_oracle.rs` (6 tests).
+- Added `mod common; use common::announce_behavior;` to multilingual and sort_oracle suites.
+- Registered all three in `PILOT_SOURCES` in `generate-test-report.py`.
+- Added `--test metadata --test multilingual --test sort_oracle` to default `test-report.sh` target list.
+- Report now covers 104 scenarios total across 7 suites.

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -74,10 +74,11 @@ fn build_date_style(form: DateForm) -> Style {
     }
 }
 
-// --- Name Rendering Tests ---
+// --- Behavior Announcements ---
 
 #[test]
 fn test_name_rendering_basic() {
+    announce_behavior("Long name form renders given-name then family name.");
     let style = build_name_style(ContributorForm::Long, None);
 
     let bib = citum_schema::bib_map!["item1" => make_book("item1", "Smith", "John", 2020, "Title")];
@@ -92,6 +93,7 @@ fn test_name_rendering_basic() {
 
 #[test]
 fn test_name_rendering_short() {
+    announce_behavior("Short name form renders family name only.");
     let style = build_name_style(ContributorForm::Short, None);
 
     let bib = citum_schema::bib_map!["item1" => make_book("item1", "Smith", "John", 2020, "Title")];
@@ -106,6 +108,7 @@ fn test_name_rendering_short() {
 
 #[test]
 fn test_name_rendering_family_only() {
+    announce_behavior("Family-only form renders surname without given name or particles.");
     let style = build_name_style(ContributorForm::FamilyOnly, None);
 
     let mut bib = indexmap::IndexMap::new();
@@ -128,6 +131,7 @@ fn test_name_rendering_family_only() {
 
 #[test]
 fn test_name_rendering_et_al() {
+    announce_behavior("Name list is truncated with et al. when it exceeds the configured minimum.");
     let style = build_name_style(
         ContributorForm::Short,
         Some(ShortenListOptions {
@@ -159,6 +163,7 @@ fn test_name_rendering_et_al() {
 
 #[test]
 fn test_name_rendering_particles() {
+    announce_behavior("Non-dropping particles are included when rendering the long name form.");
     let style = build_name_style(ContributorForm::Long, None);
 
     let mut bib = indexmap::IndexMap::new();
@@ -181,6 +186,7 @@ fn test_name_rendering_particles() {
 
 #[test]
 fn test_name_rendering_corporate() {
+    announce_behavior("Corporate names are rendered verbatim without inversion.");
     let style = build_name_style(ContributorForm::Long, None);
 
     let mut bib = indexmap::IndexMap::new();
@@ -206,10 +212,9 @@ fn test_name_rendering_corporate() {
     );
 }
 
-// --- Date Rendering Tests ---
-
 #[test]
 fn test_date_rendering_year() {
+    announce_behavior("Year-only date form renders just the year.");
     let style = build_date_style(DateForm::Year);
 
     let bib = citum_schema::bib_map!["item1" => make_book("item1", "Smith", "J", 2020, "Title")];
@@ -224,6 +229,7 @@ fn test_date_rendering_year() {
 
 #[test]
 fn test_date_rendering_full() {
+    announce_behavior("Full date form renders month, day, and year in locale order.");
     let style = build_date_style(DateForm::Full);
 
     let mut bib = indexmap::IndexMap::new();
@@ -246,6 +252,7 @@ fn test_date_rendering_full() {
 
 #[test]
 fn test_date_rendering_day_month_abbr_year() {
+    announce_behavior("Day-month-abbreviated-year form renders in day-month-year order.");
     let style = build_date_style(DateForm::DayMonthAbbrYear);
 
     let mut bib = indexmap::IndexMap::new();
@@ -269,6 +276,7 @@ fn test_date_rendering_day_month_abbr_year() {
 
 #[test]
 fn test_date_rendering_range() {
+    announce_behavior("A date range renders with an en dash between start and end years.");
     let style = build_date_style(DateForm::Year);
 
     let mut bib = indexmap::IndexMap::new();
@@ -291,6 +299,9 @@ fn test_date_rendering_range() {
 
 #[test]
 fn test_date_rendering_open_range() {
+    announce_behavior(
+        "An open date range renders with an en dash followed by a locale present term.",
+    );
     let style = build_date_style(DateForm::Year);
 
     let mut bib = indexmap::IndexMap::new();
@@ -313,6 +324,7 @@ fn test_date_rendering_open_range() {
 
 #[test]
 fn test_date_rendering_fallback() {
+    announce_behavior("A missing date falls back to the configured no-date term.");
     let style = build_date_style(DateForm::Year);
 
     let mut bib = indexmap::IndexMap::new();

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -3,6 +3,9 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
+mod common;
+use common::announce_behavior;
+
 use citum_engine::Processor;
 use citum_engine::io::load_bibliography;
 use citum_schema::Style;
@@ -34,6 +37,7 @@ fn single_item_citation(id: &str) -> Citation {
 
 #[test]
 fn test_cjk_name_rendering_asian_glyphs() {
+    announce_behavior("CJK author names are preserved and rendered with native glyphs.");
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bibliography =
@@ -54,6 +58,7 @@ fn test_cjk_name_rendering_asian_glyphs() {
 
 #[test]
 fn test_cjk_et_al_rendering() {
+    announce_behavior("CJK name lists are truncated with et al. for APA-style citations.");
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bibliography =
@@ -74,6 +79,7 @@ fn test_cjk_et_al_rendering() {
 
 #[test]
 fn test_arabic_short_forms_with_diacritics() {
+    announce_behavior("Arabic author names are rendered with diacritical marks intact.");
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bibliography =
@@ -94,6 +100,7 @@ fn test_arabic_short_forms_with_diacritics() {
 
 #[test]
 fn test_arabic_transliterated_forms() {
+    announce_behavior("Transliterated Arabic names are accepted and rendered correctly.");
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bibliography =
@@ -114,6 +121,9 @@ fn test_arabic_transliterated_forms() {
 
 #[test]
 fn test_bibliography_locales_switch_full_entry_layouts() {
+    announce_behavior(
+        "Bibliography entries switch to a locale-specific layout when the reference language matches.",
+    );
     let root = project_root();
     let style =
         load_style(&root.join("styles/experimental/locale-specific-bibliography-layouts.yaml"));

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -3,6 +3,9 @@ SPDX-License-Identifier: MPL-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
+mod common;
+use common::announce_behavior;
+
 use citum_engine::Processor;
 use citum_engine::io::load_bibliography;
 use citum_schema::Style;
@@ -31,6 +34,9 @@ fn load_sort_oracle_bibliography()
 /// Adams has 3 works in 2020 — should sort alphabetically by title.
 #[test]
 fn test_apa_7th_sort_same_author_year_by_title() {
+    announce_behavior(
+        "Works by the same author in the same year are sorted alphabetically by title.",
+    );
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bib = load_sort_oracle_bibliography();
@@ -64,6 +70,7 @@ fn test_apa_7th_sort_same_author_year_by_title() {
 /// Anonymous works should sort by title when no author is present.
 #[test]
 fn test_apa_7th_sort_anonymous_works_by_title() {
+    announce_behavior("Anonymous works sort by title with leading articles stripped.");
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bib = load_sort_oracle_bibliography();
@@ -91,6 +98,9 @@ fn test_apa_7th_sort_anonymous_works_by_title() {
 /// Multiple authors with same surname should maintain consistent alphabetical ordering.
 #[test]
 fn test_numeric_sort_by_citation_order() {
+    announce_behavior(
+        "Numeric style assigns citation numbers by fixture insertion order, not by author or title.",
+    );
     // Build a simple numeric style for testing
     let style = {
         use citum_schema::options::Processing;
@@ -166,6 +176,7 @@ fn test_numeric_sort_by_citation_order() {
 /// SMITH and WILLIAMS surnames should sort correctly in author-date and numeric styles.
 #[test]
 fn test_uppercase_surname_sort_order() {
+    announce_behavior("All-caps surnames sort in the same order as normally-cased surnames.");
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bib = load_sort_oracle_bibliography();
@@ -186,6 +197,9 @@ fn test_uppercase_surname_sort_order() {
 /// Test multi-author books and articles in same year sorted by first author.
 #[test]
 fn test_multiauthor_same_year_sort() {
+    announce_behavior(
+        "Multi-author works with the same year appear together in author-date sort order.",
+    );
     let root = project_root();
     let style = load_style(&root.join("styles/apa-7th.yaml"));
     let bib = load_sort_oracle_bibliography();
@@ -205,6 +219,9 @@ fn test_multiauthor_same_year_sort() {
 /// Numeric styles should sort by citation order, not by volume/issue.
 #[test]
 fn test_numeric_style_volume_issue_independence() {
+    announce_behavior(
+        "Numeric style numbering is determined by citation order, not by volume or issue.",
+    );
     // Build a simple numeric style for testing
     let style = {
         use citum_schema::options::Processing;

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -26,6 +26,9 @@ PILOT_SOURCES = {
     "citations": Path("crates/citum-engine/tests/citations.rs"),
     "document": Path("crates/citum-engine/tests/document.rs"),
     "i18n": Path("crates/citum-engine/tests/i18n.rs"),
+    "metadata": Path("crates/citum-engine/tests/metadata.rs"),
+    "multilingual": Path("crates/citum-engine/tests/multilingual.rs"),
+    "sort_oracle": Path("crates/citum-engine/tests/sort_oracle.rs"),
 }
 
 

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -7,7 +7,7 @@ REPORT_PATH="${ROOT_DIR}/target/test-report.md"
 REPORT_HTML_PATH="${ROOT_DIR}/target/test-report.html"
 
 if [[ $# -eq 0 ]]; then
-  set -- --test bibliography --test citations --test document --test i18n
+  set -- --test bibliography --test citations --test document --test i18n --test metadata --test multilingual --test sort_oracle
 fi
 
 mkdir -p "$(dirname "${JUNIT_PATH}")" "$(dirname "${REPORT_PATH}")"


### PR DESCRIPTION
## Summary

- Adds `announce_behavior(...)` calls to three engine integration suites not yet covered by the behavior report: `metadata.rs` (12 tests), `multilingual.rs` (5 tests), `sort_oracle.rs` (6 tests).
- Registers all three in `PILOT_SOURCES` in `generate-test-report.py` and in the default `test-report.sh` target list.
- Report grows from 81 scenarios (4 suites) to **104 scenarios across 7 suites**.

## Scope

| File | Change |
|------|--------|
| `crates/citum-engine/tests/metadata.rs` | Added `announce_behavior` to 12 name/date rendering tests |
| `crates/citum-engine/tests/multilingual.rs` | Added `mod common; use common::announce_behavior;` + 5 calls |
| `crates/citum-engine/tests/sort_oracle.rs` | Added `mod common; use common::announce_behavior;` + 6 calls |
| `scripts/generate-test-report.py` | Added 3 entries to `PILOT_SOURCES` |
| `scripts/test-report.sh` | Added `--test metadata --test multilingual --test sort_oracle` to default targets |

## Validation

```
cargo fmt                                        # clean
cargo clippy --all-targets --all-features        # clean
cargo nextest run                                # 688 passed
./scripts/test-report.sh                         # 104 scenarios, all passed
```

## Risk

Low. Changes are additive: new `println!` calls in test bodies and two mapping entries in a Python script. No production code touched.

## Follow-ups

- `multilingual_names.rs` is a unit-level API test (not acceptance-style); intentionally excluded per skill policy.
- `domain_fixtures.rs` is fixture data; not applicable.
