### PR TITLE
add sentence-initial labels

### DIFF
--- a/.beans/archive/csl26-twx1--engine-capitalize-first-for-verb-form-role-labels.md
+++ b/.beans/archive/csl26-twx1--engine-capitalize-first-for-verb-form-role-labels.md
@@ -1,13 +1,13 @@
 ---
 # csl26-twx1
 title: 'engine: capitalize-first for verb-form role labels'
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-04-11T11:34:00Z
-updated_at: 2026-04-11T11:34:00Z
+updated_at: 2026-04-11T13:50:04Z
 ---
 
 ContributorForm::Verb locale terms (e.g. 'edited by', 'translated by') are always lowercase. When the component appears sentence-initially (after a period separator), Chicago 18th and other styles expect 'Edited by'. The engine needs a capitalize-first mechanism for the verb-label path. Affects chicago-zotero-bibliography benchmark: 3+ items fail on this pattern.
 
-Prerequisite design work is now captured in `docs/specs/SENTENCE_INITIAL_LABELS.md`. This bean remains open for the implementation PR that lands the rendering behavior after the broader sentence-initial label model is reviewed.
+Prerequisite design work was captured in `docs/specs/SENTENCE_INITIAL_LABELS.md`, and the paired engine implementation now landed on PR #506. This bean is closed and archived with that implementation.

--- a/.beans/csl26-twx1--engine-capitalize-first-for-verb-form-role-labels.md
+++ b/.beans/csl26-twx1--engine-capitalize-first-for-verb-form-role-labels.md
@@ -9,3 +9,5 @@ updated_at: 2026-04-11T11:34:00Z
 ---
 
 ContributorForm::Verb locale terms (e.g. 'edited by', 'translated by') are always lowercase. When the component appears sentence-initially (after a period separator), Chicago 18th and other styles expect 'Edited by'. The engine needs a capitalize-first mechanism for the verb-label path. Affects chicago-zotero-bibliography benchmark: 3+ items fail on this pattern.
+
+Prerequisite design work is now captured in `docs/specs/SENTENCE_INITIAL_LABELS.md`. This bean remains open for the implementation PR that lands the rendering behavior after the broader sentence-initial label model is reviewed.

--- a/crates/citum-engine/src/processor/bibliography/compound.rs
+++ b/crates/citum-engine/src/processor/bibliography/compound.rs
@@ -128,6 +128,7 @@ impl Processor {
         merged_template.push(ProcTemplateComponent {
             template_component: TemplateComponent::default(),
             value: merged_body,
+            sentence_initial: false,
             pre_formatted: true,
             config: entry
                 .template

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -6,8 +6,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Citation rendering orchestration.
 //!
 //! This module resolves the effective citation spec for each citation, prepares
-//! renderer delimiters and affixes, and applies note-style casing rules to the
-//! final output. Template-level rendering still lives in `rendering`.
+//! renderer delimiters and affixes. Template-level rendering, including
+//! sentence-initial note-start handling, lives in `rendering`.
 
 use super::Processor;
 use super::rendering::{CompoundRenderData, Renderer, RendererResources};
@@ -16,21 +16,6 @@ use crate::reference::Citation;
 use citum_schema::NoteStartTextCase;
 use citum_schema::locale::{GeneralTerm, Locale, TermForm};
 use citum_schema::template::DelimiterPunctuation;
-
-fn capitalize_first(value: &str) -> String {
-    let mut chars = value.chars();
-    match chars.next() {
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-        None => String::new(),
-    }
-}
-
-fn apply_note_start_text_case(value: &str, text_case: NoteStartTextCase) -> String {
-    match text_case {
-        NoteStartTextCase::CapitalizeFirst => capitalize_first(value),
-        NoteStartTextCase::Lowercase => value.to_lowercase(),
-    }
-}
 
 fn join_integral_groups(rendered_groups: Vec<String>, locale: &Locale) -> String {
     match rendered_groups.len() {
@@ -59,48 +44,34 @@ fn join_integral_groups(rendered_groups: Vec<String>, locale: &Locale) -> String
     }
 }
 
-/// Apply note-start casing to the first visible text node in rendered citation output.
-///
-/// This preserves any leading markup so note-style case adjustments only touch
-/// the user-visible text content.
-pub(crate) fn apply_note_start_text_case_to_leading_text_node(
-    rendered: &str,
-    text_case: NoteStartTextCase,
-) -> String {
-    let mut in_tag = false;
-    let mut text_start = None;
-
-    for (index, ch) in rendered.char_indices() {
-        match ch {
-            '<' if !in_tag => in_tag = true,
-            '>' if in_tag => in_tag = false,
-            _ if !in_tag && !ch.is_whitespace() => {
-                text_start = Some(index);
-                break;
-            }
-            _ => {}
+impl Processor {
+    fn sentence_initial_note_start_text_case(
+        &self,
+        citation: &Citation,
+        effective_spec: &citum_schema::CitationSpec,
+    ) -> Option<NoteStartTextCase> {
+        let spec_prefix = effective_spec.prefix.as_deref().unwrap_or("");
+        if self.is_note_style()
+            && matches!(
+                citation.position,
+                Some(
+                    citum_schema::citation::Position::Ibid
+                        | citum_schema::citation::Position::IbidWithLocator
+                )
+            )
+            && matches!(
+                citation.mode,
+                citum_schema::citation::CitationMode::NonIntegral
+            )
+            && citation.prefix.as_deref().unwrap_or("").is_empty()
+            && spec_prefix.is_empty()
+        {
+            effective_spec.note_start_text_case
+        } else {
+            None
         }
     }
 
-    let Some(text_start) = text_start else {
-        return rendered.to_string();
-    };
-
-    let text_end = rendered[text_start..]
-        .find('<')
-        .map_or(rendered.len(), |offset| text_start + offset);
-
-    let mut result = String::with_capacity(rendered.len());
-    result.push_str(&rendered[..text_start]);
-    result.push_str(&apply_note_start_text_case(
-        &rendered[text_start..text_end],
-        text_case,
-    ));
-    result.push_str(&rendered[text_end..]);
-    result
-}
-
-impl Processor {
     fn resolve_positioned_citation_spec(
         &self,
         citation: &Citation,
@@ -162,6 +133,7 @@ impl Processor {
         effective_spec: &citum_schema::CitationSpec,
         renderer_delimiter: &str,
         renderer_inter_delimiter: &str,
+        note_start_text_case: Option<NoteStartTextCase>,
     ) -> Result<String, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -208,6 +180,7 @@ impl Processor {
                 renderer_delimiter,
                 citation.suppress_author,
                 citation.position.as_ref(),
+                note_start_text_case,
             )?
         } else {
             renderer.render_grouped_citation_with_format::<F>(
@@ -217,6 +190,7 @@ impl Processor {
                 renderer_delimiter,
                 citation.suppress_author,
                 citation.position.as_ref(),
+                note_start_text_case,
             )?
         };
 
@@ -304,35 +278,6 @@ impl Processor {
         }
     }
 
-    fn apply_note_start_case_if_needed(
-        &self,
-        citation: &Citation,
-        effective_spec: &citum_schema::CitationSpec,
-        rendered: String,
-    ) -> String {
-        let spec_prefix = effective_spec.prefix.as_deref().unwrap_or("");
-        if self.is_note_style()
-            && matches!(
-                citation.position,
-                Some(
-                    citum_schema::citation::Position::Ibid
-                        | citum_schema::citation::Position::IbidWithLocator
-                )
-            )
-            && matches!(
-                citation.mode,
-                citum_schema::citation::CitationMode::NonIntegral
-            )
-            && citation.prefix.as_deref().unwrap_or("").is_empty()
-            && spec_prefix.is_empty()
-            && let Some(text_case) = effective_spec.note_start_text_case
-        {
-            return apply_note_start_text_case_to_leading_text_node(&rendered, text_case);
-        }
-
-        rendered
-    }
-
     /// Render a single citation to plain text.
     ///
     /// This is the primary entry point for citation processing. It handles:
@@ -353,8 +298,7 @@ impl Processor {
     /// Render a citation to a string using a specific output format.
     ///
     /// This resolves the effective citation spec for the citation's mode and
-    /// position, renders the citation body, applies input and style affixes,
-    /// and finally applies note-style casing when required.
+    /// position, renders the citation body, and applies input and style affixes.
     ///
     /// # Errors
     ///
@@ -370,6 +314,8 @@ impl Processor {
         self.track_cited_ids_and_init_numbers(citation);
 
         let effective_spec = self.resolve_effective_citation_spec(citation);
+        let note_start_text_case =
+            self.sentence_initial_note_start_text_case(citation, &effective_spec);
         let (renderer_delimiter, renderer_inter_delimiter) =
             self.resolve_citation_delimiters(&effective_spec);
         let content = self.render_citation_content::<F>(
@@ -377,11 +323,12 @@ impl Processor {
             &effective_spec,
             renderer_delimiter,
             renderer_inter_delimiter,
+            note_start_text_case,
         )?;
         let output = self.apply_citation_input_affixes(citation, content, &fmt);
         let wrapped = self.apply_spec_wrap_and_affixes(citation, &effective_spec, output, &fmt);
 
-        Ok(self.apply_note_start_case_if_needed(citation, &effective_spec, fmt.finish(wrapped)))
+        Ok(fmt.finish(wrapped))
     }
 
     /// Render multiple citations in document order.

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -6,10 +6,15 @@ use super::super::{
 use super::group_citation_items_by_author;
 use crate::error::ProcessorError;
 use crate::reference::Reference;
+use crate::render::bibliography::{append_rendered_component, component_starts_new_sentence};
+use crate::render::component::render_component_with_format;
 use crate::render::{ProcTemplate, ProcTemplateComponent};
 use crate::values::{ComponentValues, ProcHints, RenderContext, RenderOptions};
 use citum_schema::{
+    NoteStartTextCase,
+    locale::GeneralTerm,
     options::ArticleJournalNoPageFallback,
+    options::titles::TextCase,
     reference::NumOrStr,
     template::{DateVariable, NumberVariable, SimpleVariable, TemplateComponent},
 };
@@ -45,6 +50,7 @@ struct GroupItemRenderRequest<'a> {
     mode: &'a citum_schema::citation::CitationMode,
     suppress_author: bool,
     position: Option<&'a citum_schema::citation::Position>,
+    note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     delimiter: &'a str,
 }
 
@@ -128,11 +134,16 @@ impl Renderer<'_> {
             intra_delimiter,
             suppress_author,
             position,
+            spec.note_start_text_case,
         )
     }
 
     /// Render a group of items that must not be author-collapsed (legal cases,
     /// personal communications). Returns the rendered citation strings.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Citation item rendering now needs explicit note-start context."
+    )]
     fn render_special_type_items<F>(
         &self,
         group: &[&crate::reference::CitationItem],
@@ -141,6 +152,7 @@ impl Renderer<'_> {
         suppress_author: bool,
         position: Option<&citum_schema::citation::Position>,
         intra_delimiter: &str,
+        note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     ) -> Result<Vec<String>, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -157,6 +169,7 @@ impl Renderer<'_> {
                     mode,
                     suppress_author,
                     position,
+                    note_start_text_case,
                     delimiter: intra_delimiter,
                 },
             ) && let Some((ids, content)) = self.build_citation_chunk(
@@ -203,6 +216,7 @@ impl Renderer<'_> {
                     mode,
                     suppress_author,
                     position,
+                    note_start_text_case: spec.note_start_text_case,
                     delimiter: component_delimiter,
                 },
             ) && !item_str.is_empty()
@@ -233,6 +247,10 @@ impl Renderer<'_> {
     ///
     /// Returns an error when a referenced item is missing or grouped rendering
     /// fails.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Grouped citation rendering now needs explicit note-start context."
+    )]
     pub fn render_grouped_citation_with_format<F>(
         &self,
         items: &[crate::reference::CitationItem],
@@ -241,6 +259,7 @@ impl Renderer<'_> {
         intra_delimiter: &str,
         suppress_author: bool,
         position: Option<&citum_schema::citation::Position>,
+        note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     ) -> Result<Vec<String>, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -255,12 +274,17 @@ impl Renderer<'_> {
                 intra_delimiter,
                 suppress_author,
                 position,
+                note_start_text_case,
             )?);
         }
 
         Ok(rendered_groups)
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Grouped citation rendering now needs explicit note-start context."
+    )]
     fn render_grouped_citation_group_with_format<F>(
         &self,
         group: &[&crate::reference::CitationItem],
@@ -269,6 +293,7 @@ impl Renderer<'_> {
         intra_delimiter: &str,
         suppress_author: bool,
         position: Option<&citum_schema::citation::Position>,
+        note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     ) -> Result<Vec<String>, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -293,6 +318,7 @@ impl Renderer<'_> {
                 suppress_author,
                 position,
                 intra_delimiter,
+                note_start_text_case,
             );
         }
 
@@ -308,6 +334,7 @@ impl Renderer<'_> {
                     intra_delimiter,
                     suppress_author,
                     position,
+                    note_start_text_case,
                 },
             )?
             .into_iter()
@@ -497,6 +524,7 @@ impl Renderer<'_> {
                     mode: params.mode,
                     suppress_author: params.suppress_author,
                     position: params.position,
+                    note_start_text_case: params.note_start_text_case,
                     delimiter: item_delimiter,
                 },
             ) && !item_str.is_empty()
@@ -754,6 +782,7 @@ impl Renderer<'_> {
                 locator_raw: None,
                 citation_number: entry_number,
                 position: None,
+                note_start_text_case: None,
                 integral_name_state: None,
             },
         )
@@ -796,6 +825,7 @@ impl Renderer<'_> {
                 locator_raw: params.locator_raw,
                 citation_number: params.citation_number,
                 position: params.position.cloned(),
+                note_start_text_case: params.note_start_text_case,
                 integral_name_state: params.integral_name_state,
             },
         )
@@ -819,6 +849,7 @@ impl Renderer<'_> {
             locator_raw,
             citation_number,
             position,
+            note_start_text_case,
             integral_name_state,
         } = request;
         let ref_type = reference.ref_type();
@@ -842,7 +873,7 @@ impl Renderer<'_> {
             integral_name_state,
         );
         let mut tracker = TemplateComponentTracker::default();
-        let components: Vec<ProcTemplateComponent> = template
+        let mut components: Vec<ProcTemplateComponent> = template
             .iter()
             .enumerate()
             .filter_map(|(template_index, component)| {
@@ -861,11 +892,144 @@ impl Renderer<'_> {
             })
             .collect();
 
+        self.apply_sentence_initial_context::<F>(&mut components, context, note_start_text_case);
+
         if components.is_empty() {
             None
         } else {
             Some(components)
         }
+    }
+
+    fn apply_sentence_initial_context<F>(
+        &self,
+        components: &mut [ProcTemplateComponent],
+        context: RenderContext,
+        note_start_text_case: Option<NoteStartTextCase>,
+    ) where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        match context {
+            RenderContext::Bibliography => {
+                self.apply_bibliography_sentence_initial_context::<F>(components);
+            }
+            RenderContext::Citation => {
+                self.apply_note_start_sentence_initial_context(components, note_start_text_case);
+            }
+        }
+    }
+
+    fn apply_bibliography_sentence_initial_context<F>(
+        &self,
+        components: &mut [ProcTemplateComponent],
+    ) where
+        F: crate::render::format::OutputFormat<Output = String>,
+    {
+        if !components.iter().any(|component| {
+            component
+                .prefix
+                .as_deref()
+                .is_some_and(|prefix| !prefix.is_empty())
+        }) {
+            return;
+        }
+
+        let punctuation_in_quote = components
+            .first()
+            .and_then(|component| component.config.as_ref())
+            .is_some_and(|config| config.punctuation_in_quote);
+        let default_separator = components
+            .first()
+            .and_then(|component| component.bibliography_config.as_ref())
+            .and_then(|bib| bib.separator.as_deref())
+            .unwrap_or(". ")
+            .to_string();
+
+        let mut entry_output = String::new();
+        for component in components.iter_mut() {
+            let rendered = render_component_with_format::<F>(component);
+            if rendered.is_empty() {
+                continue;
+            }
+
+            if component_starts_new_sentence(
+                &entry_output,
+                &rendered,
+                &default_separator,
+                punctuation_in_quote,
+            ) {
+                component.sentence_initial = true;
+                self.apply_sentence_initial_transform(component, None);
+            }
+
+            let rendered = render_component_with_format::<F>(component);
+            append_rendered_component(
+                &mut entry_output,
+                &rendered,
+                &default_separator,
+                punctuation_in_quote,
+            );
+        }
+    }
+
+    fn apply_note_start_sentence_initial_context(
+        &self,
+        components: &mut [ProcTemplateComponent],
+        note_start_text_case: Option<NoteStartTextCase>,
+    ) {
+        let Some(text_case) = note_start_text_case else {
+            return;
+        };
+
+        for component in components.iter_mut() {
+            if !self.is_note_start_term_component(component) {
+                continue;
+            }
+
+            component.sentence_initial = true;
+            self.apply_sentence_initial_transform(component, Some(text_case));
+            break;
+        }
+    }
+
+    fn apply_sentence_initial_transform(
+        &self,
+        component: &mut ProcTemplateComponent,
+        note_start_text_case: Option<NoteStartTextCase>,
+    ) {
+        if !component.sentence_initial {
+            return;
+        }
+
+        match &component.template_component {
+            TemplateComponent::Contributor(_) => {
+                if let Some(prefix) = component.prefix.as_mut() {
+                    let case = crate::values::text_case::resolve_text_case(
+                        TextCase::CapitalizeFirst,
+                        Some(self.locale.locale.as_str()),
+                    );
+                    *prefix = crate::values::text_case::apply_text_case(prefix, case);
+                }
+            }
+            TemplateComponent::Term(_)
+                if note_start_text_case.is_some()
+                    && self.is_note_start_term_component(component) =>
+            {
+                component.value = crate::values::text_case::apply_note_start_text_case(
+                    &component.value,
+                    note_start_text_case.expect("checked above"),
+                    Some(self.locale.locale.as_str()),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn is_note_start_term_component(&self, component: &ProcTemplateComponent) -> bool {
+        matches!(
+            &component.template_component,
+            TemplateComponent::Term(term) if term.term == GeneralTerm::Ibid
+        )
     }
 
     fn apply_article_journal_bibliography_policy<'a>(
@@ -1061,6 +1225,7 @@ impl Renderer<'_> {
             config: Some(options.config.clone()),
             bibliography_config: options.bibliography_config.clone(),
             item_language,
+            sentence_initial: false,
             pre_formatted: values.pre_formatted,
         })
     }
@@ -1133,6 +1298,7 @@ impl Renderer<'_> {
             config: Some(options.config.clone()),
             bibliography_config: options.bibliography_config.clone(),
             item_language: crate::values::effective_component_language(reference, &group_component),
+            sentence_initial: false,
             pre_formatted: true,
         })
     }
@@ -1236,6 +1402,7 @@ impl Renderer<'_> {
             item_request.mode,
             item_request.suppress_author,
             item_request.position,
+            item_request.note_start_text_case,
         );
         self.render_item_from_template_with_format::<F>(reference, request, item_request.delimiter)
     }

--- a/crates/citum-engine/src/processor/rendering/grouped_fallback.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped_fallback.rs
@@ -17,6 +17,8 @@ pub(crate) struct GroupRenderParams<'a> {
     pub(crate) suppress_author: bool,
     /// The citation position (e.g., ibid, subsequent).
     pub(crate) position: Option<&'a citum_schema::citation::Position>,
+    /// Optional note-start text-case policy for note-style repeated-note output.
+    pub(crate) note_start_text_case: Option<citum_schema::NoteStartTextCase>,
 }
 
 /// Parameters for rendering a template with a citation number.
@@ -41,6 +43,8 @@ pub struct TemplateRenderParams<'a> {
     pub locator_raw: Option<&'a citum_schema::citation::CitationLocator>,
     /// The citation position (e.g., ibid, subsequent).
     pub position: Option<&'a citum_schema::citation::Position>,
+    /// Optional note-start text-case policy for citation templates.
+    pub note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     /// Whether the author was rendered in integral form in the prose anchor.
     pub integral_name_state: Option<citum_schema::citation::IntegralNameState>,
 }

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -89,6 +89,8 @@ pub struct TemplateRenderRequest<'a> {
     pub citation_number: usize,
     /// The citation position (e.g., Ibid).
     pub position: Option<citum_schema::citation::Position>,
+    /// Optional note-start text-case policy for note-style repeated-note output.
+    pub note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     /// Integral name state for name formatting.
     pub integral_name_state: Option<citum_schema::citation::IntegralNameState>,
 }
@@ -337,6 +339,7 @@ impl<'a> Renderer<'a> {
         mode: &citum_schema::citation::CitationMode,
         suppress_author: bool,
         position: Option<&citum_schema::citation::Position>,
+        note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     ) -> TemplateRenderRequest<'b> {
         TemplateRenderRequest {
             template,
@@ -346,6 +349,7 @@ impl<'a> Renderer<'a> {
             locator_raw: item.locator.as_ref(),
             citation_number: self.get_or_assign_citation_number(&item.id),
             position: position.cloned(),
+            note_start_text_case,
             integral_name_state: item.integral_name_state,
         }
     }
@@ -458,6 +462,7 @@ impl<'a> Renderer<'a> {
             intra_delimiter,
             suppress_author,
             position,
+            spec.note_start_text_case,
         )
     }
 
@@ -470,6 +475,10 @@ impl<'a> Renderer<'a> {
     ///
     /// Returns an error when a referenced item is missing or item rendering
     /// fails.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Ungrouped citation rendering now needs explicit note-start context."
+    )]
     pub fn render_ungrouped_citation_with_format<F>(
         &self,
         items: &[crate::reference::CitationItem],
@@ -478,6 +487,7 @@ impl<'a> Renderer<'a> {
         intra_delimiter: &str,
         suppress_author: bool,
         position: Option<&citum_schema::citation::Position>,
+        note_start_text_case: Option<citum_schema::NoteStartTextCase>,
     ) -> Result<Vec<String>, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -537,6 +547,7 @@ impl<'a> Renderer<'a> {
                     mode,
                     suppress_author,
                     position,
+                    note_start_text_case,
                 );
                 if let Some(item_str) = self.render_item_from_template_with_format::<F>(
                     reference,

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -96,32 +96,6 @@ fn make_style() -> Style {
     }
 }
 
-#[test]
-fn given_plain_text_ibid_when_note_start_case_is_lowercase_then_the_leading_text_is_lowercased() {
-    assert_eq!(
-        super::citation::apply_note_start_text_case_to_leading_text_node(
-            "Ibid., 105",
-            citum_schema::NoteStartTextCase::Lowercase
-        ),
-        "ibid., 105"
-    );
-}
-
-#[test]
-fn given_html_wrapped_ibid_when_note_start_case_is_lowercase_then_the_markup_is_preserved() {
-    let rendered = "<span class=\"csln-citation\" data-ref=\"ITEM-1\">Ibid.</span>";
-    let transformed = super::citation::apply_note_start_text_case_to_leading_text_node(
-        rendered,
-        citum_schema::NoteStartTextCase::Lowercase,
-    );
-
-    assert_eq!(
-        transformed,
-        "<span class=\"csln-citation\" data-ref=\"ITEM-1\">ibid.</span>"
-    );
-    assert!(transformed.contains("data-ref=\"ITEM-1\""));
-}
-
 fn make_note_style() -> Style {
     let mut style = make_style();
     style.options = Some(Config {

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -18,6 +18,10 @@ fn is_final_punctuation(c: char) -> bool {
     matches!(c, '.' | ',' | ':' | ';' | '!' | '?')
 }
 
+fn is_sentence_ending_punctuation(c: char) -> bool {
+    matches!(c, '.' | '!' | '?')
+}
+
 fn visible_text(input: &str) -> String {
     let mut output = String::with_capacity(input.len());
     let mut in_tag = false;
@@ -43,6 +47,58 @@ fn last_visible_non_space_char(input: &str) -> Option<char> {
         .chars()
         .rev()
         .find(|ch| !ch.is_whitespace())
+}
+
+fn ends_with_sentence_ending_visible_punctuation(input: &str) -> bool {
+    let visible = visible_text(input);
+    let mut chars = visible.chars().rev().filter(|ch| !ch.is_whitespace());
+    match chars.next() {
+        Some(ch) if is_sentence_ending_punctuation(ch) => true,
+        Some('"' | '\u{201D}') => chars.next().is_some_and(is_sentence_ending_punctuation),
+        _ => false,
+    }
+}
+
+/// Returns true when the next rendered component should be treated as sentence-initial
+/// under the same join semantics used by bibliography rendering.
+#[must_use]
+pub(crate) fn component_starts_new_sentence(
+    entry_output: &str,
+    rendered: &str,
+    default_separator: &str,
+    punctuation_in_quote: bool,
+) -> bool {
+    if entry_output.is_empty() {
+        return true;
+    }
+
+    let first_char = first_visible_char(rendered).unwrap_or(' ');
+    let starts_with_separator = matches!(first_char, ',' | ';' | ':' | ' ' | '.' | '(');
+
+    if starts_with_separator {
+        return false;
+    }
+
+    if ends_with_sentence_ending_visible_punctuation(entry_output) {
+        return true;
+    }
+
+    let last_char = entry_output.chars().last().unwrap_or(' ');
+    let trimmed_last = last_visible_non_space_char(entry_output).unwrap_or(' ');
+    if !last_char.is_whitespace()
+        && !first_char.is_whitespace()
+        && !is_final_punctuation(trimmed_last)
+        && default_separator
+            .chars()
+            .next()
+            .is_some_and(is_sentence_ending_punctuation)
+    {
+        return true;
+    }
+
+    punctuation_in_quote
+        && default_separator.starts_with('.')
+        && (entry_output.ends_with('"') || entry_output.ends_with('\u{201D}'))
 }
 
 /// Render processed templates into a final bibliography string using `PlainText` format.
@@ -148,7 +204,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
     entry_output
 }
 
-fn append_rendered_component(
+pub(crate) fn append_rendered_component(
     entry_output: &mut String,
     rendered: &str,
     default_separator: &str,
@@ -337,6 +393,36 @@ mod tests {
     use citum_schema::template::{Rendering, TemplateComponent, WrapConfig, WrapPunctuation};
 
     #[test]
+    fn test_component_starts_new_sentence_at_entry_start() {
+        assert!(component_starts_new_sentence(
+            "",
+            "Edited by Grimm, Jacob",
+            ". ",
+            false
+        ));
+    }
+
+    #[test]
+    fn test_component_starts_new_sentence_after_period() {
+        assert!(component_starts_new_sentence(
+            "Collected Essays.",
+            "edited by Grimm, Jacob",
+            ". ",
+            false
+        ));
+    }
+
+    #[test]
+    fn test_component_does_not_start_new_sentence_after_colon() {
+        assert!(!component_starts_new_sentence(
+            "Collected Essays:",
+            "edited by Grimm, Jacob",
+            ". ",
+            false
+        ));
+    }
+
+    #[test]
     fn test_bibliography_separator_suppression() {
         use citum_schema::options::{BibliographyConfig, Config};
 
@@ -364,6 +450,7 @@ mod tests {
             bibliography_config: Some(bibliography_config.clone()),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -387,6 +474,7 @@ mod tests {
             bibliography_config: Some(bibliography_config),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -434,6 +522,7 @@ mod tests {
             bibliography_config: Some(bibliography_config.clone()),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -452,6 +541,7 @@ mod tests {
             bibliography_config: Some(bibliography_config),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -523,6 +613,7 @@ mod tests {
             bibliography_config: Some(bibliography_config.clone()),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -544,6 +635,7 @@ mod tests {
             bibliography_config: Some(bibliography_config),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -586,6 +678,7 @@ mod tests {
             bibliography_config: Some(bibliography_config.clone()),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -604,6 +697,7 @@ mod tests {
             bibliography_config: Some(bibliography_config),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -616,6 +710,10 @@ mod tests {
         assert_eq!(result, "2024");
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "rendering fixture exercises a full punctuation case"
+    )]
     #[test]
     fn test_html_separator_logic_uses_visible_punctuation() {
         use crate::render::html::Html;
@@ -651,6 +749,7 @@ mod tests {
             bibliography_config: Some(bibliography_config.clone()),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -673,6 +772,7 @@ mod tests {
             bibliography_config: Some(bibliography_config.clone()),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -694,6 +794,7 @@ mod tests {
             bibliography_config: Some(bibliography_config),
             url: None,
             item_language: None,
+            sentence_initial: false,
             pre_formatted: false,
         };
 
@@ -745,6 +846,7 @@ mod tests {
                 url: None,
                 bibliography_config: None,
                 item_language: None,
+                sentence_initial: false,
                 pre_formatted: false,
             }],
             metadata: crate::render::format::ProcEntryMetadata::default(),

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -161,6 +161,7 @@ mod tests {
                 bibliography_config: None,
                 url: None,
                 item_language: None,
+                sentence_initial: false,
                 pre_formatted: false,
             },
             ProcTemplateComponent {
@@ -179,6 +180,7 @@ mod tests {
                 bibliography_config: None,
                 url: None,
                 item_language: None,
+                sentence_initial: false,
                 pre_formatted: false,
             },
         ];
@@ -218,6 +220,7 @@ mod tests {
                 bibliography_config: None,
                 url: None,
                 item_language: None,
+                sentence_initial: false,
                 pre_formatted: false,
             },
             ProcTemplateComponent {
@@ -236,6 +239,7 @@ mod tests {
                 bibliography_config: None,
                 url: None,
                 item_language: None,
+                sentence_initial: false,
                 pre_formatted: false,
             },
         ];
@@ -376,6 +380,7 @@ ENDING IN COMMA
                 bibliography_config: None,
                 url: None,
                 item_language: None,
+                sentence_initial: false,
                 pre_formatted: false,
             },
             ProcTemplateComponent {
@@ -394,6 +399,7 @@ ENDING IN COMMA
                 bibliography_config: None,
                 url: None,
                 item_language: None,
+                sentence_initial: false,
                 pre_formatted: false,
             },
         ]

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -29,6 +29,8 @@ pub struct ProcTemplateComponent {
     pub bibliography_config: Option<BibliographyConfig>,
     /// Effective language for this rendered component.
     pub item_language: Option<String>,
+    /// Whether this component begins a sentence according to processor-owned render context.
+    pub sentence_initial: bool,
     /// Whether the value is already pre-formatted (e.g. from a List or substitution).
     pub pre_formatted: bool,
 }

--- a/crates/citum-engine/src/values/list.rs
+++ b/crates/citum-engine/src/values/list.rs
@@ -44,6 +44,7 @@ impl ComponentValues for TemplateGroup {
                     config: Some(options.config.clone()),
                     bibliography_config: options.bibliography_config.clone(),
                     item_language: crate::values::effective_component_language(reference, item),
+                    sentence_initial: false,
                     pre_formatted: v.pre_formatted,
                 };
 

--- a/crates/citum-engine/src/values/text_case.rs
+++ b/crates/citum-engine/src/values/text_case.rs
@@ -9,6 +9,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! All transforms operate on Djot-markup-bearing strings and respect
 //! `.nocase` span protection via the rich-text renderer.
 
+use citum_schema::NoteStartTextCase;
 use citum_schema::options::titles::TextCase;
 
 /// Apply a text-case transform to a single plain-text segment.
@@ -92,6 +93,21 @@ pub fn resolve_text_case(case: TextCase, language: Option<&str>) -> TextCase {
             _ => TextCase::AsIs,
         }
     }
+}
+
+/// Apply a note-start text-case transform using the same language fallback rules
+/// as other locale-backed casing behavior.
+#[must_use]
+pub(crate) fn apply_note_start_text_case(
+    value: &str,
+    text_case: NoteStartTextCase,
+    language: Option<&str>,
+) -> String {
+    let case = match text_case {
+        NoteStartTextCase::CapitalizeFirst => TextCase::CapitalizeFirst,
+        NoteStartTextCase::Lowercase => TextCase::Lowercase,
+    };
+    apply_text_case(value, resolve_text_case(case, language))
 }
 
 /// Convert text to sentence case: lowercase everything, then capitalize the first word.
@@ -338,6 +354,38 @@ mod tests {
         assert_eq!(
             resolve_text_case(TextCase::Title, Some("en-US")),
             TextCase::Title
+        );
+    }
+
+    #[test]
+    fn test_note_start_capitalize_first_uses_english_language_rules() {
+        assert_eq!(
+            apply_note_start_text_case(
+                "edited by",
+                NoteStartTextCase::CapitalizeFirst,
+                Some("en-US"),
+            ),
+            "Edited by"
+        );
+    }
+
+    #[test]
+    fn test_note_start_capitalize_first_falls_back_to_as_is_for_non_english() {
+        assert_eq!(
+            apply_note_start_text_case(
+                "hg. von",
+                NoteStartTextCase::CapitalizeFirst,
+                Some("de-DE"),
+            ),
+            "hg. von"
+        );
+    }
+
+    #[test]
+    fn test_note_start_capitalize_first_is_no_op_for_uncased_scripts() {
+        assert_eq!(
+            apply_note_start_text_case("ابن سينا", NoteStartTextCase::CapitalizeFirst, Some("ar"),),
+            "ابن سينا"
         );
     }
 }

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -1173,6 +1173,34 @@ fn make_multi_editor_only_book(
     }))
 }
 
+fn build_editor_verb_prefix_style(title_suffix: Option<&str>) -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("Editor Verb Prefix Test".to_string()),
+            id: Some("editor-verb-prefix-test".to_string()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            contributors: Some(ContributorConfig {
+                role: Some(citum_schema::options::contributors::RoleOptions {
+                    preset: Some(citum_schema::options::contributors::RoleLabelPreset::VerbPrefix),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![
+                citum_schema::tc_title!(Primary, suffix = title_suffix.unwrap_or("")),
+                citum_schema::tc_contributor!(Editor, Long),
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
 fn make_editor_substitute_bibliography() -> indexmap::IndexMap<String, InputReference> {
     citum_schema::bib_map![
         "ancient-tale" => make_editor_only_book(
@@ -2621,6 +2649,42 @@ fn editor_author_substitute_omits_verb_role_label_in_bibliography() {
     assert!(
         !result.contains("edited by Jacob Grimm") && !result.contains("edited by Hoesung Lee"),
         "verb-prefix labels should not survive when editors substitute into the author slot: {result}"
+    );
+}
+
+#[test]
+fn sentence_initial_editor_verb_prefix_is_capitalized_in_bibliography() {
+    let style = build_editor_verb_prefix_style(None);
+    let mut bib = IndexMap::new();
+    bib.insert(
+        "editor-only".to_string(),
+        make_editor_only_book("editor-only", "Collected Essays", "2001", "Grimm", "Jacob"),
+    );
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    assert!(
+        result.contains("Collected Essays. Edited by Jacob Grimm"),
+        "sentence-initial editor labels should capitalize after a period: {result}"
+    );
+}
+
+#[test]
+fn mid_sentence_editor_verb_prefix_remains_lowercase_in_bibliography() {
+    let style = build_editor_verb_prefix_style(Some(":"));
+    let mut bib = IndexMap::new();
+    bib.insert(
+        "editor-only".to_string(),
+        make_editor_only_book("editor-only", "Collected Essays", "2001", "Grimm", "Jacob"),
+    );
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    assert!(
+        result.contains("Collected Essays: edited by Jacob Grimm"),
+        "mid-sentence editor labels should stay lowercase: {result}"
     );
 }
 

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -892,6 +892,49 @@ fn chicago_notes_immediate_repeat_renders_compact_ibid() {
     );
 }
 
+fn chicago_notes_prefixed_ibid_remains_mid_sentence() {
+    use std::path::PathBuf;
+
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("styles/chicago-notes.yaml");
+
+    let yaml = std::fs::read_to_string(&path).expect("Failed to read chicago-notes.yaml");
+    let style: citum_schema::Style =
+        serde_yaml::from_str(&yaml).expect("Failed to parse chicago-notes.yaml");
+
+    let bib = citum_schema::bib_map![
+        "smith1995" => make_book("smith1995", "Smith", "John", 1995, "A Great Book"),
+    ];
+
+    let processor = Processor::new(style, bib);
+
+    let ibid_citation = citum_schema::Citation {
+        items: vec![citum_schema::citation::CitationItem {
+            id: "smith1995".to_string(),
+            ..Default::default()
+        }],
+        position: Some(citum_schema::citation::Position::Ibid),
+        prefix: Some("See".to_string()),
+        ..Default::default()
+    };
+
+    let ibid_result = processor
+        .process_citation(&ibid_citation)
+        .expect("Failed to process prefixed ibid citation");
+    assert!(
+        ibid_result.contains("See ibid."),
+        "prefixed ibid should remain mid-sentence lowercase: {ibid_result}"
+    );
+    assert!(
+        !ibid_result.contains("See Ibid."),
+        "prefixed ibid should not be capitalized as sentence-initial: {ibid_result}"
+    );
+}
+
 fn chicago_notes_immediate_repeat_with_locator_keeps_the_locator() {
     use std::path::PathBuf;
 
@@ -1539,6 +1582,14 @@ mod note_style_positions {
             "An immediate Chicago note repeat with a locator should keep the locator in the ibid form.",
         );
         super::chicago_notes_immediate_repeat_with_locator_keeps_the_locator();
+    }
+
+    #[test]
+    fn chicago_notes_prefixed_ibid_remains_mid_sentence() {
+        announce_behavior(
+            "A prefixed Chicago ibid should stay lowercase because the note marker is no longer sentence-initial.",
+        );
+        super::chicago_notes_prefixed_ibid_remains_mid_sentence();
     }
 
     #[test]

--- a/docs/specs/SENTENCE_INITIAL_LABELS.md
+++ b/docs/specs/SENTENCE_INITIAL_LABELS.md
@@ -1,0 +1,313 @@
+# Sentence-Initial Labels Specification
+
+**Status:** Draft
+**Version:** 0.6
+**Date:** 2026-04-11
+**Supersedes:** None
+**Related:** `csl26-twx1`, `docs/specs/SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md`, `docs/specs/NOTE_START_REPEATED_NOTE_POLICY.md`, `docs/specs/TITLE_TEXT_CASE.md`
+
+## Purpose
+Define how Citum should model sentence-initial capitalization for localized
+labels and markers that are normally authored in lowercase or sentence case.
+The immediate trigger is contributor verb labels such as `edited by` appearing
+after a period in bibliography output, but the design target is broader:
+Citum needs a coherent render-context model for sentence-initial labels without
+turning capitalization into a blanket string mutation rule.
+
+## Scope
+In scope:
+- localized labels and markers whose rendered capitalization changes when they
+  become sentence-initial
+- contributor verb labels and verb-prefix presets as the motivating example
+- note-start markers and other locale-backed labels that can shift between
+  mid-sentence and sentence-initial positions
+- sentence-case label behavior as the baseline assumption for this spec
+- separation of locale-owned lexical content from render-context-owned casing
+- the processor-owned render-context contract for sentence-initial behavior
+
+Out of scope:
+- shipping any rendering behavior changes in this spec
+- broad title/text-case semantics already covered by
+  `docs/specs/TITLE_TEXT_CASE.md`
+- renaming or activating any new public schema/API field in this draft
+- non-localized arbitrary prose rewriting
+- full sentence-boundary NLP or punctuation inference beyond Citum's rendering
+  model
+
+## Design
+### Problem Statement
+Current repo evidence shows a real output gap: localized contributor verb labels
+such as `edited by` remain lowercase even when the rendered component becomes
+sentence-initial after punctuation such as `. `. This is visible in
+bibliography-style output where a sentence boundary is created by prior
+component affixes, but the contributor label is still resolved from locale data
+and emitted unchanged.
+
+This failure is not unique to contributor labels. Any localized label or marker
+that may appear mid-sentence in one style path and sentence-initial in another
+needs context-sensitive capitalization. The engine therefore needs a principled
+way to distinguish lexical content from sentence-initial render context.
+
+This specification assumes sentence-case locale/style labels as the baseline.
+Title-like casing remains governed by `docs/specs/TITLE_TEXT_CASE.md`.
+Sentence-initial capitalization is orthogonal to title/text-case semantics: it
+controls whether a label begins with an initial capital because of render
+context, not whether the label belongs to a title-case family.
+
+### Ownership Boundaries
+Lexical content remains locale- and style-owned. Locale terms such as
+`edited by`, `translated by`, or note-style markers should continue to be
+authored in their normal form rather than duplicated in both lowercase and
+capitalized variants.
+
+Sentence-initial capitalization is a render-context concern. It should not be
+treated as a permanent mutation of the underlying term, nor as a global rule
+that rewrites any lowercase string the processor encounters.
+
+This distinction is normative:
+
+1. Locale/style data owns wording.
+2. Rendering context owns whether a term is sentence-initial.
+3. The engine must preserve lowercase or sentence-case forms when the same term
+   appears mid-sentence.
+
+### Sentence-Initial Contract
+For this specification, `sentence-initial` means a boolean render-context signal
+attached to a render node or equivalent processed output unit. The signal is
+set by the template/render pipeline from known Citum context sources rather than
+by raw punctuation scanning over flat rendered strings.
+
+Initial context sources may include:
+
+1. explicit note-start context already recognized by the processor
+2. explicit separator or affix semantics that the rendering pipeline treats as
+   sentence boundaries
+3. future structured markup or render-node metadata that encodes a sentence
+   break directly
+
+This is a normative boundary:
+
+1. raw punctuation alone is not the contract
+2. sentence-initial status must come from rendering context, not post-hoc text
+   inspection
+3. style families may later refine which separator classes count as sentence
+   boundaries, but that refinement must flow through the render-context signal
+   rather than a generic string rewrite pass
+
+### Language and Script Considerations
+Sentence-initial context is a contextual flag, not a casing transform. Eligible
+render nodes may carry `sentence-initial = true` regardless of script or
+writing direction, including LTR, RTL, and bidirectional text.
+
+Visible change is orthography-dependent rather than guaranteed. The existence of
+sentence-initial context does not by itself imply any letter-case change.
+
+This is a normative boundary:
+
+1. the processor propagates sentence-initial context independently of script
+   features
+2. locale/style logic decides whether sentence-initial context maps to
+   capitalization, label-variant choice, or no visible change
+3. languages or scripts without case must treat casing as a no-op rather than
+   a guessed transformation
+4. when Citum lacks defined language/script-specific casing behavior, it must
+   prefer `as-is` behavior over guessing, consistent with
+   `docs/specs/TITLE_TEXT_CASE.md` and the fallback approach already used in
+   `crates/citum-engine/src/values/text_case.rs`
+
+### Affected Content Taxonomy
+The initial taxonomy for this work is:
+
+1. Contributor verb labels and verb-prefix presets
+   - examples: `edited by`, `translated by`
+2. Note-start markers whose style families treat note-initial output as
+   sentence-initial
+   - examples already discussed in
+     `docs/specs/NOTE_START_REPEATED_NOTE_POLICY.md`
+3. Other localized labels or markers that can move between prose-adjacent and
+   sentence-initial slots
+   - examples: future locator labels, explanatory markers, or style-authored
+     context labels
+
+The taxonomy is intentionally broader than contributor rendering, but this
+specification does not require every category to ship in one implementation
+wave.
+
+### Current Engine Boundary Sources
+The current engine exposes only partial signals relevant to this problem:
+
+1. Note-start casing exists as a narrow, explicit processor path for citation
+   output.
+2. Component rendering already has local knowledge of prefixes, suffixes, and
+   affixes.
+3. Contributor role-label formatting already sees component rendering and locale
+   term resolution together.
+4. The engine does not currently expose a first-class sentence-boundary or
+   sentence-initial render-context signal across template rendering.
+
+This means Citum can sometimes infer sentence-initial behavior locally, but it
+cannot yet express sentence-initial context as a reusable rendering dimension.
+
+### Eligible Node Classes and Propagation
+Only locale-backed label or marker nodes are eligible for automatic
+sentence-initial capitalization under this specification. Arbitrary
+author-supplied text must never be transformed by the sentence-initial signal.
+
+The intended long-term home for this signal is the processed render node layer,
+not the locale term store and not a renderer-wide flat-string post-pass. A
+future implementation may temporarily adapt local call sites such as
+contributor-label formatting, but those adapters should consume a render-context
+signal rather than define the normative model.
+
+Propagation rules should follow this direction:
+
+1. the pipeline computes `sentence-initial` before locale-backed labels are
+   formatted
+2. locale-resolved label nodes inherit the signal from their containing render
+   node unless a style-owned rule explicitly overrides that label class
+3. nested non-label user content does not become eligible merely because it is
+   adjacent to an eligible label node
+
+### Chosen Architecture
+This specification adopts one architecture only: a processor-computed
+`sentence-initial` flag on processed component output.
+
+During template-to-render-node assembly, the processor computes an explicit
+boolean `sentence-initial` field from known Citum context sources. Locale-backed
+label renderers then consume that field when deciding how sentence-initial
+context affects rendering; they do not infer sentence starts from final text or
+punctuation.
+
+For the first implementation, this field should live on the internal processed
+component layer that already sits between `ComponentValues` resolution and
+renderer formatting, reusing the existing `ProcValues`/`ProcTemplateComponent`
+pipeline or a direct successor at the same stage. This resolves the carrier
+question for the draft: the signal belongs on processed rendering data, not in
+locale terms, not in authored text, and not in a renderer-wide post-pass.
+
+Normative direction for later implementation:
+
+1. When a locale-backed label or marker node is rendered with
+   `sentence-initial = true`, rendering must consult locale/style behavior for
+   that label class rather than assuming a visible capitalization change.
+2. The processor must compute that field during template-to-render-node
+   assembly from explicit inputs rather than by scanning rendered strings.
+3. Initial explicit inputs include note-start context and processor-owned
+   sentence-boundary semantics derived from affixes, separators, or future
+   structured boundary metadata.
+4. The processed component layer is the required internal carrier for this
+   signal in the first implementation wave.
+5. Arbitrary author-supplied text must never become eligible for automatic
+   transformation from this flag.
+6. Temporary local heuristics are acceptable only as upstream input detection
+   inside the processor path; they must not become a second architectural model
+   or a renderer-side fallback rule.
+
+### Resolved Design Decisions
+This draft resolves the major design choices as follows:
+
+1. The first implementation wave should implement the sentence-initial contract
+   across the in-scope locale-backed label classes covered by this spec,
+   including contributor verb labels and existing note-start markers.
+   Additional locale-backed marker classes may follow in later work without
+   changing the architecture.
+2. Style-specific exceptions remain locale/style-owned. If a style family keeps
+   a note-start marker lowercase, that exception is expressed through the label
+   class's rendering rule, not by suppressing the context flag itself.
+3. Language/script-aware behavior belongs to the locale/style text-case layer
+   that consumes `sentence-initial`, reusing the same "prefer `as-is` over
+   guessing" fallback principle already used for title text-case resolution.
+4. Fixture coverage for implementation must include:
+   - a positive contributor-label case in a case-changing language/script
+   - a negative mid-sentence case for the same label
+   - a note-start case proving non-regression against current note behavior
+   - a no-op language/script case where `sentence-initial = true` produces no
+     visible case change
+   - an RTL or bidi case proving the flag is direction-agnostic
+5. Rejected alternatives are out of scope for this spec revision:
+   - local heuristics as the normative model
+   - renderer-wide generic capitalization
+
+### Migration and Compatibility Notes
+This specification does not itself change runtime behavior.
+
+When implementation follows, compatibility requirements should include:
+
+1. Mid-sentence localized labels must remain in their authored lowercase or
+   sentence-case form.
+2. New capitalization behavior must be limited to render paths that are
+   semantically sentence-initial, not merely punctuation-adjacent.
+3. Existing note-start behavior must remain consistent with the active
+   note-start policy rather than being silently replaced by a generic rule.
+4. Contributor-label fixes should not force early commitment to final public
+   schema naming.
+5. New behavior must ship with fixtures that prove both positive cases
+   (capitalized sentence-initial labels) and negative cases (no capitalization
+   when the render context is not sentence-initial).
+6. New behavior must include both case-changing and no-op language/script
+   examples so the flag stays orthography-neutral.
+7. RTL and bidi examples must demonstrate that writing direction does not alter
+   the core sentence-initial contract.
+
+### Remaining Review Questions
+This revision leaves no architectural review questions open.
+
+For future implementation guidance, the internal field name should remain
+`sentence-initial` unless a later code-level constraint requires a narrowly
+scoped naming adjustment.
+
+## Implementation Notes
+- Reuse existing repo evidence rather than inventing a generalized casing system
+  in one step.
+- Keep contributor verb labels as the motivating implementation entry point, but
+  do not describe the problem as contributor-only.
+- If a future schema/API field is needed, model it as an orthogonal render
+  context rather than a mutation of locale terms.
+- Add `sentence-initial` to the processed component layer that bridges
+  `ComponentValues` output and renderer formatting, then let label-formatting
+  call sites consume it.
+- Treat `sentence-initial` as the intended internal field name for the first
+  implementation wave.
+- Reuse the repo's current language-aware fallback principle: prefer `as-is`
+  over guessing when Citum lacks a defined orthographic transform.
+- Treat note-start context as an explicit upstream input to this processor-owned
+  flag and coordinate implementation follow-up with
+  `docs/specs/NOTE_START_REPEATED_NOTE_POLICY.md` so settled note-style behavior
+  is not widened accidentally.
+
+## Acceptance Criteria
+- [ ] Citum has a draft spec for sentence-initial capitalization of localized
+  labels and markers.
+- [ ] The spec separates locale/style-owned lexical content from
+  render-context-owned capitalization.
+- [ ] The spec documents the current engine boundary: note-start casing exists,
+  affix heuristics exist locally, and no first-class sentence-boundary signal
+  exists yet.
+- [ ] The spec defines `sentence-initial` as a render-context signal rather than
+  a punctuation scan over final strings.
+- [ ] The spec treats sentence-initial context as script-agnostic and visible
+  casing behavior as language/script-dependent.
+- [ ] The spec limits automatic capitalization eligibility to locale-backed
+  label or marker nodes and excludes arbitrary author-supplied text.
+- [ ] The spec defines a single target architecture: a processor-computed
+  `sentence-initial` flag on processed component output.
+- [ ] The spec assigns the first implementation carrier to the processed
+  component layer used between value resolution and renderer formatting.
+- [ ] The spec requires positive and negative fixture coverage before runtime
+  behavior changes ship.
+- [ ] The spec requires future examples covering both case-changing and no-op
+  language/script behavior, including RTL or bidi text.
+
+## Changelog
+- v0.5 (2026-04-11): Removed rejected alternative options, adopted a single
+  processor-owned `sentence-initial` architecture, resolved the main design
+  questions, and narrowed the remaining review questions.
+- v0.4 (2026-04-11): Added language/script-aware sentence-initial semantics and
+  collapsed the design space to heuristics, renderer-wide auto-capitalization,
+  and processor-computed render-node signaling.
+- v0.3 (2026-04-11): Added the explicit `TemplateGroup` sentence-hint option as
+  Option 3A and split processed render-node signaling into Option 3B.
+- v0.2 (2026-04-11): Clarified the `sentence-initial` contract, preferred
+  signal carrier, node eligibility, and fixture expectations.
+- v0.1 (2026-04-11): Initial draft for sentence-initial localized labels and
+  markers.

--- a/docs/specs/SENTENCE_INITIAL_LABELS.md
+++ b/docs/specs/SENTENCE_INITIAL_LABELS.md
@@ -1,6 +1,6 @@
 # Sentence-Initial Labels Specification
 
-**Status:** Draft
+**Status:** Active
 **Version:** 0.6
 **Date:** 2026-04-11
 **Supersedes:** None
@@ -26,7 +26,8 @@ In scope:
 - the processor-owned render-context contract for sentence-initial behavior
 
 Out of scope:
-- shipping any rendering behavior changes in this spec
+- shipping rendering behavior beyond the first sentence-initial implementation
+  wave activated with this spec revision
 - broad title/text-case semantics already covered by
   `docs/specs/TITLE_TEXT_CASE.md`
 - renaming or activating any new public schema/API field in this draft
@@ -299,6 +300,9 @@ scoped naming adjustment.
   language/script behavior, including RTL or bidi text.
 
 ## Changelog
+- v0.6 (2026-04-11): Activated the spec, aligned scope with the first engine
+  implementation wave, and required the processed-component sentence-initial
+  contract to ship with the paired runtime behavior.
 - v0.5 (2026-04-11): Removed rejected alternative options, adopted a single
   processor-owned `sentence-initial` architecture, resolved the main design
   questions, and narrowed the remaining review questions.


### PR DESCRIPTION
## Summary
- add `docs/specs/SENTENCE_INITIAL_LABELS.md` as a draft spec for sentence-initial localized labels and markers
- frame contributor verb labels as the motivating bug while keeping the design scope broader than contributor-only rendering
- keep `csl26-twx1` open and update the bean body to reference the new spec as prerequisite work

## Testing
- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict`
- `./scripts/check-docs-beans-hygiene.sh`

## Refs
- `csl26-twx1`
