### PR TITLE
refactor(schema): strengthen ref and language ids

### DIFF
--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -105,7 +105,7 @@ fn parse_references(refs_json: &str) -> Result<IndexMap<String, Reference>, Stri
 
                 // Use the entire element value for parsing, keyed by its `id`.
                 let r = parse_single_reference_value(&id, Value::Object(obj.clone()))?;
-                mapped.insert(id, r);
+                mapped.insert(id.clone(), r);
             }
         }
         _ => {

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -2307,14 +2307,14 @@ fn input_reference_from_biblatex(entry: &biblatex::Entry) -> InputReference {
 fn input_reference_to_csl_json(reference: &InputReference) -> csl_legacy::csl_json::Reference {
     use csl_legacy::csl_json::{DateVariable, Reference, StringOrNumber};
 
-    let id = reference.id().unwrap_or_else(|| "item".to_string());
+    let id = reference.id().unwrap_or_else(|| "item".into());
     let mut r = Reference {
-        id,
+        id: id.to_string(),
         ..Default::default()
     };
 
     r.title = reference.title().map(|t| t.to_string());
-    r.language = reference.language();
+    r.language = reference.language().map(|lang| lang.to_string());
     r.note = reference.note();
     r.doi = reference.doi();
     r.issued = reference.csl_issued_date().and_then(|d| {
@@ -2399,7 +2399,7 @@ fn contributor_to_csl_names(
 fn render_biblatex(input: &InputBibliography) -> String {
     let mut out = String::new();
     for reference in &input.references {
-        let id = reference.id().unwrap_or_else(|| "item".to_string());
+        let id = reference.id().unwrap_or_else(|| "item".into());
         let entry_type = match reference {
             InputReference::SerialComponent(_) => "article",
             InputReference::CollectionComponent(_) => "incollection",
@@ -3556,7 +3556,7 @@ references:
             .expect("bibliography should load");
         let processor = Processor::new(style, loaded.references);
         let citations = vec![Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![CitationItem {
                 id: "smith2020".to_string(),
                 ..Default::default()

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -45,7 +45,7 @@ fn bench_rendering(c: &mut Criterion) {
     let mut bib = Bibliography::new();
     for r in input_bib.references {
         if let Some(id) = r.id() {
-            bib.insert(id.clone(), r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -181,7 +181,7 @@ fn make_ref(id: &str, family: &str, given: &str, year: i32) -> Reference {
 
 fn make_ref_with_title(id: &str, family: &str, given: &str, year: i32, title: &str) -> Reference {
     Reference::Monograph(Box::new(Monograph {
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: MonographType::Book,
         title: Some(Title::Single(title.to_string())),
         short_title: None,
@@ -281,7 +281,7 @@ where
 
     let title = format!("Title {id}");
     Reference::Monograph(Box::new(Monograph {
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: MonographType::Book,
         title: Some(Title::Single(title)),
         short_title: None,
@@ -427,7 +427,7 @@ fn build_type_variant_bench_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Type Variant Bench".to_string()),
-            id: Some("type-variant-bench".to_string()),
+            id: Some("type-variant-bench".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -525,7 +525,7 @@ fn build_compound_bench_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Compound Bench".to_string()),
-            id: Some("compound-bench".to_string()),
+            id: Some("compound-bench".into()),
             ..Default::default()
         },
         options: Some(Config {

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -18,7 +18,7 @@ fn main() {
     let processor = Processor::new(style, bib);
 
     let cite = Citation {
-        id: Some("cite1".to_string()),
+        id: Some("cite1".into()),
         mode: CitationMode::NonIntegral,
         position: None,
         suppress_author: false,

--- a/crates/citum-engine/src/ffi/biblatex.rs
+++ b/crates/citum-engine/src/ffi/biblatex.rs
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use biblatex;
 use citum_schema::reference::{
-    InputReference, Numbering, NumberingType, Publisher, WorkRelation,
+    InputReference, LangID, Numbering, NumberingType, Publisher, RefID, WorkRelation,
     contributor::{Contributor, ContributorList, StructuredName},
     date::EdtfString,
     types::{
@@ -23,13 +23,13 @@ use url::Url;
 
 /// Common fields shared across all biblatex reference conversion helpers.
 struct BibRefContext<'a> {
-    id: Option<String>,
+    id: Option<RefID>,
     title: Option<Title>,
     author: Option<Contributor>,
     editor: Option<Contributor>,
     issued: EdtfString,
     publisher: Option<Publisher>,
-    language: Option<String>,
+    language: Option<LangID>,
     field_str: &'a dyn Fn(&str) -> Option<String>,
 }
 
@@ -150,7 +150,7 @@ fn build_article_reference(ctx: BibRefContext<'_>) -> InputReference {
 /// appropriate Citum reference types. Extracts all relevant fields
 /// including contributors, dates, and metadata.
 pub(super) fn input_reference_from_biblatex(entry: &biblatex::Entry) -> InputReference {
-    let id = Some(entry.key.clone());
+    let id = Some(entry.key.clone().into());
     let field_str = |key: &str| {
         entry.fields.get(key).map(|f| {
             f.iter()
@@ -179,7 +179,9 @@ pub(super) fn input_reference_from_biblatex(entry: &biblatex::Entry) -> InputRef
         contributors_from_biblatex_persons(&all_persons)
     });
 
-    let language = field_str("langid").or_else(|| field_str("language"));
+    let language = field_str("langid")
+        .or_else(|| field_str("language"))
+        .map(Into::into);
 
     // Compute entry_type once to avoid repeated conversions
     let entry_type = entry.entry_type.to_string().to_lowercase();

--- a/crates/citum-engine/src/grouping/selector.rs
+++ b/crates/citum-engine/src/grouping/selector.rs
@@ -74,7 +74,7 @@ impl<'a> SelectorEvaluator<'a> {
     fn matches_cited_status(&self, reference: &Reference, cited: CitedStatus) -> bool {
         let id = reference.id().unwrap_or_default();
         match cited {
-            CitedStatus::Visible => self.cited_ids.contains(&id),
+            CitedStatus::Visible => self.cited_ids.contains(id.as_str()),
             CitedStatus::Any => true,
         }
     }
@@ -86,7 +86,7 @@ impl<'a> SelectorEvaluator<'a> {
     fn matches_field(reference: &Reference, field_name: &str, matcher: &FieldMatcher) -> bool {
         match field_name {
             "language" => {
-                let lang = reference.language().unwrap_or_default();
+                let lang = reference.language().unwrap_or_default().to_string();
                 Self::matches_field_value(&lang, matcher)
             }
             "note" => {

--- a/crates/citum-engine/src/grouping/sorting.rs
+++ b/crates/citum-engine/src/grouping/sorting.rs
@@ -390,7 +390,7 @@ impl<'a> GroupSorter<'a> {
 
     fn field_sort_value(reference: &Reference, field_name: &str) -> String {
         match field_name {
-            "language" => reference.language().unwrap_or_default().clone(),
+            "language" => reference.language().unwrap_or_default().to_string(),
             // Future: support for keywords, custom metadata
             _ => String::new(),
         }

--- a/crates/citum-engine/src/io.rs
+++ b/crates/citum-engine/src/io.rs
@@ -235,7 +235,7 @@ fn loaded_from_input_bibliography(
     let mut references = IndexMap::new();
     for r in input_bib.references {
         if let Some(id) = r.id() {
-            references.insert(id.clone(), r);
+            references.insert(id.to_string(), r);
         }
     }
     let sets = validate_compound_sets(input_bib.sets, &references)?;
@@ -250,7 +250,7 @@ fn loaded_from_hybrid_json_array(
     for value in references.iter().cloned() {
         let reference = parse_hybrid_json_reference(value)?;
         if let Some(id) = reference.id() {
-            bib.insert(id.clone(), reference);
+            bib.insert(id.to_string(), reference);
         }
     }
     let sets = validate_compound_sets(sets, &bib)?;
@@ -402,7 +402,7 @@ fn parse_json_bibliography(bytes: &[u8]) -> Result<LoadedBibliography, Processor
                 if r.id().is_none() {
                     r.set_id(id.clone());
                 }
-                bib.insert(id, r);
+                bib.insert(id.clone(), r);
                 found = true;
             }
         }
@@ -481,7 +481,7 @@ fn parse_yaml_bibliography(content: &str) -> Result<LoadedBibliography, Processo
     if let Ok(refs) = serde_yaml::from_str::<Vec<InputReference>>(content) {
         for r in refs {
             if let Some(id) = r.id() {
-                bib.insert(id.clone(), r);
+                bib.insert(id.to_string(), r);
             }
         }
         return Ok(LoadedBibliography {

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -27,7 +27,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! let style = Style {
 //!     info: StyleInfo {
 //!         title: Some("Simple".to_string()),
-//!         id: Some("simple".to_string()),
+//!         id: Some("simple".into()),
 //!         ..Default::default()
 //!     },
 //!     options: Some(Config {
@@ -58,7 +58,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! // Create a bibliography using native Citum reference data
 //! let mut bib = Bibliography::new();
 //! let reference = Reference::Monograph(Box::new(Monograph {
-//!     id: Some("kuhn1962".to_string()),
+//!     id: Some("kuhn1962".into()),
 //!     r#type: MonographType::Book,
 //!     title: Some(Title::Single("The Structure of Scientific Revolutions".to_string())),
 //!     author: Some(Contributor::ContributorList(ContributorList(vec![
@@ -78,7 +78,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! // Create processor and render
 //! let processor = Processor::new(style, bib);
 //! let citation = Citation {
-//!     id: Some("c1".to_string()),
+//!     id: Some("c1".into()),
 //!     items: vec![CitationItem { id: "kuhn1962".to_string(), ..Default::default() }],
 //!     ..Default::default()
 //! };

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -86,7 +86,7 @@ impl Processor {
     fn mark_group_members_assigned(assigned: &mut HashSet<String>, references: &[&Reference]) {
         for reference in references {
             if let Some(id) = reference.id() {
-                assigned.insert(id);
+                assigned.insert(id.to_string());
             }
         }
     }
@@ -102,7 +102,10 @@ impl Processor {
 
         let mut group_bibliography = Bibliography::new();
         for reference in sorted_refs {
-            group_bibliography.insert(reference.id().unwrap_or_default(), (*reference).clone());
+            group_bibliography.insert(
+                reference.id().unwrap_or_default().to_string(),
+                (*reference).clone(),
+            );
         }
 
         let resolved_sort = group
@@ -187,7 +190,7 @@ impl Processor {
         let mut previous_reference: Option<&Reference> = None;
 
         for (index, reference) in sorted_refs.into_iter().enumerate() {
-            let ref_id = reference.id().unwrap_or_default();
+            let ref_id = reference.id().unwrap_or_default().to_string();
             let entry_number = self
                 .citation_numbers
                 .borrow()

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -75,7 +75,7 @@ impl Processor {
         let substitute = bibliography_options.subsequent_author_substitute.as_ref();
 
         for (index, reference) in sorted_refs.enumerate() {
-            let ref_id = reference.id().unwrap_or_default();
+            let ref_id = reference.id().unwrap_or_default().to_string();
             let entry_number = self
                 .citation_numbers
                 .borrow()
@@ -191,7 +191,7 @@ impl Processor {
         let bibliography = self.process_sorted_refs::<_, F>(
             sorted_refs
                 .iter()
-                .filter(|r| selected.contains(&r.id().unwrap_or_default()))
+                .filter(|r| r.id().as_deref().is_some_and(|id| selected.contains(id)))
                 .copied(),
             |reference, entry_number| {
                 self.process_bibliography_entry_with_format::<F>(reference, entry_number)

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -431,7 +431,7 @@ impl<'a> Disambiguator<'a> {
         hint.group_length = self
             .author_group_length(reference, author_group_lengths, cache)
             .unwrap_or(1);
-        hints.insert(reference.id().unwrap_or_default(), hint);
+        hints.insert(reference.id().unwrap_or_default().to_string(), hint);
     }
 
     fn author_group_length(
@@ -842,7 +842,7 @@ mod tests {
     fn make_ref(id: &str, family: &str, given: &str, year: i32) -> Reference {
         let title = format!("Title {id}");
         Reference::Monograph(Box::new(Monograph {
-            id: Some(id.to_string()),
+            id: Some(id.into()),
             r#type: MonographType::Book,
             title: Some(Title::Single(title.clone())),
             short_title: None,
@@ -886,7 +886,7 @@ mod tests {
     fn make_multi_author_ref(id: &str, authors: &[(&str, &str)], year: i32) -> Reference {
         let title = format!("Title {id}");
         Reference::Monograph(Box::new(Monograph {
-            id: Some(id.to_string()),
+            id: Some(id.into()),
             r#type: MonographType::Book,
             title: Some(Title::Single(title)),
             short_title: None,
@@ -918,7 +918,7 @@ mod tests {
         Style {
             info: StyleInfo {
                 title: Some("Disambiguation Test".to_string()),
-                id: Some("disambiguation-test".to_string()),
+                id: Some("disambiguation-test".into()),
                 ..Default::default()
             },
             options: Some(config),

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -658,7 +658,7 @@ impl Renderer<'_> {
         if let Some(comp) = template.first().and_then(find_grouping_component) {
             let base_hints = self
                 .hints
-                .get(&reference.id().unwrap_or_default())
+                .get(reference.id().as_deref().unwrap_or_default())
                 .cloned()
                 .unwrap_or_default();
             // Inject citation position so subsequent et-al thresholds are applied.
@@ -1150,7 +1150,7 @@ impl Renderer<'_> {
         let default_hint = ProcHints::default();
         let base_hint = self
             .hints
-            .get(&reference.id().unwrap_or_default())
+            .get(reference.id().as_deref().unwrap_or_default())
             .unwrap_or(&default_hint);
         ProcHints {
             citation_number: (citation_number > 0).then_some(citation_number),

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -428,7 +428,7 @@ impl<'a> Renderer<'a> {
         };
 
         // Include compound sub-label (e.g. "a", "b") when applicable.
-        let ref_id = reference.id().unwrap_or_default();
+        let ref_id = reference.id().unwrap_or_default().to_string();
         let sub_label = self.citation_sub_label_for_ref(&ref_id).unwrap_or_default();
 
         // Format: "Author [Na]"

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -33,7 +33,7 @@ fn grouped_author_date_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Grouped Author Date".to_string()),
-            id: Some("grouped-author-date".to_string()),
+            id: Some("grouped-author-date".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -69,7 +69,7 @@ fn integral_name_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Integral Name Memory".to_string()),
-            id: Some("integral-name-memory".to_string()),
+            id: Some("integral-name-memory".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -119,7 +119,7 @@ fn legal_case_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Legal Case Grouping".to_string()),
-            id: Some("legal-case-grouping".to_string()),
+            id: Some("legal-case-grouping".into()),
             ..Default::default()
         },
         options: Some(Config {

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -210,6 +210,7 @@ impl Processor {
                 .sort_references(self.bibliography.values().collect(), &sort_spec.resolve())
                 .into_iter()
                 .filter_map(citum_schema::reference::InputReference::id)
+                .map(String::from)
                 .collect();
         }
 
@@ -218,6 +219,7 @@ impl Processor {
             .sort_references(self.bibliography.values().collect())
             .into_iter()
             .filter_map(citum_schema::reference::InputReference::id)
+            .map(String::from)
             .collect()
     }
 
@@ -225,6 +227,7 @@ impl Processor {
         self.sort_references(self.bibliography.values().collect())
             .into_iter()
             .filter_map(citum_schema::reference::InputReference::id)
+            .map(String::from)
             .collect()
     }
 

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -18,7 +18,7 @@ fn make_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("APA".to_string()),
-            id: Some("apa".to_string()),
+            id: Some("apa".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -170,7 +170,7 @@ fn make_grouped_compound_selection_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Grouped Compound Selection".to_string()),
-            id: Some("grouped-compound-selection".to_string()),
+            id: Some("grouped-compound-selection".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -386,7 +386,7 @@ fn test_process_citation() {
     let processor = Processor::new(style, bib);
 
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         items: vec![crate::reference::CitationItem {
             id: "kuhn1962".to_string(),
             ..Default::default()
@@ -410,7 +410,7 @@ fn test_normalize_note_context_assigns_missing_numbers() {
 
     let citations = vec![
         Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![crate::reference::CitationItem {
                 id: "kuhn1962".to_string(),
                 ..Default::default()
@@ -418,7 +418,7 @@ fn test_normalize_note_context_assigns_missing_numbers() {
             ..Default::default()
         },
         Citation {
-            id: Some("c2".to_string()),
+            id: Some("c2".into()),
             note_number: Some(7),
             items: vec![crate::reference::CitationItem {
                 id: "kuhn1962".to_string(),
@@ -427,7 +427,7 @@ fn test_normalize_note_context_assigns_missing_numbers() {
             ..Default::default()
         },
         Citation {
-            id: Some("c3".to_string()),
+            id: Some("c3".into()),
             items: vec![crate::reference::CitationItem {
                 id: "kuhn1962".to_string(),
                 ..Default::default()
@@ -454,7 +454,7 @@ fn test_process_citations_batch_api() {
 
     let citations = vec![
         Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![crate::reference::CitationItem {
                 id: "kuhn1962".to_string(),
                 ..Default::default()
@@ -462,7 +462,7 @@ fn test_process_citations_batch_api() {
             ..Default::default()
         },
         Citation {
-            id: Some("c2".to_string()),
+            id: Some("c2".into()),
             items: vec![crate::reference::CitationItem {
                 id: "kuhn1962".to_string(),
                 ..Default::default()
@@ -505,7 +505,7 @@ fn test_process_citation_treats_trimmed_none_delimiter_as_empty() {
     let bib = make_bibliography();
     let processor = Processor::new(style, bib);
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         items: vec![crate::reference::CitationItem {
             id: "kuhn1962".to_string(),
             ..Default::default()
@@ -998,7 +998,7 @@ fn test_disambiguation_givenname() {
     // Verify output
     let cit_a = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![crate::reference::CitationItem {
                 id: "smith2020a".to_string(),
                 ..Default::default()
@@ -1009,7 +1009,7 @@ fn test_disambiguation_givenname() {
 
     let cit_b = processor
         .process_citation(&Citation {
-            id: Some("c2".to_string()),
+            id: Some("c2".into()),
             items: vec![crate::reference::CitationItem {
                 id: "smith2020b".to_string(),
                 ..Default::default()
@@ -1112,7 +1112,7 @@ fn test_disambiguation_add_names() {
     // Verify output
     let cit_1 = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref1".to_string(),
                 ..Default::default()
@@ -1123,7 +1123,7 @@ fn test_disambiguation_add_names() {
 
     let cit_2 = processor
         .process_citation(&Citation {
-            id: Some("c2".to_string()),
+            id: Some("c2".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref2".to_string(),
                 ..Default::default()
@@ -1217,7 +1217,7 @@ fn test_disambiguation_combined_expansion() {
     // Verify output
     let cit_1 = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref1".to_string(),
                 ..Default::default()
@@ -1228,7 +1228,7 @@ fn test_disambiguation_combined_expansion() {
 
     let cit_2 = processor
         .process_citation(&Citation {
-            id: Some("c2".to_string()),
+            id: Some("c2".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref2".to_string(),
                 ..Default::default()
@@ -1333,7 +1333,7 @@ fn test_apa_titles_config() {
         style,
         references
             .into_iter()
-            .map(|r| (r.id().unwrap().clone(), r))
+            .map(|r| (r.id().unwrap().to_string(), r))
             .collect(),
     );
 
@@ -1416,7 +1416,7 @@ fn test_numeric_citation_numbers_with_repeated_refs() {
     // Cite ref1 first
     let cit1 = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref1".to_string(),
                 ..Default::default()
@@ -1428,7 +1428,7 @@ fn test_numeric_citation_numbers_with_repeated_refs() {
     // Cite ref2 second
     let cit2 = processor
         .process_citation(&Citation {
-            id: Some("c2".to_string()),
+            id: Some("c2".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref2".to_string(),
                 ..Default::default()
@@ -1440,7 +1440,7 @@ fn test_numeric_citation_numbers_with_repeated_refs() {
     // Cite ref1 again - should get the SAME number as before
     let cit3 = processor
         .process_citation(&Citation {
-            id: Some("c3".to_string()),
+            id: Some("c3".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref1".to_string(),
                 ..Default::default()
@@ -1501,7 +1501,7 @@ fn test_numeric_citation_numbers_follow_registry_order() {
 
     let cit = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![crate::reference::CitationItem {
                 id: "ref2".to_string(),
                 ..Default::default()
@@ -1542,7 +1542,7 @@ fn test_citation_grouping_same_author() {
     // Cite both Kuhn works in one citation - should group
     let result = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![
                 crate::reference::CitationItem {
                     id: "kuhn1962b".to_string(), // "Function..." comes first alphabetically -> a
@@ -1605,7 +1605,7 @@ fn test_label_mode_does_not_group_by_author() {
     let processor = Processor::new(style, bib);
     let result = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![
                 crate::reference::CitationItem {
                     id: "kuhn1962b".to_string(),
@@ -1653,7 +1653,7 @@ fn test_citation_grouping_different_authors() {
 
     let result = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![
                 crate::reference::CitationItem {
                     id: "kuhn1962".to_string(),
@@ -1949,7 +1949,7 @@ fn test_typst_single_item_citation_links_to_bibliography_entry() {
     let bib = make_bibliography();
     let processor = Processor::new(make_style(), bib);
     let citation = Citation {
-        id: Some("cite-1".to_string()),
+        id: Some("cite-1".into()),
         items: vec![CitationItem {
             id: "kuhn1962".to_string(),
             ..Default::default()
@@ -1980,7 +1980,7 @@ fn test_numeric_integral_citation_author_year() {
 
     // Integral mode citation - should render author + citation number
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         mode: citum_schema::citation::CitationMode::Integral,
         items: vec![crate::reference::CitationItem {
             id: "kuhn1962".to_string(),
@@ -2024,7 +2024,7 @@ fn test_numeric_non_integral_citation_number() {
 
     // Non-integral mode citation - should render citation number
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         mode: CitationMode::NonIntegral,
         items: vec![crate::reference::CitationItem {
             id: "kuhn1962".to_string(),
@@ -2071,7 +2071,7 @@ fn test_numeric_citation_number_collapse_enabled() {
     let processor = Processor::new(style, bib);
 
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         mode: CitationMode::NonIntegral,
         items: vec![
             crate::reference::CitationItem {
@@ -2129,7 +2129,7 @@ fn test_numeric_citation_number_collapse_skips_affixed_items() {
     let processor = Processor::new(style, bib);
 
     let citation = Citation {
-        id: Some("c2".to_string()),
+        id: Some("c2".into()),
         mode: CitationMode::NonIntegral,
         items: vec![
             crate::reference::CitationItem {
@@ -2245,7 +2245,7 @@ fn test_author_date_citations_preserve_input_order_without_explicit_sort() {
     let processor = Processor::new(style, bib);
     let result = processor
         .process_citation(&Citation {
-            id: Some("c1".to_string()),
+            id: Some("c1".into()),
             items: vec![
                 crate::reference::CitationItem {
                     id: "smith2020".to_string(),
@@ -2290,7 +2290,7 @@ fn test_numeric_integral_with_multiple_items() {
 
     // Integral mode with multiple items
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         mode: citum_schema::citation::CitationMode::Integral,
         items: vec![
             crate::reference::CitationItem {
@@ -2349,7 +2349,7 @@ fn test_label_integral_citation_uses_author_text() {
     let processor = Processor::new(style, bib);
 
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         mode: citum_schema::citation::CitationMode::Integral,
         items: vec![crate::reference::CitationItem {
             id: "kuhn1962".to_string(),
@@ -3421,7 +3421,7 @@ fn test_compound_numeric_number_assignment() {
     let mut bib = Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -3521,7 +3521,7 @@ bibliography:
     let mut bib = crate::reference::Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -3717,7 +3717,7 @@ fn test_compound_numeric_citation_subentry_disabled() {
     let mut bib = Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -3730,7 +3730,7 @@ fn test_compound_numeric_citation_subentry_disabled() {
     let processor = Processor::try_with_compound_sets(style, bib, sets).unwrap();
 
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         items: vec![CitationItem {
             id: "ref-a".to_string(),
             ..Default::default()
@@ -3789,7 +3789,7 @@ fn test_compound_numeric_integral_citation_sub_label() {
     let mut bib = Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -3803,7 +3803,7 @@ fn test_compound_numeric_integral_citation_sub_label() {
 
     // First member should render "Smith [1a]", not "Smith [1]"
     let cite_a = Citation {
-        id: Some("c-a".to_string()),
+        id: Some("c-a".into()),
         items: vec![CitationItem {
             id: "ref-a".to_string(),
             ..Default::default()
@@ -3819,7 +3819,7 @@ fn test_compound_numeric_integral_citation_sub_label() {
 
     // Second member should render "Jones [1b]", not "Jones [1]"
     let cite_b = Citation {
-        id: Some("c-b".to_string()),
+        id: Some("c-b".into()),
         items: vec![CitationItem {
             id: "ref-b".to_string(),
             ..Default::default()
@@ -3887,7 +3887,7 @@ bibliography:
     let mut bib = crate::reference::Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -3967,7 +3967,7 @@ bibliography:
     let mut bib = Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -4042,7 +4042,7 @@ bibliography:
     let mut bib = Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -4127,7 +4127,7 @@ fn test_compound_numeric_citation_subentry_collapse_disabled() {
     let mut bib = Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -4143,7 +4143,7 @@ fn test_compound_numeric_citation_subentry_collapse_disabled() {
 
     let processor = Processor::with_compound_sets(style, bib, sets);
     let citation = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         items: vec![
             CitationItem {
                 id: "ref-a".to_string(),
@@ -4212,7 +4212,7 @@ fn test_compound_numeric_citation_subentry_collapse_enabled() {
     let mut bib = Bibliography::new();
     for r in refs {
         if let Some(id) = r.id() {
-            bib.insert(id, r);
+            bib.insert(id.to_string(), r);
         }
     }
 
@@ -4230,7 +4230,7 @@ fn test_compound_numeric_citation_subentry_collapse_enabled() {
     let processor = Processor::with_compound_sets(style, bib, sets);
 
     let contiguous = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         items: vec![
             CitationItem {
                 id: "ref-a".to_string(),
@@ -4250,7 +4250,7 @@ fn test_compound_numeric_citation_subentry_collapse_enabled() {
     assert_eq!(processor.process_citation(&contiguous).unwrap(), "[1a-c]");
 
     let sparse = Citation {
-        id: Some("c2".to_string()),
+        id: Some("c2".into()),
         items: vec![
             CitationItem {
                 id: "ref-a".to_string(),
@@ -4546,7 +4546,7 @@ fn test_label_integral_citation_includes_label() {
 
     // Integral citation with label mode
     let cit = Citation {
-        id: Some("c1".to_string()),
+        id: Some("c1".into()),
         mode: citum_schema::citation::CitationMode::Integral,
         items: vec![crate::reference::CitationItem {
             id: "kuhn1962".to_string(),

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -179,12 +179,14 @@ pub fn effective_field_language(
     reference
         .field_languages()
         .get(scope)
-        .cloned()
+        .map(ToString::to_string)
         .or_else(|| match title {
-            Some(Title::Multilingual(multilingual)) => multilingual.lang.clone(),
+            Some(Title::Multilingual(multilingual)) => {
+                multilingual.lang.as_ref().map(ToString::to_string)
+            }
             _ => None,
         })
-        .or_else(|| reference.language())
+        .or_else(|| reference.language().map(|lang| lang.to_string()))
 }
 
 /// Resolve the effective language for the primary title of a reference.

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -2724,7 +2724,7 @@ fn test_text_case_non_english_falls_back_to_as_is() {
         id: "german".to_string(),
         ref_type: "book".to_string(),
         title: Some("Die Geschichte der Molekularbiologie".to_string()),
-        language: Some("de".to_string()),
+        language: Some("de".into()),
         ..Default::default()
     });
     let component = TemplateTitle {

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -42,7 +42,7 @@ fn build_numeric_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Numeric Test".to_string()),
-            id: Some("numeric-test".to_string()),
+            id: Some("numeric-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -70,7 +70,7 @@ fn build_sorted_style(sort: Vec<SortSpec>) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Sorted Test".to_string()),
-            id: Some("sort-test".to_string()),
+            id: Some("sort-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -103,7 +103,7 @@ fn build_title_year_sorted_style(sort: Vec<SortSpec>) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Title Year Sorted Test".to_string()),
-            id: Some("title-year-sort-test".to_string()),
+            id: Some("title-year-sort-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -133,7 +133,7 @@ fn build_container_title_short_style(title_type: TitleType) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Container Title Short Test".to_string()),
-            id: Some("container-title-short-test".to_string()),
+            id: Some("container-title-short-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -171,7 +171,7 @@ fn build_group_with_suppressed_child_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Grouped Suppression Test".to_string()),
-            id: Some("grouped-suppression-test".to_string()),
+            id: Some("grouped-suppression-test".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -203,7 +203,7 @@ fn build_status_bibliography_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Status Test".to_string()),
-            id: Some("status-test".to_string()),
+            id: Some("status-test".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -231,7 +231,7 @@ fn build_article_journal_no_page_fallback_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Article Journal Fallback Test".to_string()),
-            id: Some("article-journal-fallback-test".to_string()),
+            id: Some("article-journal-fallback-test".into()),
             ..Default::default()
         },
         options: Some(Config::default()),
@@ -332,7 +332,7 @@ fn build_bibliography_entry_link_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Bibliography Entry Link Test".to_string()),
-            id: Some("bibliography-entry-link-test".to_string()),
+            id: Some("bibliography-entry-link-test".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -356,7 +356,7 @@ fn build_bibliography_local_note_sort_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Bibliography Local Note Sort Test".to_string()),
-            id: Some("bibliography-local-note-sort-test".to_string()),
+            id: Some("bibliography-local-note-sort-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -383,7 +383,7 @@ fn build_bibliography_local_numeric_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Bibliography Local Numeric Test".to_string()),
-            id: Some("bibliography-local-numeric-test".to_string()),
+            id: Some("bibliography-local-numeric-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -409,7 +409,7 @@ fn build_numeric_citation_style_with_bibliography_local_note_sort() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Numeric Citation Local Note Sort Test".to_string()),
-            id: Some("numeric-citation-local-note-sort-test".to_string()),
+            id: Some("numeric-citation-local-note-sort-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -441,7 +441,7 @@ fn build_inline_article_journal_detail_group_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Inline Article Journal Detail Group Test".to_string()),
-            id: Some("inline-article-journal-detail-group-test".to_string()),
+            id: Some("inline-article-journal-detail-group-test".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -515,7 +515,7 @@ fn build_archive_eprint_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Archive and Eprint Test".to_string()),
-            id: Some("archive-eprint-test".to_string()),
+            id: Some("archive-eprint-test".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -545,7 +545,7 @@ fn build_archive_location_fallback_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Archive Location Fallback Test".to_string()),
-            id: Some("archive-location-fallback-test".to_string()),
+            id: Some("archive-location-fallback-test".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -586,7 +586,7 @@ fn build_multilingual_archive_name_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Multilingual Archive Name Test".to_string()),
-            id: Some("multilingual-archive-name-test".to_string()),
+            id: Some("multilingual-archive-name-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -611,7 +611,7 @@ fn build_multilingual_archive_name_style() -> Style {
 fn make_archive_eprint_reference() -> InputReference {
     InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some("archive-eprint-ref".to_string()),
+        id: Some("archive-eprint-ref".into()),
         r#type: MonographType::Preprint,
         title: Some(Title::Single("Archive-Aware Preprint".to_string())),
         container: None,
@@ -659,7 +659,7 @@ fn make_archive_eprint_reference() -> InputReference {
 fn make_multilingual_archive_name_reference() -> InputReference {
     InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some("archive-name-ref".to_string()),
+        id: Some("archive-name-ref".into()),
         r#type: MonographType::Document,
         title: Some(Title::Single("Repository Record".to_string())),
         container: None,
@@ -683,7 +683,7 @@ fn make_multilingual_archive_name_reference() -> InputReference {
         archive_info: Some(ArchiveInfo {
             name: Some(MultilingualString::Complex(MultilingualComplex {
                 original: "東京国立博物館".to_string(),
-                lang: Some("ja".to_string()),
+                lang: Some("ja".into()),
                 transliterations: HashMap::from([(
                     "ja-Latn-hepburn".to_string(),
                     "Tokyo National Museum".to_string(),
@@ -703,7 +703,7 @@ fn make_multilingual_archive_name_reference() -> InputReference {
 fn make_historical_archive_reference() -> InputReference {
     InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some("dead-sea-scrolls-demo".to_string()),
+        id: Some("dead-sea-scrolls-demo".into()),
         r#type: MonographType::Manuscript,
         title: Some(Title::Single("The Community Rule (1QS)".to_string())),
         container: None,
@@ -901,7 +901,7 @@ fn make_article_journal_with_detail(
     }
 
     InputReference::SerialComponent(Box::new(SerialComponent {
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: SerialComponentType::Article,
         title: Some(Title::Single("Fallback Article".to_string())),
         author: Some(Contributor::StructuredName(StructuredName {
@@ -979,7 +979,7 @@ fn build_processing_style(processing: Processing) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Processing Default Sort Test".to_string()),
-            id: Some("processing-default-sort-test".to_string()),
+            id: Some("processing-default-sort-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -1006,7 +1006,7 @@ fn make_style_with_substitute(substitute: Option<String>) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Subsequent Author Substitute Test".to_string()),
-            id: Some("sub-test".to_string()),
+            id: Some("sub-test".into()),
             ..Default::default()
         },
         templates: None,
@@ -1043,7 +1043,7 @@ fn make_particle_book(
 ) -> InputReference {
     InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: MonographType::Book,
         title: Some(Title::Single(format!("Title {id}"))),
         container: None,
@@ -1088,7 +1088,7 @@ fn make_editor_only_book(
 ) -> InputReference {
     InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: MonographType::Book,
         title: Some(Title::Single(title.to_string())),
         container: None,
@@ -1141,7 +1141,7 @@ fn make_multi_editor_only_book(
 
     InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: MonographType::Book,
         title: Some(Title::Single(title.to_string())),
         container: None,
@@ -1177,7 +1177,7 @@ fn build_editor_verb_prefix_style(title_suffix: Option<&str>) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Editor Verb Prefix Test".to_string()),
-            id: Some("editor-verb-prefix-test".to_string()),
+            id: Some("editor-verb-prefix-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -1223,7 +1223,7 @@ fn make_name_particle_style(display_as_sort: DisplayAsSort) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Hyphenated Particle Test".to_string()),
-            id: Some("hyphenated-particle-test".to_string()),
+            id: Some("hyphenated-particle-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -1394,7 +1394,7 @@ fn legal_case_parent_serial_uses_reporter_as_container_title() {
     let style = Style {
         info: StyleInfo {
             title: Some("Legal Reporter Parent Serial Test".to_string()),
-            id: Some("legal-reporter-parent-serial-test".to_string()),
+            id: Some("legal-reporter-parent-serial-test".into()),
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
@@ -1574,7 +1574,7 @@ fn magic_subsequent_author_substitute_reuses_the_full_author_group() {
     let style = Style {
         info: StyleInfo {
             title: Some("Magic Subsequent Author Substitute Test".to_string()),
-            id: Some("magic-subsequent-author-substitute-test".to_string()),
+            id: Some("magic-subsequent-author-substitute-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -2457,7 +2457,7 @@ fn bibliography_local_entry_links_apply_on_the_default_render_path() {
     let style = build_bibliography_entry_link_style();
     let reference = InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some("linked-book".to_string()),
+        id: Some("linked-book".into()),
         r#type: MonographType::Book,
         title: Some(Title::Single("Linked Book".to_string())),
         container: None,
@@ -2715,7 +2715,7 @@ fn given_archive_location_override_when_rendering_bibliography_then_legacy_fallb
     let InputReference::Monograph(monograph) = &mut reference else {
         panic!("archive test fixture should be a monograph");
     };
-    monograph.id = Some("archive-eprint-location-ref".to_string());
+    monograph.id = Some("archive-eprint-location-ref".into());
     monograph.archive_info = Some(ArchiveInfo {
         name: Some(MultilingualString::Simple("Houghton Library".to_string())),
         place: Some("Cambridge, MA".to_string()),
@@ -3071,12 +3071,12 @@ fn original_published_date_variable_renders_when_reference_has_original_date() {
     };
 
     let reference = InputReference::Monograph(Box::new(Monograph {
-        id: Some("gatsby".to_string()),
+        id: Some("gatsby".into()),
         title: Some(Title::Single("The Great Gatsby".to_string())),
         issued: EdtfString("1992".to_string()),
         original: Some(WorkRelation::Embedded(Box::new(InputReference::Monograph(
             Box::new(Monograph {
-                id: Some("gatsby-orig".to_string()),
+                id: Some("gatsby-orig".into()),
                 issued: EdtfString("1925".to_string()),
                 ..Default::default()
             }),

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -27,7 +27,7 @@ fn build_numeric_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Numeric Test".to_string()),
-            id: Some("numeric-test".to_string()),
+            id: Some("numeric-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -47,7 +47,7 @@ fn build_title_year_citation_style(sort: Vec<GroupSortKey>) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Title Year Citation Sort Test".to_string()),
-            id: Some("title-year-citation-sort-test".to_string()),
+            id: Some("title-year-citation-sort-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -72,7 +72,7 @@ fn build_integral_name_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Integral Name Memory".to_string()),
-            id: Some("integral-name-memory".to_string()),
+            id: Some("integral-name-memory".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -268,7 +268,7 @@ fn disambiguation_two_level_author_collisions_get_distinct_suffixes() {
     let mut bibliography = indexmap::IndexMap::new();
     for item in input {
         if let Some(id) = item.id() {
-            bibliography.insert(id, item);
+            bibliography.insert(id.to_string(), item);
         }
     }
 
@@ -460,7 +460,7 @@ fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
     let style = Style {
         info: StyleInfo {
             title: Some("Subsequent Et-Al Test".to_string()),
-            id: Some("subsequent-etal-test".to_string()),
+            id: Some("subsequent-etal-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -611,7 +611,7 @@ fn citation_scoped_contributor_shorten_applies_without_component_override() {
     let style = Style {
         info: StyleInfo {
             title: Some("Scoped contributor shorten".to_string()),
-            id: Some("scoped-contributor-shorten".to_string()),
+            id: Some("scoped-contributor-shorten".into()),
             ..Default::default()
         },
         citation: Some(CitationSpec {
@@ -1025,7 +1025,7 @@ fn note_styles_without_ibid_overrides_fall_back_to_subsequent() {
     let style = Style {
         info: StyleInfo {
             title: Some("Note Subsequent Fallback".to_string()),
-            id: Some("note-subsequent-fallback".to_string()),
+            id: Some("note-subsequent-fallback".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -1690,7 +1690,7 @@ fn test_personal_communication_citation_rendering_is_style_driven() {
 
     let mut bib = indexmap::IndexMap::new();
     for item in bib_vec {
-        bib.insert(item.id().unwrap(), item);
+        bib.insert(item.id().unwrap().to_string(), item);
     }
 
     // Mock APA 7th non-integral: (J. Oglethorpe, personal communication, January 13, 1733)

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -47,7 +47,7 @@ pub fn make_book_multi_author(
         .collect();
 
     Reference::Monograph(Box::new(Monograph {
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: MonographType::Book,
         title: Some(Title::Single(title.to_string())),
         author: Some(Contributor::ContributorList(ContributorList(author_list))),
@@ -82,7 +82,7 @@ pub fn make_article_multi_author(
         .collect();
 
     Reference::SerialComponent(Box::new(SerialComponent {
-        id: Some(id.to_string()),
+        id: Some(id.into()),
         r#type: SerialComponentType::Article,
         title: Some(Title::Single(title.to_string())),
         author: Some(Contributor::ContributorList(ContributorList(author_list))),
@@ -127,7 +127,7 @@ pub fn make_multilingual_book(params: MultilingualBookParams) -> Reference {
     );
 
     Reference::Monograph(Box::new(Monograph {
-        id: Some(params.id.to_string()),
+        id: Some(params.id.into()),
         r#type: MonographType::Book,
         title: Some(Title::Single(params.title.to_string())),
         author: Some(Contributor::Multilingual(MultilingualName {
@@ -136,7 +136,7 @@ pub fn make_multilingual_book(params: MultilingualBookParams) -> Reference {
                 given: MultilingualString::Simple(params.original_given.to_string()),
                 ..Default::default()
             },
-            lang: Some(params.lang.to_string()),
+            lang: Some(params.lang.into()),
             transliterations,
             translations: HashMap::new(),
         })),
@@ -194,7 +194,7 @@ pub fn run_test_case_native_with_options(options: TestCaseOptions) {
     let mut bibliography = indexmap::IndexMap::new();
     for item in options.input {
         if let Some(id) = item.id() {
-            bibliography.insert(id, item.clone());
+            bibliography.insert(id.to_string(), item.clone());
         }
     }
 
@@ -342,7 +342,7 @@ pub fn build_author_date_style(
     Style {
         info: StyleInfo {
             title: Some("Author-Date Disambiguation Test".to_string()),
-            id: Some("http://test.example/disambiguation".to_string()),
+            id: Some("http://test.example/disambiguation".into()),
             ..Default::default()
         },
         options: Some(Config {

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -30,7 +30,7 @@ fn given_simple_author_date_document_when_rendered_as_html_then_a_bibliography_h
     let style = Style {
         info: StyleInfo {
             title: Some("Test Style".to_string()),
-            id: Some("test".to_string()),
+            id: Some("test".into()),
             ..Default::default()
         },
         templates: None,
@@ -102,7 +102,7 @@ fn given_simple_author_date_document_when_rendered_as_djot_then_html_tags_are_no
     let style = Style {
         info: StyleInfo {
             title: Some("Test Style".to_string()),
-            id: Some("test".to_string()),
+            id: Some("test".into()),
             ..Default::default()
         },
         templates: None,

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -37,7 +37,7 @@ fn build_ml_style(name_mode: MultilingualMode, preferred_script: Option<String>)
     Style {
         info: StyleInfo {
             title: Some("Multilingual Test".to_string()),
-            id: Some("ml-test".to_string()),
+            id: Some("ml-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -65,7 +65,7 @@ fn make_german_translator_role_style() -> Style {
     Style {
         info: StyleInfo {
             title: Some("Chicago German Translator Test".to_string()),
-            id: Some("chicago-de-translator".to_string()),
+            id: Some("chicago-de-translator".into()),
             default_locale: Some("de-DE".to_string()),
             ..Default::default()
         },
@@ -127,7 +127,7 @@ fn make_german_translator_role_style() -> Style {
 fn make_german_translator_reference() -> InputReference {
     InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some("ref1".to_string()),
+        id: Some("ref1".into()),
         r#type: MonographType::Book,
         title: Some(Title::Single("Das Buch".to_string())),
         container: None,
@@ -143,7 +143,7 @@ fn make_german_translator_reference() -> InputReference {
             ..Default::default()
         })),
         issued: EdtfString("2024".to_string()),
-        language: Some("de".to_string()),
+        language: Some("de".into()),
         ..Default::default()
     }))
 }
@@ -159,7 +159,7 @@ fn given_a_simple_string_when_resolved_then_the_original_text_is_returned() {
 fn given_primary_mode_when_resolving_a_multilingual_title_then_the_original_script_is_returned() {
     let complex = MultilingualComplex {
         original: "战争与和平".to_string(),
-        lang: Some("zh".to_string()),
+        lang: Some("zh".into()),
         transliterations: {
             let mut map = HashMap::new();
             map.insert(
@@ -170,7 +170,7 @@ fn given_primary_mode_when_resolving_a_multilingual_title_then_the_original_scri
         },
         translations: {
             let mut map = HashMap::new();
-            map.insert("en".to_string(), "War and Peace".to_string());
+            map.insert("en".into(), "War and Peace".to_string());
             map
         },
     };
@@ -190,7 +190,7 @@ fn given_primary_mode_when_resolving_a_multilingual_title_then_the_original_scri
 fn given_an_exact_transliteration_match_when_resolving_then_that_transliteration_is_used() {
     let complex = MultilingualComplex {
         original: "東京".to_string(),
-        lang: Some("ja".to_string()),
+        lang: Some("ja".into()),
         transliterations: {
             let mut map = HashMap::new();
             map.insert("ja-Latn-hepburn".to_string(), "Tōkyō".to_string());
@@ -199,7 +199,7 @@ fn given_an_exact_transliteration_match_when_resolving_then_that_transliteration
         },
         translations: {
             let mut map = HashMap::new();
-            map.insert("en".to_string(), "Tokyo".to_string());
+            map.insert("en".into(), "Tokyo".to_string());
             map
         },
     };
@@ -220,7 +220,7 @@ fn given_an_exact_transliteration_match_when_resolving_then_that_transliteration
 fn given_a_transliteration_prefix_match_when_resolving_then_the_matching_transliteration_is_used() {
     let complex = MultilingualComplex {
         original: "東京".to_string(),
-        lang: Some("ja".to_string()),
+        lang: Some("ja".into()),
         transliterations: {
             let mut map = HashMap::new();
             map.insert("ja-Latn-hepburn".to_string(), "Tōkyō".to_string());
@@ -245,7 +245,7 @@ fn given_a_transliteration_prefix_match_when_resolving_then_the_matching_transli
 fn given_no_transliteration_when_transliterated_mode_is_requested_then_the_original_text_is_used() {
     let complex = MultilingualComplex {
         original: "东京".to_string(),
-        lang: Some("zh".to_string()),
+        lang: Some("zh".into()),
         transliterations: HashMap::new(), // No transliterations available
         translations: HashMap::new(),
     };
@@ -266,12 +266,12 @@ fn given_no_transliteration_when_transliterated_mode_is_requested_then_the_origi
 fn given_translated_mode_when_resolving_then_the_requested_locale_translation_is_used() {
     let complex = MultilingualComplex {
         original: "战争与和平".to_string(),
-        lang: Some("zh".to_string()),
+        lang: Some("zh".into()),
         transliterations: HashMap::new(),
         translations: {
             let mut map = HashMap::new();
-            map.insert("en".to_string(), "War and Peace".to_string());
-            map.insert("fr".to_string(), "Guerre et Paix".to_string());
+            map.insert("en".into(), "War and Peace".to_string());
+            map.insert("fr".into(), "Guerre et Paix".to_string());
             map
         },
     };
@@ -302,7 +302,7 @@ fn given_translated_mode_when_resolving_then_the_requested_locale_translation_is
 fn given_combined_mode_when_transliteration_and_translation_exist_then_both_are_combined() {
     let complex = MultilingualComplex {
         original: "战争与和平".to_string(),
-        lang: Some("zh".to_string()),
+        lang: Some("zh".into()),
         transliterations: {
             let mut map = HashMap::new();
             map.insert(
@@ -313,7 +313,7 @@ fn given_combined_mode_when_transliteration_and_translation_exist_then_both_are_
         },
         translations: {
             let mut map = HashMap::new();
-            map.insert("en".to_string(), "War and Peace".to_string());
+            map.insert("en".into(), "War and Peace".to_string());
             map
         },
     };
@@ -335,11 +335,11 @@ fn given_combined_mode_without_transliteration_when_resolving_then_original_and_
  {
     let complex = MultilingualComplex {
         original: "东京".to_string(),
-        lang: Some("zh".to_string()),
+        lang: Some("zh".into()),
         transliterations: HashMap::new(),
         translations: {
             let mut map = HashMap::new();
-            map.insert("en".to_string(), "Tokyo".to_string());
+            map.insert("en".into(), "Tokyo".to_string());
             map
         },
     };
@@ -384,7 +384,7 @@ fn given_a_multilingual_name_with_requested_script_when_resolved_then_the_transl
             dropping_particle: None,
             non_dropping_particle: None,
         },
-        lang: Some("ru".to_string()),
+        lang: Some("ru".into()),
         transliterations: {
             let mut map = HashMap::new();
             map.insert(
@@ -425,7 +425,7 @@ fn given_a_multilingual_name_with_a_script_prefix_match_when_resolved_then_the_m
             dropping_particle: None,
             non_dropping_particle: None,
         },
-        lang: Some("ru".to_string()),
+        lang: Some("ru".into()),
         transliterations: {
             let mut map = HashMap::new();
             map.insert(
@@ -467,7 +467,7 @@ fn given_a_multilingual_name_without_transliterations_when_resolved_then_the_ori
             dropping_particle: None,
             non_dropping_particle: None,
         },
-        lang: Some("ru".to_string()),
+        lang: Some("ru".into()),
         transliterations: HashMap::new(),
         translations: HashMap::new(),
     });
@@ -578,7 +578,7 @@ fn given_translated_numeric_integral_citations_when_rendered_then_the_translated
     let mut bib = indexmap::IndexMap::new();
     let mut translations = HashMap::new();
     translations.insert(
-        "en-US".to_string(),
+        "en-US".into(),
         StructuredName {
             family: MultilingualString::Simple("Tolstoy".to_string()),
             given: MultilingualString::Simple("Leo".to_string()),
@@ -591,7 +591,7 @@ fn given_translated_numeric_integral_citations_when_rendered_then_the_translated
         citum_schema::reference::InputReference::Monograph(Box::new(
             citum_schema::reference::Monograph {
                 short_title: None,
-                id: Some("item1".to_string()),
+                id: Some("item1".into()),
                 r#type: citum_schema::reference::MonographType::Book,
                 title: Some(citum_schema::reference::Title::Single(
                     "War and Peace".to_string(),
@@ -603,7 +603,7 @@ fn given_translated_numeric_integral_citations_when_rendered_then_the_translated
                         given: MultilingualString::Simple("Лев".to_string()),
                         ..Default::default()
                     },
-                    lang: Some("ru".to_string()),
+                    lang: Some("ru".into()),
                     transliterations: HashMap::new(),
                     translations,
                 })),
@@ -631,11 +631,11 @@ fn given_field_language_overrides_when_resolving_the_effective_field_language_th
  {
     let reference = InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some("item1".to_string()),
+        id: Some("item1".into()),
         r#type: MonographType::Book,
         title: Some(Title::Multilingual(MultilingualComplex {
             original: "Titel".to_string(),
-            lang: Some("de".to_string()),
+            lang: Some("de".into()),
             transliterations: HashMap::new(),
             translations: HashMap::new(),
         })),
@@ -644,8 +644,8 @@ fn given_field_language_overrides_when_resolving_the_effective_field_language_th
         editor: None,
         translator: None,
         issued: EdtfString("2024".to_string()),
-        language: Some("fr".to_string()),
-        field_languages: HashMap::from([("title".to_string(), "en".to_string())]),
+        language: Some("fr".into()),
+        field_languages: HashMap::from([("title".to_string(), "en".into())]),
         ..Default::default()
     }));
 
@@ -659,11 +659,11 @@ fn given_no_item_language_when_resolving_the_effective_item_language_then_the_mu
  {
     let reference = InputReference::Monograph(Box::new(Monograph {
         short_title: None,
-        id: Some("item1".to_string()),
+        id: Some("item1".into()),
         r#type: MonographType::Book,
         title: Some(Title::Multilingual(MultilingualComplex {
             original: "東京".to_string(),
-            lang: Some("ja".to_string()),
+            lang: Some("ja".into()),
             transliterations: HashMap::new(),
             translations: HashMap::new(),
         })),
@@ -713,7 +713,7 @@ fn given_localized_citation_templates_when_the_item_language_matches_then_the_lo
         "de-item".to_string(),
         InputReference::Monograph(Box::new(Monograph {
             short_title: None,
-            id: Some("de-item".to_string()),
+            id: Some("de-item".into()),
             r#type: MonographType::Book,
             title: Some(Title::Single("Titel".to_string())),
             container: None,
@@ -727,7 +727,7 @@ fn given_localized_citation_templates_when_the_item_language_matches_then_the_lo
             }),
             url: None,
             accessed: None,
-            language: Some("de-AT".to_string()),
+            language: Some("de-AT".into()),
             field_languages: HashMap::new(),
             note: Some("fallback".to_string()),
             isbn: None,
@@ -749,7 +749,7 @@ fn given_localized_citation_templates_when_the_item_language_matches_then_the_lo
         "fr-item".to_string(),
         InputReference::Monograph(Box::new(Monograph {
             short_title: None,
-            id: Some("fr-item".to_string()),
+            id: Some("fr-item".into()),
             r#type: MonographType::Book,
             title: Some(Title::Single("Titre".to_string())),
             container: None,
@@ -763,7 +763,7 @@ fn given_localized_citation_templates_when_the_item_language_matches_then_the_lo
             }),
             url: None,
             accessed: None,
-            language: Some("fr".to_string()),
+            language: Some("fr".into()),
             field_languages: HashMap::new(),
             note: Some("fallback".to_string()),
             isbn: None,
@@ -828,11 +828,11 @@ fn given_localized_bibliography_templates_when_only_the_multilingual_title_has_a
         "item1".to_string(),
         InputReference::Monograph(Box::new(Monograph {
             short_title: None,
-            id: Some("item1".to_string()),
+            id: Some("item1".into()),
             r#type: MonographType::Book,
             title: Some(Title::Multilingual(MultilingualComplex {
                 original: "東京".to_string(),
-                lang: Some("ja".to_string()),
+                lang: Some("ja".into()),
                 transliterations: HashMap::new(),
                 translations: HashMap::new(),
             })),
@@ -915,7 +915,7 @@ fn given_mixed_language_titles_when_rendering_the_bibliography_then_field_langua
     };
 
     let reference = InputReference::CollectionComponent(Box::new(CollectionComponent {
-        id: Some("chapter-1".to_string()),
+        id: Some("chapter-1".into()),
         r#type: citum_schema::reference::MonographComponentType::Chapter,
         title: Some(Title::Single("English Article".to_string())),
         author: None,
@@ -935,7 +935,7 @@ fn given_mixed_language_titles_when_rendering_the_bibliography_then_field_langua
                 numbering: Vec::new(),
                 url: None,
                 accessed: None,
-                language: Some("de".to_string()),
+                language: Some("de".into()),
                 field_languages: HashMap::new(),
                 note: None,
                 isbn: None,
@@ -947,10 +947,10 @@ fn given_mixed_language_titles_when_rendering_the_bibliography_then_field_langua
         pages: None,
         url: None,
         accessed: None,
-        language: Some("de".to_string()),
+        language: Some("de".into()),
         field_languages: HashMap::from([
-            ("title".to_string(), "en".to_string()),
-            ("parent-monograph.title".to_string(), "de".to_string()),
+            ("title".to_string(), "en".into()),
+            ("parent-monograph.title".to_string(), "de".into()),
         ]),
         note: None,
         doi: None,
@@ -1145,7 +1145,7 @@ fn chicago_german_override_localizes_editor_verb() {
     let style = Style {
         info: StyleInfo {
             title: Some("Chicago German Test".to_string()),
-            id: Some("chicago-de".to_string()),
+            id: Some("chicago-de".into()),
             default_locale: Some("de-DE".to_string()),
             ..Default::default()
         },
@@ -1177,7 +1177,7 @@ fn chicago_german_override_localizes_editor_verb() {
     bib.insert(
         "ref1".to_string(),
         InputReference::CollectionComponent(Box::new(CollectionComponent {
-            id: Some("ref1".to_string()),
+            id: Some("ref1".into()),
             r#type: citum_schema::reference::MonographComponentType::Chapter,
             title: Some(Title::Single("Kapitel".to_string())),
             author: Some(Contributor::StructuredName(StructuredName {
@@ -1205,7 +1205,7 @@ fn chicago_german_override_localizes_editor_verb() {
                     numbering: Vec::new(),
                     url: None,
                     accessed: None,
-                    language: Some("de".to_string()),
+                    language: Some("de".into()),
                     field_languages: HashMap::new(),
                     note: None,
                     isbn: None,
@@ -1216,7 +1216,7 @@ fn chicago_german_override_localizes_editor_verb() {
             pages: None,
             url: None,
             accessed: None,
-            language: Some("de".to_string()),
+            language: Some("de".into()),
             field_languages: HashMap::new(),
             note: None,
             doi: None,

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -25,7 +25,7 @@ fn build_name_style(form: ContributorForm, shorten: Option<ShortenListOptions>) 
     Style {
         info: StyleInfo {
             title: Some("Name Test".to_string()),
-            id: Some("name-test".to_string()),
+            id: Some("name-test".into()),
             ..Default::default()
         },
         options: Some(Config {
@@ -52,7 +52,7 @@ fn build_date_style(form: DateForm) -> Style {
     Style {
         info: StyleInfo {
             title: Some("Date Test".to_string()),
-            id: Some("date-test".to_string()),
+            id: Some("date-test".into()),
             ..Default::default()
         },
         options: Some(Config {

--- a/crates/citum-engine/tests/name_form_initialization.rs
+++ b/crates/citum-engine/tests/name_form_initialization.rs
@@ -24,7 +24,7 @@ fn build_name_form_test_style(
     Style {
         info: StyleInfo {
             title: Some("Name Form Test".to_string()),
-            id: Some("name-form-test".to_string()),
+            id: Some("name-form-test".into()),
             ..Default::default()
         },
         options: Some(Config {

--- a/crates/citum-engine/tests/regression_interview.rs
+++ b/crates/citum-engine/tests/regression_interview.rs
@@ -21,7 +21,7 @@ fn test_apa_interview_fidelity_regression() {
 
     // Create the interview reference using native Citum structs
     let reference = InputReference::Monograph(Box::new(Monograph {
-        id: Some("sr-interview".to_string()),
+        id: Some("sr-interview".into()),
         r#type: MonographType::Interview,
         title: Some(Title::Single("Thinking in Public".to_string())),
         author: Some(Contributor::StructuredName(StructuredName {

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -110,7 +110,7 @@ fn test_numeric_sort_by_citation_order() {
         Style {
             info: StyleInfo {
                 title: Some("Numeric Test".to_string()),
-                id: Some("numeric-test".to_string()),
+                id: Some("numeric-test".into()),
                 ..Default::default()
             },
             options: Some(Config {
@@ -231,7 +231,7 @@ fn test_numeric_style_volume_issue_independence() {
         Style {
             info: StyleInfo {
                 title: Some("Numeric Test".to_string()),
-                id: Some("numeric-test".to_string()),
+                id: Some("numeric-test".into()),
                 ..Default::default()
             },
             options: Some(Config {

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -9,8 +9,8 @@ use crate::reference::types::{
     Subtitle, Title, Treaty,
 };
 use crate::reference::{
-    AudioVisualType, AudioVisualWork, Event, InputReference, Numbering, NumberingType, WorkCore,
-    WorkRelation,
+    AudioVisualType, AudioVisualWork, Event, InputReference, LangID, Numbering, NumberingType,
+    RefID, WorkCore, WorkRelation,
 };
 use std::collections::HashMap;
 use url::Url;
@@ -204,14 +204,14 @@ fn archive_info_from_legacy_flat(legacy: &csl_legacy::csl_json::Reference) -> Op
 
 /// Pre-extracted common fields shared by all reference conversion functions.
 struct RefContext {
-    id: Option<String>,
+    id: Option<RefID>,
     title: Option<String>,
     short_title: Option<String>,
     created: EdtfString,
     issued: EdtfString,
     url: Option<Url>,
     accessed: Option<EdtfString>,
-    language: Option<String>,
+    language: Option<LangID>,
     note: Option<String>,
     doi: Option<String>,
     isbn: Option<String>,
@@ -744,7 +744,7 @@ pub fn input_reference_from_legacy_edited_book(
     push_legacy_contributor(&mut contributors, ContributorRole::Translator, translator);
 
     InputReference::Collection(Box::new(Collection {
-        id: Some(id),
+        id: Some(id.into()),
         r#type: CollectionType::EditedBook,
         title: title.map(Title::Single),
         short_title: extra
@@ -766,7 +766,7 @@ pub fn input_reference_from_legacy_edited_book(
         numbering,
         url: url.as_deref().and_then(|value| Url::parse(value).ok()),
         accessed: accessed.map(EdtfString::from),
-        language,
+        language: language.map(Into::into),
         field_languages: HashMap::new(),
         note,
         isbn,
@@ -1488,7 +1488,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
     fn from(mut legacy: csl_legacy::csl_json::Reference) -> Self {
         legacy.parse_note_field_hacks();
         let ctx = RefContext {
-            id: Some(legacy.id.clone()),
+            id: Some(legacy.id.clone().into()),
             title: legacy.title.clone(),
             short_title: short_title_from_legacy(&legacy, "shortTitle")
                 .or_else(|| short_title_from_legacy(&legacy, "title-short")),
@@ -1508,7 +1508,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
                 .unwrap_or(EdtfString(String::new())),
             url: legacy.url.as_ref().and_then(|u| Url::parse(u).ok()),
             accessed: legacy.accessed.clone().map(EdtfString::from),
-            language: legacy.language.clone(),
+            language: legacy.language.clone().map(Into::into),
             note: legacy.note.clone(),
             doi: legacy.doi.clone(),
             isbn: legacy.isbn.clone(),

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -1255,7 +1255,9 @@ impl InputReference {
     }
 
     /// Set the reference ID.
-    pub fn set_id(&mut self, id: String) {
+    pub fn set_id(&mut self, id: impl Into<RefID>) {
+        let id = id.into();
+
         match self {
             InputReference::Monograph(monograph) => monograph.id = Some(id),
             InputReference::CollectionComponent(component) => component.id = Some(id),

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -388,7 +388,7 @@ fn unpublished_legacy_records_promote_issued_to_created() {
 #[test]
 fn created_date_backfills_csl_issued_compatibility() {
     let reference = InputReference::Monograph(Box::new(Monograph {
-        id: Some("created-only".to_string()),
+        id: Some("created-only".into()),
         r#type: MonographType::Manuscript,
         title: Some(Title::Single("Created Only".to_string())),
         created: EdtfString("1954-05-17".to_string()),

--- a/crates/citum-schema-data/src/reference/types/common.rs
+++ b/crates/citum-schema-data/src/reference/types/common.rs
@@ -9,15 +9,112 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "bindings")]
 use specta::Type;
+use std::borrow::Borrow;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::str::FromStr;
 use url::Url;
 
 /// Unique identifier for a reference item.
-pub type RefID = String;
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "bindings", derive(Type))]
+#[serde(transparent)]
+pub struct RefID(pub String);
+
+impl RefID {
+    /// Borrow the reference identifier as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for RefID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for RefID {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for RefID {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for RefID {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl From<String> for RefID {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for RefID {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<RefID> for String {
+    fn from(value: RefID) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for RefID {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(value))
+    }
+}
+
+impl PartialEq<&str> for RefID {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<str> for RefID {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<String> for RefID {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<RefID> for &str {
+    fn eq(&self, other: &RefID) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<RefID> for String {
+    fn eq(&self, other: &RefID) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
 
 /// A numbering identifier for a work (e.g., volume, issue, number).
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -232,8 +329,101 @@ fn normalize_kind_key(value: &str) -> Option<String> {
 }
 
 /// BCP 47 language tag (e.g., `"en"`, `"de"`, `"ja"`).
-/// BCP 47 language tag (e.g., `"en"`, `"de"`, `"ja"`).
-pub type LangID = String;
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "bindings", derive(Type))]
+#[serde(transparent)]
+pub struct LangID(pub String);
+
+impl LangID {
+    /// Borrow the language identifier as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for LangID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for LangID {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for LangID {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for LangID {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl From<String> for LangID {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for LangID {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<LangID> for String {
+    fn from(value: LangID) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for LangID {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(value))
+    }
+}
+
+impl PartialEq<&str> for LangID {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<str> for LangID {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<String> for LangID {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<LangID> for &str {
+    fn eq(&self, other: &LangID) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<LangID> for String {
+    fn eq(&self, other: &LangID) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
 /// Maps field names to their language tags for multilingual references.
 pub type FieldLanguageMap = HashMap<String, LangID>;
 
@@ -542,4 +732,48 @@ pub enum RefDate {
     Edtf(citum_edtf::Edtf),
     /// A literal date string that could not be parsed as EDTF.
     Literal(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LangID, RefID};
+    #[cfg(feature = "schema")]
+    use schemars::schema_for;
+    use std::collections::HashMap;
+
+    #[test]
+    fn ref_id_round_trips_as_a_scalar_string() {
+        let id = RefID::from("kuhn1962");
+        let serialized = serde_json::to_string(&id).expect("ref id should serialize");
+        let deserialized: RefID =
+            serde_json::from_str(&serialized).expect("ref id should deserialize");
+
+        assert_eq!(serialized, "\"kuhn1962\"");
+        assert_eq!(deserialized, "kuhn1962");
+        assert_eq!(deserialized.as_ref(), "kuhn1962");
+        assert_eq!(String::from(deserialized), "kuhn1962");
+    }
+
+    #[test]
+    fn lang_id_supports_string_lookup_and_parsing() {
+        let lang = "en-US".parse::<LangID>().expect("lang id should parse");
+        let mut translations = HashMap::new();
+        translations.insert(lang.clone(), "English".to_string());
+
+        assert_eq!(lang, "en-US");
+        assert_eq!(
+            translations.get("en-US").map(String::as_str),
+            Some("English")
+        );
+    }
+
+    #[cfg(feature = "schema")]
+    #[test]
+    fn newtypes_stay_string_shaped_in_json_schema() {
+        let ref_schema = schema_for!(RefID);
+        let lang_schema = schema_for!(LangID);
+
+        assert_eq!(ref_schema.to_value()["type"], "string");
+        assert_eq!(lang_schema.to_value()["type"], "string");
+    }
 }

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -81,7 +81,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.30.1";
+pub const STYLE_SCHEMA_VERSION: &str = "0.30.2";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/citum-schema-style/src/macros.rs
+++ b/crates/citum-schema-style/src/macros.rs
@@ -203,7 +203,7 @@ macro_rules! ref_book {
     ($id:expr, $family:expr, $given:expr, $year:expr, $title:expr) => {
         $crate::reference::InputReference::Monograph(::std::boxed::Box::new(
             $crate::reference::Monograph {
-                id: Some($id.to_string()),
+                id: Some($id.into()),
                 r#type: $crate::reference::MonographType::Book,
                 title: Some($crate::reference::Title::Single($title.to_string())),
                 author: Some($crate::reference::Contributor::StructuredName(
@@ -239,7 +239,7 @@ macro_rules! ref_book_authors {
         ];
         $crate::reference::InputReference::Monograph(::std::boxed::Box::new(
             $crate::reference::Monograph {
-                id: Some($id.to_string()),
+                id: Some($id.into()),
                 r#type: $crate::reference::MonographType::Book,
                 title: Some($crate::reference::Title::Single($title.to_string())),
                 author: Some($crate::reference::Contributor::ContributorList(
@@ -258,7 +258,7 @@ macro_rules! ref_article {
     ($id:expr, $family:expr, $given:expr, $year:expr, $title:expr) => {
         $crate::reference::InputReference::SerialComponent(::std::boxed::Box::new(
             $crate::reference::SerialComponent {
-                id: Some($id.to_string()),
+                id: Some($id.into()),
                 r#type: $crate::reference::SerialComponentType::Article,
                 title: Some($crate::reference::Title::Single($title.to_string())),
                 author: Some($crate::reference::Contributor::StructuredName(
@@ -303,7 +303,7 @@ macro_rules! ref_article_authors {
         ];
         $crate::reference::InputReference::SerialComponent(::std::boxed::Box::new(
             $crate::reference::SerialComponent {
-                id: Some($id.to_string()),
+                id: Some($id.into()),
                 r#type: $crate::reference::SerialComponentType::Article,
                 title: Some($crate::reference::Title::Single($title.to_string())),
                 author: Some($crate::reference::Contributor::ContributorList(

--- a/crates/citum-schema-style/src/reference_multilingual_tests.rs
+++ b/crates/citum-schema-style/src/reference_multilingual_tests.rs
@@ -22,7 +22,7 @@ translations:
         let title: Title = serde_yaml::from_str(yaml).unwrap();
         if let Title::Multilingual(m) = title {
             assert_eq!(m.original, "战争与和平");
-            assert_eq!(m.lang, Some("zh".to_string()));
+            assert_eq!(m.lang, Some("zh".into()));
             assert_eq!(m.translations.get("en").unwrap(), "War and Peace");
         } else {
             panic!("Expected Title::Multilingual");
@@ -43,7 +43,7 @@ transliterations:
 "#;
         let name: MultilingualName = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(name.original.family.to_string(), "Tolstoy");
-        assert_eq!(name.lang, Some("ru".to_string()));
+        assert_eq!(name.lang, Some("ru".into()));
         assert!(name.transliterations.contains_key("Latn"));
     }
 
@@ -120,12 +120,16 @@ field-languages:
   parent-monograph.title: de
 "#;
         let monograph: Monograph = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(monograph.field_languages.get("title").unwrap(), "en");
+        assert_eq!(
+            monograph.field_languages.get("title").unwrap().as_ref(),
+            "en"
+        );
         assert_eq!(
             monograph
                 .field_languages
                 .get("parent-monograph.title")
-                .unwrap(),
+                .unwrap()
+                .as_ref(),
             "de"
         );
     }

--- a/crates/citum-schema-style/src/style_preset.rs
+++ b/crates/citum-schema-style/src/style_preset.rs
@@ -214,7 +214,7 @@ citation:
         let style = Style {
             info: StyleInfo {
                 title: Some("Taylor & Francis Test".to_string()),
-                id: Some("tf-test".to_string()),
+                id: Some("tf-test".into()),
                 ..Default::default()
             },
             preset: Some(StylePreset::ChicagoAuthorDate18th),

--- a/crates/citum-schema-style/tests/parent_reference.rs
+++ b/crates/citum-schema-style/tests/parent_reference.rs
@@ -9,11 +9,11 @@ use citum_schema_style::reference::{
 fn test_serial_component_with_container_id() {
     let parent_id = "journal-1".to_string();
     let component = SerialComponent {
-        id: Some("article-1".to_string()),
+        id: Some("article-1".into()),
         r#type: SerialComponentType::Article,
         title: Some(Title::Single("My Article".to_string())),
         issued: EdtfString("2023".to_string()),
-        container: Some(WorkRelation::Id(parent_id.clone())),
+        container: Some(WorkRelation::Id(parent_id.clone().into())),
         ..Default::default()
     };
 
@@ -27,11 +27,11 @@ fn test_serial_component_with_container_id() {
 fn test_collection_component_with_container_id() {
     let parent_id = "book-1".to_string();
     let component = CollectionComponent {
-        id: Some("chapter-1".to_string()),
+        id: Some("chapter-1".into()),
         r#type: MonographComponentType::Chapter,
         title: Some(Title::Single("My Chapter".to_string())),
         issued: EdtfString("2023".to_string()),
-        container: Some(WorkRelation::Id(parent_id.clone())),
+        container: Some(WorkRelation::Id(parent_id.clone().into())),
         ..Default::default()
     };
 

--- a/crates/citum-schema/tests/parent_reference.rs
+++ b/crates/citum-schema/tests/parent_reference.rs
@@ -9,11 +9,11 @@ use citum_schema::reference::{
 fn test_serial_component_with_container_id() {
     let parent_id = "journal-1".to_string();
     let component = SerialComponent {
-        id: Some("article-1".to_string()),
+        id: Some("article-1".into()),
         r#type: SerialComponentType::Article,
         title: Some(Title::Single("My Article".to_string())),
         issued: EdtfString("2023".to_string()),
-        container: Some(WorkRelation::Id(parent_id.clone())),
+        container: Some(WorkRelation::Id(parent_id.clone().into())),
         ..Default::default()
     };
 
@@ -27,11 +27,11 @@ fn test_serial_component_with_container_id() {
 fn test_collection_component_with_container_id() {
     let parent_id = "book-1".to_string();
     let component = CollectionComponent {
-        id: Some("chapter-1".to_string()),
+        id: Some("chapter-1".into()),
         r#type: MonographComponentType::Chapter,
         title: Some(Title::Single("My Chapter".to_string())),
         issued: EdtfString("2023".to_string()),
-        container: Some(WorkRelation::Id(parent_id.clone())),
+        container: Some(WorkRelation::Id(parent_id.clone().into())),
         ..Default::default()
     };
 

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,9 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.30.2 (2026-04-13)
+- Schema version bumped from 0.30.1 to 0.30.2
+
 #### schema-v0.30.0 (2026-04-12)
 - Schema version bumped from 0.29.2 to 0.30.0 (major pre-1.0)
 - Fixed style file consolidation to keep only embedded styles in `styles/embedded/`

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -191,7 +191,7 @@
         "field-languages": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "genre": {
@@ -201,9 +201,13 @@
           ]
         },
         "id": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -211,9 +215,13 @@
           "default": ""
         },
         "language": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "medium": {
@@ -334,14 +342,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -360,9 +372,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -450,13 +466,17 @@
         "field-languages": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issue": {
@@ -479,9 +499,13 @@
           }
         },
         "language": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -610,13 +634,17 @@
         "field-languages": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "isbn": {
@@ -645,9 +673,13 @@
           }
         },
         "language": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -804,7 +836,7 @@
         "field-languages": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "genre": {
@@ -814,9 +846,13 @@
           ]
         },
         "id": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issue": {
@@ -839,9 +875,13 @@
           }
         },
         "language": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "medium": {
@@ -1072,7 +1112,7 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "format": {
@@ -1084,9 +1124,13 @@
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -1105,9 +1149,13 @@
         },
         "language": {
           "description": "BCP 47 language of the dataset.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -1258,7 +1306,7 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "genre": {
@@ -1270,16 +1318,24 @@
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "language": {
           "description": "BCP 47 language of the event.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "location": {
@@ -1365,14 +1421,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -1391,9 +1451,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -1708,6 +1772,10 @@
         }
       ]
     },
+    "LangID": {
+      "description": "BCP 47 language tag (e.g., `\"en\"`, `\"de\"`, `\"ja\"`).",
+      "type": "string"
+    },
     "LegalCase": {
       "description": "A legal case (court decision).",
       "type": "object",
@@ -1745,14 +1813,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -1771,9 +1843,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -1948,7 +2024,7 @@
         "field-languages": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "genre": {
@@ -1958,9 +2034,13 @@
           ]
         },
         "id": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "isbn": {
@@ -1989,9 +2069,13 @@
           }
         },
         "language": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "medium": {
@@ -2190,9 +2274,13 @@
       "properties": {
         "lang": {
           "description": "ISO 639/BCP 47 language code for the original text.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "original": {
@@ -2224,9 +2312,13 @@
       "properties": {
         "lang": {
           "description": "ISO 639/BCP 47 language code for the original name.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "original": {
@@ -2360,7 +2452,7 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "filing-date": {
@@ -2376,9 +2468,13 @@
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -2404,9 +2500,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -2475,6 +2575,10 @@
         }
       ]
     },
+    "RefID": {
+      "description": "Unique identifier for a reference item.",
+      "type": "string"
+    },
     "Regulation": {
       "description": "An administrative regulation.",
       "type": "object",
@@ -2512,14 +2616,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -2538,9 +2646,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -2628,13 +2740,17 @@
         "field-languages": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issn": {
@@ -2644,9 +2760,13 @@
           ]
         },
         "language": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -2791,7 +2911,7 @@
         "field-languages": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "genre": {
@@ -2801,9 +2921,13 @@
           ]
         },
         "id": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issue": {
@@ -2826,9 +2950,13 @@
           }
         },
         "language": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "medium": {
@@ -3058,14 +3186,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -3084,9 +3216,13 @@
         },
         "language": {
           "description": "BCP 47 language of the software documentation.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "license": {
@@ -3186,14 +3322,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -3212,9 +3352,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -3314,14 +3458,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -3340,9 +3488,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -3500,7 +3652,7 @@
             "minItems": 2,
             "prefixItems": [
               {
-                "type": "string"
+                "$ref": "#/$defs/LangID"
               },
               {
                 "type": "string"
@@ -3517,7 +3669,7 @@
             "minItems": 2,
             "prefixItems": [
               {
-                "type": "string"
+                "$ref": "#/$defs/LangID"
               },
               {
                 "$ref": "#/$defs/StructuredTitle"
@@ -3575,14 +3727,18 @@
           "description": "Per-field language overrides.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/LangID"
           }
         },
         "id": {
           "description": "Unique identifier for this reference.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RefID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "issued": {
@@ -3601,9 +3757,13 @@
         },
         "language": {
           "description": "BCP 47 language of the document.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "note": {
@@ -3660,7 +3820,7 @@
       "anyOf": [
         {
           "description": "The target work is referenced by its ID (resolved at render time).",
-          "type": "string"
+          "$ref": "#/$defs/RefID"
         },
         {
           "description": "The target work is embedded inline.",

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -77,7 +77,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.30.1"
+      "default": "0.30.2"
     }
   },
   "additionalProperties": false,

--- a/docs/specs/STRONG_DOMAIN_TYPES_PHASE1.md
+++ b/docs/specs/STRONG_DOMAIN_TYPES_PHASE1.md
@@ -1,0 +1,90 @@
+# Strong Domain Types Phase 1 Specification
+
+**Status:** Active
+**Date:** 2026-04-13
+**Supersedes:** None
+**Related:** `crates/citum-schema-data/src/reference/types/common.rs`, `scripts/audit-primitive-types.sh`
+
+## Purpose
+
+This specification defines the first schema-first pass for replacing primitive `String`
+aliases with dedicated domain types in Citum. The goal is to strengthen the public
+reference model without changing JSON/YAML wire formats or adding new parser
+dependencies.
+
+## Scope
+
+In scope:
+
+- Convert `RefID` from a `String` alias into a dedicated transparent newtype.
+- Convert `LangID` from a `String` alias into a dedicated transparent newtype.
+- Update direct schema/data consumers that rely on string-like behavior.
+- Preserve serde, schema, and bindings output as scalar strings.
+- Capture the cargo-dependency escalation path for stricter language-tag validation.
+
+Out of scope:
+
+- Validating BCP 47 syntax in `LangID` during this phase.
+- Style, grouping, and registry identifier wrappers in `citum-schema-style`.
+- CLI-only argument structs and engine-internal scratch structs.
+- Free-form text wrappers for headings, titles, quotes, or general display strings.
+- Treating the primitive-type audit script as a policy gate.
+
+## Design
+
+### Variant A: No `Cargo.toml` changes
+
+Phase 1 uses transparent newtypes with no new dependencies.
+
+- `RefID` is an opaque wrapper over `String`.
+- `LangID` is an opaque wrapper over `String`.
+- Both types expose string ergonomics needed by existing code:
+  `Display`, `FromStr`, `From<String>`, `From<&str>`, `AsRef<str>`, `Borrow<str>`,
+  and `Deref<Target = str>`.
+- Both types derive serde/schema/bindings traits so their external wire shape
+  remains a plain string.
+
+This keeps the change as a type-safety refactor rather than a behavioral
+validation change.
+
+### Variant B: Strict language-tag validation
+
+If a future phase adds BCP 47 validation to `LangID`, that work must:
+
+- receive explicit confirmation before any `Cargo.toml` or `Cargo.lock` edit;
+- add and justify a language-tag parsing dependency;
+- define invalid-input behavior for serde/YAML/JSON ingestion;
+- verify that schemas and TypeScript bindings remain string-shaped;
+- be treated as a compatibility-sensitive follow-up PR.
+
+### Audit Script Decision
+
+The temporary root `types.sh` is promoted into `scripts/audit-primitive-types.sh`
+as a maintained triage tool for future type-strengthening passes.
+
+- Default scope is limited to Rust source under `crates/`.
+- Test, bench, doc, and obvious helper paths are excluded.
+- Output is grouped by public API and semantic field names first.
+- The script is informational only and does not define a merge gate.
+
+## Implementation Notes
+
+- Favor trait-based string ergonomics over broad code churn in downstream crates.
+- Preserve `HashMap<LangID, _>::get("en")` and `Option<RefID>::as_deref()` behavior.
+- Keep `set_id` ergonomic by accepting `impl Into<RefID>`.
+- Defer validated language-tag parsing until the repo explicitly opts into a
+  new dependency and tighter runtime behavior.
+
+## Acceptance Criteria
+
+- [x] `RefID` is a dedicated transparent type rather than a type alias.
+- [x] `LangID` is a dedicated transparent type rather than a type alias.
+- [x] JSON/YAML serde output for both types remains a scalar string.
+- [x] Schema generation still reports both types as strings.
+- [x] Direct schema/data consumers compile without `Cargo.toml` changes.
+- [x] The primitive-type audit script lives under `scripts/` and is documented
+      as a triage tool, not a policy gate.
+
+## Changelog
+
+- 2026-04-13: Initial version and first implementation.

--- a/scripts/audit-primitive-types.sh
+++ b/scripts/audit-primitive-types.sh
@@ -11,20 +11,28 @@ COMMON_GLOBS=(
   --glob '!**/target/**'
 )
 
+run_rg() {
+  local status=0
+  rg -n "${COMMON_GLOBS[@]}" "$@" || status=$?
+  if [[ "$status" -gt 1 ]]; then
+    return "$status"
+  fi
+}
+
 echo "== Existing string aliases and wrappers =="
-rg -n "${COMMON_GLOBS[@]}" \
+run_rg \
   '^\s*pub\s+(type\s+[A-Z][A-Za-z0-9_]*\s*=\s*String;|struct\s+[A-Z][A-Za-z0-9_]*\s*\(\s*(pub\s+)?String\s*\);)' \
   "$ROOT"
 
 echo
 echo "== Public struct fields with semantic primitive names =="
-rg -n "${COMMON_GLOBS[@]}" \
+run_rg \
   '\bpub\s+(id|slug|locale|language|label|name|title|path|url|uri)\s*:\s*(Option<)?String' \
   "$ROOT"
 
 echo
 echo "== Public functions with semantic primitive params =="
-rg -n "${COMMON_GLOBS[@]}" \
+run_rg \
   'pub\s+fn\s+\w+[[:space:]]*(<[^>]+>)?[[:space:]]*\(([^)]*(id|slug|locale|language|label|name|path|url|uri)\s*:\s*&?str[^)]*|[^)]*(id|slug|locale|language|label|name|path|url|uri)\s*:\s*String[^)]*)\)' \
   "$ROOT"
 

--- a/scripts/audit-primitive-types.sh
+++ b/scripts/audit-primitive-types.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-crates}"
+
+COMMON_GLOBS=(
+  --glob '*.rs'
+  --glob '!**/tests/**'
+  --glob '!**/benches/**'
+  --glob '!**/examples/**'
+  --glob '!**/target/**'
+)
+
+echo "== Existing string aliases and wrappers =="
+rg -n "${COMMON_GLOBS[@]}" \
+  '^\s*pub\s+(type\s+[A-Z][A-Za-z0-9_]*\s*=\s*String;|struct\s+[A-Z][A-Za-z0-9_]*\s*\(\s*(pub\s+)?String\s*\);)' \
+  "$ROOT"
+
+echo
+echo "== Public struct fields with semantic primitive names =="
+rg -n "${COMMON_GLOBS[@]}" \
+  '\bpub\s+(id|slug|locale|language|label|name|title|path|url|uri)\s*:\s*(Option<)?String' \
+  "$ROOT"
+
+echo
+echo "== Public functions with semantic primitive params =="
+rg -n "${COMMON_GLOBS[@]}" \
+  'pub\s+fn\s+\w+[[:space:]]*(<[^>]+>)?[[:space:]]*\(([^)]*(id|slug|locale|language|label|name|path|url|uri)\s*:\s*&?str[^)]*|[^)]*(id|slug|locale|language|label|name|path|url|uri)\s*:\s*String[^)]*)\)' \
+  "$ROOT"
+
+echo
+echo "== Primitive-heavy public structs (2+ primitive fields) =="
+find "$ROOT" -path '*/tests/*' -prune -o -path '*/benches/*' -prune -o -name '*.rs' -print \
+| xargs perl -0ne '
+  while(/pub\s+struct\s+(\w+)[^{]*\{([^}]*)\}/sg){
+    my $name=$1;
+    my $body=$2;
+    my $count=()=($body =~ /:\s*(?:String|bool|char|u(?:8|16|32|64|size)|i(?:8|16|32|64|size)|f(?:32|64)|usize|isize)\b/g);
+    print "$ARGV:$name:$count\n" if $count >= 2;
+  }
+' \
+| sort -t: -k3,3nr


### PR DESCRIPTION
## Summary
- promote `RefID` and `LangID` from string aliases to transparent newtypes
- preserve JSON/YAML/schema/bindings wire shape as strings while tightening Rust-side APIs
- add the phase 1 spec and a maintained primitive-type audit script under `scripts/`

## Testing
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- cargo run --bin citum --features schema -- schema --out-dir docs/schemas

Schema-Bump: patch