### PR TITLE
fix(release): surface release-pr failures

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,64 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@1800853f2578f8c34492ec76154caef8e163fbca # v1.17.7
+
+      - name: Install release-plz
+        shell: bash
+        run: |
+          cargo-binstall \
+            release-plz@0.3.157 \
+            --force \
+            --strategies=crate-meta-data,compile \
+            --no-confirm
+
+      - name: Configure git user from GitHub token
+        uses: release-plz/git-config@59144859caf016f8b817a2ac9b051578729173c4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run release-plz release-pr
+        id: release_pr
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          stderr_file=$(mktemp)
+          if ! release_pr_output=$(release-plz release-pr \
+            --git-token "${GITHUB_TOKEN}" \
+            --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --config .release-plz.toml \
+            --forge github \
+            -v \
+            -o json 2>"${stderr_file}"); then
+            echo "::group::release-plz release-pr stderr"
+            cat "${stderr_file}"
+            echo "::endgroup::"
+            if grep -q "422" "${stderr_file}"; then
+              echo "::error::release-plz release-pr failed with HTTP 422. See stderr above."
+            fi
+            rm -f "${stderr_file}"
+            exit 1
+          fi
+
+          rm -f "${stderr_file}"
+          echo "release_pr_output: ${release_pr_output}"
+          prs=$(echo "${release_pr_output}" | jq -c .prs)
+          echo "prs=${prs}" >> "${GITHUB_OUTPUT}"
+          if [[ "$(echo "${prs}" | jq 'length')" == "0" ]]; then
+            echo "::warning::release-plz created no release PRs for this push."
+          fi
+
+      - name: Run release-plz release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          release_output=$(release-plz release \
+            --git-token "${GITHUB_TOKEN}" \
+            --config .release-plz.toml \
+            --forge github \
+            -v \
+            -o json)
+          echo "release_output: ${release_output}"


### PR DESCRIPTION
## Summary
- replace the `release-plz/action` wrapper with explicit CLI steps in the workflow
- run `release-plz release-pr` with verbose logging and print full stderr on failure
- fail the workflow on HTTP 422 instead of masking it as a no-op

## Validation
- inspected `release-plz/action@v0.5` and confirmed the wrapper currently swallows 422 errors
- pushed branch successfully through repo pre-push hooks
