### PR TITLE
fix(engine): suppress affixes when value empty

### DIFF
--- a/.beans/archive/csl26-0ijb--apa-bib-engine-level-rendering-gaps.md
+++ b/.beans/archive/csl26-0ijb--apa-bib-engine-level-rendering-gaps.md
@@ -1,11 +1,13 @@
 ---
 # csl26-0ijb
 title: APA bib engine-level rendering gaps
-status: todo
+status: completed
 type: bug
 priority: normal
 created_at: 2026-04-17T18:40:49Z
-updated_at: 2026-04-17T18:40:49Z
+updated_at: 2026-04-17T23:25:27Z
+blocking:
+    - csl26-1t2s
 ---
 
 ## Context
@@ -49,3 +51,22 @@ Likely overlaps with known `in.` prefix bug already in session memory.
 - [ ] Audit title rendering path for APA bibliography templates
 - [ ] Trace personal-communication leak into non-personal-comm types
 - [ ] Verify container-author rendering for video-interview type
+
+## Summary of Changes
+
+Triage revealed the failures are converter defects, not engine bugs:
+
+- Engine scores **32/32 bibliography** and **18/18 citations** against `styles/embedded/apa-7th.yaml` — 100% fidelity.
+- Fresh `citum-migrate styles-legacy/apa.csl` output renders the same fixture at 16/34.
+- Direct test: Kafka (ITEM-25) renders correctly against embedded YAML (`Kafka, F. (1915). _Metamorphosis_ (D. Wyllie, Trans.). Kurt Wolff Verlag.`) and wrong against fresh-migrated YAML.
+
+Scope re-directed to converter bean **csl26-1t2s** (citum-migrate: APA converter produces broken bibliography template).
+
+### Defensive engine hardening landed
+
+Per user directive "affixes always need to be suppressed when there's otherwise no generated content", tightened the empty-value guard in `render_template_component_with_format` and group children: value is now checked via `.trim().is_empty()` so whitespace-only renders drop the component (and its affixes) instead of leaking a bare prefix/suffix.
+
+Files changed:
+- `crates/citum-engine/src/processor/rendering/grouped/core.rs` — component guard and group-child guard
+
+Gate: `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo nextest run` (1053/1053 passed). APA oracle and core quality gate unchanged (147 styles, fidelity 1.0).

--- a/.beans/csl26-1t2s--citum-migrate-apa-converter-produces-broken-biblio.md
+++ b/.beans/csl26-1t2s--citum-migrate-apa-converter-produces-broken-biblio.md
@@ -1,0 +1,40 @@
+---
+# csl26-1t2s
+title: 'citum-migrate: APA converter produces broken bibliography template'
+status: todo
+type: bug
+priority: normal
+created_at: 2026-04-17T23:25:08Z
+updated_at: 2026-04-17T23:25:08Z
+---
+
+Surfaced during csl26-0ijb triage (2026-04-17). Engine renders APA at 32/32 against embedded `styles/embedded/apa-7th.yaml`, but fresh `citum-migrate styles-legacy/apa.csl` output only scores 16/34.
+
+## Evidence
+
+- `node scripts/oracle.js styles-legacy/apa.csl` → 32/32 (embedded YAML)
+- `node scripts/oracle.js styles-legacy/apa.csl --force-migrate` → 16/34
+- Direct render of ITEM-25 (Kafka) against embedded YAML: correct
+- Same fixture against fresh-migrated YAML: `Kafka, F. 1915. in. Kurt Wolff Verlag` — no title, no parentheses on year, no translator, stray `in.`
+
+## Converter defects (observed in fresh `/tmp/apa-fresh.yaml`)
+
+1. Bibliography template uses heavy `suppress: true` branches with inferred groups (XML-shape retention) instead of declarative components.
+2. Date `wrap: parentheses` lost on `date: issued` — year renders bare.
+3. Primary title emitted with `suppress: true` at top then re-emitted inside a group — engine dedupe drops it.
+4. Translator parenthetical role+wrap not preserved from `<names variable=\"translator\">`.
+5. Bare top-level `term: in` / `term: at` components emitted without enclosing group — they render in isolation.
+6. Missing type-variants for `book`, `thesis`, `report` etc.; default template shape too weak.
+
+## Scope
+
+`crates/citum-migrate/` — inference and hand-template selection pipeline. Engine side is correct (100% fidelity on embedded YAML; defensive empty-affix suppression landed in csl26-0ijb branch).
+
+## Todo
+
+- [ ] Reproduce fresh-migration bibliography for APA against expanded fixture
+- [ ] Trace loss of date `wrap: parentheses` through migrator
+- [ ] Trace loss of translator `wrap: parentheses` + role label
+- [ ] Audit bare top-level `term:` emission — groups or suppress
+- [ ] Fix primary-title double-emit producing silent dedupe
+- [ ] Generate type-variants for `book`/`thesis`/`report` so default template isn't universal

--- a/.beans/csl26-1t2s--citum-migrate-apa-converter-produces-broken-biblio.md
+++ b/.beans/csl26-1t2s--citum-migrate-apa-converter-produces-broken-biblio.md
@@ -22,7 +22,7 @@ Surfaced during csl26-0ijb triage (2026-04-17). Engine renders APA at 32/32 agai
 1. Bibliography template uses heavy `suppress: true` branches with inferred groups (XML-shape retention) instead of declarative components.
 2. Date `wrap: parentheses` lost on `date: issued` — year renders bare.
 3. Primary title emitted with `suppress: true` at top then re-emitted inside a group — engine dedupe drops it.
-4. Translator parenthetical role+wrap not preserved from `<names variable=\"translator\">`.
+4. Translator parenthetical role+wrap not preserved from `<names variable="translator">`.
 5. Bare top-level `term: in` / `term: at` components emitted without enclosing group — they render in isolation.
 6. Missing type-variants for `book`, `thesis`, `report` etc.; default template shape too weak.
 

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1218,7 +1218,10 @@ impl Renderer<'_> {
         }
 
         let mut values = resolved_component.values::<F>(reference, hint, options)?;
-        if values.value.is_empty() {
+        // Suppress affixes when a component resolves to no meaningful content.
+        // A whitespace-only value carries no data, so its prefix/suffix must
+        // not leak into output (e.g. a ". In " prefix on an empty editor list).
+        if values.value.trim().is_empty() {
             return None;
         }
         self.apply_issued_no_date_fallback(reference, options, resolved_component, &mut values);
@@ -1287,7 +1290,7 @@ impl Renderer<'_> {
                 &fmt,
                 options.show_semantics,
             );
-            if rendered_str.is_empty() {
+            if rendered_str.trim().is_empty() {
                 continue;
             }
             if !is_term_only_component(item) {


### PR DESCRIPTION
## Summary

Completes bean csl26-0ijb. Triage showed the "APA bib engine-level rendering gaps" are actually converter defects, not engine bugs — APA renders at **32/32 bibliography** / **18/18 citations** against the embedded `styles/embedded/apa-7th.yaml`. The 16/34 figure from `--force-migrate` traces to `citum-migrate` output, and is now tracked in follow-up bean **csl26-1t2s**.

Per the user directive that *"affixes always need to be suppressed when there's otherwise no generated content"*, this PR also hardens the engine's empty-value guard:

- `render_template_component_with_format`: switch `value.is_empty()` → `value.trim().is_empty()` so whitespace-only renders drop the component (and its prefix/suffix) instead of leaking a bare affix.
- Group-child filter: same tightening, so connective punctuation cannot survive suppression of its data.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 1053/1053 passed
- [x] `node scripts/oracle.js styles-legacy/apa.csl` — 32/32 bib, 18/18 cites (unchanged)
- [x] Core quality gate — 147 styles, fidelity 1.0; only pre-existing ieee concision advisory

Refs: csl26-0ijb, csl26-1t2s
