### PR TITLE
chore(lints): centralize doc lint enforcement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,25 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [workspace.lints.rust]
+missing_docs = "deny"
 unsafe_code = "warn"
+
+[workspace.lints.rustdoc]
+bare_urls = "warn"
+broken_intra_doc_links = "deny"
+invalid_html_tags = "warn"
+missing_crate_level_docs = "warn"
+private_intra_doc_links = "warn"
+redundant_explicit_links = "warn"
+unescaped_backticks = "warn"
+
+[workspace.lints.clippy]
+empty_docs = "deny"
+four_forward_slashes = "deny"
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+missing_safety_doc = "deny"
+tabs_in_doc_comments = "deny"
 
 [profile.release]
 opt-level = 3

--- a/crates/citum-analyze/Cargo.toml
+++ b/crates/citum-analyze/Cargo.toml
@@ -21,3 +21,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 walkdir = "2.4"
+
+[lints]
+workspace = true

--- a/crates/citum-analyze/src/batch_test.rs
+++ b/crates/citum-analyze/src/batch_test.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -99,6 +99,11 @@ pub fn render_bibliography(style_yaml: &str, refs_json: &str) -> Result<String, 
 /// Checks that the style parses correctly against the Citum schema. Returns
 /// `Ok(())` when valid, or `Err` with a list of error messages when not.
 ///
+/// # Errors
+///
+/// Returns an error string when the YAML cannot be parsed into a valid Citum
+/// style.
+///
 /// # Example (JS/WASM)
 ///
 /// ```js

--- a/crates/citum-bindings/tests/integration.rs
+++ b/crates/citum-bindings/tests/integration.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /// Integration tests for citum-bindings.
 ///
 /// These tests verify the public API using minimal inline fixtures that match

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -32,3 +32,6 @@ typst-kit = { version = "0.13.1", optional = true, default-features = false, fea
 default = []
 schema = ["dep:schemars", "citum_schema/schema"]
 typst-pdf = ["dep:typst", "dep:typst-pdf", "dep:typst-kit"]
+
+[lints]
+workspace = true

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_engine::{
     Bibliography, Citation, CitationItem, DocumentFormat, Processor,
     io::{

--- a/crates/citum-edtf/src/lib.rs
+++ b/crates/citum-edtf/src/lib.rs
@@ -1,8 +1,6 @@
 //! citum_edtf - A modern EDTF (Extended Date/Time Format) parser
 //!
 //! This crate implements ISO 8601-2:2019 (EDTF) Level 0 and Level 1.
-#![deny(missing_docs)]
-
 use winnow::ascii::dec_int;
 use winnow::combinator::{alt, opt};
 use winnow::error::{ContextError, ErrMode};
@@ -425,6 +423,11 @@ fn parse_time(input: &mut &str) -> Result<Time, ErrMode<ContextError>> {
 ///
 /// This parser consumes only the recognized prefix and leaves any remaining
 /// input in `input`, following `winnow` parser conventions.
+///
+/// # Errors
+///
+/// Returns an error when the input does not begin with a valid EDTF date or
+/// datetime production.
 pub fn parse_date(input: &mut &str) -> Result<Date, ErrMode<ContextError>> {
     let year = parse_year.parse_next(input)?;
     let year_quality = parse_quality.parse_next(input)?;
@@ -485,6 +488,11 @@ pub fn parse_date(input: &mut &str) -> Result<Date, ErrMode<ContextError>> {
 ///
 /// This parser accepts a single date, a closed interval, or an open-ended
 /// interval and leaves any unconsumed suffix in `input`.
+///
+/// # Errors
+///
+/// Returns an error when the input does not begin with a valid EDTF date or
+/// interval production.
 pub fn parse(input: &mut &str) -> Result<Edtf, ErrMode<ContextError>> {
     if input.starts_with("../") {
         let _ = "../".parse_next(input)?;

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_engine::processor::disambiguation::Disambiguator;
 use citum_engine::{
     Bibliography, Citation, CitationItem, Contributor, EdtfString, Locale, Monograph,

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_engine::processor::Processor;
 use citum_engine::render::latex::Latex;
 use citum_schema::{

--- a/crates/citum-engine/src/io.rs
+++ b/crates/citum-engine/src/io.rs
@@ -106,6 +106,11 @@ pub fn render_rich_text_field<F: OutputFormat<Output = String>>(src: &str, fmt: 
 
 /// Load a list of citations from a file.
 /// Supports Citum YAML/JSON.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read or when its contents are not
+/// valid citation data in a supported format.
 pub fn load_citations(path: &Path) -> Result<Vec<Citation>, ProcessorError> {
     let bytes = fs::read(path)?;
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
@@ -149,6 +154,11 @@ pub fn load_citations(path: &Path) -> Result<Vec<Citation>, ProcessorError> {
 
 /// Load annotations from a file (YAML or JSON).
 /// Returns a mapping from reference ID to annotation text.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read or when its contents are not
+/// valid annotation data in a supported format.
 pub fn load_annotations(path: &Path) -> Result<HashMap<String, String>, ProcessorError> {
     let bytes = fs::read(path)?;
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
@@ -178,6 +188,11 @@ pub fn load_annotations(path: &Path) -> Result<HashMap<String, String>, Processo
 /// - Every member ID must exist in `bibliography`.
 /// - A member ID must not appear more than once in a single set.
 /// - A member ID must not appear across multiple sets.
+///
+/// # Errors
+///
+/// Returns an error when a compound set references an unknown ID or reuses the
+/// same member within or across sets.
 pub fn validate_compound_sets(
     sets: Option<IndexMap<String, Vec<String>>>,
     bibliography: &Bibliography,
@@ -238,6 +253,11 @@ fn loaded_from_input_bibliography(
 
 /// Load bibliography data from a file path, including optional compound sets.
 /// Supports Citum YAML/JSON/CBOR and CSL-JSON.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read, when its contents do not
+/// match a supported bibliography format, or when compound sets are invalid.
 pub fn load_bibliography_with_sets(path: &Path) -> Result<LoadedBibliography, ProcessorError> {
     let bytes = fs::read(path)?;
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
@@ -395,6 +415,11 @@ pub fn load_bibliography_with_sets(path: &Path) -> Result<LoadedBibliography, Pr
 
 /// Load a bibliography from a file given its path.
 /// Supports Citum YAML/JSON/CBOR and CSL-JSON.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read, its contents cannot be
+/// parsed, or embedded compound-set metadata is invalid.
 pub fn load_bibliography(path: &Path) -> Result<Bibliography, ProcessorError> {
     Ok(load_bibliography_with_sets(path)?.references)
 }

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -3,8 +3,6 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-#![deny(missing_docs)]
-
 //! Citum Processor
 //!
 //! This crate provides the core citation and bibliography processing functionality

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -281,6 +281,10 @@ impl Processor {
     /// 4. Applying the style's citation template.
     ///
     /// Returns the formatted citation string or an error if processing fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when referenced items are missing or rendering fails.
     pub fn process_citation(&self, citation: &Citation) -> Result<String, ProcessorError> {
         self.process_citation_with_format::<crate::render::plain::PlainText>(citation)
     }
@@ -290,6 +294,10 @@ impl Processor {
     /// This resolves the effective citation spec for the citation's mode and
     /// position, renders the citation body, applies input and style affixes,
     /// and finally applies note-style casing when required.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when referenced items are missing or rendering fails.
     pub fn process_citation_with_format<F>(
         &self,
         citation: &Citation,
@@ -318,11 +326,19 @@ impl Processor {
     /// Render multiple citations in document order.
     ///
     /// For note-based styles, normalizes context and assigns citation positions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any citation in the sequence fails to render.
     pub fn process_citations(&self, citations: &[Citation]) -> Result<Vec<String>, ProcessorError> {
         self.process_citations_with_format::<crate::render::plain::PlainText>(citations)
     }
 
     /// Render multiple citations with a custom output format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any citation in the sequence fails to render.
     pub fn process_citations_with_format<F>(
         &self,
         citations: &[Citation],

--- a/crates/citum-engine/src/processor/rendering.rs
+++ b/crates/citum-engine/src/processor/rendering.rs
@@ -644,6 +644,11 @@ impl<'a> Renderer<'a> {
     }
 
     /// Render citation items without grouping, using plain text format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced item is missing or item rendering
+    /// fails.
     pub fn render_ungrouped_citation(
         &self,
         items: &[crate::reference::CitationItem],
@@ -667,6 +672,11 @@ impl<'a> Renderer<'a> {
     ///
     /// This is the core logic for iterating over citation items, looking up references,
     /// and applying the appropriate template or fallback logic.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced item is missing or item rendering
+    /// fails.
     pub fn render_ungrouped_citation_with_format<F>(
         &self,
         items: &[crate::reference::CitationItem],
@@ -751,6 +761,11 @@ impl<'a> Renderer<'a> {
     }
 
     /// Render citation items with author grouping for author-date styles.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced item is missing or grouped rendering
+    /// fails.
     pub fn render_grouped_citation(
         &self,
         items: &[crate::reference::CitationItem],
@@ -883,6 +898,11 @@ impl<'a> Renderer<'a> {
     /// This preserves per-item output when grouping rules require items to stay
     /// separate, and otherwise applies the requested renderer format to the
     /// grouped citation output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a referenced item is missing or grouped rendering
+    /// fails.
     pub fn render_grouped_citation_with_format<F>(
         &self,
         items: &[crate::reference::CitationItem],

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -229,6 +229,11 @@ impl Processor {
     }
 
     /// Create a new processor with explicit compound sets, returning an error for invalid sets.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any compound set references unknown bibliography
+    /// entries or reuses the same member more than once.
     pub fn try_with_compound_sets(
         style: Style,
         bibliography: Bibliography,
@@ -259,6 +264,11 @@ impl Processor {
 
     /// Create a new processor with explicit locale and compound sets, returning
     /// an error for invalid sets.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any compound set references unknown bibliography
+    /// entries or reuses the same member more than once.
     pub fn try_with_locale_and_compound_sets(
         style: Style,
         bibliography: Bibliography,

--- a/crates/citum-engine/src/values/contributor.rs
+++ b/crates/citum-engine/src/values/contributor.rs
@@ -628,6 +628,12 @@ impl ComponentValues for TemplateContributor {
 
 /// Format a list of names according to style options.
 #[allow(clippy::too_many_arguments)]
+///
+/// # Panics
+///
+/// This function assumes the non-empty input check at the top remains in place;
+/// violating that invariant can trigger indexing or `unwrap()` panics in later
+/// formatting branches.
 pub fn format_names(
     names: &[crate::reference::FlatName],
     form: &ContributorForm,

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -1,8 +1,8 @@
+#![allow(missing_docs)]
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
-
 #![allow(dead_code)]
 
 use std::{fs, path::PathBuf};

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/domain_fixtures.rs
+++ b/crates/citum-engine/tests/domain_fixtures.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/multilingual_names.rs
+++ b/crates/citum-engine/tests/multilingual_names.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-migrate/Cargo.toml
+++ b/crates/citum-migrate/Cargo.toml
@@ -16,3 +16,6 @@ roxmltree = "0.20"
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 serde = { version = "1.0", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/citum-migrate/src/bin/migrate_all.rs
+++ b/crates/citum-migrate/src/bin/migrate_all.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_migrate::{MacroInliner, Upsampler};
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;

--- a/crates/citum-migrate/src/bin/update_style_info.rs
+++ b/crates/citum-migrate/src/bin/update_style_info.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_migrate::InfoExtractor;
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use csl_legacy::model::{CslNode, Style};
 use std::collections::HashMap;
 

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_migrate::{
     Compressor, MacroInliner, OptionsExtractor, TemplateCompiler, Upsampler, analysis,
     debug_output::DebugOutputFormatter, passes, preset_detector, provenance::ProvenanceTracker,

--- a/crates/citum-migrate/tests/date_inference.rs
+++ b/crates/citum-migrate/tests/date_inference.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_migrate::options_extractor::OptionsExtractor;
 use citum_schema::options::MonthFormat;
 use csl_legacy::model::{Citation, CslNode, Date, DatePart, Formatting, Info, Layout, Style};

--- a/crates/citum-migrate/tests/substitute_extraction.rs
+++ b/crates/citum-migrate/tests/substitute_extraction.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_migrate::options_extractor::OptionsExtractor;
 use citum_schema::options::SubstituteKey;
 use csl_legacy::model::{

--- a/crates/citum-migrate/tests/term_mapping.rs
+++ b/crates/citum-migrate/tests/term_mapping.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_migrate::{TemplateCompiler, Upsampler};
 use citum_schema::CslnNode;
 use citum_schema::locale::{GeneralTerm, TermForm};

--- a/crates/citum-migrate/tests/variable_once.rs
+++ b/crates/citum-migrate/tests/variable_once.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-schema-style/Cargo.toml
+++ b/crates/citum-schema-style/Cargo.toml
@@ -26,3 +26,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "formats"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/citum-schema-style/benches/formats.rs
+++ b/crates/citum-schema-style/benches/formats.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_schema_style::{InputBibliography, Style};
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::fs;

--- a/crates/citum-schema-style/src/bin/render_demo.rs
+++ b/crates/citum-schema-style/src/bin/render_demo.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_schema_style::renderer::RenderItem;
 use citum_schema_style::{CslnStyle, ItemType, Renderer, Variable};
 use std::collections::HashMap;

--- a/crates/citum-schema-style/src/citation.rs
+++ b/crates/citum-schema-style/src/citation.rs
@@ -335,6 +335,10 @@ impl CitationLocator {
     }
 
     /// Create a compound locator with two or more segments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when fewer than two locator segments are supplied.
     pub fn compound(segments: Vec<LocatorSegment>) -> Result<Self, &'static str> {
         if segments.len() < 2 {
             return Err("compound locators must contain at least two segments");
@@ -426,6 +430,11 @@ impl CitationItem {
 }
 
 /// Normalize a textual locator string into the canonical locator model.
+///
+/// # Panics
+///
+/// This function does not panic under normal use; the internal `unwrap` is
+/// guarded by the preceding segment-count match.
 pub fn normalize_locator_text(
     locator: &str,
     locale: &crate::locale::Locale,

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -15,16 +15,20 @@ pub mod citation;
 /// Bibliography grouping and sorting specifications.
 pub mod grouping;
 /// Legacy CSL 1.0 compatibility types.
+#[allow(missing_docs)]
 pub mod legacy;
 /// Locale-specific terms and translations.
 pub mod locale;
 /// Style configuration options.
+#[allow(missing_docs)]
 pub mod options;
 /// Configuration presets for common styles.
 pub mod presets;
 /// Bibliographic reference data types.
+#[allow(missing_docs)]
 pub mod reference;
 /// Citation and bibliography template components.
+#[allow(missing_docs)]
 pub mod template;
 
 /// Embedded templates for priority styles (APA, Chicago, Vancouver, IEEE, Harvard).

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -439,6 +439,10 @@ impl Locale {
 
 impl Locale {
     /// Load a locale from a YAML string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the YAML cannot be parsed into a locale.
     pub fn from_yaml_str(yaml: &str) -> Result<Self, String> {
         let raw: raw::RawLocale = serde_yaml::from_str(yaml)
             .map_err(|e| format!("Failed to parse locale YAML: {}", e))?;
@@ -491,6 +495,11 @@ impl Locale {
     }
 
     /// Load locale from a file path directly (detects format).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file cannot be read or its contents cannot be
+    /// parsed as a supported locale format.
     pub fn from_file(path: &std::path::Path) -> Result<Self, String> {
         let bytes =
             std::fs::read(path).map_err(|e| format!("Failed to read locale file: {}", e))?;

--- a/crates/citum-schema-style/tests/json_deserialization.rs
+++ b/crates/citum-schema-style/tests/json_deserialization.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_schema_style::citation::{CitationItem, IntegralNameState};
 use citum_schema_style::options::{IntegralNameContexts, IntegralNameRule, IntegralNameScope};
 use citum_schema_style::reference::{InputReference, Monograph};

--- a/crates/citum-schema-style/tests/parent_reference.rs
+++ b/crates/citum-schema-style/tests/parent_reference.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_schema_style::reference::{
     CollectionComponent, EdtfString, MonographComponentType, Parent, SerialComponent,
     SerialComponentType, Title,

--- a/crates/citum-schema-style/tests/verify_examples.rs
+++ b/crates/citum-schema-style/tests/verify_examples.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::fs;
 use std::path::PathBuf;
 

--- a/crates/citum-schema/benches/formats.rs
+++ b/crates/citum-schema/benches/formats.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_schema::{InputBibliography, Style};
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::fs;

--- a/crates/citum-schema/tests/json_deserialization.rs
+++ b/crates/citum-schema/tests/json_deserialization.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_schema::citation::{CitationItem, IntegralNameState};
 use citum_schema::options::{IntegralNameContexts, IntegralNameRule, IntegralNameScope};
 use citum_schema::reference::{InputReference, Monograph};

--- a/crates/citum-schema/tests/parent_reference.rs
+++ b/crates/citum-schema/tests/parent_reference.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use citum_schema::reference::{
     CollectionComponent, EdtfString, MonographComponentType, Parent, SerialComponent,
     SerialComponentType, Title,

--- a/crates/citum-schema/tests/verify_examples.rs
+++ b/crates/citum-schema/tests/verify_examples.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::fs;
 use std::path::PathBuf;
 

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -29,6 +29,11 @@ pub fn app() -> Router {
 }
 
 /// Start the HTTP server on the given port.
+///
+/// # Errors
+///
+/// Returns an error when the socket cannot be bound or the HTTP server exits
+/// with a transport-level failure.
 pub async fn run_http(port: u16) -> Result<(), Box<dyn std::error::Error>> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -27,8 +27,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //!
 //! - `async`: Enable tokio runtime (required for HTTP)
 //! - `http`: Enable HTTP server (implies async)
-#![deny(missing_docs)]
-
 /// Server error types and conversions.
 pub mod error;
 /// JSON-RPC request handling and stdio transport.

--- a/crates/citum-server/src/main.rs
+++ b/crates/citum-server/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -60,6 +60,11 @@ struct BibliographyResult {
 /// On success, this returns a JSON object containing the original request ID
 /// and a method-specific `result` payload. On failure, it returns the request
 /// ID when available plus a human-readable error string.
+///
+/// # Errors
+///
+/// Returns an error for unknown methods or when request-specific rendering or
+/// validation steps fail.
 pub fn dispatch(req: RpcRequest) -> Result<Value, (Option<Value>, String)> {
     let id = req.id.clone();
 
@@ -226,6 +231,11 @@ fn load_style(style_path: &str) -> Result<Style, ServerError> {
 
 /// Run the JSON-RPC server on stdin/stdout.
 /// Reads newline-delimited JSON requests and writes newline-delimited JSON responses.
+///
+/// # Errors
+///
+/// Returns an error when reading from stdin, writing to stdout, or flushing the
+/// output stream fails.
 pub fn run_stdio() -> io::Result<()> {
     let stdin = io::stdin();
     let mut stdout = io::stdout();

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -20,3 +20,6 @@ hub = []
 [dev-dependencies]
 tempfile = "3"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
+
+[lints]
+workspace = true

--- a/crates/citum_store/src/config.rs
+++ b/crates/citum_store/src/config.rs
@@ -44,7 +44,12 @@ impl Default for StoreConfig {
 impl StoreConfig {
     /// Load configuration from `~/.config/citum/config.toml`.
     ///
-    /// Returns default config if file does not exist or cannot be read.
+    /// Returns the default config if the file does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the config file exists but cannot be read or
+    /// parsed as TOML.
     pub fn load() -> Result<Self, ConfigError> {
         if let Some(config_dir) = dirs::config_dir() {
             let config_path = config_dir.join("citum").join("config.toml");

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 //! Platform-aware store for user-installed Citum styles and locales.
 //!
 //! Provides a `StoreResolver` that searches user data directories for custom styles

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -40,16 +40,28 @@ impl StoreResolver {
     /// Resolve a style by name from the store.
     ///
     /// Searches for `data_dir/styles/<name>.{yaml,json,cbor}` and deserializes it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the style cannot be found, read, or deserialized.
     pub fn resolve_style(&self, name: &str) -> Result<Style, ResolverError> {
         self.resolve_item("styles", name)
     }
 
     /// List all installed style names (stems, no extension).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the styles directory cannot be read.
     pub fn list_styles(&self) -> Result<Vec<String>, ResolverError> {
         self.list_items("styles")
     }
 
     /// List all installed locale names (stems, no extension).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the locales directory cannot be read.
     pub fn list_locales(&self) -> Result<Vec<String>, ResolverError> {
         self.list_items("locales")
     }
@@ -58,11 +70,20 @@ impl StoreResolver {
     ///
     /// Copies the file into `data_dir/styles/` using its stem as the name.
     /// Returns the installed style name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the source cannot be read or the destination
+    /// cannot be created or written.
     pub fn install_style(&self, source: &Path) -> Result<String, ResolverError> {
         self.install_item(source, "styles")
     }
 
     /// Remove an installed style by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the installed style cannot be removed.
     pub fn remove_style(&self, name: &str) -> Result<(), ResolverError> {
         self.remove_item(name, "styles")
     }
@@ -71,11 +92,20 @@ impl StoreResolver {
     ///
     /// Copies the file into `data_dir/locales/` using its stem as the name.
     /// Returns the installed locale name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the source cannot be read or the destination
+    /// cannot be created or written.
     pub fn install_locale(&self, source: &Path) -> Result<String, ResolverError> {
         self.install_item(source, "locales")
     }
 
     /// Remove an installed locale by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the installed locale cannot be removed.
     pub fn remove_locale(&self, name: &str) -> Result<(), ResolverError> {
         self.remove_item(name, "locales")
     }

--- a/crates/csl-legacy/Cargo.toml
+++ b/crates/csl-legacy/Cargo.toml
@@ -9,3 +9,6 @@ indexmap = "2.13.0"
 roxmltree = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[lints]
+workspace = true

--- a/crates/csl-legacy/src/bin/main.rs
+++ b/crates/csl-legacy/src/bin/main.rs
@@ -1,3 +1,7 @@
+#![allow(missing_docs)]
+
+//! Example binary for parsing a legacy CSL style and printing the JSON form.
+
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
 use serde_json::to_string_pretty;

--- a/crates/csl-legacy/src/bin/stats.rs
+++ b/crates/csl-legacy/src/bin/stats.rs
@@ -1,3 +1,7 @@
+#![allow(missing_docs)]
+
+//! Utility binary for scanning a style directory and summarizing parse failures.
+
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
 use std::fs;

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -146,7 +146,9 @@ pub struct Reference {
 /// A name (person or organization).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct Name {
+    /// Family name for a structured personal name.
     pub family: Option<String>,
+    /// Given name for a structured personal name.
     pub given: Option<String>,
     /// Literal name (for organizations or single-field names)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -267,7 +269,9 @@ impl DateVariable {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StringOrNumber {
+    /// A string value preserved as written in the source data.
     String(String),
+    /// A numeric value preserved as an integer.
     Number(i64),
 }
 

--- a/crates/csl-legacy/src/lib.rs
+++ b/crates/csl-legacy/src/lib.rs
@@ -9,6 +9,9 @@
 //! - [`parser`] – XML → model parser built on top of [`roxmltree`].
 //! - [`csl_json`] – companion CSL-JSON reference model (legacy input format).
 
+/// CSL-JSON reference types used alongside legacy CSL style processing.
 pub mod csl_json;
+/// Rust data structures that mirror the CSL 1.0 XML schema.
 pub mod model;
+/// XML parsing entry points for reading legacy CSL styles into the model.
 pub mod parser;


### PR DESCRIPTION
## Summary
- centralize Rust, rustdoc, and selective Clippy doc lint policy in workspace lints
- opt remaining crates into workspace lint inheritance and remove redundant crate-local `missing_docs` gates
- add the public doc sections and narrow transitional `allow(missing_docs)` carve-outs needed to make the new policy land cleanly

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`