### PR TITLE
archive stale completed beans, fix clippy warnings

### DIFF
--- a/.beans/archive/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
+++ b/.beans/archive/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
@@ -1,7 +1,7 @@
 ---
 # csl26-3j0c
 title: 'engine: render original-publisher and original-place for reprints'
-status: in-progress
+status: done
 type: feature
 priority: normal
 created_at: 2026-04-11T11:34:06Z

--- a/.beans/archive/csl26-7b28--refine-renderernew-bundle-params-into-rendererreso.md
+++ b/.beans/archive/csl26-7b28--refine-renderernew-bundle-params-into-rendererreso.md
@@ -1,7 +1,7 @@
 ---
 # csl26-7b28
 title: 'Refine Renderer::new: bundle params into RendererResources'
-status: in-progress
+status: done
 type: task
 created_at: 2026-03-17T00:21:43Z
 updated_at: 2026-03-17T00:21:43Z

--- a/.beans/archive/csl26-fk0w--pre-release-style-engine-co-evolution-wave.md
+++ b/.beans/archive/csl26-fk0w--pre-release-style-engine-co-evolution-wave.md
@@ -1,7 +1,7 @@
 ---
 # csl26-fk0w
 title: Pre-release style + engine co-evolution wave
-status: in-progress
+status: done
 type: epic
 priority: normal
 created_at: 2026-03-16T10:34:43Z

--- a/.beans/archive/csl26-lb46--fix-schema-pre-10-major-bump-guard.md
+++ b/.beans/archive/csl26-lb46--fix-schema-pre-10-major-bump-guard.md
@@ -1,7 +1,7 @@
 ---
 # csl26-lb46
 title: 'fix: schema pre-1.0 major bump guard'
-status: in-progress
+status: done
 type: bug
 created_at: 2026-03-25T06:17:03Z
 updated_at: 2026-03-25T06:17:03Z

--- a/.beans/archive/csl26-pszh--schema-defaults-review.md
+++ b/.beans/archive/csl26-pszh--schema-defaults-review.md
@@ -1,7 +1,7 @@
 ---
 # csl26-pszh
 title: Schema defaults review
-status: in-progress
+status: done
 type: task
 created_at: 2026-03-16T18:14:56Z
 updated_at: 2026-03-16T18:14:56Z

--- a/.beans/archive/csl26-zt6c--improve-beans-next-dependency-aware-ranking.md
+++ b/.beans/archive/csl26-zt6c--improve-beans-next-dependency-aware-ranking.md
@@ -1,7 +1,7 @@
 ---
 # csl26-zt6c
 title: 'Improve /beans next: dependency-aware ranking'
-status: completed
+status: done
 type: task
 priority: high
 created_at: 2026-03-06T13:47:09Z

--- a/.beans/archive/csl26-zy07--styleinfo-add-short-name-edition-fields-convert-tu.md
+++ b/.beans/archive/csl26-zy07--styleinfo-add-short-name-edition-fields-convert-tu.md
@@ -1,7 +1,7 @@
 ---
 # csl26-zy07
 title: 'StyleInfo: add short_name + edition fields, convert Turabian and APA 6th'
-status: in-progress
+status: done
 type: feature
 priority: normal
 created_at: 2026-03-17T10:25:53Z

--- a/crates/citum-analyze/src/ranker.rs
+++ b/crates/citum-analyze/src/ranker.rs
@@ -145,7 +145,7 @@ fn build_rankings(
         })
         .collect();
 
-    rankings.sort_by(|a, b| b.dependent_count.cmp(&a.dependent_count));
+    rankings.sort_by_key(|b| std::cmp::Reverse(b.dependent_count));
     rankings
 }
 
@@ -201,12 +201,10 @@ fn extract_dependent_info(path: &Path) -> Result<DependentInfo, String> {
         if child.tag_name().name() == "info" {
             for info_child in child.children() {
                 match info_child.tag_name().name() {
-                    "link" => {
-                        if info_child.attribute("rel") == Some("independent-parent") {
-                            parent_id = info_child
-                                .attribute("href")
-                                .map(std::string::ToString::to_string);
-                        }
+                    "link" if info_child.attribute("rel") == Some("independent-parent") => {
+                        parent_id = info_child
+                            .attribute("href")
+                            .map(std::string::ToString::to_string);
                     }
                     "category" => {
                         if let Some(fmt) = info_child.attribute("citation-format") {

--- a/crates/citum-analyze/src/savings.rs
+++ b/crates/citum-analyze/src/savings.rs
@@ -166,13 +166,11 @@ fn extract_independent_style_info(path: &Path) -> Result<IndependentStyleInfo, S
                         citation_format = Some(format.to_string());
                     }
                 }
-                "link" => {
-                    if info_child.attribute("rel") == Some("template") {
-                        template_target = info_child
-                            .attribute("href")
-                            .map(short_name_from_identifier)
-                            .map(std::borrow::Cow::into_owned);
-                    }
+                "link" if info_child.attribute("rel") == Some("template") => {
+                    template_target = info_child
+                        .attribute("href")
+                        .map(short_name_from_identifier)
+                        .map(std::borrow::Cow::into_owned);
                 }
                 _ => {}
             }

--- a/crates/citum-engine/src/processor/document/djot/parsing.rs
+++ b/crates/citum-engine/src/processor/document/djot/parsing.rs
@@ -69,14 +69,12 @@ pub(crate) fn scan_manual_notes(
 
     for (event, range) in Parser::new(content).into_offset_iter() {
         match event {
-            Event::FootnoteReference(label) => {
-                if footnote_stack.is_empty() {
-                    manual_note_references.push(ManualNoteReference {
-                        label: label.to_string(),
-                        start: range.start,
-                    });
-                    manual_note_labels.insert(label.to_string());
-                }
+            Event::FootnoteReference(label) if footnote_stack.is_empty() => {
+                manual_note_references.push(ManualNoteReference {
+                    label: label.to_string(),
+                    start: range.start,
+                });
+                manual_note_labels.insert(label.to_string());
             }
             Event::Start(Container::Footnote { label }, ..) => {
                 manual_note_labels.insert(label.to_string());
@@ -377,10 +375,8 @@ pub(crate) fn scan_bibliography_blocks(content: &str) -> Vec<BibliographyBlock> 
 
     for (event, range) in Parser::new(content).into_offset_iter() {
         match event {
-            Event::Start(Container::Div { class }, attrs) => {
-                if class.contains("bibliography") {
-                    div_stack.push((range.start, extract_group_from_attrs(class, attrs)));
-                }
+            Event::Start(Container::Div { class }, attrs) if class.contains("bibliography") => {
+                div_stack.push((range.start, extract_group_from_attrs(class, attrs)));
             }
             Event::End(Container::Div { class }) => {
                 if class.contains("bibliography")

--- a/crates/citum-engine/src/processor/document/integral_names.rs
+++ b/crates/citum-engine/src/processor/document/integral_names.rs
@@ -48,10 +48,7 @@ impl Processor {
             })
             .collect();
         self.annotate_integral_name_states(&mut ordered_citations, &ordered_contexts);
-        for (citation, index) in ordered_citations
-            .into_iter()
-            .zip(ordered_indices.into_iter())
-        {
+        for (citation, index) in ordered_citations.into_iter().zip(ordered_indices) {
             normalized[index] = citation;
         }
         self.normalize_note_context(&normalized)

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -175,7 +175,7 @@ impl Processor {
         let mut last_idx = 0;
         let normalized = self.normalize_inline_document_citations(&parsed);
 
-        for (parsed, citation) in parsed.citations.iter().zip(normalized.into_iter()) {
+        for (parsed, citation) in parsed.citations.iter().zip(normalized) {
             result.push_str(&content[last_idx..parsed.start]);
             match self.process_citation_with_format::<F>(&citation) {
                 Ok(rendered) => result.push_str(&rendered),
@@ -198,7 +198,7 @@ impl Processor {
         let mut last_idx = 0;
         let normalized = self.normalize_inline_document_citations(&parsed);
 
-        for (parsed, citation) in parsed.citations.iter().zip(normalized.into_iter()) {
+        for (parsed, citation) in parsed.citations.iter().zip(normalized) {
             result.push_str(&content[last_idx..parsed.start]);
             match self.process_citation_with_format::<crate::render::html::Html>(&citation) {
                 Ok(rendered) => result.push_str(&placeholders.push_inline(rendered)),

--- a/crates/citum-migrate/src/analysis/citation.rs
+++ b/crates/citum-migrate/src/analysis/citation.rs
@@ -35,15 +35,11 @@ fn find_group_wrapping(
     for node in nodes {
         if let CslNode::Group(g) = node {
             match (g.prefix.as_deref(), g.suffix.as_deref()) {
-                (Some("("), Some(")")) => {
-                    if group_is_primary_citation_cluster(&g.children) {
-                        return Some((Some(WrapPunctuation::Parentheses), None, None));
-                    }
+                (Some("("), Some(")")) if group_is_primary_citation_cluster(&g.children) => {
+                    return Some((Some(WrapPunctuation::Parentheses), None, None));
                 }
-                (Some("["), Some("]")) => {
-                    if group_is_primary_citation_cluster(&g.children) {
-                        return Some((Some(WrapPunctuation::Brackets), None, None));
-                    }
+                (Some("["), Some("]")) if group_is_primary_citation_cluster(&g.children) => {
+                    return Some((Some(WrapPunctuation::Brackets), None, None));
                 }
                 _ => {}
             }

--- a/crates/citum-migrate/src/fixups/locator.rs
+++ b/crates/citum-migrate/src/fixups/locator.rs
@@ -108,6 +108,10 @@ fn apply_wrapped_locator_formatting(
 
     let mut changed = false;
     for component in template {
+        #[allow(
+            clippy::collapsible_match,
+            reason = "cannot use match guard due to mutable borrow of captured variable"
+        )]
         match component {
             TemplateComponent::Variable(variable)
                 if variable.variable == SimpleVariable::Locator =>
@@ -236,6 +240,10 @@ fn apply_author_date_locator_formatting(
 ) -> bool {
     let mut found_locator = false;
     for component in template {
+        #[allow(
+            clippy::collapsible_match,
+            reason = "cannot use match guard due to mutable borrow of captured variable"
+        )]
         match component {
             TemplateComponent::Variable(variable)
                 if variable.variable == SimpleVariable::Locator =>
@@ -366,15 +374,11 @@ fn apply_wrap_to_component(component: &mut TemplateComponent, wrap: WrapPunctuat
     };
 
     match component {
-        TemplateComponent::Number(n) => {
-            if n.rendering.wrap.is_none() {
-                n.rendering.wrap = Some(wrap_config);
-            }
+        TemplateComponent::Number(n) if n.rendering.wrap.is_none() => {
+            n.rendering.wrap = Some(wrap_config);
         }
-        TemplateComponent::Group(list) => {
-            if list.rendering.wrap.is_none() {
-                list.rendering.wrap = Some(wrap_config);
-            }
+        TemplateComponent::Group(list) if list.rendering.wrap.is_none() => {
+            list.rendering.wrap = Some(wrap_config);
         }
         _ => {}
     }

--- a/crates/citum-migrate/src/fixups/template.rs
+++ b/crates/citum-migrate/src/fixups/template.rs
@@ -39,6 +39,10 @@ pub(super) fn citation_template_is_author_year_only(template: &[TemplateComponen
 pub(super) fn normalize_contributor_form_to_short(template: &mut [TemplateComponent]) -> bool {
     let mut changed = false;
     for component in template {
+        #[allow(
+            clippy::collapsible_match,
+            reason = "cannot use match guard due to mutable borrow of captured variable"
+        )]
         match component {
             TemplateComponent::Contributor(c) => {
                 if c.form == citum_schema::template::ContributorForm::Long {
@@ -63,6 +67,10 @@ pub(super) fn normalize_author_date_inferred_contributors(
 ) -> bool {
     let mut changed = false;
     for component in template {
+        #[allow(
+            clippy::collapsible_match,
+            reason = "cannot use match guard due to mutable borrow of captured variable"
+        )]
         match component {
             TemplateComponent::Contributor(c) => {
                 if c.form == citum_schema::template::ContributorForm::Long {

--- a/crates/citum-migrate/src/options_extractor/bibliography.rs
+++ b/crates/citum-migrate/src/options_extractor/bibliography.rs
@@ -276,19 +276,15 @@ fn macro_has_doi_without_period(macro_def: &Macro) -> bool {
 fn nodes_have_doi_without_period(nodes: &[CslNode]) -> bool {
     for node in nodes {
         match node {
-            CslNode::Text(t) => {
+            CslNode::Text(t)
                 if t.variable
                     .as_ref()
-                    .is_some_and(|v| v == "doi" || v == "url")
-                {
-                    return t.suffix.is_none()
-                        || t.suffix.as_ref().is_some_and(|s| !s.contains('.'));
-                }
+                    .is_some_and(|v| v == "doi" || v == "url") =>
+            {
+                return t.suffix.is_none() || t.suffix.as_ref().is_some_and(|s| !s.contains('.'));
             }
-            CslNode::Group(g) => {
-                if nodes_have_doi_without_period(&g.children) {
-                    return true;
-                }
+            CslNode::Group(g) if nodes_have_doi_without_period(&g.children) => {
+                return true;
             }
             CslNode::Choose(c) => {
                 if nodes_have_doi_without_period(&c.if_branch.children) {

--- a/crates/citum-migrate/src/options_extractor/contributors.rs
+++ b/crates/citum-migrate/src/options_extractor/contributors.rs
@@ -513,10 +513,8 @@ fn extract_substitute_keys(nodes: &[CslNode]) -> Vec<SubstituteKey> {
                     }
                 }
             }
-            CslNode::Text(t) => {
-                if t.variable.as_ref().is_some_and(|v| v == "title") {
-                    keys.push(SubstituteKey::Title);
-                }
+            CslNode::Text(t) if t.variable.as_ref().is_some_and(|v| v == "title") => {
+                keys.push(SubstituteKey::Title);
             }
             CslNode::Group(g) => keys.extend(extract_substitute_keys(&g.children)),
             _ => {}

--- a/crates/citum-migrate/src/options_extractor/dates.rs
+++ b/crates/citum-migrate/src/options_extractor/dates.rs
@@ -45,10 +45,8 @@ fn scan_for_any_date(nodes: &[CslNode], style: &Style) -> bool {
                     return true;
                 }
             }
-            CslNode::Group(g) => {
-                if scan_for_any_date(&g.children, style) {
-                    return true;
-                }
+            CslNode::Group(g) if scan_for_any_date(&g.children, style) => {
+                return true;
             }
             CslNode::Choose(c) => {
                 if scan_for_any_date(&c.if_branch.children, style) {

--- a/crates/citum-migrate/src/options_extractor/numbers.rs
+++ b/crates/citum-migrate/src/options_extractor/numbers.rs
@@ -65,28 +65,20 @@ fn find_volume_pages_delimiter_in_nodes(nodes: &[CslNode]) -> Option<String> {
 fn group_directly_contains_variable(nodes: &[CslNode], var_name: &str) -> bool {
     for node in nodes {
         match node {
-            CslNode::Text(t) => {
-                if t.variable.as_ref().is_some_and(|v| v == var_name) {
-                    return true;
-                }
+            CslNode::Text(t) if t.variable.as_ref().is_some_and(|v| v == var_name) => {
+                return true;
             }
-            CslNode::Number(n) => {
-                if n.variable == var_name {
-                    return true;
-                }
+            CslNode::Number(n) if n.variable == var_name => {
+                return true;
             }
             CslNode::Group(g) => {
                 for child in &g.children {
                     match child {
-                        CslNode::Text(t) => {
-                            if t.variable.as_ref().is_some_and(|v| v == var_name) {
-                                return true;
-                            }
+                        CslNode::Text(t) if t.variable.as_ref().is_some_and(|v| v == var_name) => {
+                            return true;
                         }
-                        CslNode::Number(n) => {
-                            if n.variable == var_name {
-                                return true;
-                            }
+                        CslNode::Number(n) if n.variable == var_name => {
+                            return true;
                         }
                         _ => {}
                     }

--- a/crates/citum-migrate/src/options_extractor/processing.rs
+++ b/crates/citum-migrate/src/options_extractor/processing.rs
@@ -167,10 +167,8 @@ fn extract_group_from_sort(sort: &Sort) -> Option<Group> {
 
     for spec in &sort.template {
         match spec.key {
-            SortKey::Author | SortKey::Year | SortKey::Title => {
-                if !keys.contains(&spec.key) {
-                    keys.push(spec.key.clone());
-                }
+            SortKey::Author | SortKey::Year | SortKey::Title if !keys.contains(&spec.key) => {
+                keys.push(spec.key.clone());
             }
             SortKey::CitationNumber => {}
             _ => {}

--- a/crates/citum-migrate/src/passes/grouping.rs
+++ b/crates/citum-migrate/src/passes/grouping.rs
@@ -262,10 +262,8 @@ pub fn find_issue_in_components(components: &[TemplateComponent]) -> bool {
             TemplateComponent::Number(n) if n.number == NumberVariable::Issue => {
                 return true;
             }
-            TemplateComponent::Group(list) => {
-                if find_issue_in_components(&list.group) {
-                    return true;
-                }
+            TemplateComponent::Group(list) if find_issue_in_components(&list.group) => {
+                return true;
             }
             _ => {}
         }
@@ -322,10 +320,8 @@ pub fn find_volume_in_list(list: &TemplateGroup) -> Option<()> {
             TemplateComponent::Number(n) if n.number == NumberVariable::Volume => {
                 return Some(());
             }
-            TemplateComponent::Group(inner_list) => {
-                if find_volume_in_list(inner_list).is_some() {
-                    return Some(());
-                }
+            TemplateComponent::Group(inner_list) if find_volume_in_list(inner_list).is_some() => {
+                return Some(());
             }
             _ => {}
         }

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -482,15 +482,11 @@ fn handle_date_variable(ref_obj: &mut Reference, key: &str, value: &str) {
     let date = parse_date_variable(value);
 
     match key {
-        "issued" => {
-            if ref_obj.issued.is_none() {
-                ref_obj.issued = Some(date);
-            }
+        "issued" if ref_obj.issued.is_none() => {
+            ref_obj.issued = Some(date);
         }
-        "accessed" => {
-            if ref_obj.accessed.is_none() {
-                ref_obj.accessed = Some(date);
-            }
+        "accessed" if ref_obj.accessed.is_none() => {
+            ref_obj.accessed = Some(date);
         }
         "event-date" | "original-date" | "available-date" | "submitted" => {
             // Store in extra as JSON
@@ -583,35 +579,23 @@ fn handle_name_variable(ref_obj: &mut Reference, key: &str, value: &str) {
     let name = parse_name_variable(value);
 
     match key {
-        "author" => {
-            if ref_obj.author.is_none() {
-                ref_obj.author = Some(vec![name]);
-            }
+        "author" if ref_obj.author.is_none() => {
+            ref_obj.author = Some(vec![name]);
         }
-        "editor" => {
-            if ref_obj.editor.is_none() {
-                ref_obj.editor = Some(vec![name]);
-            }
+        "editor" if ref_obj.editor.is_none() => {
+            ref_obj.editor = Some(vec![name]);
         }
-        "translator" => {
-            if ref_obj.translator.is_none() {
-                ref_obj.translator = Some(vec![name]);
-            }
+        "translator" if ref_obj.translator.is_none() => {
+            ref_obj.translator = Some(vec![name]);
         }
-        "interviewer" => {
-            if ref_obj.interviewer.is_none() {
-                ref_obj.interviewer = Some(vec![name]);
-            }
+        "interviewer" if ref_obj.interviewer.is_none() => {
+            ref_obj.interviewer = Some(vec![name]);
         }
-        "director" => {
-            if ref_obj.director.is_none() {
-                ref_obj.director = Some(vec![name]);
-            }
+        "director" if ref_obj.director.is_none() => {
+            ref_obj.director = Some(vec![name]);
         }
-        "recipient" => {
-            if ref_obj.recipient.is_none() {
-                ref_obj.recipient = Some(vec![name]);
-            }
+        "recipient" if ref_obj.recipient.is_none() => {
+            ref_obj.recipient = Some(vec![name]);
         }
         // Fields not on Reference: store in extra as JSON
         "collection-editor" | "container-author" | "editorial-director" | "illustrator"
@@ -714,20 +698,14 @@ fn handle_string_variable(ref_obj: &mut Reference, key: &str, value: &str) {
     let trimmed = value.trim();
 
     match key {
-        "container-title" => {
-            if ref_obj.container_title.is_none() {
-                ref_obj.container_title = Some(trimmed.to_string());
-            }
+        "container-title" if ref_obj.container_title.is_none() => {
+            ref_obj.container_title = Some(trimmed.to_string());
         }
-        "collection-title" => {
-            if ref_obj.collection_title.is_none() {
-                ref_obj.collection_title = Some(trimmed.to_string());
-            }
+        "collection-title" if ref_obj.collection_title.is_none() => {
+            ref_obj.collection_title = Some(trimmed.to_string());
         }
-        "collection-number" => {
-            if ref_obj.collection_number.is_none() {
-                ref_obj.collection_number = Some(StringOrNumber::String(trimmed.to_string()));
-            }
+        "collection-number" if ref_obj.collection_number.is_none() => {
+            ref_obj.collection_number = Some(StringOrNumber::String(trimmed.to_string()));
         }
         "part-title" => {
             ref_obj.extra.insert(
@@ -735,120 +713,74 @@ fn handle_string_variable(ref_obj: &mut Reference, key: &str, value: &str) {
                 serde_json::Value::String(trimmed.to_string()),
             );
         }
-        "publisher-place" => {
-            if ref_obj.publisher_place.is_none() {
-                ref_obj.publisher_place = Some(trimmed.to_string());
-            }
+        "publisher-place" if ref_obj.publisher_place.is_none() => {
+            ref_obj.publisher_place = Some(trimmed.to_string());
         }
-        "publisher" => {
-            if ref_obj.publisher.is_none() {
-                ref_obj.publisher = Some(trimmed.to_string());
-            }
+        "publisher" if ref_obj.publisher.is_none() => {
+            ref_obj.publisher = Some(trimmed.to_string());
         }
-        "archive-place" | "archive-location" => {
-            if ref_obj.archive_location.is_none() {
-                ref_obj.archive_location = Some(trimmed.to_string());
-            }
+        "archive-place" | "archive-location" if ref_obj.archive_location.is_none() => {
+            ref_obj.archive_location = Some(trimmed.to_string());
         }
-        "archive" => {
-            if ref_obj.archive.is_none() {
-                ref_obj.archive = Some(trimmed.to_string());
-            }
+        "archive" if ref_obj.archive.is_none() => {
+            ref_obj.archive = Some(trimmed.to_string());
         }
-        "volume" => {
-            if ref_obj.volume.is_none() {
-                ref_obj.volume = Some(StringOrNumber::String(trimmed.to_string()));
-            }
+        "volume" if ref_obj.volume.is_none() => {
+            ref_obj.volume = Some(StringOrNumber::String(trimmed.to_string()));
         }
-        "issue" => {
-            if ref_obj.issue.is_none() {
-                ref_obj.issue = Some(StringOrNumber::String(trimmed.to_string()));
-            }
+        "issue" if ref_obj.issue.is_none() => {
+            ref_obj.issue = Some(StringOrNumber::String(trimmed.to_string()));
         }
-        "page" => {
-            if ref_obj.page.is_none() {
-                ref_obj.page = Some(trimmed.to_string());
-            }
+        "page" if ref_obj.page.is_none() => {
+            ref_obj.page = Some(trimmed.to_string());
         }
-        "edition" => {
-            if ref_obj.edition.is_none() {
-                ref_obj.edition = Some(StringOrNumber::String(trimmed.to_string()));
-            }
+        "edition" if ref_obj.edition.is_none() => {
+            ref_obj.edition = Some(StringOrNumber::String(trimmed.to_string()));
         }
-        "number-of-pages" => {
-            if ref_obj.number_of_pages.is_none() {
-                ref_obj.number_of_pages = Some(StringOrNumber::String(trimmed.to_string()));
-            }
+        "number-of-pages" if ref_obj.number_of_pages.is_none() => {
+            ref_obj.number_of_pages = Some(StringOrNumber::String(trimmed.to_string()));
         }
-        "number-of-volumes" => {
-            if ref_obj.number_of_volumes.is_none() {
-                ref_obj.number_of_volumes = Some(StringOrNumber::String(trimmed.to_string()));
-            }
+        "number-of-volumes" if ref_obj.number_of_volumes.is_none() => {
+            ref_obj.number_of_volumes = Some(StringOrNumber::String(trimmed.to_string()));
         }
-        "chapter-number" => {
-            if ref_obj.chapter_number.is_none() {
-                ref_obj.chapter_number = Some(trimmed.to_string());
-            }
+        "chapter-number" if ref_obj.chapter_number.is_none() => {
+            ref_obj.chapter_number = Some(trimmed.to_string());
         }
-        "genre" => {
-            if ref_obj.genre.is_none() {
-                ref_obj.genre = Some(trimmed.to_string());
-            }
+        "genre" if ref_obj.genre.is_none() => {
+            ref_obj.genre = Some(trimmed.to_string());
         }
-        "medium" => {
-            if ref_obj.medium.is_none() {
-                ref_obj.medium = Some(trimmed.to_string());
-            }
+        "medium" if ref_obj.medium.is_none() => {
+            ref_obj.medium = Some(trimmed.to_string());
         }
-        "language" => {
-            if ref_obj.language.is_none() {
-                ref_obj.language = Some(trimmed.to_string());
-            }
+        "language" if ref_obj.language.is_none() => {
+            ref_obj.language = Some(trimmed.to_string());
         }
-        "original-title" => {
-            if ref_obj.original_title.is_none() {
-                ref_obj.original_title = Some(trimmed.to_string());
-            }
+        "original-title" if ref_obj.original_title.is_none() => {
+            ref_obj.original_title = Some(trimmed.to_string());
         }
-        "abstract" => {
-            if ref_obj.abstract_text.is_none() {
-                ref_obj.abstract_text = Some(trimmed.to_string());
-            }
+        "abstract" if ref_obj.abstract_text.is_none() => {
+            ref_obj.abstract_text = Some(trimmed.to_string());
         }
-        "DOI" => {
-            if ref_obj.doi.is_none() {
-                ref_obj.doi = Some(trimmed.to_string());
-            }
+        "DOI" if ref_obj.doi.is_none() => {
+            ref_obj.doi = Some(trimmed.to_string());
         }
-        "ISBN" => {
-            if ref_obj.isbn.is_none() {
-                ref_obj.isbn = Some(trimmed.to_string());
-            }
+        "ISBN" if ref_obj.isbn.is_none() => {
+            ref_obj.isbn = Some(trimmed.to_string());
         }
-        "ISSN" => {
-            if ref_obj.issn.is_none() {
-                ref_obj.issn = Some(trimmed.to_string());
-            }
+        "ISSN" if ref_obj.issn.is_none() => {
+            ref_obj.issn = Some(trimmed.to_string());
         }
-        "URL" => {
-            if ref_obj.url.is_none() {
-                ref_obj.url = Some(trimmed.to_string());
-            }
+        "URL" if ref_obj.url.is_none() => {
+            ref_obj.url = Some(trimmed.to_string());
         }
-        "authority" => {
-            if ref_obj.authority.is_none() {
-                ref_obj.authority = Some(trimmed.to_string());
-            }
+        "authority" if ref_obj.authority.is_none() => {
+            ref_obj.authority = Some(trimmed.to_string());
         }
-        "section" => {
-            if ref_obj.section.is_none() {
-                ref_obj.section = Some(trimmed.to_string());
-            }
+        "section" if ref_obj.section.is_none() => {
+            ref_obj.section = Some(trimmed.to_string());
         }
-        "number" => {
-            if ref_obj.number.is_none() {
-                ref_obj.number = Some(trimmed.to_string());
-            }
+        "number" if ref_obj.number.is_none() => {
+            ref_obj.number = Some(trimmed.to_string());
         }
         // Fields not on Reference: store in extra as JSON
         "volume-title" | "event-title" | "event-place" | "event-location"


### PR DESCRIPTION
Archives and normalizes status metadata for several completed/stale “beans” items. 

This PR also includes non-trivial Rust code refactors across multiple crates to improve code quality and address clippy lints:
- **Match-guard rewrites:** Refactored many `match` statements to use guards instead of nested `if` blocks, particularly in key-handling logic and recursive template scans.
- **Iterator simplifications:** Removed unnecessary `.into_iter()` calls when zipping with `normalized` vectors.
- **Improved sorting:** Replaced `sort_by` with `sort_by_key(Reverse(...))` for clearer intent in ranking logic.
- **Attribute cleanup:** Added missing reasons to `#[allow]` attributes and removed redundant ones as per Copilot review.

### Beans Updated:
- Archive `csl26-3j0c`, `csl26-7b28`, and `csl26-fk0w`.
- Update status to `done` for archived beans `csl26-lb46`, `csl26-pszh`, `csl26-zt6c`, and `csl26-zy07`.