### PR TITLE
feat(locale): add gender-aware term resolution

### DIFF
--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -1158,7 +1158,7 @@ fn lint_style_against_locale(style: &Style, locale: &Locale) -> LintReport {
     for requirement in requirements {
         match requirement.kind {
             LocaleRequirementKind::General { term, form } => {
-                if locale.resolved_general_term(&term, form).is_none() {
+                if locale.resolved_general_term(&term, form, None).is_none() {
                     report.warning(
                         requirement.path,
                         format!(
@@ -1168,8 +1168,8 @@ fn lint_style_against_locale(style: &Style, locale: &Locale) -> LintReport {
                 }
             }
             LocaleRequirementKind::Role { role, form } => {
-                let singular = locale.resolved_role_term(&role, false, form);
-                let plural = locale.resolved_role_term(&role, true, form);
+                let singular = locale.resolved_role_term(&role, false, form, None);
+                let plural = locale.resolved_role_term(&role, true, form, None);
                 if singular.is_none() || plural.is_none() {
                     report.warning(
                         requirement.path,
@@ -1223,12 +1223,12 @@ fn lint_locator_term(
             })
             .map(|forms| {
                 if plural {
-                    forms.plural.clone()
+                    forms.plural.as_str().to_string()
                 } else {
-                    forms.singular.clone()
+                    forms.singular.as_str().to_string()
                 }
             }),
-        _ => locale.resolved_locator_term(locator, plural, form),
+        _ => locale.resolved_locator_term(locator, plural, form, None),
     }
 }
 

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -22,9 +22,11 @@ impl Processor {
     pub(super) fn resolve_group_heading(&self, heading: &GroupHeading) -> Option<String> {
         match heading {
             GroupHeading::Literal { literal } => Some(literal.clone()),
-            GroupHeading::Term { term, form } => self
-                .locale
-                .resolved_general_term(term, form.unwrap_or(citum_schema::locale::TermForm::Long)),
+            GroupHeading::Term { term, form } => self.locale.resolved_general_term(
+                term,
+                form.unwrap_or(citum_schema::locale::TermForm::Long),
+                None,
+            ),
             GroupHeading::Localized { localized } => self.resolve_localized_heading(localized),
         }
     }

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -25,13 +25,13 @@ fn join_integral_groups(rendered_groups: Vec<String>, locale: &Locale) -> String
         1 => rendered_groups.into_iter().next().unwrap_or_default(),
         2 => {
             let conjunction = locale
-                .resolved_general_term(&GeneralTerm::And, TermForm::Long)
+                .resolved_general_term(&GeneralTerm::And, TermForm::Long, None)
                 .unwrap_or_else(|| locale.and_term(false).to_string());
             rendered_groups.join(&format!(" {} ", conjunction.trim()))
         }
         _ => {
             let conjunction = locale
-                .resolved_general_term(&GeneralTerm::And, TermForm::Long)
+                .resolved_general_term(&GeneralTerm::And, TermForm::Long, None)
                 .unwrap_or_else(|| locale.and_term(false).to_string());
             let final_delimiter = if locale.grammar_options.serial_comma {
                 format!(", {} ", conjunction.trim())

--- a/crates/citum-engine/src/processor/document/notes.rs
+++ b/crates/citum-engine/src/processor/document/notes.rs
@@ -378,6 +378,7 @@ impl Processor {
                 self.locale.resolved_general_term(
                     &citum_schema::locale::GeneralTerm::Ibid,
                     citum_schema::locale::TermForm::Long,
+                    None,
                 )
             })
             .unwrap_or_else(|| "ibid.".to_string());

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -118,6 +118,7 @@ fn make_note_style() -> Style {
                 template: Some(vec![TemplateComponent::Term(TemplateTerm {
                     term: citum_schema::locale::GeneralTerm::Ibid,
                     form: None,
+                    gender: None,
                     rendering: Rendering::default(),
                     custom: None,
                 })]),

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1342,6 +1342,7 @@ impl Renderer<'_> {
         if let Some(long) = options.locale.resolved_general_term(
             &citum_schema::locale::GeneralTerm::NoDate,
             citum_schema::locale::TermForm::Long,
+            None,
         ) {
             values.value = long;
         }

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -266,6 +266,7 @@ fn test_strip_author_component_nested_list() {
                 delimiter: None,
                 sort_separator: None,
                 links: None,
+                gender: None,
                 rendering: Rendering::default(),
                 custom: None,
             }),

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -1,16 +1,65 @@
 //! Role-label resolution for contributor rendering.
 
+use crate::reference::Reference;
 use crate::render::format::OutputFormat;
 use crate::values::RenderOptions;
-use citum_schema::locale::TermForm;
+use citum_schema::locale::{GrammaticalGender, TermForm};
 use citum_schema::options::RoleLabelPreset;
+use citum_schema::reference::ContributorGender;
 use citum_schema::template::{ContributorForm, ContributorRole, Rendering, TemplateContributor};
+
+fn map_contributor_gender(gender: ContributorGender) -> GrammaticalGender {
+    match gender {
+        ContributorGender::Masculine => GrammaticalGender::Masculine,
+        ContributorGender::Feminine => GrammaticalGender::Feminine,
+        ContributorGender::Neuter => GrammaticalGender::Neuter,
+        ContributorGender::Common => GrammaticalGender::Common,
+    }
+}
+
+fn requested_role_gender(
+    component: &TemplateContributor,
+    reference: &Reference,
+) -> Option<GrammaticalGender> {
+    if let Some(gender) = component.gender {
+        return Some(gender);
+    }
+
+    let data_role = match component.contributor {
+        ContributorRole::Author => citum_schema::reference::ContributorRole::Author,
+        ContributorRole::Editor => citum_schema::reference::ContributorRole::Editor,
+        ContributorRole::Translator => citum_schema::reference::ContributorRole::Translator,
+        ContributorRole::Director => citum_schema::reference::ContributorRole::Director,
+        ContributorRole::Composer => citum_schema::reference::ContributorRole::Composer,
+        ContributorRole::Illustrator => citum_schema::reference::ContributorRole::Illustrator,
+        ContributorRole::Recipient => citum_schema::reference::ContributorRole::Recipient,
+        ContributorRole::Interviewer => citum_schema::reference::ContributorRole::Interviewer,
+        ContributorRole::Guest => citum_schema::reference::ContributorRole::Guest,
+        ContributorRole::Chair => {
+            citum_schema::reference::ContributorRole::Custom("chair".to_string())
+        }
+        _ => return None,
+    };
+
+    let entries = reference.contributor_entries(&data_role);
+    let mut genders = entries
+        .iter()
+        .filter_map(|entry| entry.gender.map(map_contributor_gender));
+    let first = genders.next()?;
+
+    if genders.all(|gender| gender == first) {
+        Some(first)
+    } else {
+        Some(GrammaticalGender::Common)
+    }
+}
 
 /// Resolve a configured role-label preset to `(prefix, suffix)`.
 pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
     role: &ContributorRole,
     preset: RoleLabelPreset,
     names_count: usize,
+    requested_gender: Option<GrammaticalGender>,
     effective_rendering: &Rendering,
     options: &RenderOptions<'_>,
     fmt: &F,
@@ -21,7 +70,7 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
         RoleLabelPreset::VerbPrefix => {
             let term = options
                 .locale
-                .resolved_role_term(role, plural, TermForm::Verb);
+                .resolved_role_term(role, plural, TermForm::Verb, None);
             (
                 term.map(|t| {
                     super::format_role_term::<F>(&t, fmt, effective_rendering, options, "", " ")
@@ -32,7 +81,7 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
         RoleLabelPreset::VerbShortPrefix => {
             let term = options
                 .locale
-                .resolved_role_term(role, plural, TermForm::VerbShort);
+                .resolved_role_term(role, plural, TermForm::VerbShort, None);
             (
                 term.map(|t| {
                     super::format_role_term::<F>(&t, fmt, effective_rendering, options, "", " ")
@@ -41,9 +90,10 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
             )
         }
         RoleLabelPreset::ShortSuffix => {
-            let term = options
-                .locale
-                .resolved_role_term(role, plural, TermForm::Short);
+            let term =
+                options
+                    .locale
+                    .resolved_role_term(role, plural, TermForm::Short, requested_gender);
             (
                 None,
                 term.map(|t| {
@@ -52,9 +102,10 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
             )
         }
         RoleLabelPreset::LongSuffix => {
-            let term = options
-                .locale
-                .resolved_role_term(role, plural, TermForm::Long);
+            let term =
+                options
+                    .locale
+                    .resolved_role_term(role, plural, TermForm::Long, requested_gender);
             (
                 None,
                 term.map(|t| {
@@ -71,6 +122,7 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
 /// Precedence: explicit `label` config > configured role presets > form-based defaults.
 pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
     component: &TemplateContributor,
+    reference: &Reference,
     names_count: usize,
     effective_rendering: &Rendering,
     options: &RenderOptions<'_>,
@@ -93,7 +145,12 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
             _ => Some(component.contributor.clone()),
         };
 
-        let term_text = role.and_then(|r| options.locale.resolved_role_term(&r, plural, term_form));
+        let requested_gender = requested_role_gender(component, reference);
+        let term_text = role.and_then(|r| {
+            options
+                .locale
+                .resolved_role_term(&r, plural, term_form, requested_gender)
+        });
 
         return match label_config.placement {
             LabelPlacement::Prefix => (
@@ -121,10 +178,12 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
         .as_ref()
         .and_then(|contributors| contributors.effective_role_label_preset(&component.contributor))
     {
+        let requested_gender = requested_role_gender(component, reference);
         return resolve_role_label_preset(
             &component.contributor,
             preset,
             names_count,
+            requested_gender,
             effective_rendering,
             options,
             fmt,
@@ -139,7 +198,9 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
                 ContributorForm::VerbShort => TermForm::VerbShort,
                 _ => TermForm::Verb,
             };
-            let term = options.locale.resolved_role_term(role, plural, term_form);
+            let term = options
+                .locale
+                .resolved_role_term(role, plural, term_form, None);
             (
                 term.map(|t| {
                     super::format_role_term::<F>(&t, fmt, effective_rendering, options, "", " ")
@@ -158,10 +219,13 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
             | ContributorRole::Composer,
         ) => {
             let plural = names_count > 1;
-            let term =
-                options
-                    .locale
-                    .resolved_role_term(&component.contributor, plural, TermForm::Short);
+            let requested_gender = requested_role_gender(component, reference);
+            let term = options.locale.resolved_role_term(
+                &component.contributor,
+                plural,
+                TermForm::Short,
+                requested_gender,
+            );
             (
                 None,
                 term.map(|t| {

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -1,5 +1,6 @@
 //! Role-label resolution for contributor rendering.
 
+use super::contributor_role_to_reference_role;
 use crate::reference::Reference;
 use crate::render::format::OutputFormat;
 use crate::values::RenderOptions;
@@ -17,29 +18,21 @@ fn map_contributor_gender(gender: ContributorGender) -> GrammaticalGender {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) enum RoleGenderRequest {
+    Specific(GrammaticalGender),
+    NeutralOnly,
+}
+
 fn requested_role_gender(
     component: &TemplateContributor,
     reference: &Reference,
-) -> Option<GrammaticalGender> {
+) -> Option<RoleGenderRequest> {
     if let Some(gender) = component.gender {
-        return Some(gender);
+        return Some(RoleGenderRequest::Specific(gender));
     }
 
-    let data_role = match component.contributor {
-        ContributorRole::Author => citum_schema::reference::ContributorRole::Author,
-        ContributorRole::Editor => citum_schema::reference::ContributorRole::Editor,
-        ContributorRole::Translator => citum_schema::reference::ContributorRole::Translator,
-        ContributorRole::Director => citum_schema::reference::ContributorRole::Director,
-        ContributorRole::Composer => citum_schema::reference::ContributorRole::Composer,
-        ContributorRole::Illustrator => citum_schema::reference::ContributorRole::Illustrator,
-        ContributorRole::Recipient => citum_schema::reference::ContributorRole::Recipient,
-        ContributorRole::Interviewer => citum_schema::reference::ContributorRole::Interviewer,
-        ContributorRole::Guest => citum_schema::reference::ContributorRole::Guest,
-        ContributorRole::Chair => {
-            citum_schema::reference::ContributorRole::Custom("chair".to_string())
-        }
-        _ => return None,
-    };
+    let data_role = contributor_role_to_reference_role(&component.contributor)?;
 
     let entries = reference.contributor_entries(&data_role);
     let mut genders = entries
@@ -48,9 +41,27 @@ fn requested_role_gender(
     let first = genders.next()?;
 
     if genders.all(|gender| gender == first) {
-        Some(first)
+        Some(RoleGenderRequest::Specific(first))
     } else {
-        Some(GrammaticalGender::Common)
+        Some(RoleGenderRequest::NeutralOnly)
+    }
+}
+
+fn resolve_role_term_by_request(
+    locale: &citum_schema::locale::Locale,
+    role: &ContributorRole,
+    plural: bool,
+    term_form: TermForm,
+    requested_gender: Option<RoleGenderRequest>,
+) -> Option<String> {
+    match requested_gender {
+        Some(RoleGenderRequest::Specific(gender)) => {
+            locale.resolved_role_term(role, plural, term_form, Some(gender))
+        }
+        Some(RoleGenderRequest::NeutralOnly) => {
+            locale.resolved_role_term_neutral(role, plural, term_form)
+        }
+        None => locale.resolved_role_term(role, plural, term_form, None),
     }
 }
 
@@ -59,7 +70,7 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
     role: &ContributorRole,
     preset: RoleLabelPreset,
     names_count: usize,
-    requested_gender: Option<GrammaticalGender>,
+    requested_gender: Option<RoleGenderRequest>,
     effective_rendering: &Rendering,
     options: &RenderOptions<'_>,
     fmt: &F,
@@ -90,10 +101,13 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
             )
         }
         RoleLabelPreset::ShortSuffix => {
-            let term =
-                options
-                    .locale
-                    .resolved_role_term(role, plural, TermForm::Short, requested_gender);
+            let term = resolve_role_term_by_request(
+                options.locale,
+                role,
+                plural,
+                TermForm::Short,
+                requested_gender,
+            );
             (
                 None,
                 term.map(|t| {
@@ -102,10 +116,13 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
             )
         }
         RoleLabelPreset::LongSuffix => {
-            let term =
-                options
-                    .locale
-                    .resolved_role_term(role, plural, TermForm::Long, requested_gender);
+            let term = resolve_role_term_by_request(
+                options.locale,
+                role,
+                plural,
+                TermForm::Long,
+                requested_gender,
+            );
             (
                 None,
                 term.map(|t| {
@@ -147,9 +164,7 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
 
         let requested_gender = requested_role_gender(component, reference);
         let term_text = role.and_then(|r| {
-            options
-                .locale
-                .resolved_role_term(&r, plural, term_form, requested_gender)
+            resolve_role_term_by_request(options.locale, &r, plural, term_form, requested_gender)
         });
 
         return match label_config.placement {
@@ -220,7 +235,8 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
         ) => {
             let plural = names_count > 1;
             let requested_gender = requested_role_gender(component, reference);
-            let term = options.locale.resolved_role_term(
+            let term = resolve_role_term_by_request(
+                options.locale,
                 &component.contributor,
                 plural,
                 TermForm::Short,

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -16,6 +16,69 @@ use citum_schema::template::{ContributorForm, ContributorRole, TemplateContribut
 pub(crate) use names::{NameFormatContext, format_single_name};
 pub use names::{NamesOverrides, format_contributors_short, format_names};
 
+/// Resolve a contributor payload for a template contributor role.
+///
+/// This preserves the legacy `editor()` / `translator()` accessors for
+/// reference shapes that still store those roles outside the generic
+/// contributor-entry list.
+pub(super) fn contributor_for_role(
+    reference: &Reference,
+    role: &ContributorRole,
+) -> Option<citum_schema::reference::Contributor> {
+    match role {
+        ContributorRole::Author => reference.author(),
+        ContributorRole::Editor => reference.editor(),
+        ContributorRole::Translator => reference.translator(),
+        _ => contributor_role_to_reference_role(role).and_then(|role| reference.contributor(role)),
+    }
+}
+
+/// Map a template contributor role to the corresponding reference contributor role.
+pub(super) fn contributor_role_to_reference_role(
+    role: &ContributorRole,
+) -> Option<citum_schema::reference::ContributorRole> {
+    match role {
+        ContributorRole::Author => Some(citum_schema::reference::ContributorRole::Author),
+        ContributorRole::Editor => Some(citum_schema::reference::ContributorRole::Editor),
+        ContributorRole::Translator => Some(citum_schema::reference::ContributorRole::Translator),
+        ContributorRole::Recipient => Some(citum_schema::reference::ContributorRole::Recipient),
+        ContributorRole::Chair => Some(citum_schema::reference::ContributorRole::Custom(
+            "chair".to_string(),
+        )),
+        ContributorRole::Interviewer => Some(citum_schema::reference::ContributorRole::Interviewer),
+        ContributorRole::Guest => Some(citum_schema::reference::ContributorRole::Guest),
+        ContributorRole::Director => Some(citum_schema::reference::ContributorRole::Director),
+        ContributorRole::Composer => Some(citum_schema::reference::ContributorRole::Composer),
+        ContributorRole::Illustrator => Some(citum_schema::reference::ContributorRole::Illustrator),
+        ContributorRole::Inventor => Some(citum_schema::reference::ContributorRole::Custom(
+            "inventor".to_string(),
+        )),
+        ContributorRole::Counsel => Some(citum_schema::reference::ContributorRole::Custom(
+            "counsel".to_string(),
+        )),
+        ContributorRole::CollectionEditor => Some(
+            citum_schema::reference::ContributorRole::Custom("collection-editor".to_string()),
+        ),
+        ContributorRole::ContainerAuthor => Some(citum_schema::reference::ContributorRole::Custom(
+            "container-author".to_string(),
+        )),
+        ContributorRole::EditorialDirector => Some(
+            citum_schema::reference::ContributorRole::Custom("editorial-director".to_string()),
+        ),
+        ContributorRole::TextualEditor => Some(citum_schema::reference::ContributorRole::Custom(
+            "textual-editor".to_string(),
+        )),
+        ContributorRole::OriginalAuthor => Some(citum_schema::reference::ContributorRole::Custom(
+            "original-author".to_string(),
+        )),
+        ContributorRole::ReviewedAuthor => Some(citum_schema::reference::ContributorRole::Custom(
+            "reviewed-author".to_string(),
+        )),
+        ContributorRole::Interviewee | ContributorRole::Publisher => None,
+        _ => None,
+    }
+}
+
 /// Checks if a contributor role label should be omitted for a given reference.
 ///
 /// Returns true if the role appears in the configuration's role.omit list.
@@ -159,59 +222,10 @@ impl ComponentValues for TemplateContributor {
                 if options.suppress_author {
                     None
                 } else {
-                    reference.author()
+                    contributor_for_role(reference, &component.contributor)
                 }
             }
-            ContributorRole::Editor => reference.editor(),
-            ContributorRole::Translator => reference.translator(),
-            ContributorRole::Recipient => {
-                reference.contributor(citum_schema::reference::ContributorRole::Recipient)
-            }
-            ContributorRole::Chair => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("chair".to_string()),
-            ),
-            ContributorRole::Interviewer => {
-                reference.contributor(citum_schema::reference::ContributorRole::Interviewer)
-            }
-            ContributorRole::Guest => {
-                reference.contributor(citum_schema::reference::ContributorRole::Guest)
-            }
-            ContributorRole::Director => {
-                reference.contributor(citum_schema::reference::ContributorRole::Director)
-            }
-            ContributorRole::Composer => {
-                reference.contributor(citum_schema::reference::ContributorRole::Composer)
-            }
-            ContributorRole::Illustrator => {
-                reference.contributor(citum_schema::reference::ContributorRole::Illustrator)
-            }
-            ContributorRole::Interviewee => None, // Not a standard reference contributor role
-            ContributorRole::Publisher => None, // Publisher is a corporate entity, not a person contributor
-            ContributorRole::Inventor => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("inventor".to_string()),
-            ),
-            ContributorRole::Counsel => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("counsel".to_string()),
-            ),
-            ContributorRole::CollectionEditor => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("collection-editor".to_string()),
-            ),
-            ContributorRole::ContainerAuthor => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("container-author".to_string()),
-            ),
-            ContributorRole::EditorialDirector => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("editorial-director".to_string()),
-            ),
-            ContributorRole::TextualEditor => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("textual-editor".to_string()),
-            ),
-            ContributorRole::OriginalAuthor => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("original-author".to_string()),
-            ),
-            ContributorRole::ReviewedAuthor => reference.contributor(
-                citum_schema::reference::ContributorRole::Custom("reviewed-author".to_string()),
-            ),
-            _ => None, // Handle any future template contributor roles
+            _ => contributor_for_role(reference, &component.contributor),
         };
 
         // Resolve substitute config once for all substitute/suppression checks below.

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -280,6 +280,7 @@ impl ComponentValues for TemplateContributor {
         let role_omitted = is_role_label_omitted(options, &component.contributor);
         let (role_prefix, role_suffix) = labels::resolve_role_labels::<F>(
             &component,
+            reference,
             names_vec.len(),
             &effective_rendering,
             options,

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -235,6 +235,7 @@ fn resolve_substitute_role_labels<F: OutputFormat<Output = String>>(
                     known,
                     selected,
                     names_count,
+                    None,
                     effective_rendering,
                     options,
                     fmt,

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -673,9 +673,11 @@ impl ComponentValues for TemplateDate {
             }
             // For issued dates, substitute the locale's "no-date" term (e.g. "n.d.")
             if matches!(self.date, TemplateDateVar::Issued)
-                && let Some(nd) = options
-                    .locale
-                    .resolved_general_term(&GeneralTerm::NoDate, TermForm::Short)
+                && let Some(nd) = options.locale.resolved_general_term(
+                    &GeneralTerm::NoDate,
+                    TermForm::Short,
+                    None,
+                )
             {
                 return Some(ProcValues {
                     value: nd,

--- a/crates/citum-engine/src/values/locator.rs
+++ b/crates/citum-engine/src/values/locator.rs
@@ -180,7 +180,7 @@ fn render_segment_with_label_str(
         LabelForm::None => TermForm::Short, // Shouldn't reach here
     };
 
-    if let Some(term) = locale.resolved_locator_term(&seg.label, plural, term_form) {
+    if let Some(term) = locale.resolved_locator_term(&seg.label, plural, term_form, None) {
         let strip_periods = kind_cfg
             .and_then(|k| k.strip_label_periods)
             .or(global_strip)

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -5,7 +5,7 @@
 
 use crate::reference::Reference;
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
-use citum_schema::locale::TermForm;
+use citum_schema::locale::{GrammaticalGender, TermForm};
 use citum_schema::template::{NumberVariable, TemplateNumber};
 
 /// Resolve the raw value string for a number variable from a reference.
@@ -96,6 +96,7 @@ fn resolve_number_label<F: crate::render::format::OutputFormat<Output = String>>
     number: &NumberVariable,
     label_form: &citum_schema::template::LabelForm,
     value: &str,
+    requested_gender: Option<GrammaticalGender>,
     effective_rendering: &citum_schema::template::Rendering,
     options: &RenderOptions<'_>,
     fmt: &F,
@@ -112,7 +113,7 @@ fn resolve_number_label<F: crate::render::format::OutputFormat<Output = String>>
 
         options
             .locale
-            .resolved_locator_term(&locator_type, plural, term_form, None)
+            .resolved_locator_term(&locator_type, plural, term_form, requested_gender)
             .map(|t| {
                 let term_str = if crate::values::should_strip_periods(effective_rendering, options)
                 {
@@ -154,6 +155,7 @@ impl ComponentValues for TemplateNumber {
                     &self.number,
                     label_form,
                     &value,
+                    self.gender,
                     effective_rendering,
                     options,
                     &fmt,

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -112,7 +112,7 @@ fn resolve_number_label<F: crate::render::format::OutputFormat<Output = String>>
 
         options
             .locale
-            .resolved_locator_term(&locator_type, plural, term_form)
+            .resolved_locator_term(&locator_type, plural, term_form, None)
             .map(|t| {
                 let term_str = if crate::values::should_strip_periods(effective_rendering, options)
                 {

--- a/crates/citum-engine/src/values/term.rs
+++ b/crates/citum-engine/src/values/term.rs
@@ -25,7 +25,7 @@ impl ComponentValues for TemplateTerm {
         let form = self.form.unwrap_or(TermForm::Long);
         let mut value = options
             .locale
-            .resolved_general_term(&self.term, form)
+            .resolved_general_term(&self.term, form, self.gender)
             .unwrap_or_default();
 
         // Apply strip-periods if configured

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -4,7 +4,10 @@ use crate::render::plain::PlainText;
 use citum_schema::locale::{GeneralTerm, Locale, TermForm};
 use citum_schema::options::contributors::NameForm;
 use citum_schema::options::*;
-use citum_schema::reference::FlatName;
+use citum_schema::reference::{
+    Contributor, ContributorEntry, ContributorGender, EdtfString, FlatName, InputReference,
+    Monograph, MonographType, StructuredName,
+};
 use citum_schema::template::DateVariable as TemplateDateVar;
 use citum_schema::template::*;
 use csl_legacy::csl_json::{DateVariable, Name, Reference as LegacyReference};
@@ -40,6 +43,58 @@ fn make_reference() -> Reference {
         publisher: Some("University of Chicago Press".to_string()),
         ..Default::default()
     })
+}
+
+fn make_spanish_gendered_locale() -> Locale {
+    Locale::from_yaml_str(
+        r#"
+locale: es-ES
+roles:
+  editor:
+    long:
+      singular:
+        masculine: editor
+        feminine: editora
+        common: persona editora
+      plural:
+        masculine: editores
+        feminine: editoras
+        common: equipo editorial
+    short:
+      singular: ed.
+      plural: eds.
+    verb: editado por
+terms:
+  and:
+    long: y
+"#,
+    )
+    .expect("spanish locale should parse")
+}
+
+fn make_editor_reference(genders: &[ContributorGender]) -> Reference {
+    let contributors = genders
+        .iter()
+        .enumerate()
+        .map(|(idx, gender)| ContributorEntry {
+            role: citum_schema::reference::ContributorRole::Editor,
+            contributor: Contributor::StructuredName(StructuredName {
+                family: format!("Editor{idx}").into(),
+                given: format!("Nombre{idx}").into(),
+                ..Default::default()
+            }),
+            gender: Some(*gender),
+        })
+        .collect();
+
+    InputReference::Monograph(Box::new(Monograph {
+        id: Some("editor-role-ref".into()),
+        r#type: MonographType::Book,
+        title: Some(Title::Single("Obra".to_string())),
+        contributors,
+        issued: EdtfString("2024".to_string()),
+        ..Default::default()
+    }))
 }
 
 /// Helper to create `NameFormatContext` for tests.
@@ -95,6 +150,7 @@ fn test_contributor_values() {
         and: None,
         rendering: Default::default(),
         links: None,
+        gender: None,
         custom: None,
     };
 
@@ -102,6 +158,119 @@ fn test_contributor_values() {
         .values::<PlainText>(&reference, &hints, &options)
         .unwrap();
     assert_eq!(values.value, "Kuhn");
+}
+
+#[test]
+fn test_spanish_role_label_uses_feminine_form_for_single_editor() {
+    let config = make_config();
+    let locale = make_spanish_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference = make_editor_reference(&[ContributorGender::Feminine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("editor should render");
+
+    assert_eq!(values.suffix, Some(", editora".to_string()));
+}
+
+#[test]
+fn test_spanish_role_label_uses_plural_feminine_form_for_matching_group() {
+    let config = make_config();
+    let locale = make_spanish_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference =
+        make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Feminine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("editors should render");
+
+    assert_eq!(values.suffix, Some(", editoras".to_string()));
+}
+
+#[test]
+fn test_spanish_role_label_prefers_common_form_for_mixed_group() {
+    let config = make_config();
+    let locale = make_spanish_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference =
+        make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("mixed editors should render");
+
+    assert_eq!(values.suffix, Some(", equipo editorial".to_string()));
 }
 
 /// Tests the behavior of `test_date_values`.
@@ -226,6 +395,7 @@ fn test_et_al() {
         and: None,
         rendering: Default::default(),
         links: None,
+        gender: None,
         custom: None,
     };
 
@@ -284,6 +454,7 @@ fn test_et_al_delimiter_never() {
         and: None,
         rendering: Default::default(),
         links: None,
+        gender: None,
         custom: None,
     };
 
@@ -391,6 +562,7 @@ fn test_et_al_delimiter_always() {
         and: None,
         rendering: Default::default(),
         links: None,
+        gender: None,
         custom: None,
     };
 

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::reference::Reference;
 use crate::render::plain::PlainText;
-use citum_schema::locale::{GeneralTerm, Locale, TermForm};
+use citum_schema::locale::{GeneralTerm, GrammaticalGender, Locale, TermForm};
 use citum_schema::options::contributors::NameForm;
 use citum_schema::options::*;
 use citum_schema::reference::{
@@ -46,30 +46,8 @@ fn make_reference() -> Reference {
 }
 
 fn make_spanish_gendered_locale() -> Locale {
-    Locale::from_yaml_str(
-        r#"
-locale: es-ES
-roles:
-  editor:
-    long:
-      singular:
-        masculine: editor
-        feminine: editora
-        common: persona editora
-      plural:
-        masculine: editores
-        feminine: editoras
-        common: equipo editorial
-    short:
-      singular: ed.
-      plural: eds.
-    verb: editado por
-terms:
-  and:
-    long: y
-"#,
-    )
-    .expect("spanish locale should parse")
+    Locale::from_yaml_str(include_str!("../../../../locales/es-ES.yaml"))
+        .expect("spanish locale should parse")
 }
 
 fn make_editor_reference(genders: &[ContributorGender]) -> Reference {
@@ -95,6 +73,52 @@ fn make_editor_reference(genders: &[ContributorGender]) -> Reference {
         issued: EdtfString("2024".to_string()),
         ..Default::default()
     }))
+}
+
+fn make_custom_role_reference(
+    role: citum_schema::reference::ContributorRole,
+    genders: &[ContributorGender],
+) -> Reference {
+    let contributors = genders
+        .iter()
+        .enumerate()
+        .map(|(idx, gender)| ContributorEntry {
+            role: role.clone(),
+            contributor: Contributor::StructuredName(StructuredName {
+                family: format!("Persona{idx}").into(),
+                given: format!("Nombre{idx}").into(),
+                ..Default::default()
+            }),
+            gender: Some(*gender),
+        })
+        .collect();
+
+    InputReference::Monograph(Box::new(Monograph {
+        id: Some("custom-role-ref".into()),
+        r#type: MonographType::Book,
+        title: Some(Title::Single("Obra".to_string())),
+        contributors,
+        issued: EdtfString("2024".to_string()),
+        ..Default::default()
+    }))
+}
+
+fn make_gendered_locator_locale() -> Locale {
+    Locale::from_yaml_str(
+        r#"
+locale: es-ES
+locators:
+  volume:
+    short:
+      singular:
+        masculine: tomo
+        feminine: entrega
+      plural:
+        masculine: tomos
+        feminine: entregas
+"#,
+    )
+    .expect("gendered locator locale should parse")
 }
 
 /// Helper to create `NameFormatContext` for tests.
@@ -271,6 +295,98 @@ fn test_spanish_role_label_prefers_common_form_for_mixed_group() {
         .expect("mixed editors should render");
 
     assert_eq!(values.suffix, Some(", equipo editorial".to_string()));
+}
+
+#[test]
+fn test_spanish_role_label_omits_gendered_label_for_mixed_group_without_common_form() {
+    let config = make_config();
+    let locale = Locale::from_yaml_str(
+        r#"
+locale: es-ES
+roles:
+  editor:
+    long:
+      singular:
+        masculine: editor
+        feminine: editora
+      plural:
+        masculine: editores
+        feminine: editoras
+"#,
+    )
+    .expect("locale should parse");
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference =
+        make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("editors should render");
+
+    assert_eq!(values.suffix, None);
+}
+
+#[test]
+fn test_collection_editor_role_label_derives_gender_from_reference_data() {
+    let config = make_config();
+    let locale = make_spanish_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference = make_custom_role_reference(
+        citum_schema::reference::ContributorRole::Custom("collection-editor".to_string()),
+        &[ContributorGender::Feminine],
+    );
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::CollectionEditor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "collection-editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("collection editor should render");
+
+    assert_eq!(values.suffix, Some(", directora".to_string()));
 }
 
 /// Tests the behavior of `test_date_values`.
@@ -1766,6 +1882,59 @@ locators:
 
     assert_eq!(values.value, "3");
     assert_eq!(values.prefix, Some("reel ".to_string()));
+}
+
+#[test]
+fn test_template_number_gender_overrides_locator_label_resolution() {
+    let config = make_config();
+    let locale = make_gendered_locator_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let hints = ProcHints::default();
+
+    let reference = Reference::from(LegacyReference {
+        id: "book-1".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("Libro".to_string()),
+        volume: Some(csl_legacy::csl_json::StringOrNumber::String(
+            "1".to_string(),
+        )),
+        issued: Some(DateVariable::year(2024)),
+        ..Default::default()
+    });
+
+    let masculine = TemplateNumber {
+        number: NumberVariable::Volume,
+        label_form: Some(citum_schema::template::LabelForm::Short),
+        gender: Some(GrammaticalGender::Masculine),
+        ..Default::default()
+    };
+    let feminine = TemplateNumber {
+        number: NumberVariable::Volume,
+        label_form: Some(citum_schema::template::LabelForm::Short),
+        gender: Some(GrammaticalGender::Feminine),
+        ..Default::default()
+    };
+
+    let masculine_values = masculine
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("masculine volume should render");
+    let feminine_values = feminine
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("feminine volume should render");
+
+    assert_eq!(masculine_values.prefix, Some("tomo ".to_string()));
+    assert_eq!(feminine_values.prefix, Some("entrega ".to_string()));
 }
 
 #[test]

--- a/crates/citum-engine/tests/regression_interview.rs
+++ b/crates/citum-engine/tests/regression_interview.rs
@@ -36,6 +36,7 @@ fn test_apa_interview_fidelity_regression() {
                 given: "Elisabeth".into(),
                 ..Default::default()
             }),
+            gender: None,
         }],
         issued: EdtfString("1975".to_string()),
         publisher: Some(Publisher {

--- a/crates/citum-migrate/src/template_compiler/formatting.rs
+++ b/crates/citum-migrate/src/template_compiler/formatting.rs
@@ -291,6 +291,7 @@ mod tests {
         let mut term = TemplateComponent::Term(citum_schema::template::TemplateTerm {
             term: GeneralTerm::In,
             form: None,
+            gender: None,
             rendering: Rendering::default(),
             custom: None,
         });

--- a/crates/citum-schema-data/src/reference/contributor.rs
+++ b/crates/citum-schema-data/src/reference/contributor.rs
@@ -6,6 +6,22 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use std::fmt;
 
+/// Grammatical gender carried on contributor records for role-label agreement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "bindings", derive(Type))]
+#[serde(rename_all = "kebab-case")]
+pub enum ContributorGender {
+    /// Masculine grammatical gender.
+    Masculine,
+    /// Feminine grammatical gender.
+    Feminine,
+    /// Neuter grammatical gender.
+    Neuter,
+    /// Common or shared grammatical gender.
+    Common,
+}
+
 /// A contributor can be a single string, a structured name, or a list of contributors.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -192,4 +208,7 @@ pub struct ContributorEntry {
     pub role: ContributorRole,
     /// The contributor (name, organization, or list).
     pub contributor: Contributor,
+    /// The grammatical gender used for role-label agreement.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gender: Option<ContributorGender>,
 }

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -40,6 +40,7 @@ fn push_legacy_contributor(
         entries.push(ContributorEntry {
             role,
             contributor: Contributor::from(names),
+            gender: None,
         });
     }
 }
@@ -587,6 +588,7 @@ fn from_collection_component_ref(
         contributors.push(ContributorEntry {
             role: ContributorRole::Custom("container-author".to_string()),
             contributor: container_author,
+            gender: None,
         });
     }
     let container_editor = has_named_parent
@@ -1519,6 +1521,7 @@ fn from_event_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> I
                 name: organizer_name.into(),
                 location: None,
             }),
+            gender: None,
         });
     }
     InputReference::Event(Box::new(Event {

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -16,8 +16,8 @@ pub mod types;
 mod tests;
 
 pub use self::contributor::{
-    Contributor, ContributorEntry, ContributorList, ContributorRole, FlatName, SimpleName,
-    StructuredName,
+    Contributor, ContributorEntry, ContributorGender, ContributorList, ContributorRole, FlatName,
+    SimpleName, StructuredName,
 };
 pub use self::date::EdtfString;
 use self::types::common::HasNumbering;
@@ -335,7 +335,20 @@ impl InputReference {
     /// Returns `None` if no contributors with the given role exist.
     /// Returns a single `Contributor` directly, or folds multiple into a `ContributorList`.
     pub fn contributor(&self, role: ContributorRole) -> Option<Contributor> {
-        let entries: &[ContributorEntry] = match self {
+        let entries = self.all_contributor_entries();
+        collect_contributors_by_role(entries, &role)
+    }
+
+    /// Return all contributor entries matching the requested role.
+    pub fn contributor_entries(&self, role: &ContributorRole) -> Vec<&ContributorEntry> {
+        self.all_contributor_entries()
+            .iter()
+            .filter(|entry| &entry.role == role)
+            .collect()
+    }
+
+    fn all_contributor_entries(&self) -> &[ContributorEntry] {
+        match self {
             InputReference::Monograph(r) => &r.contributors,
             InputReference::Collection(r) => &r.contributors,
             InputReference::CollectionComponent(r) => &r.contributors,
@@ -344,8 +357,7 @@ impl InputReference {
             InputReference::Event(r) => &r.contributors,
             InputReference::AudioVisual(r) => &r.core.contributors,
             _ => &[],
-        };
-        collect_contributors_by_role(entries, &role)
+        }
     }
 
     /// Return the title.

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -35,6 +35,7 @@ fn fold_contributors(
             contributors.push(ContributorEntry {
                 role: role.clone(),
                 contributor: (*c).clone(),
+                gender: None,
             });
         }
     }

--- a/crates/citum-schema-style/src/embedded/locales.rs
+++ b/crates/citum-schema-style/src/embedded/locales.rs
@@ -16,6 +16,7 @@ pub fn get_locale_bytes(id: &str) -> Option<&'static [u8]> {
     match id {
         "en-US" => Some(include_bytes!("../../../../locales/en-US.yaml")),
         "de-DE" => Some(include_bytes!("../../../../locales/de-DE.yaml")),
+        "es-ES" => Some(include_bytes!("../../../../locales/es-ES.yaml")),
         "fr-FR" => Some(include_bytes!("../../../../locales/fr-FR.yaml")),
         "tr-TR" => Some(include_bytes!("../../../../locales/tr-TR.yaml")),
         _ => None,
@@ -23,7 +24,7 @@ pub fn get_locale_bytes(id: &str) -> Option<&'static [u8]> {
 }
 
 /// All available embedded locale IDs.
-pub const EMBEDDED_LOCALE_IDS: &[&str] = &["en-US", "de-DE", "fr-FR", "tr-TR"];
+pub const EMBEDDED_LOCALE_IDS: &[&str] = &["en-US", "de-DE", "es-ES", "fr-FR", "tr-TR"];
 
 /// Raw YAML bytes for an embedded locale override by ID.
 ///

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -81,7 +81,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.32.2";
+pub const STYLE_SCHEMA_VERSION: &str = "0.33.0";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -553,12 +553,49 @@ impl Locale {
         value: &MaybeGendered<String>,
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<&str> {
+        value
+            .resolve_with_fallback(requested_gender)
+            .map(String::as_str)
+    }
+
+    fn resolve_gendered_value_neutral(value: &MaybeGendered<String>) -> Option<&str> {
+        value.resolve_neutral().map(String::as_str)
+    }
+
+    fn resolve_no_date_value(
+        value: &SimpleTerm,
+        form: TermForm,
+        requested_gender: Option<GrammaticalGender>,
+    ) -> Option<&str> {
         match requested_gender {
-            Some(GrammaticalGender::Common) => value.resolve_neutral().map(String::as_str),
-            Some(gender) => value
-                .resolve_with_fallback(Some(gender))
-                .map(String::as_str),
-            None => value.resolve_with_fallback(None).map(String::as_str),
+            Some(GrammaticalGender::Common) => match form {
+                TermForm::Long => value
+                    .long
+                    .resolve_strict(Some(GrammaticalGender::Common))
+                    .map(String::as_str),
+                TermForm::Short => value
+                    .short
+                    .resolve_strict(Some(GrammaticalGender::Common))
+                    .map(String::as_str)
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| {
+                        value
+                            .long
+                            .resolve_strict(Some(GrammaticalGender::Common))
+                            .map(String::as_str)
+                    }),
+                _ => value
+                    .long
+                    .resolve_strict(Some(GrammaticalGender::Common))
+                    .map(String::as_str),
+            },
+            _ => match form {
+                TermForm::Long => Self::resolve_gendered_value(&value.long, requested_gender),
+                TermForm::Short => Self::resolve_gendered_value(&value.short, requested_gender)
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| Self::resolve_gendered_value(&value.long, requested_gender)),
+                _ => Self::resolve_gendered_value(&value.long, requested_gender),
+            },
         }
     }
 
@@ -590,6 +627,33 @@ impl Locale {
         }
     }
 
+    /// Resolve a contributor role term using only neutral/common values.
+    pub fn role_term_neutral(
+        &self,
+        role: &ContributorRole,
+        plural: bool,
+        form: TermForm,
+    ) -> Option<&str> {
+        let term = self.roles.get(role)?;
+        let simple = if plural { &term.plural } else { &term.singular };
+        let term_text = match form {
+            TermForm::Long => Self::resolve_gendered_value_neutral(&simple.long),
+            TermForm::Short => Self::resolve_gendered_value_neutral(&simple.short)
+                .filter(|value| !value.is_empty())
+                .or_else(|| Self::resolve_gendered_value_neutral(&simple.long)),
+            TermForm::Verb => Self::resolve_gendered_value(&term.verb.long, None),
+            TermForm::VerbShort => Self::resolve_gendered_value(&term.verb.short, None)
+                .filter(|value| !value.is_empty())
+                .or_else(|| Self::resolve_gendered_value(&term.verb.long, None)),
+            _ => Self::resolve_gendered_value_neutral(&simple.long),
+        };
+
+        match term_text {
+            Some(value) if !value.is_empty() => Some(value),
+            _ => None,
+        }
+    }
+
     /// Resolve a contributor role term, evaluating MF1 messages when configured.
     pub fn resolved_role_term(
         &self,
@@ -606,6 +670,24 @@ impl Locale {
         }
 
         self.role_term(role, plural, form, requested_gender)
+            .map(ToOwned::to_owned)
+    }
+
+    /// Resolve a contributor role term using only neutral/common values.
+    pub fn resolved_role_term_neutral(
+        &self,
+        role: &ContributorRole,
+        plural: bool,
+        form: TermForm,
+    ) -> Option<String> {
+        if let Some(message_id) = Self::role_message_id(role, form)
+            && let Some(resolved) =
+                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), &[])
+        {
+            return Some(resolved);
+        }
+
+        self.role_term_neutral(role, plural, form)
             .map(ToOwned::to_owned)
     }
 
@@ -708,7 +790,9 @@ impl Locale {
         }
 
         // First try the flattened map
-        if let Some(simple) = self.terms.general.get(term) {
+        if *term != GeneralTerm::NoDate
+            && let Some(simple) = self.terms.general.get(term)
+        {
             return match form {
                 TermForm::Long => Self::resolve_gendered_value(&simple.long, requested_gender),
                 TermForm::Short => Self::resolve_gendered_value(&simple.short, requested_gender)
@@ -730,16 +814,7 @@ impl Locale {
                 .terms
                 .general
                 .get(term)
-                .map(|value| match form {
-                    TermForm::Long => {
-                        Self::resolve_gendered_value(&value.long, requested_gender).unwrap_or("")
-                    }
-                    TermForm::Short => Self::resolve_gendered_value(&value.short, requested_gender)
-                        .filter(|value| !value.is_empty())
-                        .or_else(|| Self::resolve_gendered_value(&value.long, requested_gender))
-                        .unwrap_or(""),
-                    _ => Self::resolve_gendered_value(&value.long, requested_gender).unwrap_or(""),
-                })
+                .and_then(|value| Self::resolve_no_date_value(value, form, requested_gender))
                 .or(self.terms.no_date.as_deref()),
             GeneralTerm::Retrieved => self.terms.retrieved.as_deref(),
             GeneralTerm::At => self.terms.at.as_deref(),
@@ -1214,10 +1289,20 @@ impl Locale {
                         locale.terms.ibid = Some(v.to_string());
                     }
                 }
-                "no_date" | "no date" => {
+                "no date" => {
+                    let simple = Self::extract_simple_term_from_raw(value);
+                    let short_fallback = simple.short.as_default_str().to_string();
+                    locale.terms.general.insert(GeneralTerm::NoDate, simple);
+                    locale.terms.no_date.get_or_insert(short_fallback);
+                }
+                "no_date" => {
                     let simple = Self::extract_simple_term_from_raw(value);
                     locale.terms.no_date = Some(simple.short.as_str().to_string());
-                    locale.terms.general.insert(GeneralTerm::NoDate, simple);
+                    locale
+                        .terms
+                        .general
+                        .entry(GeneralTerm::NoDate)
+                        .or_insert(simple);
                 }
                 _ => {
                     // Try to parse as GeneralTerm
@@ -1975,6 +2060,48 @@ roles:
                 Some(GrammaticalGender::Common),
             ),
             Some("equipo editorial")
+        );
+    }
+
+    #[test]
+    fn test_no_date_term_falls_back_when_requested_gender_has_no_matching_slot() {
+        let locale = Locale::from_yaml_str(
+            r#"
+locale: es-ES
+terms:
+  no date:
+    long:
+      masculine: sin fecha
+  no_date: s. f.
+"#,
+        )
+        .expect("locale should parse");
+
+        assert_eq!(
+            locale.general_term(
+                &GeneralTerm::NoDate,
+                TermForm::Long,
+                Some(GrammaticalGender::Common),
+            ),
+            Some("s. f.")
+        );
+    }
+
+    #[test]
+    fn test_es_es_locale_is_embedded() {
+        let bytes = crate::embedded::get_locale_bytes("es-ES").expect("es-ES should be embedded");
+        let yaml = std::str::from_utf8(bytes).expect("embedded locale should be utf-8");
+        let locale = Locale::from_yaml_str(yaml).expect("embedded es-ES should parse");
+
+        assert_eq!(locale.locale, "es-ES");
+        assert_eq!(
+            locale.resolved_role_term(
+                &ContributorRole::Editor,
+                false,
+                TermForm::Long,
+                Some(GrammaticalGender::Feminine),
+            ),
+            Some("editora".to_string())
         );
     }
 

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -297,6 +297,7 @@ fn en_us_locator_terms() -> HashMap<LocatorType, LocatorTerm> {
                 plural: "pp.".into(),
             }),
             symbol: None,
+            gender: None,
         },
     );
 
@@ -312,6 +313,7 @@ fn en_us_locator_terms() -> HashMap<LocatorType, LocatorTerm> {
                 plural: "chs.".into(),
             }),
             symbol: None,
+            gender: None,
         },
     );
 
@@ -327,6 +329,7 @@ fn en_us_locator_terms() -> HashMap<LocatorType, LocatorTerm> {
                 plural: "vols.".into(),
             }),
             symbol: None,
+            gender: None,
         },
     );
 
@@ -345,6 +348,7 @@ fn en_us_locator_terms() -> HashMap<LocatorType, LocatorTerm> {
                 singular: "§".into(),
                 plural: "§§".into(),
             }),
+            gender: None,
         },
     );
 
@@ -360,6 +364,7 @@ fn en_us_locator_terms() -> HashMap<LocatorType, LocatorTerm> {
                 plural: "pts.".into(),
             }),
             symbol: None,
+            gender: None,
         },
     );
 
@@ -375,6 +380,7 @@ fn en_us_locator_terms() -> HashMap<LocatorType, LocatorTerm> {
                 plural: "suppls.".into(),
             }),
             symbol: None,
+            gender: None,
         },
     );
 
@@ -543,33 +549,44 @@ impl Locale {
     }
 
     /// Get a contributor role term.
-    pub fn role_term(&self, role: &ContributorRole, plural: bool, form: TermForm) -> Option<&str> {
+    fn resolve_gendered_value(
+        value: &MaybeGendered<String>,
+        requested_gender: Option<GrammaticalGender>,
+    ) -> Option<&str> {
+        match requested_gender {
+            Some(GrammaticalGender::Common) => value.resolve_neutral().map(String::as_str),
+            Some(gender) => value
+                .resolve_with_fallback(Some(gender))
+                .map(String::as_str),
+            None => value.resolve_with_fallback(None).map(String::as_str),
+        }
+    }
+
+    /// Get a contributor role term.
+    pub fn role_term(
+        &self,
+        role: &ContributorRole,
+        plural: bool,
+        form: TermForm,
+        requested_gender: Option<GrammaticalGender>,
+    ) -> Option<&str> {
         let term = self.roles.get(role)?;
         let simple = if plural { &term.plural } else { &term.singular };
         let term_text = match form {
-            TermForm::Long => &simple.long,
-            TermForm::Short => {
-                if simple.short.is_empty() {
-                    &simple.long
-                } else {
-                    &simple.short
-                }
-            }
-            TermForm::Verb => &term.verb.long,
-            TermForm::VerbShort => {
-                if term.verb.short.is_empty() {
-                    &term.verb.long
-                } else {
-                    &term.verb.short
-                }
-            }
-            _ => &simple.long,
+            TermForm::Long => Self::resolve_gendered_value(&simple.long, requested_gender),
+            TermForm::Short => Self::resolve_gendered_value(&simple.short, requested_gender)
+                .filter(|value| !value.is_empty())
+                .or_else(|| Self::resolve_gendered_value(&simple.long, requested_gender)),
+            TermForm::Verb => Self::resolve_gendered_value(&term.verb.long, None),
+            TermForm::VerbShort => Self::resolve_gendered_value(&term.verb.short, None)
+                .filter(|value| !value.is_empty())
+                .or_else(|| Self::resolve_gendered_value(&term.verb.long, None)),
+            _ => Self::resolve_gendered_value(&simple.long, requested_gender),
         };
 
-        if term_text.is_empty() {
-            None
-        } else {
-            Some(term_text.as_str())
+        match term_text {
+            Some(value) if !value.is_empty() => Some(value),
+            _ => None,
         }
     }
 
@@ -579,6 +596,7 @@ impl Locale {
         role: &ContributorRole,
         plural: bool,
         form: TermForm,
+        requested_gender: Option<GrammaticalGender>,
     ) -> Option<String> {
         if let Some(message_id) = Self::role_message_id(role, form)
             && let Some(resolved) =
@@ -587,7 +605,8 @@ impl Locale {
             return Some(resolved);
         }
 
-        self.role_term(role, plural, form).map(ToOwned::to_owned)
+        self.role_term(role, plural, form, requested_gender)
+            .map(ToOwned::to_owned)
     }
 
     /// Get a locator term.
@@ -596,6 +615,7 @@ impl Locale {
         locator: &LocatorType,
         plural: bool,
         form: TermForm,
+        requested_gender: Option<GrammaticalGender>,
     ) -> Option<&str> {
         let term = self.locators.get(locator)?;
         let form_term = match form {
@@ -606,7 +626,8 @@ impl Locale {
         };
 
         if let Some(ft) = form_term {
-            Some(if plural { &ft.plural } else { &ft.singular })
+            let value = if plural { &ft.plural } else { &ft.singular };
+            Self::resolve_gendered_value(value, requested_gender)
         } else {
             None
         }
@@ -618,6 +639,7 @@ impl Locale {
         locator: &LocatorType,
         plural: bool,
         form: TermForm,
+        requested_gender: Option<GrammaticalGender>,
     ) -> Option<String> {
         if let Some(message_id) = Self::locator_message_id(locator, form)
             && let Some(resolved) =
@@ -626,11 +648,11 @@ impl Locale {
             return Some(resolved);
         }
 
-        self.locator_term(locator, plural, form)
+        self.locator_term(locator, plural, form, requested_gender)
             .map(ToOwned::to_owned)
             .or_else(|| {
                 if let LocatorType::Custom(key) = locator {
-                    self.locator_term_any_form(locator, plural)
+                    self.locator_term_any_form(locator, plural, requested_gender)
                         .map(ToOwned::to_owned)
                         .or_else(|| Some(key.clone()))
                 } else {
@@ -639,7 +661,12 @@ impl Locale {
             })
     }
 
-    fn locator_term_any_form(&self, locator: &LocatorType, plural: bool) -> Option<&str> {
+    fn locator_term_any_form(
+        &self,
+        locator: &LocatorType,
+        plural: bool,
+        requested_gender: Option<GrammaticalGender>,
+    ) -> Option<&str> {
         let term = self.locators.get(locator)?;
         [&term.long, &term.short, &term.symbol]
             .into_iter()
@@ -647,15 +674,21 @@ impl Locale {
             .next()
             .map(|forms| {
                 if plural {
-                    forms.plural.as_str()
+                    Self::resolve_gendered_value(&forms.plural, requested_gender).unwrap_or("")
                 } else {
-                    forms.singular.as_str()
+                    Self::resolve_gendered_value(&forms.singular, requested_gender).unwrap_or("")
                 }
             })
+            .filter(|value| !value.is_empty())
     }
 
     /// Get a general term by type and form.
-    pub fn general_term(&self, term: &GeneralTerm, form: TermForm) -> Option<&str> {
+    pub fn general_term(
+        &self,
+        term: &GeneralTerm,
+        form: TermForm,
+        requested_gender: Option<GrammaticalGender>,
+    ) -> Option<&str> {
         // Legacy borrowed lookup path: prefer plain v2 messages first, then
         // alias-backed messages, and finally the v1 term tables.
         let candidate_id = format!("term.{}", Self::general_term_to_message_id(term));
@@ -676,11 +709,13 @@ impl Locale {
 
         // First try the flattened map
         if let Some(simple) = self.terms.general.get(term) {
-            return Some(match form {
-                TermForm::Long => &simple.long,
-                TermForm::Short => &simple.short,
-                _ => &simple.long,
-            });
+            return match form {
+                TermForm::Long => Self::resolve_gendered_value(&simple.long, requested_gender),
+                TermForm::Short => Self::resolve_gendered_value(&simple.short, requested_gender)
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| Self::resolve_gendered_value(&simple.long, requested_gender)),
+                _ => Self::resolve_gendered_value(&simple.long, requested_gender),
+            };
         }
 
         // Fallback to specific fields for common terms
@@ -696,9 +731,14 @@ impl Locale {
                 .general
                 .get(term)
                 .map(|value| match form {
-                    TermForm::Long => value.long.as_str(),
-                    TermForm::Short => value.short.as_str(),
-                    _ => value.long.as_str(),
+                    TermForm::Long => {
+                        Self::resolve_gendered_value(&value.long, requested_gender).unwrap_or("")
+                    }
+                    TermForm::Short => Self::resolve_gendered_value(&value.short, requested_gender)
+                        .filter(|value| !value.is_empty())
+                        .or_else(|| Self::resolve_gendered_value(&value.long, requested_gender))
+                        .unwrap_or(""),
+                    _ => Self::resolve_gendered_value(&value.long, requested_gender).unwrap_or(""),
                 })
                 .or(self.terms.no_date.as_deref()),
             GeneralTerm::Retrieved => self.terms.retrieved.as_deref(),
@@ -709,43 +749,63 @@ impl Locale {
                 .terms
                 .general
                 .get(term)
-                .map(|value| value.long.as_str()),
+                .and_then(|value| Self::resolve_gendered_value(&value.long, requested_gender)),
             GeneralTerm::To => self
                 .terms
                 .general
                 .get(term)
-                .map(|value| value.long.as_str()),
-            GeneralTerm::Anonymous => Some(&self.terms.anonymous.long),
-            GeneralTerm::Circa => Some(&self.terms.circa.long),
+                .and_then(|value| Self::resolve_gendered_value(&value.long, requested_gender)),
+            GeneralTerm::Anonymous => {
+                Self::resolve_gendered_value(&self.terms.anonymous.long, requested_gender)
+            }
+            GeneralTerm::Circa => {
+                Self::resolve_gendered_value(&self.terms.circa.long, requested_gender)
+            }
             // Fallback to locators for shared terms
-            GeneralTerm::Volume => self.locator_term(&LocatorType::Volume, false, form),
-            GeneralTerm::Issue => self.locator_term(&LocatorType::Issue, false, form),
-            GeneralTerm::Page => self.locator_term(&LocatorType::Page, false, form),
-            GeneralTerm::Chapter => self.locator_term(&LocatorType::Chapter, false, form),
-            GeneralTerm::Section => self.locator_term(&LocatorType::Section, false, form),
+            GeneralTerm::Volume => {
+                self.locator_term(&LocatorType::Volume, false, form, requested_gender)
+            }
+            GeneralTerm::Issue => {
+                self.locator_term(&LocatorType::Issue, false, form, requested_gender)
+            }
+            GeneralTerm::Page => {
+                self.locator_term(&LocatorType::Page, false, form, requested_gender)
+            }
+            GeneralTerm::Chapter => {
+                self.locator_term(&LocatorType::Chapter, false, form, requested_gender)
+            }
+            GeneralTerm::Section => {
+                self.locator_term(&LocatorType::Section, false, form, requested_gender)
+            }
             GeneralTerm::Here => self
                 .terms
                 .general
                 .get(term)
-                .map(|value| value.long.as_str()),
+                .and_then(|value| Self::resolve_gendered_value(&value.long, requested_gender)),
             GeneralTerm::Deposited => self
                 .terms
                 .general
                 .get(term)
-                .map(|value| value.long.as_str()),
+                .and_then(|value| Self::resolve_gendered_value(&value.long, requested_gender)),
             _ => None,
         }
     }
 
     /// Resolve a general term, evaluating MF1 messages when configured.
-    pub fn resolved_general_term(&self, term: &GeneralTerm, form: TermForm) -> Option<String> {
+    pub fn resolved_general_term(
+        &self,
+        term: &GeneralTerm,
+        form: TermForm,
+        requested_gender: Option<GrammaticalGender>,
+    ) -> Option<String> {
         if let Some(message_id) = Self::general_message_id(term, form)
             && let Some(resolved) = self.resolve_message_text(message_id, None, &[])
         {
             return Some(resolved);
         }
 
-        self.general_term(term, form).map(ToOwned::to_owned)
+        self.general_term(term, form, requested_gender)
+            .map(ToOwned::to_owned)
     }
 
     /// Get the "and" term based on style preference.
@@ -1088,13 +1148,12 @@ impl Locale {
             .collect();
 
         for (key, value) in &raw.locators {
-            if let Some(locator_type) = Self::parse_locator_type(key)
-                && let Some(forms) = Self::get_forms(value)
-            {
+            if let Some(locator_type) = Self::parse_locator_type(key) {
                 let locator_term = LocatorTerm {
-                    long: Self::extract_singular_plural(forms.get("long").as_ref()),
-                    short: Self::extract_singular_plural(forms.get("short").as_ref()),
-                    symbol: Self::extract_singular_plural(forms.get("symbol").as_ref()),
+                    long: Self::extract_singular_plural(value.long.as_ref().as_ref()),
+                    short: Self::extract_singular_plural(value.short.as_ref().as_ref()),
+                    symbol: Self::extract_singular_plural(value.symbol.as_ref().as_ref()),
+                    gender: value.gender,
                 };
                 locale.locators.insert(locator_type, locator_term);
             }
@@ -1110,6 +1169,7 @@ impl Locale {
                     long: Self::extract_singular_plural(forms.get("long").as_ref()),
                     short: Self::extract_singular_plural(forms.get("short").as_ref()),
                     symbol: Self::extract_singular_plural(forms.get("symbol").as_ref()),
+                    gender: None,
                 };
                 locale.locators.insert(locator_type, locator_term);
                 continue;
@@ -1156,7 +1216,7 @@ impl Locale {
                 }
                 "no_date" | "no date" => {
                     let simple = Self::extract_simple_term_from_raw(value);
-                    locale.terms.no_date = Some(simple.short.clone());
+                    locale.terms.no_date = Some(simple.short.as_str().to_string());
                     locale.terms.general.insert(GeneralTerm::NoDate, simple);
                 }
                 _ => {
@@ -1233,20 +1293,37 @@ impl Locale {
     fn extract_singular_plural(value: Option<&&raw::RawTermValue>) -> Option<SingularPlural> {
         match value {
             Some(raw::RawTermValue::SingularPlural { singular, plural }) => Some(SingularPlural {
-                singular: singular.clone(),
-                plural: plural.clone(),
+                singular: Self::from_raw_gendered_string(singular),
+                plural: Self::from_raw_gendered_string(plural),
             }),
             Some(raw::RawTermValue::Simple(s)) => Some(SingularPlural {
-                singular: s.clone(),
-                plural: s.clone(), // Fallback if only one form provided
+                singular: MaybeGendered::Plain(s.clone()),
+                plural: MaybeGendered::Plain(s.clone()), // Fallback if only one form provided
+            }),
+            Some(raw::RawTermValue::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            }) => Some(SingularPlural {
+                singular: MaybeGendered::Gendered {
+                    masculine: masculine.clone(),
+                    feminine: feminine.clone(),
+                    neuter: neuter.clone(),
+                    common: common.clone(),
+                },
+                plural: MaybeGendered::Gendered {
+                    masculine: masculine.clone(),
+                    feminine: feminine.clone(),
+                    neuter: neuter.clone(),
+                    common: common.clone(),
+                },
             }),
             Some(raw::RawTermValue::Forms(forms)) => {
                 let singular = forms
                     .get("singular")
-                    .and_then(|v| Self::extract_term_string(v, false));
-                let plural = forms
-                    .get("plural")
-                    .and_then(|v| Self::extract_term_string(v, false));
+                    .map(Self::extract_maybe_gendered_string);
+                let plural = forms.get("plural").map(Self::extract_maybe_gendered_string);
 
                 singular.map(|s| SingularPlural {
                     plural: plural.unwrap_or_else(|| s.clone()),
@@ -1264,33 +1341,17 @@ impl Locale {
     ) -> SimpleTerm {
         let long_str = long
             .as_ref()
-            .and_then(|v| Self::extract_term_string(v, plural))
+            .map(|v| Self::extract_simple_gendered_term(v, plural))
             .unwrap_or_default();
 
         let short_str = short
             .as_ref()
-            .and_then(|v| Self::extract_term_string(v, plural))
+            .map(|v| Self::extract_simple_gendered_term(v, plural))
             .unwrap_or_default();
 
         SimpleTerm {
             long: long_str,
             short: short_str,
-        }
-    }
-
-    fn extract_term_string(value: &raw::RawTermValue, plural: bool) -> Option<String> {
-        match value {
-            raw::RawTermValue::Simple(s) => Some(s.clone()),
-            raw::RawTermValue::SingularPlural {
-                singular,
-                plural: p,
-            } => Some(if plural { p.clone() } else { singular.clone() }),
-            raw::RawTermValue::Forms(forms) => {
-                let key = if plural { "plural" } else { "singular" };
-                forms
-                    .get(key)
-                    .and_then(|v| Self::extract_term_string(v, false))
-            }
         }
     }
 
@@ -1302,13 +1363,13 @@ impl Locale {
             .as_ref()
             .and_then(|v| v.as_string())
             .unwrap_or("")
-            .to_string();
+            .into();
 
         let short_str = verb_short
             .as_ref()
             .and_then(|v| v.as_string())
             .unwrap_or("")
-            .to_string();
+            .into();
 
         SimpleTerm {
             long: long_str,
@@ -1367,26 +1428,123 @@ impl Locale {
     fn extract_simple_term_from_raw(value: &raw::RawTermValue) -> SimpleTerm {
         match value {
             raw::RawTermValue::Simple(s) => SimpleTerm {
-                long: s.clone(),
-                short: s.clone(),
+                long: s.clone().into(),
+                short: s.clone().into(),
+            },
+            raw::RawTermValue::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            } => SimpleTerm {
+                long: MaybeGendered::Gendered {
+                    masculine: masculine.clone(),
+                    feminine: feminine.clone(),
+                    neuter: neuter.clone(),
+                    common: common.clone(),
+                },
+                short: MaybeGendered::Gendered {
+                    masculine: masculine.clone(),
+                    feminine: feminine.clone(),
+                    neuter: neuter.clone(),
+                    common: common.clone(),
+                },
             },
             raw::RawTermValue::Forms(forms) => {
                 let long = forms
                     .get("long")
-                    .and_then(|v| v.as_string())
-                    .unwrap_or("")
-                    .to_string();
+                    .map(Self::extract_maybe_gendered_string)
+                    .unwrap_or_default();
                 let short = forms
                     .get("short")
-                    .and_then(|v| v.as_string())
-                    .unwrap_or(&long)
-                    .to_string();
+                    .map(Self::extract_maybe_gendered_string)
+                    .unwrap_or_else(|| long.clone());
                 SimpleTerm { long, short }
             }
             raw::RawTermValue::SingularPlural { singular, .. } => SimpleTerm {
-                long: singular.clone(),
-                short: singular.clone(),
+                long: Self::from_raw_gendered_string(singular),
+                short: Self::from_raw_gendered_string(singular),
             },
+        }
+    }
+
+    fn from_raw_gendered_string(value: &raw::RawGenderedString) -> MaybeGendered<String> {
+        match value {
+            raw::RawGenderedString::Simple(value) => MaybeGendered::Plain(value.clone()),
+            raw::RawGenderedString::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            } => MaybeGendered::Gendered {
+                masculine: masculine.clone(),
+                feminine: feminine.clone(),
+                neuter: neuter.clone(),
+                common: common.clone(),
+            },
+        }
+    }
+
+    fn extract_maybe_gendered_string(value: &raw::RawTermValue) -> MaybeGendered<String> {
+        match value {
+            raw::RawTermValue::Simple(value) => MaybeGendered::Plain(value.clone()),
+            raw::RawTermValue::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            } => MaybeGendered::Gendered {
+                masculine: masculine.clone(),
+                feminine: feminine.clone(),
+                neuter: neuter.clone(),
+                common: common.clone(),
+            },
+            raw::RawTermValue::SingularPlural { singular, .. } => {
+                Self::from_raw_gendered_string(singular)
+            }
+            raw::RawTermValue::Forms(forms) => forms
+                .get("long")
+                .or_else(|| forms.get("singular"))
+                .map(Self::extract_maybe_gendered_string)
+                .unwrap_or_default(),
+        }
+    }
+
+    fn extract_simple_gendered_term(
+        value: &raw::RawTermValue,
+        plural: bool,
+    ) -> MaybeGendered<String> {
+        match value {
+            raw::RawTermValue::Simple(value) => MaybeGendered::Plain(value.clone()),
+            raw::RawTermValue::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            } => MaybeGendered::Gendered {
+                masculine: masculine.clone(),
+                feminine: feminine.clone(),
+                neuter: neuter.clone(),
+                common: common.clone(),
+            },
+            raw::RawTermValue::SingularPlural {
+                singular,
+                plural: plural_value,
+            } => {
+                if plural {
+                    Self::from_raw_gendered_string(plural_value)
+                } else {
+                    Self::from_raw_gendered_string(singular)
+                }
+            }
+            raw::RawTermValue::Forms(forms) => {
+                let key = if plural { "plural" } else { "singular" };
+                forms
+                    .get(key)
+                    .or_else(|| forms.get("long"))
+                    .map(Self::extract_maybe_gendered_string)
+                    .unwrap_or_default()
+            }
         }
     }
 
@@ -1437,15 +1595,15 @@ mod tests {
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.role_term(&ContributorRole::Editor, false, TermForm::Short),
+            locale.role_term(&ContributorRole::Editor, false, TermForm::Short, None),
             Some("ed.")
         );
         assert_eq!(
-            locale.role_term(&ContributorRole::Editor, true, TermForm::Short),
+            locale.role_term(&ContributorRole::Editor, true, TermForm::Short, None),
             Some("eds.")
         );
         assert_eq!(
-            locale.role_term(&ContributorRole::Translator, false, TermForm::Verb),
+            locale.role_term(&ContributorRole::Translator, false, TermForm::Verb, None),
             Some("translated by")
         );
     }
@@ -1455,11 +1613,11 @@ mod tests {
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Long),
+            locale.general_term(&GeneralTerm::NoDate, TermForm::Long, None),
             Some("no date")
         );
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Short),
+            locale.general_term(&GeneralTerm::NoDate, TermForm::Short, None),
             Some("n.d.")
         );
     }
@@ -1470,11 +1628,11 @@ mod tests {
         locale.terms.no_date = Some("n.d.".to_string());
 
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Short),
+            locale.general_term(&GeneralTerm::NoDate, TermForm::Short, None),
             Some("n.d.")
         );
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Long),
+            locale.general_term(&GeneralTerm::NoDate, TermForm::Long, None),
             Some("n.d.")
         );
     }
@@ -1576,11 +1734,11 @@ terms:
 
         let locale = Locale::from_yaml_str(yaml).unwrap();
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Long),
+            locale.general_term(&GeneralTerm::NoDate, TermForm::Long, None),
             Some("no date")
         );
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Short),
+            locale.general_term(&GeneralTerm::NoDate, TermForm::Short, None),
             Some("n.d.")
         );
         assert_eq!(locale.terms.no_date.as_deref(), Some("n.d."));
@@ -1654,11 +1812,11 @@ locale: en-US
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short),
+            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short, None),
             Some("p.".to_string())
         );
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, true, TermForm::Short),
+            locale.resolved_locator_term(&LocatorType::Page, true, TermForm::Short, None),
             Some("pp.".to_string())
         );
     }
@@ -1681,7 +1839,8 @@ locators:
             locale.resolved_locator_term(
                 &LocatorType::Custom("reel".to_string()),
                 false,
-                TermForm::Short
+                TermForm::Short,
+                None,
             ),
             Some("reel".to_string())
         );
@@ -1689,7 +1848,8 @@ locators:
             locale.resolved_locator_term(
                 &LocatorType::Custom("movement".to_string()),
                 false,
-                TermForm::Short
+                TermForm::Short,
+                None,
             ),
             Some("movement".to_string())
         );
@@ -1710,7 +1870,7 @@ terms:
         .expect("legacy locator terms should parse");
 
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short),
+            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short, None),
             Some("pg.".to_string())
         );
     }
@@ -1735,7 +1895,7 @@ locators:
         .expect("mixed locator forms should parse");
 
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short),
+            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short, None),
             Some("p.".to_string())
         );
     }
@@ -1765,12 +1925,56 @@ terms:
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.resolved_role_term(&ContributorRole::Editor, false, TermForm::Long),
+            locale.resolved_role_term(&ContributorRole::Editor, false, TermForm::Long, None),
             Some("editor".to_string())
         );
         assert_eq!(
-            locale.resolved_role_term(&ContributorRole::Editor, true, TermForm::Long),
+            locale.resolved_role_term(&ContributorRole::Editor, true, TermForm::Long, None),
             Some("editors".to_string())
+        );
+    }
+
+    #[test]
+    fn test_role_term_prefers_common_form_for_mixed_gender_requests() {
+        let locale = Locale::from_yaml_str(
+            r#"
+locale: es-ES
+roles:
+  editor:
+    long:
+      singular:
+        masculine: editor
+        feminine: editora
+        common: persona editora
+      plural:
+        masculine: editores
+        feminine: editoras
+        common: equipo editorial
+    short:
+      singular: ed.
+      plural: eds.
+    verb: editado por
+"#,
+        )
+        .expect("gendered locale should parse");
+
+        assert_eq!(
+            locale.role_term(
+                &ContributorRole::Editor,
+                false,
+                TermForm::Long,
+                Some(GrammaticalGender::Feminine),
+            ),
+            Some("editora")
+        );
+        assert_eq!(
+            locale.role_term(
+                &ContributorRole::Editor,
+                true,
+                TermForm::Long,
+                Some(GrammaticalGender::Common),
+            ),
+            Some("equipo editorial")
         );
     }
 

--- a/crates/citum-schema-style/src/locale/raw.rs
+++ b/crates/citum-schema-style/src/locale/raw.rs
@@ -5,7 +5,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_yaml::{Mapping, Value};
 use std::collections::HashMap;
 
 /// Raw locale format for YAML parsing.
@@ -27,7 +29,7 @@ pub struct RawLocale {
     pub terms: HashMap<String, RawTermValue>,
     /// Locator terms keyed by locator name.
     #[serde(default)]
-    pub locators: HashMap<String, RawTermValue>,
+    pub locators: HashMap<String, RawLocatorTerm>,
     /// Schema version. Absent or "1" uses the legacy term-map path.
     /// "2" activates the new messages/dateFormats/grammarOptions path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -140,27 +142,103 @@ pub struct RawRoleTerm {
     pub verb_short: Option<RawTermValue>,
 }
 
-/// A term value that can be a simple string or have singular/plural forms.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// Raw locator term with optional lexical gender.
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(untagged)]
+#[serde(rename_all = "kebab-case")]
+pub struct RawLocatorTerm {
+    /// Long-form locator term.
+    #[serde(default)]
+    pub long: Option<RawTermValue>,
+    /// Short-form locator term.
+    #[serde(default)]
+    pub short: Option<RawTermValue>,
+    /// Symbol-form locator term.
+    #[serde(default)]
+    pub symbol: Option<RawTermValue>,
+    /// Lexical gender used for noun agreement.
+    #[serde(default)]
+    pub gender: Option<crate::locale::types::GrammaticalGender>,
+}
+
+/// A term value that can be a simple string or have singular/plural forms.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub enum RawTermValue {
     /// Simple string value.
     Simple(String),
-    /// Form-keyed value (for terms with long/short forms).
-    Forms(HashMap<String, RawTermValue>),
     /// Singular/plural forms.
     SingularPlural {
         /// Singular form of the term.
-        singular: String,
+        singular: RawGenderedString,
         /// Plural form of the term.
-        plural: String,
+        plural: RawGenderedString,
+    },
+    /// Gender-specific values.
+    Gendered {
+        /// Masculine form.
+        #[serde(default)]
+        masculine: Option<String>,
+        /// Feminine form.
+        #[serde(default)]
+        feminine: Option<String>,
+        /// Neuter form.
+        #[serde(default)]
+        neuter: Option<String>,
+        /// Common or shared form.
+        #[serde(default)]
+        common: Option<String>,
+    },
+    /// Form-keyed value (for terms with long/short forms).
+    Forms(HashMap<String, RawTermValue>),
+}
+
+/// A raw string that may include gender-specific variants.
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub enum RawGenderedString {
+    /// Plain string value.
+    Simple(String),
+    /// Gender-specific values.
+    Gendered {
+        /// Masculine form.
+        #[serde(default)]
+        masculine: Option<String>,
+        /// Feminine form.
+        #[serde(default)]
+        feminine: Option<String>,
+        /// Neuter form.
+        #[serde(default)]
+        neuter: Option<String>,
+        /// Common or shared form.
+        #[serde(default)]
+        common: Option<String>,
     },
 }
 
 impl Default for RawTermValue {
     fn default() -> Self {
         RawTermValue::Simple(String::new())
+    }
+}
+
+impl<'de> Deserialize<'de> for RawTermValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        Self::from_value(value).map_err(D::Error::custom)
+    }
+}
+
+impl<'de> Deserialize<'de> for RawGenderedString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        Self::from_value(value).map_err(D::Error::custom)
     }
 }
 
@@ -171,6 +249,179 @@ impl RawTermValue {
             RawTermValue::Simple(s) => Some(s),
             _ => None,
         }
+    }
+
+    fn from_value(value: Value) -> Result<Self, String> {
+        match value {
+            Value::String(s) => Ok(Self::Simple(s)),
+            Value::Mapping(map) => {
+                if let Some((singular, plural)) = parse_singular_plural_map(&map)? {
+                    return Ok(Self::SingularPlural { singular, plural });
+                }
+
+                if let Some(gendered) = parse_gendered_map(&map)? {
+                    return Ok(gendered);
+                }
+
+                let forms = map_to_term_values(map)?;
+                Ok(Self::Forms(forms))
+            }
+            other => Err(format!(
+                "expected string or mapping for locale term, found {}",
+                value_kind(&other)
+            )),
+        }
+    }
+}
+
+impl RawGenderedString {
+    fn from_value(value: Value) -> Result<Self, String> {
+        match value {
+            Value::String(s) => Ok(Self::Simple(s)),
+            Value::Mapping(map) => parse_gendered_string_map(&map)?
+                .ok_or_else(|| "expected string or gender-specific mapping".to_string()),
+            other => Err(format!(
+                "expected string or mapping for gendered locale string, found {}",
+                value_kind(&other)
+            )),
+        }
+    }
+}
+
+fn parse_singular_plural_map(
+    map: &Mapping,
+) -> Result<Option<(RawGenderedString, RawGenderedString)>, String> {
+    if !contains_only_keys(map, &["singular", "plural"])? {
+        return Ok(None);
+    }
+
+    if map.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(singular) = map.get(Value::String("singular".to_string())) else {
+        return Ok(None);
+    };
+    let Some(plural) = map.get(Value::String("plural".to_string())) else {
+        return Ok(None);
+    };
+
+    Ok(Some((
+        RawGenderedString::from_value(singular.clone())?,
+        RawGenderedString::from_value(plural.clone())?,
+    )))
+}
+
+fn parse_gendered_map(map: &Mapping) -> Result<Option<RawTermValue>, String> {
+    parse_gender_slots(map).map(|slots| {
+        slots.map(
+            |(masculine, feminine, neuter, common)| RawTermValue::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            },
+        )
+    })
+}
+
+fn parse_gendered_string_map(map: &Mapping) -> Result<Option<RawGenderedString>, String> {
+    parse_gender_slots(map).map(|slots| {
+        slots.map(
+            |(masculine, feminine, neuter, common)| RawGenderedString::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            },
+        )
+    })
+}
+
+type GenderSlots = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn parse_gender_slots(map: &Mapping) -> Result<Option<GenderSlots>, String> {
+    if !contains_only_keys(map, &["masculine", "feminine", "neuter", "common"])? {
+        return Ok(None);
+    }
+
+    if map.is_empty() {
+        return Ok(None);
+    }
+
+    let masculine = map
+        .get(Value::String("masculine".to_string()))
+        .map(parse_string_value)
+        .transpose()?;
+    let feminine = map
+        .get(Value::String("feminine".to_string()))
+        .map(parse_string_value)
+        .transpose()?;
+    let neuter = map
+        .get(Value::String("neuter".to_string()))
+        .map(parse_string_value)
+        .transpose()?;
+    let common = map
+        .get(Value::String("common".to_string()))
+        .map(parse_string_value)
+        .transpose()?;
+
+    if masculine.is_none() && feminine.is_none() && neuter.is_none() && common.is_none() {
+        return Ok(None);
+    }
+
+    Ok(Some((masculine, feminine, neuter, common)))
+}
+
+fn contains_only_keys(map: &Mapping, allowed: &[&str]) -> Result<bool, String> {
+    for key in map.keys() {
+        let Value::String(key) = key else {
+            return Err("locale term keys must be strings".to_string());
+        };
+
+        if !allowed.contains(&key.as_str()) {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn map_to_term_values(map: Mapping) -> Result<HashMap<String, RawTermValue>, String> {
+    map.into_iter()
+        .map(|(key, value)| {
+            let Value::String(key) = key else {
+                return Err("locale term keys must be strings".to_string());
+            };
+            Ok((key, RawTermValue::from_value(value)?))
+        })
+        .collect()
+}
+
+fn parse_string_value(value: &Value) -> Result<String, String> {
+    match value {
+        Value::String(value) => Ok(value.clone()),
+        other => Err(format!(
+            "expected string in gendered locale term, found {}",
+            value_kind(other)
+        )),
+    }
+}
+
+fn value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Sequence(_) => "sequence",
+        Value::Mapping(_) => "mapping",
+        Value::Tagged(_) => "tagged value",
     }
 }
 

--- a/crates/citum-schema-style/src/locale/raw.rs
+++ b/crates/citum-schema-style/src/locale/raw.rs
@@ -8,6 +8,8 @@ use schemars::JsonSchema;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml::{Mapping, Value};
+#[cfg(feature = "schema")]
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Raw locale format for YAML parsing.
@@ -163,7 +165,6 @@ pub struct RawLocatorTerm {
 
 /// A term value that can be a simple string or have singular/plural forms.
 #[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub enum RawTermValue {
     /// Simple string value.
     Simple(String),
@@ -195,7 +196,6 @@ pub enum RawTermValue {
 
 /// A raw string that may include gender-specific variants.
 #[derive(Debug, Clone, Serialize)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub enum RawGenderedString {
     /// Plain string value.
     Simple(String),
@@ -219,6 +219,75 @@ pub enum RawGenderedString {
 impl Default for RawTermValue {
     fn default() -> Self {
         RawTermValue::Simple(String::new())
+    }
+}
+
+#[cfg(feature = "schema")]
+impl JsonSchema for RawGenderedString {
+    fn schema_name() -> Cow<'static, str> {
+        "RawGenderedString".into()
+    }
+
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "A raw string that may include gender-specific variants.",
+            "anyOf": [
+                {
+                    "description": "Plain string value.",
+                    "type": "string"
+                },
+                {
+                    "description": "Gender-specific values.",
+                    "type": "object",
+                    "properties": gender_slot_schema_properties(),
+                    "additionalProperties": false,
+                    "minProperties": 1
+                }
+            ]
+        })
+    }
+}
+
+#[cfg(feature = "schema")]
+impl JsonSchema for RawTermValue {
+    fn schema_name() -> Cow<'static, str> {
+        "RawTermValue".into()
+    }
+
+    fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "A term value that can be a simple string or have singular/plural forms.",
+            "anyOf": [
+                {
+                    "description": "Simple string value.",
+                    "type": "string"
+                },
+                {
+                    "description": "Singular/plural forms.",
+                    "type": "object",
+                    "properties": {
+                        "singular": { "$ref": "#/$defs/RawGenderedString" },
+                        "plural": { "$ref": "#/$defs/RawGenderedString" }
+                    },
+                    "required": ["singular", "plural"],
+                    "additionalProperties": false
+                },
+                {
+                    "description": "Gender-specific values.",
+                    "type": "object",
+                    "properties": gender_slot_schema_properties(),
+                    "additionalProperties": false,
+                    "minProperties": 1
+                },
+                {
+                    "description": "Form-keyed value (for terms with long/short or nested forms).",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/RawTermValue"
+                    }
+                }
+            ]
+        })
     }
 }
 
@@ -346,34 +415,34 @@ type GenderSlots = (
 );
 
 fn parse_gender_slots(map: &Mapping) -> Result<Option<GenderSlots>, String> {
-    if !contains_only_keys(map, &["masculine", "feminine", "neuter", "common"])? {
+    let (has_gender_key, has_non_gender_key) = inspect_gender_keys(map)?;
+    if !has_gender_key {
         return Ok(None);
     }
-
-    if map.is_empty() {
-        return Ok(None);
+    if has_non_gender_key {
+        return Err("gendered locale terms cannot mix gender keys with other keys".to_string());
     }
 
     let masculine = map
         .get(Value::String("masculine".to_string()))
-        .map(parse_string_value)
-        .transpose()?;
+        .map(parse_optional_string_value)
+        .transpose()?
+        .flatten();
     let feminine = map
         .get(Value::String("feminine".to_string()))
-        .map(parse_string_value)
-        .transpose()?;
+        .map(parse_optional_string_value)
+        .transpose()?
+        .flatten();
     let neuter = map
         .get(Value::String("neuter".to_string()))
-        .map(parse_string_value)
-        .transpose()?;
+        .map(parse_optional_string_value)
+        .transpose()?
+        .flatten();
     let common = map
         .get(Value::String("common".to_string()))
-        .map(parse_string_value)
-        .transpose()?;
-
-    if masculine.is_none() && feminine.is_none() && neuter.is_none() && common.is_none() {
-        return Ok(None);
-    }
+        .map(parse_optional_string_value)
+        .transpose()?
+        .flatten();
 
     Ok(Some((masculine, feminine, neuter, common)))
 }
@@ -403,14 +472,43 @@ fn map_to_term_values(map: Mapping) -> Result<HashMap<String, RawTermValue>, Str
         .collect()
 }
 
-fn parse_string_value(value: &Value) -> Result<String, String> {
+fn parse_optional_string_value(value: &Value) -> Result<Option<String>, String> {
     match value {
-        Value::String(value) => Ok(value.clone()),
+        Value::Null => Ok(None),
+        Value::String(value) => Ok(Some(value.clone())),
         other => Err(format!(
             "expected string in gendered locale term, found {}",
             value_kind(other)
         )),
     }
+}
+
+fn inspect_gender_keys(map: &Mapping) -> Result<(bool, bool), String> {
+    let mut has_gender_key = false;
+    let mut has_non_gender_key = false;
+
+    for key in map.keys() {
+        let Value::String(key) = key else {
+            return Err("locale term keys must be strings".to_string());
+        };
+
+        match key.as_str() {
+            "masculine" | "feminine" | "neuter" | "common" => has_gender_key = true,
+            _ => has_non_gender_key = true,
+        }
+    }
+
+    Ok((has_gender_key, has_non_gender_key))
+}
+
+#[cfg(feature = "schema")]
+fn gender_slot_schema_properties() -> serde_json::Value {
+    serde_json::json!({
+        "masculine": { "type": ["string", "null"] },
+        "feminine": { "type": ["string", "null"] },
+        "neuter": { "type": ["string", "null"] },
+        "common": { "type": ["string", "null"] }
+    })
 }
 
 fn value_kind(value: &Value) -> &'static str {
@@ -448,5 +546,93 @@ impl From<RawLocaleOverride> for super::types::LocaleOverride {
             grammar_options: raw.grammar_options,
             legacy_term_aliases: raw.legacy_term_aliases,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RawGenderedString, RawTermValue};
+    #[cfg(feature = "schema")]
+    use crate::locale::RawLocale;
+
+    #[test]
+    fn test_gender_slots_accept_explicit_null_values() {
+        let parsed: RawTermValue = serde_yaml::from_str(
+            r#"
+masculine: editor
+feminine: editora
+common: null
+"#,
+        )
+        .expect("gendered term with null slot should parse");
+
+        match parsed {
+            RawTermValue::Gendered {
+                masculine,
+                feminine,
+                common,
+                ..
+            } => {
+                assert_eq!(masculine.as_deref(), Some("editor"));
+                assert_eq!(feminine.as_deref(), Some("editora"));
+                assert_eq!(common, None);
+            }
+            other => panic!("expected gendered term, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_all_null_gender_slots_still_parse() {
+        let parsed: RawGenderedString = serde_yaml::from_str(
+            r#"
+masculine: null
+feminine: null
+common: null
+"#,
+        )
+        .expect("all-null gender map should parse");
+
+        match parsed {
+            RawGenderedString::Gendered {
+                masculine,
+                feminine,
+                common,
+                ..
+            } => {
+                assert!(masculine.is_none());
+                assert!(feminine.is_none());
+                assert!(common.is_none());
+            }
+            other => panic!("expected gendered string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_malformed_gender_map_reports_targeted_error() {
+        let error = serde_yaml::from_str::<RawTermValue>(
+            r#"
+masculine: editor
+femine: editora
+"#,
+        )
+        .expect_err("mixed gender-like map should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("gendered locale terms cannot mix gender keys")
+        );
+    }
+
+    #[cfg(feature = "schema")]
+    #[test]
+    fn test_raw_term_schema_remains_untagged() {
+        let schema = schemars::schema_for!(RawLocale);
+        let schema_text = serde_json::to_string(&schema).expect("schema should serialize");
+
+        assert!(schema_text.contains("\"RawTermValue\""));
+        assert!(schema_text.contains("\"type\":\"string\""));
+        assert!(schema_text.contains("\"$ref\":\"#/$defs/RawGenderedString\""));
+        assert!(!schema_text.contains("\"Simple\""));
     }
 }

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -34,6 +34,140 @@ pub enum TermForm {
     Symbol,
 }
 
+/// Grammatical gender used for locale agreement and term selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum GrammaticalGender {
+    /// Masculine grammatical gender.
+    Masculine,
+    /// Feminine grammatical gender.
+    Feminine,
+    /// Neuter grammatical gender.
+    Neuter,
+    /// Common or shared grammatical gender.
+    Common,
+}
+
+/// A value that may vary by grammatical gender.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum MaybeGendered<T> {
+    /// The value is the same for all genders.
+    Plain(T),
+    /// The value varies by grammatical gender.
+    Gendered {
+        /// Masculine variant.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        masculine: Option<T>,
+        /// Feminine variant.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        feminine: Option<T>,
+        /// Neuter variant.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        neuter: Option<T>,
+        /// Common or gender-unspecified variant.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        common: Option<T>,
+    },
+}
+
+impl<T: Default> Default for MaybeGendered<T> {
+    fn default() -> Self {
+        Self::Plain(T::default())
+    }
+}
+
+impl<T> From<T> for MaybeGendered<T> {
+    fn from(value: T) -> Self {
+        Self::Plain(value)
+    }
+}
+
+impl From<&str> for MaybeGendered<String> {
+    fn from(value: &str) -> Self {
+        Self::Plain(value.to_string())
+    }
+}
+
+impl<T> MaybeGendered<T> {
+    fn by_gender(&self, requested: GrammaticalGender) -> Option<&T> {
+        match self {
+            Self::Plain(value) => Some(value),
+            Self::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            } => match requested {
+                GrammaticalGender::Masculine => masculine.as_ref(),
+                GrammaticalGender::Feminine => feminine.as_ref(),
+                GrammaticalGender::Neuter => neuter.as_ref(),
+                GrammaticalGender::Common => common.as_ref(),
+            },
+        }
+    }
+
+    /// Resolve only the explicitly requested slot.
+    pub fn resolve_strict(&self, requested: Option<GrammaticalGender>) -> Option<&T> {
+        match self {
+            Self::Plain(value) => Some(value),
+            Self::Gendered { .. } => requested.and_then(|gender| self.by_gender(gender)),
+        }
+    }
+
+    /// Resolve a value using the documented production fallback order.
+    pub fn resolve_with_fallback(&self, requested: Option<GrammaticalGender>) -> Option<&T> {
+        match self {
+            Self::Plain(value) => Some(value),
+            Self::Gendered {
+                masculine,
+                feminine,
+                neuter,
+                common,
+            } => requested
+                .and_then(|gender| self.by_gender(gender))
+                .or(common.as_ref())
+                .or(masculine.as_ref())
+                .or(feminine.as_ref())
+                .or(neuter.as_ref()),
+        }
+    }
+
+    /// Resolve to a neutral/default form without selecting gendered slots.
+    pub fn resolve_neutral(&self) -> Option<&T> {
+        match self {
+            Self::Plain(value) => Some(value),
+            Self::Gendered { common, .. } => common.as_ref(),
+        }
+    }
+}
+
+impl MaybeGendered<String> {
+    /// Resolve to the default production string.
+    pub fn as_default_str(&self) -> &str {
+        self.resolve_with_fallback(None)
+            .map(String::as_str)
+            .unwrap_or("")
+    }
+
+    /// Whether the default resolved value is empty.
+    pub fn is_empty(&self) -> bool {
+        self.as_default_str().is_empty()
+    }
+
+    /// Resolve to a borrowed string using the default production path.
+    pub fn as_str(&self) -> &str {
+        self.as_default_str()
+    }
+
+    /// Lowercase the default resolved value.
+    pub fn to_lowercase(&self) -> String {
+        self.as_default_str().to_lowercase()
+    }
+}
+
 /// A list of general terms for citation formatting.
 ///
 /// These are the standard terms that appear in bibliographies and citations,
@@ -208,9 +342,9 @@ impl Terms {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct SimpleTerm {
     /// The long form of the term (e.g., "anonymous").
-    pub long: String,
+    pub long: MaybeGendered<String>,
     /// The short form of the term (e.g., "anon.").
-    pub short: String,
+    pub short: MaybeGendered<String>,
 }
 
 /// Terms for contributor roles.
@@ -243,6 +377,9 @@ pub struct LocatorTerm {
     /// Symbol form (e.g., "§"/"§§").
     #[serde(default)]
     pub symbol: Option<SingularPlural>,
+    /// Lexical gender for noun agreement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gender: Option<GrammaticalGender>,
 }
 
 /// A term with singular and plural forms.
@@ -252,9 +389,9 @@ pub struct LocatorTerm {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct SingularPlural {
     /// Singular form (e.g., "page").
-    pub singular: String,
+    pub singular: MaybeGendered<String>,
     /// Plural form (e.g., "pages").
-    pub plural: String,
+    pub plural: MaybeGendered<String>,
 }
 
 /// Date-related terms.
@@ -606,24 +743,24 @@ mod tests {
     #[test]
     fn test_simple_term_construction() {
         let term = SimpleTerm {
-            long: "anonymous".to_string(),
-            short: "anon.".to_string(),
+            long: "anonymous".into(),
+            short: "anon.".into(),
         };
 
-        assert_eq!(term.long, "anonymous");
-        assert_eq!(term.short, "anon.");
+        assert_eq!(term.long, MaybeGendered::Plain("anonymous".to_string()));
+        assert_eq!(term.short, MaybeGendered::Plain("anon.".to_string()));
     }
 
     /// Test that SingularPlural provides both singular and plural forms.
     #[test]
     fn test_singular_plural_construction() {
         let term = SingularPlural {
-            singular: "page".to_string(),
-            plural: "pages".to_string(),
+            singular: "page".into(),
+            plural: "pages".into(),
         };
 
-        assert_eq!(term.singular, "page");
-        assert_eq!(term.plural, "pages");
+        assert_eq!(term.singular, MaybeGendered::Plain("page".to_string()));
+        assert_eq!(term.plural, MaybeGendered::Plain("pages".to_string()));
     }
 
     /// Test that Terms::en_us() returns expected English terms.
@@ -641,10 +778,16 @@ mod tests {
         assert_eq!(terms.no_date, Some("n.d.".to_string()));
         assert_eq!(terms.ibid, Some("ibid.".to_string()));
 
-        assert_eq!(terms.anonymous.long, "anonymous");
-        assert_eq!(terms.anonymous.short, "anon.");
-        assert_eq!(terms.circa.long, "circa");
-        assert_eq!(terms.circa.short, "c.");
+        assert_eq!(
+            terms.anonymous.long,
+            MaybeGendered::Plain("anonymous".to_string())
+        );
+        assert_eq!(
+            terms.anonymous.short,
+            MaybeGendered::Plain("anon.".to_string())
+        );
+        assert_eq!(terms.circa.long, MaybeGendered::Plain("circa".to_string()));
+        assert_eq!(terms.circa.short, MaybeGendered::Plain("c.".to_string()));
     }
 
     /// Test that the legacy no-date fallback does not serialize alongside the structured term.

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -33,7 +33,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //!
 //! This keeps all conditional logic in the style, making it testable and portable.
 
-use crate::locale::{GeneralTerm, TermForm};
+use crate::locale::{GeneralTerm, GrammaticalGender, TermForm};
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -521,6 +521,9 @@ pub struct TemplateContributor {
     /// Structured link options (DOI, URL).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<crate::options::LinksConfig>,
+    /// Explicit grammatical gender override for role-label agreement.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gender: Option<GrammaticalGender>,
 
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -700,6 +703,9 @@ pub struct TemplateNumber {
     /// Structured link options (DOI, URL).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<crate::options::LinksConfig>,
+    /// Explicit grammatical gender override for number/ordinal agreement.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gender: Option<GrammaticalGender>,
 
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -977,6 +983,9 @@ pub struct TemplateTerm {
     /// Form: long (default), short, or symbol.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form: Option<TermForm>,
+    /// Explicit grammatical gender override for term selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gender: Option<GrammaticalGender>,
     #[serde(flatten, default)]
     pub rendering: Rendering,
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -533,6 +533,63 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                 </div>
             </div>
 
+            <div class="border-t border-slate-200 bg-white p-6">
+                <div class="flex items-center gap-2 mb-4">
+                    <span class="material-icons text-sm text-primary">record_voice_over</span>
+                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+                        Gender-Aware Spanish Locale Terms
+                    </h3>
+                </div>
+                <div class="grid gap-4">
+                    <div class="border-l-4 border-primary pl-4">
+                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                            Checked-In Locale
+                        </div>
+                        <div class="font-mono text-sm text-slate-900">
+                            <code class="text-xs bg-slate-100 px-1 rounded">locales/es-ES.yaml</code>
+                            now ships gendered role labels such as
+                            <code class="text-xs bg-slate-100 px-1 rounded">editor / editora / persona editora</code>.
+                        </div>
+                    </div>
+                    <div class="border-l-4 border-emerald-500 pl-4">
+                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                            Contributor-Driven Role Label
+                        </div>
+                        <div class="font-mono text-sm text-slate-900">
+                            Ana Martinez, editora
+                        </div>
+                        <div class="text-xs text-slate-500 mt-1">
+                            A feminine contributor entry selects the feminine role label from the Spanish locale.
+                        </div>
+                    </div>
+                    <div class="border-l-4 border-indigo-500 pl-4">
+                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                            Mixed-Gender Group
+                        </div>
+                        <div class="font-mono text-sm text-slate-900">
+                            Ana Martinez y Luis Pérez, equipo editorial
+                        </div>
+                        <div class="text-xs text-slate-500 mt-1">
+                            Mixed contributor genders prefer the locale's neutral/common form instead of falling back to a masculine-specific label.
+                        </div>
+                    </div>
+                    <div class="border-l-4 border-amber-500 pl-4">
+                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                            Template Override
+                        </div>
+                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-2">
+                            <pre class="font-mono text-xs text-slate-300"><span class="text-indigo-400">template</span>:
+  - <span class="text-primary">contributor</span>: <span class="text-emerald-400">editor</span>
+    <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>
+    <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span>
+  - <span class="text-primary">number</span>: <span class="text-emerald-400">volume</span>
+    <span class="text-primary">label-form</span>: <span class="text-emerald-400">short</span>
+    <span class="text-primary">gender</span>: <span class="text-emerald-400">masculine</span></pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Try It Yourself -->
             <div class="bg-white p-6 border-t border-slate-200">
                 <div class="flex items-center gap-2 mb-4">

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -128,6 +128,79 @@ Renders numeric data: volume, issue, pages, edition, etc.
   form: numeric  # numeric | ordinal | roman
 ```
 
+## [translate] Gender-Aware Locale Terms
+
+Citum locale terms can now vary by grammatical gender when the language requires it.
+
+### Reference Data
+
+Contributor-driven role labels use an explicit `gender` field on contributor entries:
+
+```yaml
+contributors:
+  - role: editor
+    contributor:
+      family: "Martinez"
+      given: "Ana"
+    gender: feminine
+```
+
+Mixed-gender contributor groups prefer a locale's neutral/common form when one exists. If a locale only provides gendered masculine/feminine variants and no neutral/common form, Citum does not silently fall back to a masculine-specific label for the mixed group.
+
+### Template Overrides
+
+Use a template-level `gender` override when a term or number label must request a specific agreement form directly:
+
+```yaml
+- contributor: editor
+  form: long
+  gender: feminine
+
+- term: volume
+  form: short
+  gender: masculine
+
+- number: volume
+  label-form: short
+  gender: feminine
+```
+
+### Locale YAML
+
+Locale terms still accept plain strings, but they can now also use gendered maps:
+
+```yaml
+roles:
+  editor:
+    long:
+      singular:
+        masculine: editor
+        feminine: editora
+        common: persona editora
+      plural:
+        masculine: editores
+        feminine: editoras
+        common: equipo editorial
+```
+
+Locator terms can also declare lexical gender metadata for noun agreement:
+
+```yaml
+locators:
+  page:
+    long:
+      singular: página
+      plural: páginas
+    short:
+      singular: p.
+      plural: pp.
+    gender: feminine
+```
+
+> [!TIP]
+> **Current scope**
+> Gender-aware rendering currently applies to locale term selection and contributor role labels. Verb-form role terms such as `edited by` remain ungendered in this release, even though they share the same underlying Rust type.
+
 ## [formatting] Rendering Options
 
 Every component can be modified with rendering options that control punctuation, formatting, and text wrapping.

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,9 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.33.0 (2026-04-18)
+- Schema version bumped from 0.32.2 to 0.33.0
+
 #### schema-v0.32.2 (2026-04-18)
 - Schema version bumped from 0.32.1 to 0.32.2
 

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -688,6 +688,17 @@
         "contributor": {
           "description": "The contributor (name, organization, or list).",
           "$ref": "#/$defs/Contributor"
+        },
+        "gender": {
+          "description": "The grammatical gender used for role-label agreement.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorGender"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -721,6 +732,31 @@
         {
           "description": "An open extension point for domain-specific roles.",
           "type": "string"
+        }
+      ]
+    },
+    "ContributorGender": {
+      "description": "Grammatical gender carried on contributor records for role-label agreement.",
+      "oneOf": [
+        {
+          "description": "Masculine grammatical gender.",
+          "type": "string",
+          "const": "masculine"
+        },
+        {
+          "description": "Feminine grammatical gender.",
+          "type": "string",
+          "const": "feminine"
+        },
+        {
+          "description": "Neuter grammatical gender.",
+          "type": "string",
+          "const": "neuter"
+        },
+        {
+          "description": "Common or shared grammatical gender.",
+          "type": "string",
+          "const": "common"
         }
       ]
     },

--- a/docs/schemas/locale.json
+++ b/docs/schemas/locale.json
@@ -310,174 +310,66 @@
     },
     "RawTermValue": {
       "description": "A term value that can be a simple string or have singular/plural forms.",
-      "oneOf": [
+      "anyOf": [
         {
           "description": "Simple string value.",
-          "type": "object",
-          "properties": {
-            "Simple": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "Simple"
-          ],
-          "additionalProperties": false
+          "type": "string"
         },
         {
           "description": "Singular/plural forms.",
           "type": "object",
           "properties": {
-            "SingularPlural": {
-              "type": "object",
-              "properties": {
-                "singular": {
-                  "description": "Singular form of the term.",
-                  "$ref": "#/$defs/RawGenderedString"
-                },
-                "plural": {
-                  "description": "Plural form of the term.",
-                  "$ref": "#/$defs/RawGenderedString"
-                }
-              },
-              "required": [
-                "singular",
-                "plural"
+            "singular": {
+              "$ref": "#/$defs/RawGenderedString"
+            },
+            "plural": {
+              "$ref": "#/$defs/RawGenderedString"
+            }
+          },
+          "required": [
+            "singular",
+            "plural"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "description": "Gender-specific values.",
+          "type": "object",
+          "properties": {
+            "masculine": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "feminine": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "neuter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "common": {
+              "type": [
+                "string",
+                "null"
               ]
             }
           },
-          "required": [
-            "SingularPlural"
-          ],
-          "additionalProperties": false
+          "additionalProperties": false,
+          "minProperties": 1
         },
         {
-          "description": "Gender-specific values.",
+          "description": "Form-keyed value (for terms with long/short or nested forms).",
           "type": "object",
-          "properties": {
-            "Gendered": {
-              "type": "object",
-              "properties": {
-                "masculine": {
-                  "description": "Masculine form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "feminine": {
-                  "description": "Feminine form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "neuter": {
-                  "description": "Neuter form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "common": {
-                  "description": "Common or shared form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                }
-              }
-            }
-          },
-          "required": [
-            "Gendered"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "description": "Form-keyed value (for terms with long/short forms).",
-          "type": "object",
-          "properties": {
-            "Forms": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/$defs/RawTermValue"
-              }
-            }
-          },
-          "required": [
-            "Forms"
-          ],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "RawGenderedString": {
-      "description": "A raw string that may include gender-specific variants.",
-      "oneOf": [
-        {
-          "description": "Plain string value.",
-          "type": "object",
-          "properties": {
-            "Simple": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "Simple"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "description": "Gender-specific values.",
-          "type": "object",
-          "properties": {
-            "Gendered": {
-              "type": "object",
-              "properties": {
-                "masculine": {
-                  "description": "Masculine form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "feminine": {
-                  "description": "Feminine form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "neuter": {
-                  "description": "Neuter form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "common": {
-                  "description": "Common or shared form.",
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "default": null
-                }
-              }
-            }
-          },
-          "required": [
-            "Gendered"
-          ],
-          "additionalProperties": false
+          "additionalProperties": {
+            "$ref": "#/$defs/RawTermValue"
+          }
         }
       ]
     },

--- a/docs/schemas/locale.json
+++ b/docs/schemas/locale.json
@@ -49,7 +49,7 @@
       "description": "Locator terms keyed by locator name.",
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/$defs/RawTermValue"
+        "$ref": "#/$defs/RawLocatorTerm"
       },
       "default": {}
     },
@@ -310,35 +310,253 @@
     },
     "RawTermValue": {
       "description": "A term value that can be a simple string or have singular/plural forms.",
-      "anyOf": [
+      "oneOf": [
         {
           "description": "Simple string value.",
-          "type": "string"
-        },
-        {
-          "description": "Form-keyed value (for terms with long/short forms).",
           "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/RawTermValue"
-          }
+          "properties": {
+            "Simple": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Simple"
+          ],
+          "additionalProperties": false
         },
         {
           "description": "Singular/plural forms.",
           "type": "object",
           "properties": {
-            "singular": {
-              "description": "Singular form of the term.",
-              "type": "string"
-            },
-            "plural": {
-              "description": "Plural form of the term.",
+            "SingularPlural": {
+              "type": "object",
+              "properties": {
+                "singular": {
+                  "description": "Singular form of the term.",
+                  "$ref": "#/$defs/RawGenderedString"
+                },
+                "plural": {
+                  "description": "Plural form of the term.",
+                  "$ref": "#/$defs/RawGenderedString"
+                }
+              },
+              "required": [
+                "singular",
+                "plural"
+              ]
+            }
+          },
+          "required": [
+            "SingularPlural"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "description": "Gender-specific values.",
+          "type": "object",
+          "properties": {
+            "Gendered": {
+              "type": "object",
+              "properties": {
+                "masculine": {
+                  "description": "Masculine form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "feminine": {
+                  "description": "Feminine form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "neuter": {
+                  "description": "Neuter form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "common": {
+                  "description": "Common or shared form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                }
+              }
+            }
+          },
+          "required": [
+            "Gendered"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "description": "Form-keyed value (for terms with long/short forms).",
+          "type": "object",
+          "properties": {
+            "Forms": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/RawTermValue"
+              }
+            }
+          },
+          "required": [
+            "Forms"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RawGenderedString": {
+      "description": "A raw string that may include gender-specific variants.",
+      "oneOf": [
+        {
+          "description": "Plain string value.",
+          "type": "object",
+          "properties": {
+            "Simple": {
               "type": "string"
             }
           },
           "required": [
-            "singular",
-            "plural"
-          ]
+            "Simple"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "description": "Gender-specific values.",
+          "type": "object",
+          "properties": {
+            "Gendered": {
+              "type": "object",
+              "properties": {
+                "masculine": {
+                  "description": "Masculine form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "feminine": {
+                  "description": "Feminine form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "neuter": {
+                  "description": "Neuter form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "common": {
+                  "description": "Common or shared form.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                }
+              }
+            }
+          },
+          "required": [
+            "Gendered"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RawLocatorTerm": {
+      "description": "Raw locator term with optional lexical gender.",
+      "type": "object",
+      "properties": {
+        "long": {
+          "description": "Long-form locator term.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "short": {
+          "description": "Short-form locator term.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "symbol": {
+          "description": "Symbol-form locator term.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "gender": {
+          "description": "Lexical gender used for noun agreement.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      }
+    },
+    "GrammaticalGender": {
+      "description": "Grammatical gender used for locale agreement and term selection.",
+      "oneOf": [
+        {
+          "description": "Masculine grammatical gender.",
+          "type": "string",
+          "const": "masculine"
+        },
+        {
+          "description": "Feminine grammatical gender.",
+          "type": "string",
+          "const": "feminine"
+        },
+        {
+          "description": "Neuter grammatical gender.",
+          "type": "string",
+          "const": "neuter"
+        },
+        {
+          "description": "Common or shared grammatical gender.",
+          "type": "string",
+          "const": "common"
         }
       ]
     },

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7,7 +7,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.32.2"
+      "default": "0.33.0"
     },
     "info": {
       "description": "Style metadata.",
@@ -564,6 +564,17 @@
             }
           ]
         },
+        "gender": {
+          "description": "Explicit grammatical gender override for role-label agreement.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "custom": {
           "description": "Custom user-defined fields for extensions.",
           "type": [
@@ -1037,6 +1048,31 @@
           "description": "Link the entire bibliography entry.",
           "type": "string",
           "const": "entry"
+        }
+      ]
+    },
+    "GrammaticalGender": {
+      "description": "Grammatical gender used for locale agreement and term selection.",
+      "oneOf": [
+        {
+          "description": "Masculine grammatical gender.",
+          "type": "string",
+          "const": "masculine"
+        },
+        {
+          "description": "Feminine grammatical gender.",
+          "type": "string",
+          "const": "feminine"
+        },
+        {
+          "description": "Neuter grammatical gender.",
+          "type": "string",
+          "const": "neuter"
+        },
+        {
+          "description": "Common or shared grammatical gender.",
+          "type": "string",
+          "const": "common"
         }
       ]
     },
@@ -1519,6 +1555,17 @@
             }
           ]
         },
+        "gender": {
+          "description": "Explicit grammatical gender override for number/ordinal agreement.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "custom": {
           "description": "Custom user-defined fields for extensions.",
           "type": [
@@ -1885,6 +1932,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/TermForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gender": {
+          "description": "Explicit grammatical gender override for term selection.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
             },
             {
               "type": "null"

--- a/docs/specs/GENDERED_LOCALE_TERMS.md
+++ b/docs/specs/GENDERED_LOCALE_TERMS.md
@@ -1,4 +1,4 @@
-**Status:** Draft  
+**Status:** Active  
 **Version:** 1.2  
 **Date:** 2026-04-15  
 **Bean:** `csl26-y3kj`
@@ -9,7 +9,7 @@ Citum's locale model currently represents every term string as a plain `String`.
 
 Two concrete cases:
 
-**Contributor role terms (Romance languages).** French “editor” is “éditeur” (masculine) or “éditrice” (feminine). A locale file author currently has no way to encode both forms; they must pick one and accept incorrect output for the other.
+**Contributor role terms (Romance languages).** Spanish “editor” is “editor” (masculine) or “editora” (feminine). A locale file author currently has no way to encode both forms; they must pick one and accept incorrect output for the other.
 
 **Ordinals (Arabic, Romance languages).** Arabic ordinals inflect for gender: the masculine first ordinal is “الأول” while the feminine is “الأولى”. No single string can represent both.
 
@@ -74,7 +74,7 @@ pub enum MaybeGendered<T> {
 }
 ```
 
-`serde(untagged)` means existing plain-string locale files deserialize without any changes: `"editor"` becomes `Plain("editor")`, and `{ masculine: "éditeur", feminine: "éditrice" }` becomes the `Gendered` variant.
+`serde(untagged)` means existing plain-string locale files deserialize without any changes: `"editor"` becomes `Plain("editor")`, and `{ masculine: "editor", feminine: "editora" }` becomes the `Gendered` variant.
 
 ### Resolution methods
 
@@ -167,7 +167,7 @@ pub struct SingularPlural {
 
 `ContributorTerm`, `LocatorTerm`, and `DateTerms` are unchanged — they compose the above types and gain gender support transitively.
 
-**Verb-form gender scope.** `ContributorTerm.verb` (e.g., "edited by") is a `SimpleTerm` and thus technically inherits `MaybeGendered<String>` capacity. However, verb-form gender agreement is out of scope for this change — the intended use is inflected role-label nouns (e.g., "éditeur/éditrice"), not verb phrases. Locale authors MUST NOT populate gendered variants on verb-form term entries in this release; any such entries will be ignored by the engine.
+**Verb-form gender scope.** `ContributorTerm.verb` (e.g., "edited by") is a `SimpleTerm` and thus technically inherits `MaybeGendered<String>` capacity. However, verb-form gender agreement is out of scope for this change — the intended use is inflected role-label nouns (e.g., "editor/editora"), not verb phrases. Locale authors MUST NOT populate gendered variants on verb-form term entries in this release; any such entries will be ignored by the engine.
 
 No term *must* become gendered; `Plain` is the default representation and is sufficient for most locales.
 
@@ -198,7 +198,7 @@ terms:
 Constraints:
 
 - `gender` is only meaningful on **noun-like terms** that serve as agreement targets (e.g., “edition”, “volume”, possibly some locators).
-- `gender` MUST NOT be used on terms where grammatical gender depends on the referent (e.g., contributor roles “editor/éditrice”); in those cases, `MaybeGendered<String>` carries variants and the agreement context comes from reference data.
+- `gender` MUST NOT be used on terms where grammatical gender depends on the referent (e.g., contributor roles “editor/editora”); in those cases, `MaybeGendered<String>` carries variants and the agreement context comes from reference data.
 
 The concrete Rust types composing these fields (`NounTerm` vs other term structs) are an implementation detail; the spec guarantees only:
 
@@ -217,18 +217,18 @@ roles:
       plural: "editors"
 ```
 
-A French locale adds gender variants only where the language requires them:
+A Spanish locale adds gender variants only where the language requires them:
 
 ```yaml
 roles:
   editor:
     long:
       singular:
-        masculine: "éditeur"
-        feminine:  "éditrice"
+        masculine: "editor"
+        feminine:  "editora"
       plural:
-        masculine: "éditeurs"
-        feminine:  "éditrices"
+        masculine: "editores"
+        feminine:  "editoras"
 ```
 
 An Arabic locale for ordinals (once ordinal term support lands):
@@ -313,7 +313,7 @@ The engine derives `requested_gender` from three sources, in strictly defined pr
 
    This maps directly to `Some(GrammaticalGender::Masculine)` in the render context.
 
-2. **Reference data** — a `gender` field on a contributor in the input reference, used when rendering contributor role labels (e.g., “éditeur” vs “éditrice”). The engine derives `requested_gender` from contributors **only when exactly one contributor is in scope** for the rendered label.
+2. **Reference data** — a `gender` field on a contributor in the input reference, used when rendering contributor role labels (e.g., “editor” vs “editora”). The engine derives `requested_gender` from contributors **only when exactly one contributor is in scope** for the rendered label.
 
    YAML:
 
@@ -328,7 +328,8 @@ The engine derives `requested_gender` from three sources, in strictly defined pr
 
    - If exactly one contributor is relevant and has a `gender`, use that `GrammaticalGender`.
    - If there are multiple contributors: collect only those that have an *explicit* `gender` field (contributors with no `gender` field are skipped, not treated as a mismatch). If all collected genders are identical and at least one contributor has a gender, use that shared gender.
-   - If no contributor has an explicit `gender`, or the collected genders differ, do not derive a `requested_gender` from reference data (i.e., pass `None` and fall back to locale defaults).
+   - If no contributor has an explicit `gender`, do not derive a `requested_gender` from reference data.
+   - If the collected genders differ, request `Common` and prefer a plain/common locale form rather than falling through to masculine/feminine-specific slots.
 
    This avoids silently gendering plural role labels from the first name only.
 
@@ -447,7 +448,7 @@ Existing locale tests MUST continue to pass unchanged:
 - [ ] `Locale::role_term`, `locator_term`, `general_term` accept `requested_gender: Option<GrammaticalGender>`.
 - [ ] All existing locale tests pass (plain-string values round-trip correctly; behavior with `None` requested gender matches prior output).
 - [ ] New snapshot tests:
-      - French contributor role with gendered variants (e.g., “éditeur/éditrice”).
+      - Spanish contributor role with gendered variants (e.g., “editor/editora”).
       - Arabic gendered ordinal agreeing with a feminine noun.
 - [ ] New unit tests for:
       - `resolve_with_fallback` behavior with each slot populated individually.
@@ -495,4 +496,3 @@ For future implementers and spec readers, these resources provide additional con
 - Specified which term kinds may safely carry lexical gender metadata vs those that should only use gendered variants (e.g., contributor roles), to avoid overloading `gender` on terms whose form depends on the referent.
 
 - Clarified the role of `RawTermValue` as a syntax-layer AST and documented its `Gendered`-shaped variant and conversion into `MaybeGendered<String>` to keep YAML validation and runtime representation aligned.
-

--- a/docs/specs/GENDERED_LOCALE_TERMS.md
+++ b/docs/specs/GENDERED_LOCALE_TERMS.md
@@ -11,13 +11,13 @@ Two concrete cases:
 
 **Contributor role terms (Romance languages).** Spanish “editor” is “editor” (masculine) or “editora” (feminine). A locale file author currently has no way to encode both forms; they must pick one and accept incorrect output for the other.
 
-**Ordinals (Arabic, Romance languages).** Arabic ordinals inflect for gender: the masculine first ordinal is “الأول” while the feminine is “الأولى”. No single string can represent both.
+**Future ordinal agreement.** Some languages also need grammatical gender for ordinals and other noun-agreement cases. This remains follow-up work, but the term model introduced here is intended to make that future work possible.
 
 Citum needs a way to:
 
 - Store gendered variants of term values where required.
 - Attach lexical gender metadata to noun-like terms for agreement.
-- Select the right variant at render time, based on an explicit agreement context.
+- Select the right variant at render time, based on an explicit agreement context where the engine currently supports it.
 
 ## Prior Art
 
@@ -43,7 +43,7 @@ Citum introduces three related but distinct pieces:
 
 1. **Gendered term values**: `MaybeGendered<T>` carries either a single value or a set of gender-specific variants.
 2. **Grammatical gender category**: `GrammaticalGender` enumerates the stable set of genders the engine recognizes for agreement.
-3. **Lexical gender metadata**: optional `gender: GrammaticalGender` on noun-like locale terms to drive agreement, especially for ordinals.
+3. **Lexical gender metadata**: optional `gender: GrammaticalGender` on locale entries that act as agreement targets. In this release, that metadata is surfaced on locator terms.
 
 The engine passes an optional **requested agreement gender** (`requested_gender: Option<GrammaticalGender>`) into term resolution. Callers that do not need gendered output pass `None` and receive existing behavior.
 
@@ -173,13 +173,15 @@ No term *must* become gendered; `Plain` is the default representation and is suf
 
 **`Default` impl and existing initializers.** The `SimpleTerm` and `SingularPlural` field-type changes are source-breaking. All existing initializers — including `Terms::en_us()`, any `Default` impl, and any test fixtures that construct these structs directly — must wrap plain string literals in `MaybeGendered::Plain(...)`. No existing locale file needs to change, but Rust construction sites must be updated in the same commit as the type change.
 
-## Lexical gender metadata on terms
+## Lexical gender metadata on locale entries
 
-In addition to gendered values, noun-like locale entries gain optional lexical gender metadata:
+In addition to gendered values, locale entries that act as agreement targets gain optional lexical gender metadata:
 
 ```rust
-pub struct NounTerm {
-    pub value: SingularPlural,
+pub struct LocatorTerm {
+    pub long: Option<SingularPlural>,
+    pub short: Option<SingularPlural>,
+    pub symbol: Option<SingularPlural>,
     pub gender: Option<GrammaticalGender>,
 }
 ```
@@ -187,22 +189,24 @@ pub struct NounTerm {
 Schema-wise, this is surfaced as a `gender` property on the term entry:
 
 ```yaml
-# In locale/fr-FR.yaml
-terms:
-  edition:
-    singular: "édition"
-    plural: "éditions"
+# In locale/es-ES.yaml
+locators:
+  page:
+    long:
+      singular: "página"
+      plural: "páginas"
     gender: feminine
 ```
 
 Constraints:
 
-- `gender` is only meaningful on **noun-like terms** that serve as agreement targets (e.g., “edition”, “volume”, possibly some locators).
+- `gender` is only meaningful on locale entries that serve as agreement targets.
+- In this release, the checked-in schema/runtime surface that metadata on locator terms.
 - `gender` MUST NOT be used on terms where grammatical gender depends on the referent (e.g., contributor roles “editor/editora”); in those cases, `MaybeGendered<String>` carries variants and the agreement context comes from reference data.
 
-The concrete Rust types composing these fields (`NounTerm` vs other term structs) are an implementation detail; the spec guarantees only:
+The concrete Rust types composing these fields are an implementation detail; the spec guarantees only:
 
-- For noun-like terms, `gender: GrammaticalGender?` is available for agreement logic.
+- For supported locale entries, `gender: GrammaticalGender?` is available for agreement logic.
 - For all terms, values are expressed via `MaybeGendered<String>` as defined above.
 
 ## YAML representation
@@ -231,23 +235,14 @@ roles:
         feminine:  "editoras"
 ```
 
-An Arabic locale for ordinals (once ordinal term support lands):
+A locator entry can also expose lexical gender metadata for future agreement work:
 
 ```yaml
-terms:
-  ordinal-01:
-    singular:
-      masculine: "الأول"
-      feminine:  "الأولى"
-```
-
-A French locale declaring the lexical gender of a noun:
-
-```yaml
-terms:
+locators:
   edition:
-    singular: "édition"
-    plural: "éditions"
+    long:
+      singular: "edición"
+      plural: "ediciones"
     gender: feminine
 ```
 
@@ -329,27 +324,24 @@ The engine derives `requested_gender` from three sources, in strictly defined pr
    - If exactly one contributor is relevant and has a `gender`, use that `GrammaticalGender`.
    - If there are multiple contributors: collect only those that have an *explicit* `gender` field (contributors with no `gender` field are skipped, not treated as a mismatch). If all collected genders are identical and at least one contributor has a gender, use that shared gender.
    - If no contributor has an explicit `gender`, do not derive a `requested_gender` from reference data.
-   - If the collected genders differ, request `Common` and prefer a plain/common locale form rather than falling through to masculine/feminine-specific slots.
+   - If the collected genders differ, use a contributor-specific neutral resolution path that prefers a plain/common locale form rather than falling through to masculine/feminine-specific slots.
 
    This avoids silently gendering plural role labels from the first name only.
 
-3. **Locale lexical gender** — a `gender` property on the term entry itself, declaring the grammatical gender of that noun. Used for ordinals and other agreement cases that must match a noun (e.g., “1re édition” because *édition* is feminine).
+3. **Locale lexical gender** — a `gender` property on the locale entry itself, declaring the grammatical gender of that noun. In this release, the schema and runtime surface this metadata on locator terms. It is available for current template-level overrides and for follow-up agreement work, but full ordinal-agreement rendering is not part of this PR.
 
    YAML (as above):
 
    ```yaml
-   terms:
+   locators:
      edition:
-       singular: "édition"
-       plural: "éditions"
+       long:
+         singular: "edición"
+         plural: "ediciones"
        gender: feminine
    ```
 
-   When a template says `number: edition, form: ordinal`, the engine:
-
-   - Looks up the “edition” term.
-   - Reads its `gender` (if any).
-   - Uses it as `requested_gender` when resolving the ordinal form.
+   The current implementation does not yet derive ordinal rendering directly from locator lexical gender. That remains follow-up work; this PR limits runtime gender-aware rendering to contributor-role labels plus explicit template overrides on the term/number components that already use locale term lookup.
 
 If none of the three sources produces a `requested_gender`, the engine passes `None` and relies entirely on the fallback behavior in `MaybeGendered::resolve_with_fallback`.
 
@@ -366,7 +358,6 @@ let value: Option<&str> = term_value
 This ensures:
 
 - Template-level override feeds directly into the gender slot selection.
-- When an ordinal is tied to a noun with lexical gender, that gender drives agreement automatically.
 - When no agreement information is known, `Plain` values still work, and `Gendered` values fall back in a deterministic order.
 
 ### Out-of-scope semantics
@@ -377,7 +368,7 @@ The following remain out of scope for this change:
 - Grammatical case, animacy, person, or full declension tables.
 - Higher-level message-format constructs that perform gender agreement across whole sentences (ICU MessageFormat-style selects).
 
-The gender feature is intentionally narrow: it only affects locale **term** values and agreement with those terms.
+The gender feature is intentionally narrow in this release: it affects locale **term** values, contributor-role label selection, and template-driven term/number lookups that already route through locale resolution.
 
 ## Raw term value and deserialization
 
@@ -444,17 +435,15 @@ Existing locale tests MUST continue to pass unchanged:
 - [ ] `GrammaticalGender` defined and used consistently for both lexical metadata and requested agreement context.
 - [ ] `SimpleTerm.long` / `.short` changed to `MaybeGendered<String>`.
 - [ ] `SingularPlural.singular` / `.plural` changed to `MaybeGendered<String>`.
-- [ ] Noun-like terms support optional lexical `gender: GrammaticalGender` in the locale schema and corresponding Rust types.
+- [ ] Supported locale entries expose optional lexical `gender: GrammaticalGender` in the locale schema and corresponding Rust types.
 - [ ] `Locale::role_term`, `locator_term`, `general_term` accept `requested_gender: Option<GrammaticalGender>`.
 - [ ] All existing locale tests pass (plain-string values round-trip correctly; behavior with `None` requested gender matches prior output).
 - [ ] New snapshot tests:
       - Spanish contributor role with gendered variants (e.g., “editor/editora”).
-      - Arabic gendered ordinal agreeing with a feminine noun.
 - [ ] New unit tests for:
       - `resolve_with_fallback` behavior with each slot populated individually.
       - Deterministic fallback when `requested_gender` is `None`.
       - Reference-data behavior for one vs multiple contributors with matching and mixed genders.
-      - Ordinal agreement derived from lexical noun gender.
 - [ ] `RawTermValue` extended with a `Gendered`-shaped variant and conversion to `MaybeGendered<String>`.
 - [ ] This spec’s `Status` set to `Active` in the same commit as the first implementation.
 
@@ -489,9 +478,9 @@ For future implementers and spec readers, these resources provide additional con
 
 - Renamed and stabilized the gender category type as `GrammaticalGender`, and documented its use both as lexical gender metadata on noun-like terms and as the requested agreement context in engine calls.
 
-- Introduced explicit lexical `gender: GrammaticalGender` metadata for noun-like locale terms (e.g., `edition`), and defined how ordinal rendering derives `requested_gender` from this metadata for gender agreement.
+- Introduced explicit lexical `gender: GrammaticalGender` metadata for supported locale entries, and narrowed the current runtime claims so full ordinal-agreement rendering remains follow-up work.
 
-- Tightened the agreement source precedence to a clear chain: template-level override → reference-data contributor gender (with defined behavior for single vs multiple contributors) → locale lexical gender, falling back to locale defaults when none apply.
+- Tightened the agreement source precedence to a clear chain: template-level override → reference-data contributor gender, falling back to locale defaults when none apply. Locale lexical gender metadata is now documented as schema/runtime surface for follow-up agreement work rather than claiming full ordinal wiring in this PR.
 
 - Specified which term kinds may safely carry lexical gender metadata vs those that should only use gendered variants (e.g., contributor roles), to avoid overloading `gender` on terms whose form depends on the referent.
 

--- a/locales/es-ES.yaml
+++ b/locales/es-ES.yaml
@@ -1,0 +1,217 @@
+locale-schema-version: "2"
+locale: es-ES
+
+evaluation:
+  message-syntax: mf2
+
+dates:
+  months:
+    long:
+      - enero
+      - febrero
+      - marzo
+      - abril
+      - mayo
+      - junio
+      - julio
+      - agosto
+      - septiembre
+      - octubre
+      - noviembre
+      - diciembre
+    short:
+      - ene.
+      - feb.
+      - mar.
+      - abr.
+      - may.
+      - jun.
+      - jul.
+      - ago.
+      - sept.
+      - oct.
+      - nov.
+      - dic.
+  seasons:
+    - primavera
+    - verano
+    - otoño
+    - invierno
+
+roles:
+  author:
+    long:
+  chair:
+    long:
+      singular: presidente
+      plural: presidentes
+    verb: presidido por
+  collection-editor:
+    long:
+      singular:
+        masculine: director
+        feminine: directora
+        common: persona directora
+      plural:
+        masculine: directores
+        feminine: directoras
+        common: equipo editorial
+    short:
+      singular: dir.
+      plural: dirs.
+    verb: bajo la dirección de
+    verb-short: dir. de
+  contributor:
+    long:
+      singular: colaborador
+      plural: colaboradores
+    short:
+      singular: colab.
+      plural: colabs.
+    verb: con
+  director:
+    long:
+      singular:
+        masculine: director
+        feminine: directora
+        common: persona directora
+      plural:
+        masculine: directores
+        feminine: directoras
+        common: equipo de dirección
+    short:
+      singular: dir.
+      plural: dirs.
+    verb: dirigido por
+    verb-short: dir. por
+  editor:
+    long:
+      singular:
+        masculine: editor
+        feminine: editora
+        common: persona editora
+      plural:
+        masculine: editores
+        feminine: editoras
+        common: equipo editorial
+    short:
+      singular: ed.
+      plural: eds.
+    verb: editado por
+    verb-short: ed. por
+  editorial-director:
+    long:
+      singular:
+        masculine: director editorial
+        feminine: directora editorial
+        common: dirección editorial
+      plural:
+        masculine: directores editoriales
+        feminine: directoras editoriales
+        common: dirección editorial
+    short:
+      singular: dir. ed.
+      plural: dirs. ed.
+    verb: bajo la dirección editorial de
+    verb-short: dir. ed. de
+  illustrator:
+    long:
+      singular:
+        masculine: ilustrador
+        feminine: ilustradora
+        common: persona ilustradora
+      plural:
+        masculine: ilustradores
+        feminine: ilustradoras
+        common: equipo de ilustración
+    short:
+      singular: il.
+      plural: ils.
+    verb: ilustrado por
+    verb-short: il. por
+  interviewer:
+    long:
+      singular:
+        masculine: entrevistador
+        feminine: entrevistadora
+        common: persona entrevistadora
+      plural:
+        masculine: entrevistadores
+        feminine: entrevistadoras
+        common: equipo entrevistador
+    verb: entrevistado por
+  recipient:
+    long:
+    verb: a
+  reviewed-author:
+    long:
+    verb: por
+  translator:
+    long:
+      singular:
+        masculine: traductor
+        feminine: traductora
+        common: persona traductora
+      plural:
+        masculine: traductores
+        feminine: traductoras
+        common: equipo de traducción
+    short:
+      singular: trad.
+      plural: trads.
+    verb: traducido por
+    verb-short: trad. por
+
+locators:
+  chapter:
+    long:
+      singular: capítulo
+      plural: capítulos
+    short:
+      singular: cap.
+      plural: caps.
+  issue:
+    long:
+      singular: número
+      plural: números
+    short:
+      singular: n.º
+      plural: n.os
+  page:
+    long:
+      singular: página
+      plural: páginas
+    short:
+      singular: p.
+      plural: pp.
+    gender: feminine
+  section:
+    long:
+      singular: sección
+      plural: secciones
+    short:
+      singular: §
+      plural: §§
+    symbol:
+      singular: §
+      plural: §§
+    gender: feminine
+  volume:
+    long:
+      singular: volumen
+      plural: volúmenes
+    short:
+      singular: vol.
+      plural: vols.
+    gender: masculine
+
+terms:
+  and:
+    long: y
+  anonymous:
+    long: anónimo
+    short: anón.
+  et_al:
+    long: et al.
+  "no date":
+    long: s. f.


### PR DESCRIPTION
## Summary
- add grammatical gender support for locale terms, noun metadata, template overrides, and contributor reference data
- make mixed-gender contributor groups prefer neutral/common role labels instead of falling back to masculine-specific forms
- add Spanish-focused contributor-role coverage, keep Arabic ordinal coverage, and regenerate schemas

## Testing
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- cargo run --bin citum --features schema -- schema --out-dir docs/schemas

Refs: csl26-y3kj