### PR TITLE
fix(migrate): map name-as-sort-order to name_order in template compiler

### DIFF
--- a/.beans/archive/csl26-no8w--fixmigrate-map-name-as-sort-order-to-name-order-in.md
+++ b/.beans/archive/csl26-no8w--fixmigrate-map-name-as-sort-order-to-name-order-in.md
@@ -1,0 +1,19 @@
+---
+# csl26-no8w
+title: 'fix(migrate): map name-as-sort-order to name-order in template'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-04-17T18:24:28Z
+updated_at: 2026-04-17T18:31:29Z
+---
+
+The compile_names() function in node_compiler.rs always sets name_order: None, ignoring the name-as-sort-order attribute from CSL. This causes bibliography entries to use given-first name order instead of family-first. Fix: map NameAsSortOrder::First → FamilyFirstOnly, NameAsSortOrder::All → FamilyFirst.
+
+## Summary of Changes
+
+Identified that compile_names() in node_compiler.rs (template_compiler crate) always set name_order: None, ignoring name-as-sort-order from the CSL <name> element.
+
+Fix: map NameAsSortOrder::First → NameOrder::FamilyFirstOnly, NameAsSortOrder::All → NameOrder::FamilyFirst.
+
+Evidence: chicago-author-date --force-migrate reduced contributors:value_mismatch from 8 to 1. 2584 CSL styles use name-as-sort-order. All 1053 tests pass; core quality gate passes (147 styles at 1.0 fidelity).

--- a/.beans/csl26-0ijb--apa-bib-engine-level-rendering-gaps.md
+++ b/.beans/csl26-0ijb--apa-bib-engine-level-rendering-gaps.md
@@ -1,0 +1,51 @@
+---
+# csl26-0ijb
+title: APA bib engine-level rendering gaps
+status: todo
+type: bug
+priority: normal
+created_at: 2026-04-17T18:40:49Z
+updated_at: 2026-04-17T18:40:49Z
+---
+
+## Context
+
+Surfaced during `/migrate-research` cycle on 2026-04-17 after PR #532 fixed
+`name-as-sort-order` mapping in the converter. Running
+`node scripts/oracle.js styles-legacy/apa.csl --force-migrate` still shows
+16/34 bibliography entries passing. The remaining 18 failures are
+engine-level (processor-defect), not converter issues.
+
+## Failure patterns
+
+1. **Spurious `in.` / `in` token** between components (15+ entries) —
+   appears where no container/parent-serial is rendered but an "in" connector
+   leaks into output.
+2. **Missing titles** — migrated YAML contains correct `title` components
+   (`/tmp/apa-fresh.yaml` has 65 title declarations across types), but engine
+   omits them from bibliography output for many types.
+3. **"personal communication" leaks** into unrelated types (chapter, video
+   interview — entries 30, 31).
+4. **Missing translator parenthetical** `(D. Wyllie, Trans.)` (entry 17 Kafka).
+5. **Container-author rendering** broken — "Container-authorS. Colbert
+   (Interviewer)" (entry 31).
+
+## Evidence
+
+- Fresh migration YAML `/tmp/apa-fresh.yaml` declares titles and translator
+  components correctly.
+- Oracle diff entries 17–34 show the patterns above; converter output is
+  structurally correct, rendering is wrong.
+
+## Scope
+
+Engine-level investigation in `crates/citum-engine/`. Not a converter task.
+Likely overlaps with known `in.` prefix bug already in session memory.
+
+## Todo
+
+- [ ] Reproduce entry 17 (Kafka translator) in engine unit test
+- [ ] Identify source of spurious `in` token
+- [ ] Audit title rendering path for APA bibliography templates
+- [ ] Trace personal-communication leak into non-personal-comm types
+- [ ] Verify container-author rendering for video-interview type

--- a/crates/citum-migrate/src/template_compiler/node_compiler.rs
+++ b/crates/citum-migrate/src/template_compiler/node_compiler.rs
@@ -93,10 +93,20 @@ impl TemplateCompiler {
             rendering.strip_periods = label.formatting.strip_periods.or(rendering.strip_periods);
         }
 
+        let name_order = match &names.options.name_as_sort_order {
+            Some(citum_schema::NameAsSortOrder::First) => {
+                Some(citum_schema::template::NameOrder::FamilyFirstOnly)
+            }
+            Some(citum_schema::NameAsSortOrder::All) => {
+                Some(citum_schema::template::NameOrder::FamilyFirst)
+            }
+            None => None,
+        };
+
         Some(TemplateComponent::Contributor(TemplateContributor {
             contributor: role,
             form,
-            name_order: None, // Use global setting by default
+            name_order,
             delimiter: names.options.delimiter.clone(),
             sort_separator: names.options.sort_separator.clone(),
             shorten,


### PR DESCRIPTION
## Summary

- `compile_names()` in `template_compiler/node_compiler.rs` always set `name_order: None`, ignoring `name-as-sort-order` from CSL `<name>` elements
- This caused bibliography entries to render author names given-first instead of family-first for ~2,584 styles that use `name-as-sort-order`
- Fix: map `NameAsSortOrder::First` → `FamilyFirstOnly` and `NameAsSortOrder::All` → `FamilyFirst` when compiling `NamesBlock` to `TemplateContributor`

## Evidence

- `chicago-author-date --force-migrate`: `contributors:value_mismatch` dropped from 8 to 1
- 1053 tests pass; core quality gate unchanged (147 styles at fidelity 1.0)

## Test plan

- [ ] `cargo nextest run` — 1053/1053 pass
- [ ] `node scripts/oracle.js styles-legacy/chicago-author-date.csl --force-migrate` — verify contributors:value_mismatch is 1 (was 8)
- [ ] Core quality gate: `node scripts/report-core.js > /tmp/r.json && node scripts/check-core-quality.js --report /tmp/r.json --baseline scripts/report-data/core-quality-baseline.json`
