### PR TITLE
feat(styles): alias 15 high-confidence journal clones

### DIFF
--- a/registry/default.yaml
+++ b/registry/default.yaml
@@ -6,12 +6,12 @@ styles:
     description: "APA 7th edition"
     fields: [psychology, social-science]
   - id: elsevier-harvard
-    aliases: [harvard, applied-clay-science, environmental-chemistry, international-biodeterioration-and-biodegradation]
+    aliases: [harvard, applied-clay-science, environmental-chemistry, international-biodeterioration-and-biodegradation, accident-analysis-and-prevention, entecho, handbook-of-clinical-neurology, journal-of-economic-impact]
     builtin: elsevier-harvard
     description: "Elsevier Harvard"
     fields: [science]
   - id: elsevier-with-titles
-    aliases: [firephyschem, journal-of-applied-engineering-sciences-technology]
+    aliases: [firephyschem, journal-of-applied-engineering-sciences-technology, biochimica-et-biophysica-acta, cancer-biomarkers, engineered-regeneration, gait-and-posture, ios-press-books, necmettin-erbakan-universitesi-fen-ve-muhendislik-bilimleri-dergisi]
     builtin: elsevier-with-titles
     description: "Elsevier with Titles"
     fields: [science]
@@ -33,11 +33,12 @@ styles:
     description: "Springer Basic Brackets"
     fields: [science]
   - id: american-medical-association
-    aliases: [ama]
+    aliases: [ama, acta-medica-portuguesa, ophthalmic-plastic-and-reconstructive-surgery, retina]
     builtin: american-medical-association
     description: "American Medical Association"
     fields: [medicine]
   - id: ieee
+    aliases: [engineering-technology-and-applied-science-research, ieee-transactions-on-medical-imaging]
     builtin: ieee
     description: "Institute of Electrical and Electronics Engineers"
     fields: [engineering]


### PR DESCRIPTION
Add 15 verified journal clones as aliases for elsevier-harvard, elsevier-with-titles, american-medical-association, and ieee based on the 2026-04-19 alias discovery report.