### PR TITLE
ci: fix setup-node for docs build

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -59,7 +59,6 @@ jobs:
           tool: cargo-nextest
 
       - name: Set up Node
-        if: ${{ inputs.refresh_compat }}
         uses: actions/setup-node@v4
         with:
           node-version: "22"


### PR DESCRIPTION
This PR removes the conditional on the  step in the deployment workflow. Without this, the  and  steps were failing when  was false (the default), leading to the 404 error on the published site.