### PR TITLE
feat(engine): add unicode sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,8 @@ dependencies = [
  "citum-schema",
  "criterion",
  "csl-legacy",
+ "icu_collator",
+ "icu_locale",
  "indexmap 2.13.0",
  "jotdown",
  "orgize",
@@ -1304,6 +1306,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e25026c579b170c59f8d3ddfc523d7dab0abe079f09eb8edaebd2417044f60"
 
 [[package]]
+name = "icu_collator"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b521b92a2666061ddda902769d8a4cf730b5c9529a845cc1b69770b12a6c9a71"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections 2.2.0",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer",
+ "icu_properties 2.2.0",
+ "icu_provider 2.2.0",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,29 +1345,52 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "yoke 0.8.1",
+ "utf8_iter",
+ "yoke 0.8.2",
  "zerofrom",
- "zerovec 0.11.5",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections 2.2.0",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider 2.2.0",
+ "potential_utf",
+ "tinystr 0.8.3",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap 0.8.1",
- "tinystr 0.8.2",
+ "serde",
+ "tinystr 0.8.3",
  "writeable 0.6.2",
- "zerovec 0.11.5",
+ "zerovec 0.11.6",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_locid"
@@ -1377,23 +1427,26 @@ checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "icu_collections 2.1.1",
+ "icu_collections 2.2.0",
  "icu_normalizer_data",
- "icu_properties 2.1.2",
- "icu_provider 2.1.1",
+ "icu_properties 2.2.0",
+ "icu_provider 2.2.0",
  "smallvec",
- "zerovec 0.11.5",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
@@ -1413,16 +1466,16 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "icu_collections 2.1.1",
+ "icu_collections 2.2.0",
  "icu_locale_core",
- "icu_properties_data 2.1.2",
- "icu_provider 2.1.1",
- "zerotrie 0.2.3",
- "zerovec 0.11.5",
+ "icu_properties_data 2.2.0",
+ "icu_provider 2.2.0",
+ "zerotrie 0.2.4",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -1433,9 +1486,9 @@ checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
@@ -1458,17 +1511,19 @@ dependencies = [
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable 0.6.2",
- "yoke 0.8.1",
+ "yoke 0.8.2",
  "zerofrom",
- "zerotrie 0.2.3",
- "zerovec 0.11.5",
+ "zerotrie 0.2.4",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -1556,7 +1611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
- "icu_properties 2.1.2",
+ "icu_properties 2.2.0",
 ]
 
 [[package]]
@@ -2222,7 +2277,9 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "zerovec 0.11.5",
+ "serde_core",
+ "writeable 0.6.2",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -3211,13 +3268,13 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
- "zerovec 0.11.5",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -3727,7 +3784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
 dependencies = [
  "serde",
- "tinystr 0.8.2",
+ "tinystr 0.8.3",
 ]
 
 [[package]]
@@ -3850,6 +3907,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -4400,6 +4463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,12 +4521,12 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive 0.8.1",
+ "yoke-derive 0.8.2",
  "zerofrom",
 ]
 
@@ -4475,9 +4544,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4540,13 +4609,14 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
- "yoke 0.8.1",
+ "yoke 0.8.2",
  "zerofrom",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -4563,14 +4633,14 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
- "yoke 0.8.1",
+ "yoke 0.8.2",
  "zerofrom",
- "zerovec-derive 0.11.2",
+ "zerovec-derive 0.11.3",
 ]
 
 [[package]]
@@ -4586,9 +4656,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -26,6 +26,8 @@ regex = "1.10"
 winnow = "0.7"
 jotdown = "0.5"
 orgize = "0.9"
+icu_collator = { version = "2.2.0", features = ["compiled_data"] }
+icu_locale = "2.2.0"
 
 [features]
 ffi = []

--- a/crates/citum-engine/src/grouping/sorting.rs
+++ b/crates/citum-engine/src/grouping/sorting.rs
@@ -16,6 +16,7 @@ use citum_schema::grouping::{GroupSort, GroupSortKey, NameSortOrder, SortKey as 
 use citum_schema::locale::Locale;
 
 use crate::reference::Reference;
+use crate::sort_support::{TextCollator, author_sort_key_opt, normalize_sort_text, title_sort_key};
 
 fn compare_optional_years(a_year: Option<i32>, b_year: Option<i32>) -> std::cmp::Ordering {
     match (a_year, b_year) {
@@ -29,6 +30,7 @@ fn compare_optional_years(a_year: Option<i32>, b_year: Option<i32>) -> std::cmp:
 /// Sorts grouped bibliography entries using group-specific sort rules.
 pub struct GroupSorter<'a> {
     locale: &'a Locale,
+    text_collator: TextCollator,
 }
 
 struct CachedReference<'a> {
@@ -67,8 +69,11 @@ enum CompiledSortKey<'a> {
 impl<'a> GroupSorter<'a> {
     /// Create a sorter that uses `locale` for locale-sensitive comparisons.
     #[must_use]
-    pub const fn new(locale: &'a Locale) -> Self {
-        Self { locale }
+    pub fn new(locale: &'a Locale) -> Self {
+        Self {
+            locale,
+            text_collator: TextCollator::new(locale),
+        }
     }
 
     /// Sort references according to a group sort specification.
@@ -97,7 +102,7 @@ impl<'a> GroupSorter<'a> {
             })
             .collect::<Vec<_>>();
 
-        cached_references.sort_by(|a, b| Self::compare_cached_references(a, b, &compiled_keys));
+        cached_references.sort_by(|a, b| self.compare_cached_references(a, b, &compiled_keys));
         cached_references
             .into_iter()
             .map(|entry| entry.reference)
@@ -221,12 +226,13 @@ impl<'a> GroupSorter<'a> {
     }
 
     fn compare_cached_references(
+        &self,
         a: &CachedReference<'_>,
         b: &CachedReference<'_>,
         compiled_keys: &[CompiledSortKey<'_>],
     ) -> std::cmp::Ordering {
         for (index, sort_key) in compiled_keys.iter().enumerate() {
-            let cmp = Self::compare_cached_value(&a.sort_values[index], &b.sort_values[index]);
+            let cmp = self.compare_cached_value(&a.sort_values[index], &b.sort_values[index]);
             let cmp = if Self::is_ascending(sort_key) {
                 cmp
             } else {
@@ -241,7 +247,7 @@ impl<'a> GroupSorter<'a> {
         std::cmp::Ordering::Equal
     }
 
-    fn compare_cached_value(a: &CachedSortValue, b: &CachedSortValue) -> std::cmp::Ordering {
+    fn compare_cached_value(&self, a: &CachedSortValue, b: &CachedSortValue) -> std::cmp::Ordering {
         match (a, b) {
             (
                 CachedSortValue::RefType {
@@ -260,13 +266,15 @@ impl<'a> GroupSorter<'a> {
             },
             (CachedSortValue::OptionalText(a_text), CachedSortValue::OptionalText(b_text)) => {
                 match (a_text, b_text) {
-                    (Some(a_value), Some(b_value)) => a_value.cmp(b_value),
+                    (Some(a_value), Some(b_value)) => self.text_collator.compare(a_value, b_value),
                     (Some(_), None) => std::cmp::Ordering::Less,
                     (None, Some(_)) => std::cmp::Ordering::Greater,
                     (None, None) => std::cmp::Ordering::Equal,
                 }
             }
-            (CachedSortValue::Text(a_text), CachedSortValue::Text(b_text)) => a_text.cmp(b_text),
+            (CachedSortValue::Text(a_text), CachedSortValue::Text(b_text)) => {
+                self.text_collator.compare(a_text, b_text)
+            }
             (CachedSortValue::Issued(a_year), CachedSortValue::Issued(b_year)) => {
                 compare_optional_years(*a_year, *b_year)
             }
@@ -294,7 +302,7 @@ impl<'a> GroupSorter<'a> {
         let a_key = self.extract_author_sort_key_opt(a, name_order);
         let b_key = self.extract_author_sort_key_opt(b, name_order);
         match (a_key, b_key) {
-            (Some(a), Some(b)) => a.cmp(&b),
+            (Some(a), Some(b)) => self.text_collator.compare(&a, &b),
             (Some(_), None) => std::cmp::Ordering::Less,
             (None, Some(_)) => std::cmp::Ordering::Greater,
             (None, None) => std::cmp::Ordering::Equal,
@@ -311,38 +319,7 @@ impl<'a> GroupSorter<'a> {
         reference: &Reference,
         name_order: NameSortOrder,
     ) -> Option<String> {
-        reference
-            .author()
-            .and_then(|c| c.to_names_vec().first().cloned())
-            .map(|name| match name_order {
-                NameSortOrder::FamilyGiven => {
-                    // Western: "Smith, John" → sort by "smith"
-                    name.family_or_literal().to_lowercase()
-                }
-                NameSortOrder::GivenFamily => {
-                    // Vietnamese: "Nguyễn Văn A" → sort by "nguyễn"
-                    // For Vietnamese names, family comes first, but we need to use
-                    // the full name since the display order matches sort order
-                    name.family_or_literal().to_lowercase()
-                }
-            })
-            .filter(|key| !key.is_empty())
-            .or_else(|| {
-                // Fallback to editor
-                reference
-                    .editor()
-                    .and_then(|c| c.to_names_vec().first().cloned())
-                    .map(|name| name.family_or_literal().to_lowercase())
-                    .filter(|key| !key.is_empty())
-            })
-            .or_else(|| {
-                reference.title().map(|t| {
-                    self.locale
-                        .strip_sort_articles(&t.to_string())
-                        .to_lowercase()
-                })
-            })
-            .filter(|key| !key.is_empty())
+        author_sort_key_opt(reference, name_order, self.locale, true)
     }
 
     /// Public helper retained for tests/debugging.
@@ -360,7 +337,7 @@ impl<'a> GroupSorter<'a> {
     fn compare_by_title(&self, a: &Reference, b: &Reference) -> std::cmp::Ordering {
         let a_title = self.title_sort_key(a);
         let b_title = self.title_sort_key(b);
-        a_title.cmp(&b_title)
+        self.text_collator.compare(&a_title, &b_title)
     }
 
     /// Compare by issued date.
@@ -376,9 +353,7 @@ impl<'a> GroupSorter<'a> {
     }
 
     fn title_sort_key(&self, reference: &Reference) -> String {
-        self.locale
-            .strip_sort_articles(&reference.title().map(|t| t.to_string()).unwrap_or_default())
-            .to_lowercase()
+        title_sort_key(reference, self.locale)
     }
 
     fn issued_year(reference: &Reference) -> Option<i32> {
@@ -390,7 +365,7 @@ impl<'a> GroupSorter<'a> {
 
     fn field_sort_value(reference: &Reference, field_name: &str) -> String {
         match field_name {
-            "language" => reference.language().unwrap_or_default().to_string(),
+            "language" => normalize_sort_text(reference.language().unwrap_or_default().as_ref()),
             // Future: support for keywords, custom metadata
             _ => String::new(),
         }
@@ -498,6 +473,60 @@ mod tests {
         assert_eq!(refs[0].id().unwrap(), "r3"); // Brown
         assert_eq!(refs[1].id().unwrap(), "r2"); // Jones
         assert_eq!(refs[2].id().unwrap(), "r1"); // Smith
+    }
+
+    #[test]
+    fn test_author_sort_uses_unicode_collation_for_accented_names() {
+        let locale = make_locale();
+        let sorter = GroupSorter::new(&locale);
+
+        let celik = make_reference("r1", "book", "Çelik", "Title", 2000);
+        let zimring = make_reference("r2", "book", "Zimring", "Title", 2000);
+        let o_tuathail = make_reference("r3", "book", "Ó Tuathail", "Title", 2000);
+
+        let mut refs = vec![&o_tuathail, &zimring, &celik];
+
+        let sort_spec = GroupSort {
+            template: vec![GroupSortKey {
+                key: GroupSortKeyType::Author,
+                ascending: true,
+                order: None,
+                sort_order: Some(NameSortOrder::FamilyGiven),
+            }],
+        };
+
+        refs = sorter.sort_references(refs, &sort_spec);
+
+        assert_eq!(refs[0].id().unwrap(), "r1");
+        assert_eq!(refs[1].id().unwrap(), "r3");
+        assert_eq!(refs[2].id().unwrap(), "r2");
+    }
+
+    #[test]
+    fn test_title_sort_uses_unicode_collation_for_accented_titles() {
+        let locale = make_locale();
+        let sorter = GroupSorter::new(&locale);
+
+        let accent = make_reference_no_author("r1", "book", "Órbitas del sur", 2000);
+        let plain = make_reference_no_author("r2", "book", "Origins of Theory", 2000);
+        let zeta = make_reference_no_author("r3", "book", "Zebra Studies", 2000);
+
+        let mut refs = vec![&zeta, &plain, &accent];
+
+        let sort_spec = GroupSort {
+            template: vec![GroupSortKey {
+                key: GroupSortKeyType::Title,
+                ascending: true,
+                order: None,
+                sort_order: None,
+            }],
+        };
+
+        refs = sorter.sort_references(refs, &sort_spec);
+
+        assert_eq!(refs[0].id().unwrap(), "r1");
+        assert_eq!(refs[1].id().unwrap(), "r2");
+        assert_eq!(refs[2].id().unwrap(), "r3");
     }
 
     #[test]

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -98,6 +98,7 @@ pub mod processor;
 pub mod reference;
 /// Output-format renderers and string conversion helpers.
 pub mod render;
+mod sort_support;
 /// Template value resolution and formatting helpers.
 pub mod values;
 

--- a/crates/citum-engine/src/processor/sorting.rs
+++ b/crates/citum-engine/src/processor/sorting.rs
@@ -4,6 +4,8 @@
 //! including support for anonymous works and article stripping for title-based sorting.
 
 use crate::reference::Reference;
+use crate::sort_support::{TextCollator, author_sort_key_opt, title_sort_key};
+use citum_schema::grouping::NameSortOrder;
 use citum_schema::locale::Locale;
 use citum_schema::options::{Config, SortKey};
 
@@ -36,13 +38,19 @@ pub struct Sorter<'a> {
     config: &'a Config,
     /// The locale used for article stripping in title-based sorts.
     locale: &'a Locale,
+    /// Locale-aware text comparator for author/title sort keys.
+    text_collator: TextCollator,
 }
 
 impl<'a> Sorter<'a> {
     /// Creates a new `Sorter` instance.
     #[must_use]
     pub fn new(config: &'a Config, locale: &'a Locale) -> Self {
-        Self { config, locale }
+        Self {
+            config,
+            locale,
+            text_collator: TextCollator::new(locale),
+        }
     }
 
     /// Sort references according to style instructions.
@@ -65,49 +73,25 @@ impl<'a> Sorter<'a> {
                 for sort in &resolved.template {
                     let cmp = match sort.key {
                         SortKey::Author => {
-                            let a_sort_key = a
-                                .author()
-                                .and_then(|c| c.to_names_vec().first().cloned())
-                                .map(|n| n.family_or_literal().to_lowercase())
-                                .filter(|s| !s.is_empty())
-                                .or_else(|| {
-                                    a.editor()
-                                        .and_then(|c| c.to_names_vec().first().cloned())
-                                        .map(|n| n.family_or_literal().to_lowercase())
-                                        .filter(|s| !s.is_empty())
-                                })
-                                .or_else(|| {
-                                    a.title().map(|t| {
-                                        self.locale
-                                            .strip_sort_articles(&t.to_string())
-                                            .to_lowercase()
-                                    })
-                                })
-                                .unwrap_or_default();
-                            let b_sort_key = b
-                                .author()
-                                .and_then(|c| c.to_names_vec().first().cloned())
-                                .map(|n| n.family_or_literal().to_lowercase())
-                                .filter(|s| !s.is_empty())
-                                .or_else(|| {
-                                    b.editor()
-                                        .and_then(|c| c.to_names_vec().first().cloned())
-                                        .map(|n| n.family_or_literal().to_lowercase())
-                                        .filter(|s| !s.is_empty())
-                                })
-                                .or_else(|| {
-                                    b.title().map(|t| {
-                                        self.locale
-                                            .strip_sort_articles(&t.to_string())
-                                            .to_lowercase()
-                                    })
-                                })
-                                .unwrap_or_default();
+                            let a_sort_key = author_sort_key_opt(
+                                a,
+                                NameSortOrder::FamilyGiven,
+                                self.locale,
+                                true,
+                            )
+                            .unwrap_or_default();
+                            let b_sort_key = author_sort_key_opt(
+                                b,
+                                NameSortOrder::FamilyGiven,
+                                self.locale,
+                                true,
+                            )
+                            .unwrap_or_default();
 
                             if sort.ascending {
-                                a_sort_key.cmp(&b_sort_key)
+                                self.text_collator.compare(&a_sort_key, &b_sort_key)
                             } else {
-                                b_sort_key.cmp(&a_sort_key)
+                                self.text_collator.compare(&b_sort_key, &a_sort_key)
                             }
                         }
                         SortKey::Year => {
@@ -123,23 +107,13 @@ impl<'a> Sorter<'a> {
                             compare_optional_years(a_year, b_year, sort.ascending)
                         }
                         SortKey::Title => {
-                            let a_title = self
-                                .locale
-                                .strip_sort_articles(
-                                    &a.title().map(|t| t.to_string()).unwrap_or_default(),
-                                )
-                                .to_lowercase();
-                            let b_title = self
-                                .locale
-                                .strip_sort_articles(
-                                    &b.title().map(|t| t.to_string()).unwrap_or_default(),
-                                )
-                                .to_lowercase();
+                            let a_title = title_sort_key(a, self.locale);
+                            let b_title = title_sort_key(b, self.locale);
 
                             if sort.ascending {
-                                a_title.cmp(&b_title)
+                                self.text_collator.compare(&a_title, &b_title)
                             } else {
-                                b_title.cmp(&a_title)
+                                self.text_collator.compare(&b_title, &a_title)
                             }
                         }
                         SortKey::CitationNumber => std::cmp::Ordering::Equal,

--- a/crates/citum-engine/src/sort_support.rs
+++ b/crates/citum-engine/src/sort_support.rs
@@ -1,0 +1,124 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Shared bibliography sort-key normalization and collation helpers.
+
+use std::cmp::Ordering;
+
+use crate::reference::Reference;
+use citum_schema::grouping::NameSortOrder;
+use citum_schema::locale::Locale;
+use icu_collator::options::{CollatorOptions, Strength};
+use icu_collator::{CollatorBorrowed, CollatorPreferences};
+use icu_locale::Locale as IcuLocale;
+
+/// Locale-aware comparator used by bibliography sorting paths.
+pub(crate) struct TextCollator {
+    collator: CollatorBorrowed<'static>,
+}
+
+impl TextCollator {
+    /// Create a collator for the active Citum locale.
+    #[must_use]
+    pub(crate) fn new(locale: &Locale) -> Self {
+        let mut options = CollatorOptions::default();
+        options.strength = Some(Strength::Secondary);
+        let collator = CollatorBorrowed::try_new(collator_preferences(locale), options)
+            .expect("ICU4X compiled collation data should be available");
+        Self { collator }
+    }
+
+    /// Compare two already-normalized sort keys.
+    #[must_use]
+    pub(crate) fn compare(&self, left: &str, right: &str) -> Ordering {
+        self.collator.compare(left, right)
+    }
+}
+
+/// Build the normalized author sort key using existing fallback rules.
+#[must_use]
+pub(crate) fn author_sort_key_opt(
+    reference: &Reference,
+    name_order: NameSortOrder,
+    locale: &Locale,
+    fallback_to_title: bool,
+) -> Option<String> {
+    reference
+        .author()
+        .and_then(|c| c.to_names_vec().first().cloned())
+        .map(|name| match name_order {
+            NameSortOrder::FamilyGiven | NameSortOrder::GivenFamily => {
+                normalize_sort_text(name.family_or_literal())
+            }
+        })
+        .filter(|key| !key.is_empty())
+        .or_else(|| {
+            reference
+                .editor()
+                .and_then(|c| c.to_names_vec().first().cloned())
+                .map(|name| normalize_sort_text(name.family_or_literal()))
+                .filter(|key| !key.is_empty())
+        })
+        .or_else(|| fallback_to_title.then(|| title_sort_key(reference, locale)))
+        .filter(|key| !key.is_empty())
+}
+
+/// Build the normalized title sort key with locale article stripping.
+#[must_use]
+pub(crate) fn title_sort_key(reference: &Reference, locale: &Locale) -> String {
+    let title = reference.title().map(|t| t.to_string()).unwrap_or_default();
+    normalize_sort_text(locale.strip_sort_articles(&title))
+}
+
+/// Normalize plain text for case-insensitive bibliography sorting.
+#[must_use]
+pub(crate) fn normalize_sort_text(text: &str) -> String {
+    text.to_lowercase()
+}
+
+fn collator_preferences(locale: &Locale) -> CollatorPreferences {
+    parse_icu_locale(&locale.locale)
+        .unwrap_or_else(default_icu_locale)
+        .into()
+}
+
+fn parse_icu_locale(locale_id: &str) -> Option<IcuLocale> {
+    let mut candidate = locale_id.trim();
+    while !candidate.is_empty() {
+        if let Ok(locale) = candidate.parse::<IcuLocale>() {
+            return Some(locale);
+        }
+        match candidate.rsplit_once('-') {
+            Some((prefix, _)) => candidate = prefix,
+            None => break,
+        }
+    }
+    None
+}
+
+fn default_icu_locale() -> IcuLocale {
+    "en-US"
+        .parse::<IcuLocale>()
+        .expect("en-US should always be a valid ICU locale")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_icu_locale_trims_unparseable_override_suffix() {
+        let parsed = parse_icu_locale("de-DE-foo_bar")
+            .expect("fallback parsing should produce a base locale");
+        assert_eq!(parsed.to_string(), "de-DE");
+    }
+
+    #[test]
+    fn test_text_collator_sorts_accented_names_near_ascii_peers() {
+        let collator = TextCollator::new(&Locale::en_us());
+        assert_eq!(collator.compare("celik", "çelik"), Ordering::Less);
+        assert_eq!(collator.compare("ó tuathail", "zukin"), Ordering::Less);
+    }
+}

--- a/crates/citum-engine/src/sort_support.rs
+++ b/crates/citum-engine/src/sort_support.rs
@@ -72,10 +72,10 @@ pub(crate) fn title_sort_key(reference: &Reference, locale: &Locale) -> String {
     normalize_sort_text(locale.strip_sort_articles(&title))
 }
 
-/// Normalize plain text for case-insensitive bibliography sorting.
+/// Normalize plain text for bibliography sorting without locale-insensitive case folding.
 #[must_use]
 pub(crate) fn normalize_sort_text(text: &str) -> String {
-    text.to_lowercase()
+    text.to_string()
 }
 
 fn collator_preferences(locale: &Locale) -> CollatorPreferences {
@@ -120,5 +120,10 @@ mod tests {
         let collator = TextCollator::new(&Locale::en_us());
         assert_eq!(collator.compare("celik", "çelik"), Ordering::Less);
         assert_eq!(collator.compare("ó tuathail", "zukin"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_normalize_sort_text_preserves_locale_sensitive_case_points() {
+        assert_eq!(normalize_sort_text("İnce"), "İnce");
     }
 }

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -752,6 +752,19 @@ fn group_sorting_orders_cluster_by_year_within_an_author_group() {
     run_test_case_native(&input, &citation_items, expected, "citation");
 }
 
+/// Test multi-item citation sorting with accented surnames.
+fn author_date_sorting_orders_cluster_with_unicode_surnames() {
+    let input = vec![
+        make_book("item1", "Zimring", "Craig", 2020, "Title A"),
+        make_book("item2", "Ó Tuathail", "Gearóid", 1998, "Title B"),
+        make_book("item3", "Çelik", "Zeynep", 1996, "Title C"),
+    ];
+    let citation_items = vec![vec!["item1", "item2", "item3"]];
+    let expected = "Çelik, (1996); Ó Tuathail, (1998); Zimring, (2020)";
+
+    run_test_case_native(&input, &citation_items, expected, "citation");
+}
+
 fn sorting_empty_dates_pushes_undated_items_to_the_end() {
     // Upstream provenance: CSL fixture `date_SortEmptyDatesCitation`.
     fn make_undated_book(id: &str, title: &str) -> InputReference {
@@ -1609,6 +1622,14 @@ mod sorting_and_grouping {
             "Grouped citation sorting should keep works together by author and then sort years within that group.",
         );
         super::group_sorting_orders_cluster_by_year_within_an_author_group();
+    }
+
+    #[test]
+    fn author_date_sorting_orders_cluster_with_unicode_surnames() {
+        announce_behavior(
+            "Author-date citation clusters should sort accented surnames with Unicode-aware collation.",
+        );
+        super::author_date_sorting_orders_cluster_with_unicode_surnames();
     }
 
     #[test]

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -216,6 +216,36 @@ fn test_multiauthor_same_year_sort() {
     );
 }
 
+/// Test accented surnames sort with Unicode-aware collation instead of bytewise ordering.
+#[test]
+fn test_apa_7th_sort_unicode_accented_surnames() {
+    announce_behavior(
+        "Accented surnames sort near their ASCII peers in author-date bibliographies.",
+    );
+    let root = project_root();
+    let style = load_style(&root.join("styles/embedded/apa-7th.yaml"));
+    let bib = load_sort_oracle_bibliography();
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    let celik_pos = result.find("Çelik, Z.").expect("Çelik should be in output");
+    let o_tuathail_pos = result
+        .find("Ó Tuathail, G.")
+        .expect("Ó Tuathail should be in output");
+    let zimring_pos = result
+        .find("Zimring, C. A.")
+        .expect("Zimring should be in output");
+
+    assert!(
+        celik_pos < o_tuathail_pos,
+        "Çelik should sort before Ó Tuathail. Got: {result}"
+    );
+    assert!(
+        o_tuathail_pos < zimring_pos,
+        "Ó Tuathail should sort before Zimring. Got: {result}"
+    );
+}
+
 /// Test numeric style volume/issue variation doesn't affect sort.
 /// Numeric styles should sort by citation order, not by volume/issue.
 #[test]

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -833,6 +833,10 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                     an entire style.
                 </p>
                 <p class="text-slate-600 leading-relaxed mb-6">
+                    The checked-in multilingual example also includes accented Latin-script surnames so bibliography
+                    sorting can be verified against Unicode-aware collation, not raw byte ordering.
+                </p>
+                <p class="text-slate-600 leading-relaxed mb-6">
                     Locale term messages use <strong>Unicode MessageFormat 2 (MF2)</strong> syntax. The current
                     evaluator supports a focused subset: variable substitution (<code class="text-xs bg-slate-100 px-1 rounded">{$var}</code>),
                     plural dispatch (<code class="text-xs bg-slate-100 px-1 rounded">.match {$count :plural}</code> with
@@ -940,10 +944,10 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                                 Mixed Corpus
                             </div>
                             <div class="font-mono text-sm text-slate-900">
-                                Anderson, Elizabeth. _Contemporary Approaches to Citation_. Oxford University Press, 2020.
+                                Çelik, Zeynep. _Streets: critical perspectives on public space_. University of California Press, 1996.
                             </div>
                             <div class="text-xs text-slate-500 mt-1">
-                                Plain English records and multilingual records can coexist in the same bibliography input
+                                Plain English, multilingual, and accented Latin-script records can coexist in the same bibliography input
                             </div>
                         </div>
                     </div>

--- a/docs/specs/UNICODE_BIBLIOGRAPHY_SORTING.md
+++ b/docs/specs/UNICODE_BIBLIOGRAPHY_SORTING.md
@@ -1,0 +1,25 @@
+# Unicode Bibliography Sorting Specification
+
+**Status:** Active
+**Date:** 2026-04-16
+**Related:** unicode-aware bibliography ordering regression
+
+## Purpose
+Define locale-aware bibliography sorting for Citum so accented and other non-ASCII names sort according to Unicode collation rules instead of raw bytewise string order.
+
+## Scope
+In scope: bibliography author/title sort comparisons in the engine, shared sort-key normalization, regression fixtures, examples, and tests. Out of scope: new public schema options, transliteration-aware sorting policy changes, or broader multilingual rendering redesign.
+
+## Design
+The engine uses ICU4X collation for text sort comparisons in both top-level bibliography sorting and grouped bibliography sorting. Existing article stripping and author/editor/title fallback behavior remains unchanged. Citum locale IDs are parsed as ICU locales when possible; if a locale override ID is not directly parseable, the engine falls back by dropping rightmost subtags until it finds a valid locale, then falls back to `en-US`.
+
+## Implementation Notes
+Use a crate-local sorting helper so both sorting pipelines build and compare text keys consistently. Normalize existing string keys with lowercase conversion before collation to preserve current case-insensitive bibliography behavior while gaining Unicode-aware ordering.
+
+## Acceptance Criteria
+- [ ] Author/date bibliography sorting places accented surnames near their ASCII peers instead of at the end of the list.
+- [ ] Grouped bibliography sorting and top-level bibliography sorting use the same locale-aware text comparison path.
+- [ ] Regression fixtures and examples include accented surnames covered by automated tests.
+
+## Changelog
+- 2026-04-16: Initial version.

--- a/examples/multilingual-refs.yaml
+++ b/examples/multilingual-refs.yaml
@@ -147,3 +147,29 @@ references:
     publisher:
       name: "서울대학교 출판부"
     language: "ko"
+
+  # 7. Latin-script record with accented surname for Unicode-aware sorting
+  - id: celik_public_space
+    class: monograph
+    type: book
+    title: "Streets: critical perspectives on public space"
+    author:
+      - family: "Çelik"
+        given: "Zeynep"
+    issued: "1996"
+    publisher:
+      name: "University of California Press"
+    language: "en"
+
+  # 8. Irish name with acute accent to verify collation near other O surnames
+  - id: o_tuathail_geopolitics
+    class: monograph
+    type: book
+    title: "Rethinking geopolitics"
+    author:
+      - family: "Ó Tuathail"
+        given: "Gearóid"
+    issued: "1998"
+    publisher:
+      name: "Routledge"
+    language: "en"

--- a/tests/fixtures/sort-oracle.json
+++ b/tests/fixtures/sort-oracle.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Sort oracle test data covering edge cases: multiple works by same author/year, anonymous works, all-caps surnames, varied volumes for numeric styles",
+  "comment": "Sort oracle test data covering edge cases: multiple works by same author/year, anonymous works, all-caps surnames, varied volumes for numeric styles, and Unicode-aware accented surname ordering",
   "SORT-1": {
     "id": "SORT-1",
     "class": "monograph",
@@ -103,5 +103,29 @@
       { "family": "Green", "given": "Lisa" }
     ],
     "issued": { "date-parts": [[2022]] }
+  },
+  "SORT-11": {
+    "id": "SORT-11",
+    "class": "monograph",
+    "type": "book",
+    "title": "Streets: critical perspectives on public space",
+    "author": [{ "family": "Çelik", "given": "Zeynep" }],
+    "issued": { "date-parts": [[1996]] }
+  },
+  "SORT-12": {
+    "id": "SORT-12",
+    "class": "monograph",
+    "type": "book",
+    "title": "A Sustainable City? Nature, Land, and Justice in Chicago",
+    "author": [{ "family": "Zimring", "given": "Carl A." }],
+    "issued": { "date-parts": [[2020]] }
+  },
+  "SORT-13": {
+    "id": "SORT-13",
+    "class": "monograph",
+    "type": "book",
+    "title": "Rethinking geopolitics",
+    "author": [{ "family": "Ó Tuathail", "given": "Gearóid" }],
+    "issued": { "date-parts": [[1998]] }
   }
 }


### PR DESCRIPTION
## Summary
- add ICU4X-backed Unicode collation for bibliography author/title sorting
- share normalized text sort-key logic across grouped and top-level sorting paths
- add regression fixtures, examples, docs, and tests for accented surname ordering

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run