### PR TITLE
feat(scripts): add web confirmation for aliases

### DIFF
--- a/.beans/archive/csl26-vepq--add-confirm-web-flag-to-find-alias-candidatesjs.md
+++ b/.beans/archive/csl26-vepq--add-confirm-web-flag-to-find-alias-candidatesjs.md
@@ -1,7 +1,7 @@
 ---
 # csl26-vepq
 title: Add --confirm-web flag to find-alias-candidates.js
-status: todo
+status: done
 type: feature
 created_at: 2026-04-19T13:11:05Z
 updated_at: 2026-04-19T13:11:05Z

--- a/docs/guides/ALIAS_DISCOVERY.md
+++ b/docs/guides/ALIAS_DISCOVERY.md
@@ -54,16 +54,21 @@ node scripts/find-alias-candidates.js --help
 **Before aliasing**, confirm the candidate is a true clone (not a same-family variant
 with intentional differences the fixture doesn't exercise — see Known Blind Spots below).
 
-### Web Confirmation (bean csl26-vepq)
+### Web Confirmation (`--confirm-web`)
 
-A `--confirm-web` flag is tracked in bean **csl26-vepq**. It will query a search API
-for each candidate above the threshold: `"<journal name>" citation style` and
-`"<journal name>" author guidelines`. The results surface whether the journal's own
-instructions name the parent style explicitly — reducing the need for per-row manual
-lookup and providing a citable evidence URL in the TSV output.
+Use the `--confirm-web` flag to automatically query a search API for each candidate
+above the threshold. The script queries: `"<journal name>" citation style author guidelines`.
 
-Until that lands, for journal-named candidates: search `site:<publisher>.com
-<journal-name> submission guidelines` and look for a named style.
+- **Backend:** Defaults to DuckDuckGo Lite (no key required). If `PERPLEXITY_API_KEY`
+  is set, it uses the Perplexity API with automatic fallback to DDG on failure.
+- **Output:** Adds `evidence_url` and `confidence_note` columns to the TSV.
+
+This reduces manual lookup time by surfacing whether the journal's own instructions
+name the parent style explicitly.
+
+```bash
+node scripts/find-alias-candidates.js --threshold 0.98 --confirm-web
+```
 
 ## Known Fixture Blind Spots & Fixes (2026-04-19)
 

--- a/scripts/find-alias-candidates.js
+++ b/scripts/find-alias-candidates.js
@@ -57,6 +57,7 @@ function parseArgs() {
     citationsFixture: DEFAULT_CITATIONS_FIXTURE,
     registryPath: DEFAULT_REGISTRY,
     stylesDir: DEFAULT_STYLES_DIR,
+    confirmWeb: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -67,6 +68,8 @@ function parseArgs() {
       options.threshold = parseFloat(args[++i]);
     } else if (arg === '--limit') {
       options.limit = parseInt(args[++i], 10);
+    } else if (arg === '--confirm-web') {
+      options.confirmWeb = true;
     } else if (arg === '--out') {
       options.out = args[++i];
     } else if (arg === '--refs-fixture') {
@@ -357,6 +360,7 @@ async function processBatch(candidates, targetFingerprints, testItems, testCitat
 
   for (const candidate of candidates) {
     try {
+      const content = fs.readFileSync(candidate.path, 'utf8');
       const rendered = renderWithCiteprocJs(candidate.path, testItems, testCitations);
       if (!rendered) {
         continue; // Skip failed renders
@@ -377,12 +381,27 @@ async function processBatch(candidates, targetFingerprints, testItems, testCitat
       }
 
       if (bestTarget) {
+        // Extract documentation links from CSL
+        const docLinks = [];
+        const docRegex = /<link\s+[^>]*href=["']([^"']+)["']\s+rel=["']documentation["']/g;
+        let match;
+        while ((match = docRegex.exec(content)) !== null) {
+          docLinks.push(match[1]);
+        }
+        // Also check reversed order of attributes
+        const docRegexRev = /<link\s+[^>]*rel=["']documentation["']\s+href=["']([^"']+)["']/g;
+        while ((match = docRegexRev.exec(content)) !== null) {
+          docLinks.push(match[1]);
+        }
+
         results.push({
           candidate_id: candidate.id,
           best_target: bestTarget,
           similarity: bestScore.similarity,
           citation_match: bestScore.citation_match,
           bib_match: bestScore.bib_match,
+          evidence_url: docLinks[0] || '',
+          confidence_note: docLinks.length > 0 ? 'found in CSL metadata' : '',
         });
       }
     } catch (e) {
@@ -428,15 +447,130 @@ async function runParallel(candidates, concurrency, targetFingerprints, testItem
 }
 
 /**
+ * Web confirmation for candidates using Perplexity or DuckDuckGo.
+ */
+async function confirmWebCandidates(results, threshold) {
+  const filtered = results.filter(r => r.similarity >= threshold);
+  console.error(`\nRunning web confirmation for ${filtered.length} candidates...`);
+
+  for (let i = 0; i < filtered.length; i++) {
+    const row = filtered[i];
+    
+    // Skip if we already have evidence from CSL metadata
+    if (row.evidence_url) {
+      console.error(`[${i + 1}/${filtered.length}] Skipping: ${row.candidate_id} (already has metadata evidence)`);
+      continue;
+    }
+
+    const query = `"${row.candidate_id.replace(/-/g, ' ')}" citation style author guidelines`;
+    
+    console.error(`[${i + 1}/${filtered.length}] Checking: ${row.candidate_id}...`);
+    
+    let confirmation = null;
+    if (process.env.PERPLEXITY_API_KEY) {
+      confirmation = await checkPerplexity(query, row.best_target);
+    }
+    
+    if (!confirmation) {
+      // Fallback to DuckDuckGo
+      confirmation = await checkDuckDuckGo(query, row.best_target);
+      // Rate limiting for DDG
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    row.evidence_url = confirmation ? confirmation.url : '';
+    row.confidence_note = confirmation ? confirmation.note : 'no web evidence found';
+  }
+}
+
+async function checkPerplexity(query, targetId) {
+  try {
+    const response = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${process.env.PERPLEXITY_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'llama-3.1-sonar-small-128k-online',
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a research assistant confirming CSL citation style aliases. Return JSON: { "url": "...", "note": "..." }'
+          },
+          {
+            role: 'user',
+            content: `Does the journal for "${query}" explicitly state they use the "${targetId}" citation style? Provide the best URL as evidence and a brief note on confidence.`
+          }
+        ],
+        response_format: { type: 'json_object' }
+      })
+    });
+
+    if (!response.ok) return null;
+    const data = await response.json();
+    return JSON.parse(data.choices[0].message.content);
+  } catch (e) {
+    return null;
+  }
+}
+
+async function checkDuckDuckGo(query, targetId) {
+  try {
+    const response = await fetch('https://html.duckduckgo.com/html/', {
+      method: 'POST',
+      headers: { 
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+      },
+      body: `q=${encodeURIComponent(query)}`
+    });
+
+    if (!response.ok) return null;
+    const html = await response.text();
+
+    // Regex for html.duckduckgo.com results
+    const urlMatch = html.match(/class=['"]result__a['"] href=['"](http[^'"]+)['"]/);
+    const snippetMatch = html.match(/class=['"]result__snippet['"]>([^<]+)/);
+
+    if (urlMatch) {
+      const url = urlMatch[1];
+      const snippet = snippetMatch ? snippetMatch[1].toLowerCase() : '';
+      const targetLower = targetId.toLowerCase().replace(/-/g, ' ');
+      
+      let note = 'found via DDG';
+      if (snippet.includes(targetLower)) {
+        note = `high confidence: snippet mentions "${targetId}"`;
+      } else if (snippet.includes('citation') || snippet.includes('style')) {
+        note = 'medium confidence: snippet mentions citation/style';
+      }
+
+      return { url, note };
+    }
+  } catch (e) {
+    // Ignore fetch errors
+  }
+  return null;
+}
+
+/**
  * Write results as TSV.
  */
-function writeTSV(results, filePath) {
+function writeTSV(results, filePath, threshold) {
   // Filter by threshold
-  const filtered = results.filter(r => r.similarity >= 0.85);
+  const filtered = results.filter(r => r.similarity >= threshold);
   // Sort by similarity descending
   filtered.sort((a, b) => b.similarity - a.similarity);
 
-  const header = ['candidate_id', 'best_target', 'similarity', 'citation_match', 'bib_match'];
+  const header = [
+    'candidate_id', 
+    'best_target', 
+    'similarity', 
+    'citation_match', 
+    'bib_match', 
+    'evidence_url', 
+    'confidence_note'
+  ];
   const lines = [header.join('\t')];
 
   for (const row of filtered) {
@@ -446,6 +580,8 @@ function writeTSV(results, filePath) {
       row.similarity.toFixed(4),
       row.citation_match.toFixed(4),
       row.bib_match.toFixed(4),
+      row.evidence_url || '',
+      row.confidence_note || '',
     ].join('\t'));
   }
 
@@ -501,11 +637,24 @@ async function main() {
 
     console.error(`Scored ${results.length} candidates`);
 
+    // Web confirmation if requested
+    if (options.confirmWeb) {
+      await confirmWebCandidates(results, options.threshold);
+    }
+
     // Write TSV
-    const filtered = writeTSV(results, options.out);
+    const filtered = writeTSV(results, options.out, options.threshold);
 
     // Output to stdout
-    const header = ['candidate_id', 'best_target', 'similarity', 'citation_match', 'bib_match'];
+    const header = [
+      'candidate_id', 
+      'best_target', 
+      'similarity', 
+      'citation_match', 
+      'bib_match', 
+      'evidence_url', 
+      'confidence_note'
+    ];
     console.log(header.join('\t'));
     for (const row of filtered) {
       console.log([
@@ -514,6 +663,8 @@ async function main() {
         row.similarity.toFixed(4),
         row.citation_match.toFixed(4),
         row.bib_match.toFixed(4),
+        row.evidence_url || '',
+        row.confidence_note || '',
       ].join('\t'));
     }
 


### PR DESCRIPTION
Enhance find-alias-candidates.js with --confirm-web flag.
- Extract documentation links from CSL metadata by default.
- Implement DuckDuckGo Lite and Perplexity search backends.
- Update TSV output with evidence and confidence notes.
- Update documentation and archive completed bean csl26-vepq.