### PR TITLE
feat(engine): render original publisher/place for reprints

### DIFF
--- a/.beans/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
+++ b/.beans/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
@@ -5,7 +5,7 @@ status: in-progress
 type: feature
 priority: normal
 created_at: 2026-04-11T11:34:06Z
-updated_at: 2026-04-14T12:55:41Z
+updated_at: 2026-04-14T13:18:35Z
 ---
 
 Chicago 18th §14.16 reprint pattern: '(original-year) current-year. Title. Original Publisher. Note. Current Publisher'. CSL fields original-publisher and original-publisher-place are not yet mapped from CSL JSON to Citum's original WorkRelation, so they silently drop. 7 chicago-zotero-bibliography benchmark items fail on this pattern (date already fixed by csl26-tpmn engine fix, but original-publisher and edition text still differ).
@@ -18,4 +18,9 @@ Chicago 18th §14.16 reprint pattern: '(original-year) current-year. Title. Orig
 - [x] Expose original publisher/place as template variables and render them in the engine.
 - [x] Add Chicago notes reprint rendering and regression coverage.
 - [x] Run full Rust verification and regenerate schemas if needed.
-- [ ] Run bean hygiene and open the PR.
+- [x] Run bean hygiene and open the PR.
+
+## Progress
+
+- PR opened: #520
+- PR status: CI green

--- a/.beans/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
+++ b/.beans/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
@@ -1,11 +1,21 @@
 ---
 # csl26-3j0c
 title: 'engine: render original-publisher and original-place for reprints'
-status: todo
+status: in-progress
 type: feature
 priority: normal
 created_at: 2026-04-11T11:34:06Z
-updated_at: 2026-04-11T11:34:06Z
+updated_at: 2026-04-14T12:55:41Z
 ---
 
 Chicago 18th §14.16 reprint pattern: '(original-year) current-year. Title. Original Publisher. Note. Current Publisher'. CSL fields original-publisher and original-publisher-place are not yet mapped from CSL JSON to Citum's original WorkRelation, so they silently drop. 7 chicago-zotero-bibliography benchmark items fail on this pattern (date already fixed by csl26-tpmn engine fix, but original-publisher and edition text still differ).
+
+
+
+## Checklist
+
+- [x] Map original-publisher and original-publisher-place into the embedded original relation.
+- [x] Expose original publisher/place as template variables and render them in the engine.
+- [x] Add Chicago notes reprint rendering and regression coverage.
+- [x] Run full Rust verification and regenerate schemas if needed.
+- [ ] Run bean hygiene and open the PR.

--- a/crates/citum-engine/src/values/variable.rs
+++ b/crates/citum-engine/src/values/variable.rs
@@ -50,6 +50,8 @@ fn resolve_variable_value(
         SimpleVariable::Issn => reference.issn(),
         SimpleVariable::Publisher => reference.publisher_str(),
         SimpleVariable::PublisherPlace => reference.publisher_place(),
+        SimpleVariable::OriginalPublisher => reference.original_publisher_str(),
+        SimpleVariable::OriginalPublisherPlace => reference.original_publisher_place(),
         SimpleVariable::Genre => reference.genre().map(|k| options.locale.lookup_genre(&k)),
         SimpleVariable::Medium => reference.medium().map(|k| options.locale.lookup_medium(&k)),
         SimpleVariable::Status => reference.status(),

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -1021,6 +1021,59 @@ fn chicago_notes_non_immediate_repeat_uses_the_subsequent_short_form() {
     );
 }
 
+fn chicago_notes_reprint_full_note_renders_original_publisher_metadata() {
+    use std::path::PathBuf;
+
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("styles/embedded/chicago-notes-18th.yaml");
+
+    let yaml = std::fs::read_to_string(&path).expect("Failed to read chicago-notes.yaml");
+    let style: citum_schema::Style =
+        serde_yaml::from_str(&yaml).expect("Failed to parse chicago-notes.yaml");
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_value(serde_json::json!({
+        "id": "reprint1994",
+        "type": "book",
+        "title": "Orientalism",
+        "author": [{ "family": "Said", "given": "Edward W." }],
+        "issued": { "date-parts": [[1994]] },
+        "publisher": "Vintage Books",
+        "publisher-place": "New York",
+        "original-date": { "date-parts": [[1901]] },
+        "original-publisher": "Old Press",
+        "original-publisher-place": "Boston"
+    }))
+    .expect("failed to parse legacy reprint fixture");
+    let id = legacy.id.clone();
+    let bib = indexmap::IndexMap::from([(id.clone(), legacy.into())]);
+    let processor = Processor::new(style, bib);
+
+    let first_citation = citum_schema::Citation {
+        items: vec![citum_schema::citation::CitationItem {
+            id,
+            ..Default::default()
+        }],
+        position: Some(citum_schema::citation::Position::First),
+        ..Default::default()
+    };
+
+    let rendered = processor
+        .process_citation(&first_citation)
+        .expect("Failed to process reprint citation");
+    assert!(
+        rendered.contains("(1901) Old Press, Boston"),
+        "reprint note should include original publisher metadata: {rendered}"
+    );
+    assert!(
+        rendered.contains("Vintage Books"),
+        "reprint note should still include current publisher metadata: {rendered}"
+    );
+}
+
 fn note_styles_without_ibid_overrides_fall_back_to_subsequent() {
     let style = Style {
         info: StyleInfo {
@@ -1598,6 +1651,14 @@ mod note_style_positions {
             "A non-immediate Chicago note repeat should use the shortened subsequent-note form instead of ibid.",
         );
         super::chicago_notes_non_immediate_repeat_uses_the_subsequent_short_form();
+    }
+
+    #[test]
+    fn chicago_notes_reprint_full_note_renders_original_publisher_metadata() {
+        announce_behavior(
+            "A full Chicago note for a reprint should include original publisher metadata before the current publication details.",
+        );
+        super::chicago_notes_reprint_full_note_renders_original_publisher_metadata();
     }
 
     #[test]

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -92,10 +92,30 @@ fn relation_monograph(
     author: Option<Contributor>,
     issued: Option<EdtfString>,
     genre: Option<String>,
+    publisher: Option<String>,
+    publisher_place: Option<String>,
 ) -> Option<WorkRelation> {
-    if title.is_none() && author.is_none() && issued.is_none() && genre.is_none() {
+    if title.is_none()
+        && author.is_none()
+        && issued.is_none()
+        && genre.is_none()
+        && publisher.is_none()
+        && publisher_place.is_none()
+    {
         return None;
     }
+
+    let publisher = match (publisher, publisher_place) {
+        (Some(name), place) => Some(Publisher {
+            name: name.into(),
+            place,
+        }),
+        (None, Some(place)) => Some(Publisher {
+            name: String::new().into(),
+            place: Some(place),
+        }),
+        (None, None) => None,
+    };
 
     Some(WorkRelation::Embedded(Box::new(InputReference::Monograph(
         Box::new(Monograph {
@@ -103,6 +123,7 @@ fn relation_monograph(
             author,
             issued: issued.unwrap_or_default(),
             genre,
+            publisher,
             ..Default::default()
         }),
     ))))
@@ -320,6 +341,8 @@ fn from_monograph_ref(
     let translator = legacy.translator.clone().map(Contributor::from);
     let original_author = legacy_extra_contributor(&legacy, "original-author");
     let original_date = legacy_extra_date(&legacy, "original-date");
+    let original_publisher = legacy_extra_str(&legacy, "original-publisher");
+    let original_publisher_place = legacy_extra_str(&legacy, "original-publisher-place");
     let volume_title = legacy_extra_str(&legacy, "volume-title");
     let part_title = legacy_extra_str(&legacy, "part-title");
     let part_number = legacy_extra_str(&legacy, "part-number");
@@ -390,6 +413,8 @@ fn from_monograph_ref(
         original_author,
         original_date,
         None,
+        original_publisher,
+        original_publisher_place,
     );
 
     let title = if r#type == MonographType::Webpage {
@@ -513,6 +538,8 @@ fn from_collection_component_ref(
     let part_number = legacy_extra_str(&legacy, "part-number");
     let original_author = legacy_extra_contributor(&legacy, "original-author");
     let original_date = legacy_extra_date(&legacy, "original-date");
+    let original_publisher = legacy_extra_str(&legacy, "original-publisher");
+    let original_publisher_place = legacy_extra_str(&legacy, "original-publisher-place");
     let parent_title = legacy.container_title.clone().map(Title::Single);
     let parent_volume = legacy
         .collection_number
@@ -687,6 +714,8 @@ fn from_collection_component_ref(
             original_author,
             original_date,
             None,
+            original_publisher,
+            original_publisher_place,
         ),
         ..Default::default()
     }))
@@ -804,6 +833,8 @@ fn from_serial_component_ref(
     let available_date = legacy_extra_date(&legacy, "available-date");
     let original_author = legacy_extra_contributor(&legacy, "original-author");
     let original_date = legacy_extra_date(&legacy, "original-date");
+    let original_publisher = legacy_extra_str(&legacy, "original-publisher");
+    let original_publisher_place = legacy_extra_str(&legacy, "original-publisher-place");
     let serial_type = match legacy.ref_type.as_str() {
         "article-journal" => SerialType::AcademicJournal,
         "article-magazine" => SerialType::Magazine,
@@ -859,6 +890,8 @@ fn from_serial_component_ref(
             .or_else(|| container_author.clone().map(Contributor::from)),
         None,
         reviewed_genre,
+        None,
+        None,
     );
     if reviewed.is_none() {
         push_legacy_contributor(
@@ -932,6 +965,8 @@ fn from_serial_component_ref(
             original_author,
             original_date,
             None,
+            original_publisher,
+            original_publisher_place,
         ),
         ..Default::default()
     }))

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -1162,6 +1162,44 @@ impl InputReference {
         }
     }
 
+    /// Return the original publisher as a string.
+    pub fn original_publisher_str(&self) -> Option<String> {
+        match self {
+            InputReference::Monograph(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            _ => None,
+        }
+    }
+
+    /// Return the original publisher place.
+    pub fn original_publisher_place(&self) -> Option<String> {
+        match self {
+            InputReference::Monograph(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            _ => None,
+        }
+    }
+
     /// Return the ISBN.
     pub fn isbn(&self) -> Option<String> {
         match self {

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -1172,3 +1172,101 @@ fn ref_type_document_with_conference_paper_genre_returns_paper_conference() {
     }));
     assert_eq!(reference.ref_type(), "paper-conference");
 }
+
+#[test]
+fn conversion_maps_original_publisher_metadata_into_original_relation() {
+    let json = r#"{
+        "id": "reprint-book",
+        "type": "book",
+        "title": "The Great Book",
+        "author": [{ "family": "Author", "given": "Ada" }],
+        "issued": { "date-parts": [[1994]] },
+        "publisher": "Vintage Books",
+        "publisher-place": "New York",
+        "original-title": "The Great Book",
+        "original-date": { "date-parts": [[1901]] },
+        "original-publisher": "Old Press",
+        "original-publisher-place": "Boston"
+    }"#;
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
+    let reference: InputReference = legacy.into();
+
+    assert_eq!(
+        reference.original_date(),
+        Some(EdtfString("1901".to_string()))
+    );
+    assert_eq!(
+        reference.original_publisher_str(),
+        Some("Old Press".to_string())
+    );
+    assert_eq!(
+        reference.original_publisher_place(),
+        Some("Boston".to_string())
+    );
+
+    let InputReference::Monograph(book) = reference else {
+        panic!("expected monograph");
+    };
+    let Some(WorkRelation::Embedded(original)) = book.original.as_ref() else {
+        panic!("expected embedded original relation");
+    };
+    let InputReference::Monograph(original_book) = original.as_ref() else {
+        panic!("expected original relation to be a monograph");
+    };
+
+    assert_eq!(
+        original_book
+            .publisher
+            .as_ref()
+            .map(|publisher| publisher.name.to_string()),
+        Some("Old Press".to_string())
+    );
+    assert_eq!(
+        original_book
+            .publisher
+            .as_ref()
+            .and_then(|publisher| publisher.place.clone()),
+        Some("Boston".to_string())
+    );
+}
+
+#[test]
+fn conversion_preserves_place_only_original_publication_metadata() {
+    let json = r#"{
+        "id": "reprint-place-only",
+        "type": "book",
+        "title": "The Great Book",
+        "author": [{ "family": "Author", "given": "Ada" }],
+        "issued": { "date-parts": [[1994]] },
+        "original-date": { "date-parts": [[1901]] },
+        "original-publisher-place": "Boston"
+    }"#;
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
+    let reference: InputReference = legacy.into();
+
+    assert_eq!(reference.original_publisher_str(), None);
+    assert_eq!(
+        reference.original_publisher_place(),
+        Some("Boston".to_string())
+    );
+
+    let InputReference::Monograph(book) = reference else {
+        panic!("expected monograph");
+    };
+    let Some(WorkRelation::Embedded(original)) = book.original.as_ref() else {
+        panic!("expected embedded original relation");
+    };
+    let InputReference::Monograph(original_book) = original.as_ref() else {
+        panic!("expected original relation to be a monograph");
+    };
+
+    assert_eq!(
+        original_book
+            .publisher
+            .as_ref()
+            .and_then(|publisher| publisher.place.clone()),
+        Some("Boston".to_string())
+    );
+}

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -81,7 +81,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.30.2";
+pub const STYLE_SCHEMA_VERSION: &str = "0.31.0";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -945,6 +945,8 @@ pub enum SimpleVariable {
     EprintClass,
     Publisher,
     PublisherPlace,
+    OriginalPublisher,
+    OriginalPublisherPlace,
     EventPlace,
     Dimensions,
     Scale,

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,9 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.31.0 (2026-04-14)
+- Schema version bumped from 0.30.2 to 0.31.0
+
 #### schema-v0.30.2 (2026-04-13)
 - Schema version bumped from 0.30.1 to 0.30.2
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -77,7 +77,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.30.2"
+      "default": "0.31.0"
     }
   },
   "additionalProperties": false,
@@ -3389,6 +3389,8 @@
         "eprint-class",
         "publisher",
         "publisher-place",
+        "original-publisher",
+        "original-publisher-place",
         "event-place",
         "dimensions",
         "scale",

--- a/styles/embedded/chicago-notes-18th.yaml
+++ b/styles/embedded/chicago-notes-18th.yaml
@@ -186,6 +186,17 @@ citation:
       form: long
       prefix: ", trans. "
     - group:
+      - date: original-published
+        form: year
+        wrap:
+          punctuation: parentheses
+      - variable: original-publisher
+        prefix: " "
+      - variable: original-publisher-place
+        prefix: ", "
+      delimiter: ""
+      prefix: " "
+    - group:
       - variable: genre
       - variable: publisher
       - date: issued


### PR DESCRIPTION
## Summary
- plumb original publisher and place from legacy CSL extras into embedded original relations
- expose original publisher variables to templates and render them in Chicago notes reprint citations
- add regression coverage and regenerate the style schema

Refs: csl26-3j0c