### PR TITLE
chore(scripts): update alias report with metadata evidence

### DIFF
--- a/scripts/find-alias-candidates.js
+++ b/scripts/find-alias-candidates.js
@@ -58,6 +58,7 @@ function parseArgs() {
     registryPath: DEFAULT_REGISTRY,
     stylesDir: DEFAULT_STYLES_DIR,
     confirmWeb: false,
+    updateMetadata: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -70,6 +71,8 @@ function parseArgs() {
       options.limit = parseInt(args[++i], 10);
     } else if (arg === '--confirm-web') {
       options.confirmWeb = true;
+    } else if (arg === '--update-metadata') {
+      options.updateMetadata = true;
     } else if (arg === '--out') {
       options.out = args[++i];
     } else if (arg === '--refs-fixture') {
@@ -353,6 +356,27 @@ function enumerateCandidates(stylesDir, builtins, knownAliases) {
 }
 
 /**
+ * Extract documentation links from CSL XML content.
+ */
+function extractCslMetadata(content) {
+  const docLinks = [];
+  const docRegex = /<link\s+[^>]*href=["']([^"']+)["']\s+rel=["']documentation["']/g;
+  let match;
+  while ((match = docRegex.exec(content)) !== null) {
+    docLinks.push(match[1]);
+  }
+  // Also check reversed order of attributes
+  const docRegexRev = /<link\s+[^>]*rel=["']documentation["']\s+href=["']([^"']+)["']/g;
+  while ((match = docRegexRev.exec(content)) !== null) {
+    docLinks.push(match[1]);
+  }
+  return {
+    url: docLinks[0] || '',
+    note: docLinks.length > 0 ? 'found in CSL metadata' : '',
+  };
+}
+
+/**
  * Process a batch of candidates concurrently.
  */
 async function processBatch(candidates, targetFingerprints, testItems, testCitations, onProgress) {
@@ -382,17 +406,7 @@ async function processBatch(candidates, targetFingerprints, testItems, testCitat
 
       if (bestTarget) {
         // Extract documentation links from CSL
-        const docLinks = [];
-        const docRegex = /<link\s+[^>]*href=["']([^"']+)["']\s+rel=["']documentation["']/g;
-        let match;
-        while ((match = docRegex.exec(content)) !== null) {
-          docLinks.push(match[1]);
-        }
-        // Also check reversed order of attributes
-        const docRegexRev = /<link\s+[^>]*rel=["']documentation["']\s+href=["']([^"']+)["']/g;
-        while ((match = docRegexRev.exec(content)) !== null) {
-          docLinks.push(match[1]);
-        }
+        const meta = extractCslMetadata(content);
 
         results.push({
           candidate_id: candidate.id,
@@ -400,8 +414,8 @@ async function processBatch(candidates, targetFingerprints, testItems, testCitat
           similarity: bestScore.similarity,
           citation_match: bestScore.citation_match,
           bib_match: bestScore.bib_match,
-          evidence_url: docLinks[0] || '',
-          confidence_note: docLinks.length > 0 ? 'found in CSL metadata' : '',
+          evidence_url: meta.url,
+          confidence_note: meta.note,
         });
       }
     } catch (e) {
@@ -590,10 +604,67 @@ function writeTSV(results, filePath, threshold) {
   return filtered;
 }
 
+async function handleUpdateMetadata(options) {
+  if (!fs.existsSync(options.out)) {
+    throw new Error(`File not found for --update-metadata: ${options.out}`);
+  }
+
+  console.error(`Updating metadata for: ${options.out}...`);
+  const content = fs.readFileSync(options.out, 'utf8');
+  const lines = content.split('\n').filter(l => l.trim().length > 0);
+  const header = lines[0].split('\t');
+  
+  const results = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cols = lines[i].split('\t');
+    const row = Object.fromEntries(header.map((h, j) => [h, cols[j]]));
+    
+    // Convert strings to floats for similarity
+    row.similarity = parseFloat(row.similarity);
+    row.citation_match = parseFloat(row.citation_match);
+    row.bib_match = parseFloat(row.bib_match);
+
+    const stylePath = path.join(options.stylesDir, `${row.candidate_id}.csl`);
+    if (fs.existsSync(stylePath)) {
+      const cslContent = fs.readFileSync(stylePath, 'utf8');
+      const meta = extractCslMetadata(cslContent);
+      row.evidence_url = meta.url;
+      row.confidence_note = meta.note;
+    }
+    results.push(row);
+  }
+
+  if (options.confirmWeb) {
+    await confirmWebCandidates(results, options.threshold);
+  }
+
+  writeTSV(results, options.out, options.threshold);
+  return results;
+}
+
 async function main() {
   const options = parseArgs();
 
   try {
+    if (options.updateMetadata) {
+      const filtered = await handleUpdateMetadata(options);
+      
+      const header = ['candidate_id', 'best_target', 'similarity', 'citation_match', 'bib_match', 'evidence_url', 'confidence_note'];
+      console.log(header.join('\t'));
+      for (const row of filtered) {
+        console.log([
+          row.candidate_id,
+          row.best_target,
+          row.similarity.toFixed(4),
+          row.citation_match.toFixed(4),
+          row.bib_match.toFixed(4),
+          row.evidence_url || '',
+          row.confidence_note || '',
+        ].join('\t'));
+      }
+      return;
+    }
+
     // Load fixtures
     const { testItems, testCitations } = loadFixtures(options.refsFixture, options.citationsFixture);
 

--- a/scripts/report-data/alias-candidates-2026-04-19.tsv
+++ b/scripts/report-data/alias-candidates-2026-04-19.tsv
@@ -1,2308 +1,2308 @@
-candidate_id	best_target	similarity	citation_match	bib_match
-accident-analysis-and-prevention	elsevier-harvard	1.0000	1.0000	1.0000
-aci-materials-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-acm-sig-proceedings-long-author-list	elsevier-with-titles	1.0000	0.7500	0.0000
-acm-sig-proceedings	elsevier-with-titles	1.0000	0.7500	0.0000
-acta-anaesthesiologica-scandinavica	elsevier-with-titles	1.0000	0.0000	0.0000
-acta-chirurgiae-orthopaedicae-et-traumatologiae-cechoslovaca	elsevier-with-titles	1.0000	0.0000	0.0000
-acta-hydrotechnica	elsevier-harvard	1.0000	1.0000	0.0000
-acta-medica-peruana	elsevier-with-titles	1.0000	1.0000	0.0000
-acta-medica-portuguesa	american-medical-association	1.0000	1.0000	1.0000
-acta-neurochirurgica	elsevier-with-titles	1.0000	0.7500	0.0000
-acta-orthopaedica-belgica	elsevier-with-titles	1.0000	0.0000	0.0000
-acta-orthopaedica	elsevier-with-titles	1.0000	0.0000	0.0000
-acta-paediatrica	elsevier-with-titles	1.0000	0.0000	0.0000
-acta-palaeontologica-polonica	springer-basic-author-date	1.0000	0.6500	0.0000
-acta-pharmaceutica-sinica-b	elsevier-with-titles	1.0000	0.0000	0.0000
-acta-physica-sinica	elsevier-with-titles	1.0000	1.0000	0.0000
-acta-physiologica	elsevier-with-titles	1.0000	0.0000	0.0000
-acta-polytechnica	ieee	1.0000	0.5000	0.0000
-acta-scientiae-veterinariae	elsevier-with-titles	1.0000	0.9500	0.0000
-acta-societatis-botanicorum-poloniae	elsevier-with-titles	1.0000	1.0000	0.0000
-advanced-functional-materials	elsevier-with-titles	1.0000	1.0000	0.0000
-advanced-pharmaceutical-bulletin	american-medical-association	1.0000	1.0000	0.0000
-advanced-science	elsevier-with-titles	1.0000	1.0000	0.0000
-advances-in-alzheimers-disease	elsevier-with-titles	1.0000	1.0000	0.0000
-advances-in-complex-systems	elsevier-with-titles	1.0000	0.9500	0.0000
-aerosol-and-air-quality-research	elsevier-harvard	1.0000	1.0000	0.0000
-aerosol-science-and-technology	elsevier-harvard	1.0000	0.1000	0.0000
-aerospace-medicine-and-human-performance	elsevier-with-titles	1.0000	0.0000	0.0000
-african-journal-of-food-agriculture-nutrition-development	elsevier-with-titles	1.0000	0.7500	0.0000
-african-online-scientific-information-systems-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000
-african-zoology	elsevier-harvard	1.0000	0.0500	0.0000
-aging-and-disease	elsevier-with-titles	1.0000	0.7500	0.0000
-aging	elsevier-with-titles	1.0000	1.0000	0.0000
-agriculturae-conspectus-scientificus	elsevier-harvard	1.0000	1.0000	0.0000
-aids	elsevier-with-titles	1.0000	1.0000	0.0000
-aims-press	elsevier-with-titles	1.0000	1.0000	0.0000
-alcoholism-clinical-and-experimental-research	elsevier-harvard	1.0000	1.0000	0.0000
-allergology-international	elsevier-with-titles	1.0000	0.0000	0.0000
-allergy	elsevier-with-titles	1.0000	0.0000	0.0000
-american-association-for-cancer-research	elsevier-with-titles	1.0000	0.0000	0.0000
-american-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000
-american-fisheries-society	elsevier-harvard	1.0000	0.0500	0.0000
-american-heart-association	elsevier-with-titles	1.0000	0.0000	0.0000
-american-institute-of-aeronautics-and-astronautics	elsevier-with-titles	1.0000	1.0000	0.0000
-american-institute-of-physics	elsevier-with-titles	1.0000	0.0000	0.0000
-american-journal-of-climate-change	elsevier-with-titles	1.0000	1.0000	0.0000
-american-journal-of-health-behavior	elsevier-with-titles	1.0000	0.0000	0.0000
-american-journal-of-plant-sciences	elsevier-with-titles	1.0000	1.0000	0.0000
-american-journal-of-respiratory-and-critical-care-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-american-journal-of-sonography	elsevier-with-titles	1.0000	1.0000	0.0000
-american-journal-of-translational-research	elsevier-with-titles	1.0000	1.0000	0.0000
-american-medical-association-alphabetical	american-medical-association	1.0000	0.9500	1.0000
-american-medical-association-brackets	american-medical-association	1.0000	0.0000	1.0000
-american-medical-association-no-et-al	american-medical-association	1.0000	1.0000	1.0000
-american-medical-association-no-url-alphabetical	american-medical-association	1.0000	0.9500	1.0000
-american-medical-association-no-url	american-medical-association	1.0000	1.0000	1.0000
-american-medical-association-parentheses	american-medical-association	1.0000	0.0000	1.0000
-american-meteorological-society	springer-basic-author-date	1.0000	0.9000	0.0000
-american-mineralogist	elsevier-harvard	1.0000	0.1000	0.0000
-american-nuclear-society	elsevier-with-titles	1.0000	0.0000	0.0000
-american-physiological-society	elsevier-with-titles	1.0000	0.0000	0.0000
-american-society-for-microbiology	elsevier-with-titles	1.0000	0.0000	0.0000
-american-society-of-civil-engineers	springer-basic-author-date	1.0000	0.5000	0.0000
-american-society-of-mechanical-engineers	elsevier-with-titles	1.0000	1.0000	0.0000
-american-statistical-association	springer-basic-author-date	1.0000	0.5000	0.0000
-anaesthesia	elsevier-with-titles	1.0000	1.0000	0.0000
-analytical-sciences	elsevier-with-titles	1.0000	0.0000	0.0000
-anesthesiology	elsevier-with-titles	1.0000	0.0000	0.0000
-angiologia	elsevier-with-titles	1.0000	0.0000	0.0000
-animal-migration	elsevier-with-titles	1.0000	0.7500	0.0000
-animal-welfare	elsevier-harvard	1.0000	0.0500	0.0000
-animal	elsevier-harvard	1.0000	0.8000	1.0000
-annals-of-allergy-asthma-and-immunology	american-medical-association	1.0000	1.0000	0.0000
-annals-of-behavioral-medicine	elsevier-with-titles	1.0000	1.0000	0.0000
-annals-of-biomedical-engineering	elsevier-with-titles	1.0000	0.7500	0.0000
-annals-of-eye-science	elsevier-with-titles	1.0000	0.0000	0.0000
-annals-of-neurology	elsevier-with-titles	1.0000	0.0000	0.0000
-annals-of-oncology	elsevier-with-titles	1.0000	0.0000	0.0000
-annals-of-public-and-cooperative-economics	elsevier-harvard	1.0000	0.0500	0.0000
-annals-of-the-new-york-academy-of-sciences	elsevier-with-titles	1.0000	0.0000	0.0000
-aporia-the-nursing-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-applied-spectroscopy-reviews	elsevier-with-titles	1.0000	0.0000	0.0000
-applied-spectroscopy	elsevier-with-titles	1.0000	0.0000	0.0000
-aquatic-living-resources	elsevier-harvard	1.0000	0.0500	0.0000
-arcadia-science	elsevier-harvard	1.0000	1.0000	0.0000
-archives-of-hand-and-microsurgery	elsevier-with-titles	1.0000	1.0000	0.0000
-archives-of-medical-research	elsevier-with-titles	1.0000	0.0000	0.0000
-archives-of-physical-medicine-and-rehabilitation	elsevier-with-titles	1.0000	0.0000	0.0000
-archivos-de-bronconeumologia	elsevier-with-titles	1.0000	0.0000	0.0000
-archivos-de-la-sociedad-espanola-de-oftalmologia	elsevier-with-titles	1.0000	0.0000	0.0000
-archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular	elsevier-with-titles	1.0000	0.0000	0.0000
-arhiv-za-higijenu-rada-i-toksikologiju	elsevier-with-titles	1.0000	1.0000	0.0000
-artery-research	elsevier-with-titles	1.0000	0.0000	0.0000
-arthropod-systematics-and-phylogeny	elsevier-harvard	1.0000	0.0500	0.0000
-arzneimitteltherapie	elsevier-with-titles	1.0000	0.9500	0.0000
-asa-cssa-sssa	springer-basic-author-date	1.0000	0.1000	0.0000
-asian-journal-of-neurosurgery	elsevier-with-titles	1.0000	1.0000	0.0000
-atlas-of-genetics-and-cytogenetics-in-oncology-and-haematology	elsevier-harvard	1.0000	1.0000	0.0000
-australian-dental-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-australian-veterinary-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-avian-conservation-and-ecology	elsevier-harvard	1.0000	0.0500	0.0000
-avian-diseases	elsevier-with-titles	1.0000	0.0000	0.0000
-baghdad-science-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-baishideng-publishing-group	elsevier-with-titles	1.0000	1.0000	0.0000
-beilstein-journal-of-organic-chemistry	elsevier-with-titles	1.0000	1.0000	0.0000
-berlin-school-of-economics-and-law-international-marketing-management	springer-basic-author-date	1.0000	0.1500	0.0000
-bibliotheque-universitaire-de-medecine-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000
-biochemical-journal	elsevier-with-titles	1.0000	0.7500	0.0000
-biochemistry-and-molecular-biology-education	elsevier-with-titles	1.0000	1.0000	0.0000
-biochemistry	elsevier-with-titles	1.0000	0.0000	0.0000
-biochimica-et-biophysica-acta	elsevier-with-titles	1.0000	1.0000	1.0000
-bioethics	ieee	1.0000	0.6500	0.0000
-biofuel-research-journal	elsevier-harvard	1.0000	0.9500	0.0000
-biological-and-pharmaceutical-bulletin	elsevier-with-titles	1.0000	0.0000	0.0000
-biological-psychiatry	elsevier-with-titles	1.0000	0.0000	0.0000
-biologiceskie-membrany	elsevier-with-titles	1.0000	0.7500	0.0000
-biology-of-reproduction	elsevier-with-titles	1.0000	1.0000	0.0000
-biomed-central	elsevier-with-titles	1.0000	0.7500	0.0000
-biomed-research-international	elsevier-with-titles	1.0000	0.7500	0.0000
-biomolecular-concepts	elsevier-with-titles	1.0000	0.7500	0.0000
-biophysical-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-biophysics-and-physicobiology	elsevier-with-titles	1.0000	1.0000	0.0000
-biopolymers	elsevier-with-titles	1.0000	0.0000	0.0000
-bioresources	springer-basic-author-date	1.0000	0.5000	0.0000
-biotechniques	elsevier-with-titles	1.0000	0.0000	0.0000
-biotechnology-and-bioprocess-engineering	elsevier-with-titles	1.0000	1.0000	0.0000
-bmj	elsevier-with-titles	1.0000	1.0000	0.0000
-boletin-de-la-sociedad-geologica-mexicana	elsevier-harvard	1.0000	0.9500	0.0000
-boletin-de-pediatria	elsevier-with-titles	1.0000	0.0000	0.0000
-bollettino-della-societa-italiana-di-paleontologia	elsevier-harvard	1.0000	0.9500	0.0000
-boreal-environment-research	springer-basic-author-date	1.0000	0.7000	0.0000
-borgyogyaszati-es-venerologiai-szemle	elsevier-with-titles	1.0000	0.0000	0.0000
-brazilian-journal-of-infectious-diseases	elsevier-with-titles	1.0000	0.0000	0.0000
-brazilian-oral-research	elsevier-with-titles	1.0000	0.0000	0.0000
-british-journal-of-anaesthesia	elsevier-with-titles	1.0000	0.0000	0.0000
-british-journal-of-nutrition	elsevier-with-titles	1.0000	0.0000	0.0000
-british-journal-of-surgery	elsevier-with-titles	1.0000	0.0000	0.0000
-budownictwo-i-architektura-pl	ieee	1.0000	1.0000	0.0000
-bulletin-du-centre-detudes-medievales-dauxerre	elsevier-with-titles	1.0000	0.0000	0.0000
-bulletin-of-applied-glycoscience	elsevier-with-titles	1.0000	0.0000	0.0000
-byzantina-symmeikta	elsevier-with-titles	1.0000	0.0000	0.0000
-cambridge-journal-of-economics	elsevier-harvard	1.0000	0.9000	0.0000
-cambridge-university-press-author-date-cambridge-a	elsevier-harvard	1.0000	0.0500	0.0000
-cambridge-university-press-author-date	elsevier-harvard	1.0000	0.0500	0.0000
-cambridge-university-press-numeric	elsevier-with-titles	1.0000	0.7500	0.0000
-canadian-geotechnical-journal	elsevier-harvard	1.0000	0.0500	0.0000
-canadian-journal-of-chemistry	elsevier-with-titles	1.0000	0.0000	0.0000
-canadian-journal-of-dietetic-practice-and-research	elsevier-with-titles	1.0000	0.0000	0.0000
-canadian-journal-of-earth-sciences	elsevier-harvard	1.0000	0.0500	0.0000
-canadian-journal-of-fisheries-and-aquatic-sciences	elsevier-harvard	1.0000	0.0500	0.0000
-canadian-journal-of-mineralogy-and-petrology	springer-basic-author-date	1.0000	0.6500	0.0000
-canadian-journal-of-physics	elsevier-with-titles	1.0000	1.0000	0.0000
-canadian-journal-of-public-health	elsevier-with-titles	1.0000	0.0000	0.0000
-canadian-journal-of-remote-sensing	elsevier-harvard	1.0000	1.0000	0.0000
-canadian-journal-of-soil-science	elsevier-harvard	1.0000	0.0500	0.0000
-cancer-biomarkers	elsevier-with-titles	1.0000	1.0000	1.0000
-cancer-drug-resistance	elsevier-with-titles	1.0000	1.0000	0.0000
-cardiff-university-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000
-cardiocore	elsevier-with-titles	1.0000	0.0000	0.0000
-cell-numeric	elsevier-with-titles	1.0000	1.0000	0.0000
-cell-research	elsevier-with-titles	1.0000	1.0000	0.0000
-cell	elsevier-with-titles	1.0000	0.0000	0.0000
-cellular-and-molecular-bioengineering	elsevier-with-titles	1.0000	0.7500	0.0000
-chemical-and-pharmaceutical-bulletin	elsevier-with-titles	1.0000	0.0000	0.0000
-chemical-biology-and-drug-design	elsevier-with-titles	1.0000	1.0000	0.0000
-chest	elsevier-with-titles	1.0000	0.0000	0.0000
-chicago-author-date-17th-edition	taylor-and-francis-chicago-author-date	1.0000	1.0000	1.0000
-chicago-in-text-shortened-author-title-no-url	chicago-shortened-notes-bibliography	1.0000	0.0000	1.0000
-chicago-in-text-shortened-author-title	chicago-shortened-notes-bibliography	1.0000	0.0000	1.0000
-chicago-shortened-notes-bibliography-access-dates	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000
-chicago-shortened-notes-bibliography-archive-place-first-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000
-chicago-shortened-notes-bibliography-archive-place-first	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000
-chicago-shortened-notes-bibliography-classic-archive-place-first-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000
-chicago-shortened-notes-bibliography-classic-archive-place-first	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000
-chicago-shortened-notes-bibliography-classic-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000
-chicago-shortened-notes-bibliography-classic	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000
-chicago-shortened-notes-bibliography-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000
-chimia	elsevier-with-titles	1.0000	1.0000	0.0000
-chinese-medical-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-chinese-science-bulletin	elsevier-with-titles	1.0000	0.9500	0.0000
-circulation-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-cirugia-cardiovascular	elsevier-with-titles	1.0000	0.0000	0.0000
-civil-engineering-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-cladistics	elsevier-harvard	1.0000	0.9500	0.0000
-climate-change-economics	elsevier-harvard	1.0000	0.9500	0.0000
-clinica-e-investigacion-en-arteriosclerosis	elsevier-with-titles	1.0000	0.0000	0.0000
-clinical-hemorheology-and-microcirculation	elsevier-with-titles	1.0000	1.0000	0.0000
-clinical-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000
-clinical-journal-of-the-american-society-of-nephrology	elsevier-with-titles	1.0000	0.0000	0.0000
-clinical-nuclear-medicine	elsevier-with-titles	1.0000	1.0000	0.0000
-clinical-orthopaedics-and-related-research	elsevier-with-titles	1.0000	0.7500	0.0000
-clinical-otolaryngology	elsevier-with-titles	1.0000	0.0000	0.0000
-clinical-pharmacology-and-therapeutics	elsevier-with-titles	1.0000	0.0000	0.0000
-clinical-radiology	elsevier-with-titles	1.0000	0.0000	0.0000
-cns-and-neurological-disorders-drug-targets	elsevier-with-titles	1.0000	0.0000	0.0000
-cns-spectrums	american-medical-association	1.0000	1.0000	0.0000
-colombian-journal-of-anesthesiology	elsevier-with-titles	1.0000	0.0000	0.0000
-comparative-parasitology	elsevier-harvard	1.0000	0.9500	0.0000
-conservation-and-society	elsevier-harvard	1.0000	0.0500	0.0000
-conservation-biology	elsevier-harvard	1.0000	0.0500	0.0000
-conservation-physiology	elsevier-harvard	1.0000	0.9500	0.0000
-corrosion	elsevier-with-titles	1.0000	0.0000	0.0000
-critical-care-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-cse-citation-sequence-brackets-8th-edition	ieee	1.0000	0.5000	0.0000
-cureus	elsevier-with-titles	1.0000	1.0000	0.0000
-current-alzheimer-research	elsevier-with-titles	1.0000	0.7500	0.0000
-current-neurology-aktualnosci-neurologiczne	elsevier-harvard	1.0000	1.0000	0.0000
-current-opinion	elsevier-with-titles	1.0000	1.0000	0.0000
-current-organic-synthesis	elsevier-with-titles	1.0000	0.6500	0.0000
-current-pharmaceutical-design	elsevier-with-titles	1.0000	1.0000	0.0000
-current-proteomics	elsevier-with-titles	1.0000	1.0000	0.0000
-current-science	elsevier-with-titles	1.0000	0.0000	0.0000
-current-topics-in-medicinal-chemistry	elsevier-with-titles	1.0000	1.0000	0.0000
-cybium	elsevier-harvard	1.0000	0.9500	0.0000
-cytometry	elsevier-with-titles	1.0000	0.0000	0.0000
-data-science-journal	elsevier-harvard	1.0000	1.0000	0.0000
-degruyter-american-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000
-dermatology-online-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-deutsche-zeitschrift-fur-sportmedizin	elsevier-with-titles	1.0000	0.0000	0.0000
-deutsches-arzteblatt	elsevier-with-titles	1.0000	0.0000	0.0000
-developmental-dynamics	american-medical-association	1.0000	1.0000	0.0000
-developmental-medicine-and-child-neurology	elsevier-with-titles	1.0000	0.0000	0.0000
-diabetologia	elsevier-with-titles	1.0000	0.7500	0.0000
-diagnostico-prenatal	elsevier-with-titles	1.0000	0.0000	0.0000
-dialisis-y-trasplante	elsevier-with-titles	1.0000	0.0000	0.0000
-diatom-research	elsevier-harvard	1.0000	0.0500	0.0000
-digestive-and-liver-disease	elsevier-with-titles	1.0000	1.0000	0.0000
-disability-and-rehabilitation	elsevier-with-titles	1.0000	1.0000	0.0000
-discover-food	elsevier-with-titles	1.0000	1.0000	0.0000
-discovery-medicine	elsevier-harvard	1.0000	0.9500	0.0000
-drug-testing-and-analysis	elsevier-with-titles	1.0000	1.0000	0.0000
-drugs-of-today	elsevier-with-titles	1.0000	0.0000	0.0000
-earthquake-engineering-and-structural-dynamics	elsevier-with-titles	1.0000	1.0000	0.0000
-ecological-restoration	elsevier-harvard	1.0000	0.0500	0.0000
-ecology-and-society	elsevier-harvard	1.0000	0.0500	0.0000
-ecology	elsevier-harvard	1.0000	0.0500	0.0000
-eksploatacja-i-niezawodnosc	elsevier-with-titles	1.0000	0.7500	0.0000
-electrophoresis	elsevier-with-titles	1.0000	1.0000	0.0000
-elife	elsevier-harvard	1.0000	1.0000	0.0000
-elsevier-american-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000
-elsevier-harvard-without-titles	elsevier-harvard	1.0000	1.0000	1.0000
-elsevier-harvard2	elsevier-harvard	1.0000	1.0000	1.0000
-elsevier-vancouver-author-date-alphabetical	elsevier-harvard	1.0000	0.9500	0.0000
-elsevier-vancouver-author-date	elsevier-harvard	1.0000	1.0000	0.0000
-elsevier-vancouver-no-et-al	elsevier-with-titles	1.0000	1.0000	0.0000
-elsevier-vancouver-short-author-list	elsevier-with-titles	1.0000	1.0000	0.0000
-elsevier-with-titles-alphabetical	elsevier-with-titles	1.0000	0.9500	1.0000
-endocrine-connections	elsevier-with-titles	1.0000	0.0000	0.0000
-endocrine-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-endocrine-press	elsevier-with-titles	1.0000	0.0000	0.0000
-endoscopia	elsevier-with-titles	1.0000	0.0000	0.0000
-energy-research-and-social-science	elsevier-with-titles	1.0000	0.0000	0.0000
-eneuro	elsevier-harvard	1.0000	0.9500	0.0000
-enfermeria-clinica	elsevier-with-titles	1.0000	0.0000	0.0000
-enfermeria-intensiva	elsevier-with-titles	1.0000	0.0000	0.0000
-engineered-regeneration	elsevier-with-titles	1.0000	1.0000	1.0000
-engineering-in-life-sciences	elsevier-with-titles	1.0000	0.7500	0.0000
-engineering-technology-and-applied-science-research	ieee	1.0000	1.0000	1.0000
-entecho	elsevier-harvard	1.0000	1.0000	1.0000
-entomological-review	elsevier-harvard	1.0000	0.9500	0.0000
-environmental-health-perspectives	elsevier-harvard	1.0000	0.0500	0.0000
-environnement-risques-et-sante	elsevier-with-titles	1.0000	1.0000	0.0000
-epidemiology-and-infection	elsevier-with-titles	1.0000	1.0000	0.0000
-epidemiology-psychiatric-sciences	elsevier-harvard	1.0000	0.0500	0.0000
-epilepsia	elsevier-with-titles	1.0000	0.0000	0.0000
-equine-veterinary-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-ergoscience	elsevier-with-titles	1.0000	1.0000	0.0000
-etri-journal	elsevier-with-titles	1.0000	0.9500	1.0000
-eurasian-journal-of-medical-investigation	elsevier-with-titles	1.0000	1.0000	0.0000
-eurasian-journal-of-medicine-and-oncology	elsevier-with-titles	1.0000	1.0000	0.0000
-eurointervention	elsevier-with-titles	1.0000	1.0000	0.0000
-europace	elsevier-with-titles	1.0000	0.0000	0.0000
-european-journal-of-anaesthesiology	elsevier-with-titles	1.0000	0.0000	0.0000
-european-journal-of-clinical-microbiology-and-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000
-european-journal-of-emergency-medicine	elsevier-with-titles	1.0000	1.0000	0.0000
-european-journal-of-endocrinology	elsevier-with-titles	1.0000	0.0000	0.0000
-european-journal-of-human-genetics	elsevier-with-titles	1.0000	0.0000	0.0000
-european-journal-of-immunology	elsevier-with-titles	1.0000	0.6500	0.0000
-european-journal-of-lipid-science-and-technology	elsevier-with-titles	1.0000	1.0000	0.0000
-european-journal-of-ophthalmology	elsevier-with-titles	1.0000	0.0000	0.0000
-european-journal-of-paediatric-neurology	elsevier-with-titles	1.0000	0.0000	0.0000
-european-journal-of-soil-science	springer-basic-author-date	1.0000	0.0500	0.0000
-evidence-based-complementary-and-alternative-medicine	elsevier-with-titles	1.0000	0.7500	0.0000
-evolutionary-anthropology	elsevier-with-titles	1.0000	0.0000	0.0000
-exercer	elsevier-with-titles	1.0000	0.0000	0.0000
-experimental-biomedical-research	elsevier-with-titles	1.0000	1.0000	0.0000
-exploration-of-targeted-anti-tumor-therapy	elsevier-with-titles	1.0000	1.0000	0.0000
-express-polymer-letters	elsevier-with-titles	1.0000	1.0000	0.0000
-extracellular-vesicles-and-circulating-nucleic-acids	elsevier-with-titles	1.0000	1.0000	0.0000
-facial-plastic-surgery-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000
-fertility-and-sterility	elsevier-with-titles	1.0000	0.0000	0.0000
-folia-amazonica	elsevier-harvard	1.0000	1.0000	0.0000
-folia-morphologia	elsevier-with-titles	1.0000	0.7500	0.0000
-food-and-agriculture-organization-of-the-united-nations-numeric	elsevier-with-titles	1.0000	0.0000	0.0000
-food-science-and-biotechnology	springer-basic-author-date	1.0000	0.1500	0.0000
-forensic-science-review	elsevier-with-titles	1.0000	0.9500	0.0000
-forestry	elsevier-harvard	1.0000	1.0000	0.0000
-frattura-ed-integrita-strutturale-fracture-and-structural-integrity	elsevier-with-titles	1.0000	0.9500	0.0000
-free-radical-research	elsevier-with-titles	1.0000	1.0000	0.0000
-french1	elsevier-with-titles	1.0000	1.0000	0.0000
-french2	elsevier-with-titles	1.0000	1.0000	0.0000
-freshwater-science	elsevier-harvard	1.0000	0.0500	0.0000
-frontiers-in-bioscience	elsevier-with-titles	1.0000	0.0000	0.0000
-frontiers-in-ecology-and-the-environment	springer-basic-author-date	1.0000	0.7000	0.0000
-frontiers-in-optics	ieee	1.0000	0.6500	0.0000
-frontiers-in-physics	elsevier-with-titles	1.0000	1.0000	0.0000
-frontiers-medical-journals	elsevier-with-titles	1.0000	0.0000	0.0000
-frontiers	elsevier-harvard	1.0000	0.9000	0.0000
-future-science-group	elsevier-with-titles	1.0000	1.0000	0.0000
-gaceta-sanitaria	elsevier-with-titles	1.0000	0.0000	0.0000
-gait-and-posture	elsevier-with-titles	1.0000	1.0000	1.0000
-gastrointestinal-endoscopy-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000
-gastrointestinal-intervention	elsevier-with-titles	1.0000	0.0000	0.0000
-gayana-botanica	elsevier-harvard	1.0000	0.1000	0.0000
-gayana	elsevier-harvard	1.0000	0.1000	0.0000
-gazeta-medica	elsevier-with-titles	1.0000	0.0000	0.0000
-genomics-and-informatics	elsevier-with-titles	1.0000	1.0000	0.0000
-geriatrie-et-psychologie-neuropsychiatrie-du-vieillissement	elsevier-with-titles	1.0000	1.0000	0.0000
-gost-r-7-0-5-2008-numeric-alphabetical	ieee	1.0000	0.5000	0.0000
-gost-r-7-0-5-2008-numeric	ieee	1.0000	0.6500	0.0000
-hainan-medical-university-journal-publisher	elsevier-with-titles	1.0000	1.0000	0.0000
-hand	elsevier-with-titles	1.0000	0.9500	0.0000
-handbook-of-clinical-neurology	elsevier-harvard	1.0000	1.0000	1.0000
-health-and-social-care-in-the-community	elsevier-with-titles	1.0000	0.7500	0.0000
-health-education-research	elsevier-with-titles	1.0000	1.0000	0.0000
-health-sports-and-rehabilitation-medicine	elsevier-harvard	1.0000	1.0000	0.0000
-heart-failure-clinics	elsevier-with-titles	1.0000	0.0000	0.0000
-heart-rhythm	elsevier-with-titles	1.0000	0.0000	0.0000
-helvetica-chimica-acta	elsevier-with-titles	1.0000	1.0000	0.0000
-hematology-oncology-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000
-hemijska-industrija	elsevier-with-titles	1.0000	0.6500	0.0000
-hepatology	elsevier-with-titles	1.0000	0.0000	0.0000
-hipertension-y-riesgo-vascular	elsevier-with-titles	1.0000	0.0000	0.0000
-hong-kong-journal-of-radiology	elsevier-with-titles	1.0000	0.0000	0.0000
-hospital-a-domicilio	elsevier-with-titles	1.0000	0.0000	0.0000
-howard-hughes-medical-institute	elsevier-with-titles	1.0000	0.0000	0.0000
-hpb	elsevier-with-titles	1.0000	0.0000	0.0000
-human-ecology	elsevier-harvard	1.0000	0.0500	1.0000
-humboldt-state-university-environmental-resources-engineering	springer-basic-author-date	1.0000	0.1000	0.0000
-hypertension-research	elsevier-with-titles	1.0000	0.0000	0.0000
-hypotheses-in-the-life-sciences	elsevier-with-titles	1.0000	1.0000	0.0000
-ibis	springer-basic-author-date	1.0000	0.6000	0.0000
-idojaras-quarterly-journal-of-the-hungarian-meteorological-service	elsevier-harvard	1.0000	0.9500	0.0000
-ieee-transactions-on-medical-imaging	ieee	1.0000	1.0000	1.0000
-igaku-toshokan	elsevier-with-titles	1.0000	0.0000	0.0000
-imperial-college-london-numerical	elsevier-with-titles	1.0000	0.0000	0.0000
-indian-journal-of-medical-research	elsevier-with-titles	1.0000	0.0000	0.0000
-indian-journal-of-orthopaedics	elsevier-with-titles	1.0000	1.0000	0.0000
-infectio	elsevier-with-titles	1.0000	0.0000	0.0000
-infectious-disease-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000
-infomin	elsevier-harvard	1.0000	0.8000	0.0000
-innovations-therapeutiques-en-oncologie	elsevier-with-titles	1.0000	1.0000	0.0000
-institut-national-de-sante-publique-du-quebec-topo	elsevier-with-titles	1.0000	0.0000	0.0000
-institute-of-mathematical-statistics	elsevier-with-titles	1.0000	0.7500	0.0000
-institute-of-physics-harvard	elsevier-harvard	1.0000	0.0500	0.0000
-institute-of-physics-numeric	elsevier-with-titles	1.0000	1.0000	0.0000
-integrated-science-publishing-journals	elsevier-with-titles	1.0000	0.0000	0.0000
-interaction-design-and-architectures	elsevier-with-titles	1.0000	0.7500	0.0000
-interactive-cardiovascular-and-thoracic-surgery	ieee	1.0000	0.6500	0.0000
-international-atomic-energy-agency	elsevier-with-titles	1.0000	0.7500	0.0000
-international-brazilian-journal-of-urology	elsevier-with-titles	1.0000	0.0000	0.0000
-international-conference-on-information-systems-development	elsevier-with-titles	1.0000	0.7500	0.0000
-international-journal-for-numerical-methods-in-biomedical-engineering	elsevier-with-titles	1.0000	1.0000	0.0000
-international-journal-of-cancer	elsevier-with-titles	1.0000	0.0000	0.0000
-international-journal-of-circuit-theory-and-applications	elsevier-with-titles	1.0000	1.0000	0.0000
-international-journal-of-clinical-research	elsevier-with-titles	1.0000	0.7500	0.0000
-international-journal-of-cosmetic-science	elsevier-with-titles	1.0000	0.7500	0.0000
-international-journal-of-electronic-commerce	elsevier-with-titles	1.0000	0.7500	0.0000
-international-journal-of-epidemiology	elsevier-with-titles	1.0000	0.0000	0.0000
-international-journal-of-exercise-science	elsevier-with-titles	1.0000	0.0000	0.0000
-international-journal-of-humanoid-robotics	elsevier-with-titles	1.0000	0.0000	0.0000
-international-journal-of-nuclear-security	elsevier-with-titles	1.0000	0.7500	0.0000
-international-journal-of-occupational-medicine-and-environmental-health	elsevier-with-titles	1.0000	1.0000	0.0000
-international-journal-of-oral-and-maxillofacial-surgery	elsevier-with-titles	1.0000	0.0000	0.0000
-international-journal-of-polymer-analysis-and-characterization	elsevier-with-titles	1.0000	1.0000	0.0000
-international-journal-of-population-data-science	elsevier-with-titles	1.0000	1.0000	0.0000
-international-journal-of-research-in-exercise-physiology	elsevier-with-titles	1.0000	0.0000	0.0000
-international-journal-of-simulation-modelling	elsevier-with-titles	1.0000	0.7500	0.0000
-international-microbiology	elsevier-with-titles	1.0000	0.7500	0.0000
-invertebrate-biology	springer-basic-author-date	1.0000	0.6500	0.0000
-ios-press-books	elsevier-with-titles	1.0000	1.0000	1.0000
-iranian-journal-of-basic-medical-sciences	elsevier-with-titles	1.0000	0.0000	0.0000
-iranian-journal-of-pharmaceutical-research	elsevier-with-titles	1.0000	0.0000	0.0000
-israel-medical-association-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-istanbul-medical-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-istanus-journal-on-applied-and-biological-sciences	elsevier-with-titles	1.0000	1.0000	0.0000
-italus-hortus	elsevier-harvard	1.0000	1.0000	0.0000
-iubmb-life	elsevier-with-titles	1.0000	0.0000	0.0000
-jacc-cardiovascular-imaging	elsevier-with-titles	1.0000	0.0000	0.0000
-jacc-cardiovascular-interventions	elsevier-with-titles	1.0000	0.0000	0.0000
-johnson-matthey-technology-review	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-and-proceedings-of-the-royal-society-of-new-south-wales	springer-basic-author-date	1.0000	0.8000	0.0000
-journal-der-deutschen-dermatologischen-gesellschaft	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-acoustics	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-adolescent-health	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-advanced-ceramics	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-alzheimers-disease	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-applied-clinical-medical-physics	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-applied-entomology	elsevier-harvard	1.0000	0.0500	0.0000
-journal-of-applied-glycoscience	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-applied-pharmaceutical-research	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-applied-polymer-science	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-atrial-fibrillation	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-australian-strength-and-conditioning	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-behavioral-health-and-psychology	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-biological-chemistry	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-biological-regulators-and-homeostatic-agents	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-biomedical-materials-research-part-a	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-bioscience-and-bioengineering	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-bone-and-mineral-research	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-breast-cancer	ieee	1.0000	0.6500	0.0000
-journal-of-cachexia-sarcopenia-and-muscle	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-cellular-and-molecular-medicine	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-chemistry-and-chemical-engineering	elsevier-with-titles	1.0000	0.6500	0.0000
-journal-of-clinical-and-translational-science	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-clinical-neurophysiology	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-clinical-oncology	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-combinatorics	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-computational-chemistry	elsevier-with-titles	1.0000	0.6500	0.0000
-journal-of-computer-information-systems	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-contemporary-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-crohns-and-colitis-supplements	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-crohns-and-colitis	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-demographic-economics	elsevier-harvard	1.0000	0.0500	0.0000
-journal-of-economic-impact	elsevier-harvard	1.0000	1.0000	1.0000
-journal-of-endodontics	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-environmental-science-and-health-part-b	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-ethnobiology	elsevier-harvard	1.0000	0.0500	0.0000
-journal-of-evolution-and-health	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-financial-and-quantitative-analysis	elsevier-harvard	1.0000	0.0000	0.0000
-journal-of-food-protection	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-forensic-sciences	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-frailty-and-aging	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-global-health	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-hazardous-materials	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-health-care-for-the-poor-and-underserved	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-hearing-science	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-human-evolution	elsevier-harvard	1.0000	0.9500	1.0000
-journal-of-human-nutrition-and-dietetics	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-hypertension	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-innovation-economics-and-management	elsevier-harvard	1.0000	1.0000	0.0000
-journal-of-institutional-and-theoretical-economics	elsevier-harvard	1.0000	0.9500	0.0000
-journal-of-instrumentation	ieee	1.0000	0.6500	0.0000
-journal-of-internal-medicine	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-korean-neurosurgical-society	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-lipid-research	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-magnetic-resonance-imaging	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-mechanical-science-and-technology	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-medical-genetics	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-medical-internet-research	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-microbiology-and-biotechnology	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-microscopy	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-midwifery-science	elsevier-with-titles	1.0000	0.9500	0.0000
-journal-of-molecular-signaling	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-multidisciplinary-applied-natural-science	ieee	1.0000	1.0000	0.0000
-journal-of-musculoskeletal-research	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-nanoscience-and-nanotechnology	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-neuroscience-and-neuroengineering	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-nutrition	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-obstetrics-and-gynaecology-canada	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-open-research-software	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-orthopaedic-research	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-orthopaedic-trauma	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-orthopaedics-trauma-and-rehabilitation	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-pain-and-symptom-management	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-paleontology	elsevier-harvard	1.0000	0.6500	0.0000
-journal-of-pediatric-surgery	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-peptide-science	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-perinatal-medicine	elsevier-with-titles	1.0000	0.9500	0.0000
-journal-of-pharmacy-and-pharmacology	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-phycology	elsevier-harvard	1.0000	0.1000	0.0000
-journal-of-physical-therapy-science	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-plant-nutrition-and-soil-science	elsevier-harvard	1.0000	1.0000	0.0000
-journal-of-psychiatry-and-neuroscience	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-rehabilitation-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-rheumatology	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-separation-science	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-shoulder-and-elbow-surgery	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-soil-and-water-conservation	elsevier-harvard	1.0000	0.0500	0.0000
-journal-of-soil-science-and-plant-nutrition	springer-basic-author-date	1.0000	0.9500	1.0000
-journal-of-sport-and-health-science	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-strength-and-conditioning-research	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-structural-geology	elsevier-harvard	1.0000	0.9500	1.0000
-journal-of-surgery-and-medicine	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-surgical-oncology	american-medical-association	1.0000	1.0000	0.0000
-journal-of-systematics-and-evolution	springer-basic-author-date	1.0000	0.1500	0.0000
-journal-of-the-american-academy-of-orthopaedic-surgeons	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-american-association-of-laboratory-animal-science	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-american-ceramic-society	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-american-college-of-cardiology	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-american-college-of-surgeons	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-american-heart-association	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-american-society-of-brewing-chemists	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-american-society-of-nephrology	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-brazilian-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-the-european-academy-of-dermatology-and-venereology	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-thrombosis-and-haemostasis	elsevier-with-titles	1.0000	1.0000	0.0000
-journal-of-tropical-ecology	elsevier-harvard	1.0000	0.0500	0.0000
-journal-of-tropical-life-science	elsevier-with-titles	1.0000	0.7500	0.0000
-journal-of-vertebrate-biology	springer-basic-author-date	1.0000	0.5500	0.0000
-journal-of-vestibular-research	elsevier-with-titles	1.0000	0.9500	1.0000
-journal-of-visualized-experiments	elsevier-with-titles	1.0000	0.0000	0.0000
-journal-of-wildlife-diseases	elsevier-harvard	1.0000	0.0500	0.0000
-journal-of-zoo-and-wildlife-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-jurnal-pangan-dan-agroindustri	elsevier-harvard	1.0000	0.0500	0.0000
-jurnal-sains-farmasi-dan-klinis	elsevier-with-titles	1.0000	1.0000	0.0000
-jurnal-teknik-mesin-indonesia	elsevier-with-titles	1.0000	0.7500	0.0000
-jyvaskylan-yliopisto-kemian-laitos	elsevier-with-titles	1.0000	0.0000	0.0000
-karger-journals	elsevier-with-titles	1.0000	1.0000	0.0000
-kidney-research-and-clinical-practice	elsevier-with-titles	1.0000	1.0000	0.0000
-klinische-padiatrie	elsevier-with-titles	1.0000	0.7500	0.0000
-knee-surgery-and-related-research	elsevier-with-titles	1.0000	0.0000	0.0000
-knee-surgery-sports-traumatology-arthroscopy	elsevier-with-titles	1.0000	0.7500	0.0000
-lancaster-university-harvard	elsevier-harvard	1.0000	0.8500	0.0000
-landes-bioscience-journals	elsevier-with-titles	1.0000	0.0000	0.0000
-lcgc	elsevier-with-titles	1.0000	0.0000	0.0000
-lethaia	springer-basic-author-date	1.0000	0.9500	0.0000
-limnology-and-oceanography	springer-basic-author-date	1.0000	0.9000	0.0000
-liver-international	elsevier-with-titles	1.0000	0.0000	0.0000
-london-south-bank-university-numeric	elsevier-with-titles	1.0000	1.0000	0.0000
-magnetic-resonance-materials-in-physics-biology-and-medicine	elsevier-with-titles	1.0000	0.7500	0.0000
-malaysian-orthopaedic-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-mammal-review	springer-basic-author-date	1.0000	0.6500	1.0000
-mammalia	springer-basic-author-date	1.0000	0.5500	0.0000
-management-of-biological-invasions	elsevier-harvard	1.0000	0.0500	0.0000
-mary-ann-liebert-harvard	elsevier-harvard	1.0000	0.9500	0.0000
-mary-ann-liebert-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000
-mathematics-and-computers-in-simulation	elsevier-with-titles	1.0000	1.0000	0.0000
-medecine-intensive-reanimation	elsevier-with-titles	1.0000	0.7500	0.0000
-medecine-sciences	elsevier-with-titles	1.0000	1.0000	0.0000
-medical-dosimetry	elsevier-with-titles	1.0000	0.0000	0.0000
-medical-education-and-clinical-practice	elsevier-with-titles	1.0000	1.0000	0.0000
-medicina-clinica	elsevier-with-titles	1.0000	0.0000	0.0000
-medicine-and-science-in-sports-and-exercise	elsevier-with-titles	1.0000	0.0000	0.0000
-medicine-publishing	elsevier-with-titles	1.0000	0.0000	0.0000
-medicinski-razgledi	elsevier-with-titles	1.0000	0.0000	0.0000
-medicinskiy-akademicheskiy-zhurnal	ieee	1.0000	0.6500	0.0000
-mediterranean-journal-of-chemistry	elsevier-with-titles	1.0000	0.0000	0.0000
-medizinische-universitat-innsbruck-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000
-memorias-do-instituto-oswaldo-cruz	springer-basic-author-date	1.0000	0.6500	0.0000
-meteorological-applications	springer-basic-author-date	1.0000	0.1500	0.0000
-methods-of-information-in-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-microbial-cell	elsevier-with-titles	1.0000	0.7500	0.0000
-microbiome-research-reports	elsevier-with-titles	1.0000	1.0000	0.0000
-modern-language-association-annotated-bibliography	modern-language-association	1.0000	1.0000	1.0000
-modern-language-association-no-url	modern-language-association	1.0000	1.0000	1.0000
-modern-language-association-notes-no-url	modern-language-association	1.0000	0.0500	1.0000
-modern-pathology	elsevier-with-titles	1.0000	0.0000	0.0000
-molecular-and-cellular-proteomics	elsevier-with-titles	1.0000	0.0000	0.0000
-molecular-biology	elsevier-with-titles	1.0000	0.7500	0.0000
-molecular-metabolism	elsevier-with-titles	1.0000	1.0000	0.0000
-molecular-psychiatry-letters	elsevier-with-titles	1.0000	0.0000	0.0000
-molecular-psychiatry	elsevier-with-titles	1.0000	0.7500	0.0000
-monographs-of-the-palaeontographical-society	springer-basic-author-date	1.0000	0.9000	0.0000
-mrs-bulletin	elsevier-with-titles	1.0000	0.0000	0.0000
-multidisciplinary-digital-publishing-institute	elsevier-with-titles	1.0000	1.0000	0.0000
-multimed	elsevier-with-titles	1.0000	0.0000	0.0000
-multiple-sclerosis-journal	elsevier-with-titles	1.0000	0.6500	0.0000
-mutagenesis	elsevier-with-titles	1.0000	1.0000	0.0000
-mycobiology	elsevier-with-titles	1.0000	1.0000	0.0000
-nano-biomedicine-and-engineering	elsevier-with-titles	1.0000	1.0000	0.0000
-national-institute-of-technology-karnataka	springer-basic-author-date	1.0000	0.5000	0.0000
-national-institute-of-technology-tiruchirappalli	springer-basic-author-date	1.0000	0.5000	0.0000
-national-library-of-medicine-grant-proposals	elsevier-with-titles	1.0000	0.0000	0.0000
-national-marine-fisheries-service-national-environmental-policy-act	elsevier-harvard	1.0000	0.0500	0.0000
-national-natural-science-foundation-of-china	elsevier-with-titles	1.0000	1.0000	0.0000
-national-science-foundation-grant-proposals	elsevier-with-titles	1.0000	0.7500	0.0000
-nature-brackets	elsevier-with-titles	1.0000	1.0000	0.0000
-nature-no-et-al	elsevier-with-titles	1.0000	0.0000	0.0000
-nature-publishing-group-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000
-nature	elsevier-with-titles	1.0000	0.0000	0.0000
-navigation	ieee	1.0000	1.0000	0.0000
-necmettin-erbakan-universitesi-fen-ve-muhendislik-bilimleri-dergisi	elsevier-with-titles	1.0000	1.0000	1.0000
-nejm-catalyst-innovations-in-care-delivery	elsevier-with-titles	1.0000	0.0000	0.0000
-nephrology-dialysis-transplantation	elsevier-with-titles	1.0000	0.7500	0.0000
-neural-plasticity	elsevier-with-titles	1.0000	0.7500	0.0000
-neurologia-argentina	elsevier-with-titles	1.0000	0.0000	0.0000
-neurologia	elsevier-with-titles	1.0000	0.0000	0.0000
-neurology-india	elsevier-with-titles	1.0000	1.0000	0.0000
-neurology	elsevier-with-titles	1.0000	0.0000	0.0000
-neuropsychopharmacology	elsevier-with-titles	1.0000	1.0000	0.0000
-neuroreport	elsevier-with-titles	1.0000	0.7500	0.0000
-neurospine	elsevier-with-titles	1.0000	0.0000	0.0000
-new-phytologist	springer-basic-author-date	1.0000	0.1500	0.0000
-nist-technical-publication-journal-of-research-of-nist	elsevier-with-titles	1.0000	0.7500	0.0000
-nlm-citation-name	elsevier-with-titles	1.0000	0.0000	0.0000
-nlm-citation-sequence-brackets-no-et-al	elsevier-with-titles	1.0000	1.0000	0.0000
-nlm-citation-sequence-brackets-year-only-no-issue	elsevier-with-titles	1.0000	1.0000	0.0000
-nlm-citation-sequence-brackets	elsevier-with-titles	1.0000	1.0000	0.0000
-nlm-citation-sequence-superscript-brackets-year-only	elsevier-with-titles	1.0000	1.0000	0.0000
-nlm-citation-sequence-superscript-year-only-no-issue	elsevier-with-titles	1.0000	0.0000	0.0000
-nlm-citation-sequence-superscript	elsevier-with-titles	1.0000	0.0000	0.0000
-nlm-citation-sequence	elsevier-with-titles	1.0000	0.0000	0.0000
-nordic-pulp-and-paper-research-journal	springer-basic-author-date	1.0000	0.5000	0.0000
-nowa-audiofonologia	elsevier-with-titles	1.0000	1.0000	0.0000
-nucleic-acids-research-web-server-issue	elsevier-with-titles	1.0000	0.0000	0.0000
-nucleic-acids-research	elsevier-with-titles	1.0000	0.0000	0.0000
-nutrition-research-reviews	elsevier-with-titles	1.0000	0.0000	0.0000
-obafemi-awolowo-university-faculty-of-technology	springer-basic-author-date	1.0000	0.0500	0.0000
-occupational-medicine	elsevier-with-titles	1.0000	1.0000	0.0000
-oecologia-australis	elsevier-harvard	1.0000	0.0500	0.0000
-oil-shale	elsevier-with-titles	1.0000	0.7500	0.0000
-oncotarget	elsevier-with-titles	1.0000	1.0000	0.0000
-operative-dentistry	elsevier-with-titles	1.0000	0.0000	0.0000
-ophthalmic-genetics	american-medical-association	1.0000	0.0000	0.0000
-ophthalmic-plastic-and-reconstructive-surgery	american-medical-association	1.0000	1.0000	1.0000
-optics-express	elsevier-with-titles	1.0000	1.0000	0.0000
-opto-electronic-advances	elsevier-with-titles	1.0000	1.0000	0.0000
-organic-geochemistry	elsevier-harvard	1.0000	0.9500	1.0000
-orthopedic-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000
-otto-von-guricke-universitat-magdeburg-medizinische-fakultat-numeric	elsevier-with-titles	1.0000	0.0000	0.0000
-oxford-journals-scimed-numeric	elsevier-with-titles	1.0000	1.0000	0.0000
-oxidation-of-metals	elsevier-with-titles	1.0000	1.0000	0.0000
-pacific-science	elsevier-harvard	1.0000	0.1000	0.0000
-paediatric-and-perinatal-epidemiology	elsevier-with-titles	1.0000	0.0000	0.0000
-pain-medicine	elsevier-with-titles	1.0000	1.0000	0.0000
-pain	elsevier-with-titles	1.0000	0.9500	0.0000
-pakistan-journal-of-agricultural-sciences	springer-basic-author-date	1.0000	0.1000	0.0000
-palaeontology	springer-basic-author-date	1.0000	0.6500	0.0000
-palaios	elsevier-harvard	1.0000	0.8500	0.0000
-paleobiology	springer-basic-author-date	1.0000	0.6500	0.0000
-parasite	elsevier-with-titles	1.0000	0.9500	0.0000
-pathogens-and-immunity	elsevier-with-titles	1.0000	1.0000	0.0000
-pediatric-allergy-and-immunology	elsevier-with-titles	1.0000	0.0000	0.0000
-pediatric-blood-and-cancer	elsevier-with-titles	1.0000	0.7500	0.0000
-pediatric-practice-and-research	elsevier-with-titles	1.0000	0.0000	0.0000
-pediatric-research	elsevier-with-titles	1.0000	0.0000	0.0000
-pediatric-urology-case-reports	elsevier-with-titles	1.0000	1.0000	0.0000
-pedosphere	elsevier-harvard	1.0000	0.9500	0.0000
-pensoft-journals	elsevier-harvard	1.0000	0.0500	0.0000
-periodicum-biologorum	elsevier-with-titles	1.0000	0.0000	0.0000
-periodontology-2000	elsevier-with-titles	1.0000	0.0000	0.0000
-perspectives-on-sexual-and-reproductive-health	elsevier-with-titles	1.0000	0.0000	0.0000
-photochemistry-and-photobiology	elsevier-with-titles	1.0000	0.0000	0.0000
-phycological-research	elsevier-harvard	1.0000	0.1000	0.0000
-physiological-and-biochemical-zoology	elsevier-harvard	1.0000	0.1000	0.0000
-plant-pathology	springer-basic-author-date	1.0000	0.1500	0.0000
-plos	elsevier-with-titles	1.0000	1.0000	0.0000
-pnas	elsevier-with-titles	1.0000	0.0000	0.0000
-polymer-reviews	elsevier-with-titles	1.0000	0.0000	0.0000
-polytechnique-montreal-ieee	ieee	1.0000	1.0000	0.0000
-poultry-science	springer-basic-author-date	1.0000	0.1000	0.0000
-praxis	elsevier-with-titles	1.0000	1.0000	0.0000
-proceedings-of-the-estonian-academy-of-sciences-numeric	elsevier-with-titles	1.0000	1.0000	0.0000
-proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021	springer-basic-author-date	1.0000	0.7000	0.0000
-proceedings-of-the-royal-society-b	elsevier-with-titles	1.0000	1.0000	0.0000
-processing-and-application-of-ceramics	ieee	1.0000	0.6500	0.0000
-progress-on-chemistry-and-application-of-chitin-and-its-derivatives	elsevier-with-titles	1.0000	0.7500	0.0000
-proteomics	elsevier-with-titles	1.0000	1.0000	0.0000
-psychiatric-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000
-psychiatric-services	elsevier-with-titles	1.0000	0.0000	0.0000
-psychiatry-and-clinical-neurosciences	elsevier-with-titles	1.0000	0.0000	0.0000
-psychosomatic-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-public-health-nutrition	elsevier-with-titles	1.0000	0.0000	0.0000
-quaternary-international	elsevier-harvard	1.0000	0.8500	1.0000
-radiation-research	elsevier-with-titles	1.0000	0.0000	0.0000
-radiochimica-acta	elsevier-with-titles	1.0000	0.7500	0.0000
-radiographics	elsevier-with-titles	1.0000	0.0000	0.0000
-radiography	elsevier-with-titles	1.0000	0.0000	0.0000
-radiologic-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000
-radiology	elsevier-with-titles	1.0000	0.0000	0.0000
-recent-patents-on-drug-delivery-and-formulation	elsevier-with-titles	1.0000	1.0000	0.0000
-renewable-agriculture-and-food-systems	elsevier-harvard	1.0000	0.6500	0.0000
-reports-of-practical-oncology-and-radiotherapy	elsevier-with-titles	1.0000	0.0000	0.0000
-research-and-education-promotion-association	elsevier-with-titles	1.0000	1.0000	0.0000
-research-institute-for-nature-and-forest	elsevier-harvard	1.0000	0.9500	0.0000
-research-on-biomedical-engineering	elsevier-harvard	1.0000	0.9000	0.0000
-retina	american-medical-association	1.0000	1.0000	1.0000
-revista-argentina-de-antropologia-biologica	springer-basic-author-date	1.0000	0.1000	0.0000
-revista-brasileira-de-ciencia-do-solo	elsevier-harvard	1.0000	0.9500	0.0000
-revista-cubana-de-meteorologia	elsevier-harvard	1.0000	0.8000	0.0000
-revista-da-sociedade-brasileira-de-medicina-tropical	elsevier-with-titles	1.0000	0.0000	0.0000
-revista-do-instituto-de-medicina-tropical-de-sao-paulo	elsevier-with-titles	1.0000	0.0000	0.0000
-revista-espanola-de-nutricion-humana-y-dietetica	elsevier-with-titles	1.0000	0.0000	0.0000
-revista-fave-seccion-ciencias-agrarias	elsevier-with-titles	1.0000	0.0000	0.0000
-revista-latinoamericana-de-metalurgia-y-materiales	elsevier-with-titles	1.0000	1.0000	0.0000
-revista-latinoamericana-de-recursos-naturales	elsevier-harvard	1.0000	0.8000	0.0000
-revista-materia	ieee	1.0000	0.6500	0.0000
-revista-medica-del-instituto-mexicano-del-seguro-social	elsevier-with-titles	1.0000	0.0000	0.0000
-revista-peruana-de-medicina-experimental-y-salud-publica	elsevier-with-titles	1.0000	0.0000	0.0000
-revista-virtual-de-quimica	elsevier-with-titles	1.0000	0.0000	0.0000
-revue-de-medecine-veterinaire	elsevier-with-titles	1.0000	0.7500	0.0000
-revue-des-etudes-byzantines	ieee	1.0000	1.0000	0.0000
-revue-francaise-dhistotechnologie	elsevier-with-titles	1.0000	1.0000	0.0000
-rhinology	elsevier-with-titles	1.0000	0.0000	0.0000
-rhodora	elsevier-harvard	1.0000	0.0500	0.0000
-risk-analysis	ieee	1.0000	0.0000	0.0000
-rivista-italiana-di-paleontologia-e-stratigrafia	elsevier-harvard	1.0000	0.0500	0.0000
-rofo	elsevier-with-titles	1.0000	0.7500	0.0000
-rossiiskii-fiziologicheskii-zhurnal-imeni-i-m-sechenova	elsevier-with-titles	1.0000	0.7500	0.0000
-ruhr-universitat-bochum-medizinische-fakultat-numeric	elsevier-with-titles	1.0000	0.7500	0.0000
-saglik-bilimleri-universitesi	elsevier-with-titles	1.0000	0.0000	0.0000
-sanamed	elsevier-with-titles	1.0000	0.0000	0.0000
-scandinavian-journal-of-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000
-scandinavian-journal-of-information-systems	elsevier-harvard	1.0000	0.1000	0.0000
-scandinavian-journal-of-rheumatology	elsevier-with-titles	1.0000	0.7500	0.0000
-scandinavian-journal-of-work-environment-and-health	elsevier-with-titles	1.0000	0.0000	0.0000
-science-translational-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-science-without-titles	elsevier-with-titles	1.0000	0.0000	0.0000
-science	elsevier-with-titles	1.0000	0.0000	0.0000
-scienceasia	elsevier-with-titles	1.0000	0.0000	0.0000
-scientia-iranica	elsevier-with-titles	1.0000	1.0000	0.0000
-seed-science-and-technology	springer-basic-author-date	1.0000	0.1500	0.0000
-sekolah-tinggi-meteorologi-klimatologi-dan-geofisika	elsevier-harvard	1.0000	0.9000	0.0000
-seminars-in-pediatric-neurology	elsevier-with-titles	1.0000	0.0000	0.0000
-serbian-archives-of-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-serdica-journal-of-computing	elsevier-with-titles	1.0000	0.7500	0.0000
-shock	elsevier-with-titles	1.0000	0.0000	0.0000
-slovensko-drustvo-za-medicinsko-informatiko	elsevier-with-titles	1.0000	0.0000	0.0000
-smyrna-tip-dergisi	elsevier-with-titles	1.0000	0.0000	0.0000
-sn-computer-science	elsevier-with-titles	1.0000	0.7500	0.0000
-social-anthropology	elsevier-harvard	1.0000	0.0500	0.0000
-societe-nationale-des-groupements-techniques-veterinaires	elsevier-with-titles	1.0000	0.0000	0.0000
-society-for-laboratory-automation-and-screening	elsevier-with-titles	1.0000	0.0000	0.0000
-society-of-automotive-engineers-technical-papers-numeric	elsevier-with-titles	1.0000	1.0000	0.0000
-sociologia-ruralis	elsevier-harvard	1.0000	1.0000	0.0000
-soil-biology-and-biochemistry	elsevier-harvard	1.0000	0.9500	1.0000
-solutions	elsevier-with-titles	1.0000	0.0000	0.0000
-south-african-journal-of-animal-science	springer-basic-author-date	1.0000	0.1000	0.0000
-south-african-journal-of-geology	springer-basic-author-date	1.0000	0.1500	0.0000
-south-african-medical-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-spandidos-publications	elsevier-with-titles	1.0000	0.0000	0.0000
-spectroscopy-letters	elsevier-with-titles	1.0000	1.0000	0.0000
-spie-bios	elsevier-with-titles	1.0000	0.0000	0.0000
-spie-journals	elsevier-with-titles	1.0000	0.0000	0.0000
-springer-basic-brackets-no-et-al-alphabetical	elsevier-with-titles	1.0000	0.7500	0.0000
-springer-basic-brackets-no-et-al	elsevier-with-titles	1.0000	0.7500	0.0000
-springer-fachzeitschriften-medizin-psychologie	elsevier-with-titles	1.0000	0.7500	0.0000
-springer-lecture-notes-in-computer-science-alphabetical	elsevier-with-titles	1.0000	0.7500	0.0000
-springer-lecture-notes-in-computer-science	elsevier-with-titles	1.0000	0.7500	0.0000
-springer-mathphys-brackets	elsevier-with-titles	1.0000	0.7500	0.0000
-springer-socpsych-brackets	elsevier-with-titles	1.0000	0.7500	0.0000
-springer-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000
-springerprotocols	elsevier-with-titles	1.0000	0.0000	0.0000
-statistika-statistics-and-economy-journal	elsevier-harvard	1.0000	0.8000	0.0000
-stroke	elsevier-with-titles	1.0000	0.0000	0.0000
-structural-control-and-health-monitoring	elsevier-with-titles	1.0000	1.0000	0.0000
-surgical-neurology-international	elsevier-with-titles	1.0000	0.9500	0.0000
-surgical-pathology-clinics	elsevier-with-titles	1.0000	0.0000	0.0000
-survey-of-ophthalmology	elsevier-with-titles	1.0000	0.0000	0.0000
-systematic-and-applied-microbiology	elsevier-with-titles	1.0000	0.9500	0.0000
-tapir-conservation	elsevier-with-titles	1.0000	1.0000	0.0000
-targetome	elsevier-with-titles	1.0000	1.0000	0.0000
-taylor-and-francis-acs	elsevier-with-titles	1.0000	0.7500	0.0000
-taylor-and-francis-ama	american-medical-association	1.0000	1.0000	0.0000
-taylor-and-francis-council-of-science-editors-numeric	elsevier-with-titles	1.0000	0.0000	0.0000
-taylor-and-francis-numeric-q	elsevier-with-titles	1.0000	1.0000	0.0000
-thai-endodontic-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-the-american-journal-of-gastroenterology	elsevier-with-titles	1.0000	0.0000	0.0000
-the-american-journal-of-pathology	elsevier-with-titles	1.0000	0.0000	0.0000
-the-american-journal-of-tropical-medicine-and-hygiene	elsevier-with-titles	1.0000	0.0000	0.0000
-the-american-midland-naturalist	springer-basic-author-date	1.0000	0.1000	0.0000
-the-american-naturalist	elsevier-harvard	1.0000	0.1000	0.0000
-the-angle-orthodontist	american-medical-association	1.0000	1.0000	0.0000
-the-bone-and-joint-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-the-british-journal-for-the-philosophy-of-science	elsevier-harvard	1.0000	0.0000	0.0000
-the-british-journal-of-cardiology	elsevier-with-titles	1.0000	0.0000	0.0000
-the-british-journal-of-psychiatry	elsevier-with-titles	1.0000	0.0000	0.0000
-the-british-journal-of-social-work	elsevier-harvard	1.0000	0.0500	0.0000
-the-canadian-journal-of-chemical-engineering	elsevier-with-titles	1.0000	1.0000	0.0000
-the-cancer-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-the-coleopterists-bulletin	elsevier-harvard	1.0000	0.0500	0.0000
-the-european-research-journal	elsevier-with-titles	1.0000	0.7500	0.0000
-the-faseb-journal	elsevier-with-titles	1.0000	0.0000	0.0000
-the-febs-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-the-geological-society-of-america	elsevier-harvard	1.0000	0.8500	0.0000
-the-institute-of-electronics-information-and-communication-engineers	elsevier-with-titles	1.0000	0.7500	0.0000
-the-journal-of-adhesive-dentistry	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-agricultural-science	springer-basic-author-date	1.0000	0.6000	0.0000
-the-journal-of-bone-and-joint-surgery	american-medical-association	1.0000	1.0000	0.0000
-the-journal-of-clinical-investigation	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-comparative-neurology	springer-basic-author-date	1.0000	0.1000	0.0000
-the-journal-of-foot-and-ankle-surgery	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-hand-surgery-asian-pacific-volume	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-hand-surgery-european-volume	elsevier-harvard	1.0000	1.0000	0.0000
-the-journal-of-immunology	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-infection-in-developing-countries	elsevier-with-titles	1.0000	1.0000	0.0000
-the-journal-of-laryngology-and-otology	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-molecular-diagnostics	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-nervous-and-mental-disease	elsevier-harvard	1.0000	1.0000	0.0000
-the-journal-of-nutrition-health-and-aging	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-pain	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-pure-and-applied-chemistry-research	elsevier-with-titles	1.0000	0.0000	0.0000
-the-journal-of-the-acoustical-society-of-america	elsevier-harvard	1.0000	1.0000	0.0000
-the-korean-journal-of-internal-medicine	elsevier-with-titles	1.0000	0.7500	0.0000
-the-korean-journal-of-mycology	elsevier-with-titles	1.0000	1.0000	0.0000
-the-new-england-journal-of-medicine	elsevier-with-titles	1.0000	0.0000	0.0000
-the-optical-society	elsevier-with-titles	1.0000	1.0000	0.0000
-the-pan-african-medical-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-the-scandinavian-journal-of-clinical-and-laboratory-investigation	elsevier-with-titles	1.0000	1.0000	0.0000
-theranostics	elsevier-with-titles	1.0000	1.0000	0.0000
-thieme-german	elsevier-with-titles	1.0000	1.0000	0.0000
-thrombosis-and-haemostasis	elsevier-with-titles	1.0000	0.0000	0.0000
-tijdschrift-voor-geneeskunde	elsevier-with-titles	1.0000	0.0000	0.0000
-traffic	elsevier-with-titles	1.0000	1.0000	0.0000
-transplantation	elsevier-with-titles	1.0000	0.0000	0.0000
-transportation-research-record	elsevier-with-titles	1.0000	0.0000	0.0000
-trends-in-glycoscience-and-glycotechnology	elsevier-with-titles	1.0000	0.0000	0.0000
-trends-journals	elsevier-with-titles	1.0000	1.0000	0.0000
-ucl-university-college-vancouver	ieee	1.0000	0.0000	0.0000
-ugeskrift-for-laeger	elsevier-with-titles	1.0000	1.0000	0.0000
-undergraduate-journal-of-experimental-microbiology-and-immunology	elsevier-with-titles	1.0000	0.0000	0.0000
-universidade-estadual-paulista-faculdade-de-engenharia-de-guaratingueta-abnt	elsevier-harvard	1.0000	0.1000	0.0000
-universitas-brawijaya-fakultas-teknologi-pertanian	elsevier-harvard	1.0000	1.0000	0.0000
-universitat-heidelberg-medizinische-fakultat-mannheim-numeric	elsevier-with-titles	1.0000	0.0000	0.0000
-universite-cheikh-anta-diop-faculte-de-medecine-de-pharmacie-et-dodontologie	elsevier-with-titles	1.0000	0.7500	0.0000
-universite-de-montreal-nlm-fr-ca	elsevier-with-titles	1.0000	0.0000	0.0000
-universite-de-picardie-jules-verne-ufr-de-medecine	elsevier-with-titles	1.0000	0.0000	0.0000
-university-of-aleppo-faculty-of-medicine	elsevier-with-titles	1.0000	0.7500	0.0000
-univerza-v-ljubljani-fakulteta-za-kemijo-in-kemijsko-tehnologijo	elsevier-with-titles	1.0000	0.7500	0.0000
-urbani-izziv-en	elsevier-harvard	1.0000	0.9500	0.0000
-urological-science	elsevier-with-titles	1.0000	0.0000	0.0000
-uspekhi-gerontologii	ieee	1.0000	0.5000	0.0000
-veterinary-medicine-austria	elsevier-harvard	1.0000	0.1000	0.0000
-veterinary-microbiology	elsevier-harvard	1.0000	0.9500	1.0000
-veterinary-pathology	elsevier-with-titles	1.0000	0.0000	0.0000
-veterinary-radiology-and-ultrasound	elsevier-with-titles	1.0000	0.0000	0.0000
-veterinary-record-open	elsevier-with-titles	1.0000	0.0000	0.0000
-vietnam-journal-of-science-and-technology	elsevier-with-titles	1.0000	1.0000	0.0000
-vitis-journal-of-grapevine-research	elsevier-harvard	1.0000	0.8500	0.0000
-vodohospodarske-technicko-ekonomicke-informace-en	ieee	1.0000	0.5000	0.0000
-vodohospodarske-technicko-ekonomicke-informace	ieee	1.0000	0.5000	0.0000
-vox-sanguinis	elsevier-with-titles	1.0000	0.7500	0.0000
-weed-science-society-of-america	elsevier-harvard	1.0000	0.0500	0.0000
-westfalische-wilhelms-universitat-munster-medizinische-fakultat	elsevier-with-titles	1.0000	0.0000	0.0000
-who-europe-numeric	elsevier-with-titles	1.0000	0.0000	0.0000
-wiley-vch-books	ieee	1.0000	0.6500	0.0000
-wiley-was	ieee	1.0000	0.6500	0.0000
-wireless-communications-and-mobile-computing	elsevier-with-titles	1.0000	1.0000	0.0000
-wissenschaftlicher-industrielogistik-dialog	elsevier-with-titles	1.0000	0.7500	0.0000
-world-applied-sciences-journal	elsevier-with-titles	1.0000	1.0000	0.0000
-world-congress-on-engineering-asset-management	elsevier-with-titles	1.0000	0.7500	0.0000
-world-organisation-for-animal-health-scientific-and-technical-review	elsevier-with-titles	1.0000	1.0000	0.0000
-worlds-poultry-science-journal	elsevier-harvard	1.0000	0.0500	0.0000
-zastosowania-komputerow-w-elektrotechnice	ieee	1.0000	1.0000	0.0000
-zdravniski-vestnik	elsevier-with-titles	1.0000	0.0000	0.0000
-zoological-journal-of-the-linnean-society	springer-basic-author-date	1.0000	0.1500	0.0000
-zoological-science	springer-basic-author-date	1.0000	0.1000	1.0000
-anglia	taylor-and-francis-chicago-author-date	0.9972	0.6500	0.0000
-chicago-author-date-16th-edition	taylor-and-francis-chicago-author-date	0.9972	0.9500	0.0000
-gender-and-society	taylor-and-francis-chicago-author-date	0.9972	0.9500	0.0000
-iran-manual-of-style	taylor-and-francis-chicago-author-date	0.9972	0.5000	0.0000
-journal-of-accounting-research	taylor-and-francis-chicago-author-date	0.9972	0.0000	0.0000
-management-international	taylor-and-francis-chicago-author-date	0.9972	0.1000	0.0000
-new-harts-rules-author-date-publisher	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000
-new-harts-rules-author-date-space-publisher	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000
-new-harts-rules-author-date	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000
-skene-journal-of-theatre-and-drama-studies	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000
-social-science-history	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000
-chicago-shortened-notes-bibliography-subsequent-title-no-url	chicago-shortened-notes-bibliography	0.9960	0.9500	1.0000
-chicago-shortened-notes-bibliography-subsequent-title	chicago-shortened-notes-bibliography	0.9960	0.9500	1.0000
-john-benjamins-publishing-company-iconicity-in-language-and-literature	taylor-and-francis-chicago-author-date	0.9944	0.6500	0.0000
-manchester-university-press-author-date	taylor-and-francis-chicago-author-date	0.9944	0.1000	0.0000
-universidade-do-porto-faculdade-de-engenharia-chicago	taylor-and-francis-chicago-author-date	0.9944	1.0000	0.0000
-american-mathematical-society-numeric	elsevier-with-titles	0.9932	0.7500	0.0000
-amerindia	springer-basic-author-date	0.9932	0.7000	0.0000
-building-structure	elsevier-with-titles	0.9932	1.0000	0.0000
-din-1505-2-numeric-alphabetical	elsevier-with-titles	0.9932	0.7500	0.0000
-din-1505-2-numeric	elsevier-with-titles	0.9932	0.7500	0.0000
-finanzarchiv	elsevier-harvard	0.9932	0.9500	0.0000
-german-council-of-economic-experts	elsevier-harvard	0.9932	0.9000	0.0000
-iso690-numeric-brackets-cs	ieee	0.9932	0.5000	0.0000
-iso690-numeric-cs	ieee	0.9932	0.0000	0.0000
-journal-of-basic-microbiology	elsevier-with-titles	0.9932	1.0000	0.0000
-neurosurgery-clinics-of-north-america	elsevier-with-titles	0.9932	0.0000	0.0000
-new-solutions	elsevier-with-titles	0.9932	0.7500	0.0000
-nueva-norma-estudios-de-la-humanidad	elsevier-harvard	0.9932	1.0000	0.0000
-photogrammetric-engineering-and-remote-sensing	elsevier-harvard	0.9932	0.0500	0.0000
-qeios	elsevier-with-titles	0.9932	0.0000	0.0000
-revista-de-derecho-de-la-universidad-austral-de-chile	elsevier-harvard	0.9932	0.0000	0.0000
-revista-portuguesa-de-arqueologia	elsevier-harvard	0.9932	0.0500	0.0000
-ruhr-universitat-bochum-lehrstuhl-fur-industrial-sales-and-service-engineering	elsevier-harvard	0.9932	0.1000	0.0000
-sist02	elsevier-with-titles	0.9932	0.0000	0.0000
-tatup-zeitschrift-fur-technikfolgenabschatzung-in-theorie-und-praxis	elsevier-harvard	0.9932	0.1000	0.0000
-the-chemical-society-of-japan	elsevier-with-titles	0.9932	0.0000	0.0000
-the-isme-journal	elsevier-with-titles	0.9932	0.7500	0.0000
-the-open-university-numeric-superscript	elsevier-with-titles	0.9932	0.0000	0.0000
-the-open-university-numeric	elsevier-with-titles	0.9932	1.0000	0.0000
-trames	elsevier-harvard	0.9932	0.0500	0.0000
-transactions-of-the-philological-society	elsevier-harvard	0.9932	0.0500	0.0000
-wiener-digitale-revue	elsevier-harvard	0.9932	0.0500	0.0000
-acta-chiropterologica	elsevier-harvard	0.9921	0.6500	0.0000
-acta-pharmaceutica	elsevier-with-titles	0.9921	0.0000	0.0000
-acta-radiologica	elsevier-with-titles	0.9921	0.0000	0.0000
-african-journal-of-marine-science	elsevier-harvard	0.9921	0.0500	0.0000
-american-journal-of-medical-genetics	elsevier-harvard	0.9921	0.0000	0.0000
-american-journal-of-roentgenology	elsevier-with-titles	0.9921	0.7500	0.0000
-american-phytopathological-society	elsevier-harvard	0.9921	0.0500	0.0000
-angiology	elsevier-with-titles	0.9921	0.0000	0.0000
-annals-of-laboratory-medicine	elsevier-with-titles	0.9921	0.7500	0.0000
-annals-of-surgery	elsevier-with-titles	0.9921	0.0000	0.0000
-arctic	elsevier-harvard	0.9921	0.6500	0.0000
-australian-archaeology	elsevier-harvard	0.9921	0.0500	0.0000
-british-journal-of-haematology	elsevier-harvard	0.9921	0.6000	0.0000
-buletin-agrohorti	elsevier-harvard	0.9921	0.6500	0.0000
-canadian-biosystems-engineering	elsevier-harvard	0.9921	0.0500	0.0000
-canadian-urological-association-journal	elsevier-with-titles	0.9921	0.0000	0.0000
-cath-lab-digest	elsevier-with-titles	0.9921	0.0000	0.0000
-cellular-and-molecular-gastroenterology-and-hepatology	elsevier-with-titles	0.9921	0.0000	0.0000
-cold-spring-harbor-laboratory-press	elsevier-harvard	0.9921	0.0500	0.0000
-copeia	springer-basic-author-date	0.9921	0.0500	0.0000
-current-protocols	elsevier-harvard	0.9921	0.5500	0.0000
-development-and-change	elsevier-harvard	0.9921	0.7000	0.0000
-earth-surface-processes-and-landforms	elsevier-harvard	0.9921	0.6500	0.0000
-edward-elgar-business-and-social-sciences	elsevier-harvard	0.9921	0.1000	0.0000
-embo-press	elsevier-harvard	0.9921	0.6000	0.0000
-environmental-conservation	elsevier-harvard	0.9921	0.6000	0.0000
-epidemiologie-et-sante-animale	elsevier-harvard	0.9921	0.0000	0.0000
-estonian-journal-of-earth-sciences	elsevier-harvard	0.9921	0.0500	0.0000
-ethnobiology-letters	elsevier-harvard	0.9921	0.0500	0.0000
-european-society-of-cardiology	elsevier-with-titles	0.9921	0.0000	0.0000
-experimental-biology-and-medicine	elsevier-with-titles	0.9921	0.0000	0.0000
-fizyoloji-medical-journal	elsevier-with-titles	0.9921	0.0000	0.0000
-folia-malacologica	springer-basic-author-date	0.9921	0.6000	0.0000
-forest-science	elsevier-harvard	0.9921	0.0000	0.0000
-geochemical-perspectives-letters	elsevier-harvard	0.9921	0.6500	0.0000
-geochronometria	elsevier-harvard	0.9921	0.6500	0.0000
-gigascience	elsevier-with-titles	0.9921	1.0000	0.0000
-haematologica	elsevier-with-titles	0.9921	0.0000	0.0000
-harvard-review-of-psychiatry	elsevier-with-titles	0.9921	0.0000	0.0000
-herpetologica	springer-basic-author-date	0.9921	0.6000	0.0000
-human-wildlife-interactions	springer-basic-author-date	0.9921	0.6000	0.0000
-hydrobiologia	elsevier-harvard	0.9921	0.6000	1.0000
-hydrological-processes	elsevier-harvard	0.9921	0.6000	0.0000
-iawa-journal	elsevier-harvard	0.9921	0.0500	0.0000
-international-journal-of-climatology	elsevier-harvard	0.9921	0.6000	0.0000
-international-journal-of-osteoarchaeology	elsevier-harvard	0.9921	0.6500	0.0000
-interpreting	elsevier-harvard	0.9921	0.0500	0.0000
-jbi-evidence-synthesis	elsevier-with-titles	0.9921	0.0000	0.0000
-journal-of-computer-assisted-tomography	elsevier-with-titles	0.9921	0.0000	0.0000
-journal-of-dairy-science	springer-basic-author-date	0.9921	0.1000	0.0000
-journal-of-dental-traumatology	elsevier-with-titles	0.9921	0.0000	0.0000
-journal-of-field-ornithology	springer-basic-author-date	0.9921	0.5500	0.0000
-journal-of-leukocyte-biology	elsevier-with-titles	0.9921	0.0000	0.0000
-journal-of-microbiology	elsevier-harvard	0.9921	0.5500	0.0000
-journal-of-neuroendocrinology	elsevier-with-titles	0.9921	0.0000	0.0000
-journal-of-occupational-and-environmental-medicine	elsevier-with-titles	0.9921	0.0000	0.0000
-kona-powder-and-particle-journal	elsevier-harvard	0.9921	1.0000	0.0000
-land-degradation-and-development	elsevier-harvard	0.9921	0.6500	0.0000
-mastozoologia-neotropical	springer-basic-author-date	0.9921	0.5500	0.0000
-media-culture-and-society	elsevier-harvard	0.9921	0.6500	0.0000
-medicinal-research-reviews	elsevier-with-titles	0.9921	0.0000	0.0000
-meteoritics-and-planetary-science	elsevier-harvard	0.9921	0.0500	0.0000
-microbiology-society	elsevier-with-titles	0.9921	0.7500	0.0000
-microcirculation	elsevier-with-titles	0.9921	0.0000	0.0000
-modern-phytomorphology	springer-basic-author-date	0.9921	0.7000	0.0000
-molecular-plant-microbe-interactions	elsevier-harvard	0.9921	0.0000	0.0000
-movement-disorders	elsevier-with-titles	0.9921	0.0000	0.0000
-natura-croatica	springer-basic-author-date	0.9921	0.0500	0.0000
-north-pacific-anadromous-fish-commission-bulletin	elsevier-harvard	0.9921	0.0500	0.0000
-organised-sound	elsevier-harvard	0.9921	0.0500	0.0000
-pain-physician	elsevier-with-titles	0.9921	0.0000	0.0000
-parasitology	springer-basic-author-date	0.9921	0.1000	0.0000
-phyllomedusa	springer-basic-author-date	0.9921	0.8500	0.0000
-phytopathologia-mediterranea	elsevier-harvard	0.9921	0.6000	0.0000
-population-space-and-place	elsevier-harvard	0.9921	0.6000	0.0000
-prehospital-emergency-care	elsevier-with-titles	0.9921	0.0000	0.0000
-proceedings-of-the-estonian-academy-of-sciences-author-date	elsevier-harvard	0.9921	0.0500	0.0000
-r-and-d-management	elsevier-harvard	0.9921	0.6000	0.0000
-respiratory-care-journal	elsevier-with-titles	0.9921	0.0000	0.0000
-respirology	elsevier-with-titles	0.9921	0.0000	0.0000
-sage-vancouver-brackets	elsevier-with-titles	0.9921	0.7500	0.0000
-sage-vancouver	elsevier-with-titles	0.9921	0.0000	0.0000
-scientific-online-letters-on-the-atmosphere	springer-basic-author-date	0.9921	0.8500	0.0000
-seed-science-research	springer-basic-author-date	0.9921	0.1000	0.0000
-sociology-of-health-and-illness	elsevier-harvard	0.9921	0.0500	0.0000
-south-african-theological-seminary	elsevier-harvard	0.9921	0.0500	0.0000
-southern-african-journal-of-critical-care	elsevier-with-titles	0.9921	1.0000	0.0000
-spine	elsevier-with-titles	0.9921	0.0000	0.0000
-stavebni-obzor	ieee	0.9921	0.5000	0.0000
-swiss-political-science-review	elsevier-harvard	0.9921	0.0500	0.0000
-the-auk	springer-basic-author-date	0.9921	0.6000	0.0000
-the-british-journal-of-criminology	elsevier-harvard	0.9921	0.0500	0.0000
-the-canadian-journal-of-psychiatry	elsevier-with-titles	0.9921	0.0000	0.0000
-the-holocene	elsevier-harvard	0.9921	0.6500	0.0000
-the-horticulture-journal	elsevier-harvard	0.9921	0.7000	0.0000
-the-journal-of-neuroscience	elsevier-harvard	0.9921	0.6500	0.0000
-the-journal-of-physiology	elsevier-harvard	0.9921	0.6500	0.0000
-the-journal-of-veterinary-medical-science	elsevier-with-titles	0.9921	0.7500	0.0000
-the-journal-of-wildlife-management	springer-basic-author-date	0.9921	0.6000	0.0000
-the-korean-journal-of-gastroenterology	elsevier-with-titles	0.9921	0.0000	0.0000
-the-plant-cell	elsevier-harvard	0.9921	0.0500	0.0000
-the-plant-genome	springer-basic-author-date	0.9921	0.1000	0.0000
-the-rockefeller-university-press	springer-basic-author-date	0.9921	0.1000	0.0000
-trabajos-de-prehistoria	elsevier-harvard	0.9921	0.0500	0.0000
-transport	elsevier-harvard	0.9921	0.0500	0.0000
-universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica	elsevier-harvard	0.9921	0.6000	0.0000
-world-mycotoxin-journal	elsevier-harvard	0.9921	0.7000	1.0000
-worlds-veterinary-journal	elsevier-harvard	0.9921	0.6500	0.0000
-the-journal-of-trauma-and-acute-care-surgery	american-medical-association	0.9894	1.0000	0.0000
-politica-tidsskrift-for-politisk-videnskab	taylor-and-francis-chicago-author-date	0.9893	0.1000	0.0000
-society-of-biblical-literature-author-date	taylor-and-francis-chicago-author-date	0.9893	0.9000	0.0000
-gender-zeitschrift-fur-geschlecht-kultur-und-gesellschaft	taylor-and-francis-chicago-author-date	0.9881	0.5000	0.0000
-john-benjamins-publishing-company-linguistik-aktuell-linguistics-today	taylor-and-francis-chicago-author-date	0.9881	0.6500	0.0000
-universidade-do-porto-faculdade-de-engenharia-chicago-pt	taylor-and-francis-chicago-author-date	0.9881	0.8500	0.0000
-american-journal-of-cancer-research	ieee	0.9881	0.5000	0.0000
-american-journal-of-clinical-pathology	american-medical-association	0.9881	1.0000	0.0000
-american-journal-of-orthodontics-and-dentofacial-orthopedics	american-medical-association	0.9881	1.0000	0.0000
-american-journal-of-surgical-pathology	american-medical-association	0.9881	1.0000	0.0000
-american-medical-association-10th-edition	american-medical-association	0.9881	1.0000	0.0000
-american-veterinary-medical-association	american-medical-association	0.9881	1.0000	0.0000
-anesthesia-and-analgesia	american-medical-association	0.9881	1.0000	0.0000
-annual-review-of-linguistics	springer-basic-author-date	0.9881	0.8500	0.0000
-annual-review-of-medicine	elsevier-with-titles	0.9881	0.0000	0.0000
-annual-review-of-nuclear-and-particle-science	elsevier-with-titles	0.9881	0.0000	0.0000
-annual-reviews-alphabetical	elsevier-with-titles	0.9881	0.0000	0.0000
-annual-reviews-author-date	springer-basic-author-date	0.9881	0.8500	0.0000
-annual-reviews-without-titles	elsevier-with-titles	0.9881	0.0000	0.0000
-annual-reviews	elsevier-with-titles	0.9881	0.0000	0.0000
-arthritis-and-rheumatism	american-medical-association	0.9881	0.0000	0.0000
-asaio-journal	american-medical-association	0.9881	1.0000	0.0000
-brachytherapy	american-medical-association	0.9881	0.0000	0.0000
-cancer-translational-medicine	american-medical-association	0.9881	1.0000	0.0000
-cell-transplantation	american-medical-association	0.9881	1.0000	0.0000
-chemical-engineering-progress	ieee	0.9881	0.5000	0.0000
-clinical-gastroenterology-and-hepatology	american-medical-association	0.9881	1.0000	0.0000
-clinical-spine-surgery	american-medical-association	0.9881	1.0000	0.0000
-cornea	american-medical-association	0.9881	1.0000	0.0000
-cse-citation-name-8th-edition	american-medical-association	0.9881	0.9500	0.0000
-cse-citation-name	american-medical-association	0.9881	0.9500	0.0000
-cse-citation-sequence-8th-edition	american-medical-association	0.9881	1.0000	0.0000
-cse-citation-sequence	american-medical-association	0.9881	1.0000	0.0000
-current-gene-therapy	ieee	0.9881	0.6500	0.0000
-current-opinion-in-endocrinology-diabetes-and-obesity	ieee	0.9881	0.5000	0.0000
-european-environment-agency-numeric	american-medical-association	0.9881	1.0000	0.0000
-eye	american-medical-association	0.9881	1.0000	0.0000
-fine-focus	elsevier-with-titles	0.9881	0.0000	0.0000
-gastroenterology	american-medical-association	0.9881	1.0000	0.0000
-haemophilia	american-medical-association	0.9881	1.0000	0.0000
-hawaii-international-conference-on-system-sciences-proceedings	ieee	0.9881	0.5000	0.0000
-histopathology	american-medical-association	0.9881	0.0000	0.0000
-hue-university-of-medicine-and-pharmacy	ieee	0.9881	0.6000	0.0000
-indian-dermatology-online-journal	american-medical-association	0.9881	0.0000	0.0000
-indoor-air	american-medical-association	0.9881	1.0000	0.0000
-inflammatory-bowel-diseases	american-medical-association	0.9881	1.0000	0.0000
-influenza-and-other-respiratory-viruses	american-medical-association	0.9881	1.0000	0.0000
-investigative-radiology	american-medical-association	0.9881	1.0000	0.0000
-journal-of-antimicrobial-chemotherapy	american-medical-association	0.9881	1.0000	0.0000
-journal-of-brachial-plexus-and-peripheral-nerve-injury	american-medical-association	0.9881	1.0000	0.0000
-journal-of-burn-care-and-research	american-medical-association	0.9881	1.0000	0.0000
-journal-of-chemometrics	american-medical-association	0.9881	1.0000	0.0000
-journal-of-clinical-neurology	american-medical-association	0.9881	1.0000	0.0000
-journal-of-clinical-rheumatology	american-medical-association	0.9881	1.0000	0.0000
-journal-of-clinical-sleep-medicine	american-medical-association	0.9881	1.0000	0.0000
-journal-of-geriatric-psychiatry-and-neurology	american-medical-association	0.9881	1.0000	0.0000
-journal-of-management-information-systems	ieee	0.9881	0.5000	0.0000
-journal-of-molecular-recognition	american-medical-association	0.9881	1.0000	0.0000
-journal-of-neuroimaging	american-medical-association	0.9881	1.0000	0.0000
-journal-of-neurological-disorders	american-medical-association	0.9881	0.0000	0.0000
-journal-of-oral-and-maxillofacial-surgery	american-medical-association	0.9881	1.0000	0.0000
-journal-of-prosthodontics	american-medical-association	0.9881	1.0000	0.0000
-journal-of-reconstructive-microsurgery	american-medical-association	0.9881	1.0000	0.0000
-journal-of-stroke	american-medical-association	0.9881	1.0000	0.0000
-journal-of-universal-computer-science	elsevier-harvard	0.9881	0.0000	0.0000
-korean-journal-of-anesthesiology	american-medical-association	0.9881	0.7000	0.0000
-laboratory-animal-science-professional	american-medical-association	0.9881	0.9500	0.0000
-muscle-and-nerve	american-medical-association	0.9881	1.0000	0.0000
-neurorehabilitation-and-neural-repair	american-medical-association	0.9881	1.0000	0.0000
-oncoimmunology	american-medical-association	0.9881	1.0000	0.0000
-ophthalmology-retina	american-medical-association	0.9881	1.0000	0.0000
-ophthalmology	american-medical-association	0.9881	1.0000	0.0000
-optometry-and-vision-science	american-medical-association	0.9881	1.0000	0.0000
-pediatric-infectious-disease-journal	american-medical-association	0.9881	1.0000	0.0000
-pediatric-physical-therapy	american-medical-association	0.9881	1.0000	0.0000
-pediatric-pulmonology	american-medical-association	0.9881	1.0000	0.0000
-pharmacoepidemiology-and-drug-safety	american-medical-association	0.9881	1.0000	0.0000
-prehospital-and-disaster-medicine	american-medical-association	0.9881	1.0000	0.0000
-protein-science	american-medical-association	0.9881	1.0000	0.0000
-scandinavian-journal-of-medicine-and-science-in-sports	american-medical-association	0.9881	1.0000	0.0000
-sexual-health	american-medical-association	0.9881	1.0000	0.0000
-spie-proceedings	american-medical-association	0.9881	1.0000	0.0000
-the-american-journal-of-cardiology	american-medical-association	0.9881	1.0000	0.0000
-the-american-journal-of-dermatopathology	american-medical-association	0.9881	1.0000	0.0000
-the-american-journal-of-geriatric-psychiatry	american-medical-association	0.9881	1.0000	0.0000
-the-bovine-practitioner	american-medical-association	0.9881	0.9500	0.0000
-the-journal-of-nuclear-medicine	american-medical-association	0.9881	0.0000	0.0000
-the-journal-of-pathology	american-medical-association	0.9881	0.0000	0.0000
-the-journal-of-urology	american-medical-association	0.9881	1.0000	0.0000
-universidade-de-sao-paulo-instituto-de-matematica-e-estatistica	elsevier-harvard	0.9881	0.0500	0.0000
-veterinary-clinical-pathology	american-medical-association	0.9881	1.0000	0.0000
-vietnam-ministry-of-education-and-training-en	ieee	0.9881	0.6000	0.0000
-vietnam-ministry-of-education-and-training-vi	ieee	0.9881	0.6000	0.0000
-western-journal-of-emergency-medicine	american-medical-association	0.9881	1.0000	0.0000
-xenotransplantation	ieee	0.9881	0.5000	0.0000
-zeitschrift-fur-allgemeinmedizin	ieee	0.9881	0.5000	0.0000
-zeitschrift-fur-zahnarztliche-implantologie	ieee	0.9881	0.5000	0.0000
-american-physics-society	elsevier-with-titles	0.9864	1.0000	0.0000
-annals-of-joint	elsevier-with-titles	0.9864	0.0000	0.0000
-anticancer-research	elsevier-with-titles	0.9864	0.0000	0.0000
-association-de-science-regionale-de-langue-francaise	elsevier-harvard	0.9864	0.8500	0.0000
-biochemical-society-transactions	elsevier-with-titles	0.9864	1.0000	0.0000
-brazilian-journal-of-psychiatry	elsevier-with-titles	0.9864	0.0000	0.0000
-british-journal-of-dermatology	elsevier-with-titles	0.9864	0.0000	0.0000
-clinical-journal-of-sport-medicine	elsevier-with-titles	0.9864	0.0000	0.0000
-european-journal-of-microbiology-and-immunology	elsevier-with-titles	0.9864	0.7500	0.0000
-european-journal-of-public-health	elsevier-with-titles	0.9864	0.0000	0.0000
-european-journal-of-ultrasound	ieee	0.9864	0.6500	0.0000
-european-journal-of-vascular-and-endovascular-surgery	elsevier-with-titles	0.9864	0.0000	0.0000
-european-respiratory-journal	elsevier-with-titles	0.9864	0.7500	0.0000
-fatigue-and-fracture-of-engineering-materials-and-structures	elsevier-with-titles	0.9864	0.0000	0.0000
-future-medicine	elsevier-with-titles	0.9864	1.0000	0.0000
-geriatrics-and-gerontology-international	elsevier-with-titles	0.9864	0.0000	0.0000
-hochschule-hannover-soziale-arbeit	springer-basic-author-date	0.9864	0.6000	0.0000
-homeopathy-thieme	elsevier-with-titles	0.9864	0.0000	0.0000
-indian-journal-of-traditional-knowledge	elsevier-with-titles	0.9864	0.0000	0.0000
-international-journal-of-obstetric-anesthesia	elsevier-with-titles	0.9864	0.0000	0.0000
-international-journal-of-sports-medicine	elsevier-with-titles	0.9864	0.9500	0.0000
-journal-of-science-and-medicine-in-sport	elsevier-with-titles	0.9864	0.0000	0.0000
-journal-of-the-american-animal-hospital-association	elsevier-with-titles	0.9864	0.0000	0.0000
-journal-of-the-science-of-food-and-agriculture	elsevier-with-titles	0.9864	0.0000	0.0000
-journal-of-veterinary-diagnostic-investigation	elsevier-with-titles	0.9864	0.0000	0.0000
-jurnal-ilmu-dan-teknologi-hasil-ternak	ieee	0.9864	0.0000	0.0000
-mediterranean-journal-of-infection-microbes-and-antimicrobials	elsevier-with-titles	0.9864	1.0000	0.0000
-molecular-oncology	elsevier-with-titles	0.9864	1.0000	0.0000
-national-institute-of-health-research	elsevier-with-titles	0.9864	0.0000	0.0000
-nlm-name-year	elsevier-harvard	0.9864	0.1000	0.0000
-pediatric-anesthesia	elsevier-with-titles	0.9864	0.0000	0.0000
-primary-care-clinics-in-office-practice	elsevier-with-titles	0.9864	0.0000	0.0000
-psychosomatics	elsevier-with-titles	0.9864	0.0000	0.0000
-sociologie	elsevier-harvard	0.9864	0.8500	0.0000
-stem-cells	elsevier-with-titles	0.9864	1.0000	0.0000
-surgical-clinics-of-north-america	elsevier-with-titles	0.9864	0.0000	0.0000
-the-institution-of-engineering-and-technology	ieee	0.9864	0.5000	0.0000
-the-journal-of-the-acoustical-society-of-america-numeric	elsevier-with-titles	0.9864	0.0000	0.0000
-the-lancet	elsevier-with-titles	0.9864	0.0000	0.0000
-the-national-medical-journal-of-india	elsevier-with-titles	0.9864	0.0000	0.0000
-the-oncologist	elsevier-with-titles	0.9864	0.0000	0.0000
-metaaltijden	taylor-and-francis-chicago-author-date	0.9853	0.8500	0.0000
-asian-studies-review	taylor-and-francis-chicago-author-date	0.9853	0.0500	0.0000
-cuadernos-de-filologia-clasica	taylor-and-francis-chicago-author-date	0.9853	0.9000	0.0000
-journal-of-interactive-marketing	taylor-and-francis-chicago-author-date	0.9853	0.6500	0.0000
-journal-of-retailing	taylor-and-francis-chicago-author-date	0.9853	0.6500	0.0000
-language	taylor-and-francis-chicago-author-date	0.9853	0.6000	0.0000
-latin-american-research-review	taylor-and-francis-chicago-author-date	0.9853	0.9000	0.0000
-reviews-of-modern-physics-with-titles	taylor-and-francis-chicago-author-date	0.9853	0.9000	0.0000
-taylor-and-francis-chicago-b-author-date	taylor-and-francis-chicago-author-date	0.9853	0.8500	0.0000
-world-politics	taylor-and-francis-chicago-author-date	0.9853	0.0000	0.0000
-berghahn-books-author-date-en-gb	elsevier-harvard	0.9853	0.0500	0.0000
-comparative-population-studies	elsevier-harvard	0.9853	0.0500	0.0000
-czech-journal-of-international-relations	elsevier-harvard	0.9853	0.0500	0.0000
-gengo-kenkyu-journal-of-the-linguistic-society-of-japan	elsevier-harvard	0.9853	0.0500	0.0000
-gesellschaft-fur-popularmusikforschung	elsevier-harvard	0.9853	0.0500	0.0000
-harvard-falmouth-university	elsevier-harvard	0.9853	0.0500	0.0000
-intellect-newgen-books	elsevier-harvard	0.9853	0.0500	0.0000
-journal-of-elections-public-opinion-and-parties	elsevier-harvard	0.9853	0.6000	0.0000
-journal-of-fish-biology	elsevier-harvard	0.9853	0.6000	0.0000
-journal-of-international-relations-and-development	elsevier-harvard	0.9853	0.0500	0.0000
-universitat-basel-iberoromanistik	elsevier-harvard	0.9853	0.0500	0.0000
-universitat-bremen-institut-fur-politikwissenschaft	elsevier-harvard	0.9853	0.0500	0.0000
-universitat-mannheim-germanistische-linguistik	elsevier-harvard	0.9853	0.0500	0.0000
-universitat-stuttgart-planung-und-partizipation	elsevier-harvard	0.9853	0.0500	0.0000
-uniwersytet-im-adama-mickiewicza-w-poznaniu-wydzial-anglistyki	elsevier-harvard	0.9853	0.0500	0.0000
-west-european-politics	elsevier-harvard	0.9853	0.0500	0.0000
-wirtschaftsuniversitat-wien-abteilung-fur-bildungswissenschaft	elsevier-harvard	0.9853	0.0500	0.0000
-wirtschaftsuniversitat-wien-handel-und-marketing	elsevier-harvard	0.9853	0.0500	0.0000
-wirtschaftsuniversitat-wien-wirtschaftspadagogik	elsevier-harvard	0.9853	0.0500	0.0000
-associacao-brasileira-de-normas-tecnicas-numerico	ieee	0.9841	0.0000	0.0000
-currents-in-biblical-research	taylor-and-francis-chicago-author-date	0.9825	0.6000	0.0000
-taylor-and-francis-chicago-f	taylor-and-francis-chicago-author-date	0.9825	0.9000	0.0000
-the-journal-of-roman-studies	taylor-and-francis-chicago-author-date	0.9825	0.0000	0.0000
-transactions-of-the-american-philological-association	taylor-and-francis-chicago-author-date	0.9825	0.0000	0.0000
-acta-anaesthesiologica-taiwanica	elsevier-with-titles	0.9821	0.0000	0.0000
-australian-critical-care	elsevier-with-titles	0.9821	0.0000	0.0000
-chinese-journal-of-aeronautics	elsevier-with-titles	0.9821	0.0000	0.0000
-journal-of-infection	elsevier-with-titles	0.9821	0.0000	0.0000
-journal-of-minimally-invasive-gynecology	elsevier-with-titles	0.9821	1.0000	0.0000
-neuroimaging-clinics-of-north-america	elsevier-with-titles	0.9821	0.0000	0.0000
-the-saudi-journal-for-dental-research	elsevier-with-titles	0.9821	0.0000	0.0000
-textual-cultures	taylor-and-francis-chicago-author-date	0.9817	1.0000	0.0000
-acm-sigchi-proceedings-extended-abstract-format	ieee	0.9813	0.5000	0.0000
-acm-sigchi-proceedings	ieee	0.9813	0.5000	0.0000
-association-for-computing-machinery	ieee	0.9813	0.5000	0.0000
-zeitschrift-fur-fantastikforschung	modern-language-association	0.9812	0.0500	0.0000
-computer-supported-cooperative-work	taylor-and-francis-chicago-author-date	0.9810	0.1000	0.0000
-cranfield-university-numeric	ieee	0.9810	0.5000	0.0000
-obstetrics-and-gynecology-science	ieee	0.9810	0.5000	0.0000
-taylor-and-francis-national-library-of-medicine	ieee	0.9810	0.5000	0.0000
-taylor-and-francis-vancouver-national-library-of-medicine	ieee	0.9810	0.0000	0.0000
-iso690-author-date-cat	taylor-and-francis-chicago-author-date	0.9809	0.6000	0.0000
-chicago-shortened-notes-bibliography-subsequent-author-classic-no-url	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000
-chicago-shortened-notes-bibliography-subsequent-author-classic	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000
-chicago-shortened-notes-bibliography-subsequent-author-no-url	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000
-chicago-shortened-notes-bibliography-subsequent-author	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000
-ucl-press-note	chicago-shortened-notes-bibliography	0.9802	0.9000	0.0000
-umea-university-harvard	taylor-and-francis-chicago-author-date	0.9797	0.6500	0.0000
-brewingscience	ieee	0.9796	0.5000	0.0000
-hochschule-rheinmain-wiesbaden-business-school-gesundheitsokonomie	elsevier-harvard	0.9796	0.0500	0.0000
-journal-of-periodontal-research	elsevier-with-titles	0.9796	0.0000	0.0000
-la-nouvelle-revue-du-travail	elsevier-harvard	0.9796	0.5500	0.0000
-medicina-delle-dipendenze-italian-journal-of-the-addictions	elsevier-harvard	0.9796	1.0000	0.0000
-the-american-journal-of-psychiatry	elsevier-with-titles	0.9796	0.0000	0.0000
-the-international-journal-of-tuberculosis-and-lung-disease	elsevier-with-titles	0.9796	0.0000	0.0000
-the-journal-of-neuropsychiatry-and-clinical-neurosciences	elsevier-with-titles	0.9796	0.0000	0.0000
-college-of-naturopathic-medicine	elsevier-harvard	0.9796	0.6000	0.0000
-lund-university-school-of-economics-and-management	elsevier-harvard	0.9796	0.7000	0.0000
-marine-turtle-newsletter	elsevier-harvard	0.9796	0.0500	0.0000
-pest-management-science	american-medical-association	0.9788	1.0000	0.0000
-preventive-nutrition-and-food-science	elsevier-harvard	0.9788	0.9500	0.0000
-chinese-gb7714-2005-numeric	elsevier-with-titles	0.9784	1.0000	0.0000
-comptes-rendus-numeric	elsevier-with-titles	0.9784	0.7500	0.0000
-database	elsevier-with-titles	0.9784	0.0000	0.0000
-expert-reviews-in-molecular-medicine	elsevier-with-titles	0.9784	1.0000	0.0000
-human-molecular-genetics	elsevier-with-titles	0.9784	0.0000	0.0000
-american-anthropological-association	taylor-and-francis-chicago-author-date	0.9775	0.6000	0.0000
-art-libraries-society-of-north-america-arlisna-reviews	chicago-shortened-notes-bibliography	0.9774	0.9000	0.0000
-journal-of-linguistics	taylor-and-francis-chicago-author-date	0.9762	0.6000	0.0000
-padagogische-hochschule-fachhochschule-nordwestschweiz	taylor-and-francis-chicago-author-date	0.9762	0.5000	0.0000
-unified-style-sheet-for-linguistics	taylor-and-francis-chicago-author-date	0.9762	0.6000	0.0000
-american-journal-of-neuroradiology	american-medical-association	0.9762	1.0000	0.0000
-bourgogne-franche-comte-nature	elsevier-harvard	0.9762	0.5500	0.0000
-european-environment-agency	elsevier-harvard	0.9762	0.7500	0.0000
-sports-health	american-medical-association	0.9762	0.9500	0.0000
-american-journal-of-botany	elsevier-harvard	0.9746	0.5500	0.0000
-applications-in-plant-sciences	elsevier-harvard	0.9746	0.5500	0.0000
-arachne	elsevier-harvard	0.9746	0.0500	0.0000
-arachnologische-mitteilungen	elsevier-harvard	0.9746	0.0500	0.0000
-bulletin-of-geosciences	elsevier-harvard	0.9746	0.0500	0.0000
-egretta	elsevier-harvard	0.9746	0.1000	0.0000
-evolution	elsevier-harvard	0.9746	0.0500	0.0000
-journal-of-evolutionary-biology	elsevier-harvard	0.9746	0.8500	0.0000
-journal-of-foraminiferal-research	elsevier-harvard	0.9746	0.8000	0.0000
-journal-of-systematic-palaeontology	elsevier-harvard	0.9746	0.0500	0.0000
-journal-of-urban-and-environmental-engineering	elsevier-harvard	0.9746	0.8500	0.0000
-journal-of-zoo-biology	elsevier-harvard	0.9746	0.1000	0.0000
-opuscula	elsevier-harvard	0.9746	0.0000	0.0000
-phytotaxa	elsevier-harvard	0.9746	0.0500	0.0000
-plant-species-biology	elsevier-harvard	0.9746	0.0500	0.0000
-raptor-journal	elsevier-harvard	0.9746	0.1000	0.0000
-silva-fennica	elsevier-harvard	0.9746	0.1000	0.0000
-the-geological-society-of-london	elsevier-harvard	0.9746	0.1000	0.0000
-the-lichenologist	elsevier-harvard	0.9746	0.0500	0.0000
-zootaxa	elsevier-harvard	0.9746	0.0500	0.0000
-unified-style-sheet-for-linguistics-de-gruyter-literature	taylor-and-francis-chicago-author-date	0.9745	0.6000	0.0000
-polish-archives-of-internal-medicine	ieee	0.9745	0.5000	0.0000
-revue-metis	elsevier-harvard	0.9745	0.0000	0.0000
-science-china-materials	ieee	0.9745	0.5000	0.0000
-archaeonautica	elsevier-harvard	0.9744	0.1000	0.0000
-bristol-university-press	elsevier-harvard	0.9744	0.6000	0.0000
-chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000
-chicago-shortened-notes-bibliography-subsequent-ibid-classic	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000
-chicago-shortened-notes-bibliography-subsequent-ibid-no-url	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000
-chicago-shortened-notes-bibliography-subsequent-ibid	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000
-cultivos-tropicales	elsevier-with-titles	0.9744	0.0000	0.0000
-universite-du-quebec-a-montreal	elsevier-harvard	0.9744	0.9000	0.0000
-eva-berlin-konferenz	ieee	0.9741	0.5000	0.0000
-harvard-university-of-bath	taylor-and-francis-chicago-author-date	0.9740	0.1000	0.0000
-waterbirds	springer-basic-author-date	0.9730	0.6000	0.0000
-brazilian-journal-of-experimental-design-data-analysis-and-inferential-statistics	ieee	0.9728	0.0000	0.0000
-iso690-numeric-en	ieee	0.9728	0.0000	0.0000
-rever-revista-de-estudos-da-religiao	elsevier-harvard	0.9728	0.6500	0.0000
-universite-du-quebec-a-montreal-prenoms	elsevier-harvard	0.9728	0.9000	0.0000
-chicago-shortened-notes-bibliography-subsequent-author-title-17th-edition	chicago-shortened-notes-bibliography	0.9728	0.9000	1.0000
-new-harts-rules-short-notes-no-url	chicago-shortened-notes-bibliography	0.9728	0.9000	0.0000
-new-harts-rules-short-notes	chicago-shortened-notes-bibliography	0.9728	0.9000	0.0000
-american-political-science-association	taylor-and-francis-chicago-author-date	0.9720	0.8500	0.0000
-journal-of-consumer-research	taylor-and-francis-chicago-author-date	0.9720	0.8500	0.0000
-politique-europeenne	taylor-and-francis-chicago-author-date	0.9720	0.1000	0.0000
-suomen-antropologi-journal-of-the-finnish-anthropological-society	taylor-and-francis-chicago-author-date	0.9720	0.6500	0.0000
-uppsala-university-library-harvard	taylor-and-francis-chicago-author-date	0.9720	0.1000	0.0000
-american-journal-of-archaeology	elsevier-harvard	0.9714	0.0000	0.0000
-antiquity	springer-basic-author-date	0.9714	0.6000	0.0000
-apa-numeric-superscript-brackets	ieee	0.9714	0.5000	0.0000
-apa-numeric-superscript	ieee	0.9714	0.0000	0.0000
-bio-protocol	elsevier-with-titles	0.9714	0.9500	0.0000
-china-national-standard-gb-t-7714-2015-numeric	elsevier-with-titles	0.9714	1.0000	0.0000
-chinese-gb7714-1987-numeric	elsevier-with-titles	0.9714	0.0000	0.0000
-journal-of-industrial-ecology	elsevier-harvard	0.9714	0.0500	0.0000
-netherlands-journal-of-geosciences-geologie-en-mijnbouw	elsevier-harvard	0.9714	0.9000	0.0000
-new-harts-rules-numbered	elsevier-with-titles	0.9714	0.0000	0.0000
-antarctic-science	elsevier-harvard	0.9702	0.1000	0.0000
-economic-geology	elsevier-harvard	0.9702	0.8000	0.0000
-ethnobiology-and-conservation	elsevier-harvard	0.9702	0.1000	0.0000
-iforest	elsevier-harvard	0.9702	0.0500	0.0000
-journal-of-the-korean-society-of-civil-engineers	elsevier-harvard	0.9702	0.8500	0.0000
-journal-of-the-royal-society-of-western-australia	elsevier-harvard	0.9702	0.1000	0.0000
-ksce-journal-of-civil-engineering	elsevier-harvard	0.9702	0.8000	0.0000
-molecular-microbiology	elsevier-harvard	0.9702	0.5500	0.0000
-neues-jahrbuch-fur-geologie-und-palaontologie	elsevier-harvard	0.9702	0.1000	0.0000
-polar-research	elsevier-harvard	0.9702	0.1000	0.0000
-springer-humanities-brackets	elsevier-with-titles	0.9702	0.7500	0.0000
-terra-nova	elsevier-harvard	0.9702	0.8000	1.0000
-the-journal-of-egyptian-archaeology	elsevier-harvard	0.9702	0.0000	0.0000
-uppsala-universitet-institutionen-for-biologisk-grundutbildning	elsevier-harvard	0.9702	0.0500	0.0000
-utah-geological-survey	elsevier-harvard	0.9702	0.8000	0.0000
-wiesbaden-business-school	elsevier-harvard	0.9702	0.0500	0.0000
-economic-commission-for-latin-america-and-the-caribbean	taylor-and-francis-chicago-author-date	0.9692	0.0500	0.0000
-fishery-bulletin	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000
-journal-of-agricultural-and-applied-economics	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000
-journal-on-efficiency-and-responsibility-in-education-and-science	taylor-and-francis-chicago-author-date	0.9692	0.0500	0.0000
-radiopaedia	american-medical-association	0.9692	0.9500	0.0000
-societes-contemporaines	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000
-stanovnistvo	taylor-and-francis-chicago-author-date	0.9692	0.5500	0.0000
-unesco-international-institute-for-educational-planning	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000
-universidade-federal-de-pernambuco-abnt	taylor-and-francis-chicago-author-date	0.9685	0.0500	0.0000
-harvard-york-st-john-university	taylor-and-francis-chicago-author-date	0.9684	0.6000	0.0000
-advanced-engineering-materials	elsevier-with-titles	0.9683	0.6500	0.0000
-advanced-healthcare-materials	elsevier-with-titles	0.9683	1.0000	0.0000
-advanced-materials	elsevier-with-titles	0.9683	1.0000	0.0000
-advanced-optical-materials	elsevier-with-titles	0.9683	1.0000	0.0000
-american-physical-society-et-al	elsevier-with-titles	0.9683	1.0000	0.0000
-andean-geology	elsevier-harvard	0.9683	0.9000	0.0000
-angewandte-chemie	elsevier-with-titles	0.9683	1.0000	0.0000
-arkivoc	elsevier-with-titles	0.9683	0.0000	0.0000
-chemical-engineering-technology	elsevier-with-titles	0.9683	0.7500	0.0000
-chemie-ingenieur-technik	elsevier-with-titles	0.9683	1.0000	0.0000
-critical-reviews-in-solid-state-and-materials-sciences	elsevier-with-titles	0.9683	0.0000	0.0000
-e3s-web-of-conferences	elsevier-with-titles	0.9683	1.0000	0.0000
-ecoscience	elsevier-harvard	0.9683	0.0500	1.0000
-elsevier-without-titles	elsevier-with-titles	0.9683	1.0000	0.0000
-flavour-and-fragrance-journal	elsevier-with-titles	0.9683	0.0000	0.0000
-harvard-london-south-bank-university	elsevier-harvard	0.9683	0.9000	0.0000
-health-sciences-university-uco-school-of-osteopathy	elsevier-harvard	0.9683	0.5500	0.0000
-hystrix-the-italian-journal-of-mammalogy	elsevier-harvard	0.9683	0.9000	0.0000
-indian-journal-of-physics	elsevier-with-titles	0.9683	1.0000	0.0000
-international-journal-of-electrochemical-science	elsevier-with-titles	0.9683	1.0000	0.0000
-international-journal-of-quantum-chemistry	elsevier-with-titles	0.9683	0.0000	0.0000
-international-pig-veterinary-society-congress-proceedings	elsevier-with-titles	0.9683	0.0000	0.0000
-iso690-numeric-lt	elsevier-with-titles	0.9683	0.9500	0.0000
-iso690-numeric-sk	elsevier-with-titles	0.9683	0.9500	0.0000
-japanese-journal-of-applied-physics	elsevier-with-titles	0.9683	0.0000	0.0000
-journal-of-anatomy	elsevier-harvard	0.9683	0.9000	0.0000
-journal-of-aoac-international	elsevier-with-titles	0.9683	0.0000	0.0000
-journal-of-avian-biology	springer-basic-author-date	0.9683	0.6000	0.0000
-journal-of-biosciences	springer-basic-author-date	0.9683	0.7000	0.0000
-journal-of-industrial-and-engineering-chemistry	elsevier-with-titles	0.9683	1.0000	0.0000
-journal-of-integrated-omics	elsevier-with-titles	0.9683	1.0000	0.0000
-journal-of-materials-research	elsevier-with-titles	0.9683	0.0000	0.0000
-journal-of-polymer-science-part-a-polymer-chemistry	elsevier-with-titles	0.9683	0.0000	0.0000
-journal-of-raman-spectroscopy	elsevier-with-titles	0.9683	1.0000	0.0000
-journal-of-small-animal-practice	elsevier-harvard	0.9683	0.0500	0.0000
-journal-of-the-electrochemical-society	elsevier-with-titles	0.9683	0.0000	0.0000
-journal-of-the-serbian-chemical-society	elsevier-with-titles	0.9683	0.0000	0.0000
-macromolecular-reaction-engineering	elsevier-with-titles	0.9683	1.0000	0.0000
-mcdonald-institute-monographs	elsevier-harvard	0.9683	0.0500	0.0000
-molecular-nutrition-and-food-research	elsevier-with-titles	0.9683	1.0000	0.0000
-nature-neuroscience-brief-communications	elsevier-with-titles	0.9683	0.0000	0.0000
-new-zealand-veterinary-journal	elsevier-harvard	0.9683	0.1000	0.0000
-oikos	springer-basic-author-date	0.9683	0.6000	0.0000
-optics-letters	elsevier-with-titles	0.9683	1.0000	0.0000
-plant-and-cell-physiology	elsevier-harvard	0.9683	1.0000	0.0000
-quaderni-degli-avogadro-colloquia	elsevier-with-titles	0.9683	1.0000	0.0000
-small	elsevier-with-titles	0.9683	1.0000	0.0000
-springer-physics-brackets	elsevier-with-titles	0.9683	1.0000	0.0000
-synthesis	elsevier-with-titles	0.9683	0.0000	0.0000
-taylor-and-francis-aip	elsevier-with-titles	0.9683	0.6500	0.0000
-tetrahedron-letters	elsevier-with-titles	0.9683	0.0000	0.0000
-transactions-of-the-materials-research-society-of-japan	elsevier-with-titles	0.9683	1.0000	0.0000
-wader-study	springer-basic-author-date	0.9683	0.6000	0.0000
-chicago-author-date-fr	taylor-and-francis-chicago-author-date	0.9670	0.8000	0.0000
-animal-conservation	elsevier-harvard	0.9668	0.8500	0.0000
-associacao-brasileira-de-normas-tecnicas-ufrgs-initials	elsevier-harvard	0.9668	0.7500	0.0000
-babesch-annual-papers-on-mediterranean-archaeology	elsevier-harvard	0.9668	0.0000	0.0000
-biological-journal-of-the-linnean-society	springer-basic-author-date	0.9668	0.1500	0.0000
-biological-reviews	elsevier-harvard	0.9668	0.8500	0.0000
-carolinea	springer-basic-author-date	0.9668	0.6000	0.0000
-creativity-and-innovation-management	elsevier-harvard	0.9668	0.9000	0.0000
-journal-of-remote-sensing	springer-basic-author-date	0.9668	0.1500	0.0000
-la-trobe-university-harvard	elsevier-harvard	0.9668	0.1000	0.0000
-peerj	springer-basic-author-date	0.9668	0.1500	0.0000
-philippine-journal-of-natural-sciences	springer-basic-author-date	0.9668	0.1500	0.0000
-sunway-college-johor-bahru	elsevier-harvard	0.9668	0.1000	0.0000
-universidade-federal-de-sergipe-departamento-de-engenharia-de-producao-abnt	elsevier-harvard	0.9668	0.8500	0.0000
-universiti-kebangsaan-malaysia	elsevier-harvard	0.9668	0.0500	0.0000
-university-of-south-australia-2017-harvard	elsevier-harvard	0.9668	0.1000	0.0000
-university-of-south-australia-harvard-2011	elsevier-harvard	0.9668	0.1000	0.0000
-university-of-south-australia-harvard-2013	elsevier-harvard	0.9668	0.1000	0.0000
-victoria-university-harvard	elsevier-harvard	0.9668	0.1000	0.0000
-acta-universitatis-agriculturae-sueciae	elsevier-harvard	0.9667	0.0500	0.0000
-clay-minerals	elsevier-harvard	0.9667	0.5500	0.0000
-clays-and-clay-minerals	elsevier-harvard	0.9667	0.5500	0.0000
-clinical-oral-implants-research	elsevier-harvard	0.9667	0.0500	0.0000
-global-ecology-and-biogeography	elsevier-harvard	0.9667	0.5000	0.0000
-inter-research-science-center	elsevier-harvard	0.9667	0.0500	0.0000
-mineralogical-magazine	elsevier-harvard	0.9667	0.5500	0.0000
-neuroendocrinology-letters	elsevier-harvard	0.9667	0.0500	0.0000
-veterinary-anaesthesia-analgesia	elsevier-harvard	0.9667	0.0500	0.0000
-ingenieria-agricola	elsevier-harvard	0.9664	0.5000	0.0000
-revista-ciencias-tecnicas-agropecuarias	elsevier-harvard	0.9664	0.5000	0.0000
-international-journal-of-polymeric-materials-and-polymeric-biomaterials	elsevier-with-titles	0.9660	0.0000	0.0000
-materials-express	elsevier-with-titles	0.9660	1.0000	0.0000
-metallurgical-and-materials-transactions-a	elsevier-with-titles	0.9660	1.0000	0.0000
-metallurgical-and-materials-transactions	elsevier-with-titles	0.9660	1.0000	0.0000
-philippika	elsevier-harvard	0.9660	0.0000	0.0000
-royal-society-of-chemistry-with-titles	elsevier-with-titles	0.9660	0.0000	0.0000
-royal-society-of-chemistry	elsevier-with-titles	0.9660	0.0000	0.0000
-l-homme-english	elsevier-harvard	0.9646	0.0500	0.0000
-journal-of-porphyrins-and-phthalocyanines	american-medical-association	0.9643	0.0000	0.0000
-science-china-chemistry	american-medical-association	0.9643	0.0000	0.0000
-american-sociological-association	taylor-and-francis-chicago-author-date	0.9641	0.5500	0.0000
-javnost-the-public	taylor-and-francis-chicago-author-date	0.9641	0.7500	0.0000
-modern-chinese-literature-and-culture	taylor-and-francis-chicago-author-date	0.9641	0.5500	0.0000
-zeitschrift-fur-religionswissenschaft-author-date	taylor-and-francis-chicago-author-date	0.9641	0.7000	0.0000
-st-patricks-college	elsevier-harvard	0.9637	0.6000	0.0000
-mexicon	elsevier-harvard	0.9634	0.0500	0.0000
-annals-of-botany	springer-basic-author-date	0.9634	0.6000	0.0000
-asia-and-the-pacific-policy-studies	springer-basic-author-date	0.9634	0.8000	1.0000
-entomologia-experimentalis-et-applicata	springer-basic-author-date	0.9634	0.1500	1.0000
-forensic-anthropology	springer-basic-author-date	0.9634	0.5500	0.0000
-geophysical-journal-international	springer-basic-author-date	0.9634	0.8500	0.0000
-hydrological-sciences-journal	springer-basic-author-date	0.9634	0.1000	0.0000
-international-journal-of-wildland-fire	springer-basic-author-date	0.9634	0.6000	1.0000
-journal-of-interactive-media-in-education-harvard	springer-basic-author-date	0.9634	0.5500	0.0000
-journal-of-new-zealand-grasslands	springer-basic-author-date	0.9634	0.5500	0.0000
-journal-of-the-american-water-resources-association	springer-basic-author-date	0.9634	0.1500	0.0000
-monash-university-csiro	springer-basic-author-date	0.9634	0.6000	0.0000
-new-zealand-plant-protection	springer-basic-author-date	0.9634	0.5500	0.0000
-reproduction-fertility-and-development	springer-basic-author-date	0.9634	0.6000	0.0000
-rose-school	springer-basic-author-date	0.9634	0.0000	0.0000
-the-australian-journal-of-agricultural-and-resource-economics	springer-basic-author-date	0.9634	0.8000	0.0000
-the-biological-bulletin	springer-basic-author-date	0.9634	0.1000	0.0000
-water-environment-research	springer-basic-author-date	0.9634	0.1000	0.0000
-glossa	taylor-and-francis-chicago-author-date	0.9629	0.6000	0.0000
-haute-ecole-de-gestion-de-geneve-iso-690	taylor-and-francis-chicago-author-date	0.9629	0.6500	0.0000
-instituto-de-investigaciones-sobre-la-universidad-y-la-educacion-moderno	taylor-and-francis-chicago-author-date	0.9629	0.0500	0.0000
-acta-universitatis-agriculturae-et-silviculturae-mendelianae-brunensis	elsevier-harvard	0.9626	0.9000	0.0000
-american-association-of-petroleum-geologists	elsevier-harvard	0.9626	0.8500	0.0000
-american-geophysical-union	elsevier-harvard	0.9626	0.9000	0.0000
-american-society-of-agricultural-and-biological-engineers	elsevier-harvard	0.9626	0.9000	0.0000
-annalen-des-naturhistorischen-museums-in-wien	elsevier-harvard	0.9626	0.0500	0.0000
-arts-university-bournemouth	elsevier-harvard	0.9626	0.8000	0.0000
-associacao-brasileira-de-normas-tecnicas-ufpr	elsevier-harvard	0.9626	0.0000	0.0000
-associacao-nacional-de-pesquisa-e-ensino-em-transportes	elsevier-harvard	0.9626	0.9500	0.0000
-biomarkers	elsevier-harvard	0.9626	0.1000	1.0000
-bulletin-of-the-seismological-society-of-america	elsevier-harvard	0.9626	0.8500	0.0000
-bursa-uludag-universitesi-egitim-bilimleri-enstitusu	elsevier-harvard	0.9626	0.9000	0.0000
-ceska-zemedelska-univerzita-v-praze-fakulta-agrobiologie-potravinovych-a-prirodnich-zdroju	elsevier-harvard	0.9626	0.9000	0.0000
-clinical-dysmorphology	elsevier-harvard	0.9626	0.8500	0.0000
-earthquake-spectra	elsevier-harvard	0.9626	0.9500	1.0000
-emerald-harvard	elsevier-harvard	0.9626	0.9500	0.0000
-eu-interinstitutional-style	elsevier-harvard	0.9626	0.9500	0.0000
-european-journal-of-political-research	elsevier-harvard	0.9626	0.9500	0.0000
-european-journal-of-taxonomy	elsevier-harvard	0.9626	0.0500	0.0000
-florida-entomologist	elsevier-harvard	0.9626	0.0500	0.0000
-french-politics	elsevier-harvard	0.9626	0.9500	0.0000
-freshwater-crayfish	elsevier-harvard	0.9626	0.0500	0.0000
-harvard-bournemouth-university	elsevier-harvard	0.9626	0.1000	1.0000
-harvard-university-of-exeter-geography	elsevier-harvard	0.9626	0.9500	0.0000
-health-education-england-harvard	elsevier-harvard	0.9626	0.1000	1.0000
-heredity	elsevier-harvard	0.9626	0.8500	0.0000
-housing-studies	elsevier-harvard	0.9626	0.9000	0.0000
-international-development-policy	elsevier-harvard	0.9626	0.5500	0.0000
-international-journal-of-language-and-communication-disorders	elsevier-harvard	0.9626	0.1000	0.0000
-international-journal-of-urban-and-regional-research	elsevier-harvard	0.9626	0.9000	0.0000
-internet-archaeology	elsevier-harvard	0.9626	0.1000	0.0000
-journal-of-information-technology	elsevier-harvard	0.9626	0.9500	0.0000
-journal-of-intercultural-studies	elsevier-harvard	0.9626	0.0500	1.0000
-journal-of-psychiatric-and-mental-health-nursing	elsevier-harvard	0.9626	0.9500	0.0000
-journal-of-studies-on-alcohol-and-drugs	elsevier-harvard	0.9626	0.9500	0.0000
-journal-of-the-marine-biological-association-of-the-united-kingdom	elsevier-harvard	0.9626	0.8500	0.0000
-journal-of-vegetation-science	elsevier-harvard	0.9626	0.8000	0.0000
-karlstad-universitet-harvard	elsevier-harvard	0.9626	0.0500	0.0000
-kth-royal-institute-of-technology-school-of-computer-science-and-communication-sv	elsevier-harvard	0.9626	0.6000	1.0000
-kth-royal-institute-of-technology-school-of-computer-science-and-communication	elsevier-harvard	0.9626	0.6000	1.0000
-mis-quarterly	elsevier-harvard	0.9626	0.1000	0.0000
-new-zealand-journal-of-forestry-science	elsevier-harvard	0.9626	0.1000	0.0000
-ocean-and-coastal-research	elsevier-harvard	0.9626	0.8500	0.0000
-oral-diseases	elsevier-harvard	0.9626	0.8500	0.0000
-oryx	elsevier-harvard	0.9626	0.9000	0.0000
-palaeontographica-abteilung-b-palaeobotany-palaeophytology	elsevier-harvard	0.9626	0.0500	0.0000
-polytechnique-montreal-apa	elsevier-harvard	0.9626	0.8500	0.0000
-preslia	elsevier-harvard	0.9626	0.0500	0.0000
-production-and-operations-management	elsevier-harvard	0.9626	0.0500	0.0000
-pure-and-applied-geophysics	elsevier-harvard	0.9626	0.9000	0.0000
-queen-margaret-university-harvard	elsevier-harvard	0.9626	0.1000	0.0000
-raffles-bulletin-of-zoology	elsevier-harvard	0.9626	0.8500	0.0000
-review-of-political-economy	elsevier-harvard	0.9626	0.1000	0.0000
-revista-de-biologia-marina-y-oceanografia	elsevier-harvard	0.9626	0.0500	0.0000
-science-and-technology-for-the-built-environment	elsevier-harvard	0.9626	0.0500	0.0000
-scientific-review-engineering-and-environmental-sciences	elsevier-harvard	0.9626	0.9000	0.0000
-seismological-research-letters	elsevier-harvard	0.9626	0.8500	0.0000
-sinergie-italian-journal-of-management	elsevier-harvard	0.9626	0.1000	0.0000
-soil-science-and-plant-nutrition	elsevier-harvard	0.9626	0.9000	0.0000
-solent-university-harvard	elsevier-harvard	0.9626	0.1000	0.0000
-springer-socpsych-author-date	elsevier-harvard	0.9626	0.1000	0.0000
-sylwan	elsevier-harvard	0.9626	0.0000	0.0000
-taylor-and-francis-harvard-x	elsevier-harvard	0.9626	0.1000	1.0000
-the-depositional-record	elsevier-harvard	0.9626	0.9000	0.0000
-the-journal-of-the-torrey-botanical-society	elsevier-harvard	0.9626	0.0500	0.0000
-the-open-university-harvard	elsevier-harvard	0.9626	0.8000	0.0000
-the-open-university-s390	elsevier-harvard	0.9626	0.8000	0.0000
-universite-de-montreal-apa	elsevier-harvard	0.9626	0.8500	0.0000
-universite-de-sherbrooke-departement-de-geomatique	elsevier-harvard	0.9626	0.9000	0.0000
-university-of-aberdeen-school-of-education-harvard	elsevier-harvard	0.9626	0.1000	0.0000
-acm-siggraph	elsevier-harvard	0.9623	0.0000	0.0000
-brain-behavior-and-evolution	elsevier-harvard	0.9623	0.0000	0.0000
-journal-of-animal-science	elsevier-harvard	0.9623	0.5000	0.0000
-karger-journals-author-date	elsevier-harvard	0.9623	0.0000	0.0000
-sexual-development	elsevier-harvard	0.9623	0.0000	0.0000
-the-company-of-biologists	elsevier-harvard	0.9623	0.5500	0.0000
-universitat-mainz-geographisches-institut	elsevier-harvard	0.9623	0.0500	0.0000
-alcohol-and-alcoholism	elsevier-harvard	0.9618	0.8500	0.0000
-american-school-of-classical-studies-at-athens	elsevier-harvard	0.9618	0.0000	0.0000
-biometrics	springer-basic-author-date	0.9618	0.1500	0.0000
-botanical-journal-of-the-linnean-society	elsevier-harvard	0.9618	0.0500	0.0000
-harvard-robert-gordon-university	elsevier-harvard	0.9618	0.0500	0.0000
-journal-of-mammalogy	elsevier-harvard	0.9618	0.0500	0.0000
-journal-of-sports-science-and-medicine	springer-basic-author-date	0.9618	0.1500	0.0000
-associacao-brasileira-de-normas-tecnicas-ipea	taylor-and-francis-chicago-author-date	0.9617	0.0500	0.0000
-associacao-brasileira-de-normas-tecnicas-ufs	taylor-and-francis-chicago-author-date	0.9617	0.0500	0.0000
-iso690-author-date-cs	elsevier-harvard	0.9615	0.1000	0.0000
-iso690-author-date-sk	elsevier-harvard	0.9615	0.1000	0.0000
-administrative-science-quarterly	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000
-british-journal-of-political-science	taylor-and-francis-chicago-author-date	0.9613	0.8000	0.0000
-bulletin-of-the-american-schools-of-oriental-research	taylor-and-francis-chicago-author-date	0.9613	0.6000	0.0000
-harvard-edge-hill-university	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000
-harvard-university-of-greenwich	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000
-harvard-university-of-wolverhampton	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000
-anthropologie-et-societes	elsevier-harvard	0.9610	0.0500	0.0000
-revue-d-anthropologie-des-connaissances	elsevier-harvard	0.9608	0.8500	0.0000
-journal-of-cardiothoracic-and-vascular-anesthesia	elsevier-with-titles	0.9603	0.0000	0.0000
-karabuk-university-graduate-school-of-natural-and-applied-sciences	elsevier-with-titles	0.9603	1.0000	0.0000
-chicago-in-text-shortened-author-no-url	modern-language-association	0.9603	0.7500	0.0000
-chicago-in-text-shortened-author	modern-language-association	0.9603	0.7500	0.0000
-the-astrophysical-journal	elsevier-harvard	0.9603	0.0500	0.0000
-behaviour	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000
-ecology-of-freshwater-fish	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000
-family-business-review	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000
-geoarchaeology	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000
-harvard-the-university-of-sheffield-town-and-regional-planning	taylor-and-francis-chicago-author-date	0.9601	0.0500	0.0000
-rmit-university-harvard	taylor-and-francis-chicago-author-date	0.9601	0.6500	0.0000
-the-botanical-review	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000
-associacao-brasileira-de-normas-tecnicas-ufrgs	elsevier-harvard	0.9600	0.7500	0.0000
-journal-of-peace-research	springer-basic-author-date	0.9600	0.0500	0.0000
-revista-portuguesa-de-musicologia-author-date	elsevier-harvard	0.9600	0.1000	0.0000
-demographic-research	taylor-and-francis-chicago-author-date	0.9595	0.5500	0.0000
-american-physics-society-without-titles	elsevier-with-titles	0.9592	1.0000	0.0000
-acme-an-international-journal-for-critical-geographies	taylor-and-francis-chicago-author-date	0.9590	0.1000	0.0000
-apa-no-initials	taylor-and-francis-chicago-author-date	0.9590	0.1000	0.0000
-bibliothek-forschung-und-praxis	taylor-and-francis-chicago-author-date	0.9590	0.0500	0.0000
-bioarchaeology-international	taylor-and-francis-chicago-author-date	0.9590	0.6000	0.0000
-chicago-author-date-access-dates	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000
-chicago-author-date-archive-place-first-no-url	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000
-chicago-author-date-archive-place-first	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000
-chicago-author-date-classic-no-url	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000
-chicago-author-date-classic	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000
-chicago-author-date-no-url	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000
-focaal-journal-of-global-and-historical-anthropology	taylor-and-francis-chicago-author-date	0.9590	0.7000	0.0000
-journal-of-the-association-of-environmental-and-resource-economists	taylor-and-francis-chicago-author-date	0.9590	0.6000	0.0000
-society-for-american-archaeology	taylor-and-francis-chicago-author-date	0.9590	0.5500	0.0000
-archeologia-e-calcolatori	elsevier-harvard	0.9589	0.0500	0.0000
-zeitschrift-fur-qualitative-forschung	springer-basic-author-date	0.9589	0.6000	0.0000
-econometrica	taylor-and-francis-chicago-author-date	0.9573	0.0000	0.0000
-austrian-journal-of-development-studies	elsevier-harvard	0.9567	0.0500	0.0000
-soziologiemagazin	elsevier-harvard	0.9567	0.0500	0.0000
-universitat-bremen-frankoromanistik-literaturwissenschaft	elsevier-harvard	0.9567	0.0500	0.0000
-zdfm-zeitschrift-fur-diversitatsforschung-und-management	elsevier-harvard	0.9567	0.0500	0.0000
-aquitania	elsevier-harvard	0.9566	0.0000	0.0000
-biblio-3w	elsevier-harvard	0.9566	0.0000	0.0000
-bulletin-de-la-societe-entomologique-de-france	elsevier-harvard	0.9566	0.5000	0.0000
-freie-universitat-berlin-geographische-wissenschaften	elsevier-harvard	0.9566	0.0500	0.0000
-gallia	elsevier-harvard	0.9566	0.1000	0.0000
-hochschule-osnabruck-fakultat-agrarwissenschaften-und-landschaftsarchitektur	elsevier-harvard	0.9566	0.0500	0.0000
-universitatsmedizin-gottingen	elsevier-harvard	0.9566	0.0500	0.0000
-wirtschaftsuniversitat-wien-institut-fur-bwl-des-aussenhandels	elsevier-harvard	0.9566	0.0500	0.0000
-bibliotheca-hertziana-max-planck-institute-for-art-history	taylor-and-francis-chicago-author-date	0.9566	0.0000	0.0000
-apa-annotated-bibliography	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-apa-eu	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-apa-no-ampersand	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-apa-single-spaced	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-apa-with-abstract	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-begell-house-apa	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-british-psychological-society	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-chungara-revista-de-antropologia-chilena	taylor-and-francis-chicago-author-date	0.9562	0.5000	0.0000
-citation-compass-apa-note	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000
-contemporary-accounting-research	taylor-and-francis-chicago-author-date	0.9562	0.8500	0.0000
-first-break	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000
-fundamental-and-applied-limnology	taylor-and-francis-chicago-author-date	0.9562	0.6000	0.0000
-groundwater	taylor-and-francis-chicago-author-date	0.9562	0.8500	0.0000
-jcom-journal-of-science-communication	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000
-journal-of-the-botanical-research-institute-of-texas	taylor-and-francis-chicago-author-date	0.9562	0.9000	0.0000
-marine-mammal-science	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-norsk-apa-manual-note	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000
-norsk-apa-manual	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-university-of-gothenburg-apa-7th-edition-swedish-legislations	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-univerza-na-primorskem-fakulteta-za-vede-o-zdravju-apa	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-urad-rs-za-makroekonomske-analize-in-razvoj	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000
-american-marketing-association	taylor-and-francis-chicago-author-date	0.9561	0.6000	0.0000
-escuela-nacional-de-antropologia-e-historia-author-date	elsevier-harvard	0.9558	0.0000	0.0000
-first-monday	elsevier-harvard	0.9558	0.8500	0.0000
-harvard-the-university-of-sheffield-school-of-east-asian-studies	elsevier-harvard	0.9558	0.8500	0.0000
-hiob-ludolf-centre-for-ethiopian-studies-with-url-doi	elsevier-harvard	0.9558	0.0000	0.0000
-journal-de-la-societe-des-oceanistes	elsevier-harvard	0.9558	0.6000	0.0000
-philosophia-scientiae	elsevier-harvard	0.9558	0.0000	0.0000
-politische-vierteljahresschrift	elsevier-harvard	0.9558	0.1000	0.0000
-the-international-spectator	elsevier-harvard	0.9558	0.0500	0.0000
-tramas-y-redes-revista-del-consejo-latinoamericano-de-ciencias-sociales	elsevier-harvard	0.9558	0.9000	0.0000
-zeitschrift-fur-papyrologie-und-epigraphik	elsevier-harvard	0.9558	0.0500	0.0000
-deutsches-archaologisches-institut	elsevier-harvard	0.9555	0.0000	0.0000
-journal-of-neolithic-archaeology	elsevier-harvard	0.9555	0.0500	0.0000
-offa	elsevier-harvard	0.9555	0.0500	0.0000
-studi-slavistici-rivista-dellassociazione-italiana-degli-slavisti	elsevier-harvard	0.9555	0.0500	0.0000
-aquatic-invasions	springer-basic-author-date	0.9554	0.6500	1.0000
-journal-of-conchology	springer-basic-author-date	0.9554	0.6500	0.0000
-northeastern-naturalist	springer-basic-author-date	0.9554	0.5500	0.0000
-the-journal-of-eukaryotic-microbiology	springer-basic-author-date	0.9554	0.6000	0.0000
-associacao-brasileira-de-normas-tecnicas-ufmg-face-full	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000
-errata	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000
-instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000
-universidade-federal-de-juiz-de-fora	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000
-universidade-federal-do-espirito-santo-abnt	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000
-iso690-numeric-cat	ieee	0.9553	0.0000	0.0000
-institut-national-de-la-recherche-scientifique-sciences-sociales	taylor-and-francis-chicago-author-date	0.9551	0.7000	0.0000
-american-journal-of-sociology	elsevier-harvard	0.9550	0.1000	0.0000
-the-quarterly-journal-of-economics	springer-basic-author-date	0.9550	0.7500	0.0000
-fachhochschule-vorarlberg-author-date	taylor-and-francis-chicago-author-date	0.9550	0.5500	0.0000
-fachhochschule-vorarlberg-note	taylor-and-francis-chicago-author-date	0.9550	0.0000	0.0000
-latin-american-perspectives	taylor-and-francis-chicago-author-date	0.9550	0.1000	0.0000
-presses-universitaires-de-rennes-archeologie-et-culture	elsevier-harvard	0.9546	0.7500	0.0000
-techniques-et-culture	elsevier-harvard	0.9546	0.0500	0.0000
-travail-et-emploi	elsevier-harvard	0.9546	0.7500	0.0000
-archiv-fur-geschichte-der-philosophie	elsevier-harvard	0.9546	0.0000	0.0000
-bulletin-de-la-societe-prehistorique-francaise	elsevier-harvard	0.9546	0.5000	0.0000
-chemistry-education-research-and-practice	elsevier-harvard	0.9546	0.5000	0.0000
-embnet-journal	elsevier-harvard	0.9546	0.5000	0.0000
-entomological-society-of-america	elsevier-harvard	0.9546	0.0500	0.0000
-environmental-microbiology	elsevier-harvard	0.9546	0.5000	0.0000
-government-and-opposition	elsevier-harvard	0.9546	0.0500	0.0000
-harvard-manchester-metropolitan-university	elsevier-harvard	0.9546	0.5500	0.0000
-health-economics-policy-and-law	elsevier-harvard	0.9546	0.6500	0.0000
-history-of-the-human-sciences	elsevier-harvard	0.9546	0.6000	0.0000
-human-reproduction-update	elsevier-harvard	0.9546	0.6000	0.0000
-iainutuban	elsevier-harvard	0.9546	0.5000	0.0000
-indiana	elsevier-harvard	0.9546	0.0500	0.0000
-international-journal-of-automotive-technology	elsevier-harvard	0.9546	0.5000	0.0000
-international-journal-of-geriatric-psychiatry	elsevier-harvard	0.9546	0.8000	0.0000
-italian-journal-of-agronomy	elsevier-harvard	0.9546	0.5500	0.0000
-journal-of-plankton-research	elsevier-harvard	0.9546	0.5000	0.0000
-journal-of-pollination-ecology	elsevier-harvard	0.9546	0.0500	0.0000
-journal-of-the-american-academy-of-audiology	elsevier-harvard	0.9546	0.5000	0.0000
-journal-of-the-royal-anthropological-institute	elsevier-harvard	0.9546	0.0500	0.0000
-journal-of-threatened-taxa	elsevier-harvard	0.9546	0.4500	0.0000
-journal-of-urban-technology	elsevier-harvard	0.9546	0.6500	0.0000
-microscopy-and-microanalysis	elsevier-harvard	0.9546	0.6000	0.0000
-national-university-of-singapore-department-of-geography-harvard	elsevier-harvard	0.9546	0.5500	0.0000
-nauplius	elsevier-harvard	0.9546	0.6000	0.0000
-plant-biology	elsevier-harvard	0.9546	0.0500	0.0000
-plant-biotechnology-journal	elsevier-harvard	0.9546	0.5500	0.0000
-restoration-ecology	elsevier-harvard	0.9546	0.0500	0.0000
-sage-harvard	elsevier-harvard	0.9546	0.6500	0.0000
-smithsonian-institution-scholarly-press-author-date	elsevier-harvard	0.9546	0.5500	0.0000
-smithsonian-institution-scholarly-press-botany	elsevier-harvard	0.9546	0.6000	0.0000
-soziologie	elsevier-harvard	0.9546	0.0500	0.0000
-spiritual-care	elsevier-harvard	0.9546	0.0500	0.0000
-the-journal-of-peasant-studies	elsevier-harvard	0.9546	0.0500	0.0000
-the-university-of-winchester-harvard	elsevier-harvard	0.9546	0.6500	0.0000
-theory-culture-and-society	elsevier-harvard	0.9546	0.6500	0.0000
-transboundary-and-emerging-diseases	elsevier-harvard	0.9546	0.6000	0.0000
-united-nations-conference-on-trade-and-development	elsevier-harvard	0.9546	0.5500	0.0000
-universitas-negeri-yogyakarta-program-pascasarjana	elsevier-harvard	0.9546	0.5000	0.0000
-university-of-lincoln-harvard	elsevier-harvard	0.9546	0.5500	0.0000
-uniwersytet-kardynala-stefana-wyszynskiego-w-warszawie-autor-rok	elsevier-harvard	0.9546	0.6000	0.0000
-water-alternatives	elsevier-harvard	0.9546	0.6000	0.0000
-zeitschrift-fur-soziologie	elsevier-harvard	0.9546	0.0500	0.0000
-pesquisa-agropecuaria-brasileira	elsevier-harvard	0.9544	0.8000	0.0000
-lien-social-et-politiques	elsevier-harvard	0.9542	0.5000	0.0000
-annals-of-applied-biology	elsevier-harvard	0.9542	0.5500	0.0000
-arachnology	elsevier-harvard	0.9542	0.0500	0.0000
-crustaceana	elsevier-harvard	0.9542	0.5000	1.0000
-geochimica-et-cosmochimica-acta	elsevier-harvard	0.9542	0.5500	0.0000
-limnetica	elsevier-harvard	0.9542	0.5000	0.0000
-tijdschrift-voor-economische-en-sociale-geografie	elsevier-harvard	0.9542	0.0500	0.0000
-harvard-staffordshire-university	elsevier-harvard	0.9540	0.6000	0.0000
-harvard-university-of-birmingham	elsevier-harvard	0.9540	0.6000	0.0000
-citizen-science-theory-and-practice	elsevier-harvard	0.9539	0.0500	1.0000
-instap-academic-press	elsevier-harvard	0.9539	0.0500	0.0000
-journal-of-computer-applications-in-archaeology	elsevier-harvard	0.9539	0.0500	0.0000
-journal-of-plant-protection-research	elsevier-harvard	0.9539	0.0500	1.0000
-oxford-journals-scimed-author-date	elsevier-harvard	0.9539	0.0500	0.0000
-southeastern-geographer	elsevier-harvard	0.9539	0.0500	0.0000
-strategic-entrepreneurship-journal	elsevier-harvard	0.9539	0.7000	0.0000
-strategic-management-journal	elsevier-harvard	0.9539	0.7000	0.0000
-iso690-numeric-fr	ieee	0.9537	0.0000	0.0000
-university-of-helsinki-faculty-of-theology	taylor-and-francis-chicago-author-date	0.9535	0.0000	0.0000
-studia-historiae-scientiarum	taylor-and-francis-chicago-author-date	0.9534	0.6500	0.0000
-bloomsbury-academic	taylor-and-francis-chicago-author-date	0.9533	0.5500	0.0000
-taxon	elsevier-harvard	0.9530	0.4500	0.0000
-chicago-shortened-notes-bibliography-17th-edition	chicago-shortened-notes-bibliography	0.9529	0.8500	1.0000
-european-review-of-international-studies	chicago-shortened-notes-bibliography	0.9529	0.6000	0.0000
-open-theology	chicago-shortened-notes-bibliography	0.9529	0.8000	0.0000
-associacao-brasileira-de-normas-tecnicas-ufmg-face-initials	taylor-and-francis-chicago-author-date	0.9526	0.0500	0.0000
-instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt-initials	taylor-and-francis-chicago-author-date	0.9526	0.0500	0.0000
-universidade-federal-do-espirito-santo-abnt-initials	taylor-and-francis-chicago-author-date	0.9526	0.0500	0.0000
-ethnologie-francaise	elsevier-harvard	0.9524	0.0000	0.0000
-postepy-higieny-i-medycyny-doswiadczalnej	elsevier-with-titles	0.9524	0.9500	0.0000
-harvard-swinburne-university-of-technology	taylor-and-francis-chicago-author-date	0.9522	0.5500	0.0000
-beltz-padagogik	springer-basic-author-date	0.9521	0.6000	0.0000
-digital-humanities-im-deutschsprachigen-raum	springer-basic-author-date	0.9521	0.6000	0.0000
-interkulturelle-germanistik-gottingen	elsevier-harvard	0.9521	0.0500	0.0000
-journal-fur-medienlinguistik	springer-basic-author-date	0.9521	0.6000	0.0000
-journal-of-historical-linguistics	springer-basic-author-date	0.9521	0.5000	0.0000
-open-gender-journal	elsevier-harvard	0.9521	0.0500	0.0000
-technische-universitat-dresden-linguistik	springer-basic-author-date	0.9521	0.6000	0.0000
-tabula	taylor-and-francis-chicago-author-date	0.9519	0.0500	0.0000
-institut-teknologi-bandung-sekolah-pascasarjana	taylor-and-francis-chicago-author-date	0.9518	0.1000	0.0000
-universita-cattolica-del-sacro-cuore	chicago-shortened-notes-bibliography	0.9512	0.1000	0.0000
-l-homme	elsevier-harvard	0.9510	0.0500	0.0000
-associacao-brasileira-de-normas-tecnicas-usp-fmvz	elsevier-harvard	0.9509	0.1000	0.0000
-universidade-do-estado-do-rio-de-janeiro-abnt	elsevier-harvard	0.9509	0.1000	0.0000
-universidade-estadual-paulista-campus-de-dracena-abnt	elsevier-harvard	0.9509	0.1000	0.0000
-iso690-author-date-pt-br	taylor-and-francis-chicago-author-date	0.9508	0.6500	0.0000
-acta-zoologica-academiae-scientiarum-hungaricae	elsevier-harvard	0.9507	0.1000	0.0000
-boreas	elsevier-harvard	0.9507	0.1000	0.0000
-environmental-and-engineering-geoscience	elsevier-harvard	0.9507	0.8500	0.0000
-equine-veterinary-education	elsevier-harvard	0.9507	0.0500	0.0000
-greek-and-roman-musical-studies	elsevier-harvard	0.9507	0.0000	0.0000
-harvard-leeds-beckett-university	elsevier-harvard	0.9507	0.9000	0.0000
-harvard-university-of-leeds	elsevier-harvard	0.9507	0.6000	0.0000
-harvard-xi-an-jiaotong-liverpool-university	elsevier-harvard	0.9507	0.6000	0.0000
-hiob-ludolf-centre-for-ethiopian-studies-long-names	elsevier-harvard	0.9507	0.0000	0.0000
-journal-of-common-market-studies	elsevier-harvard	0.9507	0.8500	0.0000
-journal-of-natural-history	elsevier-harvard	0.9507	0.1000	0.0000
-prehistoires-mediterraneennes	elsevier-harvard	0.9507	0.0000	0.0000
-taylor-and-francis-council-of-science-editors-author-date	elsevier-harvard	0.9507	0.1000	0.0000
-technische-universitat-dresden-betriebswirtschaftslehre-logistik-author-date	elsevier-harvard	0.9507	0.8500	0.0000
-journal-of-egyptian-history	chicago-shortened-notes-bibliography	0.9499	0.7500	0.0000
-the-economic-history-review	chicago-shortened-notes-bibliography	0.9499	0.6000	0.0000
-archaeometry	elsevier-harvard	0.9498	0.0500	0.0000
-ear-and-hearing	elsevier-harvard	0.9498	0.0500	0.0000
-emu-austral-ornithology	elsevier-harvard	0.9498	0.0500	0.0000
-international-journal-of-audiology	elsevier-harvard	0.9498	0.5500	1.0000
-molecular-plant-pathology	elsevier-harvard	0.9498	0.6000	0.0000
-pacific-conservation-biology	elsevier-harvard	0.9498	0.0500	0.0000
-system-dynamics-review	elsevier-harvard	0.9498	0.5000	0.0000
-topoi-orient-occident-auteur-date	elsevier-harvard	0.9496	0.0000	0.0000
-recherches-en-sciences-de-gestion	taylor-and-francis-chicago-author-date	0.9495	0.1000	0.0000
-ageing-and-society	taylor-and-francis-chicago-author-date	0.9493	0.5500	0.0000
-iso690-author-date-es	taylor-and-francis-chicago-author-date	0.9491	0.6500	0.0000
-canadian-journal-of-criminology-and-criminal-justice	taylor-and-francis-chicago-author-date	0.9490	0.5000	0.0000
-enfances-familles-generations	elsevier-harvard	0.9490	0.5000	0.0000
-management-et-avenir	elsevier-harvard	0.9490	0.8000	0.0000
-revue-des-nouvelles-technologies-de-l-information	elsevier-harvard	0.9490	0.8000	0.0000
-revue-francaise-de-gestion	elsevier-harvard	0.9490	0.8500	0.0000
-universite-nangui-abrogoua-sciences-de-la-nature-apa	elsevier-harvard	0.9490	0.8000	0.0000
-international-organization	taylor-and-francis-chicago-author-date	0.9489	0.0000	0.0000
-harvard-university-of-the-west-of-scotland	taylor-and-francis-chicago-author-date	0.9488	0.1000	0.0000
-united-nations-framework-convention-on-climate-change	taylor-and-francis-chicago-author-date	0.9488	0.0500	0.0000
-urban-habitats	taylor-and-francis-chicago-author-date	0.9488	0.6000	0.0000
-law-and-society-review	springer-basic-author-date	0.9486	0.5000	0.0000
-wirtschaftsuniversitat-wien-unternehmensrechnung-und-controlling	elsevier-harvard	0.9484	0.0500	0.0000
-european-review-of-agricultural-economics	taylor-and-francis-chicago-author-date	0.9483	0.1000	0.0000
-ucl-university-college-apa	taylor-and-francis-chicago-author-date	0.9483	0.1000	0.0000
-alternatif-politika	elsevier-harvard	0.9478	0.6500	0.0000
-annales-de-demographie-historique	elsevier-harvard	0.9478	0.6000	0.0000
-body-and-society	elsevier-harvard	0.9478	0.6500	0.0000
-feminist-theory	elsevier-harvard	0.9478	0.6500	0.0000
-gnosis-journal-of-gnostic-studies	elsevier-harvard	0.9478	0.0000	0.0000
-hiob-ludolf-centre-for-ethiopian-studies	elsevier-harvard	0.9478	0.0000	0.0000
-journal-for-the-study-of-the-new-testament	elsevier-harvard	0.9478	0.0500	0.0000
-revue-europeenne-des-migrations-internationales	elsevier-harvard	0.9478	0.5500	0.0000
-revue-francaise-d-administration-publique	elsevier-harvard	0.9478	0.6000	0.0000
-user-modeling-and-user-adapted-interaction	elsevier-harvard	0.9478	0.0000	0.0000
-wirtschaftsuniversitat-wien-health-care-management	elsevier-harvard	0.9478	0.6000	0.0000
-associacao-brasileira-de-normas-tecnicas	elsevier-harvard	0.9478	0.8500	0.0000
-universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt	elsevier-harvard	0.9478	0.1000	0.0000
-universidade-estadual-de-alagoas-abnt	elsevier-harvard	0.9478	0.1000	0.0000
-journal-of-experimental-botany	springer-basic-author-date	0.9477	0.1000	0.0000
-universitas-gadjah-mada-doctoral-program-in-pharmaceutical-sciences	elsevier-harvard	0.9477	0.7500	1.0000
-communication-et-langages	taylor-and-francis-chicago-author-date	0.9475	0.0000	0.0000
-culture-medicine-and-psychiatry	taylor-and-francis-chicago-author-date	0.9471	0.6500	0.0000
-ethnomusicology	taylor-and-francis-chicago-author-date	0.9471	0.5500	0.0000
-generic-style-rules-for-linguistics	taylor-and-francis-chicago-author-date	0.9471	0.5500	0.0000
-journal-de-la-societe-des-americanistes	taylor-and-francis-chicago-author-date	0.9471	0.8000	0.0000
-society-for-historical-archaeology	taylor-and-francis-chicago-author-date	0.9471	0.6000	0.0000
-springer-humanities-author-date	taylor-and-francis-chicago-author-date	0.9471	0.8000	0.0000
-chicago-shortened-notes-bibliography-16th-edition	chicago-shortened-notes-bibliography	0.9471	0.8500	0.0000
-chicago-shortened-notes-bibliography-subsequent-ibid-17th-edition	chicago-shortened-notes-bibliography	0.9471	0.8500	1.0000
-european-union-interinstitutional-style-guide	chicago-shortened-notes-bibliography	0.9471	0.8500	0.0000
-journal-of-human-rights	elsevier-harvard	0.9471	0.0500	0.0000
-alternatives-to-animal-experimentation	elsevier-harvard	0.9467	0.5500	0.0000
-american-society-for-pharmacology-and-experimental-therapeutics	elsevier-harvard	0.9467	0.8500	0.0000
-cell-structure-and-function	elsevier-harvard	0.9467	0.9000	0.0000
-crop-breeding-and-applied-biotechnology	elsevier-harvard	0.9467	0.0500	0.0000
-ecosistemas	elsevier-harvard	0.9467	0.0500	0.0000
-eunomia-revista-en-cultura-de-la-legalidad	elsevier-harvard	0.9467	0.5500	0.0000
-evolutionary-ecology-research	elsevier-harvard	0.9467	0.8500	0.0000
-institute-for-operations-research-and-the-management-sciences	elsevier-harvard	0.9467	0.1000	0.0000
-termedia-neuropsychiatria-i-neuropsychologia-neuropsychiatry-and-neuropsychology	elsevier-harvard	0.9467	0.0500	0.0000
-tropical-animal-health-and-production	elsevier-harvard	0.9467	0.8500	1.0000
-university-of-bradford-harvard	elsevier-harvard	0.9467	0.0500	0.0000
-veterinaria-italiana	elsevier-harvard	0.9467	0.9000	0.0000
-ausonius-editions	elsevier-harvard	0.9464	0.0000	0.0000
-barbara-budrich	springer-basic-author-date	0.9464	0.6000	0.0000
-hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften	elsevier-harvard	0.9464	0.0500	0.0000
-imperial-college-london-author-date	elsevier-harvard	0.9464	0.6000	0.0000
-the-british-journal-of-sociology	taylor-and-francis-chicago-author-date	0.9454	0.6000	0.0000
-infoclio-de-kurzbelege	chicago-shortened-notes-bibliography	0.9453	0.0000	0.0000
-technische-universitat-munchen-controlling	elsevier-harvard	0.9447	0.0500	0.0000
-mondes-en-developpement	taylor-and-francis-chicago-author-date	0.9447	0.1000	0.0000
-canadian-public-policy	taylor-and-francis-chicago-author-date	0.9443	0.8000	0.0000
-journal-of-business-logistics	taylor-and-francis-chicago-author-date	0.9443	0.8000	0.0000
-journal-of-the-air-and-waste-management-association	taylor-and-francis-chicago-author-date	0.9443	0.1000	0.0000
-register-studies	taylor-and-francis-chicago-author-date	0.9443	0.5500	0.0000
-biuletyn-polskiego-towarzystwa-jezykoznawczego	springer-basic-author-date	0.9439	0.5000	0.0000
-technische-universitat-dresden-finanzwirtschaft-und-finanzdienstleistungen-author-date	elsevier-harvard	0.9439	0.8500	0.0000
-harvard-coventry-university	taylor-and-francis-chicago-author-date	0.9434	0.5000	0.0000
-molecular-plant	elsevier-harvard	0.9433	0.5000	0.0000
-religion-in-the-roman-empire	taylor-and-francis-chicago-author-date	0.9431	0.0000	0.0000
-ulua-revista-de-historia-sociedad-y-cultura	taylor-and-francis-chicago-author-date	0.9430	0.0000	0.0000
-journal-of-archaeological-research	elsevier-harvard	0.9429	0.0500	0.0000
-journal-of-social-archaeology	elsevier-harvard	0.9429	0.5500	0.0000
-cse-name-year-8th-edition	elsevier-harvard	0.9427	0.0500	0.0000
-cse-name-year	elsevier-harvard	0.9427	0.0500	0.0000
-elementa	elsevier-harvard	0.9427	0.5500	0.0000
-facets	elsevier-harvard	0.9427	0.0500	0.0000
-harvard-european-archaeology	elsevier-harvard	0.9427	0.0500	0.0000
-institut-pertanian-bogor	elsevier-harvard	0.9427	0.0500	0.0000
-international-journal-of-plant-sciences	elsevier-harvard	0.9427	0.0500	0.0000
-journal-of-dental-research	elsevier-harvard	0.9427	0.0500	0.0000
-mammalogy-notes	elsevier-harvard	0.9427	0.0500	0.0000
-molecular-biology-and-evolution	elsevier-harvard	0.9427	0.0500	0.0000
-the-world-journal-of-biological-psychiatry	elsevier-harvard	0.9427	0.0500	0.0000
-technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling	taylor-and-francis-chicago-author-date	0.9426	0.0500	0.0000
-centre-de-recherche-sur-les-civilisations-de-l-asie-orientale-auteur-date	elsevier-harvard	0.9422	0.8500	0.0000
-freie-hochschule-stuttgart	elsevier-harvard	0.9422	0.6000	0.0000
-geneses	elsevier-harvard	0.9422	0.0500	0.0000
-geographie-et-cultures	elsevier-harvard	0.9422	0.7500	0.0000
-hochschule-bonn-rhein-sieg	elsevier-harvard	0.9422	0.0500	0.0000
-kolner-zeitschrift-fur-soziologie-und-sozialpsychologie	elsevier-harvard	0.9422	0.0500	0.0000
-metropolitiques	elsevier-harvard	0.9422	0.0500	0.0000
-springer-vs-author-date	elsevier-harvard	0.9422	0.0500	0.0000
-zeitschrift-fur-internationale-beziehungen	elsevier-harvard	0.9422	0.0500	0.0000
-austral-ecology	elsevier-harvard	0.9422	0.0500	0.0000
-harvard-kings-college-london	elsevier-harvard	0.9422	0.5500	0.0000
-harvard-limerick	elsevier-harvard	0.9422	0.0500	0.0000
-harvard-newcastle-university	elsevier-harvard	0.9422	0.5500	0.0000
-journal-fur-kulturpflanzen-journal-of-cultivated-plants	elsevier-harvard	0.9422	0.6500	0.0000
-journal-of-plant-ecology	elsevier-harvard	0.9422	0.0500	0.0000
-national-institute-of-organisation-dynamics-australia-harvard	elsevier-harvard	0.9422	0.0500	0.0000
-skuast-journal-of-research	elsevier-harvard	0.9422	0.6000	0.0000
-style-manual-australian-government	elsevier-harvard	0.9422	0.0500	0.0000
-pontifical-gregorian-university	chicago-shortened-notes-bibliography	0.9419	0.0000	0.0000
-ambio	elsevier-harvard	0.9417	0.0500	0.0000
-institut-francais-darcheologie-orientale-en	elsevier-harvard	0.9417	0.0000	0.0000
-the-american-journal-of-bioethics	elsevier-harvard	0.9417	0.0500	0.0000
-the-canadian-geographer	elsevier-harvard	0.9417	0.0500	0.0000
-harvard-university-of-the-west-of-england	elsevier-harvard	0.9414	0.6500	0.0000
-universidade-federal-de-goias-escola-de-veterinaria-e-zootecnia	elsevier-harvard	0.9414	0.7500	0.0000
-bibliotheque-d-archeologie-mediterraneenne-et-africaine-biama	elsevier-harvard	0.9413	0.0000	0.0000
-bulletin-of-insectology	springer-basic-author-date	0.9413	0.0500	0.0000
-documents-d-archeologie-francaise	elsevier-harvard	0.9413	0.0500	0.0000
-nations-and-nationalism	springer-basic-author-date	0.9413	0.5500	0.0000
-publicatiewijzer-voor-de-archeologie	springer-basic-author-date	0.9413	0.0000	0.0000
-bulletin-de-correspondance-hellenique	taylor-and-francis-chicago-author-date	0.9412	0.0000	0.0000
-journal-of-juridical-sciences	springer-basic-author-date	0.9405	0.0000	0.0000
-sociedade-brasileira-de-computacao	elsevier-harvard	0.9405	0.0000	0.0000
-suleyman-demirel-universitesi-fen-bilimleri-enstitusu	springer-basic-author-date	0.9405	0.1500	0.0000
-springer-imis-series-migrationsgesellschaften	taylor-and-francis-chicago-author-date	0.9403	0.6000	0.0000
-les-cahiers-du-journalisme	elsevier-harvard	0.9398	0.5500	0.0000
-drug-development-research	taylor-and-francis-chicago-author-date	0.9397	0.0000	0.0000
-harvard-deakin-university	taylor-and-francis-chicago-author-date	0.9397	0.6000	0.0000
-harvard-university-of-technology-sydney	taylor-and-francis-chicago-author-date	0.9397	0.5500	0.0000
-acta-naturae	ieee	0.9397	0.5000	0.0000
-institut-francais-darcheologie-orientale-arab-studies	elsevier-harvard	0.9397	0.0000	0.0000
-steel-research-international	ieee	0.9397	0.5000	0.0000
-universitat-bern-institut-fur-sozialanthropologie	elsevier-harvard	0.9392	0.0500	0.0000
-la-revue-des-sciences-de-gestion	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000
-lannee-sociologique	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000
-les-mondes-du-travail	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000
-population	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000
-revue-dhistoire-des-sciences-humaines	taylor-and-francis-chicago-author-date	0.9390	0.0000	0.0000
-revue-forestiere-francaise	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000
-revue-francaise-de-sociologie	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000
-roots-monograph-series	elsevier-harvard	0.9389	0.0500	1.0000
-journal-of-management-studies	elsevier-harvard	0.9388	0.9000	0.0000
-asian-myrmecology	elsevier-harvard	0.9388	0.0500	0.0000
-ucl-university-college-harvard	springer-basic-author-date	0.9382	0.7500	0.0000
-finance-and-society	elsevier-harvard	0.9381	0.5500	0.0000
-harvard-university-for-the-creative-arts	elsevier-harvard	0.9381	0.5000	0.0000
-estudios-de-fonetica-experimental	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-harvard-cite-them-right-10th-edition	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-harvard-cite-them-right-11th-edition	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-harvard-cite-them-right-no-et-al	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-harvard-cite-them-right	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-journal-for-veterinary-medicine-biotechnology-and-biosafety	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-literatura	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-transactions-on-maritime-science	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-ucl-institute-of-education-harvard	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000
-bollettino-d-archeologia-online	elsevier-harvard	0.9374	0.0000	0.0000
-clara-architecture-recherche	taylor-and-francis-chicago-author-date	0.9372	0.0500	0.0000
-iso690-author-date-fr-no-abstract	taylor-and-francis-chicago-author-date	0.9372	0.6000	0.0000
-iso690-author-date-fr	taylor-and-francis-chicago-author-date	0.9372	0.6000	0.0000
-aves	elsevier-harvard	0.9371	0.7500	0.0000
-les-journees-de-la-recherche-porcine	elsevier-harvard	0.9371	0.5000	0.0000
-natur-und-landschaft	elsevier-harvard	0.9371	0.0500	0.0000
-norois	elsevier-harvard	0.9371	0.8000	0.0000
-european-retail-research	elsevier-harvard	0.9370	0.1000	0.0000
-de-montfort-university-harvard	taylor-and-francis-chicago-author-date	0.9369	0.1000	0.0000
-harvard-university-of-kent	taylor-and-francis-chicago-author-date	0.9369	0.6000	0.0000
-health-reform-observer-observatoire-des-reformes-de-sante	taylor-and-francis-chicago-author-date	0.9369	0.6000	0.0000
-british-journal-of-industrial-relations	elsevier-harvard	0.9367	0.0500	0.0000
-heidelberg-university-faculty-of-medicine	elsevier-harvard	0.9367	0.0500	0.0000
-journal-of-european-public-policy	elsevier-harvard	0.9367	0.0500	0.0000
-nys-nydanske-sprogstudier	taylor-and-francis-chicago-author-date	0.9364	0.5000	0.0000
-method-and-theory-in-the-study-of-religion	elsevier-harvard	0.9359	0.0500	0.0000
-einaudi	elsevier-harvard	0.9351	0.1000	0.0000
-geografie-sbornik-cgs	elsevier-harvard	0.9351	0.1000	0.0000
-vita-latina	taylor-and-francis-chicago-author-date	0.9346	0.0000	0.0000
-european-union-interinstitutional-style-guide-author-date	taylor-and-francis-chicago-author-date	0.9343	0.0500	0.0000
-revista-biblica	chicago-shortened-notes-bibliography	0.9341	0.3000	0.0000
-hochschule-fur-soziale-arbeit-fhnw	elsevier-harvard	0.9340	0.0500	0.0000
-chicago-author-date-basque	taylor-and-francis-chicago-author-date	0.9335	0.7000	0.0000
-freshwater-biology	elsevier-harvard	0.9335	0.5000	0.0000
-informal-logic	springer-basic-author-date	0.9333	0.8500	0.0000
-harvard-university-of-cape-town	taylor-and-francis-chicago-author-date	0.9330	0.1000	0.0000
-meta	elsevier-harvard	0.9330	0.0500	0.0000
-representation	taylor-and-francis-chicago-author-date	0.9329	0.8000	0.0000
-environmental-values	springer-basic-author-date	0.9325	0.0500	0.0000
-iica-catie	springer-basic-author-date	0.9325	0.5000	0.0000
-journal-of-product-innovation-management	elsevier-harvard	0.9321	0.0500	0.0000
-antipode	springer-basic-author-date	0.9316	0.5000	0.0000
-harvard-north-west-university	springer-basic-author-date	0.9316	0.0500	0.0000
-indian-journal-of-agricultural-sciences	springer-basic-author-date	0.9316	0.5500	0.0000
-multilingual-matters	springer-basic-author-date	0.9316	0.0500	0.0000
-south-african-journal-of-enology-and-viticulture	springer-basic-author-date	0.9316	0.0500	0.0000
-technische-universitat-dresden-betriebswirtschaftslehre-marketing	taylor-and-francis-chicago-author-date	0.9315	0.5500	0.0000
-harvard-anglia-ruskin-university	taylor-and-francis-chicago-author-date	0.9310	0.1000	0.0000
-harvard-cranfield-university	taylor-and-francis-chicago-author-date	0.9310	0.1000	0.0000
-archeologicke-rozhledy	elsevier-harvard	0.9308	0.1000	0.0000
-international-journal-of-management-reviews	elsevier-harvard	0.9308	0.8500	0.0000
-natures-sciences-societes	elsevier-harvard	0.9308	0.7000	1.0000
-palaeontologia-electronica	elsevier-harvard	0.9308	0.0500	0.0000
-podzemna-voda	elsevier-harvard	0.9308	0.8000	0.0000
-royal-college-of-nursing-harvard	elsevier-harvard	0.9308	0.8000	0.0000
-universidad-de-leon-harvard	elsevier-harvard	0.9308	0.8000	0.0000
-university-of-hull-harvard	elsevier-harvard	0.9308	0.8000	0.0000
-fold-and-r	elsevier-harvard	0.9306	0.0000	0.0000
-bakhtiniana-journal-of-discourse-studies	elsevier-harvard	0.9305	0.0500	0.0000
-acta-botanica-croatica	elsevier-harvard	0.9303	0.0500	0.0000
-aging-cell	elsevier-harvard	0.9303	0.0500	0.0000
-biosocieties	elsevier-harvard	0.9303	0.0500	0.0000
-california-agriculture	elsevier-harvard	0.9303	0.0500	0.0000
-european-journal-of-information-systems	elsevier-harvard	0.9303	0.5500	0.0000
-frontiers-of-biogeography	elsevier-harvard	0.9303	0.0500	0.0000
-german-journal-of-agricultural-economics	elsevier-harvard	0.9303	0.5500	0.0000
-grasas-y-aceites	elsevier-harvard	0.9303	0.0500	0.0000
-griffith-college-harvard	elsevier-harvard	0.9303	0.5500	0.0000
-harvard-cape-peninsula-university-of-technology	elsevier-harvard	0.9303	0.5000	0.0000
-harvard-leeds-metropolitan-university	elsevier-harvard	0.9303	0.5500	0.0000
-harvard-manchester-business-school	elsevier-harvard	0.9303	0.0500	0.0000
-harvard-the-university-of-northampton	elsevier-harvard	0.9303	0.5500	0.0000
-harvard-universiti-teknologi-malaysia	elsevier-harvard	0.9303	0.5500	1.0000
-harvard-universiti-tunku-abdul-rahman	elsevier-harvard	0.9303	0.5500	1.0000
-harvard-university-of-brighton-school-of-environment-and-technology	elsevier-harvard	0.9303	0.5500	0.0000
-health-economics	elsevier-harvard	0.9303	0.5500	0.0000
-journal-of-lithic-studies	elsevier-harvard	0.9303	0.0500	0.0000
-journal-of-simulation	elsevier-harvard	0.9303	0.5500	0.0000
-keele-university-school-of-allied-health-professions	elsevier-harvard	0.9303	0.5500	0.0000
-marine-ornithology	elsevier-harvard	0.9303	0.0500	0.0000
-new-zealand-dental-journal	elsevier-harvard	0.9303	0.5500	0.0000
-nottingham-trent-university-library-harvard	elsevier-harvard	0.9303	0.0500	1.0000
-ornitologia-neotropical	elsevier-harvard	0.9303	0.0500	0.0000
-permafrost-and-periglacial-processes	elsevier-harvard	0.9303	0.0500	0.0000
-scandinavian-political-studies	elsevier-harvard	0.9303	0.0500	0.0000
-social-cognitive-and-affective-neuroscience	elsevier-harvard	0.9303	0.5500	0.0000
-style-manual-for-authors-editors-and-printers-6th-edition-snooks-co	elsevier-harvard	0.9303	0.0500	0.0000
-the-design-journal	elsevier-harvard	0.9303	0.5500	0.0000
-the-international-journal-of-developmental-biology	elsevier-harvard	0.9303	0.6000	0.0000
-the-journal-of-hellenic-studies	elsevier-harvard	0.9303	0.0500	0.0000
-the-plant-journal	elsevier-harvard	0.9303	0.5500	0.0000
-the-university-of-western-australia-harvard	elsevier-harvard	0.9303	0.0500	0.0000
-trinity-college-dublin-zoology-botany-environmental-sciences-harvard	elsevier-harvard	0.9303	0.5500	0.0000
-oxford-studies-on-the-roman-economy	elsevier-harvard	0.9301	0.0000	0.0000
-journal-of-advertising-research	taylor-and-francis-chicago-author-date	0.9295	0.0500	0.0000
-liverpool-john-moores-university-harvard	elsevier-harvard	0.9286	0.5500	0.0000
-the-open-university-m801	elsevier-harvard	0.9286	0.5500	0.0000
-universitas-negeri-semarang-fakultas-matematika-dan-ilmu-pengetahuan-alam	elsevier-harvard	0.9286	0.5500	0.0000
-ets-ecole-de-technologie-superieure	taylor-and-francis-chicago-author-date	0.9283	0.0500	0.0000
-institut-national-de-recherches-archeologiques-preventives	elsevier-harvard	0.9283	0.0500	0.0000
-institut-francais-darcheologie-orientale	elsevier-harvard	0.9281	0.0000	0.0000
-australian-road-research-board	taylor-and-francis-chicago-author-date	0.9278	0.5000	0.0000
-harvard-melbourne-polytechnic	taylor-and-francis-chicago-author-date	0.9278	0.5000	0.0000
-civitas-revista-de-ciencias-sociais	elsevier-harvard	0.9277	0.9000	0.0000
-isara-iso-690	elsevier-harvard	0.9274	0.7500	0.0000
-cahiers-mondes-anciens	taylor-and-francis-chicago-author-date	0.9271	0.0000	0.0000
-anais-da-academia-brasileira-de-ciencias	elsevier-harvard	0.9263	0.0500	0.0000
-biota-neotropica	elsevier-harvard	0.9263	0.0500	0.0000
-biotropica	elsevier-harvard	0.9263	0.0500	0.0000
-institut-francais-darcheologie-orientale-etudes-arabes	elsevier-harvard	0.9261	0.0000	0.0000
-university-of-york-harvard-archaeology	elsevier-harvard	0.9256	0.0500	0.0000
-university-of-york-harvard-environment	elsevier-harvard	0.9256	0.5500	0.0000
-university-of-york-harvard	elsevier-harvard	0.9256	0.5000	0.0000
-revista-noesis	taylor-and-francis-chicago-author-date	0.9251	0.0500	0.0000
-plant-genetic-resources-characterization-and-utilization	elsevier-harvard	0.9249	0.5500	0.0000
-journal-of-the-american-philosophical-association	elsevier-harvard	0.9240	0.0500	0.0000
-deutsche-sprache	springer-basic-author-date	0.9235	0.5500	0.0000
-contributions-to-the-archaeology-of-egypt-nubia-and-the-levant	elsevier-harvard	0.9235	0.0000	0.0000
-harvard-dundalk-institute-of-technology	elsevier-harvard	0.9235	0.0500	0.0000
-les-nouvelles-de-l-archeologie	springer-basic-author-date	0.9222	0.0000	0.0000
-arbok-hins-islenzka-fornleifafelags	taylor-and-francis-chicago-author-date	0.9212	0.0000	0.0000
-copernicus-publications	elsevier-harvard	0.9210	0.5500	0.0000
-em-normandie-business-school-harvard-english	taylor-and-francis-chicago-author-date	0.9209	0.1000	0.0000
-collection-du-centre-jean-berard	elsevier-harvard	0.9192	0.0000	0.0000
-avocetta-journal-of-ornithology	elsevier-harvard	0.9189	0.1000	0.0000
-constructivist-foundations	elsevier-harvard	0.9189	0.1000	0.0000
-diplo	elsevier-harvard	0.9189	0.1000	0.0000
-karstenia	elsevier-harvard	0.9189	0.1000	0.0000
-water-science-and-technology	elsevier-harvard	0.9188	0.5500	0.0000
-isabella-stewart-gardner-museum	elsevier-harvard	0.9187	0.0000	0.0000
-chroniques-des-activites-archeologiques-de-l-ecole-francaise-de-rome	taylor-and-francis-chicago-author-date	0.9186	0.0000	0.0000
-cardiff-university-harvard	elsevier-harvard	0.9181	0.0500	0.0000
-university-of-south-wales-harvard	elsevier-harvard	0.9181	0.5000	0.0000
-law-technology-and-humans	chicago-shortened-notes-bibliography	0.9173	0.3000	0.0000
-revue-francaise-de-pedagogie	elsevier-harvard	0.9172	0.8000	0.0000
-geological-magazine	elsevier-harvard	0.9166	0.5500	0.0000
-technische-universitat-munchen-unternehmensfuhrung	elsevier-harvard	0.9166	0.4500	0.0000
-journal-of-finance	taylor-and-francis-chicago-author-date	0.9164	0.0500	0.0000
-organization	taylor-and-francis-chicago-author-date	0.9160	0.1000	0.0000
-wirtschaftsuniversitat-wien-author-date	taylor-and-francis-chicago-author-date	0.9160	0.1500	0.0000
-atlande	taylor-and-francis-chicago-author-date	0.9153	0.0000	0.0000
-le-tapuscrit-author-date	taylor-and-francis-chicago-author-date	0.9153	0.5500	0.0000
-philipps-universitat-marburg-note	taylor-and-francis-chicago-author-date	0.9153	0.0000	0.0000
-instituto-de-pesquisas-energeticas-e-nucleares	elsevier-harvard	0.9150	0.1000	0.0000
-strategic-design-research-journal	elsevier-harvard	0.9150	0.8000	0.0000
-water-sa	elsevier-harvard	0.9150	0.8000	0.0000
-australasian-journal-of-philosophy	springer-basic-author-date	0.9148	0.4500	0.0000
-acta-adriatica	elsevier-harvard	0.9148	0.6500	0.0000
-acta-ornithologica	elsevier-harvard	0.9148	0.6000	0.0000
-american-journal-of-enology-and-viticulture	elsevier-harvard	0.9148	0.0500	0.0000
-austral-entomology	springer-basic-author-date	0.9148	0.0500	0.0000
-australian-journal-of-earth-sciences	elsevier-harvard	0.9148	0.5500	0.0000
-biologia	elsevier-harvard	0.9148	0.6000	0.0000
-bioscience	elsevier-harvard	0.9148	0.0500	0.0000
-british-journal-of-cancer	elsevier-harvard	0.9148	0.5500	0.0000
-british-journal-of-pharmacology	elsevier-harvard	0.9148	0.5500	0.0000
-bulletin-of-marine-science	elsevier-harvard	0.9148	0.0500	0.0000
-clinical-physiology-and-functional-imaging	elsevier-harvard	0.9148	0.0500	0.0000
-conservation-letters	elsevier-harvard	0.9148	0.0500	0.0000
-coral-reefs	elsevier-harvard	0.9148	0.0500	0.0000
-critical-reviews-in-plant-sciences	elsevier-harvard	0.9148	0.5500	0.0000
-ecological-entomology	elsevier-harvard	0.9148	0.6500	0.0000
-european-journal-of-entomology	elsevier-harvard	0.9148	0.6000	0.0000
-european-journal-of-pain	elsevier-harvard	0.9148	0.5500	0.0000
-evolution-and-development	elsevier-harvard	0.9148	0.5500	0.0000
-evolution-letters	elsevier-harvard	0.9148	0.6500	0.0000
-excli-journal	elsevier-harvard	0.9148	0.0500	0.0000
-friedrich-schiller-universitat-jena-medizinische-fakultat	elsevier-harvard	0.9148	0.0500	0.0000
-genes-brain-and-behavior	elsevier-harvard	0.9148	0.0500	0.0000
-genes-to-cells	elsevier-harvard	0.9148	0.5500	0.0000
-geobiology	elsevier-harvard	0.9148	0.6500	0.0000
-geografia-fisica-e-dinamica-quaternaria	elsevier-harvard	0.9148	0.5500	0.0000
-health-physics	elsevier-harvard	0.9148	0.0500	0.0000
-human-reproduction	elsevier-harvard	0.9148	0.6500	0.0000
-indian-journal-of-veterinary-and-animal-sciences-research	elsevier-harvard	0.9148	0.5500	0.0000
-international-journal-of-food-science-and-technology	springer-basic-author-date	0.9148	0.0500	0.0000
-international-union-of-forest-research-organizations-headquarters	elsevier-harvard	0.9148	0.5500	0.0000
-journal-of-comparative-pathology	elsevier-harvard	0.9148	0.6000	0.0000
-journal-of-dairy-research	springer-basic-author-date	0.9148	0.1000	1.0000
-journal-of-molecular-cell-biology	elsevier-harvard	0.9148	0.5000	0.0000
-journal-of-molecular-endocrinology	springer-basic-author-date	0.9148	0.7000	0.0000
-journal-of-oil-palm-research	elsevier-harvard	0.9148	0.5500	0.0000
-knowledge-and-management-of-aquatic-ecosystems	elsevier-harvard	0.9148	0.6000	0.0000
-life-science-alliance	elsevier-harvard	0.9148	0.5500	0.0000
-medizinische-hochschule-hannover	elsevier-harvard	0.9148	0.5500	0.0000
-molecular-biology-of-the-cell	elsevier-harvard	0.9148	0.5500	0.0000
-mycologia	elsevier-harvard	0.9148	0.0500	0.0000
-photosynthetica	elsevier-harvard	0.9148	0.0500	0.0000
-physiologia-plantarum	elsevier-harvard	0.9148	0.0500	0.0000
-protein-engineering-design-and-selection	springer-basic-author-date	0.9148	0.1000	0.0000
-reproduction	springer-basic-author-date	0.9148	0.1000	1.0000
-research-in-plant-disease	elsevier-harvard	0.9148	0.5500	0.0000
-royal-entomological-society	elsevier-harvard	0.9148	0.7000	0.0000
-scientia-agriculturae-bohemica	elsevier-harvard	0.9148	0.5500	0.0000
-sedimentology	springer-basic-author-date	0.9148	0.0500	0.0000
-stem-cell-reports	elsevier-harvard	0.9148	0.5500	0.0000
-systematic-biology	elsevier-harvard	0.9148	0.0500	0.0000
-the-international-journal-of-psychoanalysis	elsevier-harvard	0.9148	0.7000	0.0000
-weed-research	springer-basic-author-date	0.9148	0.0500	0.0000
-wirtschaftsuniversitat-wien-institut-fur-transportwirtschaft-und-logistik	elsevier-harvard	0.9130	0.0500	0.0000
-mhra-shortened-notes-no-url	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000
-mhra-shortened-notes-publisher-place-no-url	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000
-mhra-shortened-notes-publisher-place	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000
-mhra-shortened-notes	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000
-maison-de-l-orient-et-de-la-mediterranee-en	taylor-and-francis-chicago-author-date	0.9126	0.0000	0.0000
-bibliothek-fur-bildungsgeschichtliche-forschung	taylor-and-francis-chicago-author-date	0.9122	0.0000	0.0000
-revue-archeologique-du-centre-de-la-france	taylor-and-francis-chicago-author-date	0.9120	0.5500	0.0000
-norma-portuguesa-405	taylor-and-francis-chicago-author-date	0.9117	0.0500	0.0000
-bern-university-of-applied-sciences-school-of-agricultural-forest-and-food-sciences-hafl	elsevier-harvard	0.9110	0.0500	0.0000
-geographische-zeitschrift	elsevier-harvard	0.9110	0.0500	0.0000
-environment-and-planning	elsevier-harvard	0.9103	0.5500	0.0000
-geographical-analysis	elsevier-harvard	0.9103	0.5500	0.0000
-institut-national-de-sante-publique-du-quebec-napp	taylor-and-francis-chicago-author-date	0.9101	0.0500	0.0000
-tgm-wien-diplomarbeit-onorm	taylor-and-francis-chicago-author-date	0.9096	0.1000	0.0000
-societe-archeologique-de-bordeaux	elsevier-harvard	0.9090	0.0000	0.0000
-leviathan	taylor-and-francis-chicago-author-date	0.9088	0.0000	0.0000
-african-online-scientific-information-systems-harvard	taylor-and-francis-chicago-author-date	0.9085	0.6000	0.0000
-pallas	elsevier-harvard	0.9085	0.0000	0.0000
-universidade-federal-do-rio-de-janeiro-instituto-alberto-luiz-coimbra-de-pos-graduacao-e-pesquisa-de-engenharia-abnt	taylor-and-francis-chicago-author-date	0.9084	0.0500	0.0000
-nova-univerza	taylor-and-francis-chicago-author-date	0.9082	0.0000	0.0000
-mathematical-geosciences	elsevier-harvard	0.9080	0.0500	0.0000
-osterreichische-zeitschrift-fur-politikwissenschaft	elsevier-harvard	0.9074	0.0500	0.0000
-em-normandie-business-school-harvard-francais	taylor-and-francis-chicago-author-date	0.9073	0.0500	0.0000
-palaeodiversity	elsevier-harvard	0.9070	0.0000	0.0000
-technische-universitat-dresden-wirtschaftswissenschaften	elsevier-harvard	0.9069	0.0000	0.0000
-hochschule-der-kunste-bern-musikforschung	elsevier-harvard	0.9062	0.0000	0.0000
-technische-universitat-dresden-erziehungswissenschaften-author-date	elsevier-harvard	0.9062	0.1000	0.0000
-les-journees-de-la-recherche-avicole	elsevier-harvard	0.9053	0.5000	0.0000
-duale-hochschule-baden-wurttemberg-department-of-international-business	elsevier-harvard	0.9053	0.0500	0.0000
-collection-de-l-ecole-francaise-de-rome-note	taylor-and-francis-chicago-author-date	0.9046	0.0000	0.0000
-acta-ophthalmologica	taylor-and-francis-chicago-author-date	0.9045	0.5000	0.0000
-archeologia-classica	elsevier-harvard	0.9042	0.0000	0.0000
-effective-altruism-wiki	taylor-and-francis-chicago-author-date	0.9039	0.1000	0.0000
-organization-studies	taylor-and-francis-chicago-author-date	0.9039	0.1000	0.0000
-universidade-do-porto-faculdade-de-psicologia-e-de-ciencias-da-educacao	taylor-and-francis-chicago-author-date	0.9039	0.1000	0.0000
-journal-of-roman-archaeology-a	elsevier-harvard	0.9035	0.0000	0.0000
-journal-of-small-business-management	taylor-and-francis-chicago-author-date	0.9031	0.1000	0.0000
-the-accounting-review	taylor-and-francis-chicago-author-date	0.9031	0.7500	0.0000
-university-of-roehampton-harvard	taylor-and-francis-chicago-author-date	0.9022	0.0500	0.0000
-cahiers-d-ethnomusicologie	taylor-and-francis-chicago-author-date	0.9018	0.6500	0.0000
-mots	elsevier-harvard	0.9017	0.0000	0.0000
-fh-joanneum-institute-of-software-design-and-security	taylor-and-francis-chicago-author-date	0.9016	0.1000	0.0000
-apa-6th-edition	taylor-and-francis-chicago-author-date	0.9011	0.1000	0.0000
-bursa-uludag-universitesi-saglik-bilimleri-enstitusu	taylor-and-francis-chicago-author-date	0.9011	0.1000	0.0000
-harvard-durham-university-business-school	taylor-and-francis-chicago-author-date	0.9007	0.5000	0.0000
-harvard-fachhochschule-salzburg	taylor-and-francis-chicago-author-date	0.9007	0.1000	0.0000
-sciences-po-ecole-doctorale-author-date	taylor-and-francis-chicago-author-date	0.8994	0.0500	0.0000
-archaeologia-austriaca	taylor-and-francis-chicago-author-date	0.8992	0.0000	0.0000
-maison-de-l-orient-et-de-la-mediterranee	taylor-and-francis-chicago-author-date	0.8990	0.0000	0.0000
-quaternaire	springer-basic-author-date	0.8984	0.1000	0.0000
-journal-of-agricultural-and-resource-economics	taylor-and-francis-chicago-author-date	0.8975	0.0500	0.0000
-economie-et-statistique	taylor-and-francis-chicago-author-date	0.8970	0.0500	0.0000
-ergo	taylor-and-francis-chicago-author-date	0.8960	0.1000	0.0000
-incontext-studies-in-translation-and-interculturalism	taylor-and-francis-chicago-author-date	0.8960	0.1000	0.0000
-instituto-universitario-militar	taylor-and-francis-chicago-author-date	0.8955	0.1000	0.0000
-mhra-author-date-no-url	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000
-mhra-author-date-publisher-place-no-url	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000
-mhra-author-date-publisher-place	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000
-mhra-author-date	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000
-university-of-tasmania-simplified-author-date	elsevier-harvard	0.8948	0.2000	0.0000
-politeknik-negeri-manado-jurnal-p3m	ieee	0.8937	0.6000	0.0000
-antiquites-africaines	elsevier-harvard	0.8932	0.0000	0.0000
-comptes-rendus-author-date	elsevier-harvard	0.8932	0.7000	0.0000
-polygraphia	elsevier-harvard	0.8931	0.0000	0.0000
-american-college-of-clinical-pharmacy	elsevier-harvard	0.8925	0.1000	0.0000
-harvard-institut-fur-praxisforschung-de	elsevier-harvard	0.8913	0.0500	0.0000
-suburban-zeitschrift-fur-kritische-stadtforschung	elsevier-harvard	0.8913	0.0500	0.0000
-quaderni	elsevier-harvard	0.8912	0.0000	0.0000
-groupe-danthropologie-et-darcheologie-funeraire	elsevier-harvard	0.8909	0.0500	0.0000
-nehet	elsevier-harvard	0.8906	0.0000	0.0000
-ecology-letters	elsevier-harvard	0.8894	0.0500	0.0000
-marine-biology	elsevier-harvard	0.8894	0.0500	0.0000
-fachhochschule-sudwestfalen	elsevier-harvard	0.8881	0.0000	0.0000
-gallia-prehistoire	springer-basic-author-date	0.8880	0.5000	0.0000
-historical-materialism	taylor-and-francis-chicago-author-date	0.8879	0.0000	0.0000
-zeitschrift-fur-digitale-geisteswissenschaften	elsevier-harvard	0.8876	0.0000	0.0000
-flux	taylor-and-francis-chicago-author-date	0.8874	0.0500	0.0000
-cronache-di-archeologia	elsevier-harvard	0.8864	0.0000	0.0000
-owbarth-verlag	elsevier-harvard	0.8857	0.4000	0.0000
-aquatic-conservation	elsevier-harvard	0.8851	0.6000	0.0000
-journal-of-zoology	elsevier-harvard	0.8851	0.6500	0.0000
-letters-in-applied-microbiology	elsevier-harvard	0.8851	0.6500	0.0000
-revue-d-elevage-et-de-medecine-veterinaire-des-pays-tropicaux	elsevier-harvard	0.8851	0.6000	0.0000
-who-europe-harvard	springer-basic-author-date	0.8851	0.1000	0.0000
-american-society-for-horticultural-science	elsevier-harvard	0.8851	0.0500	0.0000
-archeosciences	elsevier-harvard	0.8851	0.5000	1.0000
-folia-biologica	elsevier-harvard	0.8851	0.0500	0.0000
-genetics-and-molecular-biology	elsevier-harvard	0.8851	0.0500	0.0000
-journal-of-investigative-dermatology	elsevier-harvard	0.8851	0.0500	0.0000
-journal-of-neurochemistry	elsevier-harvard	0.8851	0.0500	0.0000
-journal-of-sleep-research	elsevier-harvard	0.8851	0.5500	0.0000
-plant-physiology	elsevier-harvard	0.8851	0.5000	0.0000
-san-francisco-estuary-and-watershed-science	elsevier-harvard	0.8851	0.0500	0.0000
-science-china-earth-sciences	elsevier-harvard	0.8851	0.0500	0.0000
-science-china-life-sciences	elsevier-harvard	0.8851	0.0500	0.0000
-springer-basic-author-date-no-et-al-with-issue	elsevier-harvard	0.8851	0.0500	0.0000
-springer-basic-author-date-no-et-al	elsevier-harvard	0.8851	0.0500	0.0000
-springer-mathphys-author-date	elsevier-harvard	0.8851	0.0500	0.0000
-springer-vancouver-author-date	elsevier-harvard	0.8851	0.0500	0.0000
-ultrasound-in-medicine-and-biology	elsevier-harvard	0.8851	0.0500	0.0000
-wetlands	elsevier-harvard	0.8851	0.0500	0.0000
-isnad-metinici	taylor-and-francis-chicago-author-date	0.8848	0.1000	0.0000
-chicago-author-date-de	taylor-and-francis-chicago-author-date	0.8845	0.5500	0.0000
-development-policy-review	elsevier-harvard	0.8832	0.4500	0.0000
-mind-and-language	elsevier-harvard	0.8832	0.5000	0.0000
-steinbeis-hochschule-school-of-management-and-innovation	springer-basic-author-date	0.8831	0.0500	0.0000
-acta-neurobiologiae-experimentalis	elsevier-harvard	0.8831	0.6000	0.0000
-anatomical-sciences-education	elsevier-harvard	0.8831	0.6000	0.0000
-clinical-anatomy	elsevier-harvard	0.8831	0.6000	0.0000
-developmental-neurobiology	elsevier-harvard	0.8831	0.6000	0.0000
-human-mutation	elsevier-harvard	0.8831	0.6000	0.0000
-journal-of-cellular-biochemistry	elsevier-harvard	0.8831	0.0000	0.0000
-journal-of-limnology	elsevier-harvard	0.8831	0.6000	0.0000
-journal-of-neurophysiology	elsevier-harvard	0.8831	0.0500	0.0000
-anabases	taylor-and-francis-chicago-author-date	0.8829	0.0000	0.0000
-traces	taylor-and-francis-chicago-author-date	0.8828	0.0000	0.0000
-inventaire-general-du-patrimoine-culturel-iso-690-note	taylor-and-francis-chicago-author-date	0.8816	0.0000	0.0000
-amphibia-reptilia	elsevier-harvard	0.8815	0.5500	0.0000
-harvard-university-of-abertay-dundee	elsevier-harvard	0.8815	0.6000	0.0000
-pakistani-veterinary-journal	elsevier-harvard	0.8815	0.5500	0.0000
-colorado-state-university-school-of-biomedical-engineering	elsevier-harvard	0.8815	0.6500	0.0000
-revue-archeologique-de-lest	elsevier-harvard	0.8808	0.4000	0.0000
-american-journal-of-political-science	taylor-and-francis-chicago-author-date	0.8807	0.7000	0.0000
-urbani-izziv	elsevier-harvard	0.8807	0.6500	0.0000
-revue-archeologique-de-narbonnaise	elsevier-harvard	0.8799	0.0500	0.0000
-societe-francaise-detude-de-la-ceramique-antique-en-gaule	elsevier-harvard	0.8799	0.0500	0.0000
-uludag-universitesi-sosyal-bilimler-enstitusu-author-date	taylor-and-francis-chicago-author-date	0.8790	0.2000	0.0000
-der-moderne-staat	taylor-and-francis-chicago-author-date	0.8787	0.4500	0.0000
-soziale-welt	taylor-and-francis-chicago-author-date	0.8787	0.4500	0.0000
-sozialpadagogisches-institut-berlin-walter-may	taylor-and-francis-chicago-author-date	0.8787	0.0500	0.0000
-forschungsjournal-soziale-bewegungen-fjsb	springer-basic-author-date	0.8783	0.6000	0.0000
-association-for-computational-linguistics	elsevier-harvard	0.8783	0.5000	0.0000
-journal-of-social-philosophy	elsevier-harvard	0.8780	0.0500	0.0000
-arctic-antarctic-and-alpine-research	taylor-and-francis-chicago-author-date	0.8779	0.1000	0.0000
-cultural-studies-of-science-education	taylor-and-francis-chicago-author-date	0.8779	0.5000	0.0000
-gaia	taylor-and-francis-chicago-author-date	0.8779	0.4500	0.0000
-journal-of-music-technology-and-education	taylor-and-francis-chicago-author-date	0.8779	0.4500	0.0000
-universite-de-sherbrooke-faculte-d-education	taylor-and-francis-chicago-author-date	0.8779	0.0500	0.0000
-australian-journal-of-grape-and-wine-research	elsevier-harvard	0.8774	0.0500	0.0000
-begell-house-chicago-author-date	elsevier-harvard	0.8774	0.5500	0.0000
-brazilian-journal-of-veterinary-research-and-animal-science	elsevier-harvard	0.8774	0.6000	0.0000
-european-journal-of-neuroscience	elsevier-harvard	0.8774	0.6000	0.0000
-institute-of-mathematics-and-its-applications	elsevier-harvard	0.8774	0.6000	0.0000
-integrative-and-comparative-biology	elsevier-harvard	0.8774	0.0500	0.0000
-journal-of-move-and-therapeutic-science	elsevier-harvard	0.8774	0.6000	0.0000
-journal-of-the-royal-statistical-society	elsevier-harvard	0.8774	0.6500	0.0000
-revista-de-biologia-tropical	elsevier-harvard	0.8774	0.0500	0.0000
-traffic-injury-prevention	elsevier-harvard	0.8774	0.0000	0.0000
-georg-august-universitat-gottingen-institut-fur-ethnologie-und-ethnologische-sammlung	taylor-and-francis-chicago-author-date	0.8768	0.4500	0.0000
-estudios-de-cultura-maya	taylor-and-francis-chicago-author-date	0.8762	0.0000	0.0000
-journal-of-contemporary-water-research-and-education	taylor-and-francis-chicago-author-date	0.8762	0.8000	0.0000
-avian-pathology	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000
-bioarchaeology-of-the-near-east	taylor-and-francis-chicago-author-date	0.8759	0.4500	0.0000
-business-ethics-a-european-review	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000
-ipag-business-school-apa	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000
-journal-of-the-association-for-information-systems	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000
-journal-of-water-sanitation-and-hygiene-for-development	taylor-and-francis-chicago-author-date	0.8759	0.5000	0.0000
-kindheit-und-entwicklung	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000
-la-trobe-university-apa	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000
-planning-practice-and-research	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000
-sodertorns-hogskola-harvard	taylor-and-francis-chicago-author-date	0.8759	0.5500	0.0000
-university-college-lillebaelt-apa	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000
-university-of-gothenburg-apa-swedish-legislations	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000
-urban-studies	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000
-zurcher-hochschule-fur-angewandte-wissenschaften-soziale-arbeit	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000
-china-national-standard-gb-t-7714-2015-author-date	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000
-journal-of-applied-animal-science	elsevier-harvard	0.8750	0.0500	0.0000
-european-journal-physical-medicine-and-rehabilitation	ieee	0.8746	0.0000	0.0000
-magnetic-resonance-in-medical-sciences	ieee	0.8746	0.0000	0.0000
-turcica	chicago-shortened-notes-bibliography	0.8739	0.5500	0.0000
-annual-review-of-astronomy-and-astrophysics	springer-basic-author-date	0.8732	0.5500	0.0000
-harvard-pontificia-universidad-catolica-del-ecuador	taylor-and-francis-chicago-author-date	0.8728	0.1000	0.0000
-apa-fr-provost	taylor-and-francis-chicago-author-date	0.8727	0.1000	0.0000
-ecole-de-technologie-superieure-apa	taylor-and-francis-chicago-author-date	0.8727	0.0500	0.0000
-univerza-v-ljubljani-fakulteta-za-gradbenistvo-in-geodezijo-apa-7	taylor-and-francis-chicago-author-date	0.8725	0.1000	0.0000
-universidad-evangelica-del-paraguay	taylor-and-francis-chicago-author-date	0.8716	0.0500	0.0000
-interdisziplinare-zeitschrift-fur-technologie-und-lernen	taylor-and-francis-chicago-author-date	0.8713	0.4500	0.0000
-urban-geography	taylor-and-francis-chicago-author-date	0.8708	0.1500	0.0000
-asia-pacific-journal-of-human-resources	taylor-and-francis-chicago-author-date	0.8700	0.6500	0.0000
-international-energy-agency-organisation-for-economic-co-operation-and-development	taylor-and-francis-chicago-author-date	0.8700	0.1000	0.0000
-hamburg-school-of-food-science	elsevier-harvard	0.8695	0.0500	0.0000
-petit-chicago-author-date	taylor-and-francis-chicago-author-date	0.8688	0.0500	0.0000
-centaurus	taylor-and-francis-chicago-author-date	0.8680	0.1000	0.0000
-economia-y-politica	taylor-and-francis-chicago-author-date	0.8680	0.4500	0.0000
-journal-of-international-business-studies	taylor-and-francis-chicago-author-date	0.8680	0.1000	0.0000
-mediterranean-politics	taylor-and-francis-chicago-author-date	0.8680	0.1000	0.0000
-ferdinand-porsche-fern-fachhochschule	taylor-and-francis-chicago-author-date	0.8668	0.1000	0.0000
-duale-hochschule-baden-wurttemberg-villingen-schwenningen-roter-grubert-mattern	taylor-and-francis-chicago-author-date	0.8668	0.0000	0.0000
-journalistica	elsevier-harvard	0.8659	0.4500	0.0000
-international-journal-of-spatial-data-infrastructures-research	elsevier-harvard	0.8655	0.4500	0.0000
-ferdinand-porsche-fernfh-betriebswirtschaft-und-wirtschaftspsychologie-dgps	taylor-and-francis-chicago-author-date	0.8651	0.0500	0.0000
-forum-qualitative-sozialforschung	taylor-and-francis-chicago-author-date	0.8651	0.0500	0.0000
-universitat-basel-deutsche-sprachwissenschaft	taylor-and-francis-chicago-author-date	0.8648	0.1000	0.0000
-fachhochschule-kiel-fachbereich-medien	taylor-and-francis-chicago-author-date	0.8647	0.4500	0.0000
-chinese-gb7714-2005-author-date	taylor-and-francis-chicago-author-date	0.8647	0.0500	0.0000
-journal-of-animal-physiology-and-animal-nutrition	springer-basic-author-date	0.8640	0.0500	0.0000
-peter-lang-social-sciences	taylor-and-francis-chicago-author-date	0.8640	0.5000	0.0000
-international-studies-association	taylor-and-francis-chicago-author-date	0.8624	0.4500	0.0000
-deutsche-gesellschaft-fur-psychologie	taylor-and-francis-chicago-author-date	0.8623	0.0500	0.0000
-haute-ecole-pedagogique-fribourg	taylor-and-francis-chicago-author-date	0.8623	0.0500	0.0000
-zeitschrift-fur-padagogik	taylor-and-francis-chicago-author-date	0.8623	0.0500	0.0000
-juristische-zitierweise-schweizer	modern-language-association	0.8618	0.0500	0.0000
-international-union-of-crystallography	elsevier-harvard	0.8615	0.5000	0.0000
-canadian-journal-of-economics	taylor-and-francis-chicago-author-date	0.8615	0.6500	0.0000
-technische-universitat-dresden-forstwissenschaft	elsevier-harvard	0.8611	0.4500	0.0000
-academy-of-management-review	elsevier-harvard	0.8594	0.6000	0.0000
-pontificia-universidade-catolica-do-parana-abnt	taylor-and-francis-chicago-author-date	0.8593	0.0500	0.0000
-french4	taylor-and-francis-chicago-author-date	0.8590	0.0500	0.0000
-technische-universitat-hamburg-institut-fur-smarte-entwicklung-und-maschinenelemente	taylor-and-francis-chicago-author-date	0.8589	0.0000	0.0000
-language-in-society	taylor-and-francis-chicago-author-date	0.8589	0.5000	0.0000
-bibliothecae-it	elsevier-harvard	0.8585	0.1000	0.0000
-forum-qualitative-social-research	taylor-and-francis-chicago-author-date	0.8583	0.0500	0.0000
-myrmecological-news	elsevier-harvard	0.8582	0.0500	0.0000
-cahiers-du-centre-gustave-glotz	elsevier-harvard	0.8578	0.0000	0.0000
-food-and-agriculture-organization-of-the-united-nations	elsevier-harvard	0.8577	0.6500	0.0000
-technische-universitat-dresden-finanzwirtschaft-und-finanzdienstleistungen-author-date-with-short-titles	chicago-shortened-notes-bibliography	0.8567	0.0000	0.0000
-technische-universitat-dresden-finanzwirtschaft-und-finanzdienstleistungen-note	chicago-shortened-notes-bibliography	0.8567	0.0000	0.0000
-bioelectromagnetics	elsevier-harvard	0.8565	0.0000	0.0000
-biotechnology-and-bioengineering	elsevier-harvard	0.8565	0.5500	0.0000
-european-cells-and-materials	elsevier-harvard	0.8565	0.5500	0.0000
-human-brain-mapping	elsevier-harvard	0.8565	0.0000	0.0000
-collections-electroniques-de-l-inha-author-date	elsevier-harvard	0.8561	0.0000	0.0000
-plant-cell-and-environment	springer-basic-author-date	0.8554	0.5500	0.0000
-alkoholizmus-a-drogove-zavislosti	springer-basic-author-date	0.8553	0.0500	0.0000
-museum-national-dhistoire-naturelle	springer-basic-author-date	0.8553	0.5500	0.0000
-harvard-gesellschaft-fur-bildung-und-forschung-in-europa	elsevier-harvard	0.8548	0.0500	0.0000
-harvard-theologisches-seminar-adelshofen	elsevier-harvard	0.8548	0.0500	0.0000
-political-studies	taylor-and-francis-chicago-author-date	0.8541	0.0500	0.0000
-springer-physics-author-date	elsevier-harvard	0.8533	0.0500	0.0000
-die-bachelorarbeit-samac-et-al-in-text	taylor-and-francis-chicago-author-date	0.8532	0.0500	0.0000
-die-bachelorarbeit-samac-et-al-note	taylor-and-francis-chicago-author-date	0.8532	0.0000	0.0000
-universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement	taylor-and-francis-chicago-author-date	0.8532	0.0500	0.0000
-universite-laval-departement-dinformation-et-de-communication	taylor-and-francis-chicago-author-date	0.8530	0.0500	0.0000
-human-resource-management-journal	taylor-and-francis-chicago-author-date	0.8521	0.0500	0.0000
-novasinergia	taylor-and-francis-chicago-author-date	0.8518	0.1000	0.0000
-ethnographiques-org	taylor-and-francis-chicago-author-date	0.8518	0.4000	0.0000
-biens-symboliques-symbolic-goods	taylor-and-francis-chicago-author-date	0.8512	0.4000	0.0000
-lauterbornia	elsevier-harvard	0.8502	0.0500	0.0000
+candidate_id	best_target	similarity	citation_match	bib_match	evidence_url	confidence_note
+accident-analysis-and-prevention	elsevier-harvard	1.0000	1.0000	1.0000	https://www.elsevier.com/journals/accident-analysis-and-prevention/0001-4575/guide-for-authors	found in CSL metadata
+aci-materials-journal	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.concrete.org/publications/acimaterialsjournal/submittingtoacijournals.aspx	found in CSL metadata
+acm-sig-proceedings-long-author-list	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.acm.org/publications/authors/reference-formatting	found in CSL metadata
+acm-sig-proceedings	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.acm.org/publications/authors/reference-formatting	found in CSL metadata
+acta-anaesthesiologica-scandinavica	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1399-6576/homepage/ForAuthors.html	found in CSL metadata
+acta-chirurgiae-orthopaedicae-et-traumatologiae-cechoslovaca	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.achot.cz/instruction.php	found in CSL metadata
+acta-hydrotechnica	elsevier-harvard	1.0000	1.0000	0.0000	https://actahydrotechnica.fgg.uni-lj.si/en/instructions	found in CSL metadata
+acta-medica-peruana	elsevier-with-titles	1.0000	1.0000	0.0000	https://amp.cmp.org.pe/index.php/AMP/instructionsforauthors	found in CSL metadata
+acta-medica-portuguesa	american-medical-association	1.0000	1.0000	1.0000	https://actamedicaportuguesa.com/eng/normas-de-publicacao	found in CSL metadata
+acta-neurochirurgica	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/medicine/surgery/journal/701	found in CSL metadata
+acta-orthopaedica-belgica	elsevier-with-titles	1.0000	0.0000	0.0000	http://journals.sfu.ca/actaob/index.php/actaob/about/submissions#authorGuidelines	found in CSL metadata
+acta-orthopaedica	elsevier-with-titles	1.0000	0.0000	0.0000	https://actaorthop.org/actao/instructionsforauthors	found in CSL metadata
+acta-paediatrica	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/16512227/homepage/forauthors.html	found in CSL metadata
+acta-palaeontologica-polonica	springer-basic-author-date	1.0000	0.6500	0.0000	http://www.app.pan.pl/instruction.html	found in CSL metadata
+acta-pharmaceutica-sinica-b	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/acta-pharmaceutica-sinica-b/2211-3835/guide-for-authors	found in CSL metadata
+acta-physica-sinica	elsevier-with-titles	1.0000	1.0000	0.0000	https://wulixb.iphy.ac.cn/news/tougaoxuzhi.htm	found in CSL metadata
+acta-physiologica	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/17481716/homepage/forauthors.html	found in CSL metadata
+acta-polytechnica	ieee	1.0000	0.5000	0.0000	http://www.cvut.cz/en/facilities/ph/ap/resolveuid/a1a4420631dd2b61eff7a823f4b4f949	found in CSL metadata
+acta-scientiae-veterinariae	elsevier-with-titles	1.0000	0.9500	0.0000	http://www.ufrgs.br/actavet/instrucoes.htm	found in CSL metadata
+acta-societatis-botanicorum-poloniae	elsevier-with-titles	1.0000	1.0000	0.0000	https://pbsociety.org.pl/journals/index.php/asbp/about/submissions#authorGuidelines	found in CSL metadata
+advanced-functional-materials	elsevier-with-titles	1.0000	1.0000	0.0000	https://advanced.onlinelibrary.wiley.com/hub/journal/16163028/author-guidelines	found in CSL metadata
+advanced-pharmaceutical-bulletin	american-medical-association	1.0000	1.0000	0.0000	https://apb.tbzmed.ac.ir/InstructionsforAuthors	found in CSL metadata
+advanced-science	elsevier-with-titles	1.0000	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/21983844/homepage/author-guidelines	found in CSL metadata
+advances-in-alzheimers-disease	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.scirp.org/journal/ForAuthors.aspx?JournalID=1408	found in CSL metadata
+advances-in-complex-systems	elsevier-with-titles	1.0000	0.9500	0.0000	http://www.worldscinet.com/acs/mkt/guidelines.shtml	found in CSL metadata
+aerosol-and-air-quality-research	elsevier-harvard	1.0000	1.0000	0.0000	https://aaqr.org/page/instructions-for-authors	found in CSL metadata
+aerosol-science-and-technology	elsevier-harvard	1.0000	0.1000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=uast20&amp;page=instructions	found in CSL metadata
+aerospace-medicine-and-human-performance	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.asma.org/journal/submit-an-article	found in CSL metadata
+african-journal-of-food-agriculture-nutrition-development	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.ajfand.net/AJFAND/informationtoauthors.html#gsc.tab=0	found in CSL metadata
+african-online-scientific-information-systems-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000	https://safpj.co.za/index.php/safpj/pages/view/submission-guidelines#part_1	found in CSL metadata
+african-zoology	elsevier-harvard	1.0000	0.0500	0.0000	https://journals.co.za/upload/Guidelines_for_Authors/afzoo_auth.pdf	found in CSL metadata
+aging-and-disease	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.aginganddisease.org/EN/column/column217.shtml	found in CSL metadata
+aging	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.aging-us.com/for-authors	found in CSL metadata
+agriculturae-conspectus-scientificus	elsevier-harvard	1.0000	1.0000	0.0000	https://acs.agr.hr/acs/index.php/acs/about/submissions#authorGuidelines	found in CSL metadata
+aids	elsevier-with-titles	1.0000	1.0000	0.0000	http://edmgr.ovid.com/aids/accounts/ifauth.htm	found in CSL metadata
+aims-press	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.aimspress.com/news/140.html	found in CSL metadata
+alcoholism-clinical-and-experimental-research	elsevier-harvard	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1530-0277/homepage/ForAuthors.html	found in CSL metadata
+allergology-international	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/allergology-international/1323-8930/guide-for-authors	found in CSL metadata
+allergy	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291398-9995/homepage/ForAuthors.html	found in CSL metadata
+american-association-for-cancer-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.aacrjournals.org/site/InstrAuthors/ifora.xhtml#references	found in CSL metadata
+american-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000	https://doi.org/10.1021/acsguide.40303	found in CSL metadata
+american-fisheries-society	elsevier-harvard	1.0000	0.0500	0.0000	http://fisheries.org/docs/pub_stylefl.pdf	found in CSL metadata
+american-heart-association	elsevier-with-titles	1.0000	0.0000	0.0000	http://my.americanheart.org/professional/Research/FundingOpportunities/SupportingInformation/Literature-Cited_UCM_320683_Article.jsp#.TxfjyVGJGHU	found in CSL metadata
+american-institute-of-aeronautics-and-astronautics	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.aiaa.org/publications/journals/reference-style-and-format	found in CSL metadata
+american-institute-of-physics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.aip.org/pubservs/style/4thed/toc.html	found in CSL metadata
+american-journal-of-climate-change	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.scirp.org/journal/ajcc/	found in CSL metadata
+american-journal-of-health-behavior	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.ajhb.org/submission/guidelines.htm	found in CSL metadata
+american-journal-of-plant-sciences	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.scirp.org/journal/ajps/	found in CSL metadata
+american-journal-of-respiratory-and-critical-care-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.atsjournals.org/page/AJRCCM/instructions_for_contributors	found in CSL metadata
+american-journal-of-sonography	elsevier-with-titles	1.0000	1.0000	0.0000	https://americanjs.com/instructions-for-authors.php	found in CSL metadata
+american-journal-of-translational-research	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.ajtr.org/guidelines.html	found in CSL metadata
+american-medical-association-alphabetical	american-medical-association	1.0000	0.9500	1.0000	https://academic.oup.com/amamanualofstyle	found in CSL metadata
+american-medical-association-brackets	american-medical-association	1.0000	0.0000	1.0000	https://academic.oup.com/amamanualofstyle	found in CSL metadata
+american-medical-association-no-et-al	american-medical-association	1.0000	1.0000	1.0000	https://academic.oup.com/amamanualofstyle	found in CSL metadata
+american-medical-association-no-url-alphabetical	american-medical-association	1.0000	0.9500	1.0000	https://academic.oup.com/amamanualofstyle	found in CSL metadata
+american-medical-association-no-url	american-medical-association	1.0000	1.0000	1.0000	https://academic.oup.com/amamanualofstyle	found in CSL metadata
+american-medical-association-parentheses	american-medical-association	1.0000	0.0000	1.0000	https://academic.oup.com/amamanualofstyle	found in CSL metadata
+american-meteorological-society	springer-basic-author-date	1.0000	0.9000	0.0000	https://www.ametsoc.org/ams/index.cfm/publications/authors/journal-and-bams-authors/formatting-and-manuscript-components/references/	found in CSL metadata
+american-mineralogist	elsevier-harvard	1.0000	0.1000	0.0000	http://www.minsocam.org/msa/AmMin/All_About_References.html	found in CSL metadata
+american-nuclear-society	elsevier-with-titles	1.0000	0.0000	0.0000	http://cdn.ans.org/pubs/journals/fst/docs/fst-ref-style.pdf	found in CSL metadata
+american-physiological-society	elsevier-with-titles	1.0000	0.0000	0.0000	https://journals.physiology.org/author-info.references	found in CSL metadata
+american-society-for-microbiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://journals.asm.org/references	found in CSL metadata
+american-society-of-civil-engineers	springer-basic-author-date	1.0000	0.5000	0.0000	https://ascelibrary.org/author-center/journal#peer-review-process	found in CSL metadata
+american-society-of-mechanical-engineers	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.asme.org/publications-submissions/journals/information-for-authors/journal-guidelines/references	found in CSL metadata
+american-statistical-association	springer-basic-author-date	1.0000	0.5000	0.0000	http://amstat.tfjournals.com/asa-style-guide/	found in CSL metadata
+anaesthesia	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2044/homepage/ForAuthors.html	found in CSL metadata
+analytical-sciences	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jsac.or.jp/analsci/data/instr/InstAuthor-13-1.pdf	found in CSL metadata
+anesthesiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://pubs.asahq.org/anesthesiology/pages/instructions-for-authors-general#references	found in CSL metadata
+angiologia	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/angiologia/0003-3170/guide-for-authors	found in CSL metadata
+animal-migration	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.degruyter.com/view/supplement/s20848838_Instruction_for_Authors.pdf	found in CSL metadata
+animal-welfare	elsevier-harvard	1.0000	0.0500	0.0000	https://www.ufaw.org.uk/the-ufaw-journal/instructions-for-authors	found in CSL metadata
+animal	elsevier-harvard	1.0000	0.8000	1.0000	https://www.sciencedirect.com/journal/animal/publish/guide-for-authors	found in CSL metadata
+annals-of-allergy-asthma-and-immunology	american-medical-association	1.0000	1.0000	0.0000	https://www.elsevier.com/journals/annals-of-allergy-asthma-and-immunology/1081-1206/guide-for-authors#References	found in CSL metadata
+annals-of-behavioral-medicine	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.springer.com/medicine/journal/12160#	found in CSL metadata
+annals-of-biomedical-engineering	elsevier-with-titles	1.0000	0.7500	0.0000	https://link.springer.com/journal/10439/submission-guidelines	found in CSL metadata
+annals-of-eye-science	elsevier-with-titles	1.0000	0.0000	0.0000	https://aes.amegroups.com/pages/view/guidelines-for-authors	found in CSL metadata
+annals-of-neurology	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291531-8249/homepage/ForAuthors.html	found in CSL metadata
+annals-of-oncology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.elsevier.com/journals/annals-of-oncology/0923-7534/guide-for-authors	found in CSL metadata
+annals-of-public-and-cooperative-economics	elsevier-harvard	1.0000	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/14678292/homepage/forauthors.html	found in CSL metadata
+annals-of-the-new-york-academy-of-sciences	elsevier-with-titles	1.0000	0.0000	0.0000	https://nyaspubs.onlinelibrary.wiley.com/hub/journal/17496632/author-guidelines.html	found in CSL metadata
+aporia-the-nursing-journal	elsevier-with-titles	1.0000	0.0000	0.0000	https://uottawa.scholarsportal.info/ottawa/index.php/aporia/about/submissions#authorGuidelines	found in CSL metadata
+applied-spectroscopy-reviews	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=laps20&amp;page=instructions	found in CSL metadata
+applied-spectroscopy	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.s-a-s.org/journal/authguide/	found in CSL metadata
+aquatic-living-resources	elsevier-harvard	1.0000	0.0500	0.0000	http://journals.cambridge.org/images/fileUpload/images/ALR-InstructionsApr13.pdf	found in CSL metadata
+arcadia-science	elsevier-harvard	1.0000	1.0000	0.0000	https://research.arcadiascience.com/pub/perspective-publishing-round-one	found in CSL metadata
+archives-of-hand-and-microsurgery	elsevier-with-titles	1.0000	1.0000	0.0000	https://submit.handmicro.org/about/Author.php	found in CSL metadata
+archives-of-medical-research	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.elsevier.com/journals/archives-of-medical-research/0188-4409/guide-for-authors	found in CSL metadata
+archives-of-physical-medicine-and-rehabilitation	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.archives-pmr.org/authorinfo#preparation	found in CSL metadata
+archivos-de-bronconeumologia	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.archbronconeumol.org/es/guia-autores/	found in CSL metadata
+archivos-de-la-sociedad-espanola-de-oftalmologia	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/archivos-de-la-sociedad-espanola-de-oftalmologia/0365-6691/guide-for-authors	found in CSL metadata
+archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular	elsevier-with-titles	1.0000	0.0000	0.0000	https://apcyccv.org.pe/index.php/apccc/instrucciones	found in CSL metadata
+arhiv-za-higijenu-rada-i-toksikologiju	elsevier-with-titles	1.0000	1.0000	0.0000	https://hrcak.srce.hr/aiht?lang=en	found in CSL metadata
+artery-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/artery-research/1872-9312/guide-for-authors	found in CSL metadata
+arthropod-systematics-and-phylogeny	elsevier-harvard	1.0000	0.0500	0.0000	https://arthropod-systematics.arphahub.com/about#CopyeditingInstructions	found in CSL metadata
+arzneimitteltherapie	elsevier-with-titles	1.0000	0.9500	0.0000	http://www.arzneimitteltherapie.de/services/autorenhinweise.html	found in CSL metadata
+asa-cssa-sssa	springer-basic-author-date	1.0000	0.1000	0.0000	https://dl.sciencesocieties.org/publications/style/	found in CSL metadata
+asian-journal-of-neurosurgery	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.asianjns.org/contributors.asp	found in CSL metadata
+atlas-of-genetics-and-cytogenetics-in-oncology-and-haematology	elsevier-harvard	1.0000	1.0000	0.0000	http://atlasgeneticsoncology.org/BackpageAuthors.html#CONTRIBUTION	found in CSL metadata
+australian-dental-journal	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/18347819/homepage/forauthors.html	found in CSL metadata
+australian-veterinary-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://mc.manuscriptcentral.com/societyimages/avj/AVJ-IFA-2006.pdf	found in CSL metadata
+avian-conservation-and-ecology	elsevier-harvard	1.0000	0.0500	0.0000	http://www.ace-eco.org/about/submissions.php#literaturecited	found in CSL metadata
+avian-diseases	elsevier-with-titles	1.0000	0.0000	0.0000	https://meridian.allenpress.com/avian-diseases/pages/author-guidelines	found in CSL metadata
+baghdad-science-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.csw-journal.org/myfile/Guidelines%20for%20Authors%20E.pdf	found in CSL metadata
+baishideng-publishing-group	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.wjgnet.com/1948-5182/	found in CSL metadata
+beilstein-journal-of-organic-chemistry	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.beilstein-journals.org/bjoc/authorInstructions	found in CSL metadata
+berlin-school-of-economics-and-law-international-marketing-management	springer-basic-author-date	1.0000	0.1500	0.0000	https://github.com/citation-style-language/styles/files/2571346/GuidelinesforThesisWriting-English-Okt.2017.pdf	found in CSL metadata
+bibliotheque-universitaire-de-medecine-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.bium.ch/guide-vancouver/	found in CSL metadata
+biochemical-journal	elsevier-with-titles	1.0000	0.7500	0.0000	https://portlandpress.com/biochemj/pages/submission_checklist#References	found in CSL metadata
+biochemistry-and-molecular-biology-education	elsevier-with-titles	1.0000	1.0000	0.0000	http://iubmb.onlinelibrary.wiley.com/hub/journal/10.1002/(ISSN)1539-3429/about/author-guidelines.html	found in CSL metadata
+biochemistry	elsevier-with-titles	1.0000	0.0000	0.0000	http://pubs.acs.org/paragonplus/submission/bichaw/bichaw_authguide.pdf	found in CSL metadata
+biochimica-et-biophysica-acta	elsevier-with-titles	1.0000	1.0000	1.0000	http://www.elsevier.com/journals/bba-biomembranes/0005-2736/guide-for-authors#68000	found in CSL metadata
+bioethics	ieee	1.0000	0.6500	0.0000	https://onlinelibrary.wiley.com/page/journal/14678519/homepage/forauthors.html#3	found in CSL metadata
+biofuel-research-journal	elsevier-harvard	1.0000	0.9500	0.0000	https://www.biofueljournal.com/journal/authors.note	found in CSL metadata
+biological-and-pharmaceutical-bulletin	elsevier-with-titles	1.0000	0.0000	0.0000	http://bpb.pharm.or.jp/document/inst_e.pdf	found in CSL metadata
+biological-psychiatry	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/biological-psychiatry/0006-3223/guide-for-authors	found in CSL metadata
+biologiceskie-membrany	elsevier-with-titles	1.0000	0.7500	0.0000	https://sciencejournals.ru/journals/biomem/guid.pdf	found in CSL metadata
+biology-of-reproduction	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.biolreprod.org/site/IforA/BOR_InfoForAuthors_2013-04-19.pdf	found in CSL metadata
+biomed-central	elsevier-with-titles	1.0000	0.7500	0.0000	http://bmcbioinformatics.biomedcentral.com/submission-guidelines/preparing-your-manuscript/research-article	found in CSL metadata
+biomed-research-international	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.hindawi.com/journals/bmri/guidelines/	found in CSL metadata
+biomolecular-concepts	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.degruyter.com/publication/journal_key/BMC/downloadAsset/BMC_Instruction for Authors.pdf	found in CSL metadata
+biophysical-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://download.cell.com/images/edimages/Biophys/Instructions_to_Authors.pdf	found in CSL metadata
+biophysics-and-physicobiology	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.biophys.jp/biophysics_and_physicobiology03.html	found in CSL metadata
+biopolymers	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291097-0282/homepage/ForAuthors.html	found in CSL metadata
+bioresources	springer-basic-author-date	1.0000	0.5000	0.0000	https://www.ncsu.edu/bioresources/BioRes_Article_Template_Styles.docx	found in CSL metadata
+biotechniques	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.biotechniques.com/multimedia/archive/00082/Instructions_for_Aut_82363a.pdf	found in CSL metadata
+biotechnology-and-bioprocess-engineering	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.zotero.org/styles/trends-journals	found in CSL metadata
+bmj	elsevier-with-titles	1.0000	1.0000	0.0000	http://group.bmj.com/products/journals/instructions-for-authors/formatting#references	found in CSL metadata
+boletin-de-la-sociedad-geologica-mexicana	elsevier-harvard	1.0000	0.9500	0.0000	http://boletinsgm.igeolcu.unam.mx/bsgm/index.php/instrucciones-instructions	found in CSL metadata
+boletin-de-pediatria	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.sccalp.org/normas-para-la-presentacion-y-publicacion-de-trabajos-en-el-boletin-de-pediatria#Presentacion	found in CSL metadata
+bollettino-della-societa-italiana-di-paleontologia	elsevier-harvard	1.0000	0.9500	0.0000	https://www.paleoitalia.it/bollettino-spi/notes-for-authors/	found in CSL metadata
+boreal-environment-research	springer-basic-author-date	1.0000	0.7000	0.0000	http://www.borenv.net/	found in CSL metadata
+borgyogyaszati-es-venerologiai-szemle	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.bium.ch/guide-vancouver/	found in CSL metadata
+brazilian-journal-of-infectious-diseases	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/brazilian-journal-of-infectious-diseases/1413-8670/guide-for-authors	found in CSL metadata
+brazilian-oral-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.scielo.br/revistas/bor/iinstruc.htm	found in CSL metadata
+british-journal-of-anaesthesia	elsevier-with-titles	1.0000	0.0000	0.0000	https://bjanaesthesia.org/content/authorinfo	found in CSL metadata
+british-journal-of-nutrition	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.cambridge.org/core/journals/british-journal-of-nutrition/information/author-instructions/preparing-your-materials	found in CSL metadata
+british-journal-of-surgery	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.bjs.co.uk/view/instructionsToAuthors.html	found in CSL metadata
+budownictwo-i-architektura-pl	ieee	1.0000	1.0000	0.0000	http://bud-arch.pollub.pl/index.php/pl/dla-autorow/	found in CSL metadata
+bulletin-du-centre-detudes-medievales-dauxerre	elsevier-with-titles	1.0000	0.0000	0.0000	http://cem.revues.org/index522.html#tocfrom1n3	found in CSL metadata
+bulletin-of-applied-glycoscience	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jstage.jst.go.jp/browse/bag	found in CSL metadata
+byzantina-symmeikta	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.byzsym.org/index.php/bz/about/submissions#authorGuidelines	found in CSL metadata
+cambridge-journal-of-economics	elsevier-harvard	1.0000	0.9000	0.0000	https://academic.oup.com/cje/pages/General_Instructions	found in CSL metadata
+cambridge-university-press-author-date-cambridge-a	elsevier-harvard	1.0000	0.0500	0.0000	https://www.cambridge.org/core/services/aop-file-manager/file/620ce449008b051e8363e1bf/0219-AH-Guide-Cambridge-Reference-Styles-Feb22.pdf	found in CSL metadata
+cambridge-university-press-author-date	elsevier-harvard	1.0000	0.0500	0.0000	https://www.cambridge.org/core/services/aop-file-manager/file/610be5e3a1acae0932de3cca/Cambridge-Reference-Styles.pdf	found in CSL metadata
+cambridge-university-press-numeric	elsevier-with-titles	1.0000	0.7500	0.0000	https://authornet.cambridge.org/information/academic/guidelines_for_authors.asp	found in CSL metadata
+canadian-geotechnical-journal	elsevier-harvard	1.0000	0.0500	0.0000	https://www.nrcresearchpress.com/page/cgj/authors#9d	found in CSL metadata
+canadian-journal-of-chemistry	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nrcresearchpress.com/page/cjc/authors	found in CSL metadata
+canadian-journal-of-dietetic-practice-and-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.dietitians.ca/Downloadable-Content/Public/guide_for_authors.aspx	found in CSL metadata
+canadian-journal-of-earth-sciences	elsevier-harvard	1.0000	0.0500	0.0000	http://www.nrcresearchpress.com/page/cjes/authors#9d	found in CSL metadata
+canadian-journal-of-fisheries-and-aquatic-sciences	elsevier-harvard	1.0000	0.0500	0.0000	http://www.nrcresearchpress.com/page/cjfas/authors	found in CSL metadata
+canadian-journal-of-mineralogy-and-petrology	springer-basic-author-date	1.0000	0.6500	0.0000	https://mac-amc.myshopify.com/pages/submit-author-information	found in CSL metadata
+canadian-journal-of-physics	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.nrcresearchpress.com/page/cjp/authors#9d	found in CSL metadata
+canadian-journal-of-public-health	elsevier-with-titles	1.0000	0.0000	0.0000	https://journal.cpha.ca/index.php/cjph/about/submissions#authorGuidelines	found in CSL metadata
+canadian-journal-of-remote-sensing	elsevier-harvard	1.0000	1.0000	0.0000	https://www.tandfonline.com/journals/ujrs20	found in CSL metadata
+canadian-journal-of-soil-science	elsevier-harvard	1.0000	0.0500	0.0000	http://www.nrcresearchpress.com/page/cjss/authors#21	found in CSL metadata
+cancer-biomarkers	elsevier-with-titles	1.0000	1.0000	1.0000	https://www.iospress.com/catalog/journals/cancer-biomarkers	found in CSL metadata
+cancer-drug-resistance	elsevier-with-titles	1.0000	1.0000	0.0000	https://cdrjournal.com/pages/view/author_instructions	found in CSL metadata
+cardiff-university-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nlm.nih.gov/bsd/uniform_requirements.html	found in CSL metadata
+cardiocore	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/cardiocore/1889-898X/guide-for-authors	found in CSL metadata
+cell-numeric	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.cell.com/current-biology/authors	found in CSL metadata
+cell-research	elsevier-with-titles	1.0000	1.0000	0.0000	http://mts-cr.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions	found in CSL metadata
+cell	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.cell.com/cell/authors	found in CSL metadata
+cellular-and-molecular-bioengineering	elsevier-with-titles	1.0000	0.7500	0.0000	https://link.springer.com/journal/12195/submission-guidelines#Instructions%20for%20Authors_References	found in CSL metadata
+chemical-and-pharmaceutical-bulletin	elsevier-with-titles	1.0000	0.0000	0.0000	http://cpb.pharm.or.jp/document/inst_e.pdf	found in CSL metadata
+chemical-biology-and-drug-design	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1747-0285/homepage/ForAuthors.html	found in CSL metadata
+chest	elsevier-with-titles	1.0000	0.0000	0.0000	http://journal.publications.chestnet.org/ss/forauthors.aspx#References	found in CSL metadata
+chicago-author-date-17th-edition	taylor-and-francis-chicago-author-date	1.0000	1.0000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-in-text-shortened-author-title-no-url	chicago-shortened-notes-bibliography	1.0000	0.0000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-in-text-shortened-author-title	chicago-shortened-notes-bibliography	1.0000	0.0000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-access-dates	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-archive-place-first-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-archive-place-first	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-classic-archive-place-first-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-classic-archive-place-first	chicago-shortened-notes-bibliography	1.0000	1.0000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-classic-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-classic	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-no-url	chicago-shortened-notes-bibliography	1.0000	1.0000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chimia	elsevier-with-titles	1.0000	1.0000	0.0000	https://chimia.ch/index.php?option=com_content&amp;view=category&amp;layout=blog&amp;id=109&amp;Itemid=489&amp;lang=en	found in CSL metadata
+chinese-medical-journal	elsevier-with-titles	1.0000	1.0000	0.0000	http://edmgr.ovid.com/cmj/accounts/ifauth.htm	found in CSL metadata
+chinese-science-bulletin	elsevier-with-titles	1.0000	0.9500	0.0000	https://www.sciengine.com/CSB/authorCenter?scroll=section_1	found in CSL metadata
+circulation-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.j-circ.or.jp/english/cj/index.php/ita/	found in CSL metadata
+cirugia-cardiovascular	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/cirugia-cardiovascular/1134-0096/guide-for-authors	found in CSL metadata
+civil-engineering-journal	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.civilejournal.org/index.php/cej/about/submissions#authorGuidelines	found in CSL metadata
+cladistics	elsevier-harvard	1.0000	0.9500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291096-0031/homepage/ForAuthors.html	found in CSL metadata
+climate-change-economics	elsevier-harvard	1.0000	0.9500	0.0000	http://www.worldscientific.com/page/cce/submission-guidelines	found in CSL metadata
+clinica-e-investigacion-en-arteriosclerosis	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/clinica-e-investigacion-en-arteriosclerosis/0214-9168/guide-for-authors	found in CSL metadata
+clinical-hemorheology-and-microcirculation	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.iospress.nl/journal/clinical-hemorheology-and-microcirculation/	found in CSL metadata
+clinical-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000	https://academic.oup.com/cid/pages/Manuscript_Preparation	found in CSL metadata
+clinical-journal-of-the-american-society-of-nephrology	elsevier-with-titles	1.0000	0.0000	0.0000	https://cjasn.asnjournals.org/content/authors/ifora	found in CSL metadata
+clinical-nuclear-medicine	elsevier-with-titles	1.0000	1.0000	0.0000	http://edmgr.ovid.com/cnm/accounts/ifauth.htm	found in CSL metadata
+clinical-orthopaedics-and-related-research	elsevier-with-titles	1.0000	0.7500	0.0000	https://journals.lww.com/clinorthop/Pages/informationforauthors.aspx	found in CSL metadata
+clinical-otolaryngology	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291749-4486/homepage/ForAuthors.html	found in CSL metadata
+clinical-pharmacology-and-therapeutics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nature.com/clpt/clptguidetoauthors.pdf	found in CSL metadata
+clinical-radiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.rcr.ac.uk/sites/default/files/instructions_authors_cr.pdf	found in CSL metadata
+cns-and-neurological-disorders-drug-targets	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.benthamscience.com/cdtcnsnd/MSandI.htm	found in CSL metadata
+cns-spectrums	american-medical-association	1.0000	1.0000	0.0000	https://www.cambridge.org/core/journals/cns-spectrums/information/instructions-contributors#Manuscript_submission	found in CSL metadata
+colombian-journal-of-anesthesiology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/colombian-journal-of-anesthesiology/2256-2087/guide-for-authors	found in CSL metadata
+comparative-parasitology	elsevier-harvard	1.0000	0.9500	0.0000	https://www.helmsoc.org/HelmSoc_site/helmsoc/assets/img/COPA_Instructions.pdf	found in CSL metadata
+conservation-and-society	elsevier-harvard	1.0000	0.0500	0.0000	http://www.conservationandsociety.org/contributors.asp	found in CSL metadata
+conservation-biology	elsevier-harvard	1.0000	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1523-1739/homepage/Author_Style_Guide_apr2015.docx	found in CSL metadata
+conservation-physiology	elsevier-harvard	1.0000	0.9500	0.0000	https://academic.oup.com/conphys/pages/general_instructions	found in CSL metadata
+corrosion	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nace.org/uploadedFiles/Publications/styleguideall.pdf	found in CSL metadata
+critical-care-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://journals.lww.com/ccmjournal/Pages/informationforauthors.aspx	found in CSL metadata
+cse-citation-sequence-brackets-8th-edition	ieee	1.0000	0.5000	0.0000	http://www.scientificstyleandformat.org/Tools/SSF-Citation-Quick-Guide.html	found in CSL metadata
+cureus	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.cureus.com/author_guide#references-section	found in CSL metadata
+current-alzheimer-research	elsevier-with-titles	1.0000	0.7500	0.0000	https://benthamscience.com/journals/current-alzheimer-research/author-guidelines/#top	found in CSL metadata
+current-neurology-aktualnosci-neurologiczne	elsevier-harvard	1.0000	1.0000	0.0000	http://neurologia.com.pl/index.php/instructions-for-authors	found in CSL metadata
+current-opinion	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.elsevier.com/journals/current-opinion-in-biotechnology/0958-1669/guide-for-authors	found in CSL metadata
+current-organic-synthesis	elsevier-with-titles	1.0000	0.6500	0.0000	https://benthamscience.com/journal/manuscript-preparation.php?journalID=cos	found in CSL metadata
+current-pharmaceutical-design	elsevier-with-titles	1.0000	1.0000	0.0000	http://benthamscience.com/journals/current-pharmaceutical-design/author-guidelines/#top	found in CSL metadata
+current-proteomics	elsevier-with-titles	1.0000	1.0000	0.0000	http://benthamscience.com/journal/authors-guidelines.php?journalID=cp	found in CSL metadata
+current-science	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.currentscience.ac.in/php/inst_authors.php	found in CSL metadata
+current-topics-in-medicinal-chemistry	elsevier-with-titles	1.0000	1.0000	0.0000	http://benthamscience.com/journal-files/template-files/ctmc-template.doc	found in CSL metadata
+cybium	elsevier-harvard	1.0000	0.9500	0.0000	http://sfi-cybium.fr/en/instructions-authors	found in CSL metadata
+cytometry	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1552-4930/homepage/ForAuthors.html	found in CSL metadata
+data-science-journal	elsevier-harvard	1.0000	1.0000	0.0000	http://datascience.codata.org/about/submissions/#References	found in CSL metadata
+degruyter-american-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.degruyterbrill.com/publication/journal_key/ICOM/downloadAsset/ICOM_ACS%20numbered%20Reference%20Style%20ICOM.pdf?srsltid=AfmBOornKRcei0GtmLiKAeEjTROCfal5oCq6VrKtSgOusyXt6EFHLp60	found in CSL metadata
+dermatology-online-journal	elsevier-with-titles	1.0000	1.0000	0.0000	https://escholarship.org/uc/doj/submissionguidelines	found in CSL metadata
+deutsche-zeitschrift-fur-sportmedizin	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.germanjournalsportsmedicine.com/authors/	found in CSL metadata
+deutsches-arzteblatt	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.aerzteblatt.de/down.asp?id=9205	found in CSL metadata
+developmental-dynamics	american-medical-association	1.0000	1.0000	0.0000	https://anatomypubs.onlinelibrary.wiley.com/hub/journal/10970177/homepage/forauthors.html#refs	found in CSL metadata
+developmental-medicine-and-child-neurology	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/14698749/homepage/forauthors.html	found in CSL metadata
+diabetologia	elsevier-with-titles	1.0000	0.7500	0.0000	http://diabetologia-journal.org/for-authors/instructions-to-authors/	found in CSL metadata
+diagnostico-prenatal	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/diagnostico-prenatal/2173-4127/guide-for-authors	found in CSL metadata
+dialisis-y-trasplante	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/dialisis-y-trasplante/1886-2845/guide-for-authors	found in CSL metadata
+diatom-research	elsevier-harvard	1.0000	0.0500	0.0000	http://www.tandf.co.uk/journals/authors/style/reference/ref_TDIA.pdf	found in CSL metadata
+digestive-and-liver-disease	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.elsevier.com/journals/digestive-and-liver-disease/1590-8658/guide-for-authors	found in CSL metadata
+disability-and-rehabilitation	elsevier-with-titles	1.0000	1.0000	0.0000	http://informahealthcare.com/userimages/ContentEditor/1306847395843/Disability_and_Rehabilitation_IFAs_May_2011.pdf	found in CSL metadata
+discover-food	elsevier-with-titles	1.0000	1.0000	0.0000	https://link.springer.com/journal/44187/submission-guidelines#Instructions%20for%20Authors_References	found in CSL metadata
+discovery-medicine	elsevier-harvard	1.0000	0.9500	0.0000	http://www.discoverymedicine.com/about/information-for-authors-of-discovery-medicine/	found in CSL metadata
+drug-testing-and-analysis	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291942-7611/homepage/ForAuthors.html#Ref	found in CSL metadata
+drugs-of-today	elsevier-with-titles	1.0000	0.0000	0.0000	http://journals.prous.com/journals/servlet/xmlxsl/pk_journals.xml_instauthors_pr?p_JournalID=4	found in CSL metadata
+earthquake-engineering-and-structural-dynamics	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1096-9845/homepage/ForAuthors.html	found in CSL metadata
+ecological-restoration	elsevier-harvard	1.0000	0.0500	0.0000	https://uwpress.wisc.edu/journals/journals/er_submissions.html	found in CSL metadata
+ecology-and-society	elsevier-harvard	1.0000	0.0500	0.0000	http://www.ecologyandsociety.org/about/submissions.php#literaturecited	found in CSL metadata
+ecology	elsevier-harvard	1.0000	0.0500	0.0000	http://esapubs.org/esapubs/AuthorInstructions.htm	found in CSL metadata
+eksploatacja-i-niezawodnosc	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.ein.org.pl/en-information_for_authors	found in CSL metadata
+electrophoresis	elsevier-with-titles	1.0000	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/15222683/homepage/forauthors.html	found in CSL metadata
+elife	elsevier-harvard	1.0000	1.0000	0.0000	https://submit.elifesciences.org/html/eLife_Author_Guide.pdf	found in CSL metadata
+elsevier-american-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000	https://booksite.elsevier.com/9780081019375/content/Elsevier%20Standard%20Reference%20Styles.pdf	found in CSL metadata
+elsevier-harvard-without-titles	elsevier-harvard	1.0000	1.0000	1.0000	http://www.elsevier.com/journals/biosensors-and-bioelectronics/0956-5663/guide-for-authors#68000	found in CSL metadata
+elsevier-harvard2	elsevier-harvard	1.0000	1.0000	1.0000	http://www.elsevier.com/journals/drug-and-alcohol-dependence/0376-8716/guide-for-authors	found in CSL metadata
+elsevier-vancouver-author-date-alphabetical	elsevier-harvard	1.0000	0.9500	0.0000	https://www.elsevier.com/journals/clinical-neurophysiology/1388-2457/guide-for-authors#68000	found in CSL metadata
+elsevier-vancouver-author-date	elsevier-harvard	1.0000	1.0000	0.0000	https://www.elsevier.com/journals/clinical-neurophysiology/1388-2457/guide-for-authors#68000	found in CSL metadata
+elsevier-vancouver-no-et-al	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.sciencedirect.com/journal/journal-of-veterinary-cardiology/publish/guide-for-authors	found in CSL metadata
+elsevier-vancouver-short-author-list	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.journal-of-hepatology.eu/content/authorinfo	found in CSL metadata
+elsevier-with-titles-alphabetical	elsevier-with-titles	1.0000	0.9500	1.0000	http://www.elsevier.com/journals/cryobiology/0011-2240/guide-for-authors#68000	found in CSL metadata
+endocrine-connections	elsevier-with-titles	1.0000	0.0000	0.0000	https://ec.bioscientifica.com/page/author/author-guidelines	found in CSL metadata
+endocrine-journal	elsevier-with-titles	1.0000	1.0000	0.0000	https://s3-us-west-2.amazonaws.com/clarivate-scholarone-prod-us-west-2-s1m-public/wwwRoot/prod1/societyimages/endocrj/EJ%20Instructions%20to%20Authors_en.pdf	found in CSL metadata
+endocrine-press	elsevier-with-titles	1.0000	0.0000	0.0000	http://press.endocrine.org/page/authors#mozTocId713371	found in CSL metadata
+endoscopia	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/endoscopia/0188-9893/guide-for-authors	found in CSL metadata
+energy-research-and-social-science	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.elsevier.com/journals/energy-research-and-social-science/2214-6296/guide-for-authors	found in CSL metadata
+eneuro	elsevier-harvard	1.0000	0.9500	0.0000	https://www.eneuro.org/content/preparing-manuscript#organization	found in CSL metadata
+enfermeria-clinica	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/enfermeria-clinica/1130-8621/guide-for-authors	found in CSL metadata
+enfermeria-intensiva	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/enfermeria-intensiva/1130-2399/guide-for-authors	found in CSL metadata
+engineered-regeneration	elsevier-with-titles	1.0000	1.0000	1.0000	https://www.keaipublishing.com/en/journals/engineered-regeneration/guide-for-authors/#32	found in CSL metadata
+engineering-in-life-sciences	elsevier-with-titles	1.0000	0.7500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1618-2863/homepage/2129_guidelines.pdf	found in CSL metadata
+engineering-technology-and-applied-science-research	ieee	1.0000	1.0000	1.0000	http://etasr.com/ETASRTEMPLATE.docx	found in CSL metadata
+entecho	elsevier-harvard	1.0000	1.0000	1.0000	https://www.entecho.cz/cs-cz/o-casopisu/pokyny-pro-autory	found in CSL metadata
+entomological-review	elsevier-harvard	1.0000	0.9500	0.0000	https://www.pleiades.online/en/journal/enteng/authors-instructions/	found in CSL metadata
+environmental-health-perspectives	elsevier-harvard	1.0000	0.0500	0.0000	https://ehp.niehs.nih.gov/manuscript-style/	found in CSL metadata
+environnement-risques-et-sante	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.jle.com/fr/revues/ers/espace_auteur	found in CSL metadata
+epidemiology-and-infection	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.cambridge.org/core/journals/epidemiology-and-infection/information/instructions-contributors#references	found in CSL metadata
+epidemiology-psychiatric-sciences	elsevier-harvard	1.0000	0.0500	0.0000	https://www.cambridge.org/core/journals/epidemiology-and-psychiatric-sciences/information/author-instructions/preparing-your-materials	found in CSL metadata
+epilepsia	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1528-1167/homepage/ForAuthors.html	found in CSL metadata
+equine-veterinary-journal	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1001/(ISSN)2042-3306/homepage/ForAuthors.html	found in CSL metadata
+ergoscience	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.schulz-kirchner.de/ergotherapie/autorenhinweis_ergoscience.htm	found in CSL metadata
+etri-journal	elsevier-with-titles	1.0000	0.9500	1.0000	https://onlinelibrary.wiley.com/page/journal/22337326/homepage/forauthors.html	found in CSL metadata
+eurasian-journal-of-medical-investigation	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.ejmi.org/Instructions-for-Authors	found in CSL metadata
+eurasian-journal-of-medicine-and-oncology	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.ejmo.org/Instructions-for-Authors	found in CSL metadata
+eurointervention	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.pcronline.com/eurointervention/pages/authors-centre/instructions-to-authors/	found in CSL metadata
+europace	elsevier-with-titles	1.0000	0.0000	0.0000	https://academic.oup.com/europace/pages/General_Instructions	found in CSL metadata
+european-journal-of-anaesthesiology	elsevier-with-titles	1.0000	0.0000	0.0000	http://edmgr.ovid.com/eja/accounts/ifauth.htm	found in CSL metadata
+european-journal-of-clinical-microbiology-and-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.springer.com/biomed/medical+microbiology/journal/10096	found in CSL metadata
+european-journal-of-emergency-medicine	elsevier-with-titles	1.0000	1.0000	0.0000	http://edmgr.ovid.com/ejem/accounts/ifauth.htm	found in CSL metadata
+european-journal-of-endocrinology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.eje-online.org/site/misc/For-Authors.xhtml#refs	found in CSL metadata
+european-journal-of-human-genetics	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nature.com/ejhg/authors-and-referees/gta	found in CSL metadata
+european-journal-of-immunology	elsevier-with-titles	1.0000	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1521-4141/homepage/ForAuthors.html	found in CSL metadata
+european-journal-of-lipid-science-and-technology	elsevier-with-titles	1.0000	1.0000	0.0000	https://onlinelibrary.wiley.com/pb-assets/assets/14389312/EJLST_Instructions_to_Authors_2018-1519637641233.pdf	found in CSL metadata
+european-journal-of-ophthalmology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.eur-j-ophthalmol.com/pub/ejo-instructions-to-authors#References	found in CSL metadata
+european-journal-of-paediatric-neurology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/european-journal-of-paediatric-neurology/1090-3798/guide-for-authors	found in CSL metadata
+european-journal-of-soil-science	springer-basic-author-date	1.0000	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2389/homepage/ForAuthors.html	found in CSL metadata
+evidence-based-complementary-and-alternative-medicine	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.hindawi.com/journals/ecam/guidelines/	found in CSL metadata
+evolutionary-anthropology	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1520-6505/homepage/ForAuthors.html	found in CSL metadata
+exercer	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.exercer.fr/recos_auteurs/	found in CSL metadata
+experimental-biomedical-research	elsevier-with-titles	1.0000	1.0000	0.0000	http://experimentalbiomedicalresearch.com/ojs/index.php/ebr/about/submissions#authorGuidelines	found in CSL metadata
+exploration-of-targeted-anti-tumor-therapy	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.explorationpub.com/Journals/etat/Author_Instructions	found in CSL metadata
+express-polymer-letters	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.expresspolymlett.com/	found in CSL metadata
+extracellular-vesicles-and-circulating-nucleic-acids	elsevier-with-titles	1.0000	1.0000	0.0000	https://evcna.com/pages/view/author_instructions	found in CSL metadata
+facial-plastic-surgery-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/facial-plastic-surgery-clinics-of-north-america/1064-7406/guide-for-authors	found in CSL metadata
+fertility-and-sterility	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.fertstert.org/authorinfo	found in CSL metadata
+folia-amazonica	elsevier-harvard	1.0000	1.0000	0.0000	https:/revistas.iiap.gob.pe/index.php/foliaamazonica/guia_autores	found in CSL metadata
+folia-morphologia	elsevier-with-titles	1.0000	0.7500	0.0000	https://journals.viamedica.pl/folia_morphologica/about/submissions#authorGuidelines	found in CSL metadata
+food-and-agriculture-organization-of-the-united-nations-numeric	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.fao.org/3/cb8081en/cb8081en.pdf	found in CSL metadata
+food-science-and-biotechnology	springer-basic-author-date	1.0000	0.1500	0.0000	http://www.fsnb.or.kr/	found in CSL metadata
+forensic-science-review	elsevier-with-titles	1.0000	0.9500	0.0000	https://forums.zotero.org/discussion/36704/style-request-forensic-science-review	found in CSL metadata
+forestry	elsevier-harvard	1.0000	1.0000	0.0000	https://academic.oup.com/forestry/pages/General_Instructions	found in CSL metadata
+frattura-ed-integrita-strutturale-fracture-and-structural-integrity	elsevier-with-titles	1.0000	0.9500	0.0000	https://www.fracturae.com/index.php/fis/guidelines	found in CSL metadata
+free-radical-research	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=ifra20#References	found in CSL metadata
+french1	elsevier-with-titles	1.0000	1.0000	0.0000	http://zotero.hypotheses.org/77	found in CSL metadata
+french2	elsevier-with-titles	1.0000	1.0000	0.0000	http://zotero.hypotheses.org/77	found in CSL metadata
+freshwater-science	elsevier-harvard	1.0000	0.0500	0.0000	https://www.journals.uchicago.edu/journals/fws/instruct	found in CSL metadata
+frontiers-in-bioscience	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.bioscience.org/authors	found in CSL metadata
+frontiers-in-ecology-and-the-environment	springer-basic-author-date	1.0000	0.7000	0.0000	https://www.esa.org/frontiers-in-ecology-and-the-environment/instructions-to-authors/research-communications/	found in CSL metadata
+frontiers-in-optics	ieee	1.0000	0.6500	0.0000	http://www.frontiersinoptics.com/getmedia/eb19a31a-673f-4304-b339-0702821cf594/FiOLS-Style-Guide.aspx	found in CSL metadata
+frontiers-in-physics	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.frontiersin.org/about/AuthorGuidelines#References	found in CSL metadata
+frontiers-medical-journals	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.frontiersin.org/guidelines/author-guidelines	found in CSL metadata
+frontiers	elsevier-harvard	1.0000	0.9000	0.0000	https://www.frontiersin.org/guidelines/author-guidelines	found in CSL metadata
+future-science-group	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.futuremedicine.com/pb-assets/Nanomedicine%20Author%20Guidelines-1540302236583.pdf	found in CSL metadata
+gaceta-sanitaria	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/gaceta-sanitaria/0213-9111	found in CSL metadata
+gait-and-posture	elsevier-with-titles	1.0000	1.0000	1.0000		
+gastrointestinal-endoscopy-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/gastrointestinal-endoscopy-clinics-of-north-america/1052-5157/guide-for-authors	found in CSL metadata
+gastrointestinal-intervention	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/gastrointestinal-intervention/2213-1795/guide-for-authors	found in CSL metadata
+gayana-botanica	elsevier-harvard	1.0000	0.1000	0.0000	https://gayanabotanica.cl/index.php/gb/about/submissions	found in CSL metadata
+gayana	elsevier-harvard	1.0000	0.1000	0.0000	https://gayana.cl/index.php/gn/about/submissions	found in CSL metadata
+gazeta-medica	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.gazetamedica.pt/index.php/gazeta/about/submissions	found in CSL metadata
+genomics-and-informatics	elsevier-with-titles	1.0000	1.0000	0.0000	https://genominfo.org/authors/authors.php#2	found in CSL metadata
+geriatrie-et-psychologie-neuropsychiatrie-du-vieillissement	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.jle.com/fr/revues/gpn/espace_auteur	found in CSL metadata
+gost-r-7-0-5-2008-numeric-alphabetical	ieee	1.0000	0.5000	0.0000	http://protect.gost.ru/document.aspx?control=7&amp;id=173511	found in CSL metadata
+gost-r-7-0-5-2008-numeric	ieee	1.0000	0.6500	0.0000	http://protect.gost.ru/document.aspx?control=7&amp;id=173511	found in CSL metadata
+hainan-medical-university-journal-publisher	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.hnmujp.org/guide.html	found in CSL metadata
+hand	elsevier-with-titles	1.0000	0.9500	0.0000	http://www.springer.com/medicine/surgery/journal/11552	found in CSL metadata
+handbook-of-clinical-neurology	elsevier-harvard	1.0000	1.0000	1.0000	https://github.com/citation-style-language/styles/files/1008518/HCN_Contributor_Instructions_EMSS.docx	found in CSL metadata
+health-and-social-care-in-the-community	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.hindawi.com/journals/hsc/2024/8841667/	found in CSL metadata
+health-education-research	elsevier-with-titles	1.0000	1.0000	0.0000	https://academic.oup.com/her/pages/General_Instructions	found in CSL metadata
+health-sports-and-rehabilitation-medicine	elsevier-harvard	1.0000	1.0000	0.0000	http://jhsrm.org/for-authors/	found in CSL metadata
+heart-failure-clinics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/heart-failure-clinics/1551-7136/guide-for-authors	found in CSL metadata
+heart-rhythm	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/heart-rhythm/1547-5271/guide-for-authors	found in CSL metadata
+helvetica-chimica-acta	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.helvchimacta.ch/downloads/Instructions_for_Authors.pdf	found in CSL metadata
+hematology-oncology-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/hematology-oncology-clinics-of-north-america/0889-8588/guide-for-authors	found in CSL metadata
+hemijska-industrija	elsevier-with-titles	1.0000	0.6500	0.0000	https://www.ache-pub.org.rs/index.php/HemInd/Instructions	found in CSL metadata
+hepatology	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1527-3350/homepage/ForAuthors.html	found in CSL metadata
+hipertension-y-riesgo-vascular	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/hipertension-y-riesgo-vascular/1889-1837/guide-for-authors	found in CSL metadata
+hong-kong-journal-of-radiology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.hkjr.org/page/information-author	found in CSL metadata
+hospital-a-domicilio	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.revistahad.eu/index.php/revistahad/about/submissions	found in CSL metadata
+howard-hughes-medical-institute	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.hhmi.org/about/policies/scientific-publishing	found in CSL metadata
+hpb	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.hpbonline.org/content/authorinfo#idp1331616	found in CSL metadata
+human-ecology	elsevier-harvard	1.0000	0.0500	1.0000	https://www.springer.com/journal/10745/submission-guidelines#Instructions%20for%20Authors	found in CSL metadata
+humboldt-state-university-environmental-resources-engineering	springer-basic-author-date	1.0000	0.1000	0.0000	https://www2.humboldt.edu/engineering/resources/technical-communication	found in CSL metadata
+hypertension-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://mc.manuscriptcentral.com/societyimages/htr/HR_GTA.pdf	found in CSL metadata
+hypotheses-in-the-life-sciences	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.hy-ls.org/index.php/hyls/about/submissions#authorGuidelines	found in CSL metadata
+ibis	springer-basic-author-date	1.0000	0.6000	0.0000	https://www.bou.org.uk/ibis/author-guidelines/	found in CSL metadata
+idojaras-quarterly-journal-of-the-hungarian-meteorological-service	elsevier-harvard	1.0000	0.9500	0.0000	http://www.met.hu/downloads.php?fn=/metadmin/newspaper/2016/03/b849ea3fc271ed1ff1bb69ca01063a9a-borito-3.pdf	found in CSL metadata
+ieee-transactions-on-medical-imaging	ieee	1.0000	1.0000	1.0000	http://www.ieee.org/publications_standards/publications/authors/author_templates.html	found in CSL metadata
+igaku-toshokan	elsevier-with-titles	1.0000	0.0000	0.0000	http://plaza.umin.ac.jp/~jmla/kikanshi/kitei.html	found in CSL metadata
+imperial-college-london-numerical	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.imperial.ac.uk/admin-services/library/learning-support/reference-management/vancouver-style/	found in CSL metadata
+indian-journal-of-medical-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.ijmr.org.in/contributors.asp	found in CSL metadata
+indian-journal-of-orthopaedics	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.springer.com/journal/43465/submission-guidelines#Instructions%20for%20Authors_References	found in CSL metadata
+infectio	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/infectio/0123-9392/guide-for-authors	found in CSL metadata
+infectious-disease-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/infectious-disease-clinics-of-north-america/0891-5520/guide-for-authors	found in CSL metadata
+infomin	elsevier-harvard	1.0000	0.8000	0.0000	http://www.infomin.co.cu/index.php/i/about/submissions#authorGuidelines	found in CSL metadata
+innovations-therapeutiques-en-oncologie	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.jle.com/fr/revues/ito/contenu_libre.phtml?code_contenu=espace_auteur	found in CSL metadata
+institut-national-de-sante-publique-du-quebec-topo	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.inspq.qc.ca/pdf/publications/CollectionTOPO/TOPO-NAPP_styleguide.pdf	found in CSL metadata
+institute-of-mathematical-statistics	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.imstat.org/aop/manprep.htm	found in CSL metadata
+institute-of-physics-harvard	elsevier-harvard	1.0000	0.0500	0.0000	http://authors.iop.org/atom/help.nsf/7765E7F03B07DE5080257020002E4D9B/$File/IOPWordGuidelines.pdf	found in CSL metadata
+institute-of-physics-numeric	elsevier-with-titles	1.0000	1.0000	0.0000	http://authors.iop.org/atom/help.nsf/7765E7F03B07DE5080257020002E4D9B/$File/IOPWordGuidelines.pdf	found in CSL metadata
+integrated-science-publishing-journals	elsevier-with-titles	1.0000	0.0000	0.0000	http://pubs.iscience.in/authors	found in CSL metadata
+interaction-design-and-architectures	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.mifav.uniroma2.it/inevent/events/idea2010/index.php?s=101&amp;a=7	found in CSL metadata
+interactive-cardiovascular-and-thoracic-surgery	ieee	1.0000	0.6500	0.0000	https://academic.oup.com/icvts/pages/Submission_Online#Manuscript%20format%20and%20style	found in CSL metadata
+international-atomic-energy-agency	elsevier-with-titles	1.0000	0.7500	0.0000	https://www-pub.iaea.org/mtcd/publications/pdf/iaea_stylemanual_06.pdf	found in CSL metadata
+international-brazilian-journal-of-urology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.intbrazjurol.com.br/journal-information/information-for-authors-2/	found in CSL metadata
+international-conference-on-information-systems-development	elsevier-with-titles	1.0000	0.7500	0.0000	http://isd2014.foi.hr/calls.php#subdets	found in CSL metadata
+international-journal-for-numerical-methods-in-biomedical-engineering	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)2040-7947/homepage/ForAuthors.html	found in CSL metadata
+international-journal-of-cancer	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0215/homepage/ForAuthors.html	found in CSL metadata
+international-journal-of-circuit-theory-and-applications	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291097-007X/homepage/ForAuthors.html	found in CSL metadata
+international-journal-of-clinical-research	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.ijcrcentral.com/index.php/IJCR/information/authors	found in CSL metadata
+international-journal-of-cosmetic-science	elsevier-with-titles	1.0000	0.7500	0.0000	https://onlinelibrary.wiley.com/page/journal/14682494/homepage/forauthors.html	found in CSL metadata
+international-journal-of-electronic-commerce	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.ijec-web.org/information-for-contributors/	found in CSL metadata
+international-journal-of-epidemiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://academic.oup.com/ije/pages/Instructions_To_Authors	found in CSL metadata
+international-journal-of-exercise-science	elsevier-with-titles	1.0000	0.0000	0.0000	http://digitalcommons.wku.edu/ijes/styleguide.html	found in CSL metadata
+international-journal-of-humanoid-robotics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.worldscientific.com/sda/1037/ws-ijhr.pdf	found in CSL metadata
+international-journal-of-nuclear-security	elsevier-with-titles	1.0000	0.7500	0.0000	http://trace.tennessee.edu/ijns/policies.html#formatting	found in CSL metadata
+international-journal-of-occupational-medicine-and-environmental-health	elsevier-with-titles	1.0000	1.0000	0.0000	http://versita.com/serial/ijomeh/#tabs-submission	found in CSL metadata
+international-journal-of-oral-and-maxillofacial-surgery	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/international-journal-of-oral-and-maxillofacial-surgery/0901-5027/guide-for-authors	found in CSL metadata
+international-journal-of-polymer-analysis-and-characterization	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.tandfonline.com/action/authorSubmission?journalCode=gpac20&amp;page=instructions#refs	found in CSL metadata
+international-journal-of-population-data-science	elsevier-with-titles	1.0000	1.0000	0.0000	https://ijpds.org/author-guidelines	found in CSL metadata
+international-journal-of-research-in-exercise-physiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://ijrep.org/#about	found in CSL metadata
+international-journal-of-simulation-modelling	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.ijsimm.com/notes_for_contributors.html	found in CSL metadata
+international-microbiology	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/life+sciences/microbiology/journal/10123	found in CSL metadata
+invertebrate-biology	springer-basic-author-date	1.0000	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291744-7410/homepage/ForAuthors.html	found in CSL metadata
+ios-press-books	elsevier-with-titles	1.0000	1.0000	1.0000	http://www.iospress.nl/service/authors/	found in CSL metadata
+iranian-journal-of-basic-medical-sciences	elsevier-with-titles	1.0000	0.0000	0.0000	http://ijbms.mums.ac.ir/journal/authors.note	found in CSL metadata
+iranian-journal-of-pharmaceutical-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://ijpr.sbmu.ac.ir/journal/authors.note	found in CSL metadata
+israel-medical-association-journal	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.ima.org.il/ima/formstorage/type7/instructionsimaj.pdf	found in CSL metadata
+istanbul-medical-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://istanbulmedicaljournal.org/instructions-to-authors	found in CSL metadata
+istanus-journal-on-applied-and-biological-sciences	elsevier-with-titles	1.0000	1.0000	0.0000	https://istanus.com/istanusjabs/about/submissions	found in CSL metadata
+italus-hortus	elsevier-harvard	1.0000	1.0000	0.0000	http://www.soihs.it/italushortus/manuscript_submission.aspx	found in CSL metadata
+iubmb-life	elsevier-with-titles	1.0000	0.0000	0.0000	https://iubmb.onlinelibrary.wiley.com/hub/journal/15216551/author-guidelines.html	found in CSL metadata
+jacc-cardiovascular-imaging	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jaccsubmit-imaging.org/cgi-bin/main.plex?form_type=display_auth_instructions#refs	found in CSL metadata
+jacc-cardiovascular-interventions	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.elsevier.com/journals/jacc-cardiovascular-interventions/1936-8798/guide-for-authors	found in CSL metadata
+johnson-matthey-technology-review	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.technology.matthey.com/for-authors/#references	found in CSL metadata
+journal-and-proceedings-of-the-royal-society-of-new-south-wales	springer-basic-author-date	1.0000	0.8000	0.0000	https://royalsoc.org.au/society-publications/information-for-authors	found in CSL metadata
+journal-der-deutschen-dermatologischen-gesellschaft	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/16100387/homepage/forauthors.html	found in CSL metadata
+journal-of-acoustics	elsevier-with-titles	1.0000	1.0000	0.0000	https://joa.hapres.com/JOA_GuideforAuthors.aspx	found in CSL metadata
+journal-of-adolescent-health	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.jahonline.org/authorinfo#idp1329360	found in CSL metadata
+journal-of-advanced-ceramics	elsevier-with-titles	1.0000	1.0000	0.0000	https://mc03.manuscriptcentral.com/societyimages/jacer/JAC_Instructions%20for%20Authors_V1.3.pdf	found in CSL metadata
+journal-of-alzheimers-disease	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.j-alz.com/prep	found in CSL metadata
+journal-of-applied-clinical-medical-physics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jacmp.org/index.php/jacmp/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-applied-entomology	elsevier-harvard	1.0000	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1439-0418/homepage/ForAuthors.html	found in CSL metadata
+journal-of-applied-glycoscience	elsevier-with-titles	1.0000	1.0000	0.0000	https://jsag.jp/wp-content/uploads/2025/07/852bea8b35444b62b160ea1386dcf2e6.pdf	found in CSL metadata
+journal-of-applied-pharmaceutical-research	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.japtronline.com/index.php/JOAPR/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-applied-polymer-science	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/10974628/homepage/author-guidelines	found in CSL metadata
+journal-of-atrial-fibrillation	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.jafib.com/index.php?cont=author_submit	found in CSL metadata
+journal-of-australian-strength-and-conditioning	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.strengthandconditioning.org/images/publications/jasc-author-guidelines.pdf	found in CSL metadata
+journal-of-behavioral-health-and-psychology	elsevier-with-titles	1.0000	1.0000	0.0000	https://jbehavioralhealth.com/author-guidelines	found in CSL metadata
+journal-of-biological-chemistry	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jbc.org/site/misc/ifora.xhtml#references	found in CSL metadata
+journal-of-biological-regulators-and-homeostatic-agents	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.biolifesas.org/JBRHA.htm	found in CSL metadata
+journal-of-biomedical-materials-research-part-a	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nlm.nih.gov/bsd/uniform_requirements.html	found in CSL metadata
+journal-of-bioscience-and-bioengineering	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.elsevier.com/journals/journal-of-bioscience-and-bioengineering/1389-1723/guide-for-authors	found in CSL metadata
+journal-of-bone-and-mineral-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1523-4681/homepage/ForAuthors.html	found in CSL metadata
+journal-of-breast-cancer	ieee	1.0000	0.6500	0.0000	https://ejbc.kr/index.php?body=instruction	found in CSL metadata
+journal-of-cachexia-sarcopenia-and-muscle	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1007/13539.2190-6009/homepage/ForAuthors.html	found in CSL metadata
+journal-of-cellular-and-molecular-medicine	elsevier-with-titles	1.0000	0.7500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1582-4934/homepage/ForAuthors.html	found in CSL metadata
+journal-of-chemistry-and-chemical-engineering	elsevier-with-titles	1.0000	0.6500	0.0000	http://www.davidpublishing.com/davidpublishing/Upfile/8/19/2012/2012081969041905.pdf	found in CSL metadata
+journal-of-clinical-and-translational-science	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.cambridge.org/core/journals/journal-of-clinical-and-translational-science/information/instructions-contributors#submissionofmanuscripts	found in CSL metadata
+journal-of-clinical-neurophysiology	elsevier-with-titles	1.0000	0.0000	0.0000	http://journals.lww.com/clinicalneurophys/_layouts/15/1033/oaks.journals/informationforauthors.aspx	found in CSL metadata
+journal-of-clinical-oncology	elsevier-with-titles	1.0000	0.0000	0.0000	http://jco.ascopubs.org/site/ifc/prepguide.xhtml#Reference_Instructions	found in CSL metadata
+journal-of-combinatorics	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.e-publications.org/intlpress/support/	found in CSL metadata
+journal-of-computational-chemistry	elsevier-with-titles	1.0000	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1096-987X/homepage/jcc_author_guidelines.html	found in CSL metadata
+journal-of-computer-information-systems	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.tandfonline.com/action/journalInformation?journalCode=ucis20	found in CSL metadata
+journal-of-contemporary-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://dergipark.gov.tr/gopctd/page/369	found in CSL metadata
+journal-of-crohns-and-colitis-supplements	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.elsevier.com/journals/journal-of-crohns-and-colitis-supplements/1873-9954/guide-for-authors	found in CSL metadata
+journal-of-crohns-and-colitis	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/journal-of-crohns-and-colitis/1873-9946/guide-for-authors	found in CSL metadata
+journal-of-demographic-economics	elsevier-harvard	1.0000	0.0500	0.0000	https://www.cambridge.org/core/journals/journal-of-demographic-economics/information/author-instructions/preparing-your-materials	found in CSL metadata
+journal-of-economic-impact	elsevier-harvard	1.0000	1.0000	1.0000	http://scienceimpactpub.com/journals/index.php/jei/about/submissions#authorGuidelines/	found in CSL metadata
+journal-of-endodontics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/journal-of-endodontics/0099-2399/guide-for-authors	found in CSL metadata
+journal-of-environmental-science-and-health-part-b	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=lesb20&amp;page=instructions	found in CSL metadata
+journal-of-ethnobiology	elsevier-harvard	1.0000	0.0500	0.0000	https://ethnobiology.org/publications/journal/guidelines	found in CSL metadata
+journal-of-evolution-and-health	elsevier-with-titles	1.0000	1.0000	0.0000	http://jevohealth.com/journal/styleguide.html	found in CSL metadata
+journal-of-financial-and-quantitative-analysis	elsevier-harvard	1.0000	0.0000	0.0000	https://jfqa.org/submissions/style-guide-for-accepted-and-conditionally-accepted-papers/	found in CSL metadata
+journal-of-food-protection	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.foodprotection.org/publications/instructions-for-authors/pdf/jfp-author-instructions.pdf	found in CSL metadata
+journal-of-forensic-sciences	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291556-4029/homepage/ForAuthors.html	found in CSL metadata
+journal-of-frailty-and-aging	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.jfrailtyaging.com/instructions-for-authors.html	found in CSL metadata
+journal-of-global-health	elsevier-with-titles	1.0000	1.0000	0.0000	https://jogh.org/information-for-contributors/	found in CSL metadata
+journal-of-hazardous-materials	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.sciencedirect.com/journal/journal-of-hazardous-materials/publish/guide-for-authors	found in CSL metadata
+journal-of-health-care-for-the-poor-and-underserved	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nlm.nih.gov/bsd/uniform_requirements.html	found in CSL metadata
+journal-of-hearing-science	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.journalofhearingscience.com/index.php?/content/get_cont/3	found in CSL metadata
+journal-of-human-evolution	elsevier-harvard	1.0000	0.9500	1.0000	http://www.elsevier.com/journals/journal-of-human-evolution/0047-2484/guide-for-authors#68000	found in CSL metadata
+journal-of-human-nutrition-and-dietetics	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/1365277x/homepage/forauthors.html	found in CSL metadata
+journal-of-hypertension	elsevier-with-titles	1.0000	1.0000	0.0000	http://edmgr.ovid.com/jh/accounts/ifauth.htm	found in CSL metadata
+journal-of-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000	https://academic.oup.com/jid/pages/Instructions_For_Authors	found in CSL metadata
+journal-of-innovation-economics-and-management	elsevier-harvard	1.0000	1.0000	0.0000	https://innovations.cairn.info/en/instructions-for-authors/	found in CSL metadata
+journal-of-institutional-and-theoretical-economics	elsevier-harvard	1.0000	0.9500	0.0000	http://www.mohr.de/fileadmin/user_upload/Hinweise_Autoren_PDF/JITE_Vorlagen/EncAuth2013.pdf	found in CSL metadata
+journal-of-instrumentation	ieee	1.0000	0.6500	0.0000	http://iopscience.iop.org/1748-0221	found in CSL metadata
+journal-of-internal-medicine	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2796/homepage/ForAuthors.html	found in CSL metadata
+journal-of-korean-neurosurgical-society	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jkns.or.kr/authors/authors.php	found in CSL metadata
+journal-of-lipid-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jlr.org/site/misc/ifora.xhtml	found in CSL metadata
+journal-of-magnetic-resonance-imaging	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1522-2586/homepage/ForAuthors.html	found in CSL metadata
+journal-of-mechanical-science-and-technology	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.j-mst.org/Introduction_2.asp	found in CSL metadata
+journal-of-medical-genetics	elsevier-with-titles	1.0000	0.7500	0.0000	http://group.bmj.com/products/journals/instructions-for-authors/formatting#references	found in CSL metadata
+journal-of-medical-internet-research	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.jmir.org/cms/view/Instructions_for_Authors:Instructions_for_Authors_of_JMIR#References	found in CSL metadata
+journal-of-microbiology-and-biotechnology	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.jmb.or.kr/content/contributors/for_authors.html	found in CSL metadata
+journal-of-microscopy	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/13652818/homepage/forauthors.html	found in CSL metadata
+journal-of-midwifery-science	elsevier-with-titles	1.0000	0.9500	0.0000	https://www.egms.de/static/en/journals/zhwi/authors.htm	found in CSL metadata
+journal-of-molecular-signaling	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.jmolecularsignaling.com/about/submissions/#References	found in CSL metadata
+journal-of-multidisciplinary-applied-natural-science	ieee	1.0000	1.0000	0.0000	https://journal.pandawainstitute.com/index.php/jmans/authorguidelines	found in CSL metadata
+journal-of-musculoskeletal-research	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.worldscientific.com/toc/jmr/23/01	found in CSL metadata
+journal-of-nanoscience-and-nanotechnology	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.aspbs.com/jnn/inst-auth_jnn.htm	found in CSL metadata
+journal-of-neuroscience-and-neuroengineering	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.aspbs.com/jnsne/inst-auth_jnsne.htm	found in CSL metadata
+journal-of-nutrition	elsevier-with-titles	1.0000	0.0000	0.0000	https://academic.oup.com/jn/pages/General_Instructions	found in CSL metadata
+journal-of-obstetrics-and-gynaecology-canada	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.elsevier.com/journals/journal-of-obstetrics-and-gynaecology-canada/1701-2163/guide-for-authors	found in CSL metadata
+journal-of-open-research-software	elsevier-with-titles	1.0000	0.7500	0.0000	https://openresearchsoftware.metajnl.com/about/submissions/#onlineSubmissions	found in CSL metadata
+journal-of-orthopaedic-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1554-527X/homepage/ForAuthors.html	found in CSL metadata
+journal-of-orthopaedic-trauma	elsevier-with-titles	1.0000	0.0000	0.0000	http://edmgr.ovid.com/jot/accounts/ifauth.htm	found in CSL metadata
+journal-of-orthopaedics-trauma-and-rehabilitation	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/journal-of-orthopaedics-trauma-and-rehabilitation/2210-4917/guide-for-authors	found in CSL metadata
+journal-of-pain-and-symptom-management	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/journal-of-the-american-college-of-surgeons/1072-7515/guide-for-authors	found in CSL metadata
+journal-of-paleontology	elsevier-harvard	1.0000	0.6500	0.0000	https://www.cambridge.org/core/journals/journal-of-paleontology/information/instructions-contributors	found in CSL metadata
+journal-of-pediatric-surgery	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.jpedsurg.org/content/authorinfo	found in CSL metadata
+journal-of-peptide-science	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1387/homepage/ForAuthors.html#Ref	found in CSL metadata
+journal-of-perinatal-medicine	elsevier-with-titles	1.0000	0.9500	0.0000	http://www.degruyter.com/view/supplement/s16193997_Instructions_for_Authors_en.pdf	found in CSL metadata
+journal-of-pharmacy-and-pharmacology	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%292042-7158/homepage/ForAuthors.html	found in CSL metadata
+journal-of-phycology	elsevier-harvard	1.0000	0.1000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291529-8817/homepage/ForAuthors.html	found in CSL metadata
+journal-of-physical-therapy-science	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jstage.jst.go.jp/jstage/pub/jpts/pdf/regulation_en.pdf	found in CSL metadata
+journal-of-plant-nutrition-and-soil-science	elsevier-harvard	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291522-2624/homepage/ForAuthors.html	found in CSL metadata
+journal-of-psychiatry-and-neuroscience	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.cma.ca/jpn/instructions_for_authors#refs	found in CSL metadata
+journal-of-rehabilitation-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	https://medicaljournalssweden.se/jrm/authorguidelines	found in CSL metadata
+journal-of-rheumatology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jrheum.org/guideforauthors#references	found in CSL metadata
+journal-of-separation-science	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/store/10.1002/%28ISSN%291615-9314/asset/homepages/JSS_Instructions_to_Authors_Oct_2014.pdf?v=1&amp;s=4dc7d097074f20228608d95eaee70ac06e14008a&amp;isAguDoi=false	found in CSL metadata
+journal-of-shoulder-and-elbow-surgery	elsevier-with-titles	1.0000	0.0000	0.0000	http://journals.elsevierhealth.com/periodicals/ymse/authorinfo	found in CSL metadata
+journal-of-soil-and-water-conservation	elsevier-harvard	1.0000	0.0500	0.0000	http://www.jswconline.org/site/misc/ifora.xhtml	found in CSL metadata
+journal-of-soil-science-and-plant-nutrition	springer-basic-author-date	1.0000	0.9500	1.0000	https://www.springer.com/journal/42729/submission-guidelines#Instructions%20for%20Authors_References	found in CSL metadata
+journal-of-sport-and-health-science	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jshs.org.cn/EN/column/column290.shtml	found in CSL metadata
+journal-of-strength-and-conditioning-research	elsevier-with-titles	1.0000	0.0000	0.0000	https://edmgr.ovid.com/jscr/accounts/ifauth.htm	found in CSL metadata
+journal-of-structural-geology	elsevier-harvard	1.0000	0.9500	1.0000	https://www.elsevier.com/journals/journal-of-structural-geology/0191-8141/guide-for-authors	found in CSL metadata
+journal-of-surgery-and-medicine	elsevier-with-titles	1.0000	0.7500	0.0000	http://dergipark.gov.tr/josam/page/3139	found in CSL metadata
+journal-of-surgical-oncology	american-medical-association	1.0000	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/10969098/homepage/forauthors.html	found in CSL metadata
+journal-of-systematics-and-evolution	springer-basic-author-date	1.0000	0.1500	0.0000	https://onlinelibrary.wiley.com/page/journal/17596831/homepage/forauthors.html	found in CSL metadata
+journal-of-the-american-academy-of-orthopaedic-surgeons	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jaaos.org/site/misc/authinst.pdf	found in CSL metadata
+journal-of-the-american-association-of-laboratory-animal-science	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.aalas.org/publications/information-for-authors/cm-and-jaalas/manuscript-preparation	found in CSL metadata
+journal-of-the-american-ceramic-society	elsevier-with-titles	1.0000	0.0000	0.0000	https://ceramics.onlinelibrary.wiley.com/hub/authors_instructions	found in CSL metadata
+journal-of-the-american-college-of-cardiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jacc.org/journal/jacc	found in CSL metadata
+journal-of-the-american-college-of-surgeons	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/journal-of-the-american-college-of-surgeons/1072-7515/guide-for-authors	found in CSL metadata
+journal-of-the-american-heart-association	elsevier-with-titles	1.0000	0.0000	0.0000	http://jaha.ahajournals.org/content/author-instructions	found in CSL metadata
+journal-of-the-american-society-of-brewing-chemists	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.asbcnet.org/journal/author.htm	found in CSL metadata
+journal-of-the-american-society-of-nephrology	elsevier-with-titles	1.0000	0.0000	0.0000	http://jasn.asnjournals.org/site/misc/ifora.xhtml	found in CSL metadata
+journal-of-the-brazilian-chemical-society	elsevier-with-titles	1.0000	0.0000	0.0000	http://jbcs.sbq.org.br/	found in CSL metadata
+journal-of-the-european-academy-of-dermatology-and-venereology	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/14683083/homepage/forauthors.html	found in CSL metadata
+journal-of-thrombosis-and-haemostasis	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291538-7836/homepage/ForAuthors.html	found in CSL metadata
+journal-of-tropical-ecology	elsevier-harvard	1.0000	0.0500	0.0000	http://journals.cambridge.org/images/fileUpload/documents/tro_ifc.pdf	found in CSL metadata
+journal-of-tropical-life-science	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.jtrolis.ub.ac.id/index.php/jtrolis/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-vertebrate-biology	springer-basic-author-date	1.0000	0.5500	0.0000	https://www.jvertbiol.cz/submission.php#literature	found in CSL metadata
+journal-of-vestibular-research	elsevier-with-titles	1.0000	0.9500	1.0000	http://www.jvr-web.org/Authors.html	found in CSL metadata
+journal-of-visualized-experiments	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jove.com/author	found in CSL metadata
+journal-of-wildlife-diseases	elsevier-harvard	1.0000	0.0500	0.0000	http://www.wildlifedisease.org/wda/PUBLICATIONS/JournalofWildlifeDiseases/OnlineSubmissionandReview.aspx	found in CSL metadata
+journal-of-zoo-and-wildlife-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.bioone.org/doi/pdf/10.1638/1042-7260-44.4.1147	found in CSL metadata
+jurnal-pangan-dan-agroindustri	elsevier-harvard	1.0000	0.0500	0.0000	http://jpa.ub.ac.id/index.php/jpa/about/submissions#onlineSubmissions	found in CSL metadata
+jurnal-sains-farmasi-dan-klinis	elsevier-with-titles	1.0000	1.0000	0.0000	http://jsfk.ffarmasi.unand.ac.id/index.php/jsfk/pages/view/reference	found in CSL metadata
+jurnal-teknik-mesin-indonesia	elsevier-with-titles	1.0000	0.7500	0.0000	http://jurnal.bkstm.org/public/site/doc/JTMI_GUIDELINES_2018.docx	found in CSL metadata
+jyvaskylan-yliopisto-kemian-laitos	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jyu.fi/science/fi/kemia/opiskelu/linkkeja-ja-materiaalia/opinnaytetyon-kirjoitusohje-2017.pdf	found in CSL metadata
+karger-journals	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.karger.com/Journal/Guidelines/223832#05	found in CSL metadata
+kidney-research-and-clinical-practice	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.elsevier.com/journals/kidney-research-and-clinical-practice/2211-9132/guide-for-authors	found in CSL metadata
+klinische-padiatrie	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.thieme.de/de/klinische-paediatrie/autoren-3824.htm	found in CSL metadata
+knee-surgery-and-related-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jksrr.org/authors/sub01.html	found in CSL metadata
+knee-surgery-sports-traumatology-arthroscopy	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.kssta.org/kssta-reference-style-examples/	found in CSL metadata
+lancaster-university-harvard	elsevier-harvard	1.0000	0.8500	0.0000	http://lancaster.libguides.com/harvard/	found in CSL metadata
+landes-bioscience-journals	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nlm.nih.gov/bsd/uniform_requirements.html	found in CSL metadata
+lcgc	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.chromatographyonline.com/lcgc-author-guidelines	found in CSL metadata
+lethaia	springer-basic-author-date	1.0000	0.9500	0.0000	https://www.idunn.no/page/let/author	found in CSL metadata
+limnology-and-oceanography	springer-basic-author-date	1.0000	0.9000	0.0000	http://www.aslo.org/lo/instructions/authors.html#References	found in CSL metadata
+liver-international	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1478-3231/homepage/ForAuthors.html	found in CSL metadata
+london-south-bank-university-numeric	elsevier-with-titles	1.0000	1.0000	0.0000	https://my.lsbu.ac.uk/assets/documents/library/Numeric%20referencing%20helpsheet%2028.pdf	found in CSL metadata
+magnetic-resonance-materials-in-physics-biology-and-medicine	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/medicine/radiology/journal/10334	found in CSL metadata
+malaysian-orthopaedic-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.morthoj.org/instructions-for-authors2.php	found in CSL metadata
+mammal-review	springer-basic-author-date	1.0000	0.6500	1.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2907/homepage/ForAuthors.html	found in CSL metadata
+mammalia	springer-basic-author-date	1.0000	0.5500	0.0000	https://www.degruyter.com/publication/journal_key/MAMM/downloadAsset/MAMM_Instructions_for_Authors.pdf	found in CSL metadata
+management-of-biological-invasions	elsevier-harvard	1.0000	0.0500	0.0000	https://www.reabic.net/journals/mbi/Submission.aspx	found in CSL metadata
+mary-ann-liebert-harvard	elsevier-harvard	1.0000	0.9500	0.0000	https://home.liebertpub.com/authors/writing-guidelines/151	found in CSL metadata
+mary-ann-liebert-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000	https://home.liebertpub.com/authors/writing-guidelines/151	found in CSL metadata
+mathematics-and-computers-in-simulation	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.elsevier.com/journals/mathematics-and-computers-in-simulation/0378-4754/guide-for-authors	found in CSL metadata
+medecine-intensive-reanimation	elsevier-with-titles	1.0000	0.7500	0.0000	https://rea.revuesonline.com/pour-les-auteurs/instructions-aux-auteurs	found in CSL metadata
+medecine-sciences	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.medecinesciences.org	found in CSL metadata
+medical-dosimetry	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/medical-dosimetry/0958-3947/guide-for-authors	found in CSL metadata
+medical-education-and-clinical-practice	elsevier-with-titles	1.0000	1.0000	0.0000	https://revistas.cientifica.edu.pe/index.php/mecp/instructions	found in CSL metadata
+medicina-clinica	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.es/es-revista-medicina-clinica-2-normas-publicacion#69000	found in CSL metadata
+medicine-and-science-in-sports-and-exercise	elsevier-with-titles	1.0000	0.0000	0.0000	http://edmgr.ovid.com/msse/accounts/ifauth.htm	found in CSL metadata
+medicine-publishing	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.anaesthesiajournal.co.uk/content/authorinfo	found in CSL metadata
+medicinski-razgledi	elsevier-with-titles	1.0000	0.0000	0.0000	https://medrazgl.si/navodila-sodelavcem/	found in CSL metadata
+medicinskiy-akademicheskiy-zhurnal	ieee	1.0000	0.6500	0.0000	http://iemspb.ru/science/magazines/maj/publication-rules/	found in CSL metadata
+mediterranean-journal-of-chemistry	elsevier-with-titles	1.0000	0.0000	0.0000	www.medjchem.com/index.php/medjchem/about/submissions#authorGuidelines	found in CSL metadata
+medizinische-universitat-innsbruck-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.i-med.ac.at/studium/studierende/diplomarbeit_human.html	found in CSL metadata
+memorias-do-instituto-oswaldo-cruz	springer-basic-author-date	1.0000	0.6500	0.0000	http://memorias.ioc.fiocruz.br/instructions-to-authors	found in CSL metadata
+meteorological-applications	springer-basic-author-date	1.0000	0.1500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1469-8080/homepage/ForAuthors.html#reference_style	found in CSL metadata
+methods-of-information-in-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.thieme.com/books-main/clinical-informatics/product/4439-methods-of-information-in-medicine	found in CSL metadata
+microbial-cell	elsevier-with-titles	1.0000	0.7500	0.0000	http://microbialcell.com/for-authors-2/manuscript-preparation/#format_guidelines	found in CSL metadata
+microbiome-research-reports	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.oaepublish.com/mrr/pages/view/author_instructions	found in CSL metadata
+modern-language-association-annotated-bibliography	modern-language-association	1.0000	1.0000	1.0000	https://style.mla.org/	found in CSL metadata
+modern-language-association-no-url	modern-language-association	1.0000	1.0000	1.0000	https://style.mla.org/	found in CSL metadata
+modern-language-association-notes-no-url	modern-language-association	1.0000	0.0500	1.0000	https://style.mla.org/	found in CSL metadata
+modern-pathology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nature.com/modpathol/authors-and-referees	found in CSL metadata
+molecular-and-cellular-proteomics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.mcponline.org/site/misc/ifora.xhtml#references	found in CSL metadata
+molecular-biology	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.molecbio.ru/?view=for_authors	found in CSL metadata
+molecular-metabolism	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.elsevier.com/journals/molecular-metabolism/2212-8778/guide-for-authors	found in CSL metadata
+molecular-psychiatry-letters	elsevier-with-titles	1.0000	0.0000	0.0000	http://mts-mp.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions#style	found in CSL metadata
+molecular-psychiatry	elsevier-with-titles	1.0000	0.7500	0.0000	http://media.nature.com/full/nature-assets/mp/mp_gta.pdf	found in CSL metadata
+monographs-of-the-palaeontographical-society	springer-basic-author-date	1.0000	0.9000	0.0000	https://www.palaeosoc.org/site/page/for-authors/notes/	found in CSL metadata
+mrs-bulletin	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.springer.com/journal/43577/submission-guidelines#Instructions%20for%20Authors_References	found in CSL metadata
+multidisciplinary-digital-publishing-institute	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.mdpi.com/authors/references	found in CSL metadata
+multimed	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.revmultimed.sld.cu/templates/images/INSTRUCCIONES%20PARA%20AUTORES%20REVISTA%20MULTIMED.pdf	found in CSL metadata
+multiple-sclerosis-journal	elsevier-with-titles	1.0000	0.6500	0.0000	http://www.uk.sagepub.com/repository/binaries/pdf/MSJInstructions_to_Authors-21_04_08.pdf	found in CSL metadata
+mutagenesis	elsevier-with-titles	1.0000	1.0000	0.0000	https://academic.oup.com/mutage/pages/Instructions_To_Authors	found in CSL metadata
+mycobiology	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=tmyb20#prep	found in CSL metadata
+nano-biomedicine-and-engineering	elsevier-with-titles	1.0000	1.0000	0.0000	http://nanobe.org/index.php?journal=nbe&amp;page=about&amp;op=submissions#onlineSubmissions	found in CSL metadata
+national-institute-of-technology-karnataka	springer-basic-author-date	1.0000	0.5000	0.0000	http://nitk.ac.in/sites/default/files/public/curriculum/PG-Curriculum2016-revised.pdf	found in CSL metadata
+national-institute-of-technology-tiruchirappalli	springer-basic-author-date	1.0000	0.5000	0.0000	https://www.nitt.edu/home/academics/rules/Thesis_Guidelines.pdf	found in CSL metadata
+national-library-of-medicine-grant-proposals	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nlm.nih.gov/pubs/formats/recommendedformats1991-full.pdf	found in CSL metadata
+national-marine-fisheries-service-national-environmental-policy-act	elsevier-harvard	1.0000	0.0500	0.0000	https://github.com/citation-style-language/styles/pull/4426#issue-347066423	found in CSL metadata
+national-natural-science-foundation-of-china	elsevier-with-titles	1.0000	1.0000	0.0000	https://isisn.nsfc.gov.cn/egrantres/template/person/%E5%8F%82%E4%B8%8E%E4%BA%BA%E6%A8%A1%E6%9D%BF-%E9%80%9A%E7%94%A8.doc	found in CSL metadata
+national-science-foundation-grant-proposals	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.nsf.gov/pubs/policydocs/pappg19_1/pappg_2.jsp#IIC2e	found in CSL metadata
+nature-brackets	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.nature.com/nature/for-authors/formatting-guide	found in CSL metadata
+nature-no-et-al	elsevier-with-titles	1.0000	0.0000	0.0000	http://mts-am.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions#format	found in CSL metadata
+nature-publishing-group-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nature.com/tpj/authors-and-referees/gta	found in CSL metadata
+nature	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nature.com/nature/for-authors/formatting-guide	found in CSL metadata
+navigation	ieee	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%292161-4296/homepage/ForAuthors.html	found in CSL metadata
+necmettin-erbakan-universitesi-fen-ve-muhendislik-bilimleri-dergisi	elsevier-with-titles	1.0000	1.0000	1.0000	http://dergipark.gov.tr/neufmbd/writing-rules	found in CSL metadata
+nejm-catalyst-innovations-in-care-delivery	elsevier-with-titles	1.0000	0.0000	0.0000	https://catalyst.nejm.org/author-center/article-types	found in CSL metadata
+nephrology-dialysis-transplantation	elsevier-with-titles	1.0000	0.7500	0.0000	https://academic.oup.com/ndt/pages/author-guidelines	found in CSL metadata
+neural-plasticity	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.hindawi.com/journals/np/guidelines/	found in CSL metadata
+neurologia-argentina	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/neurologia-argentina/1853-0028/guide-for-authors	found in CSL metadata
+neurologia	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/neurologia/0213-4853/guide-for-authors	found in CSL metadata
+neurology-india	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.neurologyindia.com/contributors.asp	found in CSL metadata
+neurology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.neurology.org/site/misc/auth2.xhtml#REFERENCESTYLE	found in CSL metadata
+neuropsychopharmacology	elsevier-with-titles	1.0000	1.0000	0.0000	http://mts-npp.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions	found in CSL metadata
+neuroreport	elsevier-with-titles	1.0000	0.7500	0.0000	http://edmgr.ovid.com/nr/accounts/ifauth.htm#23	found in CSL metadata
+neurospine	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.e-neurospine.org/authors/authors.php	found in CSL metadata
+new-phytologist	springer-basic-author-date	1.0000	0.1500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291469-8137/homepage/ForAuthors.html	found in CSL metadata
+nist-technical-publication-journal-of-research-of-nist	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.nist.gov/nist-research-library/reference-format-nist-publications	found in CSL metadata
+nlm-citation-name	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nlm-citation-sequence-brackets-no-et-al	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nlm-citation-sequence-brackets-year-only-no-issue	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nlm-citation-sequence-brackets	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nlm-citation-sequence-superscript-brackets-year-only	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nlm-citation-sequence-superscript-year-only-no-issue	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nlm-citation-sequence-superscript	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nlm-citation-sequence	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+nordic-pulp-and-paper-research-journal	springer-basic-author-date	1.0000	0.5000	0.0000	http://www.npprj.se/html/main.asp?i=168&amp;h=2&amp;b=1&amp;c=100	found in CSL metadata
+nowa-audiofonologia	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.nowaaudiofonologia.pl/instructions	found in CSL metadata
+nucleic-acids-research-web-server-issue	elsevier-with-titles	1.0000	0.0000	0.0000	https://academic.oup.com/nar/pages/author-guidelines	found in CSL metadata
+nucleic-acids-research	elsevier-with-titles	1.0000	0.0000	0.0000	https://academic.oup.com/nar/pages/author-guidelines	found in CSL metadata
+nutrition-research-reviews	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.cambridge.org/core/journals/nutrition-research-reviews/information/instructions-contributors#detailedmanuscriptpreparation	found in CSL metadata
+obafemi-awolowo-university-faculty-of-technology	springer-basic-author-date	1.0000	0.0500	0.0000	http://oautekconf.org/oau_style_guide.pdf	found in CSL metadata
+occupational-medicine	elsevier-with-titles	1.0000	1.0000	0.0000	https://academic.oup.com/occmed/pages/Submission_Online	found in CSL metadata
+oecologia-australis	elsevier-harvard	1.0000	0.0500	0.0000	https://revistas.ufrj.br/index.php/oa/about/submissions#authorGuidelines	found in CSL metadata
+oil-shale	elsevier-with-titles	1.0000	0.7500	0.0000	https://kirj.ee/oil-shale-guidelines-for-authors/?v=04c19fa1e772	found in CSL metadata
+oncotarget	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.impactjournals.com/oncotarget	found in CSL metadata
+operative-dentistry	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jopdent.com/authors/authors.html	found in CSL metadata
+ophthalmic-genetics	american-medical-association	1.0000	0.0000	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=iopg20#style	found in CSL metadata
+ophthalmic-plastic-and-reconstructive-surgery	american-medical-association	1.0000	1.0000	1.0000	https://journals.lww.com/op-rs/Pages/informationforauthors.aspx	found in CSL metadata
+optics-express	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.osapublishing.org/submit/style/oestyleguide.cfm	found in CSL metadata
+opto-electronic-advances	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.oejournal.org/J/OEA/Channel/15	found in CSL metadata
+organic-geochemistry	elsevier-harvard	1.0000	0.9500	1.0000	https://www.elsevier.com/journals/organic-geochemistry/0146-6380/guide-for-authors	found in CSL metadata
+orthopedic-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/orthopedic-clinics-of-north-america/0030-5898/guide-for-authors	found in CSL metadata
+otto-von-guricke-universitat-magdeburg-medizinische-fakultat-numeric	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.med.uni-magdeburg.de/promotion.html	found in CSL metadata
+oxford-journals-scimed-numeric	elsevier-with-titles	1.0000	1.0000	0.0000	https://academic.oup.com/emph/pages/Manuscript_Preparation	found in CSL metadata
+oxidation-of-metals	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.springer.com/materials/special+types/journal/11085?detailsPage=pltci_3407509	found in CSL metadata
+pacific-science	elsevier-harvard	1.0000	0.1000	0.0000	https://pacificscience.msubmit.net/cgi-bin/main.plex?form_type=display_auth_instructions	found in CSL metadata
+paediatric-and-perinatal-epidemiology	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-3016/homepage/ForAuthors.html	found in CSL metadata
+pain-medicine	elsevier-with-titles	1.0000	1.0000	0.0000	https://academic.oup.com/painmedicine/pages/General_Instructions	found in CSL metadata
+pain	elsevier-with-titles	1.0000	0.9500	0.0000	https://edmgr.ovid.com/pain/accounts/Clinical%20Basic%20Science%20Research%20Reports_PAIN.pdf	found in CSL metadata
+pakistan-journal-of-agricultural-sciences	springer-basic-author-date	1.0000	0.1000	0.0000	https://www.pakjas.com.pk/InstructionsToAuthors.php	found in CSL metadata
+palaeontology	springer-basic-author-date	1.0000	0.6500	0.0000	https://www.palass.org/sites/default/files/media/publications/for_authors/RefExamples_2021_v1.pdf	found in CSL metadata
+palaios	elsevier-harvard	1.0000	0.8500	0.0000	http://palaios.ku.edu/instructions2011.pdf	found in CSL metadata
+paleobiology	springer-basic-author-date	1.0000	0.6500	0.0000	http://www.paleosoc.org/content/AuthorContribInstr.html	found in CSL metadata
+parasite	elsevier-with-titles	1.0000	0.9500	0.0000	https://www.parasite-journal.org/author-information/instructions-for-authors	found in CSL metadata
+pathogens-and-immunity	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.paijournal.com/index.php/paijournal/about/submissions	found in CSL metadata
+pediatric-allergy-and-immunology	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1399-3038/homepage/Society.html	found in CSL metadata
+pediatric-blood-and-cancer	elsevier-with-titles	1.0000	0.7500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291545-5017/homepage/ForAuthors.html	found in CSL metadata
+pediatric-practice-and-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://dergipark.gov.tr/pprjournal/page/1277	found in CSL metadata
+pediatric-research	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.nature.com/pr/authors-and-referees/preparation-of-articles	found in CSL metadata
+pediatric-urology-case-reports	elsevier-with-titles	1.0000	1.0000	0.0000	http://pediatricurologycasereports.com/ojs/index.php/pucr/about/submissions#authorGuidelines	found in CSL metadata
+pedosphere	elsevier-harvard	1.0000	0.9500	0.0000	https://www.elsevier.com/journals/pedosphere/1002-0160/guide-for-authors	found in CSL metadata
+pensoft-journals	elsevier-harvard	1.0000	0.0500	0.0000	https://zookeys.pensoft.net/about#CitationsandReferences	found in CSL metadata
+periodicum-biologorum	elsevier-with-titles	1.0000	0.0000	0.0000	http://hrcak.srce.hr/ojs/index.php/periodicum_biologorum/about/submissions#authorGuidelines	found in CSL metadata
+periodontology-2000	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1600-0757/homepage/ForAuthors.html	found in CSL metadata
+perspectives-on-sexual-and-reproductive-health	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1931-2393/homepage/ForAuthors.html	found in CSL metadata
+photochemistry-and-photobiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/17511097/homepage/forauthors.html	found in CSL metadata
+phycological-research	elsevier-harvard	1.0000	0.1000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291440-1835/homepage/ForAuthors.html	found in CSL metadata
+physiological-and-biochemical-zoology	elsevier-harvard	1.0000	0.1000	0.0000	http://www.press.uchicago.edu/journals/pbz/instruct.html?journal=pbz	found in CSL metadata
+plant-pathology	springer-basic-author-date	1.0000	0.1500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-3059/homepage/ForAuthors.html	found in CSL metadata
+plos	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.plosone.org/static/guidelines#references	found in CSL metadata
+pnas	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.pnas.org/site/authors/procedures.xhtml	found in CSL metadata
+polymer-reviews	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=lmsc19&amp;page=instructions#.UxwLpEMju1E	found in CSL metadata
+polytechnique-montreal-ieee	ieee	1.0000	1.0000	0.0000	https://guides.biblio.polymtl.ca/citer_ieee	found in CSL metadata
+poultry-science	springer-basic-author-date	1.0000	0.1000	0.0000	http://ps.fass.org/site/misc/PS_Inst_for_Contrib.pdf	found in CSL metadata
+praxis	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.hogrefe.com/ch/zeitschrift/praxis	found in CSL metadata
+proceedings-of-the-estonian-academy-of-sciences-numeric	elsevier-with-titles	1.0000	1.0000	0.0000	https://kirj.ee/for-authors/?v=04c19fa1e772	found in CSL metadata
+proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021	springer-basic-author-date	1.0000	0.7000	0.0000	http://2020kenya-igc-irc.rangelandcongress.org/wp-content/uploads/sites/6/2018/10/IGC-IRC-Paper-Template.docx	found in CSL metadata
+proceedings-of-the-royal-society-b	elsevier-with-titles	1.0000	1.0000	0.0000	https://royalsociety.org/journals/authors/author-guidelines/	found in CSL metadata
+processing-and-application-of-ceramics	ieee	1.0000	0.6500	0.0000	http://www.tf.uns.ac.rs/publikacije/PAC/guideforauthors.html	found in CSL metadata
+progress-on-chemistry-and-application-of-chitin-and-its-derivatives	elsevier-with-titles	1.0000	0.7500	0.0000	https://ptchit.lodz.pl/en/2022/03/11/informacje-dla-autorow/	found in CSL metadata
+proteomics	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291615-9861/homepage/ForAuthors.html#form	found in CSL metadata
+psychiatric-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/psychiatric-clinics-of-north-america/0193-953X/guide-for-authors	found in CSL metadata
+psychiatric-services	elsevier-with-titles	1.0000	0.0000	0.0000	http://ps.psychiatryonline.org/ps_ifora.aspx	found in CSL metadata
+psychiatry-and-clinical-neurosciences	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1440-1819/homepage/ForAuthors.html	found in CSL metadata
+psychosomatic-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://journals.lww.com/psychosomaticmedicine/pages/instructionsforauthors.aspx	found in CSL metadata
+public-health-nutrition	elsevier-with-titles	1.0000	0.0000	0.0000	http://assets.cambridge.org/PHN/PHN_ifc.pdf	found in CSL metadata
+quaternary-international	elsevier-harvard	1.0000	0.8500	1.0000	https://www.elsevier.com/journals/quaternary-international/1040-6182/guide-for-authors	found in CSL metadata
+radiation-research	elsevier-with-titles	1.0000	0.0000	0.0000	https://meridian.allenpress.com/DocumentLibrary/RADE/RARE_Info_for_Authors_5-30-2018.pdf	found in CSL metadata
+radiochimica-acta	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.degruyter.com/view/j/ract	found in CSL metadata
+radiographics	elsevier-with-titles	1.0000	0.0000	0.0000	http://radiographics.rsna.org/site/pia/manprep12.xhtml	found in CSL metadata
+radiography	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/radiography/1078-8174/guide-for-authors	found in CSL metadata
+radiologic-clinics-of-north-america	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/radiologic-clinics-of-north-america/0033-8389/guide-for-authors	found in CSL metadata
+radiology	elsevier-with-titles	1.0000	0.0000	0.0000	https://pubs.rsna.org/page/radiology/author-instructions#references	found in CSL metadata
+recent-patents-on-drug-delivery-and-formulation	elsevier-with-titles	1.0000	1.0000	0.0000	http://benthamscience.com/journals/recent-patents-on-drug-delivery-and-formulation/author-guidelines	found in CSL metadata
+renewable-agriculture-and-food-systems	elsevier-harvard	1.0000	0.6500	0.0000	https://www.cambridge.org/core/journals/renewable-agriculture-and-food-systems/information/instructions-contributors	found in CSL metadata
+reports-of-practical-oncology-and-radiotherapy	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/reports-of-practical-oncology-and-radiotherapy/1507-1367/guide-for-authors	found in CSL metadata
+research-and-education-promotion-association	elsevier-with-titles	1.0000	1.0000	0.0000	https://repa.jp/journals/editorial-guide-and-citation-style/	found in CSL metadata
+research-institute-for-nature-and-forest	elsevier-harvard	1.0000	0.9500	0.0000	https://inbomd-examples.netlify.app/citation_style/nl/index.html	found in CSL metadata
+research-on-biomedical-engineering	elsevier-harvard	1.0000	0.9000	0.0000	http://www.rbejournal.org/authors	found in CSL metadata
+retina	american-medical-association	1.0000	1.0000	1.0000	http://edmgr.ovid.com/retina/accounts/ifauth.htm	found in CSL metadata
+revista-argentina-de-antropologia-biologica	springer-basic-author-date	1.0000	0.1000	0.0000	http://revistas.unlp.edu.ar/index.php/raab/about/submissions#authorGuidelines	found in CSL metadata
+revista-brasileira-de-ciencia-do-solo	elsevier-harvard	1.0000	0.9500	0.0000	http://www.scielo.br/revistas/rbcs/iinstruc.htm	found in CSL metadata
+revista-cubana-de-meteorologia	elsevier-harvard	1.0000	0.8000	0.0000	http://rcm.insmet.cu/index.php/rcm/about/submissions#authorGuidelines	found in CSL metadata
+revista-da-sociedade-brasileira-de-medicina-tropical	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.scielo.br/revistas/rsbmt/iinstruc.htm	found in CSL metadata
+revista-do-instituto-de-medicina-tropical-de-sao-paulo	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.scielo.br/revistas/rimtsp/iinstruc.htm	found in CSL metadata
+revista-espanola-de-nutricion-humana-y-dietetica	elsevier-with-titles	1.0000	0.0000	0.0000		
+revista-fave-seccion-ciencias-agrarias	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.fca.unl.edu.ar/pages/investigacion/revista-fave/normas-de-publicacion.php	found in CSL metadata
+revista-latinoamericana-de-metalurgia-y-materiales	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.rlmm.org/ojs-files/download.php?f=RLMM-InstrucAutor%20Plantilla.doc	found in CSL metadata
+revista-latinoamericana-de-recursos-naturales	elsevier-harvard	1.0000	0.8000	0.0000	http://www.itson.mx/publicaciones/rlrn/Paginas/guia.aspx	found in CSL metadata
+revista-materia	ieee	1.0000	0.6500	0.0000	https://www.scielo.br/revistas/rmat/iinstruc.htm	found in CSL metadata
+revista-medica-del-instituto-mexicano-del-seguro-social	elsevier-with-titles	1.0000	0.0000	0.0000	https://revistamedica.imss.gob.mx/index.php/revista_medica/libraryFiles/downloadPublic/31	found in CSL metadata
+revista-peruana-de-medicina-experimental-y-salud-publica	elsevier-with-titles	1.0000	0.0000	0.0000	https://rpmesp.ins.gob.pe/index.php/rpmesp/pages/view/instrucciones	found in CSL metadata
+revista-virtual-de-quimica	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.uff.br/RVQ/instrucaoaosautores.pdf	found in CSL metadata
+revue-de-medecine-veterinaire	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.revmedvet.com/recommandations_fr.html	found in CSL metadata
+revue-des-etudes-byzantines	ieee	1.0000	1.0000	0.0000	http://poj.peeters-leuven.be/content.php?url=journal&amp;journal_code=REB	found in CSL metadata
+revue-francaise-dhistotechnologie	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.afhisto.fr/guide-pour-les-auteurs	found in CSL metadata
+rhinology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.rhinologyjournal.com/Instructions.php	found in CSL metadata
+rhodora	elsevier-harvard	1.0000	0.0500	0.0000	http://www.rhodora.org/rhodora/pdf/Rhod-inst2012.pdf	found in CSL metadata
+risk-analysis	ieee	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291539-6924/homepage/ForAuthors.html	found in CSL metadata
+rivista-italiana-di-paleontologia-e-stratigrafia	elsevier-harvard	1.0000	0.0500	0.0000	https://riviste.unimi.it/index.php/RIPS/about/submissions#authorGuidelines	found in CSL metadata
+rofo	elsevier-with-titles	1.0000	0.7500	0.0000	http://roefo.thieme.de/c/document_library/get_file?uuid=45dabb23-098a-4981-8a4a-0f1d74a7f2c7&amp;groupId=10157	found in CSL metadata
+rossiiskii-fiziologicheskii-zhurnal-imeni-i-m-sechenova	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.iephb.ru/rule_av_2013.pdf	found in CSL metadata
+ruhr-universitat-bochum-medizinische-fakultat-numeric	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.medizin.ruhr-uni-bochum.de/mam/content/dekanat/sachgebiete_service/promotion/merkblatt_zur_abfassung_der_dissertation_21.02.19.pdf	found in CSL metadata
+saglik-bilimleri-universitesi	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.sbu.edu.tr/FileFolder/Dosyalar/226a44f5/2017_7/tez-yazim-klavuzu-130a0155.pdf	found in CSL metadata
+sanamed	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.sanamed.rs/OJS/index.php/Sanamed/about/submissions#authorGuidelines	found in CSL metadata
+scandinavian-journal-of-infectious-diseases	elsevier-with-titles	1.0000	1.0000	0.0000	http://informahealthcare.com/page/inf/Description#Instructions	found in CSL metadata
+scandinavian-journal-of-information-systems	elsevier-harvard	1.0000	0.1000	0.0000	http://iris.cs.aau.dk/index.php/paper.html	found in CSL metadata
+scandinavian-journal-of-rheumatology	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.tandf.co.uk/journals/authors/healthcare/IRHE.pdf	found in CSL metadata
+scandinavian-journal-of-work-environment-and-health	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.sjweh.fi/instructions.php#preparation	found in CSL metadata
+science-translational-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://stm.sciencemag.org/site/misc/auth_inst_ra.xhtml#8	found in CSL metadata
+science-without-titles	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.sciencemag.org/about/authors/prep/res/refs.dtl	found in CSL metadata
+science	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.science.org/content/page/instructions-preparing-initial-manuscript#science-citation-style	found in CSL metadata
+scienceasia	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.scienceasia.org/scias_guide.pdf	found in CSL metadata
+scientia-iranica	elsevier-with-titles	1.0000	1.0000	0.0000	http://scientiairanica.sharif.edu/journal/authors.note	found in CSL metadata
+seed-science-and-technology	springer-basic-author-date	1.0000	0.1500	0.0000	https://www.seedtest.org/en/instructions-to-contributors-_content---1--1089.html	found in CSL metadata
+sekolah-tinggi-meteorologi-klimatologi-dan-geofisika	elsevier-harvard	1.0000	0.9000	0.0000	https://stmkg.ac.id/	found in CSL metadata
+seminars-in-pediatric-neurology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/seminars-in-pediatric-neurology/1071-9091/guide-for-authors	found in CSL metadata
+serbian-archives-of-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.srpskiarhiv.rs/en/instructions/	found in CSL metadata
+serdica-journal-of-computing	elsevier-with-titles	1.0000	0.7500	0.0000	http://serdica-comp.math.bas.bg/index.php/serdicajcomputing/about/submissions#authorGuidelines	found in CSL metadata
+shock	elsevier-with-titles	1.0000	0.0000	0.0000	http://edmgr.ovid.com/shk/accounts/ifauth.htm	found in CSL metadata
+slovensko-drustvo-za-medicinsko-informatiko	elsevier-with-titles	1.0000	0.0000	0.0000	https://docs.google.com/document/d/1upCPedxqcE0mPUBRWWyPMjuUCEdk7hIl/edit?usp=sharing&amp;ouid=108060715168109961711&amp;rtpof=true&amp;sd=true	found in CSL metadata
+smyrna-tip-dergisi	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.smyrnatipdergisi.com/?kategori=Yazarlara%20Bilgi	found in CSL metadata
+sn-computer-science	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.springer.com/journal/42979/submission-guidelines#Instructions%20for%20Authors_References	found in CSL metadata
+social-anthropology	elsevier-harvard	1.0000	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/14698676/homepage/forauthors.html	found in CSL metadata
+societe-nationale-des-groupements-techniques-veterinaires	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.sngtv.org/	found in CSL metadata
+society-for-laboratory-automation-and-screening	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.slas.org/publications/scientific-journals/author-instructions/	found in CSL metadata
+society-of-automotive-engineers-technical-papers-numeric	elsevier-with-titles	1.0000	1.0000	0.0000	http://volunteers.sae.org/authors/FormattingCitations.pdf	found in CSL metadata
+sociologia-ruralis	elsevier-harvard	1.0000	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/14679523/homepage/forauthors.html	found in CSL metadata
+soil-biology-and-biochemistry	elsevier-harvard	1.0000	0.9500	1.0000	http://www.elsevier.com/journals/soil-biology-and-biochemistry/0038-0717/guide-for-authors#68000	found in CSL metadata
+solutions	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.thesolutionsjournal.com/node/457	found in CSL metadata
+south-african-journal-of-animal-science	springer-basic-author-date	1.0000	0.1000	0.0000	http://www.ajol.info/index.php/sajas/about/submissions#authorGuidelines	found in CSL metadata
+south-african-journal-of-geology	springer-basic-author-date	1.0000	0.1500	0.0000	https://gssa.pub/sajg/ifora.html	found in CSL metadata
+south-african-medical-journal	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.samj.org.za/index.php/samj/about/submissions#References	found in CSL metadata
+spandidos-publications	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.spandidos-publications.com/pages/info_for_authors	found in CSL metadata
+spectroscopy-letters	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=lstl20&amp;page=instructions	found in CSL metadata
+spie-bios	elsevier-with-titles	1.0000	0.0000	0.0000	http://spie.org/x14101.xml	found in CSL metadata
+spie-journals	elsevier-with-titles	1.0000	0.0000	0.0000	http://spie.org/x85036.xml	found in CSL metadata
+springer-basic-brackets-no-et-al-alphabetical	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/instruct-authors-e.pdf	found in CSL metadata
+springer-basic-brackets-no-et-al	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/instruct-authors-e.pdf	found in CSL metadata
+springer-fachzeitschriften-medizin-psychologie	elsevier-with-titles	1.0000	0.7500	0.0000	http://static.springer.com/sgw/documents/135255/application/pdf/Musterbeitrag_Uebersichten_Leitthema_Schwerpunkt.pdf	found in CSL metadata
+springer-lecture-notes-in-computer-science-alphabetical	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/computer/lncs?SGWID=0-164-6-793341-0	found in CSL metadata
+springer-lecture-notes-in-computer-science	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/computer/lncs?SGWID=0-164-6-793341-0	found in CSL metadata
+springer-mathphys-brackets	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf	found in CSL metadata
+springer-socpsych-brackets	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/instruct-authors-e.pdf	found in CSL metadata
+springer-vancouver	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.springer.com/medicine/psychiatry/journal/127	found in CSL metadata
+springerprotocols	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.springerprotocols.com/cdp/view/contributors#ref	found in CSL metadata
+statistika-statistics-and-economy-journal	elsevier-harvard	1.0000	0.8000	0.0000	https://www.czso.cz/csu/czso/guide_for_authors	found in CSL metadata
+stroke	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.ahajournals.org/str/manuscript-preparation	found in CSL metadata
+structural-control-and-health-monitoring	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1545-2263/homepage/ForAuthors.html	found in CSL metadata
+surgical-neurology-international	elsevier-with-titles	1.0000	0.9500	0.0000	https://surgicalneurologyint.com/submit-article/	found in CSL metadata
+surgical-pathology-clinics	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/surgical-pathology-clinics/1875-9181/guide-for-authors	found in CSL metadata
+survey-of-ophthalmology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.elsevier.com/journals/survey-of-ophthalmology/0039-6257/guide-for-authors	found in CSL metadata
+systematic-and-applied-microbiology	elsevier-with-titles	1.0000	0.9500	0.0000	http://www.elsevier.com/journals/systematic-and-applied-microbiology/0723-2020/guide-for-authors	found in CSL metadata
+tapir-conservation	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.tapirconservation.org/index.php/tc/about/submissions	found in CSL metadata
+targetome	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.maxapress.com/targetome/for_authors	found in CSL metadata
+taylor-and-francis-acs	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.tandf.co.uk/journals/authors/style/reference/tf_USACS.pdf	found in CSL metadata
+taylor-and-francis-ama	american-medical-association	1.0000	1.0000	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=ytsr20#submitting-your-paper	found in CSL metadata
+taylor-and-francis-council-of-science-editors-numeric	elsevier-with-titles	1.0000	0.0000	0.0000	https://files.taylorandfrancis.com/tf_USCSEA.pdf	found in CSL metadata
+taylor-and-francis-numeric-q	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.tandf.co.uk/journals/authors/style/reference/ref_gsar.pdf	found in CSL metadata
+thai-endodontic-journal	elsevier-with-titles	1.0000	0.0000	0.0000	https://he03.tci-thaijo.org/index.php/thaiendod/about/submissions	found in CSL metadata
+the-american-journal-of-gastroenterology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nature.com/ajg/for_authors.html	found in CSL metadata
+the-american-journal-of-pathology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.journals.elsevierhealth.com/periodicals/ajpa/authorinfo	found in CSL metadata
+the-american-journal-of-tropical-medicine-and-hygiene	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.ajtmh.org/site/misc/ifora.xhtml	found in CSL metadata
+the-american-midland-naturalist	springer-basic-author-date	1.0000	0.1000	0.0000	https://www3.nd.edu/~ammidnat/editorial.html	found in CSL metadata
+the-american-naturalist	elsevier-harvard	1.0000	0.1000	0.0000	http://www.press.uchicago.edu/journals/an/instruct.html?journal=an#tprep	found in CSL metadata
+the-angle-orthodontist	american-medical-association	1.0000	1.0000	0.0000	https://meridian.allenpress.com/angle-orthodontist/pages/how-to-submit	found in CSL metadata
+the-bone-and-joint-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.bjj.boneandjoint.org.uk/site/media/Authors/Paperstructure.pdf	found in CSL metadata
+the-british-journal-for-the-philosophy-of-science	elsevier-harvard	1.0000	0.0000	0.0000	https://github.com/citation-style-language/styles/files/887880/_.BJPS-House-Style-01-2016.pdf	found in CSL metadata
+the-british-journal-of-cardiology	elsevier-with-titles	1.0000	0.0000	0.0000	http://bjcardio.co.uk/authors-instructions/	found in CSL metadata
+the-british-journal-of-psychiatry	elsevier-with-titles	1.0000	0.0000	0.0000	http://bjp.rcpsych.org/site/misc/ifora.xhtml#References	found in CSL metadata
+the-british-journal-of-social-work	elsevier-harvard	1.0000	0.0500	0.0000	https://academic.oup.com/bjsw/pages/General_Instructions	found in CSL metadata
+the-canadian-journal-of-chemical-engineering	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291939-019X/homepage/ForAuthors.html	found in CSL metadata
+the-cancer-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://edmgr.ovid.com/ppo/accounts/ifauth.htm	found in CSL metadata
+the-coleopterists-bulletin	elsevier-harvard	1.0000	0.0500	0.0000	https://www.coleopsoc.org/wp-content/uploads/2022/12/2023-TCB-MANUSCRIPT-GUIDELINES_FINAL_FOR_POSTING.pdf	found in CSL metadata
+the-european-research-journal	elsevier-with-titles	1.0000	0.7500	0.0000	http://eurj.org/?page_id=29	found in CSL metadata
+the-faseb-journal	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.fasebj.org/site/misc/rc.xhtml	found in CSL metadata
+the-febs-journal	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1742-4658/homepage/ForAuthors.html#manuscript	found in CSL metadata
+the-geological-society-of-america	elsevier-harvard	1.0000	0.8500	0.0000	http://www.geosociety.org/gsa/pubs/geology/home.aspx#overview	found in CSL metadata
+the-institute-of-electronics-information-and-communication-engineers	elsevier-with-titles	1.0000	0.7500	0.0000	http://www.ieice.org/eng/shiori/index.html	found in CSL metadata
+the-journal-of-adhesive-dentistry	elsevier-with-titles	1.0000	0.0000	0.0000	http://jad.quintessenz.de/index.php?doc=guidelines	found in CSL metadata
+the-journal-of-agricultural-science	springer-basic-author-date	1.0000	0.6000	0.0000	https://www.cambridge.org/core/journals/journal-of-agricultural-science/information/instructions-contributors	found in CSL metadata
+the-journal-of-bone-and-joint-surgery	american-medical-association	1.0000	1.0000	0.0000	https://westlibrary.txwes.edu/sites/default/files/pdf/AMACitationStyle.pdf	found in CSL metadata
+the-journal-of-clinical-investigation	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jci.org/kiosks/publish/examples	found in CSL metadata
+the-journal-of-comparative-neurology	springer-basic-author-date	1.0000	0.1000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1096-9861/homepage/ForAuthors.html	found in CSL metadata
+the-journal-of-foot-and-ankle-surgery	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jfas.org/content/authorinfo#idp1778672	found in CSL metadata
+the-journal-of-hand-surgery-asian-pacific-volume	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jhs-ap.org/main.html	found in CSL metadata
+the-journal-of-hand-surgery-european-volume	elsevier-harvard	1.0000	1.0000	0.0000	https://uk.sagepub.com/en-gb/eur/journal-of-hand-surgery-european-volume/journal201891#submission-guidelines	found in CSL metadata
+the-journal-of-immunology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.jimmunol.org/site/misc/authorinstructions.xhtml#references	found in CSL metadata
+the-journal-of-infection-in-developing-countries	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.jidc.org/index.php/journal/about/submissions#authorGuidelines	found in CSL metadata
+the-journal-of-laryngology-and-otology	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.jlo.co.uk/submitting-articles/instructions-for-authors/	found in CSL metadata
+the-journal-of-molecular-diagnostics	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.elsevier.com/journals/the-journal-of-molecular-diagnostics/1525-1578/guide-for-authors	found in CSL metadata
+the-journal-of-nervous-and-mental-disease	elsevier-harvard	1.0000	1.0000	0.0000	http://edmgr.ovid.com/jnmd/accounts/ifauth.htm	found in CSL metadata
+the-journal-of-nutrition-health-and-aging	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.springer.com/medicine/family/journal/12603	found in CSL metadata
+the-journal-of-pain	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/the-journal-of-pain/1526-5900/guide-for-authors	found in CSL metadata
+the-journal-of-pure-and-applied-chemistry-research	elsevier-with-titles	1.0000	0.0000	0.0000	http://jpacr.ub.ac.id/index.php/jpacr/about/submissions#authorGuidelines	found in CSL metadata
+the-journal-of-the-acoustical-society-of-america	elsevier-harvard	1.0000	1.0000	0.0000	http://scitation.aip.org/journals/doc/ASALIB-home/corp/pdf/jasa/author_contrib.pdf	found in CSL metadata
+the-korean-journal-of-internal-medicine	elsevier-with-titles	1.0000	0.7500	0.0000	https://www.kjim.org/authors/authors.php#11	found in CSL metadata
+the-korean-journal-of-mycology	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.kjmycology.or.kr/for-contributors/instructions-for-authors/	found in CSL metadata
+the-new-england-journal-of-medicine	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.nejm.org/page/author-center/manuscript-submission#style	found in CSL metadata
+the-optical-society	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.opticsinfobase.org/author/author.cfm	found in CSL metadata
+the-pan-african-medical-journal	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.panafrican-med-journal.com/instruction.php#References	found in CSL metadata
+the-scandinavian-journal-of-clinical-and-laboratory-investigation	elsevier-with-titles	1.0000	1.0000	0.0000	http://informahealthcare.com/page/Description?journalCode=clb#Instructions	found in CSL metadata
+theranostics	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.thno.org/ms/author	found in CSL metadata
+thieme-german	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.thieme.de/de/autorenlounge/fuer-zeitschriftenautoren-1789.htm	found in CSL metadata
+thrombosis-and-haemostasis	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.schattauer.de/en/magazine/subject-areas/journals-a-z/thrombosis-and-haemostasis.html	found in CSL metadata
+tijdschrift-voor-geneeskunde	elsevier-with-titles	1.0000	0.0000	0.0000	https://tvgg.be/nl/artikel-indienen	found in CSL metadata
+traffic	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291600-0854/homepage/ForAuthors.html	found in CSL metadata
+transplantation	elsevier-with-titles	1.0000	0.0000	0.0000	http://journals.lww.com/transplantjournal/Documents/TP_IFA_online.pdf	found in CSL metadata
+transportation-research-record	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.trb.org/GetInvolvedwithTRB/GetInvolvedSubmitaPaper.aspx	found in CSL metadata
+trends-in-glycoscience-and-glycotechnology	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.fcca.gr.jp/TIGG/Guide.html	found in CSL metadata
+trends-journals	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.cell.com/trends/ecology-evolution/authors	found in CSL metadata
+ucl-university-college-vancouver	ieee	1.0000	0.0000	0.0000	https://bibliotek.ucl.dk/vancouver	found in CSL metadata
+ugeskrift-for-laeger	elsevier-with-titles	1.0000	1.0000	0.0000	http://ugeskriftet.dk/manuskriptvejledning-0	found in CSL metadata
+undergraduate-journal-of-experimental-microbiology-and-immunology	elsevier-with-titles	1.0000	0.0000	0.0000	https://doi.org/10.1128/jmbe.v21i2.2151	found in CSL metadata
+universidade-estadual-paulista-faculdade-de-engenharia-de-guaratingueta-abnt	elsevier-harvard	1.0000	0.1000	0.0000	https://www.feg.unesp.br/#!/biblioteca/servicos-e-produtos/mendeley/	found in CSL metadata
+universitas-brawijaya-fakultas-teknologi-pertanian	elsevier-harvard	1.0000	1.0000	0.0000	https://github.com/citation-style-language/styles/pull/7644	found in CSL metadata
+universitat-heidelberg-medizinische-fakultat-mannheim-numeric	elsevier-with-titles	1.0000	0.0000	0.0000	https://www.umm.uni-heidelberg.de/fakultaet/promotion/promotion-dr-med/	found in CSL metadata
+universite-cheikh-anta-diop-faculte-de-medecine-de-pharmacie-et-dodontologie	elsevier-with-titles	1.0000	0.7500	0.0000	https://fmpos.ucad.sn/?q=charte-des-th%C3%A9ses	found in CSL metadata
+universite-de-montreal-nlm-fr-ca	elsevier-with-titles	1.0000	0.0000	0.0000	https://boite-outils.bib.umontreal.ca/citer/vancouver	found in CSL metadata
+universite-de-picardie-jules-verne-ufr-de-medecine	elsevier-with-titles	1.0000	0.0000	0.0000	http://forums.zotero.org/discussion/18705/new-csl-these-de-medecine-a-amiens/	found in CSL metadata
+university-of-aleppo-faculty-of-medicine	elsevier-with-titles	1.0000	0.7500	0.0000	https://github.com/firasuke/Citation-Style-Language-Styles/blob/master/University%20of%20Aleppo%20-%20Faculty%20of%20Medicine/documentation.md	found in CSL metadata
+univerza-v-ljubljani-fakulteta-za-kemijo-in-kemijsko-tehnologijo	elsevier-with-titles	1.0000	0.7500	0.0000	https://fkkt.uni-lj.si/fileadmin/user_upload/Studentski_referat/Pravilniki_studij/Navodila_za_izdelavo_dipl_mag_dela_2024.pdf	found in CSL metadata
+urbani-izziv-en	elsevier-harvard	1.0000	0.9500	0.0000	https://urbaniizziv.uirs.si/Instructions-for-authors	found in CSL metadata
+urological-science	elsevier-with-titles	1.0000	0.0000	0.0000	http://www.elsevier.com/journals/urological-science/1879-5226/guide-for-authors	found in CSL metadata
+uspekhi-gerontologii	ieee	1.0000	0.5000	0.0000	http://www.gersociety.ru/information/uspexi/	found in CSL metadata
+veterinary-medicine-austria	elsevier-harvard	1.0000	0.1000	0.0000	https://www.wtm.at/Instructions-for-Authors.html	found in CSL metadata
+veterinary-microbiology	elsevier-harvard	1.0000	0.9500	1.0000	https://www.elsevier.com/journals/veterinary-microbiology/0378-1135/guide-for-authors	found in CSL metadata
+veterinary-pathology	elsevier-with-titles	1.0000	0.0000	0.0000	https://us.sagepub.com/en-us/nam/veterinary-pathology/journal201966#submission-guidelines	found in CSL metadata
+veterinary-radiology-and-ultrasound	elsevier-with-titles	1.0000	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291740-8261/homepage/ForAuthors.html	found in CSL metadata
+veterinary-record-open	elsevier-with-titles	1.0000	0.0000	0.0000	https://bvajournals.onlinelibrary.wiley.com/hub/journal/20526113/author-guidelines	found in CSL metadata
+vietnam-journal-of-science-and-technology	elsevier-with-titles	1.0000	1.0000	0.0000	https://vjs.ac.vn/index.php/jst/manuscript-structure	found in CSL metadata
+vitis-journal-of-grapevine-research	elsevier-harvard	1.0000	0.8500	0.0000	https://ojs.openagrar.de/index.php/VITIS/Manuscript	found in CSL metadata
+vodohospodarske-technicko-ekonomicke-informace-en	ieee	1.0000	0.5000	0.0000	http://www.vtei.cz/en/instructions-editors/	found in CSL metadata
+vodohospodarske-technicko-ekonomicke-informace	ieee	1.0000	0.5000	0.0000	http://www.vtei.cz/pokyny-pro-autory	found in CSL metadata
+vox-sanguinis	elsevier-with-titles	1.0000	0.7500	0.0000	https://onlinelibrary.wiley.com/page/journal/14230410/homepage/forauthors.html#preparing	found in CSL metadata
+weed-science-society-of-america	elsevier-harvard	1.0000	0.0500	0.0000	https://www.cambridge.org/core/journals/weed-science/information/instructions-contributors	found in CSL metadata
+westfalische-wilhelms-universitat-munster-medizinische-fakultat	elsevier-with-titles	1.0000	0.0000	0.0000	https://campus.uni-muenster.de/fakultaet/fakultaet/dekanat/promotionen/	found in CSL metadata
+who-europe-numeric	elsevier-with-titles	1.0000	0.0000	0.0000	https://github.com/citation-style-language/styles/pull/170	found in CSL metadata
+wiley-vch-books	ieee	1.0000	0.6500	0.0000	http://www.wiley-vch.de/publish/en/authors/auguidelines	found in CSL metadata
+wiley-was	ieee	1.0000	0.6500	0.0000	https://analyticalscience.wiley.com/publication/was-magazine	found in CSL metadata
+wireless-communications-and-mobile-computing	elsevier-with-titles	1.0000	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291530-8677/homepage/ForAuthors.html	found in CSL metadata
+wissenschaftlicher-industrielogistik-dialog	elsevier-with-titles	1.0000	0.7500	0.0000	http://wild-leoben.jimdo.com/	found in CSL metadata
+world-applied-sciences-journal	elsevier-with-titles	1.0000	1.0000	0.0000	https://www.idosi.org/wasj/instructions.htm	found in CSL metadata
+world-congress-on-engineering-asset-management	elsevier-with-titles	1.0000	0.7500	0.0000	http://wceam.com/	found in CSL metadata
+world-organisation-for-animal-health-scientific-and-technical-review	elsevier-with-titles	1.0000	1.0000	0.0000	http://www.oie.int/en/publications-and-documentation/scientific-and-technical-review-free-access/instructions-to-authors/	found in CSL metadata
+worlds-poultry-science-journal	elsevier-harvard	1.0000	0.0500	0.0000	http://assets.cambridge.org/WPS/WPS_ifc.pdf	found in CSL metadata
+zastosowania-komputerow-w-elektrotechnice	ieee	1.0000	1.0000	0.0000	http://www.iee.put.poznan.pl/zkwe/download/guide.doc	found in CSL metadata
+zdravniski-vestnik	elsevier-with-titles	1.0000	0.0000	0.0000	http://ojs.szd.si/index.php/vestnik/about/submissions#authorGuidelines	found in CSL metadata
+zoological-journal-of-the-linnean-society	springer-basic-author-date	1.0000	0.1500	0.0000	https://academic.oup.com/zoolinnean/pages/General_Instructions	found in CSL metadata
+zoological-science	springer-basic-author-date	1.0000	0.1000	1.0000	https://bioone.org/journals/zoological-science/author-guidelines	found in CSL metadata
+anglia	taylor-and-francis-chicago-author-date	0.9972	0.6500	0.0000	https://www.degruyter.com/view/supplement/s18658938_Style_sheet.pdf	found in CSL metadata
+chicago-author-date-16th-edition	taylor-and-francis-chicago-author-date	0.9972	0.9500	0.0000	https://web.archive.org/web/20160830192245/http://www.chicagomanualofstyle.org/tools_citationguide.html	found in CSL metadata
+gender-and-society	taylor-and-francis-chicago-author-date	0.9972	0.9500	0.0000	https://journals.sagepub.com/pb-assets/cmscontent/gas/Manuscript-Formatting-and-Preparation-2020-1585693229180.pdf	found in CSL metadata
+iran-manual-of-style	taylor-and-francis-chicago-author-date	0.9972	0.5000	0.0000	https://irandoc.ac.ir/book/1310	found in CSL metadata
+journal-of-accounting-research	taylor-and-francis-chicago-author-date	0.9972	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/1475679x/homepage/forauthors.html	found in CSL metadata
+management-international	taylor-and-francis-chicago-author-date	0.9972	0.1000	0.0000	http://www.managementinternational.ca/en/authors-section/im-style-guide/	found in CSL metadata
+new-harts-rules-author-date-publisher	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000		
+new-harts-rules-author-date-space-publisher	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000		
+new-harts-rules-author-date	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000		
+skene-journal-of-theatre-and-drama-studies	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000	https://skenejournal.skeneproject.it/index.php/JTDS/information/authors	found in CSL metadata
+social-science-history	taylor-and-francis-chicago-author-date	0.9972	0.7000	0.0000		
+chicago-shortened-notes-bibliography-subsequent-title-no-url	chicago-shortened-notes-bibliography	0.9960	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-title	chicago-shortened-notes-bibliography	0.9960	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+john-benjamins-publishing-company-iconicity-in-language-and-literature	taylor-and-francis-chicago-author-date	0.9944	0.6500	0.0000	https://github.com/citation-style-language/styles/files/2571238/BenjaminsStylesheet.pdf	found in CSL metadata
+manchester-university-press-author-date	taylor-and-francis-chicago-author-date	0.9944	0.1000	0.0000	https://manchesteruniversitypress.co.uk/the-peer-review-and-commissioning-process/	found in CSL metadata
+universidade-do-porto-faculdade-de-engenharia-chicago	taylor-and-francis-chicago-author-date	0.9944	1.0000	0.0000	https://feup.libguides.com/chicago	found in CSL metadata
+american-mathematical-society-numeric	elsevier-with-titles	0.9932	0.7500	0.0000	https://www.ams.org/arc/styleguide	found in CSL metadata
+amerindia	springer-basic-author-date	0.9932	0.7000	0.0000	https://www.vjf.cnrs.fr/sedyl/revues.php?voirintro=O&amp;langue=en&amp;revue=Amerindia&amp;aire=CELIA	found in CSL metadata
+building-structure	elsevier-with-titles	0.9932	1.0000	0.0000	http://www.buildingstructure.cn/	found in CSL metadata
+din-1505-2-numeric-alphabetical	elsevier-with-titles	0.9932	0.7500	0.0000	http://www.bui.haw-hamburg.de/fileadmin/redaktion/diplom/Lorenzen__litverz.pdf	found in CSL metadata
+din-1505-2-numeric	elsevier-with-titles	0.9932	0.7500	0.0000	http://www.bui.haw-hamburg.de/fileadmin/redaktion/diplom/Lorenzen__litverz.pdf	found in CSL metadata
+finanzarchiv	elsevier-harvard	0.9932	0.9500	0.0000	http://www.mohr.de/fileadmin/user_upload/Hinweise_Autoren_PDF/FA_2014/Style_guide_4_Feb_2014_.pdf	found in CSL metadata
+german-council-of-economic-experts	elsevier-harvard	0.9932	0.9000	0.0000	https://www.sachverstaendigenrat-wirtschaft.de/fileadmin/dateiablage/Sonstiges/SVR_Styleguide_Literaturverzeichnis_Stand_16.03.2017.pdf	found in CSL metadata
+iso690-numeric-brackets-cs	ieee	0.9932	0.5000	0.0000	https://github.com/citation-style-language/styles/pull/466	found in CSL metadata
+iso690-numeric-cs	ieee	0.9932	0.0000	0.0000	https://github.com/citation-style-language/styles/issues/149	found in CSL metadata
+journal-of-basic-microbiology	elsevier-with-titles	0.9932	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291521-4028/homepage/ForAuthors.html	found in CSL metadata
+neurosurgery-clinics-of-north-america	elsevier-with-titles	0.9932	0.0000	0.0000	http://www.elsevier.com/journals/neurosurgery-clinics-of-north-america/1042-3680/guide-for-authors	found in CSL metadata
+new-solutions	elsevier-with-titles	0.9932	0.7500	0.0000	http://baywood.com/authors/Guidelines/NS_Guidelines.pdf	found in CSL metadata
+nueva-norma-estudios-de-la-humanidad	elsevier-harvard	0.9932	1.0000	0.0000		
+photogrammetric-engineering-and-remote-sensing	elsevier-harvard	0.9932	0.0500	0.0000	https://my.asprs.org/common/Uploaded%20files/PERS/detailed%20formatting%20instructions.pdf	found in CSL metadata
+qeios	elsevier-with-titles	0.9932	0.0000	0.0000	https://www.qeios.com/posting-policy#references	found in CSL metadata
+revista-de-derecho-de-la-universidad-austral-de-chile	elsevier-harvard	0.9932	0.0000	0.0000	http://revistas.uach.cl/index.php/revider/information/authors	found in CSL metadata
+revista-portuguesa-de-arqueologia	elsevier-harvard	0.9932	0.0500	0.0000	http://www.patrimoniocultural.gov.pt/pt/shop/catalog/revista-portuguesa-de-arqueologia/	found in CSL metadata
+ruhr-universitat-bochum-lehrstuhl-fur-industrial-sales-and-service-engineering	elsevier-harvard	0.9932	0.1000	0.0000	http://www.isse.rub.de/mam/leitfaden_zum_verfassen_fachwissenschaftlicher_arbeiten.pdf	found in CSL metadata
+sist02	elsevier-with-titles	0.9932	0.0000	0.0000	http://sti.jst.go.jp/sist/handbook/sist02_2007/main.htm	found in CSL metadata
+tatup-zeitschrift-fur-technikfolgenabschatzung-in-theorie-und-praxis	elsevier-harvard	0.9932	0.1000	0.0000	http://www.tatup.de/index.php/tatup/about/submissions	found in CSL metadata
+the-chemical-society-of-japan	elsevier-with-titles	0.9932	0.0000	0.0000	http://www.csj.jp/journals/styles/ref.html	found in CSL metadata
+the-isme-journal	elsevier-with-titles	0.9932	0.7500	0.0000	https://academic.oup.com/ismej/pages/general-instructions?login=false	found in CSL metadata
+the-open-university-numeric-superscript	elsevier-with-titles	0.9932	0.0000	0.0000	http://www.open.ac.uk/library/help-and-support/referencing-styles	found in CSL metadata
+the-open-university-numeric	elsevier-with-titles	0.9932	1.0000	0.0000	http://www.open.ac.uk/library/help-and-support/referencing-styles	found in CSL metadata
+trames	elsevier-harvard	0.9932	0.0500	0.0000	https://kirj.ee/trames-style-sheet/?v=04c19fa1e772	found in CSL metadata
+transactions-of-the-philological-society	elsevier-harvard	0.9932	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/1467968x/homepage/forauthors.html	found in CSL metadata
+wiener-digitale-revue	elsevier-harvard	0.9932	0.0500	0.0000	https://journals.univie.ac.at/index.php/wdr/about/submissions	found in CSL metadata
+acta-chiropterologica	elsevier-harvard	0.9921	0.6500	0.0000	http://system.miiz.waw.pl/ac/journal/for_authors/	found in CSL metadata
+acta-pharmaceutica	elsevier-with-titles	0.9921	0.0000	0.0000	http://public.carnet.hr/acphee/Inst.html	found in CSL metadata
+acta-radiologica	elsevier-with-titles	0.9921	0.0000	0.0000	https://uk.sagepub.com/en-gb/eur/journal/acta-radiologica#submission-guidelines	found in CSL metadata
+african-journal-of-marine-science	elsevier-harvard	0.9921	0.0500	0.0000	https://www.nisc.co.za/products/3/journals/african-journal-of-marine-science#downloads	found in CSL metadata
+american-journal-of-medical-genetics	elsevier-harvard	0.9921	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291552-4833/homepage/ForAuthors.html	found in CSL metadata
+american-journal-of-roentgenology	elsevier-with-titles	0.9921	0.7500	0.0000	https://www.ajronline.org/authorguidelines	found in CSL metadata
+american-phytopathological-society	elsevier-harvard	0.9921	0.0500	0.0000	https://apsjournals.apsnet.org/page/authorinformation#litcited	found in CSL metadata
+angiology	elsevier-with-titles	0.9921	0.0000	0.0000	https://journals.sagepub.com/author-instructions/ANG	found in CSL metadata
+annals-of-laboratory-medicine	elsevier-with-titles	0.9921	0.7500	0.0000	http://www.annlabmed.org/content/authors/file/Author%E2%80%99s_Checklist.pdf?v=2203101106	found in CSL metadata
+annals-of-surgery	elsevier-with-titles	0.9921	0.0000	0.0000	http://journals.lww.com/annalsofsurgery/_layouts/15/1033/oaks.journals/informationforauthors.aspx	found in CSL metadata
+arctic	elsevier-harvard	0.9921	0.6500	0.0000	https://arctic.ucalgary.ca/guide-authors	found in CSL metadata
+australian-archaeology	elsevier-harvard	0.9921	0.0500	0.0000		
+british-journal-of-haematology	elsevier-harvard	0.9921	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2141/homepage/ForAuthors.html	found in CSL metadata
+buletin-agrohorti	elsevier-harvard	0.9921	0.6500	0.0000	http://journal.ipb.ac.id/index.php/bulagron/article/view/26572	found in CSL metadata
+canadian-biosystems-engineering	elsevier-harvard	0.9921	0.0500	0.0000	https://www.csbe-scgab.ca/images/journal/prepareweb.pdf	found in CSL metadata
+canadian-urological-association-journal	elsevier-with-titles	0.9921	0.0000	0.0000	https://cuaj.ca/index.php/journal/about/submissions	found in CSL metadata
+cath-lab-digest	elsevier-with-titles	0.9921	0.0000	0.0000	http://www.cathlabdigest.com/author-guidelines	found in CSL metadata
+cellular-and-molecular-gastroenterology-and-hepatology	elsevier-with-titles	0.9921	0.0000	0.0000	https://www.cmghjournal.org/content/authorinfo	found in CSL metadata
+cold-spring-harbor-laboratory-press	elsevier-harvard	0.9921	0.0500	0.0000	http://genome.cshlp.org/site/misc/ifora_mspreparation.xhtml	found in CSL metadata
+copeia	springer-basic-author-date	0.9921	0.0500	0.0000	http://www.asih.org/publications/instructions-authors	found in CSL metadata
+current-protocols	elsevier-harvard	0.9921	0.5500	0.0000	http://onlinelibrary.wiley.com/book/10.1002/0471250953/homepage/ForAuthors.html	found in CSL metadata
+development-and-change	elsevier-harvard	0.9921	0.7000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291467-7660/homepage/ForAuthors.html	found in CSL metadata
+earth-surface-processes-and-landforms	elsevier-harvard	0.9921	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1096-9837/homepage/ForAuthors.html	found in CSL metadata
+edward-elgar-business-and-social-sciences	elsevier-harvard	0.9921	0.1000	0.0000	https://www.e-elgar.com/sites/e-elgar/files/images/shared/authoredguidebussocsci20151.pdf	found in CSL metadata
+embo-press	elsevier-harvard	0.9921	0.6000	0.0000	https://www.embopress.org/page/journal/14602075/authorguide#referencesformat	found in CSL metadata
+environmental-conservation	elsevier-harvard	0.9921	0.6000	0.0000	https://www.cambridge.org/core/journals/environmental-conservation/information/author-instructions/preparing-your-materials	found in CSL metadata
+epidemiologie-et-sante-animale	elsevier-harvard	0.9921	0.0000	0.0000	http://aeema.vet-alfort.fr/public/php/instructions.php	found in CSL metadata
+estonian-journal-of-earth-sciences	elsevier-harvard	0.9921	0.0500	0.0000	https://kirj.ee/earth-guidelines-for-authors/?v=04c19fa1e772	found in CSL metadata
+ethnobiology-letters	elsevier-harvard	0.9921	0.0500	0.0000	https://ojs.ethnobiology.org/index.php/ebl/about/submissions	found in CSL metadata
+european-society-of-cardiology	elsevier-with-titles	0.9921	0.0000	0.0000	https://academic.oup.com/eurheartj/pages/general_instructions	found in CSL metadata
+experimental-biology-and-medicine	elsevier-with-titles	0.9921	0.0000	0.0000	https://journals.sagepub.com/author-instructions/EBM#main%20document	found in CSL metadata
+fizyoloji-medical-journal	elsevier-with-titles	0.9921	0.0000	0.0000	https://www.fizyoloji.net/authorsguide	found in CSL metadata
+folia-malacologica	springer-basic-author-date	0.9921	0.6000	0.0000	https://www.foliamalacologica.com/Preparation-of-Manuscripts,2840.html	found in CSL metadata
+forest-science	elsevier-harvard	0.9921	0.0000	0.0000	http://www.safnet.org/publications/forscience/guideforauthors.cfm	found in CSL metadata
+geochemical-perspectives-letters	elsevier-harvard	0.9921	0.6500	0.0000	http://www.geochemicalperspectivesletters.org/information-for-authors	found in CSL metadata
+geochronometria	elsevier-harvard	0.9921	0.6500	0.0000	http://www.geochronometria.pl/pdf/Instr_for_Authors.pdf	found in CSL metadata
+gigascience	elsevier-with-titles	0.9921	1.0000	0.0000	https://academic.oup.com/gigascience/pages/instructions_to_authors	found in CSL metadata
+haematologica	elsevier-with-titles	0.9921	0.0000	0.0000	http://www.haematologica.org/information-for-authors	found in CSL metadata
+harvard-review-of-psychiatry	elsevier-with-titles	0.9921	0.0000	0.0000	https://journals.lww.com/hrpjournal/Pages/informationforauthors.aspx	found in CSL metadata
+herpetologica	springer-basic-author-date	0.9921	0.6000	0.0000	http://herpetologistsleague.org/author-guidelines/	found in CSL metadata
+human-wildlife-interactions	springer-basic-author-date	0.9921	0.6000	0.0000	http://www.berrymaninstitute.org/files/uploads/pdf/HWISubmission_Guide_FinalRev.pdf	found in CSL metadata
+hydrobiologia	elsevier-harvard	0.9921	0.6000	1.0000	http://www.springer.com/life+sciences/ecology/journal/10750	found in CSL metadata
+hydrological-processes	elsevier-harvard	0.9921	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1085/homepage/ForAuthors.html	found in CSL metadata
+iawa-journal	elsevier-harvard	0.9921	0.0500	0.0000	https://brill.com/fileasset/downloads_products/Author_Instructions/IAWA.pdf	found in CSL metadata
+international-journal-of-climatology	elsevier-harvard	0.9921	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0088/homepage/ForAuthors.html#reference_style	found in CSL metadata
+international-journal-of-osteoarchaeology	elsevier-harvard	0.9921	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1212/homepage/ForAuthors.html	found in CSL metadata
+interpreting	elsevier-harvard	0.9921	0.0500	0.0000	https://benjamins.com/catalog/intp/guidelines	found in CSL metadata
+jbi-evidence-synthesis	elsevier-with-titles	0.9921	0.0000	0.0000	https://journals.lww.com/jbisrir/Pages/IFAs_Manuscript_style_preparation_guidelines.aspx	found in CSL metadata
+journal-of-computer-assisted-tomography	elsevier-with-titles	0.9921	0.0000	0.0000	https://edmgr.ovid.com/jcat/accounts/ifauth.htm	found in CSL metadata
+journal-of-dairy-science	springer-basic-author-date	0.9921	0.1000	0.0000	https://www.journalofdairyscience.org/content/inst-auth	found in CSL metadata
+journal-of-dental-traumatology	elsevier-with-titles	0.9921	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/16009657/homepage/forauthors.html	found in CSL metadata
+journal-of-field-ornithology	springer-basic-author-date	0.9921	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291557-9263/homepage/ForAuthors.html	found in CSL metadata
+journal-of-leukocyte-biology	elsevier-with-titles	0.9921	0.0000	0.0000	https://jlb.onlinelibrary.wiley.com/hub/journal/19383673/author-information	found in CSL metadata
+journal-of-microbiology	elsevier-harvard	0.9921	0.5500	0.0000	https://www.springer.com/cda/content/document/cda_downloaddocument/JM_Instructions+for+Authors_210517.pdf?SGWID=0-0-45-1375103-p173757107	found in CSL metadata
+journal-of-neuroendocrinology	elsevier-with-titles	0.9921	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/13652826/homepage/forauthors.html	found in CSL metadata
+journal-of-occupational-and-environmental-medicine	elsevier-with-titles	0.9921	0.0000	0.0000	https://journals.lww.com/joem/pages/informationforauthors.aspx	found in CSL metadata
+kona-powder-and-particle-journal	elsevier-harvard	0.9921	1.0000	0.0000	http://www.kona.or.jp/jp/journal/info.html	found in CSL metadata
+land-degradation-and-development	elsevier-harvard	0.9921	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1099-145X/homepage/ForAuthors.html	found in CSL metadata
+mastozoologia-neotropical	springer-basic-author-date	0.9921	0.5500	0.0000	https://mn.sarem.org.ar/para-publicar-en-mn/	found in CSL metadata
+media-culture-and-society	elsevier-harvard	0.9921	0.6500	0.0000	http://www.sagepub.com/journals/Journal200958/manuscriptSubmission	found in CSL metadata
+medicinal-research-reviews	elsevier-with-titles	0.9921	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1098-1128/homepage/ForAuthors.html	found in CSL metadata
+meteoritics-and-planetary-science	elsevier-harvard	0.9921	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1945-5100/homepage/ForAuthors.html	found in CSL metadata
+microbiology-society	elsevier-with-titles	0.9921	0.7500	0.0000	http://www.microbiologyresearch.org/authors/information-for-authors#references	found in CSL metadata
+microcirculation	elsevier-with-titles	0.9921	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/15498719/homepage/forauthors.html	found in CSL metadata
+modern-phytomorphology	springer-basic-author-date	0.9921	0.7000	0.0000	https://phytomorphology.org/journal/author-guidelines/	found in CSL metadata
+molecular-plant-microbe-interactions	elsevier-harvard	0.9921	0.0000	0.0000	http://apsjournals.apsnet.org/loi/mpmi	found in CSL metadata
+movement-disorders	elsevier-with-titles	0.9921	0.0000	0.0000	https://movementdisorders.onlinelibrary.wiley.com/hub/journal/15318257/forauthors.html#Ref	found in CSL metadata
+natura-croatica	springer-basic-author-date	0.9921	0.0500	0.0000	https://hrcak.srce.hr/	found in CSL metadata
+north-pacific-anadromous-fish-commission-bulletin	elsevier-harvard	0.9921	0.0500	0.0000	https://npafc.org/bulletin/	found in CSL metadata
+organised-sound	elsevier-harvard	0.9921	0.0500	0.0000	https://www.cambridge.org/core/journals/organised-sound/information/instructions-contributors	found in CSL metadata
+pain-physician	elsevier-with-titles	0.9921	0.0000	0.0000	https://www.painphysicianjournal.com/authors/manuscript	found in CSL metadata
+parasitology	springer-basic-author-date	0.9921	0.1000	0.0000	http://assets.cambridge.org/PAR/PAR_ifc.pdf	found in CSL metadata
+phyllomedusa	springer-basic-author-date	0.9921	0.8500	0.0000	http://www.phyllomedusa.esalq.usp.br/instruction.pdf	found in CSL metadata
+phytopathologia-mediterranea	elsevier-harvard	0.9921	0.6000	0.0000	https://oajournals.fupress.net/index.php/pm/about/submissions	found in CSL metadata
+population-space-and-place	elsevier-harvard	0.9921	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291544-8452/homepage/ForAuthors.html	found in CSL metadata
+prehospital-emergency-care	elsevier-with-titles	0.9921	0.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=ipec20&amp;page=instructions	found in CSL metadata
+proceedings-of-the-estonian-academy-of-sciences-author-date	elsevier-harvard	0.9921	0.0500	0.0000	https://kirj.ee/earth-guidelines-for-authors/?v=04c19fa1e772	found in CSL metadata
+r-and-d-management	elsevier-harvard	0.9921	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-9310/homepage/ForAuthors.html	found in CSL metadata
+respiratory-care-journal	elsevier-with-titles	0.9921	0.0000	0.0000	http://rc.rcjournal.com/content/author-guidelines#references	found in CSL metadata
+respirology	elsevier-with-titles	0.9921	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/14401843/homepage/ForAuthors.html	found in CSL metadata
+sage-vancouver-brackets	elsevier-with-titles	0.9921	0.7500	0.0000	http://www.uk.sagepub.com/repository/binaries/pdf/SAGE_Vancouver_reference_style.pdf	found in CSL metadata
+sage-vancouver	elsevier-with-titles	0.9921	0.0000	0.0000	http://www.uk.sagepub.com/repository/binaries/pdf/SAGE_Vancouver_reference_style.pdf	found in CSL metadata
+scientific-online-letters-on-the-atmosphere	springer-basic-author-date	0.9921	0.8500	0.0000	https://www.metsoc.jp/sola/submission.html	found in CSL metadata
+seed-science-research	springer-basic-author-date	0.9921	0.1000	0.0000	https://www.cambridge.org/core/journals/seed-science-research/information/instructions-contributors	found in CSL metadata
+sociology-of-health-and-illness	elsevier-harvard	0.9921	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291467-9566/homepage/ForAuthors.html	found in CSL metadata
+south-african-theological-seminary	elsevier-harvard	0.9921	0.0500	0.0000	https://sats.ac.za/wp-content/uploads/2019/10/SmithHowtocitesources.pdf	found in CSL metadata
+southern-african-journal-of-critical-care	elsevier-with-titles	0.9921	1.0000	0.0000	http://www.sajcc.org.za/index.php/SAJCC/about/submissions#authorGuidelines	found in CSL metadata
+spine	elsevier-with-titles	0.9921	0.0000	0.0000	http://journals.lww.com/spinejournal/_layouts/15/1033/oaks.journals/informationforauthors.aspx	found in CSL metadata
+stavebni-obzor	ieee	0.9921	0.5000	0.0000	http://www.stavebniobzor.cz/redakce-casopisu/pokyny-pro-autory/	found in CSL metadata
+swiss-political-science-review	elsevier-harvard	0.9921	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/16626370/homepage/forauthors.html	found in CSL metadata
+the-auk	springer-basic-author-date	0.9921	0.6000	0.0000	https://academic.oup.com/auk/pages/General_Instructions#Style%20Sheet	found in CSL metadata
+the-british-journal-of-criminology	elsevier-harvard	0.9921	0.0500	0.0000	https://academic.oup.com/bjc/pages/General_Instructions	found in CSL metadata
+the-canadian-journal-of-psychiatry	elsevier-with-titles	0.9921	0.0000	0.0000	https://us.sagepub.com/en-us/nam/the-canadian-journal-of-psychiatry/journal202498#submission-guidelines	found in CSL metadata
+the-holocene	elsevier-harvard	0.9921	0.6500	0.0000	http://hol.sagepub.com/	found in CSL metadata
+the-horticulture-journal	elsevier-harvard	0.9921	0.7000	0.0000	http://hortj.org/modules/authors/index.php?content_id=2	found in CSL metadata
+the-journal-of-neuroscience	elsevier-harvard	0.9921	0.6500	0.0000	http://www.jneurosci.org/site/misc/ifa_organization.xhtml#References	found in CSL metadata
+the-journal-of-physiology	elsevier-harvard	0.9921	0.6500	0.0000	http://jp.physoc.org/site/misc/author.xhtml#submitted	found in CSL metadata
+the-journal-of-veterinary-medical-science	elsevier-with-titles	0.9921	0.7500	0.0000	http://jsvetsci.jp/jvms/instructions-for-authors/	found in CSL metadata
+the-journal-of-wildlife-management	springer-basic-author-date	0.9921	0.6000	0.0000	https://wildlife.org/get-published/	found in CSL metadata
+the-korean-journal-of-gastroenterology	elsevier-with-titles	0.9921	0.0000	0.0000	http://www.kjg.or.kr/contributors/authors.html	found in CSL metadata
+the-plant-cell	elsevier-harvard	0.9921	0.0500	0.0000	https://academic.oup.com/plcell/pages/General-Instructions	found in CSL metadata
+the-plant-genome	springer-basic-author-date	0.9921	0.1000	0.0000	https://dl.sciencesocieties.org/publications/tpg/author-instructions	found in CSL metadata
+the-rockefeller-university-press	springer-basic-author-date	0.9921	0.1000	0.0000	http://jgp.rupress.org/site/misc/ifora.xhtml	found in CSL metadata
+trabajos-de-prehistoria	elsevier-harvard	0.9921	0.0500	0.0000	http://tp.revistas.csic.es/index.php/tp/about/submissions#authorGuidelines	found in CSL metadata
+transport	elsevier-harvard	0.9921	0.0500	0.0000	https://journals.vgtu.lt/index.php/Transport/guidelinesforauthors	found in CSL metadata
+universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica	elsevier-harvard	0.9921	0.6000	0.0000	labceuunioeste.wix.com/unioeste	found in CSL metadata
+world-mycotoxin-journal	elsevier-harvard	0.9921	0.7000	1.0000	http://www.wageningenacademic.com/default.asp?pageid=92	found in CSL metadata
+worlds-veterinary-journal	elsevier-harvard	0.9921	0.6500	0.0000	https://wvj.science-line.com/guide-for-authors.html	found in CSL metadata
+the-journal-of-trauma-and-acute-care-surgery	american-medical-association	0.9894	1.0000	0.0000	https://journals.lww.com/jtrauma/Pages/instructionsforauthors.aspx	found in CSL metadata
+politica-tidsskrift-for-politisk-videnskab	taylor-and-francis-chicago-author-date	0.9893	0.1000	0.0000	https://tidsskrift.dk/politica/libraryFiles/downloadPublic/234	found in CSL metadata
+society-of-biblical-literature-author-date	taylor-and-francis-chicago-author-date	0.9893	0.9000	0.0000	http://www.sbl-site.org/publications/SBLHandbookofStyle.aspx	found in CSL metadata
+gender-zeitschrift-fur-geschlecht-kultur-und-gesellschaft	taylor-and-francis-chicago-author-date	0.9881	0.5000	0.0000	https://www.gender-zeitschrift.de/manuskripte	found in CSL metadata
+john-benjamins-publishing-company-linguistik-aktuell-linguistics-today	taylor-and-francis-chicago-author-date	0.9881	0.6500	0.0000	https://benjamins.com/catalog/la	found in CSL metadata
+universidade-do-porto-faculdade-de-engenharia-chicago-pt	taylor-and-francis-chicago-author-date	0.9881	0.8500	0.0000	https://feup.libguides.com/chicago	found in CSL metadata
+american-journal-of-cancer-research	ieee	0.9881	0.5000	0.0000	https://e-century.us/web/journal_author_info.php?journal=ajcr	found in CSL metadata
+american-journal-of-clinical-pathology	american-medical-association	0.9881	1.0000	0.0000	http://ajcp.ascpjournals.org/site/misc/ifora.xhtml#References	found in CSL metadata
+american-journal-of-orthodontics-and-dentofacial-orthopedics	american-medical-association	0.9881	1.0000	0.0000	http://journals.elsevierhealth.com/periodicals/ymod/authorinfo	found in CSL metadata
+american-journal-of-surgical-pathology	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/ajsp/accounts/ifauth.htm	found in CSL metadata
+american-medical-association-10th-edition	american-medical-association	0.9881	1.0000	0.0000	https://academic.oup.com/amamanualofstyle	found in CSL metadata
+american-veterinary-medical-association	american-medical-association	0.9881	1.0000	0.0000	https://www.avma.org/News/Journals/Pages/javma-manuscript-style.aspx	found in CSL metadata
+anesthesia-and-analgesia	american-medical-association	0.9881	1.0000	0.0000	http://www.aaeditor.org/GuideforAuthors.pdf	found in CSL metadata
+annual-review-of-linguistics	springer-basic-author-date	0.9881	0.8500	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+annual-review-of-medicine	elsevier-with-titles	0.9881	0.0000	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+annual-review-of-nuclear-and-particle-science	elsevier-with-titles	0.9881	0.0000	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+annual-reviews-alphabetical	elsevier-with-titles	0.9881	0.0000	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+annual-reviews-author-date	springer-basic-author-date	0.9881	0.8500	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+annual-reviews-without-titles	elsevier-with-titles	0.9881	0.0000	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+annual-reviews	elsevier-with-titles	0.9881	0.0000	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+arthritis-and-rheumatism	american-medical-association	0.9881	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1529-0131/homepage/ForAuthors.html	found in CSL metadata
+asaio-journal	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/asaio/accounts/MAT_IFA_online.pdf	found in CSL metadata
+brachytherapy	american-medical-association	0.9881	0.0000	0.0000	https://www.elsevier.com/journals/brachytherapy/1538-4721/guide-for-authors	found in CSL metadata
+cancer-translational-medicine	american-medical-association	0.9881	1.0000	0.0000	http://www.cancertm.com/contributors.asp#ref	found in CSL metadata
+cell-transplantation	american-medical-association	0.9881	1.0000	0.0000	https://www.cognizantcommunication.com/journal-titles/cell-transplantation	found in CSL metadata
+chemical-engineering-progress	ieee	0.9881	0.5000	0.0000	https://www.aiche.org/resources/publications/cep/guidelines-authors	found in CSL metadata
+clinical-gastroenterology-and-hepatology	american-medical-association	0.9881	1.0000	0.0000	http://www.cghjournal.org/content/authorinfo	found in CSL metadata
+clinical-spine-surgery	american-medical-association	0.9881	1.0000	0.0000	http://journals.lww.com/jspinaldisorders/Pages/Information-for-Authors.aspx	found in CSL metadata
+cornea	american-medical-association	0.9881	1.0000	0.0000	http://journals.lww.com/corneajrnl/_layouts/15/1033/oaks.journals/informationforauthors.aspx	found in CSL metadata
+cse-citation-name-8th-edition	american-medical-association	0.9881	0.9500	0.0000	http://www.scientificstyleandformat.org/Tools/SSF-Citation-Quick-Guide.html	found in CSL metadata
+cse-citation-name	american-medical-association	0.9881	0.9500	0.0000	https://www.csemanual.org/Tools/CSE-Citation-Quick-Guide.html	found in CSL metadata
+cse-citation-sequence-8th-edition	american-medical-association	0.9881	1.0000	0.0000	http://www.scientificstyleandformat.org/Tools/SSF-Citation-Quick-Guide.html	found in CSL metadata
+cse-citation-sequence	american-medical-association	0.9881	1.0000	0.0000	https://www.csemanual.org/Tools/CSE-Citation-Quick-Guide.html	found in CSL metadata
+current-gene-therapy	ieee	0.9881	0.6500	0.0000	http://benthamscience.com/journals/current-gene-therapy/author-guidelines/#top	found in CSL metadata
+current-opinion-in-endocrinology-diabetes-and-obesity	ieee	0.9881	0.5000	0.0000	https://journals.lww.com/co-endocrinology/Pages/informationforauthors.aspx	found in CSL metadata
+european-environment-agency-numeric	american-medical-association	0.9881	1.0000	0.0000	https://www.eea.europa.eu/about-us/documents/eea-writing-manual.pdf	found in CSL metadata
+eye	american-medical-association	0.9881	1.0000	0.0000	http://mts-eye.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions	found in CSL metadata
+fine-focus	elsevier-with-titles	0.9881	0.0000	0.0000	http://finefocus.org/submissions	found in CSL metadata
+gastroenterology	american-medical-association	0.9881	1.0000	0.0000	http://gastrojournal.org/authorinfo	found in CSL metadata
+haemophilia	american-medical-association	0.9881	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/13652516/homepage/ForAuthors.html#preparing	found in CSL metadata
+hawaii-international-conference-on-system-sciences-proceedings	ieee	0.9881	0.5000	0.0000	https://hicss.hawaii.edu/authors/	found in CSL metadata
+histopathology	american-medical-association	0.9881	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2559/homepage/ForAuthors.html	found in CSL metadata
+hue-university-of-medicine-and-pharmacy	ieee	0.9881	0.6000	0.0000	https://github.com/citation-style-language/styles/pull/6781	found in CSL metadata
+indian-dermatology-online-journal	american-medical-association	0.9881	0.0000	0.0000	http://www.idoj.in/contributors.asp	found in CSL metadata
+indoor-air	american-medical-association	0.9881	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291600-0668/homepage/ForAuthors.html	found in CSL metadata
+inflammatory-bowel-diseases	american-medical-association	0.9881	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291536-4844/homepage/ForAuthors.html	found in CSL metadata
+influenza-and-other-respiratory-viruses	american-medical-association	0.9881	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1750-2659/homepage/ForAuthors.html	found in CSL metadata
+investigative-radiology	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/ir/accounts/ifauth.htm	found in CSL metadata
+journal-of-antimicrobial-chemotherapy	american-medical-association	0.9881	1.0000	0.0000	https://academic.oup.com/jac/pages/general_instructions	found in CSL metadata
+journal-of-brachial-plexus-and-peripheral-nerve-injury	american-medical-association	0.9881	1.0000	0.0000	http://www.thieme.com/media/ita/JBPPNI_AuthorsInstructions.pdf	found in CSL metadata
+journal-of-burn-care-and-research	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/jbcr/accounts/ifauth.htm	found in CSL metadata
+journal-of-chemometrics	american-medical-association	0.9881	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1099-128X/homepage/ForAuthors.html	found in CSL metadata
+journal-of-clinical-neurology	american-medical-association	0.9881	1.0000	0.0000	http://submit.thejcn.com/about/author_ins.php	found in CSL metadata
+journal-of-clinical-rheumatology	american-medical-association	0.9881	1.0000	0.0000	http://journals.lww.com/jclinrheum/_layouts/15/1033/oaks.journals/informationforauthors.aspx	found in CSL metadata
+journal-of-clinical-sleep-medicine	american-medical-association	0.9881	1.0000	0.0000	http://www.aasmnet.org/jcsm/authors.aspx	found in CSL metadata
+journal-of-geriatric-psychiatry-and-neurology	american-medical-association	0.9881	1.0000	0.0000	https://us.sagepub.com/en-us/nam/journal-of-geriatric-psychiatry-and-neurology/journal201662#submission-guidelines	found in CSL metadata
+journal-of-management-information-systems	ieee	0.9881	0.5000	0.0000	http://www.jmis-web.org/info-co/	found in CSL metadata
+journal-of-molecular-recognition	american-medical-association	0.9881	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1099-1352/homepage/ForAuthors.html	found in CSL metadata
+journal-of-neuroimaging	american-medical-association	0.9881	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/15526569/homepage/forauthors.html	found in CSL metadata
+journal-of-neurological-disorders	american-medical-association	0.9881	0.0000	0.0000	http://esciencecentral.org/journals/instructionsforauthors-neurological-disorders-open-access.php	found in CSL metadata
+journal-of-oral-and-maxillofacial-surgery	american-medical-association	0.9881	1.0000	0.0000	http://www.joms.org/authorinfo	found in CSL metadata
+journal-of-prosthodontics	american-medical-association	0.9881	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/1532849x/homepage/forauthors.html	found in CSL metadata
+journal-of-reconstructive-microsurgery	american-medical-association	0.9881	1.0000	0.0000	https://www.thieme.de/de/journal-reconstructive-microsurgery/authors-9770.htm	found in CSL metadata
+journal-of-stroke	american-medical-association	0.9881	1.0000	0.0000	https://www.j-stroke.org/authors/authors.php	found in CSL metadata
+journal-of-universal-computer-science	elsevier-harvard	0.9881	0.0000	0.0000	http://www.jucs.org/ujs/jucs/info/submissions/style_guide.html	found in CSL metadata
+korean-journal-of-anesthesiology	american-medical-association	0.9881	0.7000	0.0000	http://ekja.org/index.php?body=instruction	found in CSL metadata
+laboratory-animal-science-professional	american-medical-association	0.9881	0.9500	0.0000	https://www.aalas.org/publications/information-for-authors/las-pro	found in CSL metadata
+muscle-and-nerve	american-medical-association	0.9881	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/10974598/homepage/forauthors.html	found in CSL metadata
+neurorehabilitation-and-neural-repair	american-medical-association	0.9881	1.0000	0.0000	http://www.sagepub.com/journalsProdDesc.nav?ct_p=manuscriptSubmission&amp;prodId=Journal201625	found in CSL metadata
+oncoimmunology	american-medical-association	0.9881	1.0000	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=koni20	found in CSL metadata
+ophthalmology-retina	american-medical-association	0.9881	1.0000	0.0000	https://www.elsevier.com/journals/ophthalmology-retina/2468-6530/guide-for-authors	found in CSL metadata
+ophthalmology	american-medical-association	0.9881	1.0000	0.0000	http://www.aaojournal.org/authorinfo#style	found in CSL metadata
+optometry-and-vision-science	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/ovs/accounts/ifauth.htm	found in CSL metadata
+pediatric-infectious-disease-journal	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/pidj/accounts/ifauth.htm	found in CSL metadata
+pediatric-physical-therapy	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/ped-pt/accounts/ifauth.htm	found in CSL metadata
+pediatric-pulmonology	american-medical-association	0.9881	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/10990496/homepage/forauthors.html	found in CSL metadata
+pharmacoepidemiology-and-drug-safety	american-medical-association	0.9881	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1557/homepage/ForAuthors.html	found in CSL metadata
+prehospital-and-disaster-medicine	american-medical-association	0.9881	1.0000	0.0000	https://www.cambridge.org/core/journals/prehospital-and-disaster-medicine/information/author-instructions/submitting-your-materials	found in CSL metadata
+protein-science	american-medical-association	0.9881	1.0000	0.0000	http://www.zotero.org/styles/cse-citation-sequence	found in CSL metadata
+scandinavian-journal-of-medicine-and-science-in-sports	american-medical-association	0.9881	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1600-0838/homepage/ForAuthors.html	found in CSL metadata
+sexual-health	american-medical-association	0.9881	1.0000	0.0000	http://www.publish.csiro.au/sh/forauthors/authorinstructions#15	found in CSL metadata
+spie-proceedings	american-medical-association	0.9881	1.0000	0.0000	http://spie.org/conferences-and-exhibitions/authors-and-presenters/format-your-manuscript-multimedia-files-and-references#Specifications	found in CSL metadata
+the-american-journal-of-cardiology	american-medical-association	0.9881	1.0000	0.0000	http://www.ajconline.org/authorinfo	found in CSL metadata
+the-american-journal-of-dermatopathology	american-medical-association	0.9881	1.0000	0.0000	http://edmgr.ovid.com/ajd/accounts/ifauth.htm	found in CSL metadata
+the-american-journal-of-geriatric-psychiatry	american-medical-association	0.9881	1.0000	0.0000	https://www.editorialmanager.com/jgp/default.aspx	found in CSL metadata
+the-bovine-practitioner	american-medical-association	0.9881	0.9500	0.0000	http://aabp.org/members/publications/AuthorGuidelines.pdf	found in CSL metadata
+the-journal-of-nuclear-medicine	american-medical-association	0.9881	0.0000	0.0000	http://jnm.snmjournals.org/site/misc/ifora.xhtml	found in CSL metadata
+the-journal-of-pathology	american-medical-association	0.9881	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291096-9896/homepage/ForAuthors.html#references	found in CSL metadata
+the-journal-of-urology	american-medical-association	0.9881	1.0000	0.0000	http://www.elsevier.com/journals/the-journal-of-urology/0022-5347/guide-for-authors	found in CSL metadata
+universidade-de-sao-paulo-instituto-de-matematica-e-estatistica	elsevier-harvard	0.9881	0.0500	0.0000	http://tese-exemplo.googlecode.com/files/tese-exemplo-plainnat-ime.pdf	found in CSL metadata
+veterinary-clinical-pathology	american-medical-association	0.9881	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/1939165x/homepage/forauthors.html	found in CSL metadata
+vietnam-ministry-of-education-and-training-en	ieee	0.9881	0.6000	0.0000	http://www.vdic.org.vn/en/library/guides.html	found in CSL metadata
+vietnam-ministry-of-education-and-training-vi	ieee	0.9881	0.6000	0.0000	http://www.vdic.org.vn/en/library/guides.html	found in CSL metadata
+western-journal-of-emergency-medicine	american-medical-association	0.9881	1.0000	0.0000	https://westjem.com/submission-guidelines	found in CSL metadata
+xenotransplantation	ieee	0.9881	0.5000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291399-3089/homepage/ForAuthors.html	found in CSL metadata
+zeitschrift-fur-allgemeinmedizin	ieee	0.9881	0.5000	0.0000	https://www.online-zfa.de/page/Autorenrichtlinien/22	found in CSL metadata
+zeitschrift-fur-zahnarztliche-implantologie	ieee	0.9881	0.5000	0.0000	https://www.online-zzi.de/autorengutachter/	found in CSL metadata
+american-physics-society	elsevier-with-titles	0.9864	1.0000	0.0000	https://journals.aps.org/prl/authors#techformat	found in CSL metadata
+annals-of-joint	elsevier-with-titles	0.9864	0.0000	0.0000	http://aoj.amegroups.com/public/addition/aoj/aoj-instruction-for-authors.pdf	found in CSL metadata
+anticancer-research	elsevier-with-titles	0.9864	0.0000	0.0000	http://ar.iiarjournals.org/site/misc/ifora.xhtml	found in CSL metadata
+association-de-science-regionale-de-langue-francaise	elsevier-harvard	0.9864	0.8500	0.0000	http://asrdlf2016.com/sites/default/files/users/user167/feuille_de_style_asrdlf2016c.docx	found in CSL metadata
+biochemical-society-transactions	elsevier-with-titles	0.9864	1.0000	0.0000	https://portlandpress.com/biochemsoctrans/pages/instructions_to_authors	found in CSL metadata
+brazilian-journal-of-psychiatry	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.bjp.org.br/instructions-for-authors#Manuscript_preparation	found in CSL metadata
+british-journal-of-dermatology	elsevier-with-titles	0.9864	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2133/homepage/ForAuthors.html	found in CSL metadata
+clinical-journal-of-sport-medicine	elsevier-with-titles	0.9864	0.0000	0.0000	http://edmgr.ovid.com/cjsm/accounts/ifauth.htm	found in CSL metadata
+european-journal-of-microbiology-and-immunology	elsevier-with-titles	0.9864	0.7500	0.0000	http://akademiai.com/loi/1886	found in CSL metadata
+european-journal-of-public-health	elsevier-with-titles	0.9864	0.0000	0.0000	https://academic.oup.com/eurpub/pages/Instructions_For_Authors#References	found in CSL metadata
+european-journal-of-ultrasound	ieee	0.9864	0.6500	0.0000	http://ultraschall.thieme.de/documents/10157/10820/UiM-Autorenrichtlinien2016.pdf/8cf116e9-c862-4626-bc36-945a971495af	found in CSL metadata
+european-journal-of-vascular-and-endovascular-surgery	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.elsevier.com/journals/european-journal-of-vascular-and-endovascular-surgery/1078-5884/guide-for-authors	found in CSL metadata
+european-respiratory-journal	elsevier-with-titles	0.9864	0.7500	0.0000	https://www.ersjournals.com/authors/research-ms-preparation	found in CSL metadata
+fatigue-and-fracture-of-engineering-materials-and-structures	elsevier-with-titles	0.9864	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/14602695/homepage/forauthors.html	found in CSL metadata
+future-medicine	elsevier-with-titles	0.9864	1.0000	0.0000	https://www.futuremedicine.com/authorguide/preparingyourarticle	found in CSL metadata
+geriatrics-and-gerontology-international	elsevier-with-titles	0.9864	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/14470594/homepage/forauthors.html	found in CSL metadata
+hochschule-hannover-soziale-arbeit	springer-basic-author-date	0.9864	0.6000	0.0000	https://f5.hs-hannover.de/fileadmin/HsH/Fakultaet_V/Bilder/Studium/Bachelor/Soziale_Arbeit_grundstaendig/Leitfaeden_BSW/Leitfaden_Schriftliche_Arbeiten_Soziale_Arbeit_SoSe_2018.pdf	found in CSL metadata
+homeopathy-thieme	elsevier-with-titles	0.9864	0.0000	0.0000	https://lp.thieme.de/open-access-files/175/author_instructions.pdf	found in CSL metadata
+indian-journal-of-traditional-knowledge	elsevier-with-titles	0.9864	0.0000	0.0000	http://nopr.niscair.res.in/ijtk_inst_auth.htm	found in CSL metadata
+international-journal-of-obstetric-anesthesia	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.elsevier.com/journals/international-journal-of-obstetric-anesthesia/0959-289X/guide-for-authors	found in CSL metadata
+international-journal-of-sports-medicine	elsevier-with-titles	0.9864	0.9500	0.0000	http://www.thieme.com//media/ita/pubid926886473.pdf	found in CSL metadata
+journal-of-science-and-medicine-in-sport	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.elsevier.com/journals/journal-of-science-and-medicine-in-sport/1440-2440/guide-for-authors	found in CSL metadata
+journal-of-the-american-animal-hospital-association	elsevier-with-titles	0.9864	0.0000	0.0000	https://www.jaaha.org/page/authorinstructions	found in CSL metadata
+journal-of-the-science-of-food-and-agriculture	elsevier-with-titles	0.9864	0.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/10970010/homepage/forauthors.html#preparing	found in CSL metadata
+journal-of-veterinary-diagnostic-investigation	elsevier-with-titles	0.9864	0.0000	0.0000	https://uk.sagepub.com/en-gb/eur/journal-of-veterinary-diagnostic-investigation/journal202058#submission-guidelines	found in CSL metadata
+jurnal-ilmu-dan-teknologi-hasil-ternak	ieee	0.9864	0.0000	0.0000	http://jitek.ub.ac.id/index.php/jitek/about/submissions#authorGuidelines	found in CSL metadata
+mediterranean-journal-of-infection-microbes-and-antimicrobials	elsevier-with-titles	0.9864	1.0000	0.0000	http://www.mjima.org/static.php?id=4	found in CSL metadata
+molecular-oncology	elsevier-with-titles	0.9864	1.0000	0.0000	http://www.zotero.org/styles/archives-of-hand-and-microsurgery	found in CSL metadata
+national-institute-of-health-research	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.journalslibrary.nihr.ac.uk/information-for-authors/references	found in CSL metadata
+nlm-name-year	elsevier-harvard	0.9864	0.1000	0.0000	https://www.nlm.nih.gov/citingmedicine	found in CSL metadata
+pediatric-anesthesia	elsevier-with-titles	0.9864	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1460-9592/homepage/ForAuthors.html	found in CSL metadata
+primary-care-clinics-in-office-practice	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.elsevier.com/journals/primary-care-clinics-in-office-practice/0095-4543/guide-for-authors	found in CSL metadata
+psychosomatics	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.elsevier.com/journals/psychosomatics/0033-3182/guide-for-authors	found in CSL metadata
+sociologie	elsevier-harvard	0.9864	0.8500	0.0000	https://www.revue-sociologie.org/conseils-aux-auteurs/	found in CSL metadata
+stem-cells	elsevier-with-titles	0.9864	1.0000	0.0000	http://www.stemcellsportal.com/STEM_CELLS_Info_for_Contributors#_Toc372810938	found in CSL metadata
+surgical-clinics-of-north-america	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.elsevier.com/journals/surgical-clinics-of-north-america/0039-6109/guide-for-authors	found in CSL metadata
+the-institution-of-engineering-and-technology	ieee	0.9864	0.5000	0.0000	http://digital-library.theiet.org/journals/author-guide	found in CSL metadata
+the-journal-of-the-acoustical-society-of-america-numeric	elsevier-with-titles	0.9864	0.0000	0.0000	https://pubs.aip.org/DocumentLibrary/files/publications/jasa/jasinfcon.pdf	found in CSL metadata
+the-lancet	elsevier-with-titles	0.9864	0.0000	0.0000	http://download.thelancet.com/flatcontentassets/authors/lancet-information-for-authors.pdf	found in CSL metadata
+the-national-medical-journal-of-india	elsevier-with-titles	0.9864	0.0000	0.0000	http://www.nmji.in/contributors.asp#ref	found in CSL metadata
+the-oncologist	elsevier-with-titles	0.9864	0.0000	0.0000	https://theoncologist.onlinelibrary.wiley.com/page/journal/1549490x/homepage/for_authors	found in CSL metadata
+metaaltijden	taylor-and-francis-chicago-author-date	0.9853	0.8500	0.0000	https://www.metaaltijden.nl/auteurs/	found in CSL metadata
+asian-studies-review	taylor-and-francis-chicago-author-date	0.9853	0.0500	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=casr20&amp;page=instructions	found in CSL metadata
+cuadernos-de-filologia-clasica	taylor-and-francis-chicago-author-date	0.9853	0.9000	0.0000	http://revistas.ucm.es/index.php/CFCG/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-interactive-marketing	taylor-and-francis-chicago-author-date	0.9853	0.6500	0.0000	http://www.elsevier.com/journals/journal-of-interactive-marketing/1094-9968/guide-for-authors#68000	found in CSL metadata
+journal-of-retailing	taylor-and-francis-chicago-author-date	0.9853	0.6500	0.0000	http://www.elsevier.com/journals/journal-of-retailing/0022-4359/guide-for-authors#68000	found in CSL metadata
+language	taylor-and-francis-chicago-author-date	0.9853	0.6000	0.0000	http://www.linguisticsociety.org/files/style-sheet.pdf	found in CSL metadata
+latin-american-research-review	taylor-and-francis-chicago-author-date	0.9853	0.9000	0.0000	http://lasa.international.pitt.edu/eng/larr/submission.asp	found in CSL metadata
+reviews-of-modern-physics-with-titles	taylor-and-francis-chicago-author-date	0.9853	0.9000	0.0000	http://rmp.aps.org/files/rmpgui08.pdf	found in CSL metadata
+taylor-and-francis-chicago-b-author-date	taylor-and-francis-chicago-author-date	0.9853	0.8500	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=bfsn20#references	found in CSL metadata
+world-politics	taylor-and-francis-chicago-author-date	0.9853	0.0000	0.0000	https://webshare.princeton.edu/users/piirs/pdf/World%20Politics%20Style%20Sheet.pdf	found in CSL metadata
+berghahn-books-author-date-en-gb	elsevier-harvard	0.9853	0.0500	0.0000	https://www.berghahnbooks.com/authors/	found in CSL metadata
+comparative-population-studies	elsevier-harvard	0.9853	0.0500	0.0000	http://www.comparativepopulationstudies.de/index.php/CPoS/pages/view/AGL_E	found in CSL metadata
+czech-journal-of-international-relations	elsevier-harvard	0.9853	0.0500	0.0000	https://cjir.iir.cz/index.php/cjir/guidelines	found in CSL metadata
+gengo-kenkyu-journal-of-the-linguistic-society-of-japan	elsevier-harvard	0.9853	0.0500	0.0000	https://www.ls-japan.org/	found in CSL metadata
+gesellschaft-fur-popularmusikforschung	elsevier-harvard	0.9853	0.0500	0.0000	http://www.aspm-samples.de/hinweise.html	found in CSL metadata
+harvard-falmouth-university	elsevier-harvard	0.9853	0.0500	0.0000	http://ask.fxplus.ac.uk/harvard-falmouth	found in CSL metadata
+intellect-newgen-books	elsevier-harvard	0.9853	0.0500	0.0000	https://www.intellectbooks.com/journal-editors-and-contributors#citation-style-language	found in CSL metadata
+journal-of-elections-public-opinion-and-parties	elsevier-harvard	0.9853	0.6000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=fbep&amp;page=instructions	found in CSL metadata
+journal-of-fish-biology	elsevier-harvard	0.9853	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1095-8649/homepage/ForAuthors.html	found in CSL metadata
+journal-of-international-relations-and-development	elsevier-harvard	0.9853	0.0500	0.0000	http://www.springer.com/political+science/journal/41268	found in CSL metadata
+universitat-basel-iberoromanistik	elsevier-harvard	0.9853	0.0500	0.0000	https://iberoromanistik.philhist.unibas.ch/fileadmin/user_upload/iberoromanistik/pdf-Dokumente/documentos_download/Normas_trabajos_escritos_8a_ed_2023.pdf	found in CSL metadata
+universitat-bremen-institut-fur-politikwissenschaft	elsevier-harvard	0.9853	0.0500	0.0000	http://www.politik.uni-bremen.de/ccm/cms-service/download/asset/Kompendium.pdf?asset_id=914048	found in CSL metadata
+universitat-mannheim-germanistische-linguistik	elsevier-harvard	0.9853	0.0500	0.0000	https://www.phil.uni-mannheim.de/media/Lehrstuehle/phil/deutsche_philologie/LS_Germanistische_Linguistik/Leitfaden_zur_Anfertigung_von_Hausarbeiten_allgemein_April_2016.pdf	found in CSL metadata
+universitat-stuttgart-planung-und-partizipation	elsevier-harvard	0.9853	0.0500	0.0000	https://www.ivr.uni-stuttgart.de/recht/lehre/m.-sc.-planung-und-partizipation/MPP-Standards-Stand-Oktober-2018.pdf	found in CSL metadata
+uniwersytet-im-adama-mickiewicza-w-poznaniu-wydzial-anglistyki	elsevier-harvard	0.9853	0.0500	0.0000	http://wa.amu.edu.pl/wa/stylesheet	found in CSL metadata
+west-european-politics	elsevier-harvard	0.9853	0.0500	0.0000	http://www.tandf.co.uk/journals/authors/style/reference/ref_fwep.pdf	found in CSL metadata
+wirtschaftsuniversitat-wien-abteilung-fur-bildungswissenschaft	elsevier-harvard	0.9853	0.0500	0.0000	https://www.wu.ac.at/fileadmin/wu/d/i/bildungswissenschaft/Lehre/Masterarbeiten/zitierrichtlinien.pdf	found in CSL metadata
+wirtschaftsuniversitat-wien-handel-und-marketing	elsevier-harvard	0.9853	0.0500	0.0000	https://learn.wu.ac.at/bibliothek/literaturverwaltung	found in CSL metadata
+wirtschaftsuniversitat-wien-wirtschaftspadagogik	elsevier-harvard	0.9853	0.0500	0.0000	https://learn.wu.ac.at/bibliothek/literaturverwaltung	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-numerico	ieee	0.9841	0.0000	0.0000	https://forums.zotero.org/discussion/22148/how-to-apply-disambiguation-in-citation-just-when-works-of-different-authors-are-in-the-same-year/?Focus=147094#Comment_147094	found in CSL metadata
+currents-in-biblical-research	taylor-and-francis-chicago-author-date	0.9825	0.6000	0.0000	http://www.sagepub.com/journalsProdManSub.nav?prodId=Journal201735	found in CSL metadata
+taylor-and-francis-chicago-f	taylor-and-francis-chicago-author-date	0.9825	0.9000	0.0000	http://www.tandf.co.uk/journals/authors/style/reference/tf_F.pdf	found in CSL metadata
+the-journal-of-roman-studies	taylor-and-francis-chicago-author-date	0.9825	0.0000	0.0000	http://assets.cambridge.org/JRS/JRS_ifc.pdf	found in CSL metadata
+transactions-of-the-american-philological-association	taylor-and-francis-chicago-author-date	0.9825	0.0000	0.0000	https://classicalstudies.org/sites/default/files/documents/TAPA_Style_Sheet.pdf	found in CSL metadata
+acta-anaesthesiologica-taiwanica	elsevier-with-titles	0.9821	0.0000	0.0000	http://www.elsevier.com/journals/acta-anaesthesiologica-taiwanica/1875-4597/guide-for-authors	found in CSL metadata
+australian-critical-care	elsevier-with-titles	0.9821	0.0000	0.0000	http://www.elsevier.com/journals/australian-critical-care/1036-7314/guide-for-authors	found in CSL metadata
+chinese-journal-of-aeronautics	elsevier-with-titles	0.9821	0.0000	0.0000	http://www.elsevier.com/journals/chinese-journal-of-aeronautics/1000-9361/guide-for-authors	found in CSL metadata
+journal-of-infection	elsevier-with-titles	0.9821	0.0000	0.0000	http://www.elsevier.com/journals/journal-of-infection/0163-4453/guide-for-authors	found in CSL metadata
+journal-of-minimally-invasive-gynecology	elsevier-with-titles	0.9821	1.0000	0.0000	http://www.elsevier.com/journals/journal-of-minimally-invasive-gynecology/1553-4650/guide-for-authors	found in CSL metadata
+neuroimaging-clinics-of-north-america	elsevier-with-titles	0.9821	0.0000	0.0000	http://www.elsevier.com/journals/neuroimaging-clinics-of-north-america/1052-5149/guide-for-authors	found in CSL metadata
+the-saudi-journal-for-dental-research	elsevier-with-titles	0.9821	0.0000	0.0000	http://www.elsevier.com/journals/the-saudi-journal-for-dental-research/2352-0035/guide-for-authors	found in CSL metadata
+textual-cultures	taylor-and-francis-chicago-author-date	0.9817	1.0000	0.0000	https://textualsociety.org/how-to-submit/	found in CSL metadata
+acm-sigchi-proceedings-extended-abstract-format	ieee	0.9813	0.5000	0.0000	http://www.sigchi.org/publications/chipubform/sigchi-extended-abstracts-format-2016/view	found in CSL metadata
+acm-sigchi-proceedings	ieee	0.9813	0.5000	0.0000	http://cscw.acm.org/2016/submit/sigchi-word-proceedings.zip	found in CSL metadata
+association-for-computing-machinery	ieee	0.9813	0.5000	0.0000	https://www.acm.org/publications/authors/reference-formatting	found in CSL metadata
+zeitschrift-fur-fantastikforschung	modern-language-association	0.9812	0.0500	0.0000	https://zff.openlibhums.org/site/stylesheet/	found in CSL metadata
+computer-supported-cooperative-work	taylor-and-francis-chicago-author-date	0.9810	0.1000	0.0000	https://www.springer.com/journal/10606/submission-guidelines	found in CSL metadata
+cranfield-university-numeric	ieee	0.9810	0.5000	0.0000	http://barrington.cranfield.ac.uk/help/Numbered%20Ref%20Guide%20Linked.pdf	found in CSL metadata
+obstetrics-and-gynecology-science	ieee	0.9810	0.5000	0.0000	https://www.ogscience.org/index.php?body=instructions	found in CSL metadata
+taylor-and-francis-national-library-of-medicine	ieee	0.9810	0.5000	0.0000	https://files.taylorandfrancis.com/tf_NLM.pdf	found in CSL metadata
+taylor-and-francis-vancouver-national-library-of-medicine	ieee	0.9810	0.0000	0.0000	https://www.tandf.co.uk//journals/authors/style/reference/tf_USVancouver.pdf	found in CSL metadata
+iso690-author-date-cat	taylor-and-francis-chicago-author-date	0.9809	0.6000	0.0000	http://www.aenor.es/aenor/normas/normas/fichanorma.asp?tipo=N&amp;codigo=N0051162&amp;pdf=#.U3Icf_ldW4J	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-author-classic-no-url	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-author-classic	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-author-no-url	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-author	chicago-shortened-notes-bibliography	0.9802	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+ucl-press-note	chicago-shortened-notes-bibliography	0.9802	0.9000	0.0000	https://cdn.shopify.com/s/files/1/1684/4803/files/General_guidelines_60568e26-7895-458b-b527-8e35a0963f7c.pdf?v=1699967685	found in CSL metadata
+umea-university-harvard	taylor-and-francis-chicago-author-date	0.9797	0.6500	0.0000	https://www.umu.se/bibliotek/soka-skriva-studera/skriva-referenser/harvard-hanvisningar-i-text/	found in CSL metadata
+brewingscience	ieee	0.9796	0.5000	0.0000	https://www.brewingscience.de/index.php?tpl=authors	found in CSL metadata
+hochschule-rheinmain-wiesbaden-business-school-gesundheitsokonomie	elsevier-harvard	0.9796	0.0500	0.0000	https://www.institut-praxisforschung.com/app/download/11830426012/Harvard-Zitierweise.pdf	found in CSL metadata
+journal-of-periodontal-research	elsevier-with-titles	0.9796	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1600-0765/homepage/ForAuthors.html	found in CSL metadata
+la-nouvelle-revue-du-travail	elsevier-harvard	0.9796	0.5500	0.0000	https://journals.openedition.org/nrt/531	found in CSL metadata
+medicina-delle-dipendenze-italian-journal-of-the-addictions	elsevier-harvard	0.9796	1.0000	0.0000	https://www.medicinadelledipendenze.it/rivista/istruzioni-per-gli-autori/criteri-generali-per-la-pubblicazione.html	found in CSL metadata
+the-american-journal-of-psychiatry	elsevier-with-titles	0.9796	0.0000	0.0000	https://ajp.psychiatryonline.org/ajp_ifora	found in CSL metadata
+the-international-journal-of-tuberculosis-and-lung-disease	elsevier-with-titles	0.9796	0.0000	0.0000	https://www.theunion.org/what-we-do/journals/ijtld/information-for-authors/body/Author-Instructions-2019.pdf	found in CSL metadata
+the-journal-of-neuropsychiatry-and-clinical-neurosciences	elsevier-with-titles	0.9796	0.0000	0.0000	http://neuro.psychiatryonline.org/neuro_ifora.aspx	found in CSL metadata
+college-of-naturopathic-medicine	elsevier-harvard	0.9796	0.6000	0.0000	https://github.com/citation-style-language/styles/pull/3815#issuecomment-445793526	found in CSL metadata
+lund-university-school-of-economics-and-management	elsevier-harvard	0.9796	0.7000	0.0000	http://libguides.lub.lu.se/ld.php?content_id=12012699	found in CSL metadata
+marine-turtle-newsletter	elsevier-harvard	0.9796	0.0500	0.0000	http://seaturtle.org/mtn/authors.shtml	found in CSL metadata
+pest-management-science	american-medical-association	0.9788	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1526-4998/homepage/ForAuthors.html#preparing	found in CSL metadata
+preventive-nutrition-and-food-science	elsevier-harvard	0.9788	0.9500	0.0000	https://www.pnfs.or.kr/content/about/open_access.html	found in CSL metadata
+chinese-gb7714-2005-numeric	elsevier-with-titles	0.9784	1.0000	0.0000	https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D78562D3A7E05397BE0A0AB82A	found in CSL metadata
+comptes-rendus-numeric	elsevier-with-titles	0.9784	0.7500	0.0000		
+database	elsevier-with-titles	0.9784	0.0000	0.0000	https://academic.oup.com/database/pages/instructions_for_authors	found in CSL metadata
+expert-reviews-in-molecular-medicine	elsevier-with-titles	0.9784	1.0000	0.0000	https://www.cambridge.org/core/journals/expert-reviews-in-molecular-medicine/information/instructions-contributors	found in CSL metadata
+human-molecular-genetics	elsevier-with-titles	0.9784	0.0000	0.0000	https://academic.oup.com/hmg/pages/General_Instructions	found in CSL metadata
+american-anthropological-association	taylor-and-francis-chicago-author-date	0.9775	0.6000	0.0000	http://www.aaanet.org/publications/style_guide.pdf	found in CSL metadata
+art-libraries-society-of-north-america-arlisna-reviews	chicago-shortened-notes-bibliography	0.9774	0.9000	0.0000	https://reviews.arlisna.hcommons.org/arlis-na-reviews-guidelines/	found in CSL metadata
+journal-of-linguistics	taylor-and-francis-chicago-author-date	0.9762	0.6000	0.0000	https://www.cambridge.org/core/journals/journal-of-linguistics/information/instructions-contributors	found in CSL metadata
+padagogische-hochschule-fachhochschule-nordwestschweiz	taylor-and-francis-chicago-author-date	0.9762	0.5000	0.0000	http://www.schreiben.zentrumlesen.ch/stud_zitieren_quellenverzeichnis_empfehlungen_schreibberatung.cfm	found in CSL metadata
+unified-style-sheet-for-linguistics	taylor-and-francis-chicago-author-date	0.9762	0.6000	0.0000	https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf	found in CSL metadata
+american-journal-of-neuroradiology	american-medical-association	0.9762	1.0000	0.0000	http://www.ajnr.org/site/misc/ifora.xhtml#ref	found in CSL metadata
+bourgogne-franche-comte-nature	elsevier-harvard	0.9762	0.5500	0.0000	http://www.bourgogne-franche-comte-nature.fr/fr/publier-dans-la-revue-scientifique_797.html	found in CSL metadata
+european-environment-agency	elsevier-harvard	0.9762	0.7500	0.0000	https://www.eea.europa.eu/about-us/documents/eea-writing-manual.pdf	found in CSL metadata
+sports-health	american-medical-association	0.9762	0.9500	0.0000	https://journals.sagepub.com/author-instructions/SPH#References	found in CSL metadata
+american-journal-of-botany	elsevier-harvard	0.9746	0.5500	0.0000	http://www.botany.org/ajb/ajb_Lit_Cited_Instructions.pdf	found in CSL metadata
+applications-in-plant-sciences	elsevier-harvard	0.9746	0.5500	0.0000	https://bsapubs.onlinelibrary.wiley.com/hub/journal/21680450/homepage/forauthors	found in CSL metadata
+arachne	elsevier-harvard	0.9746	0.0500	0.0000	http://www.dearge.de/arachne/	found in CSL metadata
+arachnologische-mitteilungen	elsevier-harvard	0.9746	0.0500	0.0000	https://arages.de/zeitschrift/hinweise-fuer-autoren	found in CSL metadata
+bulletin-of-geosciences	elsevier-harvard	0.9746	0.0500	0.0000	http://www.geology.cz/bulletin/instructions	found in CSL metadata
+egretta	elsevier-harvard	0.9746	0.1000	0.0000	https://www.zobodat.at/zeitschriftinfos/egretta_aut.pdf	found in CSL metadata
+evolution	elsevier-harvard	0.9746	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291558-5646/homepage/ForAuthors.html	found in CSL metadata
+journal-of-evolutionary-biology	elsevier-harvard	0.9746	0.8500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1420-9101/homepage/ForAuthors.html	found in CSL metadata
+journal-of-foraminiferal-research	elsevier-harvard	0.9746	0.8000	0.0000	https://pubs.geoscienceworld.org/jfr	found in CSL metadata
+journal-of-systematic-palaeontology	elsevier-harvard	0.9746	0.0500	0.0000	http://www.tandf.co.uk/journals/authors/style/reference/ref_tjsp.pdf	found in CSL metadata
+journal-of-urban-and-environmental-engineering	elsevier-harvard	0.9746	0.8500	0.0000	http://periodicos.ufpb.br/ojs2/index.php/juee/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-zoo-biology	elsevier-harvard	0.9746	0.1000	0.0000	http://www.escijournals.net/JZB/about/submissions#authorGuidelines	found in CSL metadata
+opuscula	elsevier-harvard	0.9746	0.0000	0.0000	https://ecsi.se/opathrom/	found in CSL metadata
+phytotaxa	elsevier-harvard	0.9746	0.0500	0.0000	https://www.mapress.com/j/pt/pages/view/forauthors	found in CSL metadata
+plant-species-biology	elsevier-harvard	0.9746	0.0500	0.0000	https://esj-journals.onlinelibrary.wiley.com/hub/journal/14421984/homepage/forauthors.html	found in CSL metadata
+raptor-journal	elsevier-harvard	0.9746	0.1000	0.0000	https://sciendo-parsed-data-feed.s3.eu-central-1.amazonaws.com/SRJ/Instructions_for_Authors.pdf	found in CSL metadata
+silva-fennica	elsevier-harvard	0.9746	0.1000	0.0000	https://silvafennica.fi/page/authors	found in CSL metadata
+the-geological-society-of-london	elsevier-harvard	0.9746	0.1000	0.0000	https://www.geolsoc.org.uk/~/media/Files/GSL/shared/pdfs/Publications/AuthorInfo_Text.pdf	found in CSL metadata
+the-lichenologist	elsevier-harvard	0.9746	0.0500	0.0000	http://journals.cambridge.org/action/displayJournal?jid=lic	found in CSL metadata
+zootaxa	elsevier-harvard	0.9746	0.0500	0.0000	http://www.mapress.com/zootaxa/support/author.html#Preparation%20of%20manuscripts	found in CSL metadata
+unified-style-sheet-for-linguistics-de-gruyter-literature	taylor-and-francis-chicago-author-date	0.9745	0.6000	0.0000		
+polish-archives-of-internal-medicine	ieee	0.9745	0.5000	0.0000	https://www.mp.pl/paim/for-authors/	found in CSL metadata
+revue-metis	elsevier-harvard	0.9745	0.0000	0.0000	https://www.anhima.fr/publications/revues/metis	found in CSL metadata
+science-china-materials	ieee	0.9745	0.5000	0.0000	https://www.sciengine.com/authorCenter/guide/Manuscript/XTQhzDPnrXRQMhhph	found in CSL metadata
+archaeonautica	elsevier-harvard	0.9744	0.1000	0.0000	https://journals.openedition.org/archaeonautica/279	found in CSL metadata
+bristol-university-press	elsevier-harvard	0.9744	0.6000	0.0000	https://bristoluniversitypressdigital.com/view/journals/evp/evp-overview.xml?tab_body=instructions-for-authors	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-ibid-classic	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-ibid-no-url	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-ibid	chicago-shortened-notes-bibliography	0.9744	0.9500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+cultivos-tropicales	elsevier-with-titles	0.9744	0.0000	0.0000	http://ediciones.inca.edu.cu/index.php/ediciones/pages/view/autores	found in CSL metadata
+universite-du-quebec-a-montreal	elsevier-harvard	0.9744	0.9000	0.0000	https://uqam-ca.libguides.com/lgb/zotero	found in CSL metadata
+eva-berlin-konferenz	ieee	0.9741	0.5000	0.0000	https://www.eva-berlin.de/en/participation/call-for-papers/	found in CSL metadata
+harvard-university-of-bath	taylor-and-francis-chicago-author-date	0.9740	0.1000	0.0000	https://library.bath.ac.uk/referencing/harvard-bath	found in CSL metadata
+waterbirds	springer-basic-author-date	0.9730	0.6000	0.0000	https://waterbirds.org/journal/information-for-contributors/	found in CSL metadata
+brazilian-journal-of-experimental-design-data-analysis-and-inferential-statistics	ieee	0.9728	0.0000	0.0000	https://bjedis.org/author-1	found in CSL metadata
+iso690-numeric-en	ieee	0.9728	0.0000	0.0000	https://forums.zotero.org/discussion/20342	found in CSL metadata
+rever-revista-de-estudos-da-religiao	elsevier-harvard	0.9728	0.6500	0.0000	http://revistas.pucsp.br/rever/about/editorialPolicies#custom-0	found in CSL metadata
+universite-du-quebec-a-montreal-prenoms	elsevier-harvard	0.9728	0.9000	0.0000	https://uqam-ca.libguides.com/etudes-feministes/citer-ses-sources	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-author-title-17th-edition	chicago-shortened-notes-bibliography	0.9728	0.9000	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+new-harts-rules-short-notes-no-url	chicago-shortened-notes-bibliography	0.9728	0.9000	0.0000		
+new-harts-rules-short-notes	chicago-shortened-notes-bibliography	0.9728	0.9000	0.0000		
+american-political-science-association	taylor-and-francis-chicago-author-date	0.9720	0.8500	0.0000	https://connect.apsanet.org/stylemanual/	found in CSL metadata
+journal-of-consumer-research	taylor-and-francis-chicago-author-date	0.9720	0.8500	0.0000	https://consumerresearcher.com/manuscript-preparation	found in CSL metadata
+politique-europeenne	taylor-and-francis-chicago-author-date	0.9720	0.1000	0.0000	http://politique-europeenne.eu/fr/	found in CSL metadata
+suomen-antropologi-journal-of-the-finnish-anthropological-society	taylor-and-francis-chicago-author-date	0.9720	0.6500	0.0000	https://journal.fi/suomenantropologi/about/submissions	found in CSL metadata
+uppsala-university-library-harvard	taylor-and-francis-chicago-author-date	0.9720	0.1000	0.0000	https://libguides-en.ub.uu.se/harvard	found in CSL metadata
+american-journal-of-archaeology	elsevier-harvard	0.9714	0.0000	0.0000	https://www.ajaonline.org/submissions/references	found in CSL metadata
+antiquity	springer-basic-author-date	0.9714	0.6000	0.0000	http://journal.antiquity.ac.uk/contribute	found in CSL metadata
+apa-numeric-superscript-brackets	ieee	0.9714	0.5000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references	found in CSL metadata
+apa-numeric-superscript	ieee	0.9714	0.0000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references	found in CSL metadata
+bio-protocol	elsevier-with-titles	0.9714	0.9500	0.0000	https://bio-protocol.org/en/authors?type=guidelines	found in CSL metadata
+china-national-standard-gb-t-7714-2015-numeric	elsevier-with-titles	0.9714	1.0000	0.0000	https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A	found in CSL metadata
+chinese-gb7714-1987-numeric	elsevier-with-titles	0.9714	0.0000	0.0000	https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D7B3D5D3A7E05397BE0A0AB82A	found in CSL metadata
+journal-of-industrial-ecology	elsevier-harvard	0.9714	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1530-9290/homepage/ForAuthors.html	found in CSL metadata
+netherlands-journal-of-geosciences-geologie-en-mijnbouw	elsevier-harvard	0.9714	0.9000	0.0000	https://www.cambridge.org/core/journals/netherlands-journal-of-geosciences/information/instructions-contributors	found in CSL metadata
+new-harts-rules-numbered	elsevier-with-titles	0.9714	0.0000	0.0000		
+antarctic-science	elsevier-harvard	0.9702	0.1000	0.0000	http://journals.cambridge.org/images/fileUpload/documents/ans_ifc.pdf	found in CSL metadata
+economic-geology	elsevier-harvard	0.9702	0.8000	0.0000	http://www.editorialmanager.com/seg/default.aspx	found in CSL metadata
+ethnobiology-and-conservation	elsevier-harvard	0.9702	0.1000	0.0000	https://ethnobioconservation.com/index.php/ebc/guide	found in CSL metadata
+iforest	elsevier-harvard	0.9702	0.0500	0.0000	http://www.sisef.it/iforest/users/?id=authors	found in CSL metadata
+journal-of-the-korean-society-of-civil-engineers	elsevier-harvard	0.9702	0.8500	0.0000	http://www.kscejournal.or.kr/plugins/sites/ksce/volume.html	found in CSL metadata
+journal-of-the-royal-society-of-western-australia	elsevier-harvard	0.9702	0.1000	0.0000	https://www.rswa.org.au/publications/RSWA%20Guide%20to%20authors%202019.pdf	found in CSL metadata
+ksce-journal-of-civil-engineering	elsevier-harvard	0.9702	0.8000	0.0000	http://www.springer.com/engineering/civil+engineering/journal/12205	found in CSL metadata
+molecular-microbiology	elsevier-harvard	0.9702	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2958/homepage/ForAuthors.html	found in CSL metadata
+neues-jahrbuch-fur-geologie-und-palaontologie	elsevier-harvard	0.9702	0.1000	0.0000	https://www.schweizerbart.de/journals/njgpa/instructions	found in CSL metadata
+polar-research	elsevier-harvard	0.9702	0.1000	0.0000	https://polarresearch.net/index.php/polar/author	found in CSL metadata
+springer-humanities-brackets	elsevier-with-titles	0.9702	0.7500	0.0000	www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_Aug2012.pdf	found in CSL metadata
+terra-nova	elsevier-harvard	0.9702	0.8000	1.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-3121/homepage/ForAuthors.html	found in CSL metadata
+the-journal-of-egyptian-archaeology	elsevier-harvard	0.9702	0.0000	0.0000	https://www.ees.ac.uk/writing-for-the-jea	found in CSL metadata
+uppsala-universitet-institutionen-for-biologisk-grundutbildning	elsevier-harvard	0.9702	0.0500	0.0000	http://www.ibg.uu.se/student/service/referenshantering	found in CSL metadata
+utah-geological-survey	elsevier-harvard	0.9702	0.8000	0.0000	http://files.geology.utah.gov/online/c/c-105.pdf	found in CSL metadata
+wiesbaden-business-school	elsevier-harvard	0.9702	0.0500	0.0000	https://www.hs-rm.de/fileadmin/user_upload/Leitfaden_Thesis_IBA.pdf	found in CSL metadata
+economic-commission-for-latin-america-and-the-caribbean	taylor-and-francis-chicago-author-date	0.9692	0.0500	0.0000	http://www.eclac.org	found in CSL metadata
+fishery-bulletin	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000	http://fishbull.noaa.gov/fguide.htm	found in CSL metadata
+journal-of-agricultural-and-applied-economics	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000	https://www.cambridge.org/core/journals/journal-of-agricultural-and-applied-economics/information/instructions-contributors	found in CSL metadata
+journal-on-efficiency-and-responsibility-in-education-and-science	taylor-and-francis-chicago-author-date	0.9692	0.0500	0.0000	https://www.eriesjournal.com/index.php/eries/about/submissions	found in CSL metadata
+radiopaedia	american-medical-association	0.9692	0.9500	0.0000	http://radiopaedia.org/articles/references-1	found in CSL metadata
+societes-contemporaines	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000	https://www.cairn.info/revue-societes-contemporaines.htm?contenu=apropos	found in CSL metadata
+stanovnistvo	taylor-and-francis-chicago-author-date	0.9692	0.5500	0.0000	https://www.idn.org.rs/ojs3/stanovnistvo/index.php/STNV/about/submissions	found in CSL metadata
+unesco-international-institute-for-educational-planning	taylor-and-francis-chicago-author-date	0.9692	0.1000	0.0000	https://box.iiep.unesco.org/s/od697NSMAiocAKX	found in CSL metadata
+universidade-federal-de-pernambuco-abnt	taylor-and-francis-chicago-author-date	0.9685	0.0500	0.0000	https://github.com/citation-style-language/styles/pull/4798#issuecomment-629918226	found in CSL metadata
+harvard-york-st-john-university	taylor-and-francis-chicago-author-date	0.9684	0.6000	0.0000	https://www.yorksj.ac.uk/ils/searchsuccess/harvardref/	found in CSL metadata
+advanced-engineering-materials	elsevier-with-titles	0.9683	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291527-2648/homepage/2266_forauthors.html	found in CSL metadata
+advanced-healthcare-materials	elsevier-with-titles	0.9683	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)2192-2659/homepage/2087_authorresources.html	found in CSL metadata
+advanced-materials	elsevier-with-titles	0.9683	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/15214095/homepage/author-guidelines	found in CSL metadata
+advanced-optical-materials	elsevier-with-titles	0.9683	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)2195-1071/homepage/2298_forauthors.html	found in CSL metadata
+american-physical-society-et-al	elsevier-with-titles	0.9683	1.0000	0.0000	https://cdn.journals.aps.org/files/styleguide-pr.pdf	found in CSL metadata
+andean-geology	elsevier-harvard	0.9683	0.9000	0.0000	http://www.andeangeology.cl/index.php/revista1/about/submissions	found in CSL metadata
+angewandte-chemie	elsevier-with-titles	0.9683	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/15213773/homepage/notice-to-authors	found in CSL metadata
+arkivoc	elsevier-with-titles	0.9683	0.0000	0.0000	https://www.arkat-usa.org/arkivoc-journal/instructions-papers/#2.2.16	found in CSL metadata
+chemical-engineering-technology	elsevier-with-titles	0.9683	0.7500	0.0000	https://onlinelibrary.wiley.com/page/journal/15214125/homepage/2044_forauthors.html	found in CSL metadata
+chemie-ingenieur-technik	elsevier-with-titles	0.9683	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1522-2640/homepage/2004_forauthors.html	found in CSL metadata
+critical-reviews-in-solid-state-and-materials-sciences	elsevier-with-titles	0.9683	0.0000	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=bsms20#refs	found in CSL metadata
+e3s-web-of-conferences	elsevier-with-titles	0.9683	1.0000	0.0000	https://www.e3s-conferences.org/doc_journal/woc/woc_1col.doc	found in CSL metadata
+ecoscience	elsevier-harvard	0.9683	0.0500	1.0000	http://www.ecoscience.ulaval.ca/en	found in CSL metadata
+elsevier-without-titles	elsevier-with-titles	0.9683	1.0000	0.0000	http://www.elsevier.com/journals/the-journal-of-chemical-thermodynamics/0021-9614/guide-for-authors#68000	found in CSL metadata
+flavour-and-fragrance-journal	elsevier-with-titles	0.9683	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1026/homepage/ForAuthors.html#Ref	found in CSL metadata
+harvard-london-south-bank-university	elsevier-harvard	0.9683	0.9000	0.0000	https://my.lsbu.ac.uk/my/applicant/Current-Applicants/Library/How-to-guides	found in CSL metadata
+health-sciences-university-uco-school-of-osteopathy	elsevier-harvard	0.9683	0.5500	0.0000	https://github.com/user-attachments/files/21712084/Full-Reference-Guide-New.pdf	found in CSL metadata
+hystrix-the-italian-journal-of-mammalogy	elsevier-harvard	0.9683	0.9000	0.0000	http://www.italian-journal-of-mammalogy.it/Instructions-for-Authors,693.html	found in CSL metadata
+indian-journal-of-physics	elsevier-with-titles	0.9683	1.0000	0.0000	https://www.editorialmanager.com/injp/default.aspx	found in CSL metadata
+international-journal-of-electrochemical-science	elsevier-with-titles	0.9683	1.0000	0.0000	http://www.electrochemsci.org/instruction.htm	found in CSL metadata
+international-journal-of-quantum-chemistry	elsevier-with-titles	0.9683	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-461X	found in CSL metadata
+international-pig-veterinary-society-congress-proceedings	elsevier-with-titles	0.9683	0.0000	0.0000	http://vw.theipvs.com/	found in CSL metadata
+iso690-numeric-lt	elsevier-with-titles	0.9683	0.9500	0.0000	http://www.kf.vu.lt/uploads/docs/Studiju%20dokumentai/metodiniai_nurodymai090204.pdf	found in CSL metadata
+iso690-numeric-sk	elsevier-with-titles	0.9683	0.9500	0.0000	http://vili.uniba.sk/AK/citovanie_priklady.pdf	found in CSL metadata
+japanese-journal-of-applied-physics	elsevier-with-titles	0.9683	0.0000	0.0000	https://iopscience.iop.org/journal/1347-4065/page/Author_Guidelines	found in CSL metadata
+journal-of-anatomy	elsevier-harvard	0.9683	0.9000	0.0000	https://onlinelibrary.wiley.com/page/journal/14697580/homepage/forauthors.html	found in CSL metadata
+journal-of-aoac-international	elsevier-with-titles	0.9683	0.0000	0.0000	http://www.aoac.org/aoac_prod_imis/AOAC/AOAC_Member/PUBSCF/JAOACCF/JN_M.aspx	found in CSL metadata
+journal-of-avian-biology	springer-basic-author-date	0.9683	0.6000	0.0000	http://www.avianbiology.org/authors/author-guidelines	found in CSL metadata
+journal-of-biosciences	springer-basic-author-date	0.9683	0.7000	0.0000	https://www.springer.com/life+sciences/journal/12038	found in CSL metadata
+journal-of-industrial-and-engineering-chemistry	elsevier-with-titles	0.9683	1.0000	0.0000	http://www.elsevier.com/journals/journal-of-industrial-and-engineering-chemistry/1226-086X/guide-for-authors	found in CSL metadata
+journal-of-integrated-omics	elsevier-with-titles	0.9683	1.0000	0.0000	http://www.jiomics.com/ojs/index.php/jio/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-materials-research	elsevier-with-titles	0.9683	0.0000	0.0000	http://www.mrs.org/jmr-format	found in CSL metadata
+journal-of-polymer-science-part-a-polymer-chemistry	elsevier-with-titles	0.9683	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1099-0518/homepage/ForAuthors.html#anchor53	found in CSL metadata
+journal-of-raman-spectroscopy	elsevier-with-titles	0.9683	1.0000	0.0000	http://www.zotero.org/styles/royal-society-of-chemistry	found in CSL metadata
+journal-of-small-animal-practice	elsevier-harvard	0.9683	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/17485827/homepage/ForAuthors.html	found in CSL metadata
+journal-of-the-electrochemical-society	elsevier-with-titles	0.9683	0.0000	0.0000	http://www.electrochem.org/dl/support/assets/jes_inst.pdf	found in CSL metadata
+journal-of-the-serbian-chemical-society	elsevier-with-titles	0.9683	0.0000	0.0000	http://www.shd-pub.org.rs/index.php/JSCS/about/submissions#authorGuidelines	found in CSL metadata
+macromolecular-reaction-engineering	elsevier-with-titles	0.9683	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1862-8338/homepage/2465_authors.html	found in CSL metadata
+mcdonald-institute-monographs	elsevier-harvard	0.9683	0.0500	0.0000	http://www.mcdonald.cam.ac.uk/publications/publication-images/mcd-instructions	found in CSL metadata
+molecular-nutrition-and-food-research	elsevier-with-titles	0.9683	1.0000	0.0000	https://onlinelibrary.wiley.com/page/journal/16134133/homepage/2216_forauthors.html#refs	found in CSL metadata
+nature-neuroscience-brief-communications	elsevier-with-titles	0.9683	0.0000	0.0000	http://www.nature.com/neuro/authors/submit/index.html#manuscript	found in CSL metadata
+new-zealand-veterinary-journal	elsevier-harvard	0.9683	0.1000	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=tnzv20#peer_review_style_guidelines	found in CSL metadata
+oikos	springer-basic-author-date	0.9683	0.6000	0.0000	http://www.oikos.ekol.lu.se/	found in CSL metadata
+optics-letters	elsevier-with-titles	0.9683	1.0000	0.0000	https://www.osapublishing.org/submit/templates/wordwp/OL_legacy.docx	found in CSL metadata
+plant-and-cell-physiology	elsevier-harvard	0.9683	1.0000	0.0000	https://academic.oup.com/pcp/pages/General_Instructions_To_Authors	found in CSL metadata
+quaderni-degli-avogadro-colloquia	elsevier-with-titles	0.9683	1.0000	0.0000	http://www.soc.chim.it/it/avogadro_colloquia	found in CSL metadata
+small	elsevier-with-titles	0.9683	1.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1613-6829/homepage/2296_authors.html	found in CSL metadata
+springer-physics-brackets	elsevier-with-titles	0.9683	1.0000	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf	found in CSL metadata
+synthesis	elsevier-with-titles	0.9683	0.0000	0.0000	https://www.thieme.de/de/synthesis/author-guidelines-58874.htm	found in CSL metadata
+taylor-and-francis-aip	elsevier-with-titles	0.9683	0.6500	0.0000	http://www.tandf.co.uk/journals/authors/style/reference/tf_O.pdf	found in CSL metadata
+tetrahedron-letters	elsevier-with-titles	0.9683	0.0000	0.0000	https://www.elsevier.com/journals/tetrahedron-letters/0040-4039/guide-for-authors	found in CSL metadata
+transactions-of-the-materials-research-society-of-japan	elsevier-with-titles	0.9683	1.0000	0.0000	http://mc.manuscriptcentral.com/mrsj	found in CSL metadata
+wader-study	springer-basic-author-date	0.9683	0.6000	0.0000	http://www.waderstudygroup.org/wader-study/wader-study-author-guidelines/	found in CSL metadata
+chicago-author-date-fr	taylor-and-francis-chicago-author-date	0.9670	0.8000	0.0000	http://guides.bib.umontreal.ca/disciplines/483-Citer-selon-le-style-Chicago?tab=2189	found in CSL metadata
+animal-conservation	elsevier-harvard	0.9668	0.8500	0.0000	https://zslpublications.onlinelibrary.wiley.com/hub/journal/14691795/about/author-guidelines	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-ufrgs-initials	elsevier-harvard	0.9668	0.7500	0.0000	https://www.ufrgs.br/bibliotecas/ferramentas/campos-basicos-abnt-mendeley	found in CSL metadata
+babesch-annual-papers-on-mediterranean-archaeology	elsevier-harvard	0.9668	0.0000	0.0000	https://www.babesch.org/instructions.html	found in CSL metadata
+biological-journal-of-the-linnean-society	springer-basic-author-date	0.9668	0.1500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1095-8312/homepage/ForAuthors.html	found in CSL metadata
+biological-reviews	elsevier-harvard	0.9668	0.8500	0.0000	https://onlinelibrary.wiley.com/page/journal/1469185x/homepage/ForAuthors.html	found in CSL metadata
+carolinea	springer-basic-author-date	0.9668	0.6000	0.0000		
+creativity-and-innovation-management	elsevier-harvard	0.9668	0.9000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291467-8691/homepage/ForAuthors.html	found in CSL metadata
+journal-of-remote-sensing	springer-basic-author-date	0.9668	0.1500	0.0000	https://spj.science.org/page/remotesensing/for-authors	found in CSL metadata
+la-trobe-university-harvard	elsevier-harvard	0.9668	0.1000	0.0000	http://www.lib.latrobe.edu.au/referencing-tool/harvard	found in CSL metadata
+peerj	springer-basic-author-date	0.9668	0.1500	0.0000	https://peerj.com/about/author-instructions/	found in CSL metadata
+philippine-journal-of-natural-sciences	springer-basic-author-date	0.9668	0.1500	0.0000	https://pjns.upv.edu.ph/authors-guide/	found in CSL metadata
+sunway-college-johor-bahru	elsevier-harvard	0.9668	0.1000	0.0000	http://www.sunway.edu.my/jb/images/library/Sunway%20JB%20Guide%20to%20Harvard%20Referencing_20150529.pdf	found in CSL metadata
+universidade-federal-de-sergipe-departamento-de-engenharia-de-producao-abnt	elsevier-harvard	0.9668	0.8500	0.0000	http://depro.ufs.br/pagina/22237	found in CSL metadata
+universiti-kebangsaan-malaysia	elsevier-harvard	0.9668	0.0500	0.0000	http://www.ukm.my/pusatsiswazah/templat-gayaukm/	found in CSL metadata
+university-of-south-australia-2017-harvard	elsevier-harvard	0.9668	0.1000	0.0000	https://www.library.unisa.edu.au/referencing-roadmap/	found in CSL metadata
+university-of-south-australia-harvard-2011	elsevier-harvard	0.9668	0.1000	0.0000	http://www.unisa.edu.au/ltu/students/study/referencing/harvard.pdf	found in CSL metadata
+university-of-south-australia-harvard-2013	elsevier-harvard	0.9668	0.1000	0.0000	http://www.unisa.edu.au/ltu/students/study/referencing/harvard.pdf	found in CSL metadata
+victoria-university-harvard	elsevier-harvard	0.9668	0.1000	0.0000	http://libraryguides.vu.edu.au/harvard	found in CSL metadata
+acta-universitatis-agriculturae-sueciae	elsevier-harvard	0.9667	0.0500	0.0000	https://www.slu.se/en/library/write--cite/cite/in-text-citations-using-the-slu-harvard-style/	found in CSL metadata
+clay-minerals	elsevier-harvard	0.9667	0.5500	0.0000	http://www.minersoc.org/submit-cm.html	found in CSL metadata
+clays-and-clay-minerals	elsevier-harvard	0.9667	0.5500	0.0000	http://www.clays.org/JOURNAL/CCMjournsubm.html	found in CSL metadata
+clinical-oral-implants-research	elsevier-harvard	0.9667	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291600-0501/homepage/ForAuthors.html	found in CSL metadata
+global-ecology-and-biogeography	elsevier-harvard	0.9667	0.5000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291466-8238/homepage/ForAuthors.html	found in CSL metadata
+inter-research-science-center	elsevier-harvard	0.9667	0.0500	0.0000	https://www.int-res.com/journals/guidelines-for-authors/guidelines-authors/	found in CSL metadata
+mineralogical-magazine	elsevier-harvard	0.9667	0.5500	0.0000	http://www.minersoc.org/submit-mm.html	found in CSL metadata
+neuroendocrinology-letters	elsevier-harvard	0.9667	0.0500	0.0000	http://www.nel.edu/instructions.htm	found in CSL metadata
+veterinary-anaesthesia-analgesia	elsevier-harvard	0.9667	0.0500	0.0000	https://www.sciencedirect.com/journal/veterinary-anaesthesia-and-analgesia/publish/guide-for-authors	found in CSL metadata
+ingenieria-agricola	elsevier-harvard	0.9664	0.5000	0.0000	http://www.actaf.co.cu/revistas/Revista%20IAGRIC/normasedito.pdf	found in CSL metadata
+revista-ciencias-tecnicas-agropecuarias	elsevier-harvard	0.9664	0.5000	0.0000	http://www.rcta.unah.edu.cu/public/journals/1/Normas_asiento_bibliogr%C3%A1fico.pdf	found in CSL metadata
+international-journal-of-polymeric-materials-and-polymeric-biomaterials	elsevier-with-titles	0.9660	0.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=gpom20	found in CSL metadata
+materials-express	elsevier-with-titles	0.9660	1.0000	0.0000	http://www.aspbs.com/mex/inst-auth_mex.htm	found in CSL metadata
+metallurgical-and-materials-transactions-a	elsevier-with-titles	0.9660	1.0000	0.0000	http://www.springer.com/materials/special+types/journal/11663	found in CSL metadata
+metallurgical-and-materials-transactions	elsevier-with-titles	0.9660	1.0000	0.0000	http://www.tms.org/pubs/journals/MT/MTauthorguide.aspx	found in CSL metadata
+philippika	elsevier-harvard	0.9660	0.0000	0.0000	http://www.harrassowitz-verlag.de/category_281.ahtml	found in CSL metadata
+royal-society-of-chemistry-with-titles	elsevier-with-titles	0.9660	0.0000	0.0000	http://www.rsc.org/learn-chemistry/resource/download/res00001664/cmp00004956/pdf	found in CSL metadata
+royal-society-of-chemistry	elsevier-with-titles	0.9660	0.0000	0.0000	http://www.rsc.org/learn-chemistry/resource/download/res00001664/cmp00004956/pdf	found in CSL metadata
+l-homme-english	elsevier-harvard	0.9646	0.0500	0.0000	http://www.editions.ehess.fr/revues/lhomme/	found in CSL metadata
+journal-of-porphyrins-and-phthalocyanines	american-medical-association	0.9643	0.0000	0.0000	https://www.worldscientific.com/page/jpp/submission-guidelines	found in CSL metadata
+science-china-chemistry	american-medical-association	0.9643	0.0000	0.0000	http://engine.scichina.com/authorCenter/guide/Manuscript/FTxe43yy66E6x8JT6	found in CSL metadata
+american-sociological-association	taylor-and-francis-chicago-author-date	0.9641	0.5500	0.0000	https://www.asanet.org/publications/journals/asa-style-guide/	found in CSL metadata
+javnost-the-public	taylor-and-francis-chicago-author-date	0.9641	0.7500	0.0000	http://www.javnost-thepublic.org/notes-for-authors/	found in CSL metadata
+modern-chinese-literature-and-culture	taylor-and-francis-chicago-author-date	0.9641	0.5500	0.0000	https://u.osu.edu/mclc/journal/submissions/	found in CSL metadata
+zeitschrift-fur-religionswissenschaft-author-date	taylor-and-francis-chicago-author-date	0.9641	0.7000	0.0000		
+st-patricks-college	elsevier-harvard	0.9637	0.6000	0.0000	https://github.com/citation-style-language/styles/pull/370	found in CSL metadata
+mexicon	elsevier-harvard	0.9634	0.0500	0.0000	https://mexicon.de/styleguide/	found in CSL metadata
+annals-of-botany	springer-basic-author-date	0.9634	0.6000	0.0000	https://academic.oup.com/aob/pages/general_instructions	found in CSL metadata
+asia-and-the-pacific-policy-studies	springer-basic-author-date	0.9634	0.8000	1.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%292050-2680/homepage/ForAuthors.html	found in CSL metadata
+entomologia-experimentalis-et-applicata	springer-basic-author-date	0.9634	0.1500	1.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291570-7458/homepage/ForAuthors.html	found in CSL metadata
+forensic-anthropology	springer-basic-author-date	0.9634	0.5500	0.0000	http://journals.upress.ufl.edu/fa/guidelines	found in CSL metadata
+geophysical-journal-international	springer-basic-author-date	0.9634	0.8500	0.0000	https://academic.oup.com/gji/pages/General_Instructions?login=false#Preparation%20of%20Manuscripts	found in CSL metadata
+hydrological-sciences-journal	springer-basic-author-date	0.9634	0.1000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=thsj&amp;page=instructions	found in CSL metadata
+international-journal-of-wildland-fire	springer-basic-author-date	0.9634	0.6000	1.0000	http://www.publish.csiro.au/nid/117/aid/424.htm	found in CSL metadata
+journal-of-interactive-media-in-education-harvard	springer-basic-author-date	0.9634	0.5500	0.0000	https://jime.open.ac.uk/about/submissions	found in CSL metadata
+journal-of-new-zealand-grasslands	springer-basic-author-date	0.9634	0.5500	0.0000	https://www.nzgajournal.org.nz/index.php/JoNZG/about/submissions	found in CSL metadata
+journal-of-the-american-water-resources-association	springer-basic-author-date	0.9634	0.1500	0.0000	http://www.awra.org/jawra/citationexamples.html	found in CSL metadata
+monash-university-csiro	springer-basic-author-date	0.9634	0.6000	0.0000	https://guides.lib.monash.edu/citing-referencing/csiro	found in CSL metadata
+new-zealand-plant-protection	springer-basic-author-date	0.9634	0.5500	0.0000	http://www.nzpps.org/conference.php?pg=authorship	found in CSL metadata
+reproduction-fertility-and-development	springer-basic-author-date	0.9634	0.6000	0.0000	http://www.publish.csiro.au/rd/forauthors/AuthorInstructions#13	found in CSL metadata
+rose-school	springer-basic-author-date	0.9634	0.0000	0.0000	http://forums.zotero.org/discussion/18066/style-request-rose-school-iuss-italy/	found in CSL metadata
+the-australian-journal-of-agricultural-and-resource-economics	springer-basic-author-date	0.9634	0.8000	0.0000	https://onlinelibrary.wiley.com/page/journal/14678489/homepage/forauthors.html#5	found in CSL metadata
+the-biological-bulletin	springer-basic-author-date	0.9634	0.1000	0.0000	http://www.biolbull.org/site/misc/ifora.xhtml#references	found in CSL metadata
+water-environment-research	springer-basic-author-date	0.9634	0.1000	0.0000	http://www.wef.org/Publications/page.aspx?id=2834#references	found in CSL metadata
+glossa	taylor-and-francis-chicago-author-date	0.9629	0.6000	0.0000	http://www.glossa-journal.org/about/submissions/#Style%20sheet	found in CSL metadata
+haute-ecole-de-gestion-de-geneve-iso-690	taylor-and-francis-chicago-author-date	0.9629	0.6500	0.0000	https://www.hesge.ch/heg/campus/infotheque/citations-et-references-bibliographiques	found in CSL metadata
+instituto-de-investigaciones-sobre-la-universidad-y-la-educacion-moderno	taylor-and-francis-chicago-author-date	0.9629	0.0500	0.0000	http://www.iisue.unam.mx/iisue/avisos/pautas-editoriales-del-IISUE.pdf	found in CSL metadata
+acta-universitatis-agriculturae-et-silviculturae-mendelianae-brunensis	elsevier-harvard	0.9626	0.9000	0.0000	https://acta.mendelu.cz/for-authors.html	found in CSL metadata
+american-association-of-petroleum-geologists	elsevier-harvard	0.9626	0.8500	0.0000	http://deg.aapg.org/Portals/0/documents/DEG_ALL.pdf	found in CSL metadata
+american-geophysical-union	elsevier-harvard	0.9626	0.9000	0.0000	http://publications.agu.org/brief-guide-agu-style-grammar/	found in CSL metadata
+american-society-of-agricultural-and-biological-engineers	elsevier-harvard	0.9626	0.9000	0.0000	http://www.asabe.org/media/59251/asabe_guide_for_authors.pdf	found in CSL metadata
+annalen-des-naturhistorischen-museums-in-wien	elsevier-harvard	0.9626	0.0500	0.0000	http://www.nhm-wien.ac.at/jart/prj3/nhm/data/uploads/archiv_annalen/Instructions_2011.pdf	found in CSL metadata
+arts-university-bournemouth	elsevier-harvard	0.9626	0.8000	0.0000	http://www.aublibrary.info/index.php/referencing	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-ufpr	elsevier-harvard	0.9626	0.0000	0.0000	https://forums.zotero.org/discussion/1464/insert-abnt-citation-style/?Focus=67797#Comment_67797	found in CSL metadata
+associacao-nacional-de-pesquisa-e-ensino-em-transportes	elsevier-harvard	0.9626	0.9500	0.0000	http://www.anpet.ufsc.br/ssat/interface/content/autor/arquivos/formato_trabalhos.pdf	found in CSL metadata
+biomarkers	elsevier-harvard	0.9626	0.1000	1.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=ibmk20#references	found in CSL metadata
+bulletin-of-the-seismological-society-of-america	elsevier-harvard	0.9626	0.8500	0.0000	https://www.seismosoc.org/publications/bssa-submission-guidelines/	found in CSL metadata
+bursa-uludag-universitesi-egitim-bilimleri-enstitusu	elsevier-harvard	0.9626	0.9000	0.0000	http://www.uludag.edu.tr/dosyalar/egitimbilimleri/tez_yazim_kurallari_Mart_2016_D%C3%BCzeltme.pdf	found in CSL metadata
+ceska-zemedelska-univerzita-v-praze-fakulta-agrobiologie-potravinovych-a-prirodnich-zdroju	elsevier-harvard	0.9626	0.9000	0.0000	http://studium.agrobiologie.cz/Nastenka_studijniho_oddeleni/Bakalarske_a_diplomove_prace/Zavazna_pravidla_citace_seznamy_pouzite_literatury.pdf	found in CSL metadata
+clinical-dysmorphology	elsevier-harvard	0.9626	0.8500	0.0000	http://journals.lww.com/clindysmorphol/_layouts/15/1033/oaks.journals/informationforauthors.aspx	found in CSL metadata
+earthquake-spectra	elsevier-harvard	0.9626	0.9500	1.0000	http://earthquakespectra.org/	found in CSL metadata
+emerald-harvard	elsevier-harvard	0.9626	0.9500	0.0000	https://www.emeraldgrouppublishing.com/use-harvard-reference-system	found in CSL metadata
+eu-interinstitutional-style	elsevier-harvard	0.9626	0.9500	0.0000	https://style-guide.europa.eu/en/home	found in CSL metadata
+european-journal-of-political-research	elsevier-harvard	0.9626	0.9500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291475-6765/homepage/ForAuthors.html	found in CSL metadata
+european-journal-of-taxonomy	elsevier-harvard	0.9626	0.0500	0.0000	https://europeanjournaloftaxonomy.eu/index.php/ejt/about/editorialPolicies#custom-1	found in CSL metadata
+florida-entomologist	elsevier-harvard	0.9626	0.0500	0.0000	http://www.flaentsoc.org/auinstr.shtml	found in CSL metadata
+french-politics	elsevier-harvard	0.9626	0.9500	0.0000	http://www.palgrave-journals.com/fp/author_instructions.html	found in CSL metadata
+freshwater-crayfish	elsevier-harvard	0.9626	0.0500	0.0000	http://www.freshwatercrayfish.org/fc.asp?uid=Guest	found in CSL metadata
+harvard-bournemouth-university	elsevier-harvard	0.9626	0.1000	1.0000	https://libguides.bournemouth.ac.uk/ld.php?content_id=33139758	found in CSL metadata
+harvard-university-of-exeter-geography	elsevier-harvard	0.9626	0.9500	0.0000	https://geography.exeter.ac.uk/media/universityofexeter/schoolofgeography/pdfs/currentstudents/Referencing_and_Style_Guide.pdf	found in CSL metadata
+health-education-england-harvard	elsevier-harvard	0.9626	0.1000	1.0000	https://libguides.bournemouth.ac.uk/bu-referencing-harvard-style/pdf-guide	found in CSL metadata
+heredity	elsevier-harvard	0.9626	0.8500	0.0000	http://mts-hdy.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions	found in CSL metadata
+housing-studies	elsevier-harvard	0.9626	0.9000	0.0000	https://www.tandf.co.uk//journals/authors/style/layout/style_chos.pdf	found in CSL metadata
+international-development-policy	elsevier-harvard	0.9626	0.5500	0.0000	https://poldev.revues.org/2085?file=1	found in CSL metadata
+international-journal-of-language-and-communication-disorders	elsevier-harvard	0.9626	0.1000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1460-6984/homepage/ForAuthors.html#Manuscript_Components	found in CSL metadata
+international-journal-of-urban-and-regional-research	elsevier-harvard	0.9626	0.9000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1468-2427/homepage/ForAuthors.html	found in CSL metadata
+internet-archaeology	elsevier-harvard	0.9626	0.1000	0.0000	https://intarch.ac.uk/authors/index.html	found in CSL metadata
+journal-of-information-technology	elsevier-harvard	0.9626	0.9500	0.0000	http://www.palgrave-journals.com/jit/author_instructions.html#Preparation-of-manuscripts	found in CSL metadata
+journal-of-intercultural-studies	elsevier-harvard	0.9626	0.0500	1.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=cjis20	found in CSL metadata
+journal-of-psychiatric-and-mental-health-nursing	elsevier-harvard	0.9626	0.9500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2850/homepage/ForAuthors.html	found in CSL metadata
+journal-of-studies-on-alcohol-and-drugs	elsevier-harvard	0.9626	0.9500	0.0000	http://www.jsad.com/jsad/static/instructions.html	found in CSL metadata
+journal-of-the-marine-biological-association-of-the-united-kingdom	elsevier-harvard	0.9626	0.8500	0.0000	http://assets.cambridge.org/MBI/MBI_ifc.pdf	found in CSL metadata
+journal-of-vegetation-science	elsevier-harvard	0.9626	0.8000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1654-1103/homepage/ForAuthors.html	found in CSL metadata
+karlstad-universitet-harvard	elsevier-harvard	0.9626	0.0500	0.0000	https://www.libguides.kau.se/harvard	found in CSL metadata
+kth-royal-institute-of-technology-school-of-computer-science-and-communication-sv	elsevier-harvard	0.9626	0.6000	1.0000	http://www.nada.kth.se/utbildning/grukth/exjobb/dokument/rapportmall.doc	found in CSL metadata
+kth-royal-institute-of-technology-school-of-computer-science-and-communication	elsevier-harvard	0.9626	0.6000	1.0000	http://www.nada.kth.se/utbildning/grukth/exjobb/dokument/rapportmalleng.doc	found in CSL metadata
+mis-quarterly	elsevier-harvard	0.9626	0.1000	0.0000	http://www.misq.org/manuscript-guidelines	found in CSL metadata
+new-zealand-journal-of-forestry-science	elsevier-harvard	0.9626	0.1000	0.0000	http://nzjforestryscience.nz/index.php/nzjfs/about/submissions#authorGuidelines	found in CSL metadata
+ocean-and-coastal-research	elsevier-harvard	0.9626	0.8500	0.0000	http://www.ocr-journal.org/index.php/instructions-for-authors	found in CSL metadata
+oral-diseases	elsevier-harvard	0.9626	0.8500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291601-0825/homepage/ForAuthors.html	found in CSL metadata
+oryx	elsevier-harvard	0.9626	0.9000	0.0000	http://www.oryxthejournal.org/files_for_linking/OryxInstructionsForContributors.pdf	found in CSL metadata
+palaeontographica-abteilung-b-palaeobotany-palaeophytology	elsevier-harvard	0.9626	0.0500	0.0000	https://www.schweizerbart.de/journals/palb/instructions	found in CSL metadata
+polytechnique-montreal-apa	elsevier-harvard	0.9626	0.8500	0.0000	https://guides.biblio.polymtl.ca/citer_apa7	found in CSL metadata
+preslia	elsevier-harvard	0.9626	0.0500	0.0000	http://www.preslia.cz/guide.html	found in CSL metadata
+production-and-operations-management	elsevier-harvard	0.9626	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/19375956/homepage/forauthors.html	found in CSL metadata
+pure-and-applied-geophysics	elsevier-harvard	0.9626	0.9000	0.0000	https://www.springer.com/birkhauser/geo+science/journal/24?detailsPage=pltci_3078163	found in CSL metadata
+queen-margaret-university-harvard	elsevier-harvard	0.9626	0.1000	0.0000	https://libguides.qmu.ac.uk/ld.php?content_id=26019494	found in CSL metadata
+raffles-bulletin-of-zoology	elsevier-harvard	0.9626	0.8500	0.0000	https://lkcnhm.nus.edu.sg/publications/raffles-bulletin-of-zoology/instructions-to-authors/	found in CSL metadata
+review-of-political-economy	elsevier-harvard	0.9626	0.1000	0.0000	https://www.tandfonline.com/action/authorSubmission?journalCode=crpe20&amp;page=instructions#mp_style	found in CSL metadata
+revista-de-biologia-marina-y-oceanografia	elsevier-harvard	0.9626	0.0500	0.0000	https://revbiolmar.uv.cl/Instructions%202019.pdf	found in CSL metadata
+science-and-technology-for-the-built-environment	elsevier-harvard	0.9626	0.0500	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=uhvc21&amp;page=instructions	found in CSL metadata
+scientific-review-engineering-and-environmental-sciences	elsevier-harvard	0.9626	0.9000	0.0000	http://iks_pn.sggw.pl/Instruction_PN_2016a.pdf	found in CSL metadata
+seismological-research-letters	elsevier-harvard	0.9626	0.8500	0.0000	https://www.seismosoc.org/publications/srl-authorsinfo/	found in CSL metadata
+sinergie-italian-journal-of-management	elsevier-harvard	0.9626	0.1000	0.0000	https://www.sijm.it/author-guidelines/	found in CSL metadata
+soil-science-and-plant-nutrition	elsevier-harvard	0.9626	0.9000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=tssp20&amp;page=instructions#.U6jU9P538jg	found in CSL metadata
+solent-university-harvard	elsevier-harvard	0.9626	0.1000	0.0000	https://portal.solent.ac.uk/library/help/factsheets/resources/referencing-harvard.pdf	found in CSL metadata
+springer-socpsych-author-date	elsevier-harvard	0.9626	0.1000	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/instruct-authors-e.pdf	found in CSL metadata
+sylwan	elsevier-harvard	0.9626	0.0000	0.0000	https://sylwan.lasy.gov.pl/apex/f?p=105:6	found in CSL metadata
+taylor-and-francis-harvard-x	elsevier-harvard	0.9626	0.1000	1.0000	http://www.tandf.co.uk/journals/authors/style/reference/tf_X.pdf	found in CSL metadata
+the-depositional-record	elsevier-harvard	0.9626	0.9000	0.0000	https://onlinelibrary.wiley.com/page/journal/20554877/homepage/forauthors.html	found in CSL metadata
+the-journal-of-the-torrey-botanical-society	elsevier-harvard	0.9626	0.0500	0.0000	http://www.bioone.org/page/tbot/authors	found in CSL metadata
+the-open-university-harvard	elsevier-harvard	0.9626	0.8000	0.0000	http://www.open.ac.uk/library/help-and-support/referencing-and-plagiarism	found in CSL metadata
+the-open-university-s390	elsevier-harvard	0.9626	0.8000	0.0000	http://www.open.ac.uk/libraryservices/documents/Harvard_citation_hlp.pdf	found in CSL metadata
+universite-de-montreal-apa	elsevier-harvard	0.9626	0.8500	0.0000	https://bib.umontreal.ca/citer/styles-bibliographiques/apa	found in CSL metadata
+universite-de-sherbrooke-departement-de-geomatique	elsevier-harvard	0.9626	0.9000	0.0000	http://www.usherbrooke.ca/geomatique/fileadmin/sites/geomatique/espace-etudiant/guide-redaction2004.pdf	found in CSL metadata
+university-of-aberdeen-school-of-education-harvard	elsevier-harvard	0.9626	0.1000	0.0000	https://www.abdn.ac.uk/library/documents/guides/ugedu010.pdf	found in CSL metadata
+acm-siggraph	elsevier-harvard	0.9623	0.0000	0.0000	http://www.siggraph.org/publications/instructions.pdf	found in CSL metadata
+brain-behavior-and-evolution	elsevier-harvard	0.9623	0.0000	0.0000	https://www.karger.com/Journal/Guidelines/223831#06	found in CSL metadata
+journal-of-animal-science	elsevier-harvard	0.9623	0.5000	0.0000	https://www.animalsciencepublications.org/publications/jas/infora	found in CSL metadata
+karger-journals-author-date	elsevier-harvard	0.9623	0.0000	0.0000	http://www.karger.com/Journal/Guidelines/224213#04	found in CSL metadata
+sexual-development	elsevier-harvard	0.9623	0.0000	0.0000	http://www.karger.com/Journal/Guidelines/231547#07	found in CSL metadata
+the-company-of-biologists	elsevier-harvard	0.9623	0.5500	0.0000	http://jeb.biologists.org/site/author/manuscript_preparation.xhtml#references	found in CSL metadata
+universitat-mainz-geographisches-institut	elsevier-harvard	0.9623	0.0500	0.0000	http://www.scribd.com/doc/143090340/00000-Wissenschaftlich-Arbeiten-2013	found in CSL metadata
+alcohol-and-alcoholism	elsevier-harvard	0.9618	0.8500	0.0000	https://academic.oup.com/alcalc/pages/General_Instructions#Instructions%20to%20authors	found in CSL metadata
+american-school-of-classical-studies-at-athens	elsevier-harvard	0.9618	0.0000	0.0000	https://www.ascsa.edu.gr/uploads/media/Guidelines10-29-18.pdf	found in CSL metadata
+biometrics	springer-basic-author-date	0.9618	0.1500	0.0000	http://www.biometrics.tibs.org/directions.html#references	found in CSL metadata
+botanical-journal-of-the-linnean-society	elsevier-harvard	0.9618	0.0500	0.0000	https://academic.oup.com/botlinnean	found in CSL metadata
+harvard-robert-gordon-university	elsevier-harvard	0.9618	0.0500	0.0000	https://libguides.rgu.ac.uk/harvard-referencing-templates	found in CSL metadata
+journal-of-mammalogy	elsevier-harvard	0.9618	0.0500	0.0000	https://academic.oup.com/jmammal/pages/author-guidelines?login=false#preparing-your-manuscript	found in CSL metadata
+journal-of-sports-science-and-medicine	springer-basic-author-date	0.9618	0.1500	0.0000	https://www.jssm.org/newauthors.php	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-ipea	taylor-and-francis-chicago-author-date	0.9617	0.0500	0.0000	https://forums.zotero.org/discussion/22148/how-to-apply-disambiguation-in-citation-just-when-works-of-different-authors-are-in-the-same-year/?Focus=147094#Comment_147094	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-ufs	taylor-and-francis-chicago-author-date	0.9617	0.0500	0.0000	https://forums.zotero.org/discussion/22148/how-to-apply-disambiguation-in-citation-just-when-works-of-different-authors-are-in-the-same-year/?Focus=147094#Comment_147094	found in CSL metadata
+iso690-author-date-cs	elsevier-harvard	0.9615	0.1000	0.0000	https://github.com/citation-style-language/styles/issues/149	found in CSL metadata
+iso690-author-date-sk	elsevier-harvard	0.9615	0.1000	0.0000	https://github.com/citation-style-language/styles/pull/846	found in CSL metadata
+administrative-science-quarterly	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000	https://us.sagepub.com/en-us/nam/administrative-science-quarterly/journal202065#submission-guidelines	found in CSL metadata
+british-journal-of-political-science	taylor-and-francis-chicago-author-date	0.9613	0.8000	0.0000	https://www.cambridge.org/core/journals/british-journal-of-political-science/information/instructions-contributors/style-guide	found in CSL metadata
+bulletin-of-the-american-schools-of-oriental-research	taylor-and-francis-chicago-author-date	0.9613	0.6000	0.0000	http://www.asor.org/asor-publications/basor/	found in CSL metadata
+harvard-edge-hill-university	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000	http://www.edgehill.ac.uk/ls/assignment-help/help-with-referencing/	found in CSL metadata
+harvard-university-of-greenwich	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000	http://www.gre.ac.uk/studyskills/referencing	found in CSL metadata
+harvard-university-of-wolverhampton	taylor-and-francis-chicago-author-date	0.9613	0.1000	0.0000	http://www.wlv.ac.uk/lib/skills_for_learning/referencing/harvard_referencing.aspx	found in CSL metadata
+anthropologie-et-societes	elsevier-harvard	0.9610	0.0500	0.0000	http://www.anthropologie-societes.ant.ulaval.ca/regles-de-publication/normes-editoriales	found in CSL metadata
+revue-d-anthropologie-des-connaissances	elsevier-harvard	0.9608	0.8500	0.0000	https://journals.openedition.org/rac/2636	found in CSL metadata
+journal-of-cardiothoracic-and-vascular-anesthesia	elsevier-with-titles	0.9603	0.0000	0.0000	http://www.jcardioanesthesia.com/authorinfo	found in CSL metadata
+karabuk-university-graduate-school-of-natural-and-applied-sciences	elsevier-with-titles	0.9603	1.0000	0.0000	http://fbe.karabuk.edu.tr/yuklenen/files/Ornek-Tez-dr.docx	found in CSL metadata
+chicago-in-text-shortened-author-no-url	modern-language-association	0.9603	0.7500	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-in-text-shortened-author	modern-language-association	0.9603	0.7500	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+the-astrophysical-journal	elsevier-harvard	0.9603	0.0500	0.0000	http://aas.org/journals/authors/common_instruct#references	found in CSL metadata
+behaviour	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000	http://www.brill.com/behaviour	found in CSL metadata
+ecology-of-freshwater-fish	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1600-0633/homepage/ForAuthors.html	found in CSL metadata
+family-business-review	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000	https://uk.sagepub.com/en-gb/eur/family-business-review/journal201921#submission-guidelines	found in CSL metadata
+geoarchaeology	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291520-6548/homepage/ForAuthors.html	found in CSL metadata
+harvard-the-university-of-sheffield-town-and-regional-planning	taylor-and-francis-chicago-author-date	0.9601	0.0500	0.0000	http://www.librarydevelopment.group.shef.ac.uk/referencing.html	found in CSL metadata
+rmit-university-harvard	taylor-and-francis-chicago-author-date	0.9601	0.6500	0.0000	https://www.lib.rmit.edu.au/easy-cite/	found in CSL metadata
+the-botanical-review	taylor-and-francis-chicago-author-date	0.9601	0.1000	0.0000	https://www.springer.com/life+sciences/plant+sciences/journal/12229	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-ufrgs	elsevier-harvard	0.9600	0.7500	0.0000	https://www.ufrgs.br/bibliotecas/ferramentas/campos-basicos-abnt-mendeley	found in CSL metadata
+journal-of-peace-research	springer-basic-author-date	0.9600	0.0500	0.0000	http://file.prio.no/journals/JPR/JPR-Notes-for-Authors-140909.pdf	found in CSL metadata
+revista-portuguesa-de-musicologia-author-date	elsevier-harvard	0.9600	0.1000	0.0000	https://rpm-ns.pt/index.php/rpm/about/submissions	found in CSL metadata
+demographic-research	taylor-and-francis-chicago-author-date	0.9595	0.5500	0.0000	http://www.demographic-research.org/files/demographic_research_reference_guidelines.pdf	found in CSL metadata
+american-physics-society-without-titles	elsevier-with-titles	0.9592	1.0000	0.0000	https://journals.aps.org/prl/authors#techformat	found in CSL metadata
+acme-an-international-journal-for-critical-geographies	taylor-and-francis-chicago-author-date	0.9590	0.1000	0.0000	https://www.acme-journal.org/index.php/acme/about/submissions	found in CSL metadata
+apa-no-initials	taylor-and-francis-chicago-author-date	0.9590	0.1000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references	found in CSL metadata
+bibliothek-forschung-und-praxis	taylor-and-francis-chicago-author-date	0.9590	0.0500	0.0000	https://www.degruyter.com/publication/journal_key/BFUP/downloadAsset/BFUP_Instructions%20for%20Authors.pdf	found in CSL metadata
+bioarchaeology-international	taylor-and-francis-chicago-author-date	0.9590	0.6000	0.0000	https://mc04.manuscriptcentral.com/societyimages/bioarchaeolint/Bioarchaeology%20International%20Author%20Guidelines.pdf	found in CSL metadata
+chicago-author-date-access-dates	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-author-date-archive-place-first-no-url	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-author-date-archive-place-first	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-author-date-classic-no-url	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-author-date-classic	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+chicago-author-date-no-url	taylor-and-francis-chicago-author-date	0.9590	0.9000	0.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+focaal-journal-of-global-and-historical-anthropology	taylor-and-francis-chicago-author-date	0.9590	0.7000	0.0000	https://journals.berghahnbooks.com/_uploads/focaal/focaal_style_guide_2021NEWMay14.pdf	found in CSL metadata
+journal-of-the-association-of-environmental-and-resource-economists	taylor-and-francis-chicago-author-date	0.9590	0.6000	0.0000	http://www.journals.uchicago.edu/journals/jaere/instruct	found in CSL metadata
+society-for-american-archaeology	taylor-and-francis-chicago-author-date	0.9590	0.5500	0.0000	https://www.saa.org/publications	found in CSL metadata
+archeologia-e-calcolatori	elsevier-harvard	0.9589	0.0500	0.0000	https://submission.archcalc.cnr.it/index.php/aec/about/submissions	found in CSL metadata
+zeitschrift-fur-qualitative-forschung	springer-basic-author-date	0.9589	0.6000	0.0000	http://www.budrich-journals.de/index.php/zqf/about/submissions#authorGuidelines	found in CSL metadata
+econometrica	taylor-and-francis-chicago-author-date	0.9573	0.0000	0.0000	https://www.econometricsociety.org/publications/econometrica/information-authors/instructions-preparing-articles-publication	found in CSL metadata
+austrian-journal-of-development-studies	elsevier-harvard	0.9567	0.0500	0.0000	https://www.mattersburgerkreis.at/site/en/articlesubmission	found in CSL metadata
+soziologiemagazin	elsevier-harvard	0.9567	0.0500	0.0000	https://soziologieblog.hypotheses.org/hinweise-fur-autor_innen	found in CSL metadata
+universitat-bremen-frankoromanistik-literaturwissenschaft	elsevier-harvard	0.9567	0.0500	0.0000	https://www.uni-bremen.de/fileadmin/user_upload/fachbereiche/fb10/fb10/pdf/romanistik/Handreichung_FrzLitwiss_Struve.pdf	found in CSL metadata
+zdfm-zeitschrift-fur-diversitatsforschung-und-management	elsevier-harvard	0.9567	0.0500	0.0000	https://www.budrich-journals.de/index.php/zdfm/about/submissions#copyrightNotice	found in CSL metadata
+aquitania	elsevier-harvard	0.9566	0.0000	0.0000	http://aquitania.u-bordeaux-montaigne.fr/images/PDF/NORMES-GENERALES.pdf	found in CSL metadata
+biblio-3w	elsevier-harvard	0.9566	0.0000	0.0000	http://www.ub.edu/geocrit/nrm-b3w.htm	found in CSL metadata
+bulletin-de-la-societe-entomologique-de-france	elsevier-harvard	0.9566	0.5000	0.0000	http://www.lasef.org/publications/le-bulletin-de-la-sef/	found in CSL metadata
+freie-universitat-berlin-geographische-wissenschaften	elsevier-harvard	0.9566	0.0500	0.0000	http://www.geo.fu-berlin.de/geog/fachrichtungen/physgeog/medien/download/Studium_und_Lehre/Empfehlungen_Hausarbeiten.pdf?1373748910	found in CSL metadata
+gallia	elsevier-harvard	0.9566	0.1000	0.0000	https://journals.openedition.org/gallia/1305#tocto1n5	found in CSL metadata
+hochschule-osnabruck-fakultat-agrarwissenschaften-und-landschaftsarchitektur	elsevier-harvard	0.9566	0.0500	0.0000	https://github.com/citation-style-language/styles/pull/3260#issuecomment-357898874	found in CSL metadata
+universitatsmedizin-gottingen	elsevier-harvard	0.9566	0.0500	0.0000	https://www.umg.eu/studium-lehre/promotion/downloads-promotion/	found in CSL metadata
+wirtschaftsuniversitat-wien-institut-fur-bwl-des-aussenhandels	elsevier-harvard	0.9566	0.0500	0.0000	https://www.wu.ac.at/fileadmin/wu/d/i/auha/Downloads/formvorschriftenba2013.pdf	found in CSL metadata
+bibliotheca-hertziana-max-planck-institute-for-art-history	taylor-and-francis-chicago-author-date	0.9566	0.0000	0.0000	https://www.biblhertz.it/3170244/rjbh_editorial_guidelines_en.pdf	found in CSL metadata
+apa-annotated-bibliography	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references	found in CSL metadata
+apa-eu	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references/examples	found in CSL metadata
+apa-no-ampersand	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references	found in CSL metadata
+apa-single-spaced	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references	found in CSL metadata
+apa-with-abstract	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://apastyle.apa.org/style-grammar-guidelines/references	found in CSL metadata
+begell-house-apa	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	http://dl.begellhouse.com/forauthors/journals/00551c876cc2f027.html	found in CSL metadata
+british-psychological-society	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://cms.bps.org.uk/sites/default/files/2022-07/BPS%20Style%20Guide.pdf	found in CSL metadata
+chungara-revista-de-antropologia-chilena	taylor-and-francis-chicago-author-date	0.9562	0.5000	0.0000	http://chungara.cl/index.php/es/instrucciones-para-autores	found in CSL metadata
+citation-compass-apa-note	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000	http://kildekompasset.no/references/apa-6th-for-footnotes.aspx	found in CSL metadata
+contemporary-accounting-research	taylor-and-francis-chicago-author-date	0.9562	0.8500	0.0000	http://www.chicagomanualofstyle.org/tools_citationguide.html	found in CSL metadata
+first-break	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000	http://fb.eage.org/index/guidelinesforauthors?p=103	found in CSL metadata
+fundamental-and-applied-limnology	taylor-and-francis-chicago-author-date	0.9562	0.6000	0.0000	https://www.schweizerbart.de/journals/fal/instructions	found in CSL metadata
+groundwater	taylor-and-francis-chicago-author-date	0.9562	0.8500	0.0000	https://www.ngwa.org/publications-and-news/journals/Groundwater/for-authors-and-reviewers-gw/prepare-a-research-paper-for-groundwater	found in CSL metadata
+jcom-journal-of-science-communication	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000	https://jcom.sissa.it/jcom/help/helpLoader.jsp?pgType=author	found in CSL metadata
+journal-of-the-botanical-research-institute-of-texas	taylor-and-francis-chicago-author-date	0.9562	0.9000	0.0000	https://www.brit.org/jbrit/guidelines	found in CSL metadata
+marine-mammal-science	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://onlinelibrary.wiley.com/page/journal/17487692/homepage/forauthors.html#rlo	found in CSL metadata
+norsk-apa-manual-note	taylor-and-francis-chicago-author-date	0.9562	0.0000	0.0000	https://kildekompasset.no/referansestiler/apa-7th-tilpasset-fotnoter	found in CSL metadata
+norsk-apa-manual	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://www.unit.no/tjenester/norsk-apa-referansestil	found in CSL metadata
+university-of-gothenburg-apa-7th-edition-swedish-legislations	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://github.com/ub-digit/citation-styles/tree/master/zotero/university-of-gothenburg-apa7-swedish-legislations/README.md	found in CSL metadata
+univerza-na-primorskem-fakulteta-za-vede-o-zdravju-apa	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://egradivapucer.splet.arnes.si/files/2023/10/Navodila_citiranje_navajanje_APA_7_20231011_delovna.pdf	found in CSL metadata
+urad-rs-za-makroekonomske-analize-in-razvoj	taylor-and-francis-chicago-author-date	0.9562	0.1000	0.0000	https://github.com/majazaloznik/mendeley-word-collaboration-manual/blob/main/docs/UMAR_CITIRANJE%20MED%20BESEDILOM%20IN%20NAVAJANJE%20VIROV%20V%20SEZNAMU%20LITERATURE.docx	found in CSL metadata
+american-marketing-association	taylor-and-francis-chicago-author-date	0.9561	0.6000	0.0000	https://www.ama.org/submission-guidelines-journal-of-marketing/	found in CSL metadata
+escuela-nacional-de-antropologia-e-historia-author-date	elsevier-harvard	0.9558	0.0000	0.0000	http://www.enah.edu.mx/index.php/difu-cul/publicaciones/normas-editoriales.pdf	found in CSL metadata
+first-monday	elsevier-harvard	0.9558	0.8500	0.0000	http://firstmonday.org/ojs/index.php/fm/about/submissions#cite	found in CSL metadata
+harvard-the-university-of-sheffield-school-of-east-asian-studies	elsevier-harvard	0.9558	0.8500	0.0000	http://www.librarydevelopment.group.shef.ac.uk/isr.html	found in CSL metadata
+hiob-ludolf-centre-for-ethiopian-studies-with-url-doi	elsevier-harvard	0.9558	0.0000	0.0000	http://www1.uni-hamburg.de/COMST/bulletin.html	found in CSL metadata
+journal-de-la-societe-des-oceanistes	elsevier-harvard	0.9558	0.6000	0.0000	https://journals.openedition.org/jso/10756	found in CSL metadata
+philosophia-scientiae	elsevier-harvard	0.9558	0.0000	0.0000	https://journals.openedition.org/philosophiascientiae/633	found in CSL metadata
+politische-vierteljahresschrift	elsevier-harvard	0.9558	0.1000	0.0000	https://link.springer.com/journal/11615/submission-guidelines#Hinweise%20f%C3%BCr%20Autorinnen%20und%20Autoren_Literatur	found in CSL metadata
+the-international-spectator	elsevier-harvard	0.9558	0.0500	0.0000	https://files.taylorandfrancis.com/ref_rspe.pdf	found in CSL metadata
+tramas-y-redes-revista-del-consejo-latinoamericano-de-ciencias-sociales	elsevier-harvard	0.9558	0.9000	0.0000	https://tramasyredes-ojs.clacso.org/ojs/index.php/tyr/about/submissions	found in CSL metadata
+zeitschrift-fur-papyrologie-und-epigraphik	elsevier-harvard	0.9558	0.0500	0.0000	https://ifa.phil-fak.uni-koeln.de/zeitschriften-reihen/zeitschrift-fuer-papyrologie-und-epigraphik-zpe/wie-sollen-die-manuskripte-eingereicht-werden	found in CSL metadata
+deutsches-archaologisches-institut	elsevier-harvard	0.9555	0.0000	0.0000	http://www.dainst.org/publikationen/publizieren-beim-dai/richtlinien	found in CSL metadata
+journal-of-neolithic-archaeology	elsevier-harvard	0.9555	0.0500	0.0000	http://www.jna.uni-kiel.de/index.php/jna/about/submissions	found in CSL metadata
+offa	elsevier-harvard	0.9555	0.0500	0.0000	https://www.ufg.uni-kiel.de/de/schriften/verlinkte-dateien/offa-richtlinien-2018	found in CSL metadata
+studi-slavistici-rivista-dellassociazione-italiana-degli-slavisti	elsevier-harvard	0.9555	0.0500	0.0000	https://oaj.fupress.net/index.php/ss/index	found in CSL metadata
+aquatic-invasions	springer-basic-author-date	0.9554	0.6500	1.0000	http://www.aquaticinvasions.net/submissions.html	found in CSL metadata
+journal-of-conchology	springer-basic-author-date	0.9554	0.6500	0.0000	https://conchsoc.org/node/537	found in CSL metadata
+northeastern-naturalist	springer-basic-author-date	0.9554	0.5500	0.0000	http://www.eaglehill.us/programs/journals/nena/NENAauthor.pdf	found in CSL metadata
+the-journal-of-eukaryotic-microbiology	springer-basic-author-date	0.9554	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1550-7408/homepage/ForAuthors.html	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-ufmg-face-full	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000	http://www.face.ufmg.br/portal/files/biblioteca/Manual_normalizacao_FACE.pdf	found in CSL metadata
+errata	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000	https://errata.com.br/errata/about/submissions	found in CSL metadata
+instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000	http://insumo.ibict.br/produtos/csl-ibict/	found in CSL metadata
+universidade-federal-de-juiz-de-fora	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000	www.ufjf.br/engenhariadeproducao/files/2010/05/manual_para_elaboracao_TCC.pdf	found in CSL metadata
+universidade-federal-do-espirito-santo-abnt	taylor-and-francis-chicago-author-date	0.9554	0.0500	0.0000	http://repositorio.ufes.br/handle/10/1532	found in CSL metadata
+iso690-numeric-cat	ieee	0.9553	0.0000	0.0000	https://tienda.aenor.com/norma-iso-690-2021-072642	found in CSL metadata
+institut-national-de-la-recherche-scientifique-sciences-sociales	taylor-and-francis-chicago-author-date	0.9551	0.7000	0.0000	http://www.chicagomanualofstyle.org/tools_citationguide.html	found in CSL metadata
+american-journal-of-sociology	elsevier-harvard	0.9550	0.1000	0.0000	https://www.journals.uchicago.edu/journals/ajs/instruct	found in CSL metadata
+the-quarterly-journal-of-economics	springer-basic-author-date	0.9550	0.7500	0.0000	https://academic.oup.com/qje/pages/Instructions_To_Authors	found in CSL metadata
+fachhochschule-vorarlberg-author-date	taylor-and-francis-chicago-author-date	0.9550	0.5500	0.0000	https://ilias.fhv.at/goto_ilias_fhv_at_fold_176959.html	found in CSL metadata
+fachhochschule-vorarlberg-note	taylor-and-francis-chicago-author-date	0.9550	0.0000	0.0000	https://ilias.fhv.at/goto_ilias_fhv_at_fold_176959.html	found in CSL metadata
+latin-american-perspectives	taylor-and-francis-chicago-author-date	0.9550	0.1000	0.0000	http://latinamericanperspectives.com/wp-content/uploads/2011/10/ManuscriptPreparation.pdf	found in CSL metadata
+presses-universitaires-de-rennes-archeologie-et-culture	elsevier-harvard	0.9546	0.7500	0.0000	http://pur-editions.fr/pdf/consignes_auteurs_archeo.pdf	found in CSL metadata
+techniques-et-culture	elsevier-harvard	0.9546	0.0500	0.0000	https://journals.openedition.org/tc/1556#tocto3n5	found in CSL metadata
+travail-et-emploi	elsevier-harvard	0.9546	0.7500	0.0000	https://dares.travail-emploi.gouv.fr/sites/default/files/160b3fae1485ea13f49bebc19e576253/Consignes_auteurices_Travail_Emploi_2022.pdf	found in CSL metadata
+archiv-fur-geschichte-der-philosophie	elsevier-harvard	0.9546	0.0000	0.0000	http://www.degruyter.com/view/supplement/s16130650_Autorenrichtlinien_de.pdf	found in CSL metadata
+bulletin-de-la-societe-prehistorique-francaise	elsevier-harvard	0.9546	0.5000	0.0000	http://www.frantiq.fr/	found in CSL metadata
+chemistry-education-research-and-practice	elsevier-harvard	0.9546	0.5000	0.0000	http://www.rsc.org/journals-books-databases/about-journals/chemistry-education-research-practice/#journal-specific-guidelines	found in CSL metadata
+embnet-journal	elsevier-harvard	0.9546	0.5000	0.0000	http://journal.embnet.org/index.php/embnetjournal/about/submissions#authorGuidelines	found in CSL metadata
+entomological-society-of-america	elsevier-harvard	0.9546	0.0500	0.0000	http://www.entsoc.org/pubs/publish/style	found in CSL metadata
+environmental-microbiology	elsevier-harvard	0.9546	0.5000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291462-2920/homepage/ForAuthors.html	found in CSL metadata
+government-and-opposition	elsevier-harvard	0.9546	0.0500	0.0000	https://www.cambridge.org/core/journals/government-and-opposition/information/instructions-contributors	found in CSL metadata
+harvard-manchester-metropolitan-university	elsevier-harvard	0.9546	0.5500	0.0000	http://libguides.mmu.ac.uk/content.php?pid=484964&amp;sid=4325239	found in CSL metadata
+health-economics-policy-and-law	elsevier-harvard	0.9546	0.6500	0.0000	http://journals.cambridge.org/action/displayJournal?jid=HEP	found in CSL metadata
+history-of-the-human-sciences	elsevier-harvard	0.9546	0.6000	0.0000	https://uk.sagepub.com/en-gb/eur/journal/history-human-sciences#ReferenceStyle	found in CSL metadata
+human-reproduction-update	elsevier-harvard	0.9546	0.6000	0.0000	https://academic.oup.com/humupd/pages/General	found in CSL metadata
+iainutuban	elsevier-harvard	0.9546	0.5000	0.0000	https://iainutuban.ac.id/wp-content/uploads/2022/11/316-DRAF-Final-panduan-skripsi-review-2023.pdf	found in CSL metadata
+indiana	elsevier-harvard	0.9546	0.0500	0.0000	http://journals.iai.spk-berlin.de/index.php/indiana/about/submissions#authorGuidelines	found in CSL metadata
+international-journal-of-automotive-technology	elsevier-harvard	0.9546	0.5000	0.0000	https://submit.ijat.net/about/Author.php	found in CSL metadata
+international-journal-of-geriatric-psychiatry	elsevier-harvard	0.9546	0.8000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1166/homepage/ForAuthors.html	found in CSL metadata
+italian-journal-of-agronomy	elsevier-harvard	0.9546	0.5500	0.0000	http://www.agronomy.it/index.php/agro/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-plankton-research	elsevier-harvard	0.9546	0.5000	0.0000	https://academic.oup.com/plankt/pages/ms_prep_submission#references	found in CSL metadata
+journal-of-pollination-ecology	elsevier-harvard	0.9546	0.0500	0.0000	http://www.pollinationecology.org/user-files/JPE_Instruction%20for%20authors.pdf	found in CSL metadata
+journal-of-the-american-academy-of-audiology	elsevier-harvard	0.9546	0.5000	0.0000	http://www.audiology.org/publications-resources/journal-american-academy-audiology/instructions-authors	found in CSL metadata
+journal-of-the-royal-anthropological-institute	elsevier-harvard	0.9546	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-9655/homepage/ForAuthors.html	found in CSL metadata
+journal-of-threatened-taxa	elsevier-harvard	0.9546	0.4500	0.0000	https://www.threatenedtaxa.org/index.php/JoTT/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-urban-technology	elsevier-harvard	0.9546	0.6500	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=cjut20&amp;#style	found in CSL metadata
+microscopy-and-microanalysis	elsevier-harvard	0.9546	0.6000	0.0000	http://assets.cambridge.org/MAM/MAM_ifc.pdf	found in CSL metadata
+national-university-of-singapore-department-of-geography-harvard	elsevier-harvard	0.9546	0.5500	0.0000	http://www.fas.nus.edu.sg/geog/documents/undergraduate/HT_Guide_JG_2017.pdf	found in CSL metadata
+nauplius	elsevier-harvard	0.9546	0.6000	0.0000	http://www.scielo.br/revistas/nau/iinstruc.htm	found in CSL metadata
+plant-biology	elsevier-harvard	0.9546	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291438-8677/homepage/ForAuthors.html	found in CSL metadata
+plant-biotechnology-journal	elsevier-harvard	0.9546	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-7652/homepage/ForAuthors.html	found in CSL metadata
+restoration-ecology	elsevier-harvard	0.9546	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/1526100x/homepage/forauthors.html	found in CSL metadata
+sage-harvard	elsevier-harvard	0.9546	0.6500	0.0000	https://uk.sagepub.com/sites/default/files/sage_harvard_reference_style_0.pdf	found in CSL metadata
+smithsonian-institution-scholarly-press-author-date	elsevier-harvard	0.9546	0.5500	0.0000	https://scholarlypress.si.edu/resources/guidelinesforms/	found in CSL metadata
+smithsonian-institution-scholarly-press-botany	elsevier-harvard	0.9546	0.6000	0.0000	https://scholarlypress.si.edu/resources/guidelinesforms/	found in CSL metadata
+soziologie	elsevier-harvard	0.9546	0.0500	0.0000	http://www.uni-leipzig.de/~sozio/content/site/redsoz_hinweise.php	found in CSL metadata
+spiritual-care	elsevier-harvard	0.9546	0.0500	0.0000	https://www.degruyter.com/journal/key/spircare/html	found in CSL metadata
+the-journal-of-peasant-studies	elsevier-harvard	0.9546	0.0500	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=fjps20&amp;page=instructions#.UiEmqqwju1F	found in CSL metadata
+the-university-of-winchester-harvard	elsevier-harvard	0.9546	0.6500	0.0000	http://mla.winchester.ac.uk/?attachment_id=2060	found in CSL metadata
+theory-culture-and-society	elsevier-harvard	0.9546	0.6500	0.0000	http://www.uk.sagepub.com/journals/Journal200853/manuscriptSubmission	found in CSL metadata
+transboundary-and-emerging-diseases	elsevier-harvard	0.9546	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1865-1682/homepage/ForAuthors.html	found in CSL metadata
+united-nations-conference-on-trade-and-development	elsevier-harvard	0.9546	0.5500	0.0000	https://storage.unctad.org/Zotero/Zotero_UNCTAD_User_Guide.pdf	found in CSL metadata
+universitas-negeri-yogyakarta-program-pascasarjana	elsevier-harvard	0.9546	0.5000	0.0000	http://pps.uny.ac.id/	found in CSL metadata
+university-of-lincoln-harvard	elsevier-harvard	0.9546	0.5500	0.0000	http://guides.library.lincoln.ac.uk/learn/referencing	found in CSL metadata
+uniwersytet-kardynala-stefana-wyszynskiego-w-warszawie-autor-rok	elsevier-harvard	0.9546	0.6000	0.0000	https://wydawnictwo.uksw.edu.pl/strony/dla-autorow-6	found in CSL metadata
+water-alternatives	elsevier-harvard	0.9546	0.6000	0.0000	http://www.water-alternatives.org/index.php/guide	found in CSL metadata
+zeitschrift-fur-soziologie	elsevier-harvard	0.9546	0.0500	0.0000	http://www.zfs-online.org/index.php/zfs/information/authors	found in CSL metadata
+pesquisa-agropecuaria-brasileira	elsevier-harvard	0.9544	0.8000	0.0000	http://seer.sct.embrapa.br/index.php/pab/about/submissions#authorGuidelines	found in CSL metadata
+lien-social-et-politiques	elsevier-harvard	0.9542	0.5000	0.0000	http://lsp.inrs.ca/la-revue/	found in CSL metadata
+annals-of-applied-biology	elsevier-harvard	0.9542	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291744-7348/homepage/ForAuthors.html	found in CSL metadata
+arachnology	elsevier-harvard	0.9542	0.0500	0.0000	http://wiki.britishspiders.org.uk/index.php5?title=Publications/Guidelines_for_the_submission_of_articles	found in CSL metadata
+crustaceana	elsevier-harvard	0.9542	0.5000	1.0000	https://brill.com/view/journals/cr/cr-overview.xml	found in CSL metadata
+geochimica-et-cosmochimica-acta	elsevier-harvard	0.9542	0.5500	0.0000	http://www.elsevier.com/journals/geochimica-et-cosmochimica-acta/0016-7037/guide-for-authors	found in CSL metadata
+limnetica	elsevier-harvard	0.9542	0.5000	0.0000	http://www.limnetica.com/	found in CSL metadata
+tijdschrift-voor-economische-en-sociale-geografie	elsevier-harvard	0.9542	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-9663/homepage/ForAuthors.html	found in CSL metadata
+harvard-staffordshire-university	elsevier-harvard	0.9540	0.6000	0.0000	http://www.staffs.ac.uk/support_depts/infoservices/learning_support/refzone/harvard/index.jsp	found in CSL metadata
+harvard-university-of-birmingham	elsevier-harvard	0.9540	0.6000	0.0000	https://intranet.birmingham.ac.uk/as/libraryservices/icite/referencing/harvard/index.aspx	found in CSL metadata
+citizen-science-theory-and-practice	elsevier-harvard	0.9539	0.0500	1.0000	http://theoryandpractice.citizenscienceassociation.org/about/submissions/#References	found in CSL metadata
+instap-academic-press	elsevier-harvard	0.9539	0.0500	0.0000	http://instappress.com/submitting-manuscripts/style-guide/	found in CSL metadata
+journal-of-computer-applications-in-archaeology	elsevier-harvard	0.9539	0.0500	0.0000	http://journal.caa-international.org/about/submissions/#References	found in CSL metadata
+journal-of-plant-protection-research	elsevier-harvard	0.9539	0.0500	1.0000	http://www.plantprotection.pl/Instructions-for-Authors,972.html	found in CSL metadata
+oxford-journals-scimed-author-date	elsevier-harvard	0.9539	0.0500	0.0000	https://academic.oup.com/femsre/pages/Manuscript_Styling	found in CSL metadata
+southeastern-geographer	elsevier-harvard	0.9539	0.0500	0.0000	https://sedaag.org/southeastern-geographer/	found in CSL metadata
+strategic-entrepreneurship-journal	elsevier-harvard	0.9539	0.7000	0.0000	https://onlinelibrary.wiley.com/page/journal/1932443x/homepage/forauthors.html	found in CSL metadata
+strategic-management-journal	elsevier-harvard	0.9539	0.7000	0.0000	http://smj.strategicmanagement.net/submission_guidlines.php	found in CSL metadata
+iso690-numeric-fr	ieee	0.9537	0.0000	0.0000	https://forums.zotero.org/discussion/23511	found in CSL metadata
+university-of-helsinki-faculty-of-theology	taylor-and-francis-chicago-author-date	0.9535	0.0000	0.0000	https://blogs.helsinki.fi/tutkivakirjoittaminen/files/2019/03/Teologian_tyyli_19.pdf	found in CSL metadata
+studia-historiae-scientiarum	taylor-and-francis-chicago-author-date	0.9534	0.6500	0.0000	https://ejournals.eu/en/journal/studia-historiae-scientiarum/page/for-authors	found in CSL metadata
+bloomsbury-academic	taylor-and-francis-chicago-author-date	0.9533	0.5500	0.0000	http://www.zotero.org/styles/american-marketing-association	found in CSL metadata
+taxon	elsevier-harvard	0.9530	0.4500	0.0000	https://onlinelibrary.wiley.com/page/journal/19968175/homepage/author-guidelines	found in CSL metadata
+chicago-shortened-notes-bibliography-17th-edition	chicago-shortened-notes-bibliography	0.9529	0.8500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+european-review-of-international-studies	chicago-shortened-notes-bibliography	0.9529	0.6000	0.0000	https://brill.com/fileasset/downloads_products/Author_Instructions/ERIS.pdf	found in CSL metadata
+open-theology	chicago-shortened-notes-bibliography	0.9529	0.8000	0.0000	https://www.degruyter.com/publication/journal_key/OPTH/downloadAsset/OPTH_Instruction%20for%20Authors.pdf	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-ufmg-face-initials	taylor-and-francis-chicago-author-date	0.9526	0.0500	0.0000	http://www.face.ufmg.br/portal/files/biblioteca/Manual_normalizacao_FACE.pdf	found in CSL metadata
+instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt-initials	taylor-and-francis-chicago-author-date	0.9526	0.0500	0.0000	http://insumo.ibict.br/produtos/csl-ibict/	found in CSL metadata
+universidade-federal-do-espirito-santo-abnt-initials	taylor-and-francis-chicago-author-date	0.9526	0.0500	0.0000	http://repositorio.ufes.br/handle/10/1532	found in CSL metadata
+ethnologie-francaise	elsevier-harvard	0.9524	0.0000	0.0000	http://www.puf.com/puf_wiki/images/e/e3/Charte_Ethnologie_fran%C3%A7aise.pdf	found in CSL metadata
+postepy-higieny-i-medycyny-doswiadczalnej	elsevier-with-titles	0.9524	0.9500	0.0000	http://www.phmd.pl/page.php?IDpage=117	found in CSL metadata
+harvard-swinburne-university-of-technology	taylor-and-francis-chicago-author-date	0.9522	0.5500	0.0000	https://www.swinburne.edu.au/library/search/referencing-guides/harvard-style-guide/	found in CSL metadata
+beltz-padagogik	springer-basic-author-date	0.9521	0.6000	0.0000	http://www.beltz.de/fachmedien/paedagogik.html	found in CSL metadata
+digital-humanities-im-deutschsprachigen-raum	springer-basic-author-date	0.9521	0.6000	0.0000	https://www.dhd2022.de/wp-content/uploads/2021/07/Zitationsguidelines.pdf	found in CSL metadata
+interkulturelle-germanistik-gottingen	elsevier-harvard	0.9521	0.0500	0.0000	https://www.uni-goettingen.de/de/document/download/a0a0b1c0a7c078514d67fb2d8eae354c.pdf/Formatierungsvorgaben%20f%C3%BCr%20Seminar-%20und%20Masterarbeiten.pdf	found in CSL metadata
+journal-fur-medienlinguistik	springer-basic-author-date	0.9521	0.6000	0.0000	https://jfml.org/libraryFiles/downloadPublic/5	found in CSL metadata
+journal-of-historical-linguistics	springer-basic-author-date	0.9521	0.5000	0.0000	https://benjamins.com/#catalog/journals/jhl/submission	found in CSL metadata
+open-gender-journal	elsevier-harvard	0.9521	0.0500	0.0000	https://opengenderjournal.de/styleguide	found in CSL metadata
+technische-universitat-dresden-linguistik	springer-basic-author-date	0.9521	0.6000	0.0000	https://tu-dresden.de/gsw/slk/germanistik/al/ressourcen/dateien/studium/200424_Stylesheet_ALI.pdf	found in CSL metadata
+tabula	taylor-and-francis-chicago-author-date	0.9519	0.0500	0.0000	http://www.acal.es/index.php/publica-con-nosotros	found in CSL metadata
+institut-teknologi-bandung-sekolah-pascasarjana	taylor-and-francis-chicago-author-date	0.9518	0.1000	0.0000	http://www.sps.itb.ac.id/in/pedoman-tesis-dan-disertasi/	found in CSL metadata
+universita-cattolica-del-sacro-cuore	chicago-shortened-notes-bibliography	0.9512	0.1000	0.0000	http://www.unicatt.it/	found in CSL metadata
+l-homme	elsevier-harvard	0.9510	0.0500	0.0000	http://www.editions.ehess.fr/revues/lhomme/	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas-usp-fmvz	elsevier-harvard	0.9509	0.1000	0.0000	https://drive.google.com/file/d/1aGzkTiQOADXYa809BAj_IHvl6_xgJKW9/view	found in CSL metadata
+universidade-do-estado-do-rio-de-janeiro-abnt	elsevier-harvard	0.9509	0.1000	0.0000	https://issuu.com/redesirius/docs/roteiro_uerj_web	found in CSL metadata
+universidade-estadual-paulista-campus-de-dracena-abnt	elsevier-harvard	0.9509	0.1000	0.0000	http://www.dracena.unesp.br/#!/servicos/biblioteca/estilo-para-zotero/	found in CSL metadata
+iso690-author-date-pt-br	taylor-and-francis-chicago-author-date	0.9508	0.6500	0.0000	http://www.iso.org/iso/catalogue_detail.htm?csnumber=43320	found in CSL metadata
+acta-zoologica-academiae-scientiarum-hungaricae	elsevier-harvard	0.9507	0.1000	0.0000	http://actazool.nhmus.hu/	found in CSL metadata
+boreas	elsevier-harvard	0.9507	0.1000	0.0000	https://onlinelibrary.wiley.com/page/journal/15023885/homepage/forauthors.html	found in CSL metadata
+environmental-and-engineering-geoscience	elsevier-harvard	0.9507	0.8500	0.0000	https://aeg.memberclicks.net/assets/docs/Publications/EEG-Author-Instructions.pdf	found in CSL metadata
+equine-veterinary-education	elsevier-harvard	0.9507	0.0500	0.0000	https://beva.onlinelibrary.wiley.com/hub/journal/20423292/homepage/forauthors.html	found in CSL metadata
+greek-and-roman-musical-studies	elsevier-harvard	0.9507	0.0000	0.0000	https://brill.com/fileasset/downloads_products/Author_Instructions/GRMS.pdf	found in CSL metadata
+harvard-leeds-beckett-university	elsevier-harvard	0.9507	0.9000	0.0000	https://library.leedsbeckett.ac.uk/articulate/rise/quote_unquote/index_target.html#/lessons/nPbUYlJ7xTxtNuf93tegoBBjfEyjdJdo	found in CSL metadata
+harvard-university-of-leeds	elsevier-harvard	0.9507	0.6000	0.0000	https://library.leeds.ac.uk/info/1402/referencing/50/leeds_harvard_introduction	found in CSL metadata
+harvard-xi-an-jiaotong-liverpool-university	elsevier-harvard	0.9507	0.6000	0.0000	https://libguides.lib.xjtlu.edu.cn/ld.php?content_id=5887149	found in CSL metadata
+hiob-ludolf-centre-for-ethiopian-studies-long-names	elsevier-harvard	0.9507	0.0000	0.0000	http://www1.uni-hamburg.de/COMST/bulletin.html	found in CSL metadata
+journal-of-common-market-studies	elsevier-harvard	0.9507	0.8500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291468-5965/homepage/ForAuthors.html#Style	found in CSL metadata
+journal-of-natural-history	elsevier-harvard	0.9507	0.1000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=TNAH20&amp;page=instructions	found in CSL metadata
+prehistoires-mediterraneennes	elsevier-harvard	0.9507	0.0000	0.0000	https://journals.openedition.org/pm/	found in CSL metadata
+taylor-and-francis-council-of-science-editors-author-date	elsevier-harvard	0.9507	0.1000	0.0000	http://www.tandf.co.uk/journals/authors/style/reference/tf_CSE.pdf	found in CSL metadata
+technische-universitat-dresden-betriebswirtschaftslehre-logistik-author-date	elsevier-harvard	0.9507	0.8500	0.0000	https://tu-dresden.de/bu/wirtschaft/bwllog/ressourcen/dateien/studium/studienarbeiten/dateien_studienarbeiten/20180619_Homepage_Hinweise-zu-Zitierungen.pdf?lang=de	found in CSL metadata
+journal-of-egyptian-history	chicago-shortened-notes-bibliography	0.9499	0.7500	0.0000	https://brill.com/view/journals/jeh/jeh-overview.xml	found in CSL metadata
+the-economic-history-review	chicago-shortened-notes-bibliography	0.9499	0.6000	0.0000	https://onlinelibrary.wiley.com/page/journal/14680289/homepage/forauthors.html	found in CSL metadata
+archaeometry	elsevier-harvard	0.9498	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291475-4754/homepage/ForAuthors.html	found in CSL metadata
+ear-and-hearing	elsevier-harvard	0.9498	0.0500	0.0000	http://edmgr.ovid.com/eandh/accounts/ifauth.htm	found in CSL metadata
+emu-austral-ornithology	elsevier-harvard	0.9498	0.0500	0.0000	https://www.publish.csiro.au/wr/forauthors/AuthorInstructions#15	found in CSL metadata
+international-journal-of-audiology	elsevier-harvard	0.9498	0.5500	1.0000	http://informahealthcare.com/userimages/ContentEditor/1273231534162/IJA_IFA_online.pdf	found in CSL metadata
+molecular-plant-pathology	elsevier-harvard	0.9498	0.6000	0.0000	https://bsppjournals.onlinelibrary.wiley.com/pb-assets/hub-assets/bsppjournals/13643703/MPP%20Author%20Guidelines%202021-1.pdf	found in CSL metadata
+pacific-conservation-biology	elsevier-harvard	0.9498	0.0500	0.0000	https://www.publish.csiro.au/pc/forauthors/AuthorInstructions#13	found in CSL metadata
+system-dynamics-review	elsevier-harvard	0.9498	0.5000	0.0000	https://onlinelibrary.wiley.com/page/journal/10991727/homepage/forauthors.html	found in CSL metadata
+topoi-orient-occident-auteur-date	elsevier-harvard	0.9496	0.0000	0.0000	https://www.mom.fr/recherche-et-formation/collections-topoi	found in CSL metadata
+recherches-en-sciences-de-gestion	taylor-and-francis-chicago-author-date	0.9495	0.1000	0.0000	http://164.132.163.82/SiteIseor/rsdg.asp	found in CSL metadata
+ageing-and-society	taylor-and-francis-chicago-author-date	0.9493	0.5500	0.0000	https://www.cambridge.org/core/journals/ageing-and-society/information/instructions-contributors	found in CSL metadata
+iso690-author-date-es	taylor-and-francis-chicago-author-date	0.9491	0.6500	0.0000	https://www.aenor.com/normas-y-libros/buscador-de-normas/UNE?c=N0051162	found in CSL metadata
+canadian-journal-of-criminology-and-criminal-justice	taylor-and-francis-chicago-author-date	0.9490	0.5000	0.0000	https://www.utpjournals.press/journals/cjccj/submissions#_Toc111532224	found in CSL metadata
+enfances-familles-generations	elsevier-harvard	0.9490	0.5000	0.0000	https://www.efg.inrs.ca/soumettre/	found in CSL metadata
+management-et-avenir	elsevier-harvard	0.9490	0.8000	0.0000	http://www.managementetavenir.net/la-recherche/soumettre-un-article-independant.html	found in CSL metadata
+revue-des-nouvelles-technologies-de-l-information	elsevier-harvard	0.9490	0.8000	0.0000	http://editions-rnti.fr/?m=infosoumission	found in CSL metadata
+revue-francaise-de-gestion	elsevier-harvard	0.9490	0.8500	0.0000	https://www.jle.com/fr/revues/rfg/espace_auteur	found in CSL metadata
+universite-nangui-abrogoua-sciences-de-la-nature-apa	elsevier-harvard	0.9490	0.8000	0.0000	https://github.com/EhoumanEvans/CitationStyle/raw/master/universite_nangui_abrogoua_ufr_sn_citation_style.pdf	found in CSL metadata
+international-organization	taylor-and-francis-chicago-author-date	0.9489	0.0000	0.0000	http://assets.cambridge.org/INO/INO_ifc.pdf	found in CSL metadata
+harvard-university-of-the-west-of-scotland	taylor-and-francis-chicago-author-date	0.9488	0.1000	0.0000	http://moodle.uws.ac.uk/pluginfile.php/322388/mod_resource/content/1/CoRE/index.htm	found in CSL metadata
+united-nations-framework-convention-on-climate-change	taylor-and-francis-chicago-author-date	0.9488	0.0500	0.0000	https://sia.unfccc.int/publishing/Assets/PR-000010/StreamAssets/UNFCCC_style_guide.pdf	found in CSL metadata
+urban-habitats	taylor-and-francis-chicago-author-date	0.9488	0.6000	0.0000	http://urbanhabitats.org/submissions.html	found in CSL metadata
+law-and-society-review	springer-basic-author-date	0.9486	0.5000	0.0000	http://www.lawandsociety.org/review/review_stylesheet.html	found in CSL metadata
+wirtschaftsuniversitat-wien-unternehmensrechnung-und-controlling	elsevier-harvard	0.9484	0.0500	0.0000	https://www.wu.ac.at/fileadmin/wu/d/i/uco/Infoblatt_Abschlussarbeiten.pdf	found in CSL metadata
+european-review-of-agricultural-economics	taylor-and-francis-chicago-author-date	0.9483	0.1000	0.0000	https://academic.oup.com/erae/pages/General_Instructions	found in CSL metadata
+ucl-university-college-apa	taylor-and-francis-chicago-author-date	0.9483	0.1000	0.0000	https://sites.google.com/ucl.dk/ucl-formelle-krav/apa	found in CSL metadata
+alternatif-politika	elsevier-harvard	0.9478	0.6500	0.0000	https://alternatifpolitika.com/site/dosyalar/diger/yazarlar_icin_onemli_notlar.docx	found in CSL metadata
+annales-de-demographie-historique	elsevier-harvard	0.9478	0.6000	0.0000	http://www.societededemographiehistorique.fr/les-annales-de-deacutemographie-historique.html	found in CSL metadata
+body-and-society	elsevier-harvard	0.9478	0.6500	0.0000	https://us.sagepub.com/en-us/nam/journal/body-society#ReferenceStyle	found in CSL metadata
+feminist-theory	elsevier-harvard	0.9478	0.6500	0.0000	https://journals.sagepub.com/author-instructions/FTY#ReferenceStyle	found in CSL metadata
+gnosis-journal-of-gnostic-studies	elsevier-harvard	0.9478	0.0000	0.0000	https://brill.com/view/journals/gnos/gnos-overview.xml?contents=artsub	found in CSL metadata
+hiob-ludolf-centre-for-ethiopian-studies	elsevier-harvard	0.9478	0.0000	0.0000	http://www1.uni-hamburg.de/COMST/bulletin.html	found in CSL metadata
+journal-for-the-study-of-the-new-testament	elsevier-harvard	0.9478	0.0500	0.0000	https://journals.sagepub.com/author-instructions/JNT	found in CSL metadata
+revue-europeenne-des-migrations-internationales	elsevier-harvard	0.9478	0.5500	0.0000	https://remi.revues.org/5848	found in CSL metadata
+revue-francaise-d-administration-publique	elsevier-harvard	0.9478	0.6000	0.0000	https://www.ena.fr/La-recherche-a-l-ENA/Publications/rfap	found in CSL metadata
+user-modeling-and-user-adapted-interaction	elsevier-harvard	0.9478	0.0000	0.0000	http://www.springer.com/computer/hci/journal/11257	found in CSL metadata
+wirtschaftsuniversitat-wien-health-care-management	elsevier-harvard	0.9478	0.6000	0.0000	https://www.complexity-research.com/pdf/WissArb.pdf	found in CSL metadata
+associacao-brasileira-de-normas-tecnicas	elsevier-harvard	0.9478	0.8500	0.0000	https://forums.zotero.org/discussion/22148/how-to-apply-disambiguation-in-citation-just-when-works-of-different-authors-are-in-the-same-year/?Focus=147094#Comment_147094	found in CSL metadata
+universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt	elsevier-harvard	0.9478	0.1000	0.0000	https://www.abntcatalogo.com.br/norma.aspx?ID=408006	found in CSL metadata
+universidade-estadual-de-alagoas-abnt	elsevier-harvard	0.9478	0.1000	0.0000	https://www.abntcatalogo.com.br/norma.aspx?ID=408006	found in CSL metadata
+journal-of-experimental-botany	springer-basic-author-date	0.9477	0.1000	0.0000	https://academic.oup.com/jxb/pages/manuscript-preparation	found in CSL metadata
+universitas-gadjah-mada-doctoral-program-in-pharmaceutical-sciences	elsevier-harvard	0.9477	0.7500	1.0000	https://programdoktor.farmasi.ugm.ac.id/academic-guideline/	found in CSL metadata
+communication-et-langages	taylor-and-francis-chicago-author-date	0.9475	0.0000	0.0000	http://www.necplus.eu/action/displayJournal?jid=CML	found in CSL metadata
+culture-medicine-and-psychiatry	taylor-and-francis-chicago-author-date	0.9471	0.6500	0.0000	http://www.springer.com/social+sciences/anthropology+%26+archaeology/journal/11013	found in CSL metadata
+ethnomusicology	taylor-and-francis-chicago-author-date	0.9471	0.5500	0.0000	http://www.ethnomusicology.org/?Pub_JournalAuthors	found in CSL metadata
+generic-style-rules-for-linguistics	taylor-and-francis-chicago-author-date	0.9471	0.5500	0.0000	https://www.eva.mpg.de/linguistics/past-research-resources/resources/generic-style-rules.html	found in CSL metadata
+journal-de-la-societe-des-americanistes	taylor-and-francis-chicago-author-date	0.9471	0.8000	0.0000	https://journals.openedition.org/jsa/7663	found in CSL metadata
+society-for-historical-archaeology	taylor-and-francis-chicago-author-date	0.9471	0.6000	0.0000	http://www.sha.org/publications/for_authors.cfm	found in CSL metadata
+springer-humanities-author-date	taylor-and-francis-chicago-author-date	0.9471	0.8000	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf	found in CSL metadata
+chicago-shortened-notes-bibliography-16th-edition	chicago-shortened-notes-bibliography	0.9471	0.8500	0.0000	https://web.archive.org/web/20160830192245/http://www.chicagomanualofstyle.org/tools_citationguide.html	found in CSL metadata
+chicago-shortened-notes-bibliography-subsequent-ibid-17th-edition	chicago-shortened-notes-bibliography	0.9471	0.8500	1.0000	https://www.chicagomanualofstyle.org/	found in CSL metadata
+european-union-interinstitutional-style-guide	chicago-shortened-notes-bibliography	0.9471	0.8500	0.0000	https://docs.google.com/file/d/0B-opIuO3xlZsYkV4dXVfVm1PYWM/edit	found in CSL metadata
+journal-of-human-rights	elsevier-harvard	0.9471	0.0500	0.0000	https://jhr.uconn.edu/submissions/	found in CSL metadata
+alternatives-to-animal-experimentation	elsevier-harvard	0.9467	0.5500	0.0000	http://www.altex.ch/en/index.html?id=34	found in CSL metadata
+american-society-for-pharmacology-and-experimental-therapeutics	elsevier-harvard	0.9467	0.8500	0.0000	http://molpharm.aspetjournals.org/site/misc/ifora.xhtml#References	found in CSL metadata
+cell-structure-and-function	elsevier-harvard	0.9467	0.9000	0.0000	http://www.jscb.gr.jp/csf/en/csf_regulation.html	found in CSL metadata
+crop-breeding-and-applied-biotechnology	elsevier-harvard	0.9467	0.0500	0.0000	http://www.sbmp.org.br/cbab/siscbab/modules/tiny3/	found in CSL metadata
+ecosistemas	elsevier-harvard	0.9467	0.0500	0.0000	https://www.revistaecosistemas.net/public/journals/1/docs/Normasparaautores_RevistaEcosistemas.pdf	found in CSL metadata
+eunomia-revista-en-cultura-de-la-legalidad	elsevier-harvard	0.9467	0.5500	0.0000	https://e-revistas.uc3m.es/index.php/EUNOM/information/authors	found in CSL metadata
+evolutionary-ecology-research	elsevier-harvard	0.9467	0.8500	0.0000	http://www.evolutionary-ecology.com/advice/AdviceFrames.html	found in CSL metadata
+institute-for-operations-research-and-the-management-sciences	elsevier-harvard	0.9467	0.1000	0.0000	https://pubsonline.informs.org/pb-assets/INFORMS_style_guide-1.6-1574695301483.pdf	found in CSL metadata
+termedia-neuropsychiatria-i-neuropsychologia-neuropsychiatry-and-neuropsychology	elsevier-harvard	0.9467	0.0500	0.0000	https://www.termedia.pl/Czasopismo/Neuropsychiatria_i_Neuropsychologia-46/Dla_autorow	found in CSL metadata
+tropical-animal-health-and-production	elsevier-harvard	0.9467	0.8500	1.0000	http://www.springer.com/life+sciences/animal+sciences/journal/11250	found in CSL metadata
+university-of-bradford-harvard	elsevier-harvard	0.9467	0.0500	0.0000	https://www.brad.ac.uk/library/find-out-about/referencing/	found in CSL metadata
+veterinaria-italiana	elsevier-harvard	0.9467	0.9000	0.0000	http://www.izs.it/vet_italiana/guidelines_gen_guidelines_vet_it.htm	found in CSL metadata
+ausonius-editions	elsevier-harvard	0.9464	0.0000	0.0000	https://ausoniuseditions.u-bordeaux-montaigne.fr	found in CSL metadata
+barbara-budrich	springer-basic-author-date	0.9464	0.6000	0.0000	https://budrich.de/wiki/doku.php?id=formatierung:stylesheet	found in CSL metadata
+hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften	elsevier-harvard	0.9464	0.0500	0.0000	https://mediapool.hm.edu/media/fk11/fk11_lokal/2023_/sozialearbeit_1/2_dokumente_34/2_4_formulare_informationen_1/Standards_Wiss_Arbeiten_FK_11_24_06.pdf	found in CSL metadata
+imperial-college-london-author-date	elsevier-harvard	0.9464	0.6000	0.0000	http://www.imperial.ac.uk/admin-services/library/learning-support/reference-management/harvard-style/	found in CSL metadata
+the-british-journal-of-sociology	taylor-and-francis-chicago-author-date	0.9454	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1468-4446/homepage/ForAuthors.html	found in CSL metadata
+infoclio-de-kurzbelege	chicago-shortened-notes-bibliography	0.9453	0.0000	0.0000	https://www.infoclio.ch/de/zitierstil#zotero	found in CSL metadata
+technische-universitat-munchen-controlling	elsevier-harvard	0.9447	0.0500	0.0000	http://www.controlling.wi.tum.de/lehre/abschlussarbeiten/	found in CSL metadata
+mondes-en-developpement	taylor-and-francis-chicago-author-date	0.9447	0.1000	0.0000		
+canadian-public-policy	taylor-and-francis-chicago-author-date	0.9443	0.8000	0.0000	http://economics.ca/cpp/en/authors.php	found in CSL metadata
+journal-of-business-logistics	taylor-and-francis-chicago-author-date	0.9443	0.8000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)2158-1592/homepage/ForAuthors.html	found in CSL metadata
+journal-of-the-air-and-waste-management-association	taylor-and-francis-chicago-author-date	0.9443	0.1000	0.0000	http://www.awma.org/publications/journal/submit-a-manuscript	found in CSL metadata
+register-studies	taylor-and-francis-chicago-author-date	0.9443	0.5500	0.0000	https://benjamins.com/catalog/rs	found in CSL metadata
+biuletyn-polskiego-towarzystwa-jezykoznawczego	springer-basic-author-date	0.9439	0.5000	0.0000		
+technische-universitat-dresden-finanzwirtschaft-und-finanzdienstleistungen-author-date	elsevier-harvard	0.9439	0.8500	0.0000	https://bildungsportal.sachsen.de/opal/url/RepositoryEntry/683835403	found in CSL metadata
+harvard-coventry-university	taylor-and-francis-chicago-author-date	0.9434	0.5000	0.0000	http://www.coventry.ac.uk/Global/03%20Study%20section%20assets/Academic%20Support/CAW/Sept%2013_%20Harvard%20Guide%20v3%200%202.pdf	found in CSL metadata
+molecular-plant	elsevier-harvard	0.9433	0.5000	0.0000	http://www.cell.com/molecular-plant/authors	found in CSL metadata
+religion-in-the-roman-empire	taylor-and-francis-chicago-author-date	0.9431	0.0000	0.0000	https://www.mohr.de/fileadmin/user_upload/Zeitschriften/Richtlinien_Autoren/2016/RRE_Style_sheet-neu.pdf	found in CSL metadata
+ulua-revista-de-historia-sociedad-y-cultura	taylor-and-francis-chicago-author-date	0.9430	0.0000	0.0000	https://ulua.uv.mx/index.php/ulua/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-archaeological-research	elsevier-harvard	0.9429	0.0500	0.0000	http://www.springer.com/social+sciences/anthropology+%26+archaeology/journal/10814	found in CSL metadata
+journal-of-social-archaeology	elsevier-harvard	0.9429	0.5500	0.0000	http://www.uk.sagepub.com/msg/jsa.htm#ReferenceStyle	found in CSL metadata
+cse-name-year-8th-edition	elsevier-harvard	0.9427	0.0500	0.0000	http://www.scientificstyleandformat.org/Tools/SSF-Citation-Quick-Guide.html	found in CSL metadata
+cse-name-year	elsevier-harvard	0.9427	0.0500	0.0000	https://www.csemanual.org/Tools/CSE-Citation-Quick-Guide.html	found in CSL metadata
+elementa	elsevier-harvard	0.9427	0.5500	0.0000	https://home.elementascience.org/for-authors/style-guide/	found in CSL metadata
+facets	elsevier-harvard	0.9427	0.0500	0.0000	https://www.facetsjournal.com/for-authors/instructions-to-authors	found in CSL metadata
+harvard-european-archaeology	elsevier-harvard	0.9427	0.0500	0.0000	https://forums.zotero.org/discussion/8353/styles-bibliographies-years-in-wrong-order/?Focus=38719#Comment_38719	found in CSL metadata
+institut-pertanian-bogor	elsevier-harvard	0.9427	0.0500	0.0000	http://ppki.staff.ipb.ac.id/unduhan/	found in CSL metadata
+international-journal-of-plant-sciences	elsevier-harvard	0.9427	0.0500	0.0000	http://www.press.uchicago.edu/journals/ijps/instruct.html?journal=ijps	found in CSL metadata
+journal-of-dental-research	elsevier-harvard	0.9427	0.0500	0.0000	https://journals.sagepub.com/author-instructions/JDR	found in CSL metadata
+mammalogy-notes	elsevier-harvard	0.9427	0.0500	0.0000	https://mammalogynotes.org/ojs/index.php/mn/about/submissions	found in CSL metadata
+molecular-biology-and-evolution	elsevier-harvard	0.9427	0.0500	0.0000	https://academic.oup.com/mbe/pages/General_Author_Guidelines#References	found in CSL metadata
+the-world-journal-of-biological-psychiatry	elsevier-harvard	0.9427	0.0500	0.0000	http://informahealthcare.com/page/wbp/Description#Instructions	found in CSL metadata
+technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling	taylor-and-francis-chicago-author-date	0.9426	0.0500	0.0000	https://tu-dresden.de/bu/wirtschaft/bwl/brw/ressourcen/dateien/studium/Richtlinien-wiss-Arbeiten-Stand-Januar-2020.pdf?lang=de	found in CSL metadata
+centre-de-recherche-sur-les-civilisations-de-l-asie-orientale-auteur-date	elsevier-harvard	0.9422	0.8500	0.0000		
+freie-hochschule-stuttgart	elsevier-harvard	0.9422	0.6000	0.0000	http://www.freie-hochschule-stuttgart.de	found in CSL metadata
+geneses	elsevier-harvard	0.9422	0.0500	0.0000	http://geneses.hypotheses.org/la-revue/2	found in CSL metadata
+geographie-et-cultures	elsevier-harvard	0.9422	0.7500	0.0000	https://journals.openedition.org/gc/605	found in CSL metadata
+hochschule-bonn-rhein-sieg	elsevier-harvard	0.9422	0.0500	0.0000	https://github.com/citation-style-language/styles/pull/7242#issuecomment-2402289631	found in CSL metadata
+kolner-zeitschrift-fur-soziologie-und-sozialpsychologie	elsevier-harvard	0.9422	0.0500	0.0000	http://kzfss.uni-koeln.de/die-zeitschrift/konventionen/#accordion-2-t1	found in CSL metadata
+metropolitiques	elsevier-harvard	0.9422	0.0500	0.0000	https://metropolitiques.eu/Charte-editoriale-6	found in CSL metadata
+springer-vs-author-date	elsevier-harvard	0.9422	0.0500	0.0000	https://github.com/citation-style-language/styles/files/978822/Hinweise.zur.Manuskripterstellung_final.pdf	found in CSL metadata
+zeitschrift-fur-internationale-beziehungen	elsevier-harvard	0.9422	0.0500	0.0000	http://www.zib.nomos.de/fileadmin/zib/doc/ZIB_Richtlinien_Autorenhinweise.pdf	found in CSL metadata
+austral-ecology	elsevier-harvard	0.9422	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1442-9993/homepage/ForAuthors.html	found in CSL metadata
+harvard-kings-college-london	elsevier-harvard	0.9422	0.5500	0.0000	http://www.kcl.ac.uk/library/help/plagiarism/citing/index.aspx	found in CSL metadata
+harvard-limerick	elsevier-harvard	0.9422	0.0500	0.0000	https://libguides.ul.ie/citeitright	found in CSL metadata
+harvard-newcastle-university	elsevier-harvard	0.9422	0.5500	0.0000	http://libguides.ncl.ac.uk/referencing	found in CSL metadata
+journal-fur-kulturpflanzen-journal-of-cultivated-plants	elsevier-harvard	0.9422	0.6500	0.0000	https://ojs.openagrar.de/index.php/Kulturpflanzenjournal/Autorenhinweise	found in CSL metadata
+journal-of-plant-ecology	elsevier-harvard	0.9422	0.0500	0.0000	https://academic.oup.com/jpe/pages/General_Instructions#Literature%20Citation	found in CSL metadata
+national-institute-of-organisation-dynamics-australia-harvard	elsevier-harvard	0.9422	0.0500	0.0000	https://www.nioda.org.au/wp-content/uploads/2019/07/NIODA-Referencing.pdf	found in CSL metadata
+skuast-journal-of-research	elsevier-harvard	0.9422	0.6000	0.0000	https://indianjournals.com/journals/SKUASTJR?opentab=past-issues	found in CSL metadata
+style-manual-australian-government	elsevier-harvard	0.9422	0.0500	0.0000	https://www.stylemanual.gov.au/style-rules-and-conventions/referencing-and-attribution/author-date	found in CSL metadata
+pontifical-gregorian-university	chicago-shortened-notes-bibliography	0.9419	0.0000	0.0000	http://www.unigre.it	found in CSL metadata
+ambio	elsevier-harvard	0.9417	0.0500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/Instructions_for_authors_AMBIO_2013.pdf	found in CSL metadata
+institut-francais-darcheologie-orientale-en	elsevier-harvard	0.9417	0.0000	0.0000	https://www.ifao.egnet.net/publications/publier/normes-ed/	found in CSL metadata
+the-american-journal-of-bioethics	elsevier-harvard	0.9417	0.0500	0.0000	https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=uajb20	found in CSL metadata
+the-canadian-geographer	elsevier-harvard	0.9417	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1541-0064/homepage/ForAuthors.html	found in CSL metadata
+harvard-university-of-the-west-of-england	elsevier-harvard	0.9414	0.6500	0.0000	https://www.uwe.ac.uk/study/study-support/study-skills/referencing/uwe-bristol-harvard	found in CSL metadata
+universidade-federal-de-goias-escola-de-veterinaria-e-zootecnia	elsevier-harvard	0.9414	0.7500	0.0000	https://files.cercomp.ufg.br/weby/up/442/o/PPGZ2023_Guia_Normalizacao_Bibliografica_EVZ.pdf	found in CSL metadata
+bibliotheque-d-archeologie-mediterraneenne-et-africaine-biama	elsevier-harvard	0.9413	0.0000	0.0000	http://ccj.cnrs.fr/spip.php?rubrique89	found in CSL metadata
+bulletin-of-insectology	springer-basic-author-date	0.9413	0.0500	0.0000	http://www.bulletinofinsectology.org/Instructions%20for%20authors2.htm	found in CSL metadata
+documents-d-archeologie-francaise	elsevier-harvard	0.9413	0.0500	0.0000	http://www.culture.gouv.fr/culture/dp/daf_archeo/documents_pdf/Recommandations/construire_sa_bibliographie.pdf	found in CSL metadata
+nations-and-nationalism	springer-basic-author-date	0.9413	0.5500	0.0000	https://onlinelibrary.wiley.com/page/journal/14698129/homepage/forauthors.html	found in CSL metadata
+publicatiewijzer-voor-de-archeologie	springer-basic-author-date	0.9413	0.0000	0.0000	https://www.aup.nl/nl/book/9789053566930/publicatiewijzer-voor-de-archeologie	found in CSL metadata
+bulletin-de-correspondance-hellenique	taylor-and-francis-chicago-author-date	0.9412	0.0000	0.0000	https://fiches-pratiques.efa.gr/books/publier-a-lefa/page/presentation-de-la-bibliographie-finale	found in CSL metadata
+journal-of-juridical-sciences	springer-basic-author-date	0.9405	0.0000	0.0000	https://journals.ufs.ac.za/index.php/jjs/information/authors	found in CSL metadata
+sociedade-brasileira-de-computacao	elsevier-harvard	0.9405	0.0000	0.0000	https://forums.zotero.org/discussion/19203/preliminar-sociedade-brasileira-de-computacao-style/	found in CSL metadata
+suleyman-demirel-universitesi-fen-bilimleri-enstitusu	springer-basic-author-date	0.9405	0.1500	0.0000	https://fenbilimleri.sdu.edu.tr/tr/tez/tez-yazim-sablonlari-15991s.html	found in CSL metadata
+springer-imis-series-migrationsgesellschaften	taylor-and-francis-chicago-author-date	0.9403	0.6000	0.0000		
+les-cahiers-du-journalisme	elsevier-harvard	0.9398	0.5500	0.0000	https://cahiersdujournalisme.org/FicheCitaElec.pdf	found in CSL metadata
+drug-development-research	taylor-and-francis-chicago-author-date	0.9397	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1098-2299/homepage/ForAuthors.html	found in CSL metadata
+harvard-deakin-university	taylor-and-francis-chicago-author-date	0.9397	0.6000	0.0000	http://www.deakin.edu.au/students/studying/study-support/referencing/harvard	found in CSL metadata
+harvard-university-of-technology-sydney	taylor-and-francis-chicago-author-date	0.9397	0.5500	0.0000	https://www.lib.uts.edu.au/help/referencing/harvard-uts-referencing-guide	found in CSL metadata
+acta-naturae	ieee	0.9397	0.5000	0.0000	http://actanaturae.ru/	found in CSL metadata
+institut-francais-darcheologie-orientale-arab-studies	elsevier-harvard	0.9397	0.0000	0.0000	https://www.ifao.egnet.net/publications/publier/normes-ed/	found in CSL metadata
+steel-research-international	ieee	0.9397	0.5000	0.0000	https://onlinelibrary.wiley.com/page/journal/1869344x/homepage/author-guidelines	found in CSL metadata
+universitat-bern-institut-fur-sozialanthropologie	elsevier-harvard	0.9392	0.0500	0.0000	https://www.anthro.unibe.ch/unibe/portal/fak_historisch/dkk/anthro/content/e40416/e176505/section176510/files176511/Zitieren_ger.pdf	found in CSL metadata
+la-revue-des-sciences-de-gestion	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000	https://www.larsg.fr/mise-en-page-des-articles/	found in CSL metadata
+lannee-sociologique	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000	https://www.puf.com/collections/Ann%C3%A9e_sociologique_-l--	found in CSL metadata
+les-mondes-du-travail	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000	https://lesmondesdutravail.net/contrib/	found in CSL metadata
+population	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000	https://www.revue-population.fr/pour-les_auteur%c2%b7es/consignes_aux_auteurs/	found in CSL metadata
+revue-dhistoire-des-sciences-humaines	taylor-and-francis-chicago-author-date	0.9390	0.0000	0.0000	https://journals.openedition.org/rhsh/1273	found in CSL metadata
+revue-forestiere-francaise	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000	https://hal.archives-ouvertes.fr/REVUE-FORESTIERE-FRANCAISE/	found in CSL metadata
+revue-francaise-de-sociologie	taylor-and-francis-chicago-author-date	0.9390	0.0500	0.0000	http://www.rfs-revue.com/	found in CSL metadata
+roots-monograph-series	elsevier-harvard	0.9389	0.0500	1.0000	https://www.cluster-roots.uni-kiel.de/en/publications/roots-publications/roots-publications-material/20210210-roots-guidelines-for-authors-of-roots-pub.pdf	found in CSL metadata
+journal-of-management-studies	elsevier-harvard	0.9388	0.9000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-6486/homepage/ForAuthors.html	found in CSL metadata
+asian-myrmecology	elsevier-harvard	0.9388	0.0500	0.0000	http://www.asian-myrmecology.org/guidelines.html#:~:text=of%20the%20manuscript.-,References,-Authors%20are%20encouraged	found in CSL metadata
+ucl-university-college-harvard	springer-basic-author-date	0.9382	0.7500	0.0000	https://sites.google.com/ucl.dk/ucl-formelle-krav/harvard	found in CSL metadata
+finance-and-society	elsevier-harvard	0.9381	0.5500	0.0000	http://financeandsociety.ed.ac.uk//pages/view/house-style	found in CSL metadata
+harvard-university-for-the-creative-arts	elsevier-harvard	0.9381	0.5000	0.0000	http://www.uca.ac.uk/library/academic-support/harvard-referencing/	found in CSL metadata
+estudios-de-fonetica-experimental	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	http://stel.ub.edu/labfon/en/content/publication-estudios-de-fonetica-experimental#Normes	found in CSL metadata
+harvard-cite-them-right-10th-edition	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	http://www.citethemrightonline.com/	found in CSL metadata
+harvard-cite-them-right-11th-edition	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	http://www.citethemrightonline.com/	found in CSL metadata
+harvard-cite-them-right-no-et-al	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	http://www.citethemrightonline.com/	found in CSL metadata
+harvard-cite-them-right	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	http://www.citethemrightonline.com/	found in CSL metadata
+journal-for-veterinary-medicine-biotechnology-and-biosafety	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	http://jvmbbs.kharkov.ua/rules.php	found in CSL metadata
+literatura	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	https://www.journals.vu.lt/literatura/about/submissions	found in CSL metadata
+transactions-on-maritime-science	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	https://www.toms.com.hr/index.php/toms/guidelines-3	found in CSL metadata
+ucl-institute-of-education-harvard	taylor-and-francis-chicago-author-date	0.9374	0.0500	0.0000	https://libguides.ioe.ac.uk/harvard	found in CSL metadata
+bollettino-d-archeologia-online	elsevier-harvard	0.9374	0.0000	0.0000	http://bollettinodiarcheologiaonline.beniculturali.it/norme-redazionali/	found in CSL metadata
+clara-architecture-recherche	taylor-and-francis-chicago-author-date	0.9372	0.0500	0.0000	http://clararevue.ulb.be/OJS/index.php/CLARA	found in CSL metadata
+iso690-author-date-fr-no-abstract	taylor-and-francis-chicago-author-date	0.9372	0.6000	0.0000	https://github.com/citation-style-language/styles/pull/405	found in CSL metadata
+iso690-author-date-fr	taylor-and-francis-chicago-author-date	0.9372	0.6000	0.0000	https://forums.zotero.org/discussion/23511	found in CSL metadata
+aves	elsevier-harvard	0.9371	0.7500	0.0000	https://aves.natagora.be/instructions-auteurs	found in CSL metadata
+les-journees-de-la-recherche-porcine	elsevier-harvard	0.9371	0.5000	0.0000	http://www.journees-recherche-porcine.com/consig/index.htm	found in CSL metadata
+natur-und-landschaft	elsevier-harvard	0.9371	0.0500	0.0000	https://www.natur-und-landschaft.de/de/service/beitrag-einreichen-1	found in CSL metadata
+norois	elsevier-harvard	0.9371	0.8000	0.0000	https://journals.openedition.org/norois/1025#tocto1n11	found in CSL metadata
+european-retail-research	elsevier-harvard	0.9370	0.1000	0.0000	http://unitrier.t3-hoster.com/produkt-1.html	found in CSL metadata
+de-montfort-university-harvard	taylor-and-francis-chicago-author-date	0.9369	0.1000	0.0000	http://www.library.dmu.ac.uk/Images/Selfstudy/Harvard.pdf	found in CSL metadata
+harvard-university-of-kent	taylor-and-francis-chicago-author-date	0.9369	0.6000	0.0000	http://www.kent.ac.uk/ai/Harvard-Style-Guide-July-2014.pdf	found in CSL metadata
+health-reform-observer-observatoire-des-reformes-de-sante	taylor-and-francis-chicago-author-date	0.9369	0.6000	0.0000	https://escarpmentpress.org/hro-ors/pages/view/how-to-format-ms	found in CSL metadata
+british-journal-of-industrial-relations	elsevier-harvard	0.9367	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291467-8543/homepage/ForAuthors.html	found in CSL metadata
+heidelberg-university-faculty-of-medicine	elsevier-harvard	0.9367	0.0500	0.0000	http://www.medizinische-fakultaet-hd.uni-heidelberg.de/fileadmin/Dekanat/Abfassungsrichtlinien_Sept_2015.pdf	found in CSL metadata
+journal-of-european-public-policy	elsevier-harvard	0.9367	0.0500	0.0000	http://www.tandf.co.uk/journals/pdf/rjpp-refs.pdf	found in CSL metadata
+nys-nydanske-sprogstudier	taylor-and-francis-chicago-author-date	0.9364	0.5000	0.0000	https://dsn.dk/nys/04-nys-stylesheet	found in CSL metadata
+method-and-theory-in-the-study-of-religion	elsevier-harvard	0.9359	0.0500	0.0000	https://brill.com/view/journals/mtsr/mtsr-overview.xml	found in CSL metadata
+einaudi	elsevier-harvard	0.9351	0.1000	0.0000	https://forums.zotero.org/discussion/68966/csl-style-request-einaudi	found in CSL metadata
+geografie-sbornik-cgs	elsevier-harvard	0.9351	0.1000	0.0000	http://geography.cz/sbornik/about-proceedings/instructions-for-authors/	found in CSL metadata
+vita-latina	taylor-and-francis-chicago-author-date	0.9346	0.0000	0.0000	http://vitalatina.upv.univ-montp3.fr/page-3/	found in CSL metadata
+european-union-interinstitutional-style-guide-author-date	taylor-and-francis-chicago-author-date	0.9343	0.0500	0.0000	https://publications.europa.eu/code/en/en-250904.htm	found in CSL metadata
+revista-biblica	chicago-shortened-notes-bibliography	0.9341	0.3000	0.0000	https://www.revistabiblica.com/publicacion/	found in CSL metadata
+hochschule-fur-soziale-arbeit-fhnw	elsevier-harvard	0.9340	0.0500	0.0000	https://www.fhnw.ch/de/die-fhnw/bibliothek-fhnw/lernen-und-arbeiten/wissenschaftliches-arbeiten/media/leitfaden-wiss-arbeiten_hsa_fhnw.pdf/@@display-file/file	found in CSL metadata
+chicago-author-date-basque	taylor-and-francis-chicago-author-date	0.9335	0.7000	0.0000	https://forums.zotero.org/discussion/21077/modificated-style-kukutza-for-basque/	found in CSL metadata
+freshwater-biology	elsevier-harvard	0.9335	0.5000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2427/homepage/ForAuthors.html	found in CSL metadata
+informal-logic	springer-basic-author-date	0.9333	0.8500	0.0000	https://informallogic.ca/index.php/informal_logic/about/submissions	found in CSL metadata
+harvard-university-of-cape-town	taylor-and-francis-chicago-author-date	0.9330	0.1000	0.0000	http://www.lib.uct.ac.za/wp-content/uploads/2014/02/harvard-uct-2014.pdf	found in CSL metadata
+meta	elsevier-harvard	0.9330	0.0500	0.0000	https://www.erudit.org/fr/revues/meta/#journal-info-editorial_policy	found in CSL metadata
+representation	taylor-and-francis-chicago-author-date	0.9329	0.8000	0.0000	https://www.tandfonline.com/action/authorSubmission?journalCode=rrep20&amp;page=instructions	found in CSL metadata
+environmental-values	springer-basic-author-date	0.9325	0.0500	0.0000	http://www.whpress.co.uk/EV/EVinst.html	found in CSL metadata
+iica-catie	springer-basic-author-date	0.9325	0.5000	0.0000	http://repiica.iica.int/docs/B4013e/B4013e.pdf	found in CSL metadata
+journal-of-product-innovation-management	elsevier-harvard	0.9321	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291540-5885/homepage/ForAuthors.html	found in CSL metadata
+antipode	springer-basic-author-date	0.9316	0.5000	0.0000	https://mc.manuscriptcentral.com/societyimages/anti/Final%20format%20(papers).doc	found in CSL metadata
+harvard-north-west-university	springer-basic-author-date	0.9316	0.0500	0.0000	https://libguides.nwu.ac.za/harvard-referencing/home	found in CSL metadata
+indian-journal-of-agricultural-sciences	springer-basic-author-date	0.9316	0.5500	0.0000	https://epubs.icar.org.in/index.php/IJAgS/about/submissions	found in CSL metadata
+multilingual-matters	springer-basic-author-date	0.9316	0.0500	0.0000	https://www.multilingual-matters.com/page/guidelines-for-authors/	found in CSL metadata
+south-african-journal-of-enology-and-viticulture	springer-basic-author-date	0.9316	0.0500	0.0000	http://www.journals.ac.za/index.php/sajev/about/submissions#authorGuidelines	found in CSL metadata
+technische-universitat-dresden-betriebswirtschaftslehre-marketing	taylor-and-francis-chicago-author-date	0.9315	0.5500	0.0000	https://bildungsportal.sachsen.de/opal/auth/RepositoryEntry/428277778/CourseNode/94280218863497/Leitfaden+Wiss.+Arbeiten+Februar+2021.pdf	found in CSL metadata
+harvard-anglia-ruskin-university	taylor-and-francis-chicago-author-date	0.9310	0.1000	0.0000	http://libweb.anglia.ac.uk/referencing/harvard.htm	found in CSL metadata
+harvard-cranfield-university	taylor-and-francis-chicago-author-date	0.9310	0.1000	0.0000	http://www.som.cranfield.ac.uk/som/dinamic-content/media/mirc/Referencing/AuthorDateReferencingGuide2014.pdf	found in CSL metadata
+archeologicke-rozhledy	elsevier-harvard	0.9308	0.1000	0.0000	https://archeologickerozhledy.cz/index.php/ar/authguid#ref_tex	found in CSL metadata
+international-journal-of-management-reviews	elsevier-harvard	0.9308	0.8500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1468-2370/homepage/ForAuthors.html	found in CSL metadata
+natures-sciences-societes	elsevier-harvard	0.9308	0.7000	1.0000	https://www.nss-journal.org/author-information/instructions-for-authors	found in CSL metadata
+palaeontologia-electronica	elsevier-harvard	0.9308	0.0500	0.0000	http://palaeo-electronica.org/guide2011.pdf	found in CSL metadata
+podzemna-voda	elsevier-harvard	0.9308	0.8000	0.0000	http://sah-podzemnavoda.sk/cms/page.php?8	found in CSL metadata
+royal-college-of-nursing-harvard	elsevier-harvard	0.9308	0.8000	0.0000	https://github.com/citation-style-language/styles/pull/4255#issuecomment-526675875	found in CSL metadata
+universidad-de-leon-harvard	elsevier-harvard	0.9308	0.8000	0.0000	http://buleria.unileon.es/handle/10612/5930	found in CSL metadata
+university-of-hull-harvard	elsevier-harvard	0.9308	0.8000	0.0000	https://libguides.hull.ac.uk/referencing/harvard	found in CSL metadata
+fold-and-r	elsevier-harvard	0.9306	0.0000	0.0000	http://www.fastionline.org/folderabout.php?view=authnotes	found in CSL metadata
+bakhtiniana-journal-of-discourse-studies	elsevier-harvard	0.9305	0.0500	0.0000	https://revistas.pucsp.br/index.php/bakhtiniana/about/submissions#authorGuidelines	found in CSL metadata
+acta-botanica-croatica	elsevier-harvard	0.9303	0.0500	0.0000	http://www.abc.botanic.hr/index.php/abc/about/submissions#authorGuidelines	found in CSL metadata
+aging-cell	elsevier-harvard	0.9303	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291474-9726/homepage/ForAuthors.html	found in CSL metadata
+biosocieties	elsevier-harvard	0.9303	0.0500	0.0000	http://www.springer.com/social+sciences/journal/41292#References	found in CSL metadata
+california-agriculture	elsevier-harvard	0.9303	0.0500	0.0000	http://calag.ucanr.edu/SubmitArticles/#Matters%20of%20style	found in CSL metadata
+european-journal-of-information-systems	elsevier-harvard	0.9303	0.5500	0.0000	http://www.palgrave.com/gp/journal/41303/authors/presentation-formatting	found in CSL metadata
+frontiers-of-biogeography	elsevier-harvard	0.9303	0.0500	0.0000	https://escholarship.org/uc/fb/authorinformation	found in CSL metadata
+german-journal-of-agricultural-economics	elsevier-harvard	0.9303	0.5500	0.0000	https://www.gjae-online.de/instructions-for-authors/	found in CSL metadata
+grasas-y-aceites	elsevier-harvard	0.9303	0.0500	0.0000	http://grasasyaceites.revistas.csic.es/index.php/grasasyaceites/about/submissions#authorGuidelines	found in CSL metadata
+griffith-college-harvard	elsevier-harvard	0.9303	0.5500	0.0000	https://github.com/citation-style-language/styles/pull/4027#issuecomment-479049130	found in CSL metadata
+harvard-cape-peninsula-university-of-technology	elsevier-harvard	0.9303	0.5000	0.0000	http://www.cput.ac.za/files/images_folder/cpgs/Harvard.pdf	found in CSL metadata
+harvard-leeds-metropolitan-university	elsevier-harvard	0.9303	0.5500	0.0000	http://skillsforlearning.leedsmet.ac.uk/Quote_Unquote.pdf	found in CSL metadata
+harvard-manchester-business-school	elsevier-harvard	0.9303	0.0500	0.0000	http://www.library.manchester.ac.uk/academicsupport/referencing/	found in CSL metadata
+harvard-the-university-of-northampton	elsevier-harvard	0.9303	0.5500	0.0000	http://www.northampton.ac.uk/downloads/download/207/referencing-guides	found in CSL metadata
+harvard-universiti-teknologi-malaysia	elsevier-harvard	0.9303	0.5500	1.0000	http://www.sps.utm.my/sps/?option=com_content&amp;task=view&amp;id=279&amp;Itemid=	found in CSL metadata
+harvard-universiti-tunku-abdul-rahman	elsevier-harvard	0.9303	0.5500	1.0000	http://research.utar.edu.my/ipsrweb/guideline.html	found in CSL metadata
+harvard-university-of-brighton-school-of-environment-and-technology	elsevier-harvard	0.9303	0.5500	0.0000	https://student.brighton.ac.uk/mod_docs/sci_eng/environment/course_handbooks/gyggskills.pdf	found in CSL metadata
+health-economics	elsevier-harvard	0.9303	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1099-1050/homepage/ForAuthors.html	found in CSL metadata
+journal-of-lithic-studies	elsevier-harvard	0.9303	0.0500	0.0000	http://journals.ed.ac.uk/lithicstudies/article/view/1403/1951	found in CSL metadata
+journal-of-simulation	elsevier-harvard	0.9303	0.5500	0.0000	http://www.palgrave-journals.com/jos/author_instructions.html#References	found in CSL metadata
+keele-university-school-of-allied-health-professions	elsevier-harvard	0.9303	0.5500	0.0000	https://github.com/citation-style-language/styles/files/14024519/SAHP_REFERENCE_MANUAL_1.5b.docx	found in CSL metadata
+marine-ornithology	elsevier-harvard	0.9303	0.0500	0.0000	http://www.marineornithology.org/content/get.cgi?p=subm	found in CSL metadata
+new-zealand-dental-journal	elsevier-harvard	0.9303	0.5500	0.0000	https://www.researchgate.net/profile/Lee_Smith28/publication/315481211_Understanding_Bachelor_of_Oral_Health_Student_and_educators%27_understandings_of_professionalism/links/58e2dedd92851c1b9d6a0796/Understanding-Bachelor-of-Oral-Health-Student-and-educators-understandings-of-professionalism.pdf	found in CSL metadata
+nottingham-trent-university-library-harvard	elsevier-harvard	0.9303	0.0500	1.0000	https://www.ntu.ac.uk/m/library/referencing-made-easy	found in CSL metadata
+ornitologia-neotropical	elsevier-harvard	0.9303	0.0500	0.0000	http://www.neotropicalornithology.org/	found in CSL metadata
+permafrost-and-periglacial-processes	elsevier-harvard	0.9303	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1530/homepage/ForAuthors.html	found in CSL metadata
+scandinavian-political-studies	elsevier-harvard	0.9303	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-9477/homepage/ForAuthors.html	found in CSL metadata
+social-cognitive-and-affective-neuroscience	elsevier-harvard	0.9303	0.5500	0.0000	https://academic.oup.com/scan/pages/General_Instructions	found in CSL metadata
+style-manual-for-authors-editors-and-printers-6th-edition-snooks-co	elsevier-harvard	0.9303	0.0500	0.0000	https://catalogue.nla.gov.au/Record/45358	found in CSL metadata
+the-design-journal	elsevier-harvard	0.9303	0.5500	0.0000	http://www.bergpublishers.com/bergjournals/thedesignjournal/tabid/3650/default.aspx	found in CSL metadata
+the-international-journal-of-developmental-biology	elsevier-harvard	0.9303	0.6000	0.0000	http://www.ijdb.ehu.es/web/descarga/mschecklist	found in CSL metadata
+the-journal-of-hellenic-studies	elsevier-harvard	0.9303	0.0500	0.0000	http://www.hellenicsociety.org.uk/publications/	found in CSL metadata
+the-plant-journal	elsevier-harvard	0.9303	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-313X/homepage/ForAuthors.html	found in CSL metadata
+the-university-of-western-australia-harvard	elsevier-harvard	0.9303	0.0500	0.0000	http://guides.library.uwa.edu.au/friendly.php?s=harvard	found in CSL metadata
+trinity-college-dublin-zoology-botany-environmental-sciences-harvard	elsevier-harvard	0.9303	0.5500	0.0000	https://github.com/citation-style-language/styles/pull/5893	found in CSL metadata
+oxford-studies-on-the-roman-economy	elsevier-harvard	0.9301	0.0000	0.0000	https://oxrep.classics.ox.ac.uk/oxford_studies_on_the_roman_economy/guidelines_for_authors/	found in CSL metadata
+journal-of-advertising-research	taylor-and-francis-chicago-author-date	0.9295	0.0500	0.0000	http://www.journalofadvertisingresearch.com/content/submit-manuscript	found in CSL metadata
+liverpool-john-moores-university-harvard	elsevier-harvard	0.9286	0.5500	0.0000	https://www.ljmu.ac.uk/~/media/library/library-skills/harvardreferencingfullguidenew.pdf?la=en	found in CSL metadata
+the-open-university-m801	elsevier-harvard	0.9286	0.5500	0.0000	http://www.open.ac.uk/library/help-and-support/referencing-styles	found in CSL metadata
+universitas-negeri-semarang-fakultas-matematika-dan-ilmu-pengetahuan-alam	elsevier-harvard	0.9286	0.5500	0.0000	http://fisika.unnes.ac.id/wp-content/uploads/2010/03/Panduan-Penulisan-Skripsi-TA-Artikel-rev-2014.pdf	found in CSL metadata
+ets-ecole-de-technologie-superieure	taylor-and-francis-chicago-author-date	0.9283	0.0500	0.0000	http://etsmtl.ca/Etudiants-actuels/Cycles-sup/Realisation-etudes/Guides-gabarits/Guide_redaction	found in CSL metadata
+institut-national-de-recherches-archeologiques-preventives	elsevier-harvard	0.9283	0.0500	0.0000	https://multimedia.inrap.fr/Ressources-documentaires/Tutoriels-FAQ/p-20507-Memento-bibliographique.htm	found in CSL metadata
+institut-francais-darcheologie-orientale	elsevier-harvard	0.9281	0.0000	0.0000	https://www.ifao.egnet.net/publications/publier/normes-ed/	found in CSL metadata
+australian-road-research-board	taylor-and-francis-chicago-author-date	0.9278	0.5000	0.0000	https://www.railknowledgebank.com/Presto/pl/NmQ5ZmY0YWQtNTc4NS00YzZiLTk3MTItNjEzYWQxZTgyMTRlLjcxNjg=	found in CSL metadata
+harvard-melbourne-polytechnic	taylor-and-francis-chicago-author-date	0.9278	0.5000	0.0000	https://melbournepolytechnic.spydus.com/reference.html	found in CSL metadata
+civitas-revista-de-ciencias-sociais	elsevier-harvard	0.9277	0.9000	0.0000	http://revistaseletronicas.pucrs.br/ojs/index.php/civitas/about/submissions#authorGuidelines	found in CSL metadata
+isara-iso-690	elsevier-harvard	0.9274	0.7500	0.0000	https://doc.isara.fr/se-former/guide-de-referencement-bibliographique/	found in CSL metadata
+cahiers-mondes-anciens	taylor-and-francis-chicago-author-date	0.9271	0.0000	0.0000	https://journals.openedition.org/mondesanciens/273	found in CSL metadata
+anais-da-academia-brasileira-de-ciencias	elsevier-harvard	0.9263	0.0500	0.0000	https://www.scielo.br/journal/aabc/about/#instructions	found in CSL metadata
+biota-neotropica	elsevier-harvard	0.9263	0.0500	0.0000	http://www.biotaneotropica.org.br/v17n3/en/instruction	found in CSL metadata
+biotropica	elsevier-harvard	0.9263	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291744-7429/homepage/ForAuthors.html	found in CSL metadata
+institut-francais-darcheologie-orientale-etudes-arabes	elsevier-harvard	0.9261	0.0000	0.0000	https://www.ifao.egnet.net/publications/publier/normes-ed/	found in CSL metadata
+university-of-york-harvard-archaeology	elsevier-harvard	0.9256	0.0500	0.0000	https://www.york.ac.uk/students/studying/develop-your-skills/study-skills/study/integrity/referencing-styles/	found in CSL metadata
+university-of-york-harvard-environment	elsevier-harvard	0.9256	0.5500	0.0000	https://www.york.ac.uk/students/studying/develop-your-skills/study-skills/study/integrity/referencing-styles/	found in CSL metadata
+university-of-york-harvard	elsevier-harvard	0.9256	0.5000	0.0000	https://www.york.ac.uk/students/studying/develop-your-skills/study-skills/study/integrity/referencing-styles/	found in CSL metadata
+revista-noesis	taylor-and-francis-chicago-author-date	0.9251	0.0500	0.0000	http://erevistas.uacj.mx/ojs/index.php/RevistasUACJ/article/view/1153/994	found in CSL metadata
+plant-genetic-resources-characterization-and-utilization	elsevier-harvard	0.9249	0.5500	0.0000	https://www.cambridge.org/core/journals/plant-genetic-resources/information/instructions-contributors	found in CSL metadata
+journal-of-the-american-philosophical-association	elsevier-harvard	0.9240	0.0500	0.0000	https://www.cambridge.org/core/journals/journal-of-the-american-philosophical-association/information/author-instructions/preparing-your-materials	found in CSL metadata
+deutsche-sprache	springer-basic-author-date	0.9235	0.5500	0.0000	http://pub.ids-mannheim.de/laufend/deusprach/hinweise.pdf	found in CSL metadata
+contributions-to-the-archaeology-of-egypt-nubia-and-the-levant	elsevier-harvard	0.9235	0.0000	0.0000	https://www.orea.oeaw.ac.at/en/publications/series/contributions-to-the-archaeology-of-egypt-nubia-and-the-levant-caenl/	found in CSL metadata
+harvard-dundalk-institute-of-technology	elsevier-harvard	0.9235	0.0500	0.0000	https://www.dkit.ie/library/support/guide-harvard-referencing	found in CSL metadata
+les-nouvelles-de-l-archeologie	springer-basic-author-date	0.9222	0.0000	0.0000	https://journals.openedition.org/nda/1554	found in CSL metadata
+arbok-hins-islenzka-fornleifafelags	taylor-and-francis-chicago-author-date	0.9212	0.0000	0.0000	https://hif.is/leidbeiningar-fyrir-hofunda/	found in CSL metadata
+copernicus-publications	elsevier-harvard	0.9210	0.5500	0.0000	https://publications.copernicus.org/for_authors/manuscript_preparation.html	found in CSL metadata
+em-normandie-business-school-harvard-english	taylor-and-francis-chicago-author-date	0.9209	0.1000	0.0000	https://drive.google.com/file/d/1dkgiDfAtnFVgcuF0hZetJrqJ_vWbUUyO/view	found in CSL metadata
+collection-du-centre-jean-berard	elsevier-harvard	0.9192	0.0000	0.0000	http://www.centre-jean-berard.cnrs.fr/	found in CSL metadata
+avocetta-journal-of-ornithology	elsevier-harvard	0.9189	0.1000	0.0000	https://www.avocetta.org/author-guidelines/	found in CSL metadata
+constructivist-foundations	elsevier-harvard	0.9189	0.1000	0.0000	https://constructivist.info/guidelines/	found in CSL metadata
+diplo	elsevier-harvard	0.9189	0.1000	0.0000	http://diplomacy.edu/	found in CSL metadata
+karstenia	elsevier-harvard	0.9189	0.1000	0.0000	http://karstenia.fi/instructions-to-authors/#Manuscript%20preparation	found in CSL metadata
+water-science-and-technology	elsevier-harvard	0.9188	0.5500	0.0000	http://www.iwaponline.com/wst/i2a.htm	found in CSL metadata
+isabella-stewart-gardner-museum	elsevier-harvard	0.9187	0.0000	0.0000	https://www.gardnermuseum.org/	found in CSL metadata
+chroniques-des-activites-archeologiques-de-l-ecole-francaise-de-rome	taylor-and-francis-chicago-author-date	0.9186	0.0000	0.0000	http://cefr.revues.org/216	found in CSL metadata
+cardiff-university-harvard	elsevier-harvard	0.9181	0.0500	0.0000	https://xerte.cardiff.ac.uk/play_4191	found in CSL metadata
+university-of-south-wales-harvard	elsevier-harvard	0.9181	0.5000	0.0000	https://www.southwales.ac.uk/services/library/referencing-guides/	found in CSL metadata
+law-technology-and-humans	chicago-shortened-notes-bibliography	0.9173	0.3000	0.0000	http://www.zotero.org/styles/chicago-shortened-notes-bibliography	found in CSL metadata
+revue-francaise-de-pedagogie	elsevier-harvard	0.9172	0.8000	0.0000	https://journals.openedition.org/rfp/4286	found in CSL metadata
+geological-magazine	elsevier-harvard	0.9166	0.5500	0.0000	http://journals.cambridge.org/action/displayJournal?jid=GEO	found in CSL metadata
+technische-universitat-munchen-unternehmensfuhrung	elsevier-harvard	0.9166	0.4500	0.0000	http://www.uf.wi.tum.de/lehre/abschlussarbeiten/	found in CSL metadata
+journal-of-finance	taylor-and-francis-chicago-author-date	0.9164	0.0500	0.0000	http://www.afajof.org/details/page/2870711/Submissions.html	found in CSL metadata
+organization	taylor-and-francis-chicago-author-date	0.9160	0.1000	0.0000	http://www.uk.sagepub.com/journals/Journal200981/manuscriptSubmission	found in CSL metadata
+wirtschaftsuniversitat-wien-author-date	taylor-and-francis-chicago-author-date	0.9160	0.1500	0.0000	https://learn.wu.ac.at/bibliothek/literaturverwaltung	found in CSL metadata
+atlande	taylor-and-francis-chicago-author-date	0.9153	0.0000	0.0000	http://atlande.eu/atlande-author-date-v2_documentation.pdf	found in CSL metadata
+le-tapuscrit-author-date	taylor-and-francis-chicago-author-date	0.9153	0.5500	0.0000	http://www.editions.ehess.fr/ouvrages/ouvrage/le-tapuscrit/	found in CSL metadata
+philipps-universitat-marburg-note	taylor-and-francis-chicago-author-date	0.9153	0.0000	0.0000	https://github.com/citation-style-language/styles/files/1839191/ZitierrichtlinienFB21Lehramt.pdf	found in CSL metadata
+instituto-de-pesquisas-energeticas-e-nucleares	elsevier-harvard	0.9150	0.1000	0.0000	https://www.ipen.br/portal_por/conteudo/biblioteca/arquivos/GuiaIPEN_2017-10-24_versao_4.pdf	found in CSL metadata
+strategic-design-research-journal	elsevier-harvard	0.9150	0.8000	0.0000	http://revistas.unisinos.br/index.php/sdrj/about/submissions#onlineSubmissions	found in CSL metadata
+water-sa	elsevier-harvard	0.9150	0.8000	0.0000	http://www.wrc.org.za/Pages/KH_WaterSA.aspx?dt=5&amp;ms=62	found in CSL metadata
+australasian-journal-of-philosophy	springer-basic-author-date	0.9148	0.4500	0.0000	https://aap.org.au/style	found in CSL metadata
+acta-adriatica	elsevier-harvard	0.9148	0.6500	0.0000	https://acta.izor.hr/ojs/index.php/acta/about/submissions#authorGuidelines	found in CSL metadata
+acta-ornithologica	elsevier-harvard	0.9148	0.6000	0.0000	https://miiz.waw.pl/periodicals/acta-ornithologica/acta_ornithologica.pdf	found in CSL metadata
+american-journal-of-enology-and-viticulture	elsevier-harvard	0.9148	0.0500	0.0000	http://www.ajevonline.org/content/authors	found in CSL metadata
+austral-entomology	springer-basic-author-date	0.9148	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/20521758/homepage/forauthors.html	found in CSL metadata
+australian-journal-of-earth-sciences	elsevier-harvard	0.9148	0.5500	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=taje20&amp;page=instructions	found in CSL metadata
+biologia	elsevier-harvard	0.9148	0.6000	0.0000	http://www.degruyter.com/view/j/biolog	found in CSL metadata
+bioscience	elsevier-harvard	0.9148	0.0500	0.0000	https://academic.oup.com/bioscience/pages/General_Instructions#MANUSCRIPT%20PREPARATION	found in CSL metadata
+british-journal-of-cancer	elsevier-harvard	0.9148	0.5500	0.0000	http://www.nature.com/bjc/authors/submit.html#how-to-submit	found in CSL metadata
+british-journal-of-pharmacology	elsevier-harvard	0.9148	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1476-5381/homepage/ForAuthors.html	found in CSL metadata
+bulletin-of-marine-science	elsevier-harvard	0.9148	0.0500	0.0000	http://www.rsmas.miami.edu/bms/PDF/INSTRUCTIONS_TO_AUTHORS.pdf	found in CSL metadata
+clinical-physiology-and-functional-imaging	elsevier-harvard	0.9148	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/1475097x/homepage/ForAuthors.html	found in CSL metadata
+conservation-letters	elsevier-harvard	0.9148	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291755-263X/homepage/ForAuthors.html	found in CSL metadata
+coral-reefs	elsevier-harvard	0.9148	0.0500	0.0000	http://www.springer.com/life+sciences/ecology/journal/338	found in CSL metadata
+critical-reviews-in-plant-sciences	elsevier-harvard	0.9148	0.5500	0.0000	http://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=bpts20	found in CSL metadata
+ecological-entomology	elsevier-harvard	0.9148	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2311/homepage/ForAuthors.html	found in CSL metadata
+european-journal-of-entomology	elsevier-harvard	0.9148	0.6000	0.0000	https://www.eje.cz/artkey/inf-990000-2600_Manuscript.php	found in CSL metadata
+european-journal-of-pain	elsevier-harvard	0.9148	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291532-2149/homepage/ForAuthors.html#References_	found in CSL metadata
+evolution-and-development	elsevier-harvard	0.9148	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291525-142X/homepage/ForAuthors.html	found in CSL metadata
+evolution-letters	elsevier-harvard	0.9148	0.6500	0.0000	https://onlinelibrary.wiley.com/page/journal/20563744/homepage/forauthors.html	found in CSL metadata
+excli-journal	elsevier-harvard	0.9148	0.0500	0.0000	http://www.excli.de/instructions_to_authors.php	found in CSL metadata
+friedrich-schiller-universitat-jena-medizinische-fakultat	elsevier-harvard	0.9148	0.0500	0.0000	http://www.uniklinikum-jena.de/MedWeb_media/Downloads/Dekanat_Promotionsstelle/Formulare/Zitierweise.pdf	found in CSL metadata
+genes-brain-and-behavior	elsevier-harvard	0.9148	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1601-183X/homepage/ForAuthors.html	found in CSL metadata
+genes-to-cells	elsevier-harvard	0.9148	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2443/homepage/ForAuthors.html	found in CSL metadata
+geobiology	elsevier-harvard	0.9148	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291472-4669/homepage/ForAuthors.html	found in CSL metadata
+geografia-fisica-e-dinamica-quaternaria	elsevier-harvard	0.9148	0.5500	0.0000	https://www.gfdq.glaciologia.it/index.php/GFDQ/information/authors	found in CSL metadata
+health-physics	elsevier-harvard	0.9148	0.0500	0.0000	https://www.editorialmanager.com/hpj/default1.aspx	found in CSL metadata
+human-reproduction	elsevier-harvard	0.9148	0.6500	0.0000	https://academic.oup.com/humrep/pages/Manuscript_Preparation	found in CSL metadata
+indian-journal-of-veterinary-and-animal-sciences-research	elsevier-harvard	0.9148	0.5500	0.0000	https://www.tanuvas.ac.in/pdf/ijvasr_author.pdf	found in CSL metadata
+international-journal-of-food-science-and-technology	springer-basic-author-date	0.9148	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2621/homepage/ForAuthors.html	found in CSL metadata
+international-union-of-forest-research-organizations-headquarters	elsevier-harvard	0.9148	0.5500	0.0000	https://www.iufro.org/fileadmin/material/publications/iufro-hq-citation-style.pdf	found in CSL metadata
+journal-of-comparative-pathology	elsevier-harvard	0.9148	0.6000	0.0000	https://www.elsevier.com/journals/journal-of-comparative-pathology/0021-9975/guide-for-authors	found in CSL metadata
+journal-of-dairy-research	springer-basic-author-date	0.9148	0.1000	1.0000	https://www.cambridge.org/core/journals/journal-of-dairy-research/information	found in CSL metadata
+journal-of-molecular-cell-biology	elsevier-harvard	0.9148	0.5000	0.0000	https://academic.oup.com/jmcb/pages/general_instructions#MANUSCRIPT%20ORGANIZATION	found in CSL metadata
+journal-of-molecular-endocrinology	springer-basic-author-date	0.9148	0.7000	0.0000	http://jme.endocrinology-journals.org/site/misc/For-Authors.xhtml#refs	found in CSL metadata
+journal-of-oil-palm-research	elsevier-harvard	0.9148	0.5500	0.0000	http://jopr.mpob.gov.my/guide-t/	found in CSL metadata
+knowledge-and-management-of-aquatic-ecosystems	elsevier-harvard	0.9148	0.6000	0.0000	https://www.kmae-journal.org/author-information/instructions-for-authors	found in CSL metadata
+life-science-alliance	elsevier-harvard	0.9148	0.5500	0.0000	https://www.life-science-alliance.org/manuscript-prep#format	found in CSL metadata
+medizinische-hochschule-hannover	elsevier-harvard	0.9148	0.5500	0.0000	https://www.mhh.de/bibliothek/literatur-verwalten/mhh-citation-style	found in CSL metadata
+molecular-biology-of-the-cell	elsevier-harvard	0.9148	0.5500	0.0000	https://www.molbiolcell.org/info-for-authors#formats	found in CSL metadata
+mycologia	elsevier-harvard	0.9148	0.0500	0.0000	http://www.mycologia.org/content/105/1/230.full	found in CSL metadata
+photosynthetica	elsevier-harvard	0.9148	0.0500	0.0000	https://ps.ueb.cas.cz/artkey/inf-990000-0200_For-Authors.php	found in CSL metadata
+physiologia-plantarum	elsevier-harvard	0.9148	0.0500	0.0000	http://physiologiaplantarum.org/instructions-for-manuscrip/#Citations%20and%20References	found in CSL metadata
+protein-engineering-design-and-selection	springer-basic-author-date	0.9148	0.1000	0.0000	https://academic.oup.com/peds/pages/Manuscript_Preparation	found in CSL metadata
+reproduction	springer-basic-author-date	0.9148	0.1000	1.0000	http://www.reproduction-online.org/site/misc/For-Authors.xhtml#refs	found in CSL metadata
+research-in-plant-disease	elsevier-harvard	0.9148	0.5500	0.0000	https://www.online-rpd.org/authors/authors.php?v_type=&amp;lang=en	found in CSL metadata
+royal-entomological-society	elsevier-harvard	0.9148	0.7000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-2311/homepage/ForAuthors.html	found in CSL metadata
+scientia-agriculturae-bohemica	elsevier-harvard	0.9148	0.5500	0.0000	http://sab.czu.cz/?r=5601	found in CSL metadata
+sedimentology	springer-basic-author-date	0.9148	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/13653091/homepage/forauthors.html	found in CSL metadata
+stem-cell-reports	elsevier-harvard	0.9148	0.5500	0.0000	http://www.cell.com/stem-cell-reports/authors	found in CSL metadata
+systematic-biology	elsevier-harvard	0.9148	0.0500	0.0000	https://academic.oup.com/sysbio/pages/general_instructions	found in CSL metadata
+the-international-journal-of-psychoanalysis	elsevier-harvard	0.9148	0.7000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291745-8315/homepage/ForAuthors.html	found in CSL metadata
+weed-research	springer-basic-author-date	0.9148	0.0500	0.0000	https://onlinelibrary.wiley.com/page/journal/13653180/homepage/forauthors.html	found in CSL metadata
+wirtschaftsuniversitat-wien-institut-fur-transportwirtschaft-und-logistik	elsevier-harvard	0.9130	0.0500	0.0000	https://www.wu.ac.at/fileadmin/wu/d/i/itl/Lehre/210226_ITL_Richtlinien_zum_wissenschaftlichen_Arbeiten.pdf	found in CSL metadata
+mhra-shortened-notes-no-url	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+mhra-shortened-notes-publisher-place-no-url	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+mhra-shortened-notes-publisher-place	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+mhra-shortened-notes	chicago-shortened-notes-bibliography	0.9128	0.6000	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+maison-de-l-orient-et-de-la-mediterranee-en	taylor-and-francis-chicago-author-date	0.9126	0.0000	0.0000	https://www.mom.fr/sites/mom.fr/files/img/Publications/mom-editions_3_normes-bibliographie.pdf	found in CSL metadata
+bibliothek-fur-bildungsgeschichtliche-forschung	taylor-and-francis-chicago-author-date	0.9122	0.0000	0.0000	https://jb-historische-bildungsforschung.de/editorial/guidelines.xml	found in CSL metadata
+revue-archeologique-du-centre-de-la-france	taylor-and-francis-chicago-author-date	0.9120	0.5500	0.0000	http://racf.revues.org/920#tocto2n12	found in CSL metadata
+norma-portuguesa-405	taylor-and-francis-chicago-author-date	0.9117	0.0500	0.0000	https://github.com/citation-style-language/styles/pull/413	found in CSL metadata
+bern-university-of-applied-sciences-school-of-agricultural-forest-and-food-sciences-hafl	elsevier-harvard	0.9110	0.0500	0.0000		
+geographische-zeitschrift	elsevier-harvard	0.9110	0.0500	0.0000	https://s3.eu-central-1.amazonaws.com/datahub.dav.assets/assets/FSV/guidelines/zeitschriften-jahrbuecher.pdf	found in CSL metadata
+environment-and-planning	elsevier-harvard	0.9103	0.5500	0.0000	http://www.envplan.com/ref_examples.html	found in CSL metadata
+geographical-analysis	elsevier-harvard	0.9103	0.5500	0.0000	https://onlinelibrary.wiley.com/page/journal/15384632/homepage/forauthors.html	found in CSL metadata
+institut-national-de-sante-publique-du-quebec-napp	taylor-and-francis-chicago-author-date	0.9101	0.0500	0.0000	http://www.inspq.qc.ca/pdf/publications/CollectionTOPO/TOPO-NAPP_styleguide.pdf	found in CSL metadata
+tgm-wien-diplomarbeit-onorm	taylor-and-francis-chicago-author-date	0.9096	0.1000	0.0000	https://github.com/citation-style-language/styles/pull/3929#issuecomment-480520187	found in CSL metadata
+societe-archeologique-de-bordeaux	elsevier-harvard	0.9090	0.0000	0.0000	http://www.societe-archeologique-bordeaux.fr/publications/recommandations-aux-auteurs.html	found in CSL metadata
+leviathan	taylor-and-francis-chicago-author-date	0.9088	0.0000	0.0000	https://www.nomos.de/zeitschriften/leviathan/#autorenhinweise	found in CSL metadata
+african-online-scientific-information-systems-harvard	taylor-and-francis-chicago-author-date	0.9085	0.6000	0.0000	https://books.aosis.co.za/index.php/ob/submission-guideline	found in CSL metadata
+pallas	elsevier-harvard	0.9085	0.0000	0.0000	https://journals.openedition.org/pallas/2624	found in CSL metadata
+universidade-federal-do-rio-de-janeiro-instituto-alberto-luiz-coimbra-de-pos-graduacao-e-pesquisa-de-engenharia-abnt	taylor-and-francis-chicago-author-date	0.9084	0.0500	0.0000	https://www.abntcatalogo.com.br/norma.aspx?ID=408006	found in CSL metadata
+nova-univerza	taylor-and-francis-chicago-author-date	0.9082	0.0000	0.0000	https://www.nova-uni.si/wp-content/uploads/2024/09/Tehnicna-navodila-za-izdelavo-zakljucnih-del-2024-k-3.pdf	found in CSL metadata
+mathematical-geosciences	elsevier-harvard	0.9080	0.0500	0.0000	https://www.springer.com/earth+sciences+and+geography/journal/11004?detailsPage=pltci_3160931	found in CSL metadata
+osterreichische-zeitschrift-fur-politikwissenschaft	elsevier-harvard	0.9074	0.0500	0.0000	http://www.oezp.at/authors_e.php	found in CSL metadata
+em-normandie-business-school-harvard-francais	taylor-and-francis-chicago-author-date	0.9073	0.0500	0.0000	https://drive.google.com/file/d/1dkgiDfAtnFVgcuF0hZetJrqJ_vWbUUyO/view	found in CSL metadata
+palaeodiversity	elsevier-harvard	0.9070	0.0000	0.0000	http://www.palaeodiversity.org/authors.htm	found in CSL metadata
+technische-universitat-dresden-wirtschaftswissenschaften	elsevier-harvard	0.9069	0.0000	0.0000		
+hochschule-der-kunste-bern-musikforschung	elsevier-harvard	0.9062	0.0000	0.0000	https://github.com/citation-style-language/styles/pull/7901	found in CSL metadata
+technische-universitat-dresden-erziehungswissenschaften-author-date	elsevier-harvard	0.9062	0.1000	0.0000	https://tu-dresden.de/gsw/ew/ressourcen/dateien/studium/pdf/broschuere_booklet.pdf?lang=de	found in CSL metadata
+les-journees-de-la-recherche-avicole	elsevier-harvard	0.9053	0.5000	0.0000	http://www.journees-de-la-recherche.org/JRA/page-JRA1024.php?page=fr	found in CSL metadata
+duale-hochschule-baden-wurttemberg-department-of-international-business	elsevier-harvard	0.9053	0.0500	0.0000	https://www.dhbw-stuttgart.de/studierendenportale/bwl-ib/Zitierrichtlinien/Guidelines_for_Academic_Writing_v1.7.1.pdf	found in CSL metadata
+collection-de-l-ecole-francaise-de-rome-note	taylor-and-francis-chicago-author-date	0.9046	0.0000	0.0000	http://www.publications.efrome.it/opencms/export/sites/efrome/documenti/norme_fr.pdf	found in CSL metadata
+acta-ophthalmologica	taylor-and-francis-chicago-author-date	0.9045	0.5000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291755-3768/homepage/ForAuthors.html	found in CSL metadata
+archeologia-classica	elsevier-harvard	0.9042	0.0000	0.0000	http://www.antichita.uniroma1.it/node/8243	found in CSL metadata
+effective-altruism-wiki	taylor-and-francis-chicago-author-date	0.9039	0.1000	0.0000	https://forum.effectivealtruism.org/tag/style-guide	found in CSL metadata
+organization-studies	taylor-and-francis-chicago-author-date	0.9039	0.1000	0.0000	https://journals.sagepub.com/author-instructions/OSS	found in CSL metadata
+universidade-do-porto-faculdade-de-psicologia-e-de-ciencias-da-educacao	taylor-and-francis-chicago-author-date	0.9039	0.1000	0.0000	https://www.fpce.up.pt/ciie/?q=publication/revista-educa%C3%A7%C3%A3o-sociedade-culturas/page/instrucoes-aos-autores	found in CSL metadata
+journal-of-roman-archaeology-a	elsevier-harvard	0.9035	0.0000	0.0000	http://www.journalofromanarch.com/GuidelinesForAuthors.pdf	found in CSL metadata
+journal-of-small-business-management	taylor-and-francis-chicago-author-date	0.9031	0.1000	0.0000	https://onlinelibrary.wiley.com/page/journal/1540627x/homepage/forauthors.html	found in CSL metadata
+the-accounting-review	taylor-and-francis-chicago-author-date	0.9031	0.7500	0.0000	https://aaahq.org/portals/0/documents/publications/00_MANUSCRIPT_PREPARATION_AND_STYLE_11.29.22.pdf	found in CSL metadata
+university-of-roehampton-harvard	taylor-and-francis-chicago-author-date	0.9022	0.0500	0.0000	https://library.roehampton.ac.uk/ld.php?content_id=32542499	found in CSL metadata
+cahiers-d-ethnomusicologie	taylor-and-francis-chicago-author-date	0.9018	0.6500	0.0000	http://www.adem-geneve.com/fr/cahiers-d-ethnomusicologie-contribution	found in CSL metadata
+mots	elsevier-harvard	0.9017	0.0000	0.0000	https://journals.openedition.org/mots/76	found in CSL metadata
+fh-joanneum-institute-of-software-design-and-security	taylor-and-francis-chicago-author-date	0.9016	0.1000	0.0000	https://pages-iit.fh-joanneum.at/iit/typst-thesis-template/doc.html	found in CSL metadata
+apa-6th-edition	taylor-and-francis-chicago-author-date	0.9011	0.1000	0.0000	http://owl.english.purdue.edu/owl/resource/560/01/	found in CSL metadata
+bursa-uludag-universitesi-saglik-bilimleri-enstitusu	taylor-and-francis-chicago-author-date	0.9011	0.1000	0.0000		
+harvard-durham-university-business-school	taylor-and-francis-chicago-author-date	0.9007	0.5000	0.0000	http://www.dur.ac.uk/resources/library/teaching/writingyourbibliography.pdf	found in CSL metadata
+harvard-fachhochschule-salzburg	taylor-and-francis-chicago-author-date	0.9007	0.1000	0.0000	http://www.users.fh-salzburg.ac.at/~bhechenl/mw/images/RichtigReferenzieren.pdf	found in CSL metadata
+sciences-po-ecole-doctorale-author-date	taylor-and-francis-chicago-author-date	0.8994	0.0500	0.0000	https://sciencespo.libguides.com/zotero/styles	found in CSL metadata
+archaeologia-austriaca	taylor-and-francis-chicago-author-date	0.8992	0.0000	0.0000	https://www.orea.oeaw.ac.at/en/publications/journals/archaeologia-austriaca/	found in CSL metadata
+maison-de-l-orient-et-de-la-mediterranee	taylor-and-francis-chicago-author-date	0.8990	0.0000	0.0000	https://www.mom.fr/sites/mom.fr/files/img/Publications/mom-editions_3_normes-bibliographie.pdf	found in CSL metadata
+quaternaire	springer-basic-author-date	0.8984	0.1000	0.0000	https://journals.openedition.org/quaternaire/1243#tocto2n3	found in CSL metadata
+journal-of-agricultural-and-resource-economics	taylor-and-francis-chicago-author-date	0.8975	0.0500	0.0000	http://www.waeaonline.org/publications/jare/submission-guidelines	found in CSL metadata
+economie-et-statistique	taylor-and-francis-chicago-author-date	0.8970	0.0500	0.0000	http://www.insee.fr/fr/publications-et-services/collection.asp?id=2	found in CSL metadata
+ergo	taylor-and-francis-chicago-author-date	0.8960	0.1000	0.0000	https://www.ergophiljournal.org/submit.html	found in CSL metadata
+incontext-studies-in-translation-and-interculturalism	taylor-and-francis-chicago-author-date	0.8960	0.1000	0.0000	https://incontextjournal.org/index.php/incontext/about/submissions	found in CSL metadata
+instituto-universitario-militar	taylor-and-francis-chicago-author-date	0.8955	0.1000	0.0000	https://www.ium.pt/files/publicacoes/Atualidade/7/IUM_Atualidade_7_IUM_Author-Guidelines.pdf	found in CSL metadata
+mhra-author-date-no-url	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+mhra-author-date-publisher-place-no-url	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+mhra-author-date-publisher-place	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+mhra-author-date	taylor-and-francis-chicago-author-date	0.8954	0.5500	0.0000	https://www.mhra.org.uk/style/	found in CSL metadata
+university-of-tasmania-simplified-author-date	elsevier-harvard	0.8948	0.2000	0.0000	https://utas.libguides.com/referencing/simplified_authordate	found in CSL metadata
+politeknik-negeri-manado-jurnal-p3m	ieee	0.8937	0.6000	0.0000	http://p3m.polimdo.ac.id/jurnal/index.php/JTIB/about/submissions#references	found in CSL metadata
+antiquites-africaines	elsevier-harvard	0.8932	0.0000	0.0000	https://journals.openedition.org/antafr/340	found in CSL metadata
+comptes-rendus-author-date	elsevier-harvard	0.8932	0.7000	0.0000		
+polygraphia	elsevier-harvard	0.8931	0.0000	0.0000	https://polygraphia.it/wp-content/uploads/2020/07/Norme-Polygraphia-2020.pdf	found in CSL metadata
+american-college-of-clinical-pharmacy	elsevier-harvard	0.8925	0.1000	0.0000	https://www.accp.com/docs/sap/References.pdf	found in CSL metadata
+harvard-institut-fur-praxisforschung-de	elsevier-harvard	0.8913	0.0500	0.0000	http://www.institut-praxisforschung.com/app/download/6167762784/Harvard-Zitierweise.pdf?t=1410296308	found in CSL metadata
+suburban-zeitschrift-fur-kritische-stadtforschung	elsevier-harvard	0.8913	0.0500	0.0000	https://zeitschrift-suburban.de/sys/index.php/suburban/about/submissions	found in CSL metadata
+quaderni	elsevier-harvard	0.8912	0.0000	0.0000	https://www.quaderniarcheocaor.beniculturali.it/index.php/qua/about/submissions	found in CSL metadata
+groupe-danthropologie-et-darcheologie-funeraire	elsevier-harvard	0.8909	0.0500	0.0000	https://www.gaaf-asso.fr/wp-content/uploads/Collection-Publication-du-Gaaf_Recommandations_auteurs_DEF-V3.pdf	found in CSL metadata
+nehet	elsevier-harvard	0.8906	0.0000	0.0000	http://sfe-egyptologie.website/index.php/publications/la-revue-nehet	found in CSL metadata
+ecology-letters	elsevier-harvard	0.8894	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291461-0248/homepage/ForAuthors.html	found in CSL metadata
+marine-biology	elsevier-harvard	0.8894	0.0500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf	found in CSL metadata
+fachhochschule-sudwestfalen	elsevier-harvard	0.8881	0.0000	0.0000	https://publikationen.fhb.fh-swf.de/receive/fhswf_mods_00000001	found in CSL metadata
+gallia-prehistoire	springer-basic-author-date	0.8880	0.5000	0.0000	http://www.persee.fr/collection/galip	found in CSL metadata
+historical-materialism	taylor-and-francis-chicago-author-date	0.8879	0.0000	0.0000	http://www.historicalmaterialism.org/instructions-for-authors	found in CSL metadata
+zeitschrift-fur-digitale-geisteswissenschaften	elsevier-harvard	0.8876	0.0000	0.0000	https://www.zfdg.de/s-wie-style	found in CSL metadata
+flux	taylor-and-francis-chicago-author-date	0.8874	0.0500	0.0000	https://revue-flux.cairn.info/recommandations-aux-auteurs/	found in CSL metadata
+cronache-di-archeologia	elsevier-harvard	0.8864	0.0000	0.0000	https://edizioniquasar.it/collections/cronache-di-archeologia	found in CSL metadata
+owbarth-verlag	elsevier-harvard	0.8857	0.4000	0.0000	https://github.com/citation-style-language/styles/pull/581	found in CSL metadata
+aquatic-conservation	elsevier-harvard	0.8851	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-0755/homepage/ForAuthors.html	found in CSL metadata
+journal-of-zoology	elsevier-harvard	0.8851	0.6500	0.0000	https://zslpublications.onlinelibrary.wiley.com/hub/journal/14697998/author-guidelines	found in CSL metadata
+letters-in-applied-microbiology	elsevier-harvard	0.8851	0.6500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1472-765X/homepage/ForAuthors.html	found in CSL metadata
+revue-d-elevage-et-de-medecine-veterinaire-des-pays-tropicaux	elsevier-harvard	0.8851	0.6000	0.0000	http://remvt.cirad.fr/gb/presentation/note.html	found in CSL metadata
+who-europe-harvard	springer-basic-author-date	0.8851	0.1000	0.0000	https://github.com/citation-style-language/styles/pull/170	found in CSL metadata
+american-society-for-horticultural-science	elsevier-harvard	0.8851	0.0500	0.0000	https://cdn.ymaws.com/ashs.org/resource/resmgr/publications/ashspubsstylemanualweb.pdf	found in CSL metadata
+archeosciences	elsevier-harvard	0.8851	0.5000	1.0000	https://journals.openedition.org/archeosciences/	found in CSL metadata
+folia-biologica	elsevier-harvard	0.8851	0.0500	0.0000	https://fb.cuni.cz/instructions-to-authors-4293	found in CSL metadata
+genetics-and-molecular-biology	elsevier-harvard	0.8851	0.0500	0.0000	http://www.scielo.br/revistas/gmb/iinstruc.htm	found in CSL metadata
+journal-of-investigative-dermatology	elsevier-harvard	0.8851	0.0500	0.0000	http://www.jidonline.org/content/authorinfo	found in CSL metadata
+journal-of-neurochemistry	elsevier-harvard	0.8851	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1471-4159	found in CSL metadata
+journal-of-sleep-research	elsevier-harvard	0.8851	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2869/homepage/ForAuthors.html	found in CSL metadata
+plant-physiology	elsevier-harvard	0.8851	0.5000	0.0000	http://www.plantphysiol.org/site/misc/ifora.xhtml#Literature%20cited	found in CSL metadata
+san-francisco-estuary-and-watershed-science	elsevier-harvard	0.8851	0.0500	0.0000	https://escholarship.org/uc/jmie_sfews/submissionguidelines	found in CSL metadata
+science-china-earth-sciences	elsevier-harvard	0.8851	0.0500	0.0000	https://www.springer.com/earth+sciences+and+geography/journal/11430	found in CSL metadata
+science-china-life-sciences	elsevier-harvard	0.8851	0.0500	0.0000	http://www.springer.com/life+sciences/journal/11427	found in CSL metadata
+springer-basic-author-date-no-et-al-with-issue	elsevier-harvard	0.8851	0.0500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/instruct-authors-e.pdf	found in CSL metadata
+springer-basic-author-date-no-et-al	elsevier-harvard	0.8851	0.0500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/instruct-authors-e.pdf	found in CSL metadata
+springer-mathphys-author-date	elsevier-harvard	0.8851	0.0500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf	found in CSL metadata
+springer-vancouver-author-date	elsevier-harvard	0.8851	0.0500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf	found in CSL metadata
+ultrasound-in-medicine-and-biology	elsevier-harvard	0.8851	0.0500	0.0000	http://www.elsevier.com/journals/ultrasound-in-medicine-and-biology/0301-5629/guide-for-authors	found in CSL metadata
+wetlands	elsevier-harvard	0.8851	0.0500	0.0000	http://www.springer.com/life+sciences/ecology/journal/13157	found in CSL metadata
+isnad-metinici	taylor-and-francis-chicago-author-date	0.8848	0.1000	0.0000	https://www.isnadsistemi.org	found in CSL metadata
+chicago-author-date-de	taylor-and-francis-chicago-author-date	0.8845	0.5500	0.0000	http://www.chicagomanualofstyle.org/tools_citationguide.html	found in CSL metadata
+development-policy-review	elsevier-harvard	0.8832	0.4500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291467-7679/homepage/ForAuthors.html	found in CSL metadata
+mind-and-language	elsevier-harvard	0.8832	0.5000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1468-0017/homepage/ForAuthors.html	found in CSL metadata
+steinbeis-hochschule-school-of-management-and-innovation	springer-basic-author-date	0.8831	0.0500	0.0000	https://shb-smi-community.academyfive.net/files/Startseite/Info_Point/Wissenschaftliches_Arbeiten/Guidelineszumwissenschaftlichenarbeiten_v1.3.pdf	found in CSL metadata
+acta-neurobiologiae-experimentalis	elsevier-harvard	0.8831	0.6000	0.0000	https://www.exeley.com/exeley/journals/acta_neurobiologiae_experimentalis/supp/Acta%20Neurobiologiae%20Experimentalis%20-%20Instructions%20for%20Authors.pdf	found in CSL metadata
+anatomical-sciences-education	elsevier-harvard	0.8831	0.6000	0.0000	https://anatomypubs.onlinelibrary.wiley.com/hub/journal/19359780/homepage/forauthors.html#5	found in CSL metadata
+clinical-anatomy	elsevier-harvard	0.8831	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1098-2353/homepage/ForAuthors.html	found in CSL metadata
+developmental-neurobiology	elsevier-harvard	0.8831	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291932-846X/homepage/ForAuthors.html	found in CSL metadata
+human-mutation	elsevier-harvard	0.8831	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1098-1004/homepage/ForAuthors.html	found in CSL metadata
+journal-of-cellular-biochemistry	elsevier-harvard	0.8831	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-4644	found in CSL metadata
+journal-of-limnology	elsevier-harvard	0.8831	0.6000	0.0000	http://www.jlimnol.it/index.php/jlimnol/about/submissions	found in CSL metadata
+journal-of-neurophysiology	elsevier-harvard	0.8831	0.0500	0.0000	https://www.physiology.org/author-info.manuscript-composition	found in CSL metadata
+anabases	taylor-and-francis-chicago-author-date	0.8829	0.0000	0.0000	https://journals.openedition.org/anabases/1358	found in CSL metadata
+traces	taylor-and-francis-chicago-author-date	0.8828	0.0000	0.0000	http://traces.revues.org/	found in CSL metadata
+inventaire-general-du-patrimoine-culturel-iso-690-note	taylor-and-francis-chicago-author-date	0.8816	0.0000	0.0000	https://github.com/Emic37/igpc-zotero-styles	found in CSL metadata
+amphibia-reptilia	elsevier-harvard	0.8815	0.5500	0.0000	http://www.brill.com/amphibia-reptilia	found in CSL metadata
+harvard-university-of-abertay-dundee	elsevier-harvard	0.8815	0.6000	0.0000	https://portal.abertay.ac.uk/portal/page/portal/Library/Referencing	found in CSL metadata
+pakistani-veterinary-journal	elsevier-harvard	0.8815	0.5500	0.0000	http://www.pvj.com.pk/Instructions.htm	found in CSL metadata
+colorado-state-university-school-of-biomedical-engineering	elsevier-harvard	0.8815	0.6500	0.0000	https://forums.zotero.org/discussion/68950/modified-chicago-citation-style	found in CSL metadata
+revue-archeologique-de-lest	elsevier-harvard	0.8808	0.4000	0.0000	https://journals.openedition.org/rae/1161#tocfrom2n1	found in CSL metadata
+american-journal-of-political-science	taylor-and-francis-chicago-author-date	0.8807	0.7000	0.0000	http://www.ajps.org/AJPS%20Style%20Guide.pdf	found in CSL metadata
+urbani-izziv	elsevier-harvard	0.8807	0.6500	0.0000	https://urbaniizziv.uirs.si/Navodila-za-avtorje	found in CSL metadata
+revue-archeologique-de-narbonnaise	elsevier-harvard	0.8799	0.0500	0.0000	https://www.asm.cnrs.fr/images/Site/Editions/RAN/RAN-auteurs.pdf	found in CSL metadata
+societe-francaise-detude-de-la-ceramique-antique-en-gaule	elsevier-harvard	0.8799	0.0500	0.0000	http://sfecag.free.fr/recommandations.pdf	found in CSL metadata
+uludag-universitesi-sosyal-bilimler-enstitusu-author-date	taylor-and-francis-chicago-author-date	0.8790	0.2000	0.0000		
+der-moderne-staat	taylor-and-francis-chicago-author-date	0.8787	0.4500	0.0000	http://www.budrich-journals.de/index.php/dms/about/submissions#authorGuidelines	found in CSL metadata
+soziale-welt	taylor-and-francis-chicago-author-date	0.8787	0.4500	0.0000	http://www.soziale-welt.nomos.de/fileadmin/soziale-welt/doc/Autorenhinweise_sw.pdf	found in CSL metadata
+sozialpadagogisches-institut-berlin-walter-may	taylor-and-francis-chicago-author-date	0.8787	0.0500	0.0000	http://www.stiftung-spi.de	found in CSL metadata
+forschungsjournal-soziale-bewegungen-fjsb	springer-basic-author-date	0.8783	0.6000	0.0000	https://github.com/citation-style-language/styles/files/7492338/8_FJSB.Formatstandards_fur.AutorInnen_08.2019_final.pdf	found in CSL metadata
+association-for-computational-linguistics	elsevier-harvard	0.8783	0.5000	0.0000	http://www.aclweb.org/	found in CSL metadata
+journal-of-social-philosophy	elsevier-harvard	0.8780	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-9833/homepage/ForAuthors.html	found in CSL metadata
+arctic-antarctic-and-alpine-research	taylor-and-francis-chicago-author-date	0.8779	0.1000	0.0000	http://aaarjournal.org/page/format?code=iaar-site	found in CSL metadata
+cultural-studies-of-science-education	taylor-and-francis-chicago-author-date	0.8779	0.5000	0.0000	http://www.springer.com/education+%26+language/science+education/journal/11422	found in CSL metadata
+gaia	taylor-and-francis-chicago-author-date	0.8779	0.4500	0.0000	https://gaia.oekom.de/index.php/gaia/Authors#References	found in CSL metadata
+journal-of-music-technology-and-education	taylor-and-francis-chicago-author-date	0.8779	0.4500	0.0000	http://www.intellectbooks.co.uk/journals/page/index,name=journalstyleguide/	found in CSL metadata
+universite-de-sherbrooke-faculte-d-education	taylor-and-francis-chicago-author-date	0.8779	0.0500	0.0000	http://www.usherbrooke.ca/education/fileadmin/sites/education/documents/Intranet/Documents_officiels/GuidePresentation_complet.pdf	found in CSL metadata
+australian-journal-of-grape-and-wine-research	elsevier-harvard	0.8774	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291755-0238/homepage/ForAuthors.html	found in CSL metadata
+begell-house-chicago-author-date	elsevier-harvard	0.8774	0.5500	0.0000	http://dl.begellhouse.com/forauthors/journals/6a7c7e10642258cc.html	found in CSL metadata
+brazilian-journal-of-veterinary-research-and-animal-science	elsevier-harvard	0.8774	0.6000	0.0000	https://www.revistas.usp.br/bjvras/about/submissions	found in CSL metadata
+european-journal-of-neuroscience	elsevier-harvard	0.8774	0.6000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291460-9568/homepage/ForAuthors.html	found in CSL metadata
+institute-of-mathematics-and-its-applications	elsevier-harvard	0.8774	0.6000	0.0000	https://academic.oup.com/teamat/pages/General_Instructions	found in CSL metadata
+integrative-and-comparative-biology	elsevier-harvard	0.8774	0.0500	0.0000	https://academic.oup.com/icb/pages/Manuscript_Preparation_Submission	found in CSL metadata
+journal-of-move-and-therapeutic-science	elsevier-harvard	0.8774	0.6000	0.0000	https://jomts.com/index.php/move/investigacion_original	found in CSL metadata
+journal-of-the-royal-statistical-society	elsevier-harvard	0.8774	0.6500	0.0000	https://rss.onlinelibrary.wiley.com/hub/journal/1467985x/author-guidelines	found in CSL metadata
+revista-de-biologia-tropical	elsevier-harvard	0.8774	0.0500	0.0000	http://biologiatropical.ucr.ac.cr/	found in CSL metadata
+traffic-injury-prevention	elsevier-harvard	0.8774	0.0000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=gcpi20&amp;page=instructions	found in CSL metadata
+georg-august-universitat-gottingen-institut-fur-ethnologie-und-ethnologische-sammlung	taylor-and-francis-chicago-author-date	0.8768	0.4500	0.0000	http://www.uni-goettingen.de/de/86102.html	found in CSL metadata
+estudios-de-cultura-maya	taylor-and-francis-chicago-author-date	0.8762	0.0000	0.0000	https://revistas-filologicas.unam.mx/estudios-cultura-maya/index.php/ecm/about/submissions#authorGuidelines	found in CSL metadata
+journal-of-contemporary-water-research-and-education	taylor-and-francis-chicago-author-date	0.8762	0.8000	0.0000	https://ucowr.org/wp-content/uploads/2020/11/Original-Research-Article-Author-Instructions.pdf	found in CSL metadata
+avian-pathology	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000	http://www.tandf.co.uk/journals/authors/cavpauth.asp	found in CSL metadata
+bioarchaeology-of-the-near-east	taylor-and-francis-chicago-author-date	0.8759	0.4500	0.0000	http://www.anthropology.uw.edu.pl/	found in CSL metadata
+business-ethics-a-european-review	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1467-8608/homepage/ForAuthors.html	found in CSL metadata
+ipag-business-school-apa	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000	https://github.com/citation-style-language/styles/pull/3937#issuecomment-464334736	found in CSL metadata
+journal-of-the-association-for-information-systems	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000	http://aisel.aisnet.org/jais/authorinfo.html	found in CSL metadata
+journal-of-water-sanitation-and-hygiene-for-development	taylor-and-francis-chicago-author-date	0.8759	0.5000	0.0000	http://washdev.iwaponline.com/content/instructions-authors	found in CSL metadata
+kindheit-und-entwicklung	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000	http://www.hogrefe.de/zeitschriften/kindheit-und-entwicklung/	found in CSL metadata
+la-trobe-university-apa	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000	http://www.lib.latrobe.edu.au/referencing-tool/apa-6	found in CSL metadata
+planning-practice-and-research	taylor-and-francis-chicago-author-date	0.8759	0.1000	0.0000	http://www.tandfonline.com/action/authorSubmission?journalCode=cppr20&amp;page=instructions#mp_style	found in CSL metadata
+sodertorns-hogskola-harvard	taylor-and-francis-chicago-author-date	0.8759	0.5500	0.0000	https://www.sh.se/p3/ext/content.nsf/aget?openagent&amp;key=guider_till_olika_format_1354269274669	found in CSL metadata
+university-college-lillebaelt-apa	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000	http://esdhweb.ucl.dk/476790.Formm%C3%A6ssige%20krav%202014.pdf	found in CSL metadata
+university-of-gothenburg-apa-swedish-legislations	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000	https://github.com/ub-digit/citation-styles/tree/master/zotero/university-of-gothenburg-apa-swedish-legislations/README.md	found in CSL metadata
+urban-studies	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000	http://www.sagepub.com/journalsProdDesc.nav?prodId=Journal201866#tabview=manuscriptSubmission	found in CSL metadata
+zurcher-hochschule-fur-angewandte-wissenschaften-soziale-arbeit	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000	https://gpmpublic.zhaw.ch/GPMDocProdDPublic/Hilfsmittel/Dept_S/S_HM_Richtlinien_fuer_wissenschaftliches_Arbeiten.pdf	found in CSL metadata
+china-national-standard-gb-t-7714-2015-author-date	taylor-and-francis-chicago-author-date	0.8759	0.0500	0.0000	https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A	found in CSL metadata
+journal-of-applied-animal-science	elsevier-harvard	0.8750	0.0500	0.0000	http://www.vs.mahidol.ac.th/jaas	found in CSL metadata
+european-journal-physical-medicine-and-rehabilitation	ieee	0.8746	0.0000	0.0000	https://www.minervamedica.it/en/journals/europa-medicophysica/notice-to-authors.php	found in CSL metadata
+magnetic-resonance-in-medical-sciences	ieee	0.8746	0.0000	0.0000	https://www.jsmrm.jp/uploads/files/journal/19-3%20MRMS_Instruction%20for%20Authors%20(002).pdf	found in CSL metadata
+turcica	chicago-shortened-notes-bibliography	0.8739	0.5500	0.0000	https://www.peeters-leuven.be/pdf/Turcica_Instructions_FR.pdf	found in CSL metadata
+annual-review-of-astronomy-and-astrophysics	springer-basic-author-date	0.8732	0.5500	0.0000	http://www.annualreviews.org/page/authors/author-instructions/preparing/handbooks	found in CSL metadata
+harvard-pontificia-universidad-catolica-del-ecuador	taylor-and-francis-chicago-author-date	0.8728	0.1000	0.0000	http://www.puce.edu.ec/economia/docs/2012/Normas_Harvard_-_APA_ejemplos.pdf	found in CSL metadata
+apa-fr-provost	taylor-and-francis-chicago-author-date	0.8727	0.1000	0.0000	http://www.worldcat.org/oclc/693823953	found in CSL metadata
+ecole-de-technologie-superieure-apa	taylor-and-francis-chicago-author-date	0.8727	0.0500	0.0000	https://etsmtl.ca/Etudiants-actuels/Cycles-sup/Realisation-etudes/Guides-gabarits/Guide_redaction	found in CSL metadata
+univerza-v-ljubljani-fakulteta-za-gradbenistvo-in-geodezijo-apa-7	taylor-and-francis-chicago-author-date	0.8725	0.1000	0.0000	https://www.fgg.uni-lj.si/wp-content/uploads/2025/02/Citiranje-virov-UL-FGG.pdf	found in CSL metadata
+universidad-evangelica-del-paraguay	taylor-and-francis-chicago-author-date	0.8716	0.0500	0.0000	http://www.universidadevangelica.edu.py/	found in CSL metadata
+interdisziplinare-zeitschrift-fur-technologie-und-lernen	taylor-and-francis-chicago-author-date	0.8713	0.4500	0.0000	http://www.itel-journal.org/index.php/itel/about/submissions#authorGuidelines	found in CSL metadata
+urban-geography	taylor-and-francis-chicago-author-date	0.8708	0.1500	0.0000	https://www.tandfonline.com/action/authorSubmission?journalCode=rurb20&amp;page=instructions#refs	found in CSL metadata
+asia-pacific-journal-of-human-resources	taylor-and-francis-chicago-author-date	0.8700	0.6500	0.0000	https://onlinelibrary.wiley.com/page/journal/17447941/homepage/forauthors.html	found in CSL metadata
+international-energy-agency-organisation-for-economic-co-operation-and-development	taylor-and-francis-chicago-author-date	0.8700	0.1000	0.0000	https://www.oecd.org/about/publishing/OECD-Style-Guide-Third-Edition.pdf	found in CSL metadata
+hamburg-school-of-food-science	elsevier-harvard	0.8695	0.0500	0.0000	http://hsfs.org/	found in CSL metadata
+petit-chicago-author-date	taylor-and-francis-chicago-author-date	0.8688	0.0500	0.0000	http://guides.bib.umontreal.ca/disciplines/159-Sociologie	found in CSL metadata
+centaurus	taylor-and-francis-chicago-author-date	0.8680	0.1000	0.0000	http://www.blackwellpublishing.com/pdf/centaurus_style_guide.pdf	found in CSL metadata
+economia-y-politica	taylor-and-francis-chicago-author-date	0.8680	0.4500	0.0000	http://www.economiaypolitica.cl/index.php/eyp/Normas-para-autores	found in CSL metadata
+journal-of-international-business-studies	taylor-and-francis-chicago-author-date	0.8680	0.1000	0.0000	https://www.palgrave.com/gp/journal/41267/authors/presentation-formatting	found in CSL metadata
+mediterranean-politics	taylor-and-francis-chicago-author-date	0.8680	0.1000	0.0000	http://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=fmed20	found in CSL metadata
+ferdinand-porsche-fern-fachhochschule	taylor-and-francis-chicago-author-date	0.8668	0.1000	0.0000	https://github.com/christoph425/ffh_csl_styles/raw/main/Richtlinien_wissenschaftliche_Arbeiten_WP.pdf	found in CSL metadata
+duale-hochschule-baden-wurttemberg-villingen-schwenningen-roter-grubert-mattern	taylor-and-francis-chicago-author-date	0.8668	0.0000	0.0000	https://moodle.dhbw-vs.de/mod/resource/view.php?id=5965	found in CSL metadata
+journalistica	elsevier-harvard	0.8659	0.4500	0.0000	http://ojs.statsbiblioteket.dk/index.php/journalistica/about/submissions#authorGuidelines	found in CSL metadata
+international-journal-of-spatial-data-infrastructures-research	elsevier-harvard	0.8655	0.4500	0.0000	http://ijsdir.jrc.ec.europa.eu/index.php/ijsdir/pages/view/authors	found in CSL metadata
+ferdinand-porsche-fernfh-betriebswirtschaft-und-wirtschaftspsychologie-dgps	taylor-and-francis-chicago-author-date	0.8651	0.0500	0.0000	https://github.com/citation-style-language/styles/pull/6989	found in CSL metadata
+forum-qualitative-sozialforschung	taylor-and-francis-chicago-author-date	0.8651	0.0500	0.0000	http://www.qualitative-research.net/index.php/fqs/about/submissions#authorGuidelines	found in CSL metadata
+universitat-basel-deutsche-sprachwissenschaft	taylor-and-francis-chicago-author-date	0.8648	0.1000	0.0000	https://germanistik.philhist.unibas.ch/fileadmin/user_upload/germanistik/Merkblaetter_und_Dokumente/Leitfaden_DeutscheSprachwissenschaft_HS18._Kopie.pdf	found in CSL metadata
+fachhochschule-kiel-fachbereich-medien	taylor-and-francis-chicago-author-date	0.8647	0.4500	0.0000	https://www.fh-kiel.de/fileadmin/data/multimedia/Pruefungsangelegenheiten/Zitierkonventionen_Dez2012.pdf	found in CSL metadata
+chinese-gb7714-2005-author-date	taylor-and-francis-chicago-author-date	0.8647	0.0500	0.0000	https://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D78562D3A7E05397BE0A0AB82A	found in CSL metadata
+journal-of-animal-physiology-and-animal-nutrition	springer-basic-author-date	0.8640	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1439-0396/homepage/ForAuthors.html	found in CSL metadata
+peter-lang-social-sciences	taylor-and-francis-chicago-author-date	0.8640	0.5000	0.0000	https://www.peterlang.com/app/uploads/2021/07/Peter-Lang-Style-Guidelines-British-English.docx	found in CSL metadata
+international-studies-association	taylor-and-francis-chicago-author-date	0.8624	0.4500	0.0000	http://www.blackwellpublishing.com/pdf/ISAJournals_technical_stylesheets_11apr11.pdf	found in CSL metadata
+deutsche-gesellschaft-fur-psychologie	taylor-and-francis-chicago-author-date	0.8623	0.0500	0.0000	https://github.com/citation-style-language/styles/pull/432	found in CSL metadata
+haute-ecole-pedagogique-fribourg	taylor-and-francis-chicago-author-date	0.8623	0.0500	0.0000	https://www.hepfr.ch/sites/default/files/guide_apa_hepfr.pdf	found in CSL metadata
+zeitschrift-fur-padagogik	taylor-and-francis-chicago-author-date	0.8623	0.0500	0.0000	http://www.beltz.de/fileadmin/beltz/downloads/zfpaed/Manuskripthinweise_ZfPaed_2013.pdf	found in CSL metadata
+juristische-zitierweise-schweizer	modern-language-association	0.8618	0.0500	0.0000	http://www.worldcat.org/oclc/1013162746	found in CSL metadata
+international-union-of-crystallography	elsevier-harvard	0.8615	0.5000	0.0000	http://journals.iucr.org/d/services/notesforauthors.html	found in CSL metadata
+canadian-journal-of-economics	taylor-and-francis-chicago-author-date	0.8615	0.6500	0.0000	http://economics.ca/cje/en/style.php	found in CSL metadata
+technische-universitat-dresden-forstwissenschaft	elsevier-harvard	0.8611	0.4500	0.0000	https://github.com/citation-style-language/styles/files/3089047/Aufbau.wiss.Arbeit-.Grundzuge.Prof.Waldschutz.Waldschutz.Waldschutz.pdf	found in CSL metadata
+academy-of-management-review	elsevier-harvard	0.8594	0.6000	0.0000	https://aom.org/docs/default-source/events/amjstyleguide.aspx	found in CSL metadata
+pontificia-universidade-catolica-do-parana-abnt	taylor-and-francis-chicago-author-date	0.8593	0.0500	0.0000		
+french4	taylor-and-francis-chicago-author-date	0.8590	0.0500	0.0000	http://zotero.hypotheses.org/77	found in CSL metadata
+technische-universitat-hamburg-institut-fur-smarte-entwicklung-und-maschinenelemente	taylor-and-francis-chicago-author-date	0.8589	0.0000	0.0000	https://www.tuhh.de/isem/informationen-fuer-abschlussarbeitende/dokumentation-zitationsstil	found in CSL metadata
+language-in-society	taylor-and-francis-chicago-author-date	0.8589	0.5000	0.0000	http://assets.cambridge.org/LSY/LSY_ifc.pdf	found in CSL metadata
+bibliothecae-it	elsevier-harvard	0.8585	0.1000	0.0000	https://bibliothecae.unibo.it/about/submissions#authorGuidelines	found in CSL metadata
+forum-qualitative-social-research	taylor-and-francis-chicago-author-date	0.8583	0.0500	0.0000	http://www.qualitative-research.net/index.php/fqs/about/submissions#authorGuidelines	found in CSL metadata
+myrmecological-news	elsevier-harvard	0.8582	0.0500	0.0000	http://myrmecologicalnews.org/cms/index.php?option=com_content&amp;view=article&amp;id=31&amp;Itemid=40	found in CSL metadata
+cahiers-du-centre-gustave-glotz	elsevier-harvard	0.8578	0.0000	0.0000	http://www.anhima.fr/IMG/docx/normes-ccg-2013.docx	found in CSL metadata
+food-and-agriculture-organization-of-the-united-nations	elsevier-harvard	0.8577	0.6500	0.0000	https://www.fao.org/3/cb8081en/cb8081en.pdf	found in CSL metadata
+technische-universitat-dresden-finanzwirtschaft-und-finanzdienstleistungen-author-date-with-short-titles	chicago-shortened-notes-bibliography	0.8567	0.0000	0.0000	https://bildungsportal.sachsen.de/opal/url/RepositoryEntry/683835403	found in CSL metadata
+technische-universitat-dresden-finanzwirtschaft-und-finanzdienstleistungen-note	chicago-shortened-notes-bibliography	0.8567	0.0000	0.0000	https://bildungsportal.sachsen.de/opal/url/RepositoryEntry/683835403	found in CSL metadata
+bioelectromagnetics	elsevier-harvard	0.8565	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291521-186X/homepage/ForAuthors.html	found in CSL metadata
+biotechnology-and-bioengineering	elsevier-harvard	0.8565	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291097-0290/homepage/ForAuthors.html	found in CSL metadata
+european-cells-and-materials	elsevier-harvard	0.8565	0.5500	0.0000	http://www.ecmjournal.org/journal/instructions_to_authors.htm#references	found in CSL metadata
+human-brain-mapping	elsevier-harvard	0.8565	0.0000	0.0000	http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1097-0193/homepage/ForAuthors.html	found in CSL metadata
+collections-electroniques-de-l-inha-author-date	elsevier-harvard	0.8561	0.0000	0.0000	http://inha.revues.org/2662	found in CSL metadata
+plant-cell-and-environment	springer-basic-author-date	0.8554	0.5500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-3040/homepage/ForAuthors.html	found in CSL metadata
+alkoholizmus-a-drogove-zavislosti	springer-basic-author-date	0.8553	0.0500	0.0000	https://www.adzpo.sk/sk/adzpo-pokyny-pre-autorov	found in CSL metadata
+museum-national-dhistoire-naturelle	springer-basic-author-date	0.8553	0.5500	0.0000		
+harvard-gesellschaft-fur-bildung-und-forschung-in-europa	elsevier-harvard	0.8548	0.0500	0.0000	http://gbfe.org/	found in CSL metadata
+harvard-theologisches-seminar-adelshofen	elsevier-harvard	0.8548	0.0500	0.0000	http://www.lza.de/theologisches-seminar/	found in CSL metadata
+political-studies	taylor-and-francis-chicago-author-date	0.8541	0.0500	0.0000	http://www.psa.ac.uk/members/membership-benefits/publications/political-studies	found in CSL metadata
+springer-physics-author-date	elsevier-harvard	0.8533	0.0500	0.0000	http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf	found in CSL metadata
+die-bachelorarbeit-samac-et-al-in-text	taylor-and-francis-chicago-author-date	0.8532	0.0500	0.0000	http://www.amazon.de/Bachelorarbeit-P%C3%A4dagogischen-Hochschule-wissenschaftlicher-Lehrerbildung/dp/3708901886	found in CSL metadata
+die-bachelorarbeit-samac-et-al-note	taylor-and-francis-chicago-author-date	0.8532	0.0000	0.0000	http://www.amazon.de/Bachelorarbeit-P%C3%A4dagogischen-Hochschule-wissenschaftlicher-Lehrerbildung/dp/3708901886	found in CSL metadata
+universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement	taylor-and-francis-chicago-author-date	0.8532	0.0500	0.0000	http://www.lim.uni-bremen.de/de/richtlinien?file=files/burmann/lehre/Richtlinien_Abschlussarbeiten_Stand_2015_11.pdf	found in CSL metadata
+universite-laval-departement-dinformation-et-de-communication	taylor-and-francis-chicago-author-date	0.8530	0.0500	0.0000	http://www.com.ulaval.ca/etudes/boite-a-outils/guide-de-redaction/	found in CSL metadata
+human-resource-management-journal	taylor-and-francis-chicago-author-date	0.8521	0.0500	0.0000	http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291748-8583/homepage/ForAuthors.html	found in CSL metadata
+novasinergia	taylor-and-francis-chicago-author-date	0.8518	0.1000	0.0000	https://novasinergia.unach.edu.ec/index.php/novasinergia/about/submissions#authorGuidelines	found in CSL metadata
+ethnographiques-org	taylor-and-francis-chicago-author-date	0.8518	0.4000	0.0000	https://www.ethnographiques.org/note-pour-la-redaction-d-articles	found in CSL metadata
+biens-symboliques-symbolic-goods	taylor-and-francis-chicago-author-date	0.8512	0.4000	0.0000	https://revue.biens-symboliques.net/200	found in CSL metadata
+lauterbornia	elsevier-harvard	0.8502	0.0500	0.0000	http://blog.lauterbornia.de/verfasserrichtlinien/	found in CSL metadata


### PR DESCRIPTION
Regenerate the 2026-04-19 alias candidate report using the new metadata extraction feature. This populates the evidence_url and confidence_note columns for most high-similarity candidates.