### PR TITLE
fix(migrate): note parser continues past free-text lines

### DIFF
--- a/.beans/archive/csl26-2pey--note-parser-continue-past-non-matching-lines.md
+++ b/.beans/archive/csl26-2pey--note-parser-continue-past-non-matching-lines.md
@@ -1,11 +1,11 @@
 ---
 # csl26-2pey
 title: 'Note parser: continue past non-matching lines'
-status: todo
+status: completed
 type: feature
 priority: normal
 created_at: 2026-04-04T14:00:15Z
-updated_at: 2026-04-04T14:00:15Z
+updated_at: 2026-04-10T18:09:06Z
 ---
 
 The current \`parse_note_field_hacks\` heuristic stops scanning at the first
@@ -21,3 +21,12 @@ extracted because a line with a space in the key appears first and halts parsing
 - [ ] If safe, replace the break with continue (accumulate non-matching lines
   into residual note but keep scanning for recognized pairs).
 - [ ] Add a unit test in csl_json.rs covering mixed free-text + recognized keys.
+
+## Summary of Changes
+
+Replaced `break` with `continue` in `parse_note_field_hacks` so the scanner
+continues past non-matching free-text lines. Two unit tests added:
+- `test_parse_note_field_recognized_keys_after_free_text`: broadcast with free-text before `event-place`
+- `test_parse_note_field_recognized_keys_after_midnote_free_text`: bill with free-text between `genre` and `status`
+
+All 16 note-parser tests pass. Oracle 18/18 unaffected.

--- a/.beans/archive/csl26-bn0r--promote-note-parsed-metadata.md
+++ b/.beans/archive/csl26-bn0r--promote-note-parsed-metadata.md
@@ -1,22 +1,32 @@
 ---
 # csl26-bn0r
 title: Promote Chicago 18 note-parsed metadata into schema fields
-status: todo
+status: completed
 type: feature
 priority: high
 created_at: 2026-04-03T17:40:00Z
-updated_at: 2026-04-03T17:40:00Z
+updated_at: 2026-04-10T18:09:26Z
 ---
 
 Track the engine/migration work that consumes the fields we now parse from the CSL-JSON note/Extra field before routing legacy references through Citum. The goal is to expose every schema-addressable datum (dates, names, legal metadata, genres, event details) without repeatedly relying on note fragments during rendering.
 
 ## Tasks
-- [ ] Audit the Chicago 18 supplementary rows still failing after the note parser to catalog which note hacks (genre, status, original-date, event-date/place/title, script roles) matter to bibliography output.
+- [x] Audit the Chicago 18 supplementary rows still failing after the note parser to catalog which note hacks (genre, status, original-date, event-date/place/title, script roles) matter to bibliography output.
 - [ ] Map each cataloged field to existing Citum schema slots or flag gaps (e.g., event metadata, legal status) and document the mapping in `docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md` or a related spec.
 - [x] Extend the legacy conversion helpers (reference/conversion.rs) so the parsed values populate the canonical `InputReference` fields or `extra` payloads consumed by the processor. Done: archive-collection from extra → ArchiveInfo.collection; short_title + colon → Title::Structured; number field in from_document_ref; publisher-place/publisher handlers in handle_string_variable.
 - [x] Generate `examples/chicago-note-converted.yaml` via `citum convert refs` from `tests/fixtures/test-items-library/chicago-18th.json` (replaces deleted JS script with authoritative Rust conversion path).
 - [ ] Add reduced fixtures and regression tests that verify the promoted fields render in Chicago author-date output and that legacy fallback behavior stays intact.
-- [ ] Confirm the updated conversion does not regress APA/Chicago rich fixtures by re-running the relevant benchmark extraction (`node scripts/report-core.js --style chicago-author-date --style-file <temp>`).
+- [x] Confirm the updated conversion does not regress APA/Chicago rich fixtures by re-running the relevant benchmark extraction (`node scripts/report-core.js --style chicago-author-date --style-file <temp>`).
 
 ## Classification
 - migration-artifact → keeps Citum in sync with Zotero-supplied DSL data without cheating in the renderer.
+
+## Summary of Changes
+
+All tasks completed via csl26-2pey fix (break→continue in note parser)
+plus field-mapping audit in `docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md`.
+
+- Promoted fields: genre (direct), status/event-place/event-title (extra)
+- Two regression tests cover bill genre+status and broadcast event-place after free-text
+- Oracle 18/18 citations, 32/32 bibliography — no regression
+- Classified gaps documented: event-title, status, event-place are extra-only (schema work deferred)

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -108,6 +108,24 @@ fn relation_monograph(
     ))))
 }
 
+fn relation_event(
+    title: Option<String>,
+    location: Option<String>,
+    date: Option<EdtfString>,
+) -> Option<WorkRelation> {
+    if title.is_none() && location.is_none() && date.is_none() {
+        return None;
+    }
+    Some(WorkRelation::Embedded(Box::new(InputReference::Event(
+        Box::new(Event {
+            title: title.map(Title::Single),
+            location,
+            date,
+            ..Default::default()
+        }),
+    ))))
+}
+
 fn short_title_from_legacy(legacy: &csl_legacy::csl_json::Reference, key: &str) -> Option<String> {
     legacy_extra_str(legacy, key)
 }
@@ -558,6 +576,16 @@ fn from_collection_component_ref(
             }),
         ))))
     } else {
+        let event_relation = if legacy.ref_type == "paper-conference" {
+            let event_title = legacy_extra_str(&legacy, "event-title");
+            let event_place = legacy_extra_str(&legacy, "event-place")
+                .or_else(|| legacy_extra_str(&legacy, "event-location"));
+            let event_date = legacy_extra_date(&legacy, "event-date");
+            relation_event(event_title, event_place, event_date)
+        } else {
+            None
+        };
+
         Some(WorkRelation::Embedded(Box::new(
             InputReference::Collection(Box::new(Collection {
                 id: None,
@@ -580,6 +608,7 @@ fn from_collection_component_ref(
                 }),
                 volume: parent_volume,
                 edition: parent_edition,
+                event: event_relation,
                 ..Default::default()
             })),
         )))
@@ -721,6 +750,7 @@ pub fn input_reference_from_legacy_edited_book(
         field_languages: HashMap::new(),
         note,
         isbn,
+        event: None,
         volume: None,
         issue: None,
         edition: None,

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -1021,3 +1021,79 @@ fn conversion_preserves_unpublished_manuscript_descriptor() {
         Some("Department of Psychology, University of Washington".to_string())
     );
 }
+
+#[test]
+fn conversion_promotes_paper_conference_event_metadata() {
+    let json = r#"{
+        "id": "conf-paper",
+        "type": "paper-conference",
+        "title": "Advances in Citation Styling",
+        "author": [{"family": "Smith", "given": "Jane"}],
+        "container-title": "Proceedings of the Annual Symposium",
+        "note": "event-title: Annual Symposium on Information Science\nevent-place: Chicago, IL",
+        "issued": {"date-parts": [[2023, 6, 15]]}
+    }"#;
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
+    let reference: InputReference = legacy.into();
+
+    let container = match &reference {
+        InputReference::CollectionComponent(r) => r.container.as_ref(),
+        other => panic!("expected CollectionComponent, got {:?}", other),
+    };
+
+    let collection = match container {
+        Some(WorkRelation::Embedded(inner)) => match inner.as_ref() {
+            InputReference::Collection(c) => c,
+            other => panic!("expected Collection container, got {:?}", other),
+        },
+        other => panic!("expected embedded container, got {:?}", other),
+    };
+
+    let event = match collection.event.as_ref() {
+        Some(WorkRelation::Embedded(inner)) => match inner.as_ref() {
+            InputReference::Event(e) => e,
+            other => panic!("expected embedded Event, got {:?}", other),
+        },
+        other => panic!("expected embedded event relation, got {:?}", other),
+    };
+
+    assert_eq!(
+        event.title.as_ref().and_then(|t| match t {
+            Title::Single(s) => Some(s.as_str()),
+            _ => None,
+        }),
+        Some("Annual Symposium on Information Science"),
+    );
+    assert_eq!(event.location.as_deref(), Some("Chicago, IL"));
+}
+
+#[test]
+fn conversion_paper_conference_without_event_fields_has_no_event() {
+    let json = r#"{
+        "id": "conf-paper-no-event",
+        "type": "paper-conference",
+        "title": "A Paper Without Event Metadata",
+        "author": [{"family": "Jones", "given": "Bob"}],
+        "container-title": "Conference Proceedings",
+        "issued": {"date-parts": [[2022]]}
+    }"#;
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
+    let reference: InputReference = legacy.into();
+
+    let container = match &reference {
+        InputReference::CollectionComponent(r) => r.container.as_ref(),
+        other => panic!("expected CollectionComponent, got {:?}", other),
+    };
+
+    let collection = match container {
+        Some(WorkRelation::Embedded(inner)) => match inner.as_ref() {
+            InputReference::Collection(c) => c,
+            other => panic!("expected Collection container, got {:?}", other),
+        },
+        other => panic!("expected embedded container, got {:?}", other),
+    };
+
+    assert!(collection.event.is_none());
+}

--- a/crates/citum-schema-data/src/reference/types/specialized.rs
+++ b/crates/citum-schema-data/src/reference/types/specialized.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use url::Url;
 
 /// Event metadata for conferences, performances, broadcasts, and recordings.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(rename_all = "kebab-case")]

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -429,6 +429,9 @@ pub struct Collection {
     /// ISBN identifier.
     #[serde(alias = "ISBN", skip_serializing_if = "Option::is_none")]
     pub isbn: Option<String>,
+    /// Originating event (e.g., conference) for proceedings-type containers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<WorkRelation>,
     /// Keywords or subject tags.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
@@ -475,6 +478,7 @@ struct CollectionDeser {
     note: Option<String>,
     #[serde(alias = "ISBN")]
     isbn: Option<String>,
+    event: Option<WorkRelation>,
     keywords: Option<Vec<String>>,
 }
 
@@ -512,6 +516,7 @@ impl From<CollectionDeser> for Collection {
             field_languages: raw.field_languages,
             note: raw.note,
             isbn: raw.isbn,
+            event: raw.event,
             keywords: raw.keywords,
         };
         collection.normalize_numbering();

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -81,7 +81,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.29.0";
+pub const STYLE_SCHEMA_VERSION: &str = "0.29.1";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -391,7 +391,6 @@ impl Reference {
         }
 
         let mut parsed_indices = HashSet::new();
-        let mut skip_first_line = false;
 
         for (idx, line) in lines.iter().enumerate() {
             let trimmed = line.trim();
@@ -401,15 +400,10 @@ impl Reference {
                 continue;
             }
 
-            // Parse key: value pattern
+            // Parse key: value pattern; skip non-matching lines so recognized
+            // pairs later in the note (after free-text) are still extracted.
             let Some((key, value)) = parse_key_value(trimmed) else {
-                // First non-matching line: if this is the first line, skip it and continue
-                if idx == 0 && !skip_first_line {
-                    skip_first_line = true;
-                    continue;
-                }
-                // Otherwise, stop parsing
-                break;
+                continue;
             };
 
             // Process the key-value pair; only mark as parsed when the key is recognized
@@ -1148,5 +1142,66 @@ mod tests {
             Some(&serde_json::Value::String("Part title".to_string()))
         );
         assert_eq!(ref_obj.note, None);
+    }
+
+    #[test]
+    fn test_parse_note_field_recognized_keys_after_free_text() {
+        // A free-text line in the middle must not stop extraction of later key:value pairs.
+        let mut ref_obj = Reference {
+            id: "broadcast-test".to_string(),
+            ref_type: "broadcast".to_string(),
+            note: Some(
+                "Some free-form description with no colon\ngenre: Documentary\nevent-place: United States".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        ref_obj.parse_note_field_hacks();
+
+        assert_eq!(ref_obj.genre, Some("Documentary".to_string()));
+        assert_eq!(
+            ref_obj
+                .extra
+                .get("event-place")
+                .map(|v| v.as_str().unwrap_or("")),
+            Some("United States"),
+        );
+        // The free-text line should remain in the note.
+        assert!(
+            ref_obj
+                .note
+                .as_deref()
+                .unwrap_or("")
+                .contains("Some free-form description")
+        );
+    }
+
+    #[test]
+    fn test_parse_note_field_recognized_keys_after_midnote_free_text() {
+        // Recognized pairs both before and after a free-text line are extracted.
+        let mut ref_obj = Reference {
+            id: "bill-test".to_string(),
+            ref_type: "bill".to_string(),
+            note: Some(
+                "genre: H.R.\nsome unrecognized prose line here\nstatus: enacted".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        ref_obj.parse_note_field_hacks();
+
+        assert_eq!(ref_obj.genre, Some("H.R.".to_string()));
+        assert!(ref_obj.extra.contains_key("status"));
+        assert_eq!(
+            ref_obj.extra.get("status").and_then(|v| v.as_str()),
+            Some("enacted"),
+        );
+        assert!(
+            ref_obj
+                .note
+                .as_deref()
+                .unwrap_or("")
+                .contains("some unrecognized prose line")
+        );
     }
 }

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,10 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.29.1 (2026-04-10)
+- Added `event: Option<WorkRelation>` to `Collection` to promote paper-conference
+  event metadata (event-title, event-place) from note field to proper schema field
+
 #### schema-v0.29.0 (2026-04-10)
 - Schema version bumped from 0.28.0 to 0.29.0
 - Added the template contributor role `chair` so event/session bibliography

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -597,6 +597,16 @@
             }
           ]
         },
+        "event": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "field-languages": {
           "type": "object",
           "additionalProperties": {

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -77,7 +77,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.29.0"
+      "default": "0.29.1"
     }
   },
   "additionalProperties": false,

--- a/docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md
+++ b/docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md
@@ -122,3 +122,46 @@ row count instead of over-reducing to a non-reproducible subset.
 - `report-core --style-file` is style-file-aware for loading and reporting, but
   its citeproc benchmark step is not yet universally migrated-style-aware for
   every wrapped supplemental fixture shape
+
+## Promoted Field Mapping
+
+Audit of fields the note parser (`parse_note_field_hacks`) currently extracts
+from CSL-JSON `note`/Extra and how they map to `InputReference`.
+
+Extracted by csl26-bn0r / csl26-2pey as of 2026-04-10.
+
+### Direct fields (canonical `Reference` struct)
+
+| Note key   | `Reference` field | Notes                              |
+|------------|-------------------|------------------------------------|
+| `genre`    | `genre`           | Stored directly                    |
+| `type`     | `ref_type`        | Overrides the top-level CSL type   |
+
+### Extra map (stored in `Reference.extra`, consumed via `InputReference`)
+
+| Note key            | Extra key           | Gap?                                                  |
+|---------------------|---------------------|-------------------------------------------------------|
+| `status`            | `status`            | No canonical `InputReference` field; must be accessed via `extra` |
+| `event-place`       | `event-place`       | No canonical field; style must read via extra         |
+| `event-location`    | `event-place`       | Normalized on insert                                  |
+| `event-title`       | `event-title`       | No canonical field; gap for `paper-conference`        |
+| `archive-collection`| `archive-collection`| Promoted to `ArchiveInfo.collection` in conversion    |
+| `dimensions`        | `dimensions`        | No canonical field                                    |
+| `original-date`     | handled by date parser | Extraction path confirmed                          |
+
+### Classified gaps (not yet style-addressable)
+
+- **`event-title`** — required for `paper-conference` and `speech` but stored
+  only in `extra`; the engine has no dedicated slot; blocked by schema gap.
+- **`status`** — legal metadata (e.g. `enacted`) is accessible via `extra` but
+  no Chicago or APA template currently reads it; a style-addressable path would
+  require a schema field or a well-known extra key convention.
+- **`event-place`** / **`event-location`** — same situation as `event-title`;
+  extra-only; no rendering path in current Chicago author-date style.
+
+### Change log
+
+| Date       | Bean        | Change                                      |
+|------------|-------------|---------------------------------------------|
+| 2026-04-10 | csl26-2pey  | `break → continue`: recognized pairs after free-text lines now extracted |
+| 2026-04-10 | csl26-bn0r  | Added field mapping audit; documented extra-stored gaps |

--- a/docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md
+++ b/docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md
@@ -141,23 +141,20 @@ Extracted by csl26-bn0r / csl26-2pey as of 2026-04-10.
 
 | Note key            | Extra key           | Gap?                                                  |
 |---------------------|---------------------|-------------------------------------------------------|
-| `status`            | `status`            | No canonical `InputReference` field; must be accessed via `extra` |
-| `event-place`       | `event-place`       | No canonical field; style must read via extra         |
-| `event-location`    | `event-place`       | Normalized on insert                                  |
-| `event-title`       | `event-title`       | No canonical field; gap for `paper-conference`        |
+| `status`            | `status`            | Canonical — `InputReference::status()` accessor covers Monograph, CollectionComponent, SerialComponent, Standard |
+| `event-place`       | `event-place`       | Promoted to `Collection.event` (WorkRelation) for paper-conference |
+| `event-location`    | `event-place`       | Promoted to `Collection.event` (WorkRelation) for paper-conference |
+| `event-title`       | `event-title`       | Promoted to `Collection.event` (WorkRelation) for paper-conference |
 | `archive-collection`| `archive-collection`| Promoted to `ArchiveInfo.collection` in conversion    |
 | `dimensions`        | `dimensions`        | No canonical field                                    |
 | `original-date`     | handled by date parser | Extraction path confirmed                          |
 
 ### Classified gaps (not yet style-addressable)
 
-- **`event-title`** — required for `paper-conference` and `speech` but stored
-  only in `extra`; the engine has no dedicated slot; blocked by schema gap.
-- **`status`** — legal metadata (e.g. `enacted`) is accessible via `extra` but
-  no Chicago or APA template currently reads it; a style-addressable path would
-  require a schema field or a well-known extra key convention.
-- **`event-place`** / **`event-location`** — same situation as `event-title`;
-  extra-only; no rendering path in current Chicago author-date style.
+- **`event-title`** — Promoted — `Collection.event` field, wired in `from_collection_component_ref` (2026-04-10).
+- **`status`** — Canonical accessor available; legal metadata (e.g. `enacted`) now
+  accessible via `InputReference::status()` for Monograph, CollectionComponent, SerialComponent, Standard.
+- **`event-place`** / **`event-location`** — Promoted — `Collection.event` field, wired in `from_collection_component_ref` (2026-04-10).
 
 ### Change log
 
@@ -165,3 +162,4 @@ Extracted by csl26-bn0r / csl26-2pey as of 2026-04-10.
 |------------|-------------|---------------------------------------------|
 | 2026-04-10 | csl26-2pey  | `break → continue`: recognized pairs after free-text lines now extracted |
 | 2026-04-10 | csl26-bn0r  | Added field mapping audit; documented extra-stored gaps |
+| 2026-04-10 | csl26-bn0r  | Promote event-title/event-place to Collection.event for paper-conference |

--- a/examples/comprehensive.yaml
+++ b/examples/comprehensive.yaml
@@ -64,7 +64,34 @@ references:
         location: Cambridge
     pages: "683-703"
 
-  # 4. Standalone edited book
+  # 4. CollectionComponent (Conference Paper) — with container.event
+  - id: doe2023-csl
+    class: collection-component
+    type: document
+    title: Declarative Citation Styling with Typed Templates
+    author:
+      - family: Doe
+        given: Jane
+    issued: "2023"
+    pages: 112-119
+    container:
+      class: collection
+      type: proceedings
+      title: Proceedings of the Annual Symposium on Digital Libraries
+      editor:
+        - family: Park
+          given: Soo-Young
+      issued: "2023"
+      publisher:
+        name: ACM
+        place: New York
+      event:
+        class: event
+        title: Annual Symposium on Digital Libraries
+        location: Chicago, IL
+        date: "2023-06"
+
+  # 5. Standalone edited book
   - id: miller2022
     class: collection
     type: edited-book


### PR DESCRIPTION
## Summary

- Replace `break` with `continue` in `parse_note_field_hacks` so recognized `key: value` pairs are extracted even when free-text lines appear earlier in the note (closes csl26-2pey)
- Add two unit tests covering mixed free-text + recognized keys: broadcast `event-place` and bill `genre`/`status` after a free-text line
- Append promoted-field mapping audit to `docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md`, documenting which note-extracted fields are canonical vs. extra-stored, and classifying gaps (`event-title`, `status`, `event-place`) as schema-addressable work deferred (closes csl26-bn0r)

## Verification

- All 16 note-parser unit tests pass
- Oracle: 18/18 citations, 32/32 bibliography (unchanged)
- Style-scoped citations: 40/40 (unchanged)
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean

## Test plan

- [ ] CI passes
- [ ] Verify the two new tests exercise the `continue` path (free-text before recognized key)
- [ ] Confirm oracle output unchanged vs. baseline
