### PR TITLE
feat(spec): original publication relation support

### DIFF
--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -3105,6 +3105,79 @@ fn original_published_date_variable_renders_when_reference_has_original_date() {
     );
 }
 
+#[test]
+fn original_published_date_variable_renders_for_patent_references() {
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Original-date patent test".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::OriginalPublished,
+                    form: DateForm::Year,
+                    rendering: Rendering {
+                        prefix: Some("(".to_string()),
+                        suffix: Some(") ".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::Issued,
+                    form: DateForm::Year,
+                    ..Default::default()
+                }),
+                TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    form: Some(TitleForm::Long),
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let reference: InputReference = serde_json::from_str(
+        r#"{
+            "class": "patent",
+            "id": "patent",
+            "title": "Improved Widget",
+            "patent-number": "US-123",
+            "issued": "1992",
+            "original": {
+                "class": "monograph",
+                "type": "book",
+                "id": "patent-orig",
+                "issued": "1901"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let bibliography = IndexMap::from([("patent".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor
+        .render_selected_bibliography_with_format::<PlainText, _>(["patent".to_string()])
+        .trim()
+        .to_string();
+
+    assert!(
+        rendered.contains("(1901)"),
+        "expected original-published year '(1901)' in output: {rendered}"
+    );
+    assert!(
+        rendered.contains("1992"),
+        "expected issued year '1992' in output: {rendered}"
+    );
+    assert!(
+        rendered.contains("Improved Widget"),
+        "expected title in output: {rendered}"
+    );
+}
+
 mod annotated_html_preview {
     use super::announce_behavior;
     use rstest::rstest;

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -129,6 +129,17 @@ fn relation_monograph(
     ))))
 }
 
+fn legacy_original_relation(legacy: &csl_legacy::csl_json::Reference) -> Option<WorkRelation> {
+    relation_monograph(
+        legacy.original_title.clone().map(Title::Single),
+        legacy_extra_contributor(legacy, "original-author"),
+        legacy_extra_date(legacy, "original-date"),
+        None,
+        legacy_extra_str(legacy, "original-publisher"),
+        legacy_extra_str(legacy, "original-publisher-place"),
+    )
+}
+
 fn relation_event(
     title: Option<String>,
     location: Option<String>,
@@ -254,9 +265,11 @@ fn legacy_type_uses_created(ref_type: &str) -> bool {
 }
 
 fn from_software_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     InputReference::Software(Box::new(Software {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title),
+        original,
         author: legacy.author.map(Contributor::from),
         created: ctx.created,
         issued: ctx.issued,
@@ -976,6 +989,7 @@ fn from_audio_visual_ref(
     legacy: csl_legacy::csl_json::Reference,
     ctx: RefContext,
 ) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     let r#type = match legacy.ref_type.as_str() {
         "motion_picture" => AudioVisualType::Film,
         "song" => AudioVisualType::Recording,
@@ -1048,6 +1062,7 @@ fn from_audio_visual_ref(
             contributors,
             created: ctx.created,
             issued: ctx.issued,
+            original,
             language: ctx.language,
             genre: legacy.genre,
         },
@@ -1072,9 +1087,11 @@ fn from_audio_visual_ref(
 }
 
 fn from_legal_case_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     InputReference::LegalCase(Box::new(LegalCase {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title.clone()),
+        original,
         authority: legacy.authority,
         volume: legacy.volume.map(|v| v.to_string()),
         reporter: legacy.container_title,
@@ -1092,9 +1109,11 @@ fn from_legal_case_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext)
 }
 
 fn from_statute_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     InputReference::Statute(Box::new(Statute {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title.clone()),
+        original,
         authority: legacy.authority,
         volume: legacy.volume.map(|v| v.to_string()),
         code: legacy.container_title,
@@ -1114,9 +1133,11 @@ fn from_statute_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) ->
 }
 
 fn from_regulation_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     InputReference::Regulation(Box::new(Regulation {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title.clone()),
+        original,
         authority: legacy.authority,
         volume: legacy.volume.map(|v| v.to_string()),
         code: legacy.container_title,
@@ -1133,9 +1154,11 @@ fn from_regulation_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext)
 }
 
 fn from_treaty_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     InputReference::Treaty(Box::new(Treaty {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title.clone()),
+        original,
         author: legacy.author.map(Contributor::from),
         volume: legacy.volume.map(|v| v.to_string()),
         reporter: legacy.container_title,
@@ -1152,9 +1175,11 @@ fn from_treaty_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> 
 }
 
 fn from_standard_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     InputReference::Standard(Box::new(Standard {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title.clone()),
+        original,
         authority: legacy.authority,
         standard_number: legacy.number.unwrap_or_default(),
         created: ctx.created,
@@ -1174,11 +1199,13 @@ fn from_standard_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
 }
 
 fn from_patent_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     InputReference::Patent(Box::new(Patent {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title.clone()),
         author: legacy.author.map(Contributor::from),
         assignee: None,
+        original,
         patent_number: legacy.number.unwrap_or_default(),
         application_number: None,
         created: ctx.created,
@@ -1196,6 +1223,7 @@ fn from_patent_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> 
 }
 
 fn from_dataset_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     let version = legacy_extra_str(&legacy, "version");
     let synthesized_title = ctx.title.clone().or_else(|| {
         legacy
@@ -1214,6 +1242,7 @@ fn from_dataset_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) ->
         id: ctx.id,
         title: build_title(synthesized_title, ctx.short_title.clone()),
         author: legacy.author.map(Contributor::from),
+        original,
         created: ctx.created,
         issued: ctx.issued,
         publisher: legacy.publisher.map(|n| Publisher {
@@ -1314,6 +1343,7 @@ fn from_document_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
         Some(ai) if ai.collection.is_some() => None,
         _ => legacy.archive.clone(),
     };
+    let original = legacy_original_relation(&legacy);
 
     let volume = legacy.volume.map(|v| v.to_string());
     let number = legacy.number.clone();
@@ -1375,7 +1405,7 @@ fn from_document_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
         archive_info,
         eprint: None,
         keywords: None,
-        original: None,
+        original,
         ..Default::default()
     }))
 }
@@ -1455,6 +1485,7 @@ fn from_preprint_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
 }
 
 fn from_event_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
     let producer_names = legacy_extra_names(&legacy, "producer")
         .or_else(|| legacy_extra_names(&legacy, "executive-producer"));
     let host_names = legacy_extra_names(&legacy, "host");
@@ -1493,6 +1524,7 @@ fn from_event_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> I
     InputReference::Event(Box::new(Event {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title.clone()),
+        original,
         container: legacy.container_title.clone().map(|t| {
             WorkRelation::Embedded(Box::new(InputReference::Monograph(Box::new(Monograph {
                 title: Some(Title::Single(t)),

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -1128,15 +1128,67 @@ impl InputReference {
     pub fn original_date(&self) -> Option<EdtfString> {
         match self {
             InputReference::Monograph(r) => r.original.as_ref().and_then(|c| match c {
-                WorkRelation::Embedded(p) => p.issued(),
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
             InputReference::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
-                WorkRelation::Embedded(p) => p.issued(),
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
             InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
-                WorkRelation::Embedded(p) => p.issued(),
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
             _ => None,
@@ -1155,6 +1207,58 @@ impl InputReference {
                 WorkRelation::Id(_) => None,
             }),
             InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.title(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
@@ -1177,6 +1281,58 @@ impl InputReference {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
+            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
+                WorkRelation::Id(_) => None,
+            }),
             _ => None,
         }
     }
@@ -1193,6 +1349,58 @@ impl InputReference {
                 WorkRelation::Id(_) => None,
             }),
             InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+                WorkRelation::Embedded(p) => p.publisher_place(),
+                WorkRelation::Id(_) => None,
+            }),
+            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -1270,3 +1270,196 @@ fn conversion_preserves_place_only_original_publication_metadata() {
         Some("Boston".to_string())
     );
 }
+
+#[test]
+fn specialized_reference_round_trips_original_relation() {
+    let reference: InputReference = serde_json::from_str(
+        r#"{
+            "class": "patent",
+            "title": "Improved Widget",
+            "patent-number": "US-123",
+            "original": {
+                "class": "monograph",
+                "type": "book",
+                "title": "Widget Prototype",
+                "issued": "1901"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        reference.original_title(),
+        Some(Title::Single("Widget Prototype".to_string()))
+    );
+    let serialized = serde_json::to_value(&reference).unwrap();
+    assert!(serialized.get("original").is_some());
+}
+
+#[test]
+fn legal_reference_round_trips_original_relation() {
+    let reference: InputReference = serde_json::from_str(
+        r#"{
+            "class": "legal-case",
+            "title": "Example v. Example",
+            "original": {
+                "class": "monograph",
+                "type": "book",
+                "title": "Original Reporter",
+                "issued": "1901"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        reference.original_title(),
+        Some(Title::Single("Original Reporter".to_string()))
+    );
+    let serialized = serde_json::to_value(&reference).unwrap();
+    assert!(serialized.get("original").is_some());
+}
+
+#[test]
+fn audio_visual_round_trips_original_relation_via_work_core() {
+    let reference: InputReference = serde_json::from_str(
+        r#"{
+            "class": "audio-visual",
+            "type": "film",
+            "title": "Metropolis",
+            "original": {
+                "class": "monograph",
+                "type": "book",
+                "title": "Metropolis (Original Release)",
+                "issued": "1927"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        reference.original_title(),
+        Some(Title::Single("Metropolis (Original Release)".to_string()))
+    );
+    let serialized = serde_json::to_value(&reference).unwrap();
+    assert!(serialized.get("original").is_some());
+}
+
+#[test]
+fn original_date_uses_created_fallback_for_newly_supported_variants() {
+    let reference: InputReference = serde_json::from_str(
+        r#"{
+            "class": "patent",
+            "id": "patent-with-original",
+            "patent-number": "US-123",
+            "original": {
+                "class": "monograph",
+                "type": "book",
+                "id": "original-work",
+                "created": "1901-05-17"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        reference.original_date(),
+        Some(EdtfString("1901-05-17".to_string()))
+    );
+}
+
+#[test]
+fn conversion_maps_original_relation_for_patent_references() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+            "id": "patent-original",
+            "type": "patent",
+            "title": "Improved Widget",
+            "number": "US-123",
+            "original-title": "Widget Prototype",
+            "original-date": { "date-parts": [[1901]] },
+            "original-publisher": "Old Patent Office"
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+
+    assert_eq!(
+        reference.original_title(),
+        Some(Title::Single("Widget Prototype".to_string()))
+    );
+    assert_eq!(
+        reference.original_publisher_str(),
+        Some("Old Patent Office".to_string())
+    );
+}
+
+#[test]
+fn conversion_maps_original_relation_for_event_references() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+            "id": "event-original",
+            "type": "speech",
+            "title": "Conference Talk",
+            "issued": { "date-parts": [[2010, 6, 1]] },
+            "original-title": "Lecture Manuscript",
+            "original-date": { "date-parts": [[1901]] },
+            "original-publisher-place": "Boston"
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+
+    assert_eq!(
+        reference.original_title(),
+        Some(Title::Single("Lecture Manuscript".to_string()))
+    );
+    assert_eq!(
+        reference.original_publisher_place(),
+        Some("Boston".to_string())
+    );
+}
+
+#[test]
+fn conversion_maps_original_relation_for_legal_case_references() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+            "id": "case-original",
+            "type": "legal_case",
+            "title": "Example v. Example",
+            "container-title": "Reporter",
+            "original-title": "Original Reporter Edition",
+            "original-date": { "date-parts": [[1901]] },
+            "original-publisher": "Old Press",
+            "original-publisher-place": "Boston"
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+
+    assert_eq!(
+        reference.original_title(),
+        Some(Title::Single("Original Reporter Edition".to_string()))
+    );
+    assert_eq!(
+        reference.original_publisher_str(),
+        Some("Old Press".to_string())
+    );
+
+    let InputReference::LegalCase(case_ref) = reference else {
+        panic!("expected legal case");
+    };
+    let Some(WorkRelation::Embedded(original)) = case_ref.original.as_ref() else {
+        panic!("expected embedded original");
+    };
+    let InputReference::Monograph(original_book) = original.as_ref() else {
+        panic!("expected original relation to normalize to a monograph");
+    };
+    assert_eq!(
+        original_book
+            .publisher
+            .as_ref()
+            .and_then(|publisher| publisher.place.clone()),
+        Some("Boston".to_string())
+    );
+}

--- a/crates/citum-schema-data/src/reference/types/legal.rs
+++ b/crates/citum-schema-data/src/reference/types/legal.rs
@@ -1,6 +1,7 @@
 //! Legal document types: cases, statutes, treaties, hearings, regulations, and briefs.
 
 use super::common::{FieldLanguageMap, LangID, RefID, Title};
+use crate::reference::WorkRelation;
 use crate::reference::contributor::Contributor;
 use crate::reference::date::EdtfString;
 #[cfg(feature = "schema")]
@@ -24,6 +25,9 @@ pub struct LegalCase {
     /// Case name (e.g., "Brown v. Board of Education")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this case record derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Court or authority (e.g., "U.S. Supreme Court")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority: Option<String>,
@@ -81,6 +85,9 @@ pub struct Statute {
     /// Statute name (e.g., "Civil Rights Act of 1964")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this statute derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Legislative body (e.g., "U.S. Congress")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority: Option<String>,
@@ -144,6 +151,9 @@ pub struct Treaty {
     /// Treaty name (e.g., "Treaty of Versailles")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this treaty derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Parties to the treaty
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<Contributor>,
@@ -198,6 +208,9 @@ pub struct Hearing {
     /// Hearing title
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this hearing record derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Legislative body conducting the hearing (e.g., "U.S. Senate Committee on Finance")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority: Option<String>,
@@ -246,6 +259,9 @@ pub struct Regulation {
     /// Regulation title
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this regulation derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Regulatory authority (e.g., "EPA", "Federal Register")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority: Option<String>,
@@ -300,6 +316,9 @@ pub struct Brief {
     /// Brief title or case name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this brief derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Court (e.g., "U.S. Supreme Court")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority: Option<String>,

--- a/crates/citum-schema-data/src/reference/types/specialized.rs
+++ b/crates/citum-schema-data/src/reference/types/specialized.rs
@@ -33,6 +33,9 @@ pub struct Event {
     /// Recurring event series (e.g., annual conference series).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub series: Option<WorkRelation>,
+    /// Original work or publication from which this event derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Event location (city, venue).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<String>,
@@ -86,6 +89,9 @@ pub struct Classic {
     /// The primary container for this work.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container: Option<WorkRelation>,
+    /// Original work or publication from which this edition derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Author (e.g., "Aristotle")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<Contributor>,
@@ -152,6 +158,7 @@ struct ClassicDeser {
     id: Option<RefID>,
     title: Option<Title>,
     container: Option<WorkRelation>,
+    original: Option<WorkRelation>,
     author: Option<Contributor>,
     editor: Option<Contributor>,
     translator: Option<Contributor>,
@@ -189,6 +196,7 @@ impl From<ClassicDeser> for Classic {
             id: raw.id,
             title: raw.title,
             container: raw.container,
+            original: raw.original,
             author: raw.author,
             editor: raw.editor,
             translator: raw.translator,
@@ -259,6 +267,9 @@ pub struct Patent {
     /// Assignee (patent holder)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assignee: Option<Contributor>,
+    /// Original work or publication from which this patent derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Patent number (e.g., "U.S. Patent No. 7,347,809")
     pub patent_number: String,
     /// Application number
@@ -319,6 +330,9 @@ pub struct Dataset {
     /// Dataset author(s)/creator(s)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<Contributor>,
+    /// Original work or publication from which this dataset derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Creation or origination date of the dataset.
     #[cfg_attr(feature = "bindings", specta(type = String))]
     #[serde(default, skip_serializing_if = "EdtfString::is_empty")]
@@ -380,6 +394,9 @@ pub struct Standard {
     /// Standard title
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this standard derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Standards organization (e.g., "ISO", "ANSI", "IEEE")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authority: Option<String>,
@@ -434,6 +451,9 @@ pub struct Software {
     /// Software title
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
+    /// Original work or publication from which this software derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// Author(s)/developer(s)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<Contributor>,
@@ -511,6 +531,9 @@ pub struct WorkCore {
     #[cfg_attr(feature = "bindings", specta(type = String))]
     #[serde(default, skip_serializing_if = "EdtfString::is_empty")]
     pub issued: EdtfString,
+    /// Original work or publication from which this work derives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub original: Option<WorkRelation>,
     /// BCP 47 language of the work.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<LangID>,
@@ -606,6 +629,7 @@ struct AudioVisualDeser {
     #[cfg_attr(feature = "bindings", specta(type = String))]
     #[serde(default)]
     issued: EdtfString,
+    original: Option<WorkRelation>,
     language: Option<LangID>,
     genre: Option<String>,
     // AudioVisualWork-specific fields
@@ -653,6 +677,7 @@ impl From<AudioVisualDeser> for AudioVisualWork {
                 contributors: raw.contributors,
                 created: raw.created,
                 issued: raw.issued,
+                original: raw.original,
                 language: raw.language,
                 genre: raw.genre,
             },

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -81,7 +81,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.32.0";
+pub const STYLE_SCHEMA_VERSION: &str = "0.32.1";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,9 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.32.1 (2026-04-17)
+- Schema version bumped from 0.32.0 to 0.32.1
+
 #### schema-v0.32.0 (2026-04-14)
 - Add `grouped` field to `Citation` for cite-site dynamic compound grouping
 

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -249,6 +249,16 @@
             "$ref": "#/$defs/Numbering"
           }
         },
+        "original": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "platform": {
           "type": [
             "string",
@@ -388,6 +398,17 @@
             "null"
           ]
         },
+        "original": {
+          "description": "Original work or publication from which this brief derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "title": {
           "description": "Brief title or case name",
           "anyOf": [
@@ -525,6 +546,16 @@
           "items": {
             "$ref": "#/$defs/Numbering"
           }
+        },
+        "original": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "publisher": {
           "anyOf": [
@@ -1165,6 +1196,17 @@
             "null"
           ]
         },
+        "original": {
+          "description": "Original work or publication from which this dataset derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "publisher": {
           "description": "Publisher or repository (e.g., \"Zenodo\", \"Dryad\")",
           "anyOf": [
@@ -1359,6 +1401,17 @@
             "null"
           ]
         },
+        "original": {
+          "description": "Original work or publication from which this event derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "series": {
           "description": "Recurring event series (e.g., annual conference series).",
           "anyOf": [
@@ -1465,6 +1518,17 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "original": {
+          "description": "Original work or publication from which this hearing record derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "session-number": {
@@ -1857,6 +1921,17 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "original": {
+          "description": "Original work or publication from which this case record derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "page": {
@@ -2516,6 +2591,17 @@
             "null"
           ]
         },
+        "original": {
+          "description": "Original work or publication from which this patent derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "patent-number": {
           "description": "Patent number (e.g., \"U.S. Patent No. 7,347,809\")",
           "type": "string"
@@ -2660,6 +2746,17 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "original": {
+          "description": "Original work or publication from which this regulation derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "section": {
@@ -3239,6 +3336,17 @@
             "null"
           ]
         },
+        "original": {
+          "description": "Original work or publication from which this software derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "platform": {
           "description": "Platform (e.g., \"Windows\", \"macOS\", \"Linux\", \"cross-platform\")",
           "type": [
@@ -3366,6 +3474,17 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "original": {
+          "description": "Original work or publication from which this standard derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "publisher": {
@@ -3509,6 +3628,17 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "original": {
+          "description": "Original work or publication from which this statute derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "page": {
@@ -3771,6 +3901,17 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "original": {
+          "description": "Original work or publication from which this treaty derives.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkRelation"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "page": {

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -77,7 +77,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.32.0"
+      "default": "0.32.1"
     }
   },
   "additionalProperties": false,

--- a/docs/specs/ORIGINAL_PUBLICATION_RELATION_SUPPORT.md
+++ b/docs/specs/ORIGINAL_PUBLICATION_RELATION_SUPPORT.md
@@ -1,0 +1,68 @@
+# Original Publication Relation Support Specification
+
+**Status:** Draft
+**Date:** 2026-04-17
+**Related:** csl26-1nsh
+
+## Purpose
+Support the rendering of "original" publication metadata (original date, title, publisher) across all citeable Citum work/reference types. Currently, the `original` relation is only available on a subset of types (`Monograph`, `CollectionComponent`, `SerialComponent`), which causes data loss during CSL-JSON migration for other types (e.g., `Patent`, `Event`) and prevents correct rendering of the `original-date` variable in styles like Chicago 18th.
+
+## Scope
+In scope:
+- Adding `original` field to all remaining citeable `InputReference` variants that represent works or documents.
+- Updating accessors to handle all variants.
+- Updating legacy CSL-JSON conversion to populate the new field.
+
+Out of scope:
+- Adding `original` to pure container records (`Collection`, `Serial`). These represent aggregating publications rather than citeable works in the current model, and this feature does not require modeling an "original collection" or "original serial" relation.
+- Resolving `WorkRelation::Id` at the engine level for non-bibliographic contexts.
+- Adding other relations (like `reviewed`) to more types.
+
+## Design
+
+### 1. Schema Expansion
+The `original` field of type `Option<WorkRelation>` will be added to all citeable `InputReference` variants that currently lack it. This ensures that any work-like bibliographic item can track its original version while leaving pure container records unchanged.
+
+- **Files**: `crates/citum-schema-data/src/reference/types/specialized.rs`, `crates/citum-schema-data/src/reference/types/legal.rs`
+- **Impacted Structs**:
+    - `Patent`, `Classic`, `Dataset`, `Standard`, `Software`, `Event`
+    - `WorkCore` (covers `AudioVisualWork`)
+    - `LegalCase`, `Statute`, `Treaty`, `Hearing`, `Regulation`, `Brief`
+- **Explicit non-goals**:
+    - `Collection`
+    - `Serial`
+
+### 2. Robust Accessors
+The accessor methods in `InputReference` will be updated to match all variants.
+
+- **Files**: `crates/citum-schema-data/src/reference/mod.rs`
+- **Methods**: `original_date()`, `original_title()`, `original_publisher_str()`, `original_publisher_place()`.
+- **Logic Change**: In `original_date()`, the embedded reference's date will be fetched via `p.csl_issued_date()` instead of `p.issued()`. This ensures that if the original work only has a `created` date (common for unpublished works or archival items), it is correctly picked up as the "original date".
+
+### 3. Legacy CSL-JSON Migration
+The CSL-JSON to Citum conversion logic will be updated to read `original-title` from the structured `csl_legacy::csl_json::Reference.original_title` field and extract the remaining legacy `original-*` data (`original-author`, `original-date`, `original-publisher`, `original-publisher-place`) from the `extra` map, then populate the `original` struct.
+
+- **Files**: `crates/citum-schema-data/src/reference/conversion.rs`
+- **Entry points**: extend the specialized and legal conversion paths that currently return work/document variants without `original` support. In practice this means `from_patent_ref`, `from_dataset_ref`, `from_standard_ref`, `from_event_ref`, the legal converters (`from_legal_case_ref`, `from_statute_ref`, `from_regulation_ref`, `from_treaty_ref`, `from_document_ref` for `Brief`/`Hearing`), and the shared monograph-style path already used by `Software`.
+- **Normalization rule**: v1 intentionally normalizes migrated `original-*` metadata into an embedded `Monograph` via `relation_monograph`, even when the citing item is a patent, event, legal item, or audio-visual work.
+- **Preserved fields**: the normalized embedded original preserves only the fields expressible by legacy CSL `original-*` data in current inputs: `title`, `author`, `issued`/effective original date, `publisher`, and `publisher-place`.
+- **Out of scope for v1**: preserving the source subtype of the original work, modeling type-specific original-only fields, or guaranteeing round-tripping back to the same non-monograph subtype.
+
+## Benefits
+- **Full CSL Compatibility**: Resolves failures in benchmarks where `original-date` was previously ignored for non-book types.
+- **Architectural Consistency**: Adheres to the Citum philosophy that `original` is a semantic relation to another work, not just a set of flat strings.
+- **Improved Data Fidelity**: Captures reprints and original versions for all types of materials, improving Chicago and APA style accuracy.
+
+## Risks & Considerations
+- **Memory Usage**: Adding `Option<WorkRelation>` to more structs increases the memory footprint of the `InputReference` enum. Unlike `Option<Box<T>>`, `Option<WorkRelation>` is larger because `WorkRelation` has an `Id(RefID)` variant where `RefID` wraps a `String`. However, given that these fields are essential for CSL fidelity and usually `None`, the impact is considered acceptable for the required feature parity.
+- **ID Resolution**: If `original` uses `WorkRelation::Id`, resolution currently happens at the engine level. The `original_date` accessor on `InputReference` returns `None` for IDs. This is acceptable as most legacy data from Zotero/CSL-JSON is migrated as `Embedded`.
+
+## Acceptance Criteria
+- [ ] `original` field is present in every citeable work/document `InputReference` variant except the out-of-scope pure container records `Collection` and `Serial`.
+- [ ] `InputReference::original_date()` returns the correct date for all reference types when an `original` work is embedded.
+- [ ] Legacy conversion populates `original` for representative non-structural types including `Patent`, `Event`, and one legal/document path.
+- [ ] The spec and implementation treat migrated `original-*` metadata as a deliberately normalized embedded `Monograph` relation in v1.
+- [ ] Chicago Author-Date 18th benchmark shows improvement in `original-date` rendering cases.
+
+## Changelog
+- 2026-04-17: Initial version.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -57,3 +57,4 @@ to make sure the document should be a spec rather than architecture or policy.
 | [`ARCHIVAL_UNPUBLISHED_SUPPORT.md`](./ARCHIVAL_UNPUBLISHED_SUPPORT.md) | ArchiveInfo/EprintInfo structs; Preprint type; archive_location semantic fix |
 | [`EDTF_HISTORICAL_ERA_RENDERING.md`](./EDTF_HISTORICAL_ERA_RENDERING.md) | Locale-backed rendering of valid historical EDTF years |
 | [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md) | ICU MF1 parameterized message system replacing flat YAML term files |
+| [`ORIGINAL_PUBLICATION_RELATION_SUPPORT.md`](./ORIGINAL_PUBLICATION_RELATION_SUPPORT.md) | Universal original publication metadata support across all types |


### PR DESCRIPTION
Draft a specification to expand the original WorkRelation field to all InputReference variants. This ensures original-date and other original publication metadata are correctly captured and rendered across all types, resolving gaps identified in Chicago 18th benchmarks.