### PR TITLE
fix(release): use tagged manifest baseline

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -39,6 +39,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare released manifest snapshot
+        id: released_manifest
+        shell: bash
+        run: |
+          latest_tag=$(git tag --sort=version:refname -l 'v*' | tail -n 1)
+          if [[ -z "${latest_tag}" ]]; then
+            echo "::error::No root release tag matching v* was found."
+            exit 1
+          fi
+
+          snapshot_dir="${RUNNER_TEMP}/release-plz-registry-manifest"
+          git worktree add --detach "${snapshot_dir}" "${latest_tag}"
+          echo "tag=${latest_tag}" >> "${GITHUB_OUTPUT}"
+          echo "manifest_path=${snapshot_dir}/Cargo.toml" >> "${GITHUB_OUTPUT}"
+          echo "Using released manifest from ${latest_tag}"
+
       - name: Run release-plz release-pr
         id: release_pr
         shell: bash
@@ -50,6 +66,7 @@ jobs:
             --git-token "${GITHUB_TOKEN}" \
             --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
             --config .release-plz.toml \
+            --registry-manifest-path "${{ steps.released_manifest.outputs.manifest_path }}" \
             --forge github \
             -v \
             -o json 2>"${stderr_file}"); then
@@ -79,7 +96,14 @@ jobs:
           release_output=$(release-plz release \
             --git-token "${GITHUB_TOKEN}" \
             --config .release-plz.toml \
+            --registry-manifest-path "${{ steps.released_manifest.outputs.manifest_path }}" \
             --forge github \
             -v \
             -o json)
           echo "release_output: ${release_output}"
+
+      - name: Clean up released manifest snapshot
+        if: always()
+        shell: bash
+        run: |
+          git worktree remove --force "${RUNNER_TEMP}/release-plz-registry-manifest"


### PR DESCRIPTION
## Summary
- check out the latest `v*` tag into a temp worktree during the release workflow
- pass that tagged `Cargo.toml` to `release-plz` via `--registry-manifest-path`
- keep the earlier verbose logging so release-pr failures remain visible

## Why
This workspace does not publish to crates.io, so `release-plz` needs a local released manifest snapshot to diff against. Local testing only planned the `0.11.0` bump when comparing against `v0.10.0` explicitly.

## Validation
- confirmed `release-plz update` only planned the version bump when `--registry-manifest-path` pointed at a checkout of `v0.10.0`
- pushed branch successfully through repo pre-push hooks
