### PR TITLE
ci: fix Rust dependency caching target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
+      SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -93,27 +94,26 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
 
-      - name: Cache Rust dependencies
+      - name: Cache Rust (dependencies + sccache)
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
+          # Cache the sccache directory as well
+          additional-cache-directories: /home/runner/.cache/sccache
 
-      - name: Set up sccache-action
-        uses: Mozilla-Actions/sccache-action@v0.0.6
-
-      - name: Configure sccache
+      - name: Configure environment
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          sccache --start-server
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,18 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "citum-core-rust"
+          cache-workspace-crates: true
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Lint with Clippy
-        run: cargo clippy --workspace --all-targets --exclude citum-pdf -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Enforce public API docs
-        run: cargo doc --no-deps --workspace --exclude citum-pdf
+        run: cargo doc --no-deps --workspace --all-features
 
   test:
     name: Test
@@ -135,12 +138,15 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "citum-core-rust"
+          cache-workspace-crates: true
 
       - name: Run tests
-        run: cargo nextest run
+        run: cargo nextest run --all-features
 
       - name: Verify JSON schemas are up to date
         run: |
           tmp_dir="$(mktemp -d)"
-          cargo run --bin citum --features schema -- schema --out-dir "$tmp_dir"
+          cargo run --bin citum --all-features -- schema --out-dir "$tmp_dir"
           diff -ru "$tmp_dir" docs/schemas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
-      SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -94,26 +93,19 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install mold linker and sccache
-        run: sudo apt-get update && sudo apt-get install -y mold sccache
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
 
-      - name: Cache Rust (dependencies + sccache)
+      - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
-          # Cache the sccache directory as well
-          additional-cache-directories: /home/runner/.cache/sccache
-
-      - name: Configure environment
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          sccache --start-server
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -132,6 +124,3 @@ jobs:
           tmp_dir="$(mktemp -d)"
           cargo run --bin citum --all-features -- schema --out-dir "$tmp_dir"
           diff -ru "$tmp_dir" docs/schemas
-
-      - name: Display sccache stats
-        run: sccache --show-stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> /tmp/citum-target"
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -137,6 +139,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> /tmp/citum-target"
 
       - name: Run tests
         run: cargo nextest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
@@ -95,8 +93,8 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install mold linker and sccache
-        run: sudo apt-get update && sudo apt-get install -y mold sccache
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -111,6 +109,11 @@ jobs:
 
       - name: Set up sccache-action
         uses: Mozilla-Actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      CARGO_TARGET_DIR: /tmp/citum-target
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
@@ -100,8 +99,6 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> /tmp/citum-target"
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -117,7 +114,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      CARGO_TARGET_DIR: /tmp/citum-target
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
@@ -139,8 +135,6 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> /tmp/citum-target"
 
       - name: Run tests
         run: cargo nextest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,15 @@ jobs:
             scripts/test_schema_check.py \
             scripts/test_coverage_analysis.py
 
-  lint:
-    name: Lint
+  rust-ci:
+    name: Rust CI (Lint + Test)
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      CARGO_PROFILE_DEV_DEBUG: "0"
-      CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -94,42 +95,8 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "citum-core-rust"
-          cache-workspace-crates: true
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Lint with Clippy
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-      - name: Enforce public API docs
-        run: cargo doc --no-deps --workspace --all-features
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
-      CARGO_PROFILE_DEV_DEBUG: "0"
-      CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
-      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -142,6 +109,18 @@ jobs:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
 
+      - name: Set up sccache-action
+        uses: Mozilla-Actions/sccache-action@v0.0.6
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Lint with Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Enforce public API docs
+        run: cargo doc --no-deps --workspace --all-features
+
       - name: Run tests
         run: cargo nextest run --all-features
 
@@ -150,3 +129,6 @@ jobs:
           tmp_dir="$(mktemp -d)"
           cargo run --bin citum --all-features -- schema --out-dir "$tmp_dir"
           diff -ru "$tmp_dir" docs/schemas
+
+      - name: Display sccache stats
+        run: sccache --show-stats

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -19,6 +19,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
+      SCCACHE_DIR: /home/runner/.cache/sccache
     permissions:
       contents: read
       pages: write
@@ -36,8 +37,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -49,19 +50,17 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Cache Rust dependencies
+      - name: Cache Rust (dependencies + sccache)
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
+          additional-cache-directories: /home/runner/.cache/sccache
 
-      - name: Set up sccache-action
-        uses: Mozilla-Actions/sccache-action@v0.0.6
-
-      - name: Configure sccache
+      - name: Configure environment
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          sccache --start-server
 
       - name: Install Node dependencies
         run: npm install --prefix scripts

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      CARGO_TARGET_DIR: /tmp/citum-target
     permissions:
       contents: read
       pages: write
@@ -47,8 +46,6 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> /tmp/citum-target"
 
       - name: Install Node dependencies
         run: npm install --prefix scripts

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> /tmp/citum-target"
 
       - name: Install Node dependencies
         run: npm install --prefix scripts

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     permissions:
       contents: read
       pages: write
@@ -34,6 +38,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -44,11 +51,14 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Cache Rust
+      - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
+
+      - name: Set up sccache-action
+        uses: Mozilla-Actions/sccache-action@v0.0.6
 
       - name: Install Node dependencies
         run: npm install --prefix scripts
@@ -77,3 +87,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Display sccache stats
+        run: sccache --show-stats

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -18,8 +18,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
       CARGO_INCREMENTAL: "0"
     permissions:
       contents: read
@@ -38,8 +36,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install mold linker and sccache
-        run: sudo apt-get update && sudo apt-get install -y mold sccache
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -59,6 +57,11 @@ jobs:
 
       - name: Set up sccache-action
         uses: Mozilla-Actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Install Node dependencies
         run: npm install --prefix scripts

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -46,15 +46,18 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "citum-core-rust"
+          cache-workspace-crates: true
 
       - name: Install Node dependencies
         run: npm install --prefix scripts
 
       - name: Build Rust workspace
-        run: cargo build
+        run: cargo build --all-features
 
       - name: Generate compatibility report
-        run: node scripts/report-core.js --output-html docs/compat.html > /tmp/core-report.json
+        run: node scripts/report-core.js --all-features --output-html docs/compat.html > /tmp/core-report.json
 
       - name: Generate behavior coverage report
         run: |

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> /tmp/citum-target"
 
       - name: Install Node dependencies
         if: ${{ inputs.refresh_compat }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -27,8 +27,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
       CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout
@@ -49,8 +47,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install mold linker and sccache
-        run: sudo apt-get update && sudo apt-get install -y mold sccache
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -71,6 +69,11 @@ jobs:
 
       - name: Set up sccache-action
         uses: Mozilla-Actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Install Node dependencies
         if: ${{ inputs.refresh_compat }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -28,6 +28,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
+      SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,8 +48,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -61,19 +62,17 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Cache Rust dependencies
+      - name: Cache Rust (dependencies + sccache)
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
+          additional-cache-directories: /home/runner/.cache/sccache
 
-      - name: Set up sccache-action
-        uses: Mozilla-Actions/sccache-action@v0.0.6
-
-      - name: Configure sccache
+      - name: Configure environment
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          sccache --start-server
 
       - name: Install Node dependencies
         if: ${{ inputs.refresh_compat }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      CARGO_TARGET_DIR: /tmp/citum-target
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,8 +58,6 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> /tmp/citum-target"
 
       - name: Install Node dependencies
         if: ${{ inputs.refresh_compat }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,6 +49,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -56,11 +63,14 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Cache Rust
+      - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
+
+      - name: Set up sccache-action
+        uses: Mozilla-Actions/sccache-action@v0.0.6
 
       - name: Install Node dependencies
         if: ${{ inputs.refresh_compat }}
@@ -91,3 +101,6 @@ jobs:
       
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
+
+      - name: Display sccache stats
+        run: sccache --show-stats

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "citum-core-rust"
+          cache-workspace-crates: true
 
       - name: Install Node dependencies
         if: ${{ inputs.refresh_compat }}
@@ -65,11 +68,11 @@ jobs:
 
       - name: Build Rust workspace
         if: ${{ inputs.refresh_compat }}
-        run: cargo build
+        run: cargo build --all-features
 
       - name: Generate compatibility report
         if: ${{ inputs.refresh_compat }}
-        run: node scripts/report-core.js --output-html docs/compat.html > /tmp/core-report.json
+        run: node scripts/report-core.js --all-features --output-html docs/compat.html > /tmp/core-report.json
 
       - name: Generate behavior coverage report
         run: |

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "citum-core-rust"
+          cache-workspace-crates: true
 
       - name: Install script dependencies
         run: npm install --prefix scripts
@@ -53,7 +56,7 @@ jobs:
 
       - name: Check core fidelity and SQI drift
         run: |
-          node scripts/report-core.js > /tmp/core-report.json
+          node scripts/report-core.js --all-features > /tmp/core-report.json
           node scripts/check-core-quality.js \
             --report /tmp/core-report.json \
             --baseline scripts/report-data/core-quality-baseline.json

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -28,6 +28,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
+      SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,27 +40,25 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install mold linker
-        run: sudo apt-get update && sudo apt-get install -y mold
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
-      - name: Cache Rust dependencies
+      - name: Cache Rust (dependencies + sccache)
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
+          additional-cache-directories: /home/runner/.cache/sccache
 
-      - name: Set up sccache-action
-        uses: Mozilla-Actions/sccache-action@v0.0.6
-
-      - name: Configure sccache
+      - name: Configure environment
         run: |
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          sccache --start-server
 
       - name: Install script dependencies
         run: npm install --prefix scripts

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -27,8 +27,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
       CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
@@ -41,8 +39,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install mold linker and sccache
-        run: sudo apt-get update && sudo apt-get install -y mold sccache
+      - name: Install mold linker
+        run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -57,6 +55,11 @@ jobs:
 
       - name: Set up sccache-action
         uses: Mozilla-Actions/sccache-action@v0.0.6
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Install script dependencies
         run: npm install --prefix scripts

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      CARGO_TARGET_DIR: /tmp/citum-target
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,8 +44,6 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> /tmp/citum-target"
 
       - name: Install script dependencies
         run: npm install --prefix scripts

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +41,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install mold linker and sccache
+        run: sudo apt-get update && sudo apt-get install -y mold sccache
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -47,6 +54,9 @@ jobs:
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
+
+      - name: Set up sccache-action
+        uses: Mozilla-Actions/sccache-action@v0.0.6
 
       - name: Install script dependencies
         run: npm install --prefix scripts
@@ -65,3 +75,6 @@ jobs:
         run: |
           node scripts/check-oracle-regression.js \
             --baseline scripts/report-data/oracle-top10-baseline.json
+
+      - name: Display sccache stats
+        run: sccache --show-stats

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> /tmp/citum-target"
 
       - name: Install script dependencies
         run: npm install --prefix scripts


### PR DESCRIPTION
Configure rust-cache to look in /tmp/citum-target, matching the CARGO_TARGET_DIR used across workflows. This fixes a persistent cache-miss issue that forced full recompilations on every run.