### PR TITLE
fix(engine): apa song routing and term text-case

### DIFF
--- a/.beans/csl26-5ap9--apa-authored-containerized-works-follow-up.md
+++ b/.beans/csl26-5ap9--apa-authored-containerized-works-follow-up.md
@@ -5,63 +5,106 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-04-09T15:40:00Z
-updated_at: 2026-04-09T18:45:00Z
+updated_at: 2026-04-09T20:45:00Z
 ---
 
 Own the remaining APA rich bibliography rows after the web-native and
 container-packaging clusters are removed.
 
-Current verified state:
+Current verified state (post PR #500):
 - baseline APA gate remains `40 / 40`
-- supplemental APA diagnostic benchmark improved from `44 / 74` to `54 / 74`
-- this bean initially owns rows `49` to `58` and `60` to `74`
-- rows may be split into narrower follow-on beans when a sub-bucket exceeds 3
-  rows or spans more than one subsystem
+- supplemental APA diagnostic benchmark: `71 / 74` (up from `54 / 74`)
+- 3 rows remain open: `71`, `73`, `74`
 
-Current sub-buckets:
-- audiovisual role / container defects: `49`, `50`, `61`, `63`
-- chapter / entry / proceedings defects:
-  reduced structural cluster moved from `0 / 10` to `9 / 10`
-  remaining local miss: `27a Book chapter`
-- conference / presentation classification defects: `67`, `69`, `70`, `73`
-- archive / preprint / thesis / artwork / manuscript packaging defects:
-  `52`, `53`, `54`, `55`, `58`, `60`, `64`, `65`
+## Completed in PR #500
 
-Expected owning subsystem:
-- mixed `citum_migrate`, `citum_engine`, and style YAML
+- Routed `song` CSL type through `AudioVisual` (Recording subtype);
+  corrected Composer/Performer/Translator role assignment.
+- Implemented `HasNumbering` for `AudioVisualWork`; `volume()` and
+  `number()` were silently returning `None` for all AudioVisual refs.
+- Applied `text-case` transforms in term renderer (was ignored).
+- Removed all "Retrieved DATE, from URL" patterns (7 occurrences) from
+  `apa-7th.yaml` and `preset-bases/apa-7th.yaml`.
+- Added `song:` type variant template with catalog number, volume/track
+  parenthetical, and `[medium]` bracket rendering.
+- Restored `editor` contributor to chapter "In" group.
+- Added `archive-name`/`archive-location` group to the default template.
 
-Current mismatch shape:
-- performer / director / studio / label / media details are not packaging like
-  APA expects
-- chapter / entry / proceedings metadata is now mostly preserved, but one
-  editor-translator edge case still needs dedicated cleanup
-- conference and presentation rows are inconsistently classified and routed
-- archive / thesis / manuscript / artwork rows overuse retrieval-date fallback
-  and under-render archive / repository context
+## Resolved sub-buckets (closed rows)
 
-Completed in this pass:
-- rerouted report chapters with pages + parent title into the component path
-- rerouted encyclopedia entries into the collection-component path
-- preserved parent edition and container-author metadata for chapter-like rows
-- added APA chapter / proceedings / dictionary-entry variants to avoid generic
-  retrieval fallback
-- added a focused structural regression in
-  `crates/citum-engine/tests/bibliography.rs`
+- audiovisual: `49`, `50`, `61`, `63` — song routing + numbering fix
+- chapter / entry / proceedings: all rows except `71` (see below)
+- archive cluster: resolved via archive group on default template
 
-Remaining tasks:
-- [ ] Isolate and resolve the `27a Book chapter` editor+translator edge case.
-- [ ] Split or complete the audiovisual sub-bucket.
-- [ ] Split or complete the conference / presentation sub-bucket.
-- [ ] Split or complete the archive / thesis / manuscript / artwork sub-bucket.
+## Remaining open rows
+
+### Row 71 — `27 Book chapter` (container-author + editor coexist)
+
+oracle: `In C. Author, Title of book...`
+citum:  `In C. Author, S. S. Editor, editors., Title of book...`
+
+Root cause: chapter "In" group renders both `container-author` AND
+`editor` simultaneously. APA rule: when `container-author` is present,
+suppress editors from the "In" clause.
+
+Fix path: need conditional suppression in the template engine — show
+`editor` only when `container-author` is absent. This is a template
+engine capability gap (no `fallback` or `if-empty` between contributor
+components). Engine work required before this can be fixed in YAML.
+
+### Row 73 — `33 Conference presentation`
+
+oracle: `Author, F. (2013a, May). 33 Conference... In F. Chair & S. Chair
+         (Chairs), Session title [Symposium]...`
+citum:  `Author, F. (2013g). 33 Conference... [Symposium], Session title...`
+
+Two distinct issues:
+1. **Year-suffix order** — `2013g` vs `2013a`; disambiguation ordering
+   across the full fixture differs from citeproc-js. Owned by
+   `csl26-mwnt`.
+2. **Month in date** — oracle renders `(2013a, May)`; citum renders year
+   only. The `event-date` field in CSL extra notes carries the month.
+3. **Session/chair format** — oracle renders `In F. Chair & S. Chair
+   (Chairs), Session title`; citum omits the "In" clause entirely.
+   The `event` type variant needs a chair/session rendering block.
+
+### Row 74 — `9 Preprint with archive`
+
+oracle: `Author, A. A. (2018d). 9 Preprint with archive (A. A. Editor,
+         editors.; A. A. Translator, Trans.; No. 123445). PsyArXiv...`
+citum:  `Author, A. A. (2018q). 9 Preprint with archive (A. A. Translator,
+         Trans.)`
+
+Two distinct issues:
+1. **Year-suffix order** — `2018q` vs `2018d`. Owned by `csl26-mwnt`.
+2. **Missing editor in parenthetical** — editor is not rendering inside
+   the `(...)` info group for preprints/reports. The preprint/report
+   template needs an `editor` component inside the parenthetical group.
+3. **Missing report number** — `No. 123445` absent; number accessor for
+   this reference type likely needs a fix or the template needs a
+   `number: report-number` component.
+
+## Remaining tasks
+
+- [ ] Engine: add conditional suppression (show editor only when
+      container-author absent) so row 71 can be fixed in YAML.
+- [ ] Style YAML: add `event:` type variant with chair/session "In" block
+      for conference presentations (row 73).
+- [ ] Style YAML: add `editor` component inside preprint parenthetical
+      group; verify report-number accessor for preprint type (row 74).
+- [ ] Delegate year-suffix rows 73 and 74 to `csl26-mwnt` once structural
+      data is rendering correctly.
 
 ## Acceptance
-- every row currently owned by this bean either matches exactly or is moved to
-  a narrower successor bean with an explicit classification and handoff
+
+- every row currently owned by this bean either matches exactly or is
+  moved to a narrower successor bean with explicit classification
 - baseline APA remains `40 / 40`
 - no unknown residuals remain in this bucket
 
 ## Stop-Loss Rule
-- Stop after 2 distinct implementation attempts per sub-bucket with no net
-  gain.
+
+- Stop after 2 distinct implementation attempts per sub-bucket with no
+  net gain.
 - Reclassify immediately as `style-defect`, `processor-defect`,
   `migration-artifact`, or explicit divergence and record the handoff.

--- a/crates/citum-engine/src/values/term.rs
+++ b/crates/citum-engine/src/values/term.rs
@@ -33,6 +33,11 @@ impl ComponentValues for TemplateTerm {
             value = crate::values::strip_trailing_periods(&value);
         }
 
+        // Apply text-case if configured
+        if let Some(tc) = effective_rendering.text_case {
+            value = crate::values::text_case::apply_text_case(&value, tc);
+        }
+
         if value.is_empty() {
             None
         } else {

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -893,6 +893,7 @@ fn from_audio_visual_ref(
 ) -> InputReference {
     let r#type = match legacy.ref_type.as_str() {
         "motion_picture" => AudioVisualType::Film,
+        "song" => AudioVisualType::Recording,
         "broadcast" => AudioVisualType::Broadcast,
         _ => AudioVisualType::Broadcast,
     };
@@ -907,6 +908,13 @@ fn from_audio_visual_ref(
         ContributorRole::Composer,
         legacy_extra_names(&legacy, "composer"),
     );
+    // For recordings (song type), `author` is the performer; store it as Performer
+    // so that Composer takes precedence as the primary author in APA style.
+    let author_role = if legacy.ref_type == "song" {
+        ContributorRole::Performer
+    } else {
+        ContributorRole::Author
+    };
     push_legacy_contributor(
         &mut contributors,
         ContributorRole::Performer,
@@ -918,11 +926,33 @@ fn from_audio_visual_ref(
         legacy_extra_names(&legacy, "producer")
             .or_else(|| legacy_extra_names(&legacy, "executive-producer")),
     );
+    push_legacy_contributor(&mut contributors, author_role, legacy.author.clone());
     push_legacy_contributor(
         &mut contributors,
-        ContributorRole::Author,
-        legacy.author.clone(),
+        ContributorRole::Translator,
+        legacy.translator.clone(),
     );
+
+    let mut numbering: Vec<Numbering> = legacy
+        .number
+        .into_iter()
+        .map(|number| Numbering {
+            r#type: NumberingType::Number,
+            value: number,
+        })
+        .collect();
+    if let Some(vol) = legacy.volume.map(|v| v.to_string()) {
+        numbering.push(Numbering {
+            r#type: NumberingType::Volume,
+            value: vol,
+        });
+    }
+    if let Some(chapter) = legacy.chapter_number.clone() {
+        numbering.push(Numbering {
+            r#type: NumberingType::Chapter,
+            value: chapter,
+        });
+    }
 
     InputReference::AudioVisual(Box::new(AudioVisualWork {
         id: ctx.id,
@@ -942,14 +972,7 @@ fn from_audio_visual_ref(
                 ..Default::default()
             }))))
         }),
-        numbering: legacy
-            .number
-            .into_iter()
-            .map(|number| Numbering {
-                r#type: NumberingType::Number,
-                value: number,
-            })
-            .collect(),
+        numbering,
         publisher: legacy.publisher.map(|name| Publisher {
             name: name.into(),
             place: legacy.publisher_place,
@@ -1384,7 +1407,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
             "article-journal" | "article" | "article-magazine" | "article-newspaper" => {
                 from_serial_component_ref(legacy, ctx)
             }
-            "motion_picture" => from_audio_visual_ref(legacy, ctx),
+            "motion_picture" | "song" => from_audio_visual_ref(legacy, ctx),
             "broadcast" => from_serial_component_ref(legacy, ctx),
             "speech" | "presentation" => from_event_ref(legacy, ctx),
             "bill" => from_bill_ref(legacy, ctx),

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -110,6 +110,7 @@ impl InputReference {
             InputReference::CollectionComponent(reference) => Some(reference.as_ref()),
             InputReference::SerialComponent(reference) => Some(reference.as_ref()),
             InputReference::Classic(reference) => Some(reference.as_ref()),
+            InputReference::AudioVisual(reference) => Some(reference.as_ref()),
             _ => None,
         }
     }
@@ -292,7 +293,9 @@ impl InputReference {
                     .or_else(|| r.translator.clone())
             }
             InputReference::Classic(r) => r.translator.clone(),
-            InputReference::AudioVisual(_) => None,
+            InputReference::AudioVisual(r) => {
+                collect_contributors_by_role(&r.core.contributors, &ContributorRole::Translator)
+            }
             _ => None,
         }
     }

--- a/crates/citum-schema-data/src/reference/types/specialized.rs
+++ b/crates/citum-schema-data/src/reference/types/specialized.rs
@@ -627,6 +627,12 @@ struct AudioVisualDeser {
     note: Option<String>,
 }
 
+impl HasNumbering for AudioVisualWork {
+    fn numbering(&self) -> &[Numbering] {
+        &self.numbering
+    }
+}
+
 impl From<AudioVisualDeser> for AudioVisualWork {
     fn from(raw: AudioVisualDeser) -> Self {
         let mut numbering = raw.numbering;

--- a/locales/en-US.yaml
+++ b/locales/en-US.yaml
@@ -956,6 +956,7 @@ vocab:
   medium:
     film: "Film"
     video: "Video"
+    cd: "CD"
     audio-cd: "Audio CD"
     vinyl: "Vinyl"
     dvd: "DVD"

--- a/styles/apa-7th.yaml
+++ b/styles/apa-7th.yaml
@@ -208,13 +208,7 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - group:
-      - date: accessed
-        form: year-month-day
-        prefix: "Retrieved "
-        suffix: ", from"
-      - variable: url
-      delimiter: " "
+    - variable: url
       prefix: " "
     article-magazine:
     - contributor: author
@@ -310,10 +304,6 @@ bibliography:
       wrap:
         punctuation: parentheses
       prefix: " "
-    - number: edition
-      wrap:
-        punctuation: parentheses
-      prefix: " "
     - title: primary
       emph: false
     - contributor: translator
@@ -330,7 +320,6 @@ bibliography:
       - contributor: container-author
         form: long
         name-order: given-first
-        suffix: ","
       - contributor: editor
         form: long
         name-order: given-first
@@ -520,6 +509,48 @@ bibliography:
       prefix: " https://doi.org/"
     - variable: url
       prefix: " "
+    song:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - delimiter: "; "
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+      group:
+      - contributor: translator
+        form: long
+        name-order: given-first
+        label: {term: translator, form: short, placement: suffix}
+      - variable: number
+      - delimiter: ", "
+        group:
+        - delimiter: ""
+          group:
+          - term: volume
+            form: short
+            text-case: capitalize-first
+            suffix: " "
+          - number: volume
+        - number: chapter-number
+    - variable: medium
+      text-case: capitalize-first
+      wrap:
+        punctuation: brackets
+      prefix: " "
+    - variable: publisher
+      prefix: ". "
+      suffix: "."
+    - variable: url
+      prefix: " "
     motion-picture:
     - contributor: author
       form: long
@@ -532,10 +563,15 @@ bibliography:
       prefix: " "
     - title: primary
       emph: true
-    - variable: medium
+    - delimiter: "; "
       wrap:
         punctuation: brackets
       prefix: " "
+      group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
     - variable: publisher
       prefix: ". "
       suffix: "."
@@ -772,11 +808,13 @@ bibliography:
     suffix: "."
   - variable: doi
     prefix: "https://doi.org/"
-  - delimiter: " "
+  - variable: url
     prefix: " "
-    group:
-    - date: accessed
-      form: year-month-day
-      prefix: "Retrieved "
-      suffix: ", from"
-    - variable: url
+  - group:
+    - variable: archive-name
+    - variable: archive-location
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    delimiter: ""
+    prefix: ". "

--- a/styles/preset-bases/apa-7th.yaml
+++ b/styles/preset-bases/apa-7th.yaml
@@ -460,13 +460,7 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - items: &id004
-      - date: accessed
-        form: year-month-day
-        prefix: "Retrieved "
-        suffix: ", from"
-      - variable: url
-      delimiter: " "
+    - variable: url
       prefix: " "
     article-magazine:
     - contributor: author
@@ -562,8 +556,7 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - items: *id004
-      delimiter: " "
+    - variable: url
       prefix: " "
     broadcast:
     - contributor: author
@@ -621,8 +614,7 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - items: *id004
-      delimiter: " "
+    - variable: url
       prefix: " "
     chapter:
     - contributor: author
@@ -759,8 +751,7 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - items: *id004
-      delimiter: " "
+    - variable: url
       prefix: " "
     legal-case:
     - title: primary
@@ -853,17 +844,8 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: " https://doi.org/"
-    - delimiter: " "
+    - variable: url
       prefix: " "
-      group:
-      - date: accessed
-        form: month-day
-        prefix: "Retrieved "
-      - date: accessed
-        form: year
-        prefix: ", "
-        suffix: ", from"
-      - variable: url
     software:
     - contributor: author
       form: long
@@ -922,8 +904,7 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - items: *id004
-      delimiter: " "
+    - variable: url
       prefix: " "
     standard:
     - contributor: author
@@ -980,8 +961,7 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - items: *id004
-      delimiter: " "
+    - variable: url
       prefix: " "
     webpage:
     - contributor: author
@@ -1038,11 +1018,36 @@ bibliography:
       suffix: "."
     - variable: doi
       prefix: "https://doi.org/"
-    - items: *id004
-      delimiter: " "
+    - variable: url
       prefix: " "
     personal-communication: []
-    [motion-picture, broadcast, interview]:
+    motion-picture:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: true
+    - delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+      group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+    - variable: publisher
+      prefix: ". "
+      suffix: "."
+    - variable: url
+      prefix: " "
+    broadcast:
     - contributor: author
       form: long
       name-order: family-first
@@ -1053,30 +1058,53 @@ bibliography:
         punctuation: parentheses
       prefix: " "
     - title: primary
-      emph: true
+      emph: false
+      suffix: ""
     - number: issue
-      wrap:
-        punctuation: parentheses
-        inner-prefix: "No. "
-      prefix: " "
-    - variable: note
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: genre
-      wrap:
-        punctuation: brackets
-        inner-suffix: "; Film"
-      prefix: " "
-      suffix: "."
-    - variable: medium
+      prefix: " ("
+      suffix: ")"
+    - delimiter: "; "
       wrap:
         punctuation: brackets
       prefix: " "
-      suffix: "."
+      group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
     - title: parent-serial
       emph: true
       prefix: " In "
+      suffix: "."
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - variable: url
+      prefix: " "
+    interview:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year-month-day
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+      suffix: "."
+      group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+    - variable: publisher
+      prefix: " "
       suffix: "."
     - variable: url
       prefix: " "
@@ -1145,11 +1173,5 @@ bibliography:
     suffix: "."
   - variable: doi
     prefix: "https://doi.org/"
-  - delimiter: " "
+  - variable: url
     prefix: " "
-    group:
-    - date: accessed
-      form: year-month-day
-      prefix: "Retrieved "
-      suffix: ", from"
-    - variable: url


### PR DESCRIPTION
## Summary

- Routes `song` CSL type through `AudioVisual` (Recording subtype) instead of falling through to document; enables Composer, Performer, and Translator roles for song references
- Implements `HasNumbering` for `AudioVisualWork` and adds it to the `numbered()` match arm — fixes `volume()` and `number()` always returning `None` for AudioVisual references
- Applies `text-case` transforms in the term renderer (`TemplateTerm` had the field but it was silently ignored)
- Removes all "Retrieved DATE, from URL" patterns from `apa-7th.yaml` and `preset-bases/apa-7th.yaml` (7 occurrences replaced with plain `url` variable)
- Adds `song:` type variant template with catalog number, volume/track parenthetical and medium bracket rendering
- Restores `editor` contributor to chapter "In" group
- Adds `archive-name`/`archive-location` group to the default template

**APA bibliography oracle: 60 → 71 / 74** (997/997 unit tests pass)

## Remaining failures (3)

Tracked in `csl26-5ap9` with full root-cause notes.

| Row | Issue | Owner |
|-----|-------|-------|
| 71 | Chapter: both `container-author` and `editor` render in "In" clause; needs conditional suppression — engine capability gap | `csl26-5ap9` |
| 73 | Conference presentation: year-suffix order (`2013g` vs `2013a`), missing month from `event-date`, missing "In Chair (Chairs), Session" block | `csl26-5ap9` / `csl26-mwnt` |
| 74 | Preprint: year-suffix order (`2018q` vs `2018d`), missing editor and report number in parenthetical | `csl26-5ap9` / `csl26-mwnt` |

## Test plan

- [x] `cargo nextest run` — 997/997 pass
- [x] APA oracle — 71/74

Refs: csl26-5ap9, csl26-mwnt
