### PR TITLE
fix: benchmark min_pass_rate threshold + engine original-date

### DIFF
--- a/.beans/archive/csl26-ft25--fix-benchmark-pass-semantics-add-min-pass-rate-thr.md
+++ b/.beans/archive/csl26-ft25--fix-benchmark-pass-semantics-add-min-pass-rate-thr.md
@@ -1,0 +1,18 @@
+---
+# csl26-ft25
+title: 'Fix benchmark pass semantics: add min_pass_rate threshold'
+status: completed
+type: bug
+priority: high
+created_at: 2026-04-11T11:04:13Z
+updated_at: 2026-04-11T11:20:19Z
+---
+
+The citeproc-oracle benchmark run sets status='pass' whenever the oracle runs without crashing, regardless of match rate. A 73% match rate (292/400) gets a green 'pass' badge. Fix: add min_pass_rate field to benchmark run config. When set, status becomes 'pass'/'fail' based on match rate vs threshold; when absent, status becomes 'ok' (neutral) to distinguish 'ran OK' from 'actually passed a quality bar'. Update HTML renderer accordingly.
+
+## Summary of Changes
+
+- Added `min_pass_rate` field to benchmark run config in `scripts/report-data/verification-policy.yaml` and validation in `scripts/lib/verification-policy.js`
+- Changed `runBenchmarkRun` status logic from binary pass/error to tri-state: `pass` (rate >= threshold), `fail` (rate < threshold), `ok` (no threshold set, ran without error)
+- Updated HTML renderer status badge: emerald for pass, slate for ok, red for fail/error
+- Set `min_pass_rate: 0.73` on `chicago-zotero-bibliography` benchmark run

--- a/.beans/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
+++ b/.beans/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
@@ -1,0 +1,11 @@
+---
+# csl26-3j0c
+title: 'engine: render original-publisher and original-place for reprints'
+status: todo
+type: feature
+priority: normal
+created_at: 2026-04-11T11:34:06Z
+updated_at: 2026-04-11T11:34:06Z
+---
+
+Chicago 18th §14.16 reprint pattern: '(original-year) current-year. Title. Original Publisher. Note. Current Publisher'. CSL fields original-publisher and original-publisher-place are not yet mapped from CSL JSON to Citum's original WorkRelation, so they silently drop. 7 chicago-zotero-bibliography benchmark items fail on this pattern (date already fixed by csl26-tpmn engine fix, but original-publisher and edition text still differ).

--- a/.beans/csl26-tpmn--chicago-author-date-chicago-18-rich-fidelity-follo.md
+++ b/.beans/csl26-tpmn--chicago-author-date-chicago-18-rich-fidelity-follo.md
@@ -165,9 +165,9 @@ Policy / architecture constraints established in this pass:
 
 ## Investigation Findings (2026-04-11)
 
-Engine fix landed:  was silently returning None
-in the TemplateDate value dispatch. Wired to reference.original_date().
-Committed as fix(engine): render date: original-published.
+Engine fix landed: `date: original-published` was silently returning `None`
+in the TemplateDate value dispatch. Wired to `reference.original_date()`.
+Committed as `fix(engine): render date: original-published`.
 
 Chicago Zotero benchmark baseline: 294/401 (73.3%) — at the min_pass_rate threshold.
 

--- a/.beans/csl26-tpmn--chicago-author-date-chicago-18-rich-fidelity-follo.md
+++ b/.beans/csl26-tpmn--chicago-author-date-chicago-18-rich-fidelity-follo.md
@@ -1,11 +1,11 @@
 ---
 # csl26-tpmn
 title: Chicago author-date Chicago 18 rich fidelity follow-up
-status: in-progress
+status: draft
 type: task
 priority: high
 created_at: 2026-04-02T11:56:15Z
-updated_at: 2026-04-11T11:04:16Z
+updated_at: 2026-04-11T11:26:32Z
 ---
 
 Continue the Chicago author-date fidelity pass using the raw Chicago 18 Zotero
@@ -162,3 +162,26 @@ Policy / architecture constraints established in this pass:
 - Keep this bean as the single tracking document for iterative Chicago
   author-date follow-up unless the work clearly splits into separate style and
   processor streams.
+
+## Investigation Findings (2026-04-11)
+
+Engine fix landed:  was silently returning None
+in the TemplateDate value dispatch. Wired to reference.original_date().
+Committed as fix(engine): render date: original-published.
+
+Chicago Zotero benchmark baseline: 294/401 (73.3%) — at the min_pass_rate threshold.
+
+Failure analysis (108 remaining):
+- 7 reprint-date items: need (original-year) current-year pattern AND original-publisher AND edition — style+processor gap
+- 3 edited-by capitalization: verb-form terms aren't capitalized sentence-initially
+- 98 complex/processor-level: multi-author name order, interview context, missing fields, type-specific formatting
+
+Conclusion: 0.85 target requires processor changes (multi-author formatting, verb-label
+capitalize-first, original-publisher rendering). Style-YAML alone cannot close the gap.
+Demoting to draft pending processor work.
+
+## Summary of Changes
+
+- Reporting semantics: implemented separately in csl26-ft25 (committed)
+- Engine OriginalPublished fix: committed fix(engine): render date: original-published
+- Style YAML: no changes warranted (failures are processor-level)

--- a/.beans/csl26-tpmn--chicago-author-date-chicago-18-rich-fidelity-follo.md
+++ b/.beans/csl26-tpmn--chicago-author-date-chicago-18-rich-fidelity-follo.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-04-02T11:56:15Z
-updated_at: 2026-04-03T17:30:00Z
+updated_at: 2026-04-11T11:04:16Z
 ---
 
 Continue the Chicago author-date fidelity pass using the raw Chicago 18 Zotero

--- a/.beans/csl26-twx1--engine-capitalize-first-for-verb-form-role-labels.md
+++ b/.beans/csl26-twx1--engine-capitalize-first-for-verb-form-role-labels.md
@@ -1,0 +1,11 @@
+---
+# csl26-twx1
+title: 'engine: capitalize-first for verb-form role labels'
+status: todo
+type: bug
+priority: high
+created_at: 2026-04-11T11:34:00Z
+updated_at: 2026-04-11T11:34:00Z
+---
+
+ContributorForm::Verb locale terms (e.g. 'edited by', 'translated by') are always lowercase. When the component appears sentence-initially (after a period separator), Chicago 18th and other styles expect 'Edited by'. The engine needs a capitalize-first mechanism for the verb-label path. Affects chicago-zotero-bibliography benchmark: 3+ items fail on this pattern.

--- a/.beans/csl26-zzun--engine-fix-multi-author-name-order-in-non-first-po.md
+++ b/.beans/csl26-zzun--engine-fix-multi-author-name-order-in-non-first-po.md
@@ -1,0 +1,11 @@
+---
+# csl26-zzun
+title: 'engine: fix multi-author name order in non-first positions'
+status: todo
+type: bug
+priority: normal
+created_at: 2026-04-11T11:34:13Z
+updated_at: 2026-04-11T11:34:13Z
+---
+
+In bibliography multi-author contributor lists, non-first authors are being rendered family-first when they should be given-first (e.g. 'Grene, David, and Lattimore, Richmond' vs 'Grene, David, and Richmond Lattimore'). This is a known gap affecting chicago-zotero-bibliography and likely other styles. name-order: family-first should only apply to the first contributor in a list.

--- a/.codex/agents/migration-researcher.md
+++ b/.codex/agents/migration-researcher.md
@@ -12,7 +12,7 @@ do_not_use_when:
 default_model: gpt-5.4-mini
 default_reasoning_effort: medium
 scope:
-  - Primary write scope: `crates/citum_migrate/`
+  - Primary write scope is `crates/citum_migrate/`
   - Read supporting evidence from `docs/`, `scripts/`, `styles-legacy/`, and test fixtures as needed.
   - Stay cluster-bounded: one target cluster per pass.
 verification:

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -658,6 +658,7 @@ impl ComponentValues for TemplateDate {
         let date_opt: Option<EdtfString> = match self.date {
             TemplateDateVar::Issued => reference.csl_issued_date(),
             TemplateDateVar::Accessed => reference.accessed(),
+            TemplateDateVar::OriginalPublished => reference.original_date(),
             _ => None,
         };
 

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -8,8 +8,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 mod common;
 use common::*;
 
-use citum_engine::{render::html::Html, render::plain::PlainText, Processor};
+use citum_engine::{Processor, render::html::Html, render::plain::PlainText};
 use citum_schema::{
+    BibliographySpec, CitationSpec, Style, StyleInfo,
     options::{
         AndOptions, ArticleJournalBibliographyConfig, ArticleJournalNoPageFallback,
         BibliographyOptions, Config, ContributorConfig, DelimiterPrecedesLast,
@@ -18,17 +19,16 @@ use citum_schema::{
         SortSpec,
     },
     reference::{
-        types::{ArchiveInfo, EprintInfo, MultilingualComplex, MultilingualString},
         Contributor, EdtfString, InputReference, Monograph, MonographType, Numbering,
         NumberingType, Serial, SerialComponent, SerialComponentType, SerialType, StructuredName,
         Title, WorkRelation,
+        types::{ArchiveInfo, EprintInfo, MultilingualComplex, MultilingualString},
     },
     template::{
         DateForm, DateVariable, DelimiterPunctuation, NumberVariable, Rendering, SimpleVariable,
         TemplateComponent, TemplateDate, TemplateGroup, TemplateNumber, TemplateTitle,
         TemplateVariable, TitleForm, TitleType,
     },
-    BibliographySpec, CitationSpec, Style, StyleInfo,
 };
 use indexmap::IndexMap;
 use rstest::rstest;

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -8,9 +8,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 mod common;
 use common::*;
 
-use citum_engine::{Processor, render::html::Html, render::plain::PlainText};
+use citum_engine::{render::html::Html, render::plain::PlainText, Processor};
 use citum_schema::{
-    BibliographySpec, CitationSpec, Style, StyleInfo,
     options::{
         AndOptions, ArticleJournalBibliographyConfig, ArticleJournalNoPageFallback,
         BibliographyOptions, Config, ContributorConfig, DelimiterPrecedesLast,
@@ -19,16 +18,17 @@ use citum_schema::{
         SortSpec,
     },
     reference::{
+        types::{ArchiveInfo, EprintInfo, MultilingualComplex, MultilingualString},
         Contributor, EdtfString, InputReference, Monograph, MonographType, Numbering,
         NumberingType, Serial, SerialComponent, SerialComponentType, SerialType, StructuredName,
         Title, WorkRelation,
-        types::{ArchiveInfo, EprintInfo, MultilingualComplex, MultilingualString},
     },
     template::{
         DateForm, DateVariable, DelimiterPunctuation, NumberVariable, Rendering, SimpleVariable,
         TemplateComponent, TemplateDate, TemplateGroup, TemplateNumber, TemplateTitle,
         TemplateVariable, TitleForm, TitleType,
     },
+    BibliographySpec, CitationSpec, Style, StyleInfo,
 };
 use indexmap::IndexMap;
 use rstest::rstest;
@@ -2969,6 +2969,76 @@ mod local_overrides {
         );
         super::bibliography_local_processing_changes_default_bibliography_sort();
     }
+}
+
+#[test]
+fn original_published_date_variable_renders_when_reference_has_original_date() {
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Original-date test".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::OriginalPublished,
+                    form: DateForm::Year,
+                    rendering: Rendering {
+                        prefix: Some("(".to_string()),
+                        suffix: Some(") ".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::Issued,
+                    form: DateForm::Year,
+                    ..Default::default()
+                }),
+                TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    form: Some(TitleForm::Long),
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        id: Some("gatsby".to_string()),
+        title: Some(Title::Single("The Great Gatsby".to_string())),
+        issued: EdtfString("1992".to_string()),
+        original: Some(WorkRelation::Embedded(Box::new(InputReference::Monograph(
+            Box::new(Monograph {
+                id: Some("gatsby-orig".to_string()),
+                issued: EdtfString("1925".to_string()),
+                ..Default::default()
+            }),
+        )))),
+        ..Default::default()
+    }));
+
+    let bibliography = IndexMap::from([("gatsby".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor
+        .render_selected_bibliography_with_format::<PlainText, _>(["gatsby".to_string()])
+        .trim()
+        .to_string();
+
+    assert!(
+        rendered.contains("(1925)"),
+        "expected original-published year '(1925)' in output: {rendered}"
+    );
+    assert!(
+        rendered.contains("1992"),
+        "expected issued year '1992' in output: {rendered}"
+    );
+    assert!(
+        rendered.contains("The Great Gatsby"),
+        "expected title in output: {rendered}"
+    );
 }
 
 mod annotated_html_preview {

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -7,16 +7,16 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use std::{fs, path::PathBuf};
 
-use citum_engine::io::load_bibliography;
 use citum_engine::Processor;
+use citum_engine::io::load_bibliography;
 use citum_schema::{
+    CitationSpec, Style, StyleInfo,
     citation::{Citation, CitationItem, CitationMode},
     reference::{
         Contributor, ContributorList, EdtfString, InputReference as Reference, Monograph,
         MonographType, MultilingualString, Serial, SerialComponent, SerialComponentType,
         SerialType, StructuredName, Title, WorkRelation,
     },
-    CitationSpec, Style, StyleInfo,
 };
 
 // --- Helper Functions for Test Data Construction ---

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -7,16 +7,16 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use std::{fs, path::PathBuf};
 
-use citum_engine::Processor;
 use citum_engine::io::load_bibliography;
+use citum_engine::Processor;
 use citum_schema::{
-    CitationSpec, Style, StyleInfo,
     citation::{Citation, CitationItem, CitationMode},
     reference::{
         Contributor, ContributorList, EdtfString, InputReference as Reference, Monograph,
         MonographType, MultilingualString, Serial, SerialComponent, SerialComponentType,
         SerialType, StructuredName, Title, WorkRelation,
     },
+    CitationSpec, Style, StyleInfo,
 };
 
 // --- Helper Functions for Test Data Construction ---

--- a/scripts/lib/verification-policy.js
+++ b/scripts/lib/verification-policy.js
@@ -81,6 +81,12 @@ function validateBenchmarkRun(run, label) {
   ensureOptionalString(run.refs_fixture, `${label}.refs_fixture`);
   ensureOptionalString(run.citations_fixture, `${label}.citations_fixture`);
   assert(typeof run.count_toward_fidelity === 'boolean', `${label}.count_toward_fidelity must be a boolean`);
+  if (run.min_pass_rate != null) {
+    assert(
+      typeof run.min_pass_rate === 'number' && run.min_pass_rate >= 0 && run.min_pass_rate <= 1,
+      `${label}.min_pass_rate must be a number between 0 and 1`
+    );
+  }
   assert(run.id && run.label && run.refs_fixture, `${label} must define id, label, and refs_fixture`);
   if (run.runner === 'native-smoke') {
     assert(run.scope === 'bibliography', `${label}.scope must be bibliography for native-smoke runs`);
@@ -209,6 +215,7 @@ function resolveVerificationPolicy(styleName, policy) {
       citationsFixture: run.citations_fixture || null,
       scope: run.scope,
       countTowardFidelity: run.count_toward_fidelity,
+      minPassRate: run.min_pass_rate ?? null,
     })),
   };
 }

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -1368,7 +1368,6 @@ function toPublishedBenchmarkRunRecord(benchmarkRunRecord) {
     runner: benchmarkRunRecord.runner,
     scope: benchmarkRunRecord.scope,
     countTowardFidelity: benchmarkRunRecord.countTowardFidelity,
-    minPassRate: benchmarkRunRecord.minPassRate ?? null,
     refsFixture: toRepoRelativePath(benchmarkRunRecord.refsFixture),
     citationsFixture: toRepoRelativePath(benchmarkRunRecord.citationsFixture),
     status: benchmarkRunRecord.status,
@@ -1389,24 +1388,25 @@ function toPublishedBenchmarkRunRecord(benchmarkRunRecord) {
   };
 }
 
+function determineBenchmarkStatus(oracleResult, minPassRate) {
+  if (oracleResult.error) return 'error';
+  if (minPassRate != null) {
+    const bib = oracleResult.bibliography || { passed: 0, total: 0 };
+    const cit = oracleResult.citations || { passed: 0, total: 0 };
+    const totalPassed = (bib.passed || 0) + (cit.passed || 0);
+    const totalItems = (bib.total || 0) + (cit.total || 0);
+    const matchRate = totalItems > 0 ? totalPassed / totalItems : 0;
+    return matchRate >= minPassRate ? 'pass' : 'fail';
+  }
+  return 'ok';
+}
+
 async function runBenchmarkRun(runtime, styleSpec, stylePath, styleYamlPath, benchmarkRun) {
   const resolvedRun = resolveBenchmarkRunConfig(benchmarkRun);
   try {
     if (resolvedRun.runner === BENCHMARK_RUNNERS.CITEPROC_ORACLE) {
       const oracleResult = await runCiteprocBenchmarkOracle(runtime, stylePath, styleSpec.name, resolvedRun);
-      let benchmarkStatus;
-      if (oracleResult.error) {
-        benchmarkStatus = 'error';
-      } else if (resolvedRun.minPassRate != null) {
-        const bib = oracleResult.bibliography || { passed: 0, total: 0 };
-        const cit = oracleResult.citations || { passed: 0, total: 0 };
-        const totalPassed = (bib.passed || 0) + (cit.passed || 0);
-        const totalItems = (bib.total || 0) + (cit.total || 0);
-        const matchRate = totalItems > 0 ? totalPassed / totalItems : 0;
-        benchmarkStatus = matchRate >= resolvedRun.minPassRate ? 'pass' : 'fail';
-      } else {
-        benchmarkStatus = 'ok';
-      }
+      const benchmarkStatus = determineBenchmarkStatus(oracleResult, resolvedRun.minPassRate);
       return formatBenchmarkRunRecord(resolvedRun, {
         status: benchmarkStatus,
         error: oracleResult.error || null,
@@ -3402,6 +3402,7 @@ module.exports = {
   mergeBenchmarkRunIntoOracle,
   mergeOracleResults,
   toPublishedBenchmarkRunRecord,
+  determineBenchmarkStatus,
   selectPrimaryComparator,
   serializeTimingSummary,
   textSimilarity,

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -1316,6 +1316,7 @@ function formatBenchmarkRunRecord(benchmarkRun, extras = {}) {
     runner: benchmarkRun.runner,
     scope: benchmarkRun.scope,
     countTowardFidelity: benchmarkRun.countTowardFidelity,
+    minPassRate: benchmarkRun.minPassRate ?? null,
     refsFixture: benchmarkRun.refsFixture,
     citationsFixture: benchmarkRun.citationsFixture || null,
     ...extras,
@@ -1342,6 +1343,7 @@ function summarizeBenchmarkRunRecord(benchmarkRunRecord) {
     scope: benchmarkRunRecord.scope,
     status: benchmarkRunRecord.status,
     countTowardFidelity: benchmarkRunRecord.countTowardFidelity,
+    minPassRate: benchmarkRunRecord.minPassRate ?? null,
     citations: summarizeSection(benchmarkRunRecord.citations),
     bibliography: summarizeSection(benchmarkRunRecord.bibliography),
     bibliographyEntries: benchmarkRunRecord.bibliographyEntries ?? null,
@@ -1366,6 +1368,7 @@ function toPublishedBenchmarkRunRecord(benchmarkRunRecord) {
     runner: benchmarkRunRecord.runner,
     scope: benchmarkRunRecord.scope,
     countTowardFidelity: benchmarkRunRecord.countTowardFidelity,
+    minPassRate: benchmarkRunRecord.minPassRate ?? null,
     refsFixture: toRepoRelativePath(benchmarkRunRecord.refsFixture),
     citationsFixture: toRepoRelativePath(benchmarkRunRecord.citationsFixture),
     status: benchmarkRunRecord.status,
@@ -1391,8 +1394,21 @@ async function runBenchmarkRun(runtime, styleSpec, stylePath, styleYamlPath, ben
   try {
     if (resolvedRun.runner === BENCHMARK_RUNNERS.CITEPROC_ORACLE) {
       const oracleResult = await runCiteprocBenchmarkOracle(runtime, stylePath, styleSpec.name, resolvedRun);
+      let benchmarkStatus;
+      if (oracleResult.error) {
+        benchmarkStatus = 'error';
+      } else if (resolvedRun.minPassRate != null) {
+        const bib = oracleResult.bibliography || { passed: 0, total: 0 };
+        const cit = oracleResult.citations || { passed: 0, total: 0 };
+        const totalPassed = (bib.passed || 0) + (cit.passed || 0);
+        const totalItems = (bib.total || 0) + (cit.total || 0);
+        const matchRate = totalItems > 0 ? totalPassed / totalItems : 0;
+        benchmarkStatus = matchRate >= resolvedRun.minPassRate ? 'pass' : 'fail';
+      } else {
+        benchmarkStatus = 'ok';
+      }
       return formatBenchmarkRunRecord(resolvedRun, {
-        status: oracleResult.error ? 'error' : 'pass',
+        status: benchmarkStatus,
         error: oracleResult.error || null,
         oracleResult,
         citations: oracleResult.citations || { passed: 0, total: 0, entries: [] },
@@ -2899,9 +2915,14 @@ function generateDetailContent(style) {
     for (const benchmarkRun of style.benchmarkRunResults) {
       const statusClass = benchmarkRun.status === 'pass'
         ? 'bg-emerald-100 text-emerald-700'
-        : 'bg-red-100 text-red-700';
+        : benchmarkRun.status === 'ok'
+          ? 'bg-slate-100 text-slate-600'
+          : 'bg-red-100 text-red-700';
       const scopeText = benchmarkRun.scope === 'both' ? 'citation + bibliography' : benchmarkRun.scope;
       const contributionText = benchmarkRun.countTowardFidelity ? 'counts toward fidelity' : 'diagnostic only';
+      const thresholdText = benchmarkRun.minPassRate != null
+        ? `${(benchmarkRun.minPassRate * 100).toFixed(0)}%`
+        : 'none';
       const bibliographyText = benchmarkRun.bibliography
         ? `${benchmarkRun.bibliography.passed}/${benchmarkRun.bibliography.total}`
         : benchmarkRun.bibliographyEntries != null
@@ -2923,6 +2944,7 @@ function generateDetailContent(style) {
                                             <div><span class="font-semibold text-slate-700">Runner:</span> <span class="font-mono text-slate-600">${escapeHtml(benchmarkRun.runner)}</span></div>
                                             <div><span class="font-semibold text-slate-700">Scope:</span> <span class="font-mono text-slate-600">${escapeHtml(scopeText)}</span></div>
                                             <div><span class="font-semibold text-slate-700">Contribution:</span> <span class="font-mono text-slate-600">${escapeHtml(contributionText)}</span></div>
+                                            <div><span class="font-semibold text-slate-700">Threshold:</span> <span class="font-mono text-slate-600">${escapeHtml(thresholdText)}</span></div>
                                             <div><span class="font-semibold text-slate-700">Bibliography:</span> <span class="font-mono text-slate-600">${escapeHtml(bibliographyText)}</span></div>
                                             ${benchmarkRun.citations ? `<div><span class="font-semibold text-slate-700">Citations:</span> <span class="font-mono text-slate-600">${escapeHtml(citationsText)}</span></div>` : ''}
                                             <div><span class="font-semibold text-slate-700">Refs fixture:</span> <span class="font-mono text-slate-600">${escapeHtml(benchmarkRun.refsFixture)}</span></div>

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -38,6 +38,7 @@ const {
   runCachedJsonJob,
   selectPrimaryComparator,
   toPublishedBenchmarkRunRecord,
+  determineBenchmarkStatus,
 } = require('./report-core');
 
 const projectRoot = path.resolve(__dirname, '..');
@@ -425,6 +426,74 @@ test('published benchmark run records are compact and repo-relative', () => {
     bibliographyEntries: null,
   });
   assert.equal(Object.hasOwn(published, 'oracleResult'), false);
+  assert.equal(Object.hasOwn(published, 'minPassRate'), false);
+});
+
+test('min_pass_rate resolves to minPassRate in resolved policy', () => {
+  const policy = validateVerificationPolicy({
+    version: 1,
+    defaults: { authority: 'citeproc-js', secondary: [], scopes: ['citation', 'bibliography'] },
+    styles: {
+      'chicago-author-date': {
+        benchmark_runs: [{
+          id: 'zotero-bib',
+          label: 'Zotero bibliography',
+          runner: 'citeproc-oracle',
+          refs_fixture: 'tests/fixtures/test-items-library/chicago-18th.json',
+          scope: 'bibliography',
+          count_toward_fidelity: true,
+          min_pass_rate: 0.73,
+        }],
+      },
+    },
+  });
+  const stylePolicy = resolveVerificationPolicy('chicago-author-date', policy);
+  assert.equal(stylePolicy.benchmarkRuns[0].minPassRate, 0.73);
+});
+
+test('min_pass_rate validation rejects out-of-range values', () => {
+  const base = {
+    version: 1,
+    defaults: { authority: 'citeproc-js', secondary: [], scopes: ['citation', 'bibliography'] },
+    styles: {
+      sample: {
+        benchmark_runs: [{
+          id: 'r',
+          label: 'R',
+          runner: 'citeproc-oracle',
+          refs_fixture: 'tests/fixtures/test-items-library/chicago-18th.json',
+          scope: 'bibliography',
+          count_toward_fidelity: false,
+        }],
+      },
+    },
+  };
+  assert.throws(
+    () => validateVerificationPolicy({
+      ...base,
+      styles: { sample: { benchmark_runs: [{ ...base.styles.sample.benchmark_runs[0], min_pass_rate: 1.5 }] } },
+    }),
+    /min_pass_rate must be a number between 0 and 1/
+  );
+  assert.throws(
+    () => validateVerificationPolicy({
+      ...base,
+      styles: { sample: { benchmark_runs: [{ ...base.styles.sample.benchmark_runs[0], min_pass_rate: -0.1 }] } },
+    }),
+    /min_pass_rate must be a number between 0 and 1/
+  );
+});
+
+test('determineBenchmarkStatus returns pass/fail/ok/error based on threshold and result', () => {
+  const passing = { bibliography: { passed: 8, total: 10 }, citations: { passed: 0, total: 0 } };
+  const failing = { bibliography: { passed: 5, total: 10 }, citations: { passed: 0, total: 0 } };
+  const errored = { error: 'citeproc-js crashed', bibliography: null, citations: null };
+
+  assert.equal(determineBenchmarkStatus(errored, 0.73), 'error');
+  assert.equal(determineBenchmarkStatus(passing, 0.73), 'pass');
+  assert.equal(determineBenchmarkStatus(failing, 0.73), 'fail');
+  assert.equal(determineBenchmarkStatus(passing, null), 'ok');
+  assert.equal(determineBenchmarkStatus(failing, null), 'ok');
 });
 
 test('comparison text helper supports both live-oracle and native-snapshot entry shapes', () => {

--- a/scripts/report-data/verification-policy.yaml
+++ b/scripts/report-data/verification-policy.yaml
@@ -142,6 +142,7 @@ styles:
         refs_fixture: tests/fixtures/test-items-library/chicago-18th.json
         scope: bibliography
         count_toward_fidelity: true
+        min_pass_rate: 0.73
       - id: relational-comprehensive-smoke
         label: Relational comprehensive native smoke
         runner: native-smoke


### PR DESCRIPTION
## Summary

- **Workstream A**: Add `min_pass_rate` threshold to benchmark runs — replaces the binary pass/error status with a tri-state `pass`/`fail`/`ok` system. Chicago Zotero bibliography benchmark (294/401, 73.3%) is wired to `min_pass_rate: 0.73` as its initial floor.
- **Workstream B**: Fix `date: original-published` silently returning `None` — the `TemplateDateVar::OriginalPublished` arm fell through to the wildcard match in `values/date.rs`. One-line fix routes it to `reference.original_date()`.

## Changes

**Benchmark threshold (A):**
- `scripts/lib/verification-policy.js`: validate and propagate `min_pass_rate`
- `scripts/report-core.js`: tri-state status logic; HTML renderer colours (`ok` → slate, `pass` → emerald, `fail` → red)
- `scripts/report-data/verification-policy.yaml`: `min_pass_rate: 0.73` on `chicago-zotero-bibliography`

**Engine fix (B):**
- `crates/citum-engine/src/values/date.rs`: add `OriginalPublished` match arm
- `crates/citum-engine/tests/bibliography.rs`: regression test with `original: WorkRelation::Embedded(Monograph { issued: EdtfString("1925") })`

**Follow-up beans created** (all blocked on processor work; Chicago 0.85 target is unblocked once these land):
- `csl26-twx1` — verb-form role labels capitalize-first sentence-initially
- `csl26-3j0c` — map `original-publisher`/`original-publisher-place` to WorkRelation
- `csl26-zzun` — non-first author name order (given-first in bibliography)

## Test plan

- [ ] `cargo nextest run --test bibliography` — `original_published_date_variable_renders_when_reference_has_original_date` passes
- [ ] `node scripts/report-core.js | node scripts/check-core-quality.js --report /dev/stdin --baseline scripts/report-data/core-quality-baseline.json` — portfolio gate green
- [ ] `node scripts/report-core.js` — chicago-zotero-bibliography status shows `pass` at 73.3%
