### PR TITLE
fix(engine): short title as author substitute

### DIFF
--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -8,6 +8,7 @@ use crate::reference::Reference;
 use crate::render::format::OutputFormat;
 use crate::values::{ProcHints, ProcValues, RenderContext, RenderOptions};
 use citum_schema::options::{RoleLabelPreset, SubstituteKey};
+use citum_schema::reference::Title;
 use citum_schema::template::{ContributorRole, Rendering, TemplateComponent, TemplateContributor};
 
 enum ResolvedRole {
@@ -457,7 +458,20 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
             }
             SubstituteKey::Title => {
                 if let Some(title) = reference.title() {
-                    let title_str = title.to_string();
+                    // In citation context use a short-form title (main title only,
+                    // no subtitle) so the substitute doesn't bloat the in-text cite.
+                    // In bibliography use the full display form.
+                    let title_str = match options.context {
+                        RenderContext::Citation => match title {
+                            Title::Structured(s) => s.main.clone(),
+                            Title::MultiStructured(v) => {
+                                v.first().map(|(_, s)| s.main.clone()).unwrap_or_default()
+                            }
+                            Title::Shorthand(abbr, _) => abbr.clone(),
+                            _ => title.to_string(),
+                        },
+                        _ => title.to_string(),
+                    };
                     // In citations: quote the title per CSL conventions.
                     // In bibliography: use title as-is (will be styled normally).
                     let value = if options.context == RenderContext::Citation {

--- a/examples/chicago-note-converted.yaml
+++ b/examples/chicago-note-converted.yaml
@@ -191,7 +191,9 @@ references:
     collection: O’Laughlin Papers
 - class: hearing
   id: 6188419/VCP6HK7G
-  title: 'Homeland Security Act of 2002: Hearings on H.R. 5005, Day 3, Before the Select Comm. on Homeland Security'
+  title:
+    main: Homeland Security Act of 2002
+    sub: [Hearings on H.R. 5005, Day 3, Before the Select Comm. on Homeland Security]
   authority: U.S. House of Representatives, Select Committee on Homeland Security
   issued: '2002'
   accessed: 2025-04-11
@@ -234,7 +236,9 @@ references:
   container:
     class: collection
     type: edited-book
-    title: 'Moving foreword: real introductions to totally made-up books'
+    title:
+      main: Moving foreword
+      sub: real introductions to totally made-up books
     editor:
     - given: Jon
       family: Chattman
@@ -243,9 +247,6 @@ references:
       place: Dallas, TX
   pages: xv–xvii
   language: en
-  note: |-
-    OCLC: 1089276783
-    container-title-short: Moving foreword
   genre: foreword
 - class: monograph
   id: 6188419/RY7PJ7H7
@@ -304,7 +305,9 @@ references:
 - class: monograph
   id: 6188419/7RP5QFT2
   type: document
-  title: 'Documentary operationality: beyond representation'
+  title:
+    main: Documentary operationality
+    sub: Beyond representation
   author:
   - given: Toby
     family: Lee

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -226,8 +226,8 @@ test('apa-7th concision regression reflects preset-first success', () => {
   const loaded = loadStyleYaml(style.name);
   const concision = computeConcisionScore(loaded.resolvedStyleData, style.format);
 
-  assert.equal(concision.variantSelectors, 62, 'resolved APA should reflect the embedded authored variant selectors');
-  assert.equal(concision.score, 31.8, `expected embedded APA concision, got ${concision.score}`);
+  assert.equal(concision.variantSelectors, 26, 'resolved APA should reflect the embedded authored variant selectors');
+  assert.equal(concision.score, 57.6, `expected embedded APA concision, got ${concision.score}`);
 });
 
 test('report-core exposes expected benchmark labels for representative styles', () => {

--- a/styles/embedded/apa-7th.yaml
+++ b/styles/embedded/apa-7th.yaml
@@ -78,12 +78,6 @@ citation:
     wrap:
       punctuation: parentheses
     type-variants:
-      ? article-journal, article-magazine, article-newspaper, book, broadcast, chapter, dataset, entry-encyclopedia, interview, motion-picture, paper-conference, patent, report, software, song, standard, thesis, webpage
-      : - contributor: author
-          form: short
-        - date: issued
-          form: year
-        - variable: locator
       ? legal-case, treaty, hearing
       : - title: primary
           form: short
@@ -103,8 +97,6 @@ citation:
     template:
     - contributor: author
       form: short
-    - title: primary
-      form: short
     - date: issued
       form: year
     - variable: locator
@@ -116,16 +108,6 @@ citation:
       contributors:
         and: text
     type-variants:
-      ? article-journal, article-magazine, article-newspaper, book, broadcast, chapter, dataset, entry-encyclopedia, interview, motion-picture, paper-conference, patent, report, software, song, standard, thesis, webpage
-      : - contributor: author
-          form: short
-        - delimiter: ", "
-          wrap:
-            punctuation: parentheses
-          group:
-          - date: issued
-            form: year
-          - variable: locator
       ? legal-case, treaty, hearing
       : - title: primary
           form: short
@@ -152,8 +134,6 @@ citation:
         - variable: locator
     template:
     - contributor: author
-      form: short
-    - title: primary
       form: short
     - delimiter: ", "
       wrap:


### PR DESCRIPTION
## Summary

- Engine: when a title substitutes for a missing author in citation context, use only the main title component for structured titles (no subtitle), and the abbreviation for shorthand titles — prevents the full compound title from bloating parenthetical cites
- Style: removes redundant per-type non-integral overrides that duplicated the default template
- Style: restores `legal-case, treaty, hearing` non-integral type-variant with `emph: true` so APA italic rendering is correct for legal titles in parenthetical citations

## Root cause

`SubstituteKey::Title` was calling `title.to_string()` which for `Title::Structured` joins main and subtitle with `": "`. In citation context this produced the full compound string as the author-substitute, making it appear twice when the title slot also rendered.

## Test plan

- [x] `cargo nextest run` — 1024/1024 pass
- [x] `citum render refs -b examples/chicago-note-converted.yaml -s styles/embedded/apa-7th.yaml` — hearing non-integral now `("Homeland Security Act of 2002," 2002)`; legal cases italic
