### PR TITLE
fix(release): remove unsupported release-plz flag

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -189,7 +189,6 @@ jobs:
           release_output=$(release-plz release \
             --git-token "${GITHUB_TOKEN}" \
             --config .release-plz.toml \
-            --registry-manifest-path "${{ steps.released_manifest.outputs.manifest_path }}" \
             --forge github \
             -v \
             -o json)


### PR DESCRIPTION
## Summary
Remove the unsupported --registry-manifest-path flag from the release-plz release step.

## Changes
- keep the tagged-manifest baseline on release-pr
- stop passing that flag to release-plz release
- unblock the post-merge Release workflow from creating the actual v0.11.0 release

## Verification
- release-plz 0.3.157 help confirms release does not support --registry-manifest-path
- workflow YAML parses cleanly
- previous main runs 23030169487 and 23030338755 failed on this exact flag mismatch