### PR TITLE
test(migration): expand csl-to-citum reporting

### DIFF
--- a/crates/citum-migrate/tests/term_mapping.rs
+++ b/crates/citum-migrate/tests/term_mapping.rs
@@ -4,8 +4,15 @@ use citum_schema::locale::{GeneralTerm, TermForm};
 use citum_schema::template::{NumberVariable, SimpleVariable, TemplateComponent};
 use csl_legacy::model::{CslNode, Formatting, Label, Names, Text};
 
+fn announce_behavior(summary: &str) {
+    println!("behavior: {summary}");
+}
+
 #[test]
 fn test_upsample_term() {
+    announce_behavior(
+        "A CSL text term migrates to a Citum term node with the matching normalized term and default long form.",
+    );
     let legacy_node = CslNode::Text(Text {
         term: Some("in".to_string()),
         formatting: Formatting::default(),
@@ -37,6 +44,9 @@ fn test_upsample_term() {
 
 #[test]
 fn test_upsample_term_with_form() {
+    announce_behavior(
+        "An unknown CSL term value stays literal during migration instead of being coerced into an unsupported Citum term.",
+    );
     let legacy_node = CslNode::Text(Text {
         term: Some("editor".to_string()),
         form: Some("short".to_string()),
@@ -70,6 +80,9 @@ fn test_upsample_term_with_form() {
 
 #[test]
 fn test_upsample_term_preserves_strip_periods() {
+    announce_behavior(
+        "A CSL term with strip-periods keeps that formatting flag when migrated into a Citum term node.",
+    );
     let legacy_node = CslNode::Text(Text {
         term: Some("in".to_string()),
         formatting: Formatting::default(),
@@ -100,6 +113,9 @@ fn test_upsample_term_preserves_strip_periods() {
 
 #[test]
 fn test_upsample_label_preserves_strip_periods() {
+    announce_behavior(
+        "A CSL label keeps strip-periods metadata when migration lifts it into Citum variable label settings.",
+    );
     let legacy_node = CslNode::Label(Label {
         variable: Some("page".to_string()),
         form: Some("short".to_string()),
@@ -130,6 +146,9 @@ fn test_upsample_label_preserves_strip_periods() {
 
 #[test]
 fn test_upsample_strip_periods_preserves_none_and_false() {
+    announce_behavior(
+        "Migration preserves both omitted and explicit false strip-periods settings instead of normalizing them away.",
+    );
     let upsampler = Upsampler::new();
 
     let term_nodes = upsampler.upsample_nodes(&[CslNode::Text(Text {
@@ -177,6 +196,9 @@ fn test_upsample_strip_periods_preserves_none_and_false() {
 
 #[test]
 fn test_template_compiler_preserves_strip_periods_through_compilation() {
+    announce_behavior(
+        "Strip-periods formatting survives the full CSL-to-Citum migration pipeline through template compilation for terms, labels, and contributors.",
+    );
     let upsampler = Upsampler::new();
     let compiler = TemplateCompiler;
     let legacy_nodes = vec![

--- a/crates/citum-migrate/tests/variable_once.rs
+++ b/crates/citum-migrate/tests/variable_once.rs
@@ -11,8 +11,15 @@ use citum_schema::template::{
     TemplateContributor, TemplateDate, TemplateList, TemplateVariable, TypeSelector,
 };
 
+fn announce_behavior(summary: &str) {
+    println!("behavior: {summary}");
+}
+
 #[test]
 fn test_contributor_cross_list_duplicate_suppressed() {
+    announce_behavior(
+        "When two migrated sibling lists both render author, the later author branch is suppressed so CSL variable-once behavior is preserved.",
+    );
     // Setup: Create two sibling lists where 'author' appears in both.
     // After deduplication, the second list should have 'author' suppressed.
     let mut components = vec![
@@ -77,6 +84,9 @@ fn test_contributor_cross_list_duplicate_suppressed() {
 
 #[test]
 fn test_date_cross_list_duplicate_suppressed() {
+    announce_behavior(
+        "When two migrated sibling lists both render issued dates, the later date branch is suppressed to preserve CSL variable-once behavior.",
+    );
     // Setup: Create two sibling lists where 'issued' appears in both.
     // After deduplication, the second list should have 'issued' suppressed.
     let mut components = vec![
@@ -141,6 +151,9 @@ fn test_date_cross_list_duplicate_suppressed() {
 
 #[test]
 fn test_variable_cross_list_duplicate_suppressed() {
+    announce_behavior(
+        "When a migrated top-level variable and sibling list both render publisher, the later list rendering is suppressed to avoid duplicate output.",
+    );
     // Setup: Create a top-level variable and a sibling list with the same variable.
     // After deduplication, the list variable should be suppressed.
     let mut components = vec![
@@ -199,6 +212,9 @@ fn test_variable_cross_list_duplicate_suppressed() {
 
 #[test]
 fn test_nested_list_variable_once_per_branch() {
+    announce_behavior(
+        "Nested migrated lists track variable-once suppression per branch so inner duplicates are handled without leaking outer-list state.",
+    );
     // Setup: Create nested lists where a variable appears at different nesting levels.
     // Each nesting level should track its own scope across all sibling components.
     let mut components = vec![

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,13 @@ then drill into strategy and implementation details only as needed.
 1. [`TIER_STATUS.md`](./TIER_STATUS.md) - current strict oracle style status.
 2. [`compat.html`](https://citum.github.io/citum-core/compat.html) - published compatibility snapshot.
 3. `behavior-report.html` - published engine behavior coverage page generated in CI, with source locations for the selected engine behavior suites.
-4. `migration-behavior-report.html` - published migration behavior coverage page generated in CI, with source locations for reviewer-facing `citum-migrate` suites.
+4. `migration-behavior-report.html` - published CSL-to-Citum migration behavior coverage page generated in CI, with source locations for reviewer-facing `citum-migrate` suites.
 5. [`guides/RENDERING_WORKFLOW.md`](./guides/RENDERING_WORKFLOW.md) - operational rendering and verification workflow.
 6. [`architecture/ROADMAP.md`](./architecture/ROADMAP.md) - strategic direction and phase sequencing.
 
 Generate the compatibility snapshot locally with `node scripts/report-core.js --output-html docs/compat.html`.
 Generate the local behavior report with `./scripts/test-report.sh`.
-Generate the local migration behavior report with `./scripts/migration-test-report.sh`.
+Generate the local CSL-to-Citum migration behavior report with `./scripts/migration-test-report.sh`.
 
 ## Active Guides
 

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -164,6 +164,22 @@ def summarize_counts(entries: list[Scenario]) -> str:
     return ", ".join(parts) + "."
 
 
+def compute_status_counts(scenarios: list[Scenario]) -> dict[str, int]:
+    counts = {"passed": 0, "failed": 0, "skipped": 0}
+    for scenario in scenarios:
+        counts[scenario.status] += 1
+    return counts
+
+
+def summarize_status_counts(counts: dict[str, int]) -> str:
+    parts = [f"{counts['passed']} passed"]
+    if counts["failed"]:
+        parts.append(f"{counts['failed']} failed")
+    if counts["skipped"]:
+        parts.append(f"{counts['skipped']} skipped")
+    return ", ".join(parts)
+
+
 def parse_status(testcase: ET.Element) -> str:
     child_tags = {strip_tag(child.tag) for child in testcase}
     if "failure" in child_tags or "error" in child_tags:
@@ -320,6 +336,9 @@ def build_markdown_report(
     for scenario in scenarios:
         domains[scenario.domain].append(scenario)
         families[scenario.family].append(scenario)
+    status_counts = compute_status_counts(scenarios)
+    derived = sum(1 for scenario in scenarios if scenario.derived_from_name)
+    authored = len(scenarios) - derived
 
     lines: list[str] = []
     lines.append(f"# {report_title}")
@@ -330,6 +349,11 @@ def build_markdown_report(
     lines.append("")
     lines.append("## Overview")
     lines.append("")
+    lines.append(f"- **Total coverage**: {len(scenarios)} scenarios across {len(families)} suites.")
+    lines.append(f"- **Status**: {summarize_status_counts(status_counts)}.")
+    lines.append(
+        f"- **Scenario summaries**: {authored} authored behavior summaries, {derived} derived from test names."
+    )
 
     for family in sorted(families):
         entries = families[family]
@@ -349,7 +373,16 @@ def build_markdown_report(
                     + f", and {family_domains[-1]}"
                 )
         scenario_label = "scenario" if len(entries) == 1 else "scenarios"
-        lines.append(f"- **{family}**: {len(entries)} {scenario_label}{domain_text}.")
+        family_authored = sum(1 for entry in entries if not entry.derived_from_name)
+        family_derived = len(entries) - family_authored
+        family_status = summarize_status_counts(compute_status_counts(entries))
+        summary = f"- **{family}**: {len(entries)} {scenario_label}{domain_text}; {family_status}"
+        if family_derived:
+            summary += f"; {family_authored} authored, {family_derived} derived"
+        else:
+            summary += "; all authored"
+        summary += "."
+        lines.append(summary)
 
     failures = [scenario for scenario in scenarios if scenario.status == "failed"]
     if failures:
@@ -371,8 +404,14 @@ def build_markdown_report(
         lines.append(f"## {domain}")
         lines.append("")
         lines.append(summarize_counts(entries))
+        if all_passed:
+            lines.append("All scenarios in this section are passing.")
         if derived:
-            lines.append(f"{derived} scenario summaries were derived from test names.")
+            lines.append(
+                f"Scenario summaries in this section: {len(entries) - derived} authored, {derived} derived from test names."
+            )
+        else:
+            lines.append("Scenario summaries in this section are fully authored for reviewer-facing migration coverage.")
         lines.append("")
 
         for scenario in entries:
@@ -398,8 +437,22 @@ def build_html_report(
     for scenario in scenarios:
         domains[scenario.domain].append(scenario)
         families[scenario.family].append(scenario)
+    status_counts = compute_status_counts(scenarios)
+    derived = sum(1 for scenario in scenarios if scenario.derived_from_name)
+    authored = len(scenarios) - derived
 
     overview_items: list[str] = []
+    overview_items.append(
+        f"<li><strong>Total coverage</strong>: {len(scenarios)} scenarios across {len(families)} suites.</li>"
+    )
+    overview_items.append(
+        f"<li><strong>Status</strong>: {html.escape(summarize_status_counts(status_counts))}.</li>"
+    )
+    overview_items.append(
+        "<li><strong>Scenario summaries</strong>: "
+        f"{authored} authored behavior summaries, {derived} derived from test names."
+        "</li>"
+    )
     for family in sorted(families):
         entries = families[family]
         family_domains = sorted(
@@ -418,8 +471,22 @@ def build_html_report(
                     + f", and {family_domains[-1]}"
                 )
         scenario_label = "scenario" if len(entries) == 1 else "scenarios"
+        family_authored = sum(1 for entry in entries if not entry.derived_from_name)
+        family_derived = len(entries) - family_authored
+        family_status = summarize_status_counts(compute_status_counts(entries))
+        summary = (
+            f"<li><strong>{html.escape(family)}</strong>: {len(entries)} {scenario_label}"
+            f"{html.escape(domain_text)}; {html.escape(family_status)}"
+        )
+        if family_derived:
+            summary += (
+                f"; {family_authored} authored, {family_derived} derived"
+            )
+        else:
+            summary += "; all authored"
+        summary += ".</li>"
         overview_items.append(
-            f"<li><strong>{html.escape(family)}</strong>: {len(entries)} {scenario_label}{html.escape(domain_text)}.</li>"
+            summary
         )
 
     section_html: list[str] = []
@@ -458,9 +525,20 @@ def build_html_report(
                 )
 
         notes = ""
+        section_notes: list[str] = []
+        if all_passed:
+            section_notes.append("All scenarios in this section are passing.")
         if derived:
-            notes = (
-                f'<p class="section-note">{derived} scenario summaries were derived from test names.</p>'
+            section_notes.append(
+                f"Scenario summaries in this section: {len(entries) - derived} authored, {derived} derived from test names."
+            )
+        else:
+            section_notes.append(
+                "Scenario summaries in this section are fully authored for reviewer-facing migration coverage."
+            )
+        if section_notes:
+            notes = "".join(
+                f'<p class="section-note">{html.escape(note)}</p>' for note in section_notes
             )
 
         section_html.append(

--- a/scripts/migration-test-report.sh
+++ b/scripts/migration-test-report.sh
@@ -7,7 +7,11 @@ REPORT_PATH="${ROOT_DIR}/target/migration-behavior-report.md"
 REPORT_HTML_PATH="${ROOT_DIR}/target/migration-behavior-report.html"
 
 if [[ $# -eq 0 ]]; then
-  set -- --test date_inference --test substitute_extraction
+  set -- \
+    --test date_inference \
+    --test substitute_extraction \
+    --test term_mapping \
+    --test variable_once
 fi
 
 mkdir -p "$(dirname "${JUNIT_PATH}")" "$(dirname "${REPORT_PATH}")"
@@ -24,10 +28,12 @@ python3 "${ROOT_DIR}/scripts/generate-test-report.py" \
   --output "${REPORT_PATH}" \
   --output-html "${REPORT_HTML_PATH}" \
   --source-root "${ROOT_DIR}" \
-  --report-title "Migration Behavior Coverage" \
-  --report-lede "This page is generated from reviewer-facing citum-migrate suites that exercise user-visible migration behavior." \
+  --report-title "CSL-to-Citum Migration Behavior Coverage" \
+  --report-lede "This page is generated from reviewer-facing citum-migrate suites that exercise user-visible behavior in the migration from CSL styles to Citum styles." \
   --source-map "date_inference=crates/citum-migrate/tests/date_inference.rs" \
   --source-map "substitute_extraction=crates/citum-migrate/tests/substitute_extraction.rs" \
+  --source-map "term_mapping=crates/citum-migrate/tests/term_mapping.rs" \
+  --source-map "variable_once=crates/citum-migrate/tests/variable_once.rs" \
   || report_status=$?
 
 if [[ ${test_status} -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- clarify that the migration report tracks migration from CSL styles to Citum styles
- expand the default migration report coverage from two suites to all current citum-migrate suites
- convert the remaining migration suites to authored reviewer-facing behavior summaries and enrich the report overview

## Testing
- ./scripts/migration-test-report.sh
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run