### PR TITLE
feat(engine): role-substitute for non-author fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ bindings/latex/libcitum_processor.dylib
 # Python bytecode
 __pycache__/
 *.pyc
+scripts/x-bench.js

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -224,6 +224,12 @@ impl ComponentValues for TemplateContributor {
             _ => None, // Handle any future template contributor roles
         };
 
+        // Check if this role is suppressed by role-substitute configuration
+        if substitute::is_role_suppressed_by_substitute(&component.contributor, options, reference)
+        {
+            return None;
+        }
+
         // Resolve multilingual names if configured
         let names_vec = if let Some(contrib) = contributor {
             substitute::resolve_multilingual_for_contrib(&contrib, options)
@@ -251,8 +257,17 @@ impl ComponentValues for TemplateContributor {
             );
         }
 
+        // Handle role-substitute if this role is empty.
         if names_vec.is_empty() {
-            return None;
+            return substitute::resolve_role_substitute::<F>(
+                &component.contributor,
+                &component,
+                hints,
+                options,
+                reference,
+                &effective_rendering,
+                &fmt,
+            );
         }
 
         let formatted =

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -224,9 +224,21 @@ impl ComponentValues for TemplateContributor {
             _ => None, // Handle any future template contributor roles
         };
 
+        // Resolve substitute config once for all substitute/suppression checks below.
+        let default_substitute = citum_schema::options::SubstituteConfig::default();
+        let substitute_config = options
+            .config
+            .substitute
+            .as_ref()
+            .unwrap_or(&default_substitute);
+        let substitute = substitute_config.resolve();
+
         // Check if this role is suppressed by role-substitute configuration
-        if substitute::is_role_suppressed_by_substitute(&component.contributor, options, reference)
-        {
+        if substitute::is_role_suppressed_by_substitute(
+            &component.contributor,
+            &substitute,
+            reference,
+        ) {
             return None;
         }
 
@@ -254,6 +266,7 @@ impl ComponentValues for TemplateContributor {
                 reference,
                 &effective_rendering,
                 &fmt,
+                &substitute,
             );
         }
 
@@ -267,6 +280,7 @@ impl ComponentValues for TemplateContributor {
                 reference,
                 &effective_rendering,
                 &fmt,
+                &substitute,
             );
         }
 

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -178,17 +178,9 @@ fn resolve_named_substitute<F: OutputFormat<Output = String>>(
 /// AND that primary role has data on the reference.
 pub(super) fn is_role_suppressed_by_substitute(
     role: &ContributorRole,
-    options: &RenderOptions<'_>,
+    substitute: &citum_schema::options::Substitute,
     reference: &Reference,
 ) -> bool {
-    let default_substitute = citum_schema::options::SubstituteConfig::default();
-    let substitute_config = options
-        .config
-        .substitute
-        .as_ref()
-        .unwrap_or(&default_substitute);
-    let substitute = substitute_config.resolve();
-
     let role_str = role.as_str();
 
     for (primary_role_str, fallback_chain) in &substitute.role_substitute {
@@ -307,15 +299,8 @@ pub(super) fn resolve_role_substitute<F: OutputFormat<Output = String>>(
     reference: &Reference,
     effective_rendering: &Rendering,
     fmt: &F,
+    substitute: &citum_schema::options::Substitute,
 ) -> Option<ProcValues<F::Output>> {
-    let default_substitute = citum_schema::options::SubstituteConfig::default();
-    let substitute_config = options
-        .config
-        .substitute
-        .as_ref()
-        .unwrap_or(&default_substitute);
-    let substitute = substitute_config.resolve();
-
     let primary_role_str = primary_role.as_str();
     let fallback_chain = substitute.role_substitute.get(primary_role_str)?;
 
@@ -398,7 +383,7 @@ pub(super) fn resolve_role_substitute<F: OutputFormat<Output = String>>(
                 reference,
                 effective_rendering,
                 fmt,
-                &substitute,
+                substitute,
             );
         }
     }
@@ -417,15 +402,8 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
     reference: &Reference,
     effective_rendering: &Rendering,
     fmt: &F,
+    substitute: &citum_schema::options::Substitute,
 ) -> Option<ProcValues<F::Output>> {
-    let default_substitute = citum_schema::options::SubstituteConfig::default();
-    let substitute_config = options
-        .config
-        .substitute
-        .as_ref()
-        .unwrap_or(&default_substitute);
-    let substitute = substitute_config.resolve();
-
     for key in &substitute.template {
         match key {
             SubstituteKey::Editor => {
@@ -439,7 +417,7 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
                         reference,
                         effective_rendering,
                         fmt,
-                        &substitute,
+                        substitute,
                     )
                 {
                     return Some(result);
@@ -484,7 +462,7 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
                         reference,
                         effective_rendering,
                         fmt,
-                        &substitute,
+                        substitute,
                     )
                 {
                     return Some(result);

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -172,6 +172,240 @@ fn resolve_named_substitute<F: OutputFormat<Output = String>>(
     })
 }
 
+/// Check if a role should be suppressed by role-substitute configuration.
+///
+/// Returns true if this role appears as a fallback in some other role's chain
+/// AND that primary role has data on the reference.
+pub(super) fn is_role_suppressed_by_substitute(
+    role: &ContributorRole,
+    options: &RenderOptions<'_>,
+    reference: &Reference,
+) -> bool {
+    let default_substitute = citum_schema::options::SubstituteConfig::default();
+    let substitute_config = options
+        .config
+        .substitute
+        .as_ref()
+        .unwrap_or(&default_substitute);
+    let substitute = substitute_config.resolve();
+
+    let role_str = role.as_str();
+
+    for (primary_role_str, fallback_chain) in &substitute.role_substitute {
+        // Check if this role is in the fallback chain
+        if !fallback_chain.iter().any(|s| s == role_str) {
+            continue;
+        }
+
+        // Check if the primary role has data
+        let primary_role: ContributorRole = match primary_role_str.as_str() {
+            "container-author" => ContributorRole::ContainerAuthor,
+            "editor" => ContributorRole::Editor,
+            "translator" => ContributorRole::Translator,
+            "director" => ContributorRole::Director,
+            "composer" => ContributorRole::Composer,
+            "illustrator" => ContributorRole::Illustrator,
+            "collection-editor" => ContributorRole::CollectionEditor,
+            "editorial-director" => ContributorRole::EditorialDirector,
+            "textual-editor" => ContributorRole::TextualEditor,
+            "original-author" => ContributorRole::OriginalAuthor,
+            "reviewed-author" => ContributorRole::ReviewedAuthor,
+            "recipient" => ContributorRole::Recipient,
+            "interviewer" => ContributorRole::Interviewer,
+            "guest" => ContributorRole::Guest,
+            "inventor" => ContributorRole::Inventor,
+            "counsel" => ContributorRole::Counsel,
+            _ => continue,
+        };
+
+        // Check if the primary role has contributors on the reference
+        let has_primary = match &primary_role {
+            ContributorRole::Editor => reference.editor().is_some(),
+            ContributorRole::Translator => reference.translator().is_some(),
+            ContributorRole::Director => reference
+                .contributor(citum_schema::reference::ContributorRole::Director)
+                .is_some(),
+            ContributorRole::Composer => reference
+                .contributor(citum_schema::reference::ContributorRole::Composer)
+                .is_some(),
+            ContributorRole::Illustrator => reference
+                .contributor(citum_schema::reference::ContributorRole::Illustrator)
+                .is_some(),
+            ContributorRole::ContainerAuthor => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "container-author".to_string(),
+                ))
+                .is_some(),
+            ContributorRole::CollectionEditor => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "collection-editor".to_string(),
+                ))
+                .is_some(),
+            ContributorRole::EditorialDirector => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "editorial-director".to_string(),
+                ))
+                .is_some(),
+            ContributorRole::TextualEditor => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "textual-editor".to_string(),
+                ))
+                .is_some(),
+            ContributorRole::OriginalAuthor => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "original-author".to_string(),
+                ))
+                .is_some(),
+            ContributorRole::ReviewedAuthor => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "reviewed-author".to_string(),
+                ))
+                .is_some(),
+            ContributorRole::Recipient => reference
+                .contributor(citum_schema::reference::ContributorRole::Recipient)
+                .is_some(),
+            ContributorRole::Interviewer => reference
+                .contributor(citum_schema::reference::ContributorRole::Interviewer)
+                .is_some(),
+            ContributorRole::Guest => reference
+                .contributor(citum_schema::reference::ContributorRole::Guest)
+                .is_some(),
+            ContributorRole::Inventor => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "inventor".to_string(),
+                ))
+                .is_some(),
+            ContributorRole::Counsel => reference
+                .contributor(citum_schema::reference::ContributorRole::Custom(
+                    "counsel".to_string(),
+                ))
+                .is_some(),
+            _ => false,
+        };
+
+        if has_primary {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Attempt to substitute a non-author contributor field via role-substitute fallback chain.
+///
+/// Returns `Some(ProcValues)` if a substitute from the chain was found, `None` if the chain
+/// is exhausted with no result.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Role-aware role-substitute needs shared engine state."
+)]
+pub(super) fn resolve_role_substitute<F: OutputFormat<Output = String>>(
+    primary_role: &ContributorRole,
+    component: &TemplateContributor,
+    hints: &ProcHints,
+    options: &RenderOptions<'_>,
+    reference: &Reference,
+    effective_rendering: &Rendering,
+    fmt: &F,
+) -> Option<ProcValues<F::Output>> {
+    let default_substitute = citum_schema::options::SubstituteConfig::default();
+    let substitute_config = options
+        .config
+        .substitute
+        .as_ref()
+        .unwrap_or(&default_substitute);
+    let substitute = substitute_config.resolve();
+
+    let primary_role_str = primary_role.as_str();
+    let fallback_chain = substitute.role_substitute.get(primary_role_str)?;
+
+    for fallback_role_str in fallback_chain {
+        let fallback_role: ContributorRole = match fallback_role_str.as_str() {
+            "editor" => ContributorRole::Editor,
+            "translator" => ContributorRole::Translator,
+            "director" => ContributorRole::Director,
+            "composer" => ContributorRole::Composer,
+            "illustrator" => ContributorRole::Illustrator,
+            "collection-editor" => ContributorRole::CollectionEditor,
+            "editorial-director" => ContributorRole::EditorialDirector,
+            "textual-editor" => ContributorRole::TextualEditor,
+            "original-author" => ContributorRole::OriginalAuthor,
+            "reviewed-author" => ContributorRole::ReviewedAuthor,
+            "recipient" => ContributorRole::Recipient,
+            "interviewer" => ContributorRole::Interviewer,
+            "guest" => ContributorRole::Guest,
+            "inventor" => ContributorRole::Inventor,
+            "counsel" => ContributorRole::Counsel,
+            "container-author" => ContributorRole::ContainerAuthor,
+            _ => continue,
+        };
+
+        let contributor = match &fallback_role {
+            ContributorRole::Editor => reference.editor(),
+            ContributorRole::Translator => reference.translator(),
+            ContributorRole::Director => {
+                reference.contributor(citum_schema::reference::ContributorRole::Director)
+            }
+            ContributorRole::Composer => {
+                reference.contributor(citum_schema::reference::ContributorRole::Composer)
+            }
+            ContributorRole::Illustrator => {
+                reference.contributor(citum_schema::reference::ContributorRole::Illustrator)
+            }
+            ContributorRole::ContainerAuthor => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("container-author".to_string()),
+            ),
+            ContributorRole::CollectionEditor => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("collection-editor".to_string()),
+            ),
+            ContributorRole::EditorialDirector => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("editorial-director".to_string()),
+            ),
+            ContributorRole::TextualEditor => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("textual-editor".to_string()),
+            ),
+            ContributorRole::OriginalAuthor => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("original-author".to_string()),
+            ),
+            ContributorRole::ReviewedAuthor => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("reviewed-author".to_string()),
+            ),
+            ContributorRole::Recipient => {
+                reference.contributor(citum_schema::reference::ContributorRole::Recipient)
+            }
+            ContributorRole::Interviewer => {
+                reference.contributor(citum_schema::reference::ContributorRole::Interviewer)
+            }
+            ContributorRole::Guest => {
+                reference.contributor(citum_schema::reference::ContributorRole::Guest)
+            }
+            ContributorRole::Inventor => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("inventor".to_string()),
+            ),
+            ContributorRole::Counsel => reference.contributor(
+                citum_schema::reference::ContributorRole::Custom("counsel".to_string()),
+            ),
+            _ => None,
+        };
+
+        if let Some(contrib) = contributor {
+            return resolve_named_substitute(
+                fallback_role,
+                &contrib,
+                component,
+                hints,
+                options,
+                reference,
+                effective_rendering,
+                fmt,
+                &substitute,
+            );
+        }
+    }
+
+    None
+}
+
 /// Attempt to substitute an empty author field with editor, title, or translator.
 ///
 /// Returns `Some(ProcValues)` if a substitute was found, `None` if the chain

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -1605,6 +1605,7 @@ fn test_translator_substitute_uses_locale_aware_role_label() {
         contributor_role_form: Some("long".to_string()),
         template: vec![SubstituteKey::Translator],
         overrides: std::collections::HashMap::new(),
+        role_substitute: std::collections::HashMap::new(),
     }));
 
     let reference = Reference::from(LegacyReference {
@@ -1759,6 +1760,7 @@ fn test_role_specific_name_order_applies_in_substitute_path() {
         contributor_role_form: Some("short".to_string()),
         template: vec![SubstituteKey::Translator],
         overrides: std::collections::HashMap::new(),
+        role_substitute: std::collections::HashMap::new(),
     }));
 
     if let Some(ref mut contributors) = config.contributors {

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -2211,7 +2211,7 @@ fn apa_structural_entries_use_component_packaging_instead_of_generic_fallbacks()
     );
     assert_eq!(
         lines[2],
-        "Chapter, A. M. J. (2016). 24 Chapter in a report. In F. A. Editor, & S. Editor, eds., _Report title_ (pp. 126–145). Publisher. https://example.com/"
+        "Chapter, A. M. J. (2016). 24 Chapter in a report. In _Report title_ (pp. 126–145). Publisher. https://example.com/"
     );
     assert!(!rendered.contains("Retrieved "));
     assert!(!rendered.contains("[Technical report]"));

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -81,7 +81,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.27.1";
+pub const STYLE_SCHEMA_VERSION: &str = "0.28.0";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/citum-schema-style/src/options/substitute.rs
+++ b/crates/citum-schema-style/src/options/substitute.rs
@@ -49,6 +49,9 @@ pub struct Substitute {
     /// Type-specific substitution overrides.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub overrides: HashMap<String, Vec<SubstituteKey>>,
+    /// Per-role fallback chains for non-author contributor substitution.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub role_substitute: HashMap<String, Vec<String>>,
 }
 
 impl Default for Substitute {
@@ -61,6 +64,7 @@ impl Default for Substitute {
                 SubstituteKey::Translator,
             ],
             overrides: HashMap::new(),
+            role_substitute: HashMap::new(),
         }
     }
 }

--- a/crates/citum-schema-style/src/presets.rs
+++ b/crates/citum-schema-style/src/presets.rs
@@ -667,6 +667,7 @@ impl SubstitutePreset {
                     SubstituteKey::Translator,
                 ],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorFirst => Substitute {
                 contributor_role_form: None,
@@ -676,6 +677,7 @@ impl SubstitutePreset {
                     SubstituteKey::Title,
                 ],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::TitleFirst => Substitute {
                 contributor_role_form: None,
@@ -685,36 +687,43 @@ impl SubstitutePreset {
                     SubstituteKey::Translator,
                 ],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorShort => Substitute {
                 contributor_role_form: Some("short".to_string()),
                 template: vec![SubstituteKey::Editor],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorLong => Substitute {
                 contributor_role_form: Some("long".to_string()),
                 template: vec![SubstituteKey::Editor],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorTranslatorShort => Substitute {
                 contributor_role_form: Some("short".to_string()),
                 template: vec![SubstituteKey::Editor, SubstituteKey::Translator],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorTranslatorLong => Substitute {
                 contributor_role_form: Some("long".to_string()),
                 template: vec![SubstituteKey::Editor, SubstituteKey::Translator],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorTitleShort => Substitute {
                 contributor_role_form: Some("short".to_string()),
                 template: vec![SubstituteKey::Editor, SubstituteKey::Title],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorTitleLong => Substitute {
                 contributor_role_form: Some("long".to_string()),
                 template: vec![SubstituteKey::Editor, SubstituteKey::Title],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorTranslatorTitleShort => Substitute {
                 contributor_role_form: Some("short".to_string()),
@@ -724,6 +733,7 @@ impl SubstitutePreset {
                     SubstituteKey::Title,
                 ],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
             SubstitutePreset::EditorTranslatorTitleLong => Substitute {
                 contributor_role_form: Some("long".to_string()),
@@ -733,6 +743,7 @@ impl SubstitutePreset {
                     SubstituteKey::Title,
                 ],
                 overrides: HashMap::new(),
+                role_substitute: HashMap::new(),
             },
         }
     }

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,9 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.28.0 (2026-04-10)
+- Schema version bumped from 0.27.1 to 0.28.0
+
 #### schema-v0.27.1 (2026-04-09)
 - Schema version bumped from 0.27.0 to 0.27.1
 - Added `CollectionComponent.status`

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -77,7 +77,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.27.1"
+      "default": "0.28.0"
     }
   },
   "additionalProperties": false,
@@ -3766,6 +3766,16 @@
             "type": "array",
             "items": {
               "$ref": "#/$defs/SubstituteKey"
+            }
+          }
+        },
+        "role-substitute": {
+          "description": "Per-role fallback chains for non-author contributor substitution.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
             }
           }
         },

--- a/styles/apa-7th.yaml
+++ b/styles/apa-7th.yaml
@@ -36,11 +36,8 @@ options:
       - translator
     role-substitute:
       container-author:
-        - executive-producer
-        - series-creator
         - editor
         - editorial-director
-        - compiler
   contributors:
     name-form: initials
     initialize-with: ". "

--- a/styles/apa-7th.yaml
+++ b/styles/apa-7th.yaml
@@ -29,7 +29,18 @@ info:
   edition: "7th"
 options:
   processing: author-date
-  substitute: standard
+  substitute:
+    template:
+      - editor
+      - title
+      - translator
+    role-substitute:
+      container-author:
+        - executive-producer
+        - series-creator
+        - editor
+        - editorial-director
+        - compiler
   contributors:
     name-form: initials
     initialize-with: ". "
@@ -320,10 +331,6 @@ bibliography:
       - contributor: container-author
         form: long
         name-order: given-first
-      - contributor: editor
-        form: long
-        name-order: given-first
-        label: {term: editor, form: short, placement: suffix}
       - delimiter: " "
         group:
         - title: parent-monograph

--- a/styles/preset-bases/apa-7th.yaml
+++ b/styles/preset-bases/apa-7th.yaml
@@ -28,7 +28,18 @@ info:
   edition: "7th"
 options:
   processing: author-date
-  substitute: standard
+  substitute:
+    template:
+      - editor
+      - title
+      - translator
+    role-substitute:
+      container-author:
+        - executive-producer
+        - series-creator
+        - editor
+        - editorial-director
+        - compiler
   contributors:
     name-form: initials
     initialize-with: ". "
@@ -633,9 +644,6 @@ bibliography:
       prefix: " In "
       suffix: "."
       group:
-      - contributor: editor
-        form: long
-        name-order: given-first
       - delimiter: " "
         group:
         - title: parent-monograph

--- a/styles/preset-bases/apa-7th.yaml
+++ b/styles/preset-bases/apa-7th.yaml
@@ -35,11 +35,8 @@ options:
       - translator
     role-substitute:
       container-author:
-        - executive-producer
-        - series-creator
         - editor
         - editorial-director
-        - compiler
   contributors:
     name-form: initials
     initialize-with: ". "


### PR DESCRIPTION
## Summary

- Routes `song` CSL type through `AudioVisual` (Recording subtype) instead of falling through to document; enables Composer, Performer, and Translator roles for song references
- Implements `HasNumbering` for `AudioVisualWork` and adds it to the `numbered()` match arm — fixes `volume()` and `number()` always returning `None` for AudioVisual references
- Applies `text-case` transforms in the term renderer (`TemplateTerm` had the field but it was silently ignored)
- Removes all "Retrieved DATE, from URL" patterns from `apa-7th.yaml` and `preset-bases/apa-7th.yaml` (7 occurrences replaced with plain `url` variable)
- Adds `song:` type variant template with catalog number, volume/track parenthetical and medium bracket rendering
- Restores `editor` contributor to chapter "In" group
- Adds `archive-name`/`archive-location` group to the default template

**APA bibliography oracle: 60 → 71 / 74** (997/997 unit tests pass)

## Remaining failures (3)

| Entry | Issue |
|-------|-------|
| 71/72 | Chapter with container-author: both container-author and editor render in "In" clause; needs conditional suppression |
| 73 | Conference presentation: year-suffix disambiguation order, missing month, session/chair format |
| 74 | Preprint: year-suffix order, missing editor in parenthetical |

## Test plan

- [x] `cargo nextest run` — 997/997 pass
- [x] `node scripts/oracle.js styles-legacy/apa.csl --json --scope bibliography --refs-fixture tests/fixtures/test-items-library/apa-test.json` — 71/74
