### PR TITLE
refactor(processor): simplify document and rendering flows

### DIFF
--- a/.beans/csl26-rsw1--clean-up-clippy-warning-hotspots-with-rust-simplify.md
+++ b/.beans/csl26-rsw1--clean-up-clippy-warning-hotspots-with-rust-simplify.md
@@ -1,11 +1,11 @@
 ---
 # csl26-rsw1
 title: Clean up clippy warning hotspots with rust-simplify
-status: todo
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-03-13T22:44:40Z
-updated_at: 2026-03-13T22:44:40Z
+updated_at: 2026-03-14T15:05:00Z
 ---
 
 Follow-up to archived bean `csl26-xtt0` and PR
@@ -61,12 +61,12 @@ Secondary cleanup targets once the engine warnings are materially reduced:
 
 ## Checklist
 
-- [ ] Simplify `crates/citum-engine/src/processor/document/mod.rs`
-  - [ ] reduce `process_document`
-  - [ ] reduce `prepare_note_citation_state`
-- [ ] Simplify `crates/citum-engine/src/processor/rendering.rs`
-  - [ ] reduce `render_grouped_citation_with_format`
-  - [ ] reduce `process_template_request_with_format`
+- [x] Simplify `crates/citum-engine/src/processor/document/mod.rs`
+  - [x] reduce `process_document`
+  - [x] reduce `prepare_note_citation_state`
+- [x] Simplify `crates/citum-engine/src/processor/rendering.rs`
+  - [x] reduce `render_grouped_citation_with_format`
+  - [x] reduce `process_template_request_with_format`
 - [ ] Simplify `crates/citum-engine/src/values/contributor.rs`
   - [ ] reduce `values`
   - [ ] reduce `format_names`
@@ -81,9 +81,9 @@ Secondary cleanup targets once the engine warnings are materially reduced:
   - [ ] reduce `values`
 - [ ] Simplify `crates/citum-engine/src/io.rs`
   - [ ] reduce `load_bibliography_with_sets`
-- [ ] Re-run `cargo clippy --all-targets --all-features -- -D warnings` once the
+- [x] Re-run `cargo clippy --all-targets --all-features -- -D warnings` once the
       current target slice is complete
-- [ ] Archive or update this bean when the warning cleanup frontier changes
+- [x] Archive or update this bean when the warning cleanup frontier changes
 
 ## Rust-Simplify Direction
 
@@ -117,3 +117,10 @@ Secondary cleanup targets once the engine warnings are materially reduced:
 - `processor/tests.rs` may continue migrating toward the crate's BDD naming
   style, but only for behavior-contract tests; low-level unit coverage does not
   need to be renamed wholesale.
+
+## Progress
+
+- 2026-03-14: completed the first processor-focused slice by extracting
+  document bibliography orchestration, note-state preparation helpers, grouped
+  citation assembly helpers, and template-render component helpers; the
+  remaining frontier is `values/*`, `io.rs`, and secondary non-engine targets.

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -269,6 +269,12 @@ impl HtmlPlaceholderRegistry {
     }
 }
 
+#[derive(Debug)]
+struct RenderedDocumentBody {
+    content: String,
+    placeholders: Option<HtmlPlaceholderRegistry>,
+}
+
 #[derive(Debug, Clone)]
 enum NoteOccurrence {
     Manual { label: String, start: usize },
@@ -364,185 +370,179 @@ impl Processor {
             parsed.frontmatter_integral_names.as_ref(),
         );
         let processor = owned_processor.as_ref().unwrap_or(self);
-
-        // Strip any frontmatter from the content passed to rendering.
         let body = &content[parsed.body_start..];
+        if let Some(groups) = parsed.frontmatter_groups.clone() {
+            return processor.process_document_with_frontmatter_groups::<P, F>(
+                body, parsed, groups, parser, format,
+            );
+        }
 
-        // Check what mode we're in before consuming parsed
-        let has_frontmatter = parsed.frontmatter_groups.is_some();
-        let has_blocks = !parsed.bibliography_blocks.is_empty();
+        if !parsed.bibliography_blocks.is_empty() {
+            return processor
+                .process_document_with_bibliography_blocks::<P, F>(body, parsed, parser, format);
+        }
 
-        // Handle frontmatter groups if present (check before inline blocks)
-        if has_frontmatter {
-            let groups = parsed.frontmatter_groups.as_ref().unwrap().clone();
-            let rendered = if matches!(format, DocumentFormat::Html) {
-                let mut placeholders = HtmlPlaceholderRegistry::default();
-                let rendered = if processor.is_note_style() {
-                    processor.process_note_document_html(body, parsed, &mut placeholders)
-                } else {
-                    processor.process_inline_document_html(body, parsed, &mut placeholders)
-                };
-                let bib_content = rewrite_group_headings_for_document(
+        processor.process_document_with_default_bibliography::<P, F>(body, parsed, parser, format)
+    }
+
+    fn process_document_with_frontmatter_groups<P, F>(
+        &self,
+        body: &str,
+        parsed: ParsedDocument,
+        groups: Vec<citum_schema::grouping::BibliographyGroup>,
+        parser: &P,
+        format: DocumentFormat,
+    ) -> String
+    where
+        P: CitationParser,
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        self.render_document_with_trailing_bibliography::<P, F, _>(
+            body,
+            parsed,
+            parser,
+            format,
+            |processor| {
+                rewrite_group_headings_for_document(
                     processor.render_document_bibliography_groups::<F>(&groups),
                     format,
-                );
-                let mut result = rendered;
-                if !bib_content.trim().is_empty() {
-                    let bib_heading = "\n\n# Bibliography\n\n";
-                    result.push_str(bib_heading);
-                    result.push_str(&placeholders.push_block(bib_content));
-                }
-                let html = parser.finalize_html_output(&result);
-                return placeholders.apply(html);
-            } else if processor.is_note_style() {
-                processor.process_note_document::<F>(body, parsed)
-            } else {
-                processor.process_inline_document::<F>(body, parsed)
-            };
+                )
+            },
+        )
+    }
 
-            let bib_content = rewrite_group_headings_for_document(
-                processor.render_document_bibliography_groups::<F>(&groups),
-                format,
-            );
-            let mut result = rendered;
-            if !bib_content.trim().is_empty() {
-                let bib_heading = match format {
-                    DocumentFormat::Latex => "\n\n\\section*{Bibliography}\n\n",
-                    DocumentFormat::Typst => "\n\n= Bibliography\n\n",
-                    _ => "\n\n# Bibliography\n\n",
-                };
-                result.push_str(bib_heading);
-                result.push_str(&bib_content);
-            }
-            let result = rewrite_document_markup_for_typst(result, format);
-            return match format {
-                DocumentFormat::Html => parser.finalize_html_output(&result),
-                DocumentFormat::Djot
-                | DocumentFormat::Plain
-                | DocumentFormat::Latex
-                | DocumentFormat::Typst => result,
-            };
-        }
+    fn process_document_with_bibliography_blocks<P, F>(
+        &self,
+        body: &str,
+        parsed: ParsedDocument,
+        parser: &P,
+        format: DocumentFormat,
+    ) -> String
+    where
+        P: CitationParser,
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        let blocks = parsed.bibliography_blocks.clone();
+        let staged = stage_document_bibliography_blocks(body, &blocks);
+        let parsed_staged = parser.parse_document(&staged, &self.locale);
+        let mut rendered = self.render_document_body::<F>(&staged, parsed_staged, format);
+        self.replace_document_bibliography_blocks::<F>(&mut rendered, &blocks, format);
+        self.finalize_document_output(parser, format, rendered)
+    }
 
-        // Handle inline bibliography blocks
-        if has_blocks {
-            let blocks = parsed.bibliography_blocks.clone();
+    fn process_document_with_default_bibliography<P, F>(
+        &self,
+        body: &str,
+        parsed: ParsedDocument,
+        parser: &P,
+        format: DocumentFormat,
+    ) -> String
+    where
+        P: CitationParser,
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        self.render_document_with_trailing_bibliography::<P, F, _>(
+            body,
+            parsed,
+            parser,
+            format,
+            |processor| processor.render_grouped_bibliography_with_format::<F>(),
+        )
+    }
 
-            // Replace each block with a stable placeholder before citation rendering so
-            // that citation-text length changes don't corrupt the block byte offsets.
-            let mut staged = body.to_string();
-            for (i, block) in blocks.iter().enumerate().rev() {
-                let placeholder = format!("\x00BIBBLOCK{i}\x00");
-                staged.replace_range(block.start..block.end, &placeholder);
-            }
+    fn render_document_with_trailing_bibliography<P, F, B>(
+        &self,
+        body: &str,
+        parsed: ParsedDocument,
+        parser: &P,
+        format: DocumentFormat,
+        render_bibliography: B,
+    ) -> String
+    where
+        P: CitationParser,
+        F: crate::render::format::OutputFormat<Output = String>,
+        B: FnOnce(&Self) -> String,
+    {
+        let mut rendered = self.render_document_body::<F>(body, parsed, format);
+        let bibliography = render_bibliography(self);
+        append_document_bibliography(&mut rendered, format, bibliography);
+        self.finalize_document_output(parser, format, rendered)
+    }
 
-            // Re-parse on the placeholder content so citation offsets are correct.
-            let parsed_staged = parser.parse_document(&staged, &self.locale);
-            let rendered = if matches!(format, DocumentFormat::Html) {
-                let mut placeholders = HtmlPlaceholderRegistry::default();
-                let rendered = if processor.is_note_style() {
-                    processor.process_note_document_html(&staged, parsed_staged, &mut placeholders)
-                } else {
-                    processor.process_inline_document_html(
-                        &staged,
-                        parsed_staged,
-                        &mut placeholders,
-                    )
-                };
-
-                let mut result = rendered;
-                for (i, block) in blocks.iter().enumerate() {
-                    let placeholder = format!("\x00BIBBLOCK{i}\x00");
-                    let rendered_group =
-                        processor.render_document_bibliography_block::<F>(&block.group);
-                    let bib_token = placeholders.push_block(rendered_group.body);
-                    let replacement = if let Some(heading_text) = rendered_group.heading {
-                        format!("## {heading_text}\n\n{bib_token}\n")
-                    } else {
-                        format!("{bib_token}\n")
-                    };
-                    result = result.replace(&placeholder, &replacement);
-                }
-
-                let html = parser.finalize_html_output(&result);
-                return placeholders.apply(html);
-            } else if processor.is_note_style() {
-                processor.process_note_document::<F>(&staged, parsed_staged)
-            } else {
-                processor.process_inline_document::<F>(&staged, parsed_staged)
-            };
-
-            // Swap placeholders for rendered bibliographies.
-            let mut result = rendered;
-            for (i, block) in blocks.iter().enumerate() {
-                let placeholder = format!("\x00BIBBLOCK{i}\x00");
-                let rendered_group =
-                    processor.render_document_bibliography_block::<F>(&block.group);
-                let replacement = if let Some(heading_text) = rendered_group.heading {
-                    let prefix = match format {
-                        DocumentFormat::Latex => format!("\\subsection*{{{heading_text}}}\n\n"),
-                        DocumentFormat::Typst => format!("== {heading_text}\n\n"),
-                        _ => format!("## {heading_text}\n\n"),
-                    };
-                    format!("{prefix}{}\n", rendered_group.body)
-                } else {
-                    format!("{}\n", rendered_group.body)
-                };
-                result = result.replace(&placeholder, &replacement);
-            }
-
-            let result = rewrite_document_markup_for_typst(result, format);
-            return match format {
-                DocumentFormat::Html => parser.finalize_html_output(&result),
-                DocumentFormat::Djot
-                | DocumentFormat::Plain
-                | DocumentFormat::Latex
-                | DocumentFormat::Typst => result,
-            };
-        }
-
-        // Default behavior: append bibliography with heading
-        let rendered = if matches!(format, DocumentFormat::Html) {
+    fn render_document_body<F>(
+        &self,
+        content: &str,
+        parsed: ParsedDocument,
+        format: DocumentFormat,
+    ) -> RenderedDocumentBody
+    where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        if matches!(format, DocumentFormat::Html) {
             let mut placeholders = HtmlPlaceholderRegistry::default();
-            let rendered = if processor.is_note_style() {
-                processor.process_note_document_html(body, parsed, &mut placeholders)
+            let content = if self.is_note_style() {
+                self.process_note_document_html(content, parsed, &mut placeholders)
             } else {
-                processor.process_inline_document_html(body, parsed, &mut placeholders)
+                self.process_inline_document_html(content, parsed, &mut placeholders)
             };
+            return RenderedDocumentBody {
+                content,
+                placeholders: Some(placeholders),
+            };
+        }
 
-            let bib_content = processor.render_grouped_bibliography_with_format::<F>();
-            let mut result = rendered;
-            if !bib_content.trim().is_empty() {
-                result.push_str("\n\n# Bibliography\n\n");
-                result.push_str(&placeholders.push_block(bib_content));
-            }
-            let html = parser.finalize_html_output(&result);
-            return placeholders.apply(html);
-        } else if processor.is_note_style() {
-            processor.process_note_document::<F>(body, parsed)
+        let content = if self.is_note_style() {
+            self.process_note_document::<F>(content, parsed)
         } else {
-            processor.process_inline_document::<F>(body, parsed)
+            self.process_inline_document::<F>(content, parsed)
         };
 
-        let bib_content = processor.render_grouped_bibliography_with_format::<F>();
-        let mut result = rendered;
-        if !bib_content.trim().is_empty() {
-            let bib_heading = match format {
-                DocumentFormat::Latex => "\n\n\\section*{Bibliography}\n\n",
-                DocumentFormat::Typst => "\n\n= Bibliography\n\n",
-                _ => "\n\n# Bibliography\n\n",
-            };
-            result.push_str(bib_heading);
-            result.push_str(&bib_content);
+        RenderedDocumentBody {
+            content,
+            placeholders: None,
         }
-        let result = rewrite_document_markup_for_typst(result, format);
+    }
 
-        match format {
-            DocumentFormat::Html => parser.finalize_html_output(&result),
-            DocumentFormat::Djot
-            | DocumentFormat::Plain
-            | DocumentFormat::Latex
-            | DocumentFormat::Typst => result,
+    fn replace_document_bibliography_blocks<F>(
+        &self,
+        rendered: &mut RenderedDocumentBody,
+        blocks: &[djot::BibliographyBlock],
+        format: DocumentFormat,
+    ) where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        for (index, block) in blocks.iter().enumerate() {
+            let placeholder = bibliography_block_placeholder(index);
+            let rendered_group = self.render_document_bibliography_block::<F>(&block.group);
+            let replacement = render_document_bibliography_block_replacement(
+                rendered.placeholders.as_mut(),
+                format,
+                rendered_group.heading,
+                rendered_group.body,
+            );
+            rendered.content = rendered.content.replace(&placeholder, &replacement);
+        }
+    }
+
+    fn finalize_document_output<P>(
+        &self,
+        parser: &P,
+        format: DocumentFormat,
+        rendered: RenderedDocumentBody,
+    ) -> String
+    where
+        P: CitationParser,
+    {
+        let result = rewrite_document_markup_for_typst(rendered.content, format);
+        match rendered.placeholders {
+            Some(placeholders) => placeholders.apply(parser.finalize_html_output(&result)),
+            None => match format {
+                DocumentFormat::Html => parser.finalize_html_output(&result),
+                DocumentFormat::Djot
+                | DocumentFormat::Plain
+                | DocumentFormat::Latex
+                | DocumentFormat::Typst => result,
+            },
         }
     }
 
@@ -747,119 +747,28 @@ impl Processor {
         &self,
         parsed: &mut ParsedDocument,
     ) -> (Vec<GeneratedNote>, HashMap<String, Vec<usize>>) {
-        let mut used_labels = parsed.manual_note_labels.clone();
-        let mut manual_numbers: HashMap<String, u32> = HashMap::new();
-        let mut manual_citations: HashMap<String, Vec<usize>> = HashMap::new();
-        let mut note_occurrences: Vec<NoteOccurrence> = parsed
-            .manual_note_references
-            .iter()
-            .map(|note| NoteOccurrence::Manual {
-                label: note.label.clone(),
-                start: note.start,
-            })
-            .collect();
+        let (note_occurrences, manual_citations) = collect_note_occurrences(parsed);
+        let generated_notes = assign_note_numbers(parsed, &note_occurrences, &manual_citations);
+        self.apply_note_citation_annotations(parsed, &note_occurrences, &manual_citations);
+        (generated_notes, manual_citations)
+    }
 
-        for (index, parsed_citation) in parsed.citations.iter().enumerate() {
-            match &parsed_citation.placement {
-                CitationPlacement::InlineProse => {
-                    note_occurrences.push(NoteOccurrence::Generated {
-                        citation_index: index,
-                        start: parsed_citation.start,
-                    })
-                }
-                CitationPlacement::ManualFootnote { label } => {
-                    manual_citations
-                        .entry(label.clone())
-                        .or_default()
-                        .push(index);
-                }
-            }
-        }
-
-        for indices in manual_citations.values_mut() {
-            indices.sort_by_key(|index| parsed.citations[*index].start);
-        }
-
-        note_occurrences.sort_by_key(NoteOccurrence::start);
-
-        let mut next_note = 1_u32;
-        let mut generated_notes = Vec::new();
-        for occurrence in &note_occurrences {
-            match occurrence {
-                NoteOccurrence::Manual { label, .. } => {
-                    manual_numbers.entry(label.clone()).or_insert_with(|| {
-                        let current = next_note;
-                        next_note = next_note.saturating_add(1);
-                        current
-                    });
-                }
-                NoteOccurrence::Generated { citation_index, .. } => {
-                    let note_number = next_note;
-                    next_note = next_note.saturating_add(1);
-                    parsed.citations[*citation_index].citation.note_number = Some(note_number);
-                    generated_notes.push(GeneratedNote {
-                        citation_index: *citation_index,
-                        label: next_generated_note_label(&mut used_labels, note_number),
-                        note_number,
-                    });
-                }
-            }
-        }
-
-        // Definitions without a matching in-body reference still need stable note context.
-        let mut orphan_labels: Vec<_> = manual_citations
-            .keys()
-            .filter(|label| !manual_numbers.contains_key(*label))
-            .cloned()
-            .collect();
-        orphan_labels.sort_by_key(|label| {
-            manual_citations
-                .get(label)
-                .and_then(|indices| indices.first())
-                .map(|index| parsed.citations[*index].start)
-                .unwrap_or(usize::MAX)
-        });
-        for label in orphan_labels {
-            manual_numbers.insert(label, {
-                let current = next_note;
-                next_note = next_note.saturating_add(1);
-                current
-            });
-        }
-
-        for (label, indices) in &manual_citations {
-            if let Some(note_number) = manual_numbers.get(label).copied() {
-                for index in indices {
-                    parsed.citations[*index].citation.note_number = Some(note_number);
-                }
-            }
-        }
-
-        let ordered_indices = build_note_order_indices(&note_occurrences, &manual_citations);
-        let mut ordered_citations: Vec<Citation> = ordered_indices
-            .iter()
-            .map(|index| parsed.citations[*index].citation.clone())
-            .collect();
-        let ordered_contexts: Vec<_> = ordered_indices
-            .iter()
-            .map(|index| IntegralNameContext {
-                placement: parsed.citations[*index].placement.clone(),
-                structure: parsed.citations[*index].structure.clone(),
-            })
-            .collect();
+    fn apply_note_citation_annotations(
+        &self,
+        parsed: &mut ParsedDocument,
+        note_occurrences: &[NoteOccurrence],
+        manual_citations: &HashMap<String, Vec<usize>>,
+    ) {
+        let ordered_indices = build_note_order_indices(note_occurrences, manual_citations);
+        let (mut ordered_citations, ordered_contexts) =
+            ordered_note_citations_and_contexts(parsed, &ordered_indices);
         self.annotate_integral_name_states(&mut ordered_citations, &ordered_contexts);
         ordered_citations = self.normalize_note_context(&ordered_citations);
         self.annotate_positions(&mut ordered_citations);
 
-        for (ordered, index) in ordered_citations
-            .into_iter()
-            .zip(ordered_indices.into_iter())
-        {
-            parsed.citations[index].citation = ordered;
+        for (citation, index) in ordered_citations.into_iter().zip(ordered_indices) {
+            parsed.citations[index].citation = citation;
         }
-
-        generated_notes.sort_by_key(|note| note.note_number);
-        (generated_notes, manual_citations)
     }
 
     fn prepare_note_citations<F>(
@@ -1254,6 +1163,238 @@ impl Processor {
             },
         }
     }
+}
+
+fn stage_document_bibliography_blocks(body: &str, blocks: &[djot::BibliographyBlock]) -> String {
+    let mut staged = body.to_string();
+    for (index, block) in blocks.iter().enumerate().rev() {
+        staged.replace_range(
+            block.start..block.end,
+            &bibliography_block_placeholder(index),
+        );
+    }
+    staged
+}
+
+fn bibliography_block_placeholder(index: usize) -> String {
+    format!("\x00BIBBLOCK{index}\x00")
+}
+
+fn append_document_bibliography(
+    rendered: &mut RenderedDocumentBody,
+    format: DocumentFormat,
+    bibliography: String,
+) {
+    if bibliography.trim().is_empty() {
+        return;
+    }
+
+    rendered
+        .content
+        .push_str(document_bibliography_heading(format));
+    if let Some(placeholders) = rendered.placeholders.as_mut() {
+        rendered
+            .content
+            .push_str(&placeholders.push_block(bibliography));
+    } else {
+        rendered.content.push_str(&bibliography);
+    }
+}
+
+fn document_bibliography_heading(format: DocumentFormat) -> &'static str {
+    match format {
+        DocumentFormat::Latex => "\n\n\\section*{Bibliography}\n\n",
+        DocumentFormat::Typst => "\n\n= Bibliography\n\n",
+        DocumentFormat::Plain | DocumentFormat::Djot | DocumentFormat::Html => {
+            "\n\n# Bibliography\n\n"
+        }
+    }
+}
+
+fn render_document_bibliography_block_replacement(
+    placeholders: Option<&mut HtmlPlaceholderRegistry>,
+    format: DocumentFormat,
+    heading: Option<String>,
+    body: String,
+) -> String {
+    if let Some(placeholders) = placeholders {
+        let token = placeholders.push_block(body);
+        return match heading {
+            Some(heading) => format!("## {heading}\n\n{token}\n"),
+            None => format!("{token}\n"),
+        };
+    }
+
+    match heading {
+        Some(heading) => {
+            let prefix = match format {
+                DocumentFormat::Latex => format!("\\subsection*{{{heading}}}\n\n"),
+                DocumentFormat::Typst => format!("== {heading}\n\n"),
+                DocumentFormat::Plain | DocumentFormat::Djot | DocumentFormat::Html => {
+                    format!("## {heading}\n\n")
+                }
+            };
+            format!("{prefix}{body}\n")
+        }
+        None => format!("{body}\n"),
+    }
+}
+
+fn collect_note_occurrences(
+    parsed: &ParsedDocument,
+) -> (Vec<NoteOccurrence>, HashMap<String, Vec<usize>>) {
+    let mut note_occurrences: Vec<NoteOccurrence> = parsed
+        .manual_note_references
+        .iter()
+        .map(|note| NoteOccurrence::Manual {
+            label: note.label.clone(),
+            start: note.start,
+        })
+        .collect();
+    let mut manual_citations: HashMap<String, Vec<usize>> = HashMap::new();
+
+    for (index, parsed_citation) in parsed.citations.iter().enumerate() {
+        match &parsed_citation.placement {
+            CitationPlacement::InlineProse => {
+                note_occurrences.push(NoteOccurrence::Generated {
+                    citation_index: index,
+                    start: parsed_citation.start,
+                });
+            }
+            CitationPlacement::ManualFootnote { label } => {
+                manual_citations
+                    .entry(label.clone())
+                    .or_default()
+                    .push(index);
+            }
+        }
+    }
+
+    for indices in manual_citations.values_mut() {
+        indices.sort_by_key(|index| parsed.citations[*index].start);
+    }
+    note_occurrences.sort_by_key(NoteOccurrence::start);
+
+    (note_occurrences, manual_citations)
+}
+
+fn assign_note_numbers(
+    parsed: &mut ParsedDocument,
+    note_occurrences: &[NoteOccurrence],
+    manual_citations: &HashMap<String, Vec<usize>>,
+) -> Vec<GeneratedNote> {
+    let mut used_labels = parsed.manual_note_labels.clone();
+    let mut manual_numbers: HashMap<String, u32> = HashMap::new();
+    let mut next_note = 1_u32;
+    let mut generated_notes = assign_note_occurrence_numbers(
+        parsed,
+        note_occurrences,
+        &mut used_labels,
+        &mut manual_numbers,
+        &mut next_note,
+    );
+    assign_orphan_manual_note_numbers(
+        parsed,
+        manual_citations,
+        &mut manual_numbers,
+        &mut next_note,
+    );
+    apply_manual_note_numbers(parsed, manual_citations, &manual_numbers);
+    generated_notes.sort_by_key(|note| note.note_number);
+    generated_notes
+}
+
+fn assign_note_occurrence_numbers(
+    parsed: &mut ParsedDocument,
+    note_occurrences: &[NoteOccurrence],
+    used_labels: &mut HashSet<String>,
+    manual_numbers: &mut HashMap<String, u32>,
+    next_note: &mut u32,
+) -> Vec<GeneratedNote> {
+    let mut generated_notes = Vec::new();
+
+    for occurrence in note_occurrences {
+        match occurrence {
+            NoteOccurrence::Manual { label, .. } => {
+                manual_numbers
+                    .entry(label.clone())
+                    .or_insert_with(|| take_next_note_number(next_note));
+            }
+            NoteOccurrence::Generated { citation_index, .. } => {
+                let note_number = take_next_note_number(next_note);
+                parsed.citations[*citation_index].citation.note_number = Some(note_number);
+                generated_notes.push(GeneratedNote {
+                    citation_index: *citation_index,
+                    label: next_generated_note_label(used_labels, note_number),
+                    note_number,
+                });
+            }
+        }
+    }
+
+    generated_notes
+}
+
+fn assign_orphan_manual_note_numbers(
+    parsed: &ParsedDocument,
+    manual_citations: &HashMap<String, Vec<usize>>,
+    manual_numbers: &mut HashMap<String, u32>,
+    next_note: &mut u32,
+) {
+    let mut orphan_labels: Vec<_> = manual_citations
+        .keys()
+        .filter(|label| !manual_numbers.contains_key(*label))
+        .cloned()
+        .collect();
+    orphan_labels.sort_by_key(|label| {
+        manual_citations
+            .get(label)
+            .and_then(|indices| indices.first())
+            .map(|index| parsed.citations[*index].start)
+            .unwrap_or(usize::MAX)
+    });
+
+    for label in orphan_labels {
+        manual_numbers.insert(label, take_next_note_number(next_note));
+    }
+}
+
+fn apply_manual_note_numbers(
+    parsed: &mut ParsedDocument,
+    manual_citations: &HashMap<String, Vec<usize>>,
+    manual_numbers: &HashMap<String, u32>,
+) {
+    for (label, indices) in manual_citations {
+        if let Some(note_number) = manual_numbers.get(label).copied() {
+            for index in indices {
+                parsed.citations[*index].citation.note_number = Some(note_number);
+            }
+        }
+    }
+}
+
+fn ordered_note_citations_and_contexts(
+    parsed: &ParsedDocument,
+    ordered_indices: &[usize],
+) -> (Vec<Citation>, Vec<IntegralNameContext>) {
+    let citations = ordered_indices
+        .iter()
+        .map(|index| parsed.citations[*index].citation.clone())
+        .collect();
+    let contexts = ordered_indices
+        .iter()
+        .map(|index| IntegralNameContext {
+            placement: parsed.citations[*index].placement.clone(),
+            structure: parsed.citations[*index].structure.clone(),
+        })
+        .collect();
+    (citations, contexts)
+}
+
+fn take_next_note_number(next_note: &mut u32) -> u32 {
+    let current = *next_note;
+    *next_note = (*next_note).saturating_add(1);
+    current
 }
 
 fn merge_note_rule(default: NoteRule, config: &StyleNoteConfig) -> NoteRule {

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -146,6 +146,32 @@ struct TemplateRenderRequest<'a> {
     integral_name_state: Option<citum_schema::citation::IntegralNameState>,
 }
 
+#[derive(Default)]
+struct TemplateComponentTracker {
+    rendered_vars: HashSet<String>,
+    substituted_bases: HashSet<String>,
+}
+
+impl TemplateComponentTracker {
+    fn should_skip(&self, var_key: Option<&str>) -> bool {
+        let Some(var_key) = var_key else {
+            return false;
+        };
+        let base = key_base(var_key);
+        self.rendered_vars.contains(var_key) || self.substituted_bases.contains(&base)
+    }
+
+    fn mark_rendered(&mut self, var_key: Option<String>, substituted_key: Option<&str>) {
+        if let Some(var_key) = var_key {
+            self.rendered_vars.insert(var_key);
+        }
+        if let Some(substituted_key) = substituted_key {
+            self.rendered_vars.insert(substituted_key.to_string());
+            self.substituted_bases.insert(key_base(substituted_key));
+        }
+    }
+}
+
 impl<'a> Renderer<'a> {
     /// Creates a new `Renderer` instance.
     pub fn new(
@@ -877,7 +903,6 @@ impl<'a> Renderer<'a> {
         let groups: Vec<(String, Vec<&CitationItem>)> = group_citation_items_by_author(self, items);
 
         let mut rendered_groups = Vec::new();
-        let fmt = F::default();
 
         for (_author_key, group) in groups {
             let first_item = group[0];
@@ -926,93 +951,18 @@ impl<'a> Renderer<'a> {
                 continue;
             }
 
-            // Fallback to default hardcoded grouping (or if no integral template)
-            let author_part = self.render_author_for_grouping_with_format::<F>(
+            if let Some(citation) = self.render_fallback_grouped_citation_with_format::<F>(
+                &group,
                 first_ref,
                 first_item,
                 template,
-                mode,
-                suppress_author,
-                position,
-            );
-
-            let (item_parts, group_delimiter) = self.render_group_item_parts_with_format::<F>(
-                &fmt,
-                &group,
                 spec,
                 mode,
+                intra_delimiter,
                 suppress_author,
                 position,
-                intra_delimiter,
-            )?;
-
-            let group_ids: Vec<String> = group.iter().map(|item| item.id.clone()).collect();
-            let prefix = first_item.prefix.as_deref().unwrap_or("");
-            if !author_part.is_empty() && !item_parts.is_empty() {
-                let author_item_delimiter = group_delimiter.as_deref().unwrap_or(intra_delimiter);
-                let repeated_item_delimiter = if author_item_delimiter.trim().is_empty() {
-                    ", "
-                } else {
-                    author_item_delimiter
-                };
-                let joined_items = item_parts.join(repeated_item_delimiter);
-                // Format based on citation mode:
-                // Integral: "Kuhn (1962a, 1962b)" - items in parentheses
-                // NonIntegral: "Kuhn, 1962a, 1962b" - no inner parens (outer wrap adds them)
-                let content = match mode {
-                    citum_schema::citation::CitationMode::Integral => {
-                        // Check for visibility overrides
-                        if suppress_author {
-                            // Should theoretically not happen in narrative mode, but handle gracefully
-                            format!("({})", joined_items)
-                        } else {
-                            // Default narrative: Kuhn (1962)
-                            format!("{} ({})", author_part, joined_items)
-                        }
-                    }
-                    citum_schema::citation::CitationMode::NonIntegral => {
-                        if suppress_author {
-                            // Parenthetical SuppressAuthor: 1962
-                            joined_items
-                        } else {
-                            // Default parenthetical: Kuhn, 1962
-                            if self.config.punctuation_in_quote
-                                && author_item_delimiter.starts_with(',')
-                                && (author_part.ends_with('"') || author_part.ends_with('\u{201D}'))
-                            {
-                                let is_curly = author_part.ends_with('\u{201D}');
-                                let quote_char = if is_curly { '\u{201D}' } else { '"' };
-                                let trimmed =
-                                    &author_part[..author_part.len() - quote_char.len_utf8()];
-                                format!(
-                                    "{},{}{}{}",
-                                    trimmed,
-                                    quote_char,
-                                    &author_item_delimiter[1..],
-                                    joined_items
-                                )
-                            } else {
-                                format!("{}{}{}", author_part, author_item_delimiter, joined_items)
-                            }
-                        }
-                    }
-                };
-                let ids = group_ids.clone();
-                let content = self.affix_content(&fmt, content, Some(prefix), None);
-                rendered_groups.push(fmt.citation(ids, content));
-            } else if !author_part.is_empty() {
-                let ids = group_ids.clone();
-                rendered_groups.push(fmt.citation(
-                    ids,
-                    self.affix_content(&fmt, author_part, Some(prefix), None),
-                ));
-            } else if !item_parts.is_empty() {
-                // Item-only case (SuppressAuthor)
-                let content = item_parts.join(intra_delimiter);
-                rendered_groups.push(fmt.citation(
-                    group_ids,
-                    self.affix_content(&fmt, content, Some(prefix), None),
-                ));
+            )? {
+                rendered_groups.push(citation);
             }
         }
 
@@ -1309,16 +1259,201 @@ impl<'a> Renderer<'a> {
             locator: locator.as_deref(),
             locator_label,
         };
+        let hint = self.build_template_render_hint(
+            reference,
+            options.context,
+            citation_number,
+            position,
+            integral_name_state,
+        );
+        let ref_type = reference.ref_type().to_string();
+        let mut tracker = TemplateComponentTracker::default();
+        let components: Vec<ProcTemplateComponent> = template
+            .iter()
+            .filter_map(|component| {
+                self.render_template_component_with_format::<F>(
+                    reference,
+                    &ref_type,
+                    &options,
+                    &hint,
+                    component,
+                    &mut tracker,
+                )
+            })
+            .collect();
+
+        if components.is_empty() {
+            None
+        } else {
+            Some(components)
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn render_fallback_grouped_citation_with_format<F>(
+        &self,
+        group: &[&crate::reference::CitationItem],
+        first_ref: &Reference,
+        first_item: &crate::reference::CitationItem,
+        template: &[TemplateComponent],
+        spec: &citum_schema::CitationSpec,
+        mode: &citum_schema::citation::CitationMode,
+        intra_delimiter: &str,
+        suppress_author: bool,
+        position: Option<&citum_schema::citation::Position>,
+    ) -> Result<Option<String>, ProcessorError>
+    where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        let fmt = F::default();
+        let author_part = self.render_author_for_grouping_with_format::<F>(
+            first_ref,
+            first_item,
+            template,
+            mode,
+            suppress_author,
+            position,
+        );
+        let (item_parts, group_delimiter) = self.render_group_item_parts_with_format::<F>(
+            &fmt,
+            group,
+            spec,
+            mode,
+            suppress_author,
+            position,
+            intra_delimiter,
+        )?;
+        let Some(content) = self.build_grouped_citation_content(
+            &author_part,
+            &item_parts,
+            mode,
+            intra_delimiter,
+            group_delimiter.as_deref(),
+            suppress_author,
+        ) else {
+            return Ok(None);
+        };
+        let group_ids = group.iter().map(|item| item.id.clone()).collect();
+        let prefix = first_item.prefix.as_deref().unwrap_or("");
+
+        Ok(Some(fmt.citation(
+            group_ids,
+            self.affix_content(&fmt, content, Some(prefix), None),
+        )))
+    }
+
+    fn build_grouped_citation_content(
+        &self,
+        author_part: &str,
+        item_parts: &[String],
+        mode: &citum_schema::citation::CitationMode,
+        intra_delimiter: &str,
+        group_delimiter: Option<&str>,
+        suppress_author: bool,
+    ) -> Option<String> {
+        if !author_part.is_empty() && !item_parts.is_empty() {
+            let author_item_delimiter = group_delimiter.unwrap_or(intra_delimiter);
+            let repeated_item_delimiter = if author_item_delimiter.trim().is_empty() {
+                ", "
+            } else {
+                author_item_delimiter
+            };
+            let joined_items = item_parts.join(repeated_item_delimiter);
+            return Some(match mode {
+                citum_schema::citation::CitationMode::Integral => {
+                    self.format_integral_grouped_items(author_part, &joined_items, suppress_author)
+                }
+                citum_schema::citation::CitationMode::NonIntegral => self
+                    .format_non_integral_grouped_items(
+                        author_part,
+                        author_item_delimiter,
+                        &joined_items,
+                        suppress_author,
+                    ),
+            });
+        }
+
+        if !author_part.is_empty() {
+            return Some(author_part.to_string());
+        }
+
+        if !item_parts.is_empty() {
+            return Some(item_parts.join(intra_delimiter));
+        }
+
+        None
+    }
+
+    fn format_integral_grouped_items(
+        &self,
+        author_part: &str,
+        joined_items: &str,
+        suppress_author: bool,
+    ) -> String {
+        if suppress_author {
+            format!("({joined_items})")
+        } else {
+            format!("{author_part} ({joined_items})")
+        }
+    }
+
+    fn format_non_integral_grouped_items(
+        &self,
+        author_part: &str,
+        author_item_delimiter: &str,
+        joined_items: &str,
+        suppress_author: bool,
+    ) -> String {
+        if suppress_author {
+            return joined_items.to_string();
+        }
+
+        if let Some(adjusted) =
+            self.adjust_grouped_author_quote_punctuation(author_part, author_item_delimiter)
+        {
+            return format!("{adjusted}{joined_items}");
+        }
+
+        format!("{author_part}{author_item_delimiter}{joined_items}")
+    }
+
+    fn adjust_grouped_author_quote_punctuation(
+        &self,
+        author_part: &str,
+        author_item_delimiter: &str,
+    ) -> Option<String> {
+        if !self.config.punctuation_in_quote
+            || !author_item_delimiter.starts_with(',')
+            || !(author_part.ends_with('"') || author_part.ends_with('\u{201D}'))
+        {
+            return None;
+        }
+
+        let is_curly = author_part.ends_with('\u{201D}');
+        let quote_char = if is_curly { '\u{201D}' } else { '"' };
+        let trimmed = &author_part[..author_part.len() - quote_char.len_utf8()];
+        Some(format!(
+            "{trimmed},{quote_char}{}",
+            &author_item_delimiter[1..]
+        ))
+    }
+
+    fn build_template_render_hint(
+        &self,
+        reference: &Reference,
+        context: RenderContext,
+        citation_number: usize,
+        position: Option<citum_schema::citation::Position>,
+        integral_name_state: Option<citum_schema::citation::IntegralNameState>,
+    ) -> ProcHints {
         let default_hint = ProcHints::default();
         let base_hint = self
             .hints
             .get(&reference.id().unwrap_or_default())
             .unwrap_or(&default_hint);
-
-        // Create a hint with citation number and position
-        let hint = ProcHints {
+        ProcHints {
             citation_number: (citation_number > 0).then_some(citation_number),
-            citation_sub_label: if options.context == RenderContext::Citation {
+            citation_sub_label: if context == RenderContext::Citation {
                 reference
                     .id()
                     .as_deref()
@@ -1329,93 +1464,94 @@ impl<'a> Renderer<'a> {
             position,
             integral_name_state,
             ..base_hint.clone()
-        };
+        }
+    }
 
-        // Track rendered variables to prevent duplicates (CSL 1.0 spec:
-        // "Substituted variables are suppressed in the rest of the output")
-        let mut rendered_vars: HashSet<String> = HashSet::new();
-        // Track base keys of substituted variables so they suppress all contextual
-        // variants (for example "title:Primary" should suppress title with suffixes).
-        let mut substituted_bases: HashSet<String> = HashSet::new();
+    fn render_template_component_with_format<F>(
+        &self,
+        reference: &Reference,
+        ref_type: &str,
+        options: &RenderOptions<'_>,
+        hint: &ProcHints,
+        component: &TemplateComponent,
+        tracker: &mut TemplateComponentTracker,
+    ) -> Option<ProcTemplateComponent>
+    where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        let resolved_component = resolve_component_for_ref_type(component, ref_type);
+        let var_key = get_variable_key(&resolved_component);
+        if tracker.should_skip(var_key.as_deref()) {
+            return None;
+        }
 
-        let components: Vec<ProcTemplateComponent> = template
-            .iter()
-            .filter_map(|component| {
-                let ref_type = reference.ref_type().to_string();
-                let resolved_component = resolve_component_for_ref_type(component, &ref_type);
-                // Get unique key for this variable (e.g., "contributor:Author")
-                let var_key = get_variable_key(&resolved_component);
+        let mut values = resolved_component.values::<F>(reference, hint, options)?;
+        if values.value.is_empty() {
+            return None;
+        }
+        self.apply_issued_no_date_fallback(reference, options, &resolved_component, &mut values);
+        self.apply_entry_link_fallback(reference, options, &mut values);
 
-                // Skip if this variable was already rendered
-                if let Some(ref key) = var_key {
-                    let base = key_base(key);
-                    if rendered_vars.contains(key) || substituted_bases.contains(&base) {
-                        return None;
-                    }
-                }
+        let item_language =
+            crate::values::effective_component_language(reference, &resolved_component);
+        tracker.mark_rendered(var_key, values.substituted_key.as_deref());
 
-                // Extract value from reference using the requested format
-                let mut values = resolved_component.values::<F>(reference, &hint, &options)?;
-                if values.value.is_empty() {
-                    return None;
-                }
-                if matches!(
-                    resolved_component,
-                    TemplateComponent::Date(citum_schema::template::TemplateDate {
-                        date: citum_schema::template::DateVariable::Issued,
-                        ..
-                    })
-                ) && reference.issued().is_none_or(|issued| issued.0.is_empty())
-                    && self.preferred_no_date_term_form() == citum_schema::locale::TermForm::Long
-                    && let Some(long) = options.locale.general_term(
-                        &citum_schema::locale::GeneralTerm::NoDate,
-                        citum_schema::locale::TermForm::Long,
-                    )
-                {
-                    values.value = long.to_string();
-                }
-                let item_language =
-                    crate::values::effective_component_language(reference, &resolved_component);
+        Some(ProcTemplateComponent {
+            template_component: resolved_component,
+            value: values.value,
+            prefix: values.prefix,
+            suffix: values.suffix,
+            url: values.url,
+            ref_type: Some(ref_type.to_string()),
+            config: Some(options.config.clone()),
+            item_language,
+            pre_formatted: values.pre_formatted,
+        })
+    }
 
-                // If whole-entry linking is enabled and this component doesn't have a URL,
-                // try to resolve it from global config.
-                if values.url.is_none()
-                    && let Some(links) = &options.config.links
-                {
-                    use citum_schema::options::LinkAnchor;
-                    if matches!(links.anchor, Some(LinkAnchor::Entry)) {
-                        values.url = crate::values::resolve_url(links, reference);
-                    }
-                }
-
-                // Mark variable as rendered for deduplication
-                if let Some(key) = var_key {
-                    rendered_vars.insert(key);
-                }
-                // Also mark substituted variable (e.g., title when it replaces author)
-                if let Some(sub_key) = &values.substituted_key {
-                    rendered_vars.insert(sub_key.clone());
-                    substituted_bases.insert(key_base(sub_key));
-                }
-
-                Some(ProcTemplateComponent {
-                    template_component: resolved_component,
-                    value: values.value,
-                    prefix: values.prefix,
-                    suffix: values.suffix,
-                    url: values.url,
-                    ref_type: Some(ref_type),
-                    config: Some(options.config.clone()),
-                    item_language,
-                    pre_formatted: values.pre_formatted,
-                })
+    fn apply_issued_no_date_fallback(
+        &self,
+        reference: &Reference,
+        options: &RenderOptions<'_>,
+        component: &TemplateComponent,
+        values: &mut crate::values::ProcValues<String>,
+    ) {
+        if !matches!(
+            component,
+            TemplateComponent::Date(citum_schema::template::TemplateDate {
+                date: citum_schema::template::DateVariable::Issued,
+                ..
             })
-            .collect();
+        ) || !reference.issued().is_none_or(|issued| issued.0.is_empty())
+            || self.preferred_no_date_term_form() != citum_schema::locale::TermForm::Long
+        {
+            return;
+        }
 
-        if components.is_empty() {
-            None
-        } else {
-            Some(components)
+        if let Some(long) = options.locale.general_term(
+            &citum_schema::locale::GeneralTerm::NoDate,
+            citum_schema::locale::TermForm::Long,
+        ) {
+            values.value = long.to_string();
+        }
+    }
+
+    fn apply_entry_link_fallback(
+        &self,
+        reference: &Reference,
+        options: &RenderOptions<'_>,
+        values: &mut crate::values::ProcValues<String>,
+    ) {
+        if values.url.is_some() {
+            return;
+        }
+
+        let Some(links) = &options.config.links else {
+            return;
+        };
+        use citum_schema::options::LinkAnchor;
+        if matches!(links.anchor, Some(LinkAnchor::Entry)) {
+            values.url = crate::values::resolve_url(links, reference);
         }
     }
 


### PR DESCRIPTION
## Summary
- extract document-level bibliography orchestration and note-state helper phases
- split grouped citation fallback assembly and template render processing into smaller helpers
- update bean csl26-rsw1 to record the completed processor-focused slice

## Test plan
- [x] cargo fmt
- [x] cargo test -p citum-engine --test document
- [x] cargo test -p citum-engine --lib
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo nextest run