### PR TITLE
fix(engine): treaty/hearing citation double-title and short-form

### DIFF
--- a/.beans/archive/csl26-tj5r--fix-apa-treatyhearing-citation-double-title-and-sh.md
+++ b/.beans/archive/csl26-tj5r--fix-apa-treatyhearing-citation-double-title-and-sh.md
@@ -1,0 +1,18 @@
+---
+# csl26-tj5r
+title: 'fix: APA treaty/hearing citation double-title and short-form'
+status: completed
+type: bug
+priority: high
+created_at: 2026-04-14T11:33:49Z
+updated_at: 2026-04-14T11:35:55Z
+---
+
+Two bugs causing broken APA parenthetical citations for treaty and hearing:
+1. requires_full_group_item_rendering missing treaty/hearing → double title
+2. Title::Structured ignores form: short → full compound title instead of main only
+
+## Summary of Changes
+
+- core.rs: added treaty and hearing to requires_full_group_item_rendering
+- title.rs: render_structured_title now takes a short flag; Structured titles with form: short return main only

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -609,6 +609,16 @@ impl Renderer<'_> {
         self.render_integral_explicit_group::<F>(group, spec, mode, suppress_author, position)
     }
 
+    /// Returns true for non-integral citation types that must render as a single
+    /// unit via [`render_special_type_items`] rather than the split author+items
+    /// path used for standard author-date groups.
+    ///
+    /// Title-first types (`legal-case`, `treaty`, `hearing`) need this because
+    /// their type-variant template leads with a title component, not a
+    /// contributor. The grouped path strips only `Contributor::Author`, so the
+    /// title would render twice (plain in the author slot, emph in the item
+    /// slot). `personal-communication` is included because its per-item date
+    /// and term must stay together and not be collapsed across items.
     fn requires_full_group_item_rendering(
         &self,
         mode: &citum_schema::citation::CitationMode,
@@ -617,7 +627,7 @@ impl Renderer<'_> {
         matches!(mode, citum_schema::citation::CitationMode::NonIntegral)
             && matches!(
                 reference.ref_type().as_str(),
-                "legal-case" | "personal-communication"
+                "legal-case" | "treaty" | "hearing" | "personal-communication"
             )
     }
 

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -2792,3 +2792,67 @@ fn test_text_case_no_config_means_no_transform() {
     // No text-case configured: title rendered as-is (just smart quotes)
     assert_eq!(result, "The Quick Brown Fox");
 }
+
+/// `form: short` on a structured title returns only the main part, not the
+/// full compound string.
+#[test]
+fn test_structured_title_form_short_returns_main_only() {
+    use citum_schema::reference::types::{StructuredTitle, Subtitle, Title};
+
+    let config = Config::default();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let hints = ProcHints::default();
+
+    let mut reference = Reference::from(LegacyReference {
+        id: "treaty".to_string(),
+        ref_type: "treaty".to_string(),
+        title: Some("placeholder".to_string()),
+        ..Default::default()
+    });
+    if let Reference::Treaty(ref mut m) = reference {
+        m.title = Some(Title::Structured(StructuredTitle {
+            full: None,
+            main: "Homeland Security Act of 2002".to_string(),
+            sub: Subtitle::Vector(vec![
+                "Hearings on H.R. 5005".to_string(),
+                "Day 3".to_string(),
+            ]),
+        }));
+    }
+
+    // Without form: short — full compound title
+    let full_component = TemplateTitle {
+        title: TitleType::Primary,
+        ..Default::default()
+    };
+    let full = full_component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+    assert_eq!(
+        full.value,
+        "Homeland Security Act of 2002: Hearings on H.R. 5005: Day 3"
+    );
+
+    // With form: short — main only, subtitles suppressed
+    let short_component = TemplateTitle {
+        title: TitleType::Primary,
+        form: Some(TitleForm::Short),
+        ..Default::default()
+    };
+    let short = short_component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+    assert_eq!(short.value, "Homeland Security Act of 2002");
+}

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -185,14 +185,20 @@ fn render_structured_title<F: crate::render::format::OutputFormat<Output = Strin
     st: &StructuredTitle,
     fmt: &F,
     case: Option<TextCase>,
+    short: bool,
 ) -> (String, bool) {
+    let (main_rendered, has_link) = render_part_with_case(&st.main, fmt, case);
+    if short {
+        return (main_rendered, has_link);
+    }
+
     let subtitle_case = case.map(|c| match c {
         TextCase::SentenceNlm => TextCase::Lowercase,
         other => other,
     });
 
-    let (main_rendered, mut has_link) = render_part_with_case(&st.main, fmt, case);
     let mut parts = vec![main_rendered];
+    let mut has_link = has_link;
 
     let subs: Vec<&str> = match &st.sub {
         Subtitle::String(s) => vec![s.as_str()],
@@ -302,9 +308,17 @@ impl ComponentValues for TemplateTitle {
         // Render title with structured-title-aware case transforms
         let rendered: Option<(String, bool, bool)> = title.as_ref().map(|title| match title {
             Title::Structured(st) => {
-                let raw_text = title_text(title, self.form.as_ref());
-                let (value, has_link) = render_structured_title(st, &fmt, effective_case);
-                let pre_formatted = looks_like_djot_markup(&raw_text);
+                let short = matches!(self.form, Some(TitleForm::Short));
+                let (value, has_link) = render_structured_title(st, &fmt, effective_case, short);
+                // Scope pre_formatted to what was actually rendered: when
+                // short=true only main was rendered, so check only main for
+                // Djot markers; checking the full title would incorrectly set
+                // the flag when a subtitle contains markup but value does not.
+                let pre_formatted = if short {
+                    looks_like_djot_markup(&st.main)
+                } else {
+                    looks_like_djot_markup(&title_text(title, self.form.as_ref()))
+                };
                 (value, has_link, pre_formatted)
             }
             Title::Multilingual(m) => {


### PR DESCRIPTION
## Root cause

Two bugs introduced/exposed by the earlier `eaf9c773` fix:

**1. Double-title rendering** (`grouped/core.rs`): `requires_full_group_item_rendering` listed `legal-case` and `personal-communication` but not `treaty` or `hearing`. These three types share the same type-variant in `apa-7th.yaml` (title-first, not contributor-first). Without the guard, treaty/hearing fell into the split author+items path:
- `render_author_for_grouping_with_format` extracted the title as "author part" (plain, no emph)
- `filter_author_from_template` only strips `Contributor::Author`, leaving the title in the item template
- `render_group_item_parts_with_format` re-rendered the same title (emph)
- Result: `(plain-title, _emph-title_, year)`

**2. Structured title ignores `form: short`** (`values/title.rs`): The `Title::Structured` arm in `ComponentValues::values` called `render_structured_title` unconditionally, always joining `main + all subs` with `: `. The `form: short` check was present for `Shorthand` but never reached `Structured`. The earlier `substitute.rs` fix only covered the substitute key path.

## Changes

- `render_structured_title`: added `short: bool` parameter; when true, returns only `main` (skips subtitle loop)
- `requires_full_group_item_rendering`: added `"treaty" | "hearing"` to the allow-list

## Result

```
Before: (Treaty Banning Nuclear Weapon Tests..., _Treaty Banning Nuclear Weapon Tests..._, 1963)
After:  (_Treaty Banning Nuclear Weapon Tests..._, 1963)

Before: (Homeland Security Act of 2002: Hearings on H.R. 5005: Day 3: ..., _Homeland Security Act of 2002: Hearings..._, 2002)
After:  (_Homeland Security Act of 2002_, 2002)
```

Bibliography rendering is unchanged (form: short not set there).

1024/1024 tests pass.
