### PR TITLE
docs: tighten CLAUDE.md and codex skill accuracy

### DIFF
--- a/.codex/skills/rust-simplify/SKILL.md
+++ b/.codex/skills/rust-simplify/SKILL.md
@@ -9,7 +9,6 @@ Use this skill for bounded Rust cleanup work in the Citum workspace when the tas
 improve code quality rather than fix a specific bug.
 
 Read first:
-- `AGENTS.md`
 - `docs/guides/CODING_STANDARDS.md`
 - `docs/guides/CODEX_SKILLS.md`
 

--- a/.codex/skills/style-evolve/SKILL.md
+++ b/.codex/skills/style-evolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: style-evolve
-description: Public Codex entrypoint for Citum style work. Route upgrade, migrate, or create requests to the shared workflow docs and internal roles.
+description: "Public Codex entrypoint for Citum style work. Activate on: 'upgrade', 'migrate', 'create', any style authoring request, or any request to fix/improve/convert a Citum or CSL citation style. Route to the shared workflow docs and internal roles."
 ---
 
 # Style Evolve
@@ -22,7 +22,7 @@ Read first:
 ## Routing
 
 - Use `spec-planner` when the request needs architecture or schema decisions.
-- Use `migrate-researcher` when the evidence points to `citum_migrate`.
+- Use `migration-researcher` when the evidence points to `citum_migrate`.
 - Use `rust-implementer` for bounded Rust fixes.
 - Use `style-qa-reviewer` for the final style QA gate.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Do not consider the task done until CI passes.
 Style tasks: use **`/style-evolve`** (`upgrade`, `migrate`, `create`). Codex skills
 live in `.codex/skills/` and are installed with `./scripts/install-codex-skills.sh`.
 Claude skills remain in `.claude/skills/`.
+Rust quality tasks: use **`/rust-simplify`** (file-length, duplication cleanup) or **`/rust-refine`** (API shape, clippy suppression removal).
 
 ## Task Management
 
@@ -118,7 +119,7 @@ Transition citation management from CSL 1.0 (procedural XML) to Citum (declarati
 1. **Parsing** — `csl-legacy` (complete)
 2. **Migrating** — `citum_migrate`
 3. **Processing** — `citum_engine`
-4. **Rendering** — match citeproc-js exactly
+4. **Rendering** — match citeproc-js exactly for CSL-derived styles; match biblatex behavior for biblatex-derived styles
 
 ```
 crates/

--- a/docs/guides/STYLE_WORKFLOW_EXECUTION.md
+++ b/docs/guides/STYLE_WORKFLOW_EXECUTION.md
@@ -55,9 +55,9 @@ Every workflow should report:
 - Keep host wrappers short and refer back here instead of restating the loop.
 
 ## Acceptance Criteria
-- [ ] Shared style workflows reference this guide instead of duplicating the same loop text.
-- [ ] The evidence ladder is defined here exactly once.
-- [ ] The shared output contract is expressed here in host-neutral terms.
+- [x] Shared style workflows reference this guide instead of duplicating the same loop text.
+- [x] The evidence ladder is defined here exactly once.
+- [x] The shared output contract is expressed here in host-neutral terms.
 
 ## Changelog
 - 2026-04-04: Initial version.


### PR DESCRIPTION
## Summary

Doc/skill audit identified 10 issues in `CLAUDE.md` and skill files — correctness
defects, stale references, and missing trigger conditions. This PR fixes 9 of them
(issue 2, oracle scenario count, deferred pending fixture path resolution).

- **CLAUDE.md**: narrow rendering goal to CSL-derived styles only (biblatex-derived
  styles must not be compared against citeproc-js); add Rust quality skill routing
  note for `/rust-simplify` and `/rust-refine`
- **`.codex/skills/style-evolve`**: fix role name `migrate-researcher` →
  `migration-researcher` (matches actual agent file); add explicit trigger phrases
  to description so Codex agents know when to activate
- **`.codex/skills/rust-simplify`**: remove broken `AGENTS.md` reference (file
  does not exist)
- **`docs/guides/STYLE_WORKFLOW_EXECUTION.md`**: mark acceptance criteria complete
  (5+ skills now reference this guide; evidence ladder and output contract are
  both present)

Global skill fixes (outside repo — applied separately):
- `~/.claude/skills/commit/SKILL.md`: add `Cargo.toml` detection guard (Rust vs
  Bun toolchain); replace hook-blocked `gh pr create --body "$(cat..."` with
  `--body-file` pattern
- `~/.claude/skills/learned/verify-fmt-before-push.md`: `cargo fmt --all -- --check`
  → `cargo fmt --check` to match canonical gate command

## Test plan

- [ ] CI passes (docs/style-only change — no Rust gate)
