### PR TITLE
fix(engine): citation type routing improvements

### DIFF
--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -1311,6 +1311,9 @@ impl InputReference {
                     {
                         return genre.to_string();
                     }
+                    if self.genre().as_deref() == Some("conference-paper") {
+                        return "paper-conference".to_string();
+                    }
                     if r.medium
                         .as_deref()
                         .is_some_and(|m| m.to_ascii_lowercase().contains("interview"))

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -1162,3 +1162,13 @@ fn conversion_chapter_without_named_parent_keeps_volume_but_avoids_empty_contain
             .any(|numbering| numbering.r#type == NumberingType::Volume && numbering.value == "2")
     );
 }
+
+#[test]
+fn ref_type_document_with_conference_paper_genre_returns_paper_conference() {
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        r#type: MonographType::Document,
+        genre: Some("conference-paper".to_string()),
+        ..Default::default()
+    }));
+    assert_eq!(reference.ref_type(), "paper-conference");
+}

--- a/examples/chicago-note-converted.yaml
+++ b/examples/chicago-note-converted.yaml
@@ -77,9 +77,9 @@ references:
   issued: '2021'
   url: https://www.govinfo.gov/content/pkg/DCPD-202100401/pdf/DCPD-202100401.pdf
   language: en
-- class: audio-visual
+- class: monograph
   id: 6188419/EDMI8NQY
-  type: recording
+  type: interview
   title: Bernie Sanders with Cardi B
   contributors:
   - role: interviewer
@@ -92,7 +92,7 @@ references:
   issued: 2019-08-15
   url: https://youtu.be/p1ubTsrZFBU
   language: en
-  platform: YouTube
+  medium: video
 - class: audio-visual
   id: 6188419/EXVHRUDT
   type: episode
@@ -189,12 +189,10 @@ references:
   archive-info:
     name: Harvard College Library
     collection: O’Laughlin Papers
-- class: monograph
+- class: hearing
   id: 6188419/VCP6HK7G
-  type: document
   title: 'Homeland Security Act of 2002: Hearings on H.R. 5005, Day 3, Before the Select Comm. on Homeland Security'
-  author:
-  - name: David Walker, Comptroller General of the United States
+  authority: U.S. House of Representatives, Select Committee on Homeland Security
   issued: '2002'
   accessed: 2025-04-11
   language: en

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -226,8 +226,8 @@ test('apa-7th concision regression reflects preset-first success', () => {
   const loaded = loadStyleYaml(style.name);
   const concision = computeConcisionScore(loaded.resolvedStyleData, style.format);
 
-  assert.equal(concision.variantSelectors, 56, 'resolved APA should reflect the embedded authored variant selectors');
-  assert.equal(concision.score, 36.6, `expected embedded APA concision, got ${concision.score}`);
+  assert.equal(concision.variantSelectors, 62, 'resolved APA should reflect the embedded authored variant selectors');
+  assert.equal(concision.score, 31.8, `expected embedded APA concision, got ${concision.score}`);
 });
 
 test('report-core exposes expected benchmark labels for representative styles', () => {

--- a/styles/embedded/apa-7th.yaml
+++ b/styles/embedded/apa-7th.yaml
@@ -78,20 +78,20 @@ citation:
     wrap:
       punctuation: parentheses
     type-variants:
-      ? article-journal, article-magazine, article-newspaper, book, broadcast, chapter, dataset, entry-encyclopedia, interview, motion-picture, paper-conference, patent, report, software, standard, thesis, webpage
+      ? article-journal, article-magazine, article-newspaper, book, broadcast, chapter, dataset, entry-encyclopedia, interview, motion-picture, paper-conference, patent, report, software, song, standard, thesis, webpage
       : - contributor: author
           form: short
         - date: issued
           form: year
         - variable: locator
-      legal-case:
-      - title: primary
-        form: short
-        emph: true
-        quote: false
-      - date: issued
-        form: year
-      - variable: locator
+      ? legal-case, treaty, hearing
+      : - title: primary
+          form: short
+          emph: true
+          quote: false
+        - date: issued
+          form: year
+        - variable: locator
       personal-communication:
       - contributor: author
         form: long
@@ -116,7 +116,7 @@ citation:
       contributors:
         and: text
     type-variants:
-      ? article-journal, article-magazine, article-newspaper, book, broadcast, chapter, dataset, entry-encyclopedia, interview, motion-picture, paper-conference, patent, report, software, standard, thesis, webpage
+      ? article-journal, article-magazine, article-newspaper, book, broadcast, chapter, dataset, entry-encyclopedia, interview, motion-picture, paper-conference, patent, report, software, song, standard, thesis, webpage
       : - contributor: author
           form: short
         - delimiter: ", "
@@ -126,18 +126,18 @@ citation:
           - date: issued
             form: year
           - variable: locator
-      legal-case:
-      - title: primary
-        form: short
-        emph: true
-        quote: false
-      - delimiter: ", "
-        wrap:
-          punctuation: parentheses
-        group:
-        - date: issued
-          form: year
-        - variable: locator
+      ? legal-case, treaty, hearing
+      : - title: primary
+          form: short
+          emph: true
+          quote: false
+        - delimiter: ", "
+          wrap:
+            punctuation: parentheses
+          group:
+          - date: issued
+            form: year
+          - variable: locator
       personal-communication:
       - contributor: author
         form: long


### PR DESCRIPTION
## Summary

- Reclassify Bernie Sanders item from `audio-visual/recording` to `monograph/interview`
- Reclassify Walker hearing from `monograph/document` to `class: hearing` with `authority` field
- Add `song`, `treaty`, and `hearing` citation type-variants to APA 7th (both integral and non-integral)
- Route `Monograph::Document` with `genre: conference-paper` to `paper-conference` in `ref_type()`

## Test plan

- [ ] `cargo nextest run` passes (1021/1021 green at commit)
- [ ] `citum render refs -b examples/chicago-note-converted.yaml -s styles/embedded/apa-7th.yaml` produces correct citations for Bernie Sanders (interview), Walker (hearing), Weingartner (song), Treaty, and Lee (paper-conference)
