### PR TITLE
ci: automate docs deployment and fix 404

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,6 +1,8 @@
 name: Deploy Documentation
 
 on:
+  push:
+    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       refresh_compat:

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ bindings/latex/libcitum_processor.dylib
 __pycache__/
 *.pyc
 scripts/x-bench.js
+docs/guides/style-author-guide.html


### PR DESCRIPTION
This PR fixes the 404 error by automating the documentation deployment whenever changes are pushed to main. It also ensures the generated HTML file is ignored by git.