### PR TITLE
refactor(schema): rename StylePreset→StyleBase, preset→extends

### DIFF
--- a/.beans/archive/csl26-v961--rename-stylepresetstylebase-presetextends-add-styl.md
+++ b/.beans/archive/csl26-v961--rename-stylepresetstylebase-presetextends-add-styl.md
@@ -1,0 +1,22 @@
+---
+# csl26-v961
+title: Rename StylePreset→StyleBase, preset→extends; add style taxonomy
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-20T11:20:00Z
+updated_at: 2026-04-20T11:29:25Z
+---
+
+Breaking rename: StylePreset→StyleBase, YAML key preset:→extends: (no alias; all files updated), add StyleKind enum to RegistryEntry (base/profile/journal/independent), new STYLE_TAXONOMY.md spec, update STYLE_PRESET_ARCHITECTURE.md to v2.0.
+
+## Summary of Changes
+
+- Renamed `StylePreset` → `StyleBase` and module `style_preset.rs` → `style_base.rs`
+- Renamed YAML key `preset:` → `extends:` — breaking rename, no serde alias; all styles/*.yaml and test fixtures updated
+- Renamed `preset_detector.rs` → `base_detector.rs` in citum-migrate
+- Added `StyleKind` enum (base/profile/journal/independent) to `RegistryEntry`
+- Updated 6 embedded YAML files; 16 registry entries annotated with `kind:`
+- New `docs/specs/STYLE_TAXONOMY.md` (four-tier model, Active)
+- Updated `docs/specs/STYLE_PRESET_ARCHITECTURE.md` to v2.0
+- All 1070 tests green; commit 68ff0c18

--- a/.beans/csl26-nrkn--validate-publisher-family-bases-before-profile-wra.md
+++ b/.beans/csl26-nrkn--validate-publisher-family-bases-before-profile-wra.md
@@ -1,0 +1,90 @@
+---
+# csl26-nrkn
+title: Validate publisher-family bases before profile-wrapper conversion
+status: todo
+type: task
+priority: normal
+tags:
+    - styles
+    - taxonomy
+    - verification
+created_at: 2026-04-21T12:14:46Z
+updated_at: 2026-04-21T12:14:46Z
+---
+
+Evaluate the embedded publisher/profile styles that were tentatively remapped to
+existing bases during the style-taxonomy rename work, and decide which of those
+styles are actually thin parent-plus-deltas wrappers versus independent authored
+styles.
+
+This bean exists because the uncommitted follow-on on `refactor/style-taxonomy-rename`
+showed that broad family grouping is plausible, but the specific `extends:`
+assignments to today's Tier-1 bases are not evidence-stable enough to land as
+registry/spec truth.
+
+## Why this is a follow-up instead of part of the current PR
+- The branch-local `extends:` experiments changed rendered output materially on
+  the shared `tests/fixtures/references-expanded.json` surface; this is not a
+  metadata-only taxonomy edit.
+- Publisher guidance supports family grouping, but not the exact current base
+  mappings in every case.
+- Some candidate mappings conflict with the style's own source metadata:
+  - `taylor-and-francis-council-of-science-editors-author-date` points to
+    `cse-name-year`, not APA.
+  - `springer-basic-brackets` points back to `springer-basic-author-date`, not IEEE.
+  - `elsevier-harvard` points to `ecology-letters`, not APA.
+
+## Evidence to carry forward
+- Representative profile/base comparisons on the shared fixture changed about
+  70-152 rendered lines.
+- Working-tree `extends:` additions alone changed about 56-93 rendered lines vs
+  the committed branch state in sampled styles.
+- Authority order for style decisions remains:
+  1. publisher or journal guide
+  2. publisher house rules
+  3. named parent-style manual or base reference
+  4. CSL/template-link evidence
+  5. current Citum YAML structure
+
+## Candidate styles to evaluate
+- `elsevier-harvard`
+- `elsevier-vancouver`
+- `springer-basic-author-date`
+- `springer-basic-brackets`
+- `springer-vancouver-brackets`
+- `taylor-and-francis-council-of-science-editors-author-date`
+- `taylor-and-francis-national-library-of-medicine`
+- `chicago-shortened-notes-bibliography` as the control case for a proven profile
+
+## Required outcome for each style
+Classify each style as exactly one of:
+- thin profile on an existing base
+- thin profile on a new publisher/standards base
+- independent/self-contained style
+
+## Tasks
+- [ ] Build a per-style evidence table using the authority order above.
+- [ ] Record the current publisher-guide relationship, if any, for each candidate profile.
+- [ ] Record the CSL template-link or named-parent evidence for each candidate profile.
+- [ ] Re-run reduced citation/bibliography fixture comparisons for each style against its candidate base or family base.
+- [ ] Decide the classification for each candidate style.
+- [ ] Update the taxonomy wording so `profile` means guide-backed parent-plus-deltas, not output-similar-to-an-existing-base.
+- [ ] Split any required implementation into narrower beans if new bases or converter work are needed.
+
+## Acceptance
+- there is a per-style evidence table covering all candidate profiles
+- each profile has a written classification decision and rationale
+- no style is converted to a thin wrapper unless reduced YAML reproduces current
+  accepted behavior on the chosen verification surface
+- taxonomy language is tightened to prevent future output-similarity shortcuts
+
+## Stop-Loss Rule
+- do not reland the reverted branch-local `extends:` mappings just because they
+  seem directionally correct
+- if a style needs a new publisher-family or standards-specific base, record
+  that explicitly instead of forcing it onto an existing Tier-1 base
+
+## Related
+- csl26-v961
+- csl26-ocdt
+- csl26-wp6y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,13 @@ jobs:
           shared-key: "citum-core-semver"
           cache-workspace-crates: true
 
-      - name: Check publishable crates for semver violations
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@v2
         with:
-          rust-toolchain: stable
-          feature-group: default-features
+          tool: cargo-semver-checks
+
+      - name: Check publishable crates for semver violations
+        run: |
+          cargo semver-checks \
+            --workspace \
+            --baseline-rev ${{ github.event.pull_request.base.sha }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -46,15 +46,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -129,9 +129,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -242,10 +242,10 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -279,9 +279,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "by_address"
@@ -396,9 +396,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -488,7 +488,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "csl-legacy",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars",
  "serde",
  "serde_json",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -513,12 +513,12 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
  "csl-legacy",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -529,15 +529,15 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "citum-engine"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -548,7 +548,7 @@ dependencies = [
  "csl-legacy",
  "icu_collator",
  "icu_locale",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "jotdown",
  "orgize",
  "regex",
@@ -559,17 +559,17 @@ dependencies = [
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "url",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "citum-migrate"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
  "deno_core",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "roxmltree",
  "serde",
  "serde_json",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "typst",
  "typst-kit",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -599,11 +599,11 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars",
  "serde",
  "serde_json",
@@ -614,14 +614,14 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
  "citum-schema-data",
  "criterion",
  "csl-legacy",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars",
  "serde",
  "serde_json",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -695,18 +695,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.66"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -743,9 +743,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comemo"
@@ -863,9 +863,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "roxmltree",
  "serde",
  "serde_json",
@@ -951,7 +951,7 @@ dependencies = [
  "deno_path_util",
  "deno_unsync",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "inventory",
  "libc",
  "parking_lot",
@@ -1009,7 +1009,7 @@ version = "0.274.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9560662cdbffa3428ebac40f3ea5fb46ef8b557c41b04f62af045e56defd487"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "stringcase",
@@ -1209,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1235,9 +1235,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1520,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hayagriva"
@@ -1533,7 +1533,7 @@ dependencies = [
  "biblatex 0.10.0",
  "ciborium",
  "citationberg",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "numerals",
  "paste",
  "serde",
@@ -1613,9 +1613,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1627,7 +1627,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
 ]
@@ -1649,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "hypher"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e25026c579b170c59f8d3ddfc523d7dab0abe079f09eb8edaebd2417044f60"
+checksum = "bef68590049bab63a464eee1a1158ac04c6f6613a546d8d90f78636b8b94f171"
 
 [[package]]
 name = "icu_calendar"
@@ -1749,10 +1748,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
- "litemap 0.8.1",
+ "litemap 0.8.2",
  "serde",
  "tinystr 0.8.3",
- "writeable 0.6.2",
+ "writeable 0.6.3",
  "zerovec 0.11.6",
 ]
 
@@ -1889,7 +1888,7 @@ dependencies = [
  "icu_locale_core",
  "serde",
  "stable_deref_trait",
- "writeable 0.6.2",
+ "writeable 0.6.3",
  "yoke 0.8.2",
  "zerofrom",
  "zerotrie 0.2.4",
@@ -1992,19 +1991,19 @@ checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
- "gif 0.14.1",
+ "gif 0.14.2",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "zune-core 0.5.1",
- "zune-jpeg 0.5.12",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -2036,21 +2035,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "indextree"
-version = "4.7.4"
+version = "4.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9e21e48c85fa6643a38caca564645a3bbc9211edf506fc8ed690c7e7b4d3c7"
+checksum = "5cee462cd93b03891663339b59a21246cc5fc2cc95060d0bb5059e25cd50edc4"
 dependencies = [
  "indextree-macros",
 ]
@@ -2107,6 +2106,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2116,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixdtf"
@@ -2140,9 +2148,9 @@ checksum = "3fff02adc563a0901266af314a47aa676f950a2f328a60b20691fdba0946fd98"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2193,9 +2201,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -2215,9 +2223,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -2261,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2325,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2336,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -2379,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2418,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2522,7 +2530,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df03c7d216de06f93f398ef06f1385a60f2c597bb96f8195c8d98e08a26b1d5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "itoa",
  "memchr",
  "ryu",
@@ -2609,19 +2617,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "plist"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -2674,7 +2676,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2701,12 +2703,12 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "serde_core",
- "writeable 0.6.2",
+ "writeable 0.6.3",
  "zerovec 0.11.6",
 ]
 
@@ -2741,7 +2743,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2765,12 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qcms"
@@ -2805,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2826,9 +2825,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]
@@ -2851,9 +2850,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2885,7 +2884,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2944,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relative-path"
@@ -3034,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -3044,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3063,7 +3062,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3076,7 +3075,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3095,7 +3094,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85d1ccd519e61834798eb52c4e886e8c2d7d698dd3d6ce0b1b47eb8557f1181"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytemuck",
  "core_maths",
  "log",
@@ -3129,7 +3128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -3157,9 +3156,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3218,7 +3217,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3278,7 +3277,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3291,7 +3290,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3316,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simplecss"
@@ -3368,12 +3367,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3401,7 +3400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e9b845c713b099203e50efa3994c73ff25dfcde803d851afde7c818185896f"
 dependencies = [
  "ctor",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc_version",
  "serde_json",
  "specta-macros",
@@ -3603,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3689,9 +3688,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -3713,7 +3712,7 @@ dependencies = [
  "num-traits",
  "temporal_rs",
  "timezone_provider",
- "writeable 0.6.2",
+ "writeable 0.6.3",
  "zoneinfo64",
 ]
 
@@ -3731,14 +3730,14 @@ dependencies = [
  "num-traits",
  "timezone_provider",
  "tinystr 0.8.3",
- "writeable 0.6.2",
+ "writeable 0.6.3",
 ]
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -3883,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3898,9 +3897,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3915,9 +3914,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3947,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -3960,33 +3959,33 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4103,7 +4102,7 @@ dependencies = [
  "comemo",
  "ecow",
  "if_chain",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stacker",
  "toml",
  "typst-library",
@@ -4187,7 +4186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722b0d6dfd05aa5bb7da7f282586f624f452e3f285cd3a10ac0d7e99f3bc3048"
 dependencies = [
  "az",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bumpalo",
  "chinese-number",
  "ciborium",
@@ -4202,7 +4201,7 @@ dependencies = [
  "icu_provider 1.5.0",
  "icu_provider_blob",
  "image",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "kamadak-exif",
  "kurbo 0.11.3",
  "lipsum",
@@ -4265,7 +4264,7 @@ dependencies = [
  "comemo",
  "ecow",
  "image",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "miniz_oxide",
  "pdf-writer",
  "serde",
@@ -4440,9 +4439,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-vo"
@@ -4538,12 +4537,12 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "147.2.1"
+version = "147.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab71899655e8368fa29d66044b4ba011178dc93c65cf0263068432e77e7359"
+checksum = "628be10f644833fcd285a48a27a6bf0d53a05c850059b5f60cd17b7ff5a2eed5"
 dependencies = [
  "bindgen",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fslock",
  "gzip-header",
  "home",
@@ -4583,11 +4582,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4596,14 +4595,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4614,9 +4613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4624,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4637,9 +4636,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4661,7 +4660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser 0.244.0",
 ]
@@ -4726,8 +4725,8 @@ version = "0.221.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d06bfa36ab3ac2be0dee563380147a5b81ba10dd8885d7fbbc9eb574be67d185"
 dependencies = [
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4736,17 +4735,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4827,15 +4826,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4867,28 +4857,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4904,12 +4877,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4920,12 +4887,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4940,22 +4901,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4970,12 +4919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4986,12 +4929,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5006,12 +4943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,16 +4955,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -5054,6 +4988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,7 +5012,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5102,8 +5042,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5122,7 +5062,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5139,7 +5079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
 dependencies = [
  "font-types",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "kurbo 0.12.0",
  "log",
  "read-fonts",
@@ -5159,9 +5099,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -5248,18 +5188,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5268,18 +5208,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5399,9 +5339,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.12"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.21.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -13,7 +13,7 @@ use citum_engine::values::{
     effective_field_language, effective_item_language, resolve_multilingual_string,
 };
 use citum_schema::{
-    BibliographySpec, CitationSpec, LocalizedTemplateSpec, Style, StyleInfo, StylePreset,
+    BibliographySpec, CitationSpec, LocalizedTemplateSpec, Style, StyleBase, StyleInfo,
     options::{
         Config, ContributorConfig, MultilingualConfig, MultilingualMode, Processing,
         RoleLabelPreset, RoleOptions, RoleRendering, TitleRendering,
@@ -1149,7 +1149,7 @@ fn chicago_german_override_localizes_editor_verb() {
             default_locale: Some("de-DE".to_string()),
             ..Default::default()
         },
-        preset: Some(StylePreset::ChicagoAuthorDate18th),
+        extends: Some(StyleBase::ChicagoAuthorDate18th),
         options: Some(Config {
             locale_override: Some("de-DE-chicago".to_string()),
             contributors: Some(ContributorConfig {

--- a/crates/citum-migrate/src/base_detector.rs
+++ b/crates/citum-migrate/src/base_detector.rs
@@ -3,11 +3,11 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-//! Detects when extracted configuration matches known presets.
+//! Detects when extracted configuration matches known style bases.
 //!
-//! This module implements preset detection for Phase 3 of the style aliasing
+//! This module implements base detection for Phase 3 of the style aliasing
 //! design. When migrating CSL 1.0 styles, it compares extracted configuration
-//! to known preset patterns and emits preset names instead of expanded configs.
+//! to known base patterns and emits base names instead of expanded configs.
 //!
 //! ## Detection Strategy
 //!
@@ -23,19 +23,18 @@ use citum_schema::options::{
 };
 use citum_schema::presets::{ContributorPreset, DatePreset, TitlePreset};
 
-/// Holistic style presets that combine multiple configuration aspects.
+/// Holistic style bases that combine multiple configuration aspects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StylePreset {
+pub enum StyleBase {
     Apa,
     Chicago,
     Ieee,
-    Elsevier,
     Vancouver,
     Harvard,
 }
 
-/// Detects a holistic style preset from a full configuration.
-pub fn detect_style_preset(config: &Config) -> Option<StylePreset> {
+/// Detects the style base from a full configuration.
+pub fn detect_style_base(config: &Config) -> Option<StyleBase> {
     let cp = config
         .contributors
         .as_ref()
@@ -43,13 +42,11 @@ pub fn detect_style_preset(config: &Config) -> Option<StylePreset> {
     let tp = config.titles.as_ref().and_then(detect_title_preset);
 
     match (cp, tp) {
-        (Some(ContributorPreset::Apa), Some(TitlePreset::Apa)) => Some(StylePreset::Apa),
-        (Some(ContributorPreset::Chicago), Some(TitlePreset::Chicago)) => {
-            Some(StylePreset::Chicago)
-        }
-        (Some(ContributorPreset::Ieee), Some(TitlePreset::Chicago)) => Some(StylePreset::Ieee),
-        (Some(ContributorPreset::Vancouver), _) => Some(StylePreset::Vancouver),
-        (Some(ContributorPreset::Harvard), _) => Some(StylePreset::Harvard),
+        (Some(ContributorPreset::Apa), Some(TitlePreset::Apa)) => Some(StyleBase::Apa),
+        (Some(ContributorPreset::Chicago), Some(TitlePreset::Chicago)) => Some(StyleBase::Chicago),
+        (Some(ContributorPreset::Ieee), Some(TitlePreset::Chicago)) => Some(StyleBase::Ieee),
+        (Some(ContributorPreset::Vancouver), _) => Some(StyleBase::Vancouver),
+        (Some(ContributorPreset::Harvard), _) => Some(StyleBase::Harvard),
         _ => None,
     }
 }

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 
 /// CSL 1.0 analysis utilities.
 pub mod analysis;
+/// Base detector for style classification.
+pub mod base_detector;
 /// YAML/template compressor for reducing style size.
 pub mod compressor;
 /// Debug output formatting.
@@ -18,8 +20,6 @@ mod js_runtime;
 pub mod options_extractor;
 /// Multi-pass processing pipeline.
 pub mod passes;
-/// Preset detector for style classification.
-pub mod preset_detector;
 /// Provenance tracking for style migration.
 pub mod provenance;
 /// CSL 1.0 to Citum template compilation.
@@ -29,11 +29,11 @@ pub mod template_resolver;
 /// Upsampler for style enhancement.
 pub mod upsampler;
 
+pub use base_detector::{detect_contributor_preset, detect_date_preset, detect_title_preset};
 pub use compressor::Compressor;
 pub use debug_output::DebugOutputFormatter;
 pub use info_extractor::InfoExtractor;
 pub use options_extractor::OptionsExtractor;
-pub use preset_detector::{detect_contributor_preset, detect_date_preset, detect_title_preset};
 pub use provenance::{ProvenanceTracker, SourceLocation};
 pub use template_compiler::TemplateCompiler;
 pub use upsampler::Upsampler;

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -2,6 +2,7 @@
 
 use citum_migrate::{
     Compressor, MacroInliner, OptionsExtractor, TemplateCompiler, Upsampler, analysis,
+    base_detector,
     debug_output::DebugOutputFormatter,
     fixups::{
         citation_template_has_citation_number, citation_template_is_author_year_only,
@@ -13,7 +14,7 @@ use citum_migrate::{
         note_citation_template_is_underfit, scrub_inferred_literal_artifacts,
         should_merge_inferred_type_template,
     },
-    passes, preset_detector,
+    passes,
     provenance::ProvenanceTracker,
     template_resolver,
 };
@@ -954,7 +955,7 @@ fn validate_and_normalize_inferred_citations(
 fn apply_author_date_bibliography_passes(
     new_bib: &mut Vec<TemplateComponent>,
     options: &mut citum_schema::options::Config,
-    style_preset: Option<preset_detector::StylePreset>,
+    style_base: Option<base_detector::StyleBase>,
 ) {
     // Detect if the style uses space prefix for volume (Elsevier pattern)
     let volume_list_has_space_prefix = new_bib.iter().any(|c| {
@@ -978,7 +979,7 @@ fn apply_author_date_bibliography_passes(
             component,
             vol_pages_delim.clone(),
             volume_list_has_space_prefix,
-            style_preset,
+            style_base,
         );
     }
 
@@ -1007,22 +1008,22 @@ fn apply_author_date_bibliography_passes(
     passes::reorder::reorder_serial_components(new_bib);
 
     // Combine volume and issue into a grouped structure: volume(issue)
-    passes::grouping::group_volume_and_issue(new_bib, options, style_preset);
+    passes::grouping::group_volume_and_issue(new_bib, options, style_base);
 
     // Move pages to after the container-title/volume List for serial types.
     passes::reorder::reorder_pages_for_serials(new_bib);
 
     // Reorder publisher-place for Chicago journal articles.
-    passes::reorder::reorder_publisher_place_for_chicago(new_bib, style_preset);
+    passes::reorder::reorder_publisher_place_for_chicago(new_bib, style_base);
 
     // Reorder chapters for APA: "In " prefix + editors before book title
-    passes::reorder::reorder_chapters_for_apa(new_bib, style_preset);
+    passes::reorder::reorder_chapters_for_apa(new_bib, style_base);
 
     // Reorder chapters for Chicago: "In" prefix + book title before editors
-    passes::reorder::reorder_chapters_for_chicago(new_bib, style_preset);
+    passes::reorder::reorder_chapters_for_chicago(new_bib, style_base);
 
     // Fix Chicago issue placement
-    passes::deduplicate::suppress_duplicate_issue_for_journals(new_bib, style_preset);
+    passes::deduplicate::suppress_duplicate_issue_for_journals(new_bib, style_base);
 }
 
 /// Run the full XML compilation pipeline for bibliography and citation templates.
@@ -1137,13 +1138,13 @@ fn compile_from_xml(
     }
 
     // Detect holistic style preset for semantic fixups
-    let style_preset = preset_detector::detect_style_preset(options);
-    if let Some(preset) = style_preset {
-        eprintln!("Detected style preset: {preset:?}");
+    let style_base = base_detector::detect_style_base(options);
+    if let Some(base) = style_base {
+        eprintln!("Detected style base: {base:?}");
     }
 
     if is_in_text_class && is_author_date_processing {
-        apply_author_date_bibliography_passes(&mut new_bib, options, style_preset);
+        apply_author_date_bibliography_passes(&mut new_bib, options, style_base);
     }
 
     let type_templates_opt = if type_templates.is_empty() {
@@ -1284,7 +1285,7 @@ fn apply_type_overrides(
     component: &mut TemplateComponent,
     volume_pages_delimiter: Option<DelimiterPunctuation>,
     volume_list_has_space_prefix: bool,
-    style_preset: Option<preset_detector::StylePreset>,
+    style_base: Option<base_detector::StyleBase>,
 ) {
     if let TemplateComponent::Group(list) = component {
         for item in &mut list.group {
@@ -1292,7 +1293,7 @@ fn apply_type_overrides(
                 item,
                 volume_pages_delimiter.clone(),
                 volume_list_has_space_prefix,
-                style_preset,
+                style_base,
             );
         }
     }
@@ -1308,19 +1309,19 @@ fn relax_inferred_bibliography_date_suppression(template: &mut [TemplateComponen
 
 fn apply_preset_extractions(options: &mut citum_schema::options::Config) {
     if let Some(contributors) = options.contributors.clone()
-        && let Some(preset) = preset_detector::detect_contributor_preset(&contributors)
+        && let Some(preset) = base_detector::detect_contributor_preset(&contributors)
     {
         options.contributors = Some(preset.config());
     }
 
     if let Some(titles) = options.titles.clone()
-        && let Some(preset) = preset_detector::detect_title_preset(&titles)
+        && let Some(preset) = base_detector::detect_title_preset(&titles)
     {
         options.titles = Some(preset.config());
     }
 
     if let Some(dates) = options.dates.clone()
-        && let Some(preset) = preset_detector::detect_date_preset(&dates)
+        && let Some(preset) = base_detector::detect_date_preset(&dates)
     {
         options.dates = Some(preset.config());
     }

--- a/crates/citum-migrate/src/passes/deduplicate.rs
+++ b/crates/citum-migrate/src/passes/deduplicate.rs
@@ -184,7 +184,7 @@ pub fn list_signature(list: &citum_schema::template::TemplateGroup) -> String {
 /// Suppress duplicate issue in parent-monograph lists for article-journal types.
 pub fn suppress_duplicate_issue_for_journals(
     _components: &mut [TemplateComponent],
-    _style_preset: Option<crate::preset_detector::StylePreset>,
+    _style_preset: Option<crate::base_detector::StyleBase>,
 ) {
     // Overrides-based suppression removed as component-level overrides are deprecated.
 }

--- a/crates/citum-migrate/src/passes/grouping.rs
+++ b/crates/citum-migrate/src/passes/grouping.rs
@@ -72,7 +72,7 @@ fn group_vol_issue_and_date_top_level(
 fn group_vol_issue_issue_at_top(
     components: &mut Vec<TemplateComponent>,
     issue_idx: usize,
-    style_preset: Option<crate::preset_detector::StylePreset>,
+    style_base: Option<crate::base_detector::StyleBase>,
     vol_issue_delimiter: DelimiterPunctuation,
 ) {
     let list_idx = components.iter().enumerate().find_map(|(idx, c)| {
@@ -113,7 +113,7 @@ fn group_vol_issue_issue_at_top(
                 issue_with_parens,
                 vol_issue_delimiter.clone(),
             )
-            && matches!(style_preset, Some(crate::preset_detector::StylePreset::Apa))
+            && matches!(style_base, Some(crate::base_detector::StyleBase::Apa))
             && !list_contains_title(list)
         {
             list.delimiter = Some(DelimiterPunctuation::Comma);
@@ -168,7 +168,7 @@ fn group_vol_issue_both_nested(
 pub fn group_volume_and_issue(
     components: &mut Vec<TemplateComponent>,
     options: &citum_schema::options::Config,
-    style_preset: Option<crate::preset_detector::StylePreset>,
+    style_base: Option<crate::base_detector::StyleBase>,
 ) {
     // Volume-issue spacing varies by style:
     // - APA (comma delimiter): no space, e.g., "2(2)"
@@ -213,7 +213,7 @@ pub fn group_volume_and_issue(
     }
 
     if let Some(issue_idx) = issue_pos {
-        group_vol_issue_issue_at_top(components, issue_idx, style_preset, vol_issue_delimiter);
+        group_vol_issue_issue_at_top(components, issue_idx, style_base, vol_issue_delimiter);
     } else if vol_pos.is_none() {
         group_vol_issue_both_nested(components, vol_issue_delimiter);
     }

--- a/crates/citum-migrate/src/passes/reorder.rs
+++ b/crates/citum-migrate/src/passes/reorder.rs
@@ -134,13 +134,13 @@ pub fn reorder_pages_for_serials(components: &mut Vec<TemplateComponent>) {
 /// Reorder publisher-place for Chicago journal articles.
 pub fn reorder_publisher_place_for_chicago(
     components: &mut Vec<TemplateComponent>,
-    style_preset: Option<crate::preset_detector::StylePreset>,
+    style_base: Option<crate::base_detector::StyleBase>,
 ) {
-    use crate::preset_detector::StylePreset;
+    use crate::base_detector::StyleBase;
     use citum_schema::template::{SimpleVariable, TitleType};
 
     // Only apply to Chicago styles
-    if !matches!(style_preset, Some(StylePreset::Chicago)) {
+    if !matches!(style_base, Some(StyleBase::Chicago)) {
         return;
     }
 
@@ -187,13 +187,13 @@ pub fn reorder_publisher_place_for_chicago(
 /// Reorder chapter components for APA style.
 pub fn reorder_chapters_for_apa(
     components: &mut Vec<TemplateComponent>,
-    style_preset: Option<crate::preset_detector::StylePreset>,
+    style_base: Option<crate::base_detector::StyleBase>,
 ) {
-    use crate::preset_detector::StylePreset;
+    use crate::base_detector::StyleBase;
     use citum_schema::template::{ContributorRole, TitleType};
 
     // Only apply to APA styles
-    if !matches!(style_preset, Some(StylePreset::Apa)) {
+    if !matches!(style_base, Some(StyleBase::Apa)) {
         return;
     }
 
@@ -226,13 +226,13 @@ pub fn reorder_chapters_for_apa(
 /// Reorder chapter components for Chicago style.
 pub fn reorder_chapters_for_chicago(
     components: &mut Vec<TemplateComponent>,
-    style_preset: Option<crate::preset_detector::StylePreset>,
+    style_base: Option<crate::base_detector::StyleBase>,
 ) {
-    use crate::preset_detector::StylePreset;
+    use crate::base_detector::StyleBase;
     use citum_schema::template::{ContributorRole, TitleType};
 
     // Only apply to Chicago styles
-    if !matches!(style_preset, Some(StylePreset::Chicago)) {
+    if !matches!(style_base, Some(StyleBase::Chicago)) {
         return;
     }
 

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -33,8 +33,8 @@ pub mod locale;
 pub mod options;
 /// Configuration presets for common styles.
 pub mod presets;
-/// Style-level preset architecture (Level 2: named compiled-in Style structs).
-pub mod style_preset;
+/// Style base-inheritance mechanism (named compiled-in Style structs).
+pub mod style_base;
 /// Citation and bibliography template components.
 #[allow(missing_docs, reason = "internal derives")]
 pub mod template;
@@ -71,7 +71,7 @@ pub use options::TextCase;
 pub use options::{BibliographyOptions, CitationOptions, Config};
 pub use presets::{ContributorPreset, DatePreset, SortPreset, SubstitutePreset, TitlePreset};
 pub use registry::{RegistryEntry, StyleRegistry};
-pub use style_preset::StylePreset;
+pub use style_base::StyleBase;
 pub use template::{
     Rendering, TemplateComponent, TemplateContributor, TemplateDate, TemplateGroup, TemplateNumber,
     TemplateTerm, TemplateTitle, TemplateVariable, TypeSelector, WrapConfig, WrapPunctuation,
@@ -81,7 +81,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.34.0";
+pub const STYLE_SCHEMA_VERSION: &str = "0.35.0";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]
@@ -142,14 +142,14 @@ pub struct Style {
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
-    /// Style-level preset reference with optional variant delta overlay.
+    /// Extends a base style, with optional local overrides.
     ///
-    /// When present, the base [`StylePreset`] is resolved and the variant
-    /// delta merged before any further processing. Explicit `options`,
+    /// When present, the base [`StyleBase`] is resolved and the local
+    /// overrides are merged before any further processing. Explicit `options`,
     /// `citation`, and `bibliography` keys at the same document level take
-    /// precedence over the resolved preset.
+    /// precedence over the resolved base.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preset: Option<style_preset::StylePreset>,
+    pub extends: Option<style_base::StyleBase>,
     /// Raw YAML captured when the style was loaded via [`Style::from_yaml_str`]
     /// or [`Style::from_yaml_bytes`]. Used by [`merge_style_overlay`] for
     /// null-aware overlay merging (e.g., `ibid: ~` correctly clears an
@@ -160,14 +160,13 @@ pub struct Style {
 }
 
 impl Style {
-    /// Resolve this style into its final effective form by applying presets.
+    /// Resolve this style into its final effective form by applying base inheritance.
     ///
-    /// If the `preset` field is present, the base [`StylePreset`] is loaded,
-    /// the optional `variant` delta is applied over it, and finally any
-    /// explicit `options`, `citation`, or `bibliography` keys in the current
+    /// If the `extends` field is present, the base [`StyleBase`] is loaded
+    /// and any explicit `options`, `citation`, or `bibliography` keys in the current
     /// style document are merged on top (taking ultimate precedence).
     ///
-    /// Returns the original style unchanged if no preset is specified.
+    /// Returns the original style unchanged if no base is specified.
     #[must_use]
     pub fn into_resolved(self) -> Self {
         self.into_resolved_recursive(&mut HashSet::new())
@@ -175,34 +174,34 @@ impl Style {
 
     /// Internal recursive resolver with loop protection.
     #[must_use]
-    pub fn into_resolved_recursive(self, visited: &mut HashSet<StylePreset>) -> Self {
-        let Some(preset) = self.preset.clone() else {
+    pub fn into_resolved_recursive(self, visited: &mut HashSet<StyleBase>) -> Self {
+        let Some(base) = self.extends.clone() else {
             return self;
         };
 
-        if visited.contains(&preset) {
+        if visited.contains(&base) {
             // Loop detected: return the style as-is to avoid infinite recursion.
             return self;
         }
-        visited.insert(preset.clone());
+        visited.insert(base.clone());
 
-        // 1. Load the preset base (recursively resolves if the base itself has a preset).
-        let mut effective = preset.resolve_with_visited(visited);
+        // 1. Load the base (recursively resolves if the base itself has an extends field).
+        let mut effective = base.resolve_with_visited(visited);
 
         // 2. Apply style-level overrides from the local file (self).
         merge_style_overlay(&mut effective, &self);
 
         // 3. Preserve local file metadata for round-tripping.
         effective.version = self.version;
-        effective.preset = self.preset;
+        effective.extends = self.extends;
 
         effective
     }
 
     /// Parse a Citum style from a YAML string, preserving raw YAML for
-    /// null-aware overlay merging during preset resolution.
+    /// null-aware overlay merging during base resolution.
     ///
-    /// Preferred over `serde_yaml::from_str` when the style may be preset-backed,
+    /// Preferred over `serde_yaml::from_str` when the style extends a base,
     /// so that `ibid: ~` and similar null overrides correctly clear inherited values.
     ///
     /// # Errors
@@ -1511,7 +1510,7 @@ bibliography:
     #[test]
     fn null_type_variants_override_clears_preset_type_variants() {
         let child_yaml = r#"
-preset: chicago-notes-18th
+extends: chicago-notes-18th
 citation:
   type-variants: ~
   template:

--- a/crates/citum-schema-style/src/registry.rs
+++ b/crates/citum-schema-style/src/registry.rs
@@ -10,6 +10,21 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Tier classification for a style in the registry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum StyleKind {
+    /// Complete style that serves as an inheritance root.
+    Base,
+    /// Organizational adaptation of a base style (publisher, society, standards body).
+    Profile,
+    /// Pure alias pointing to a profile or base style.
+    Journal,
+    /// Standalone style with no aliases and no inheritance role.
+    Independent,
+}
+
 /// A single entry in a style registry.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -31,6 +46,9 @@ pub struct RegistryEntry {
     /// Subject/domain classification tags (default empty).
     #[serde(default)]
     pub fields: Vec<String>,
+    /// Tier classification (base, profile, journal, independent).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<StyleKind>,
 }
 
 /// A registry of citation styles with alias resolution.
@@ -102,6 +120,7 @@ impl StyleRegistry {
                 path: None,
                 description: None,
                 fields: Vec::new(),
+                kind: None,
             });
         }
 
@@ -168,6 +187,7 @@ mod tests {
                 path: None,
                 description: Some("APA 7th edition".to_string()),
                 fields: vec!["psychology".to_string()],
+                kind: None,
             }],
         };
 
@@ -186,6 +206,7 @@ mod tests {
                 path: None,
                 description: Some("APA 7th edition".to_string()),
                 fields: vec!["psychology".to_string()],
+                kind: None,
             }],
         };
 
@@ -205,6 +226,7 @@ mod tests {
                     path: None,
                     description: None,
                     fields: vec![],
+                    kind: None,
                 },
                 RegistryEntry {
                     id: "mla".to_string(),
@@ -213,6 +235,7 @@ mod tests {
                     path: None,
                     description: None,
                     fields: vec![],
+                    kind: None,
                 },
             ],
         };
@@ -232,6 +255,7 @@ mod tests {
                 path: None,
                 description: Some("APA 7th edition".to_string()),
                 fields: vec!["psychology".to_string()],
+                kind: None,
             }],
         };
 
@@ -245,6 +269,7 @@ mod tests {
                     builtin: None,
                     description: Some("Custom style".to_string()),
                     fields: vec![],
+                    kind: None,
                 },
                 RegistryEntry {
                     id: "apa-7th".to_string(),
@@ -253,6 +278,7 @@ mod tests {
                     path: None,
                     description: Some("APA 7th edition (modified)".to_string()),
                     fields: vec!["psychology".to_string(), "custom".to_string()],
+                    kind: None,
                 },
             ],
         };

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -1,0 +1,387 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Style base-inheritance mechanism for named compiled-in styles.
+//!
+//! This module provides [`StyleBase`] — a mechanism for naming
+//! well-known compiled-in styles so that a YAML file can declare
+//! `extends: chicago-notes-18th` and inherit the full style, then override
+//! any fields it needs at the top level of the style document.
+
+use crate::Style;
+use crate::embedded::get_embedded_style;
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// A named, compiled-in style base that serves as an inheritance root.
+///
+/// A style file declares `extends: <key>` to inherit a complete base style.
+/// Any top-level fields in the file (`options`, `citation`, `bibliography`,
+/// etc.) are merged over the base, with local fields taking
+/// ultimate precedence.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum StyleBase {
+    /// Chicago Manual of Style 18th edition — notes without bibliography.
+    #[serde(rename = "chicago-notes-18th")]
+    ChicagoNotes18th,
+    /// Chicago Manual of Style 18th edition — author-date system.
+    #[serde(rename = "chicago-author-date-18th")]
+    ChicagoAuthorDate18th,
+    /// Chicago Manual of Style (shortened notes and bibliography).
+    #[serde(rename = "chicago-shortened-notes-bibliography")]
+    ChicagoShortenedNotesBibliography,
+    /// APA 7th edition — author-date system.
+    #[serde(rename = "apa-7th")]
+    Apa7th,
+    /// Elsevier Harvard (author-date).
+    ElsevierHarvard,
+    /// Elsevier with Titles (numeric).
+    ElsevierWithTitles,
+    /// Elsevier Vancouver (numeric).
+    ElsevierVancouver,
+    /// Springer Basic (author-date).
+    SpringerBasicAuthorDate,
+    /// Springer Vancouver Brackets (numeric).
+    SpringerVancouverBrackets,
+    /// Springer Basic Brackets (numeric).
+    SpringerBasicBrackets,
+    /// American Medical Association 11th edition (numeric).
+    AmericanMedicalAssociation,
+    /// Institute of Electrical and Electronics Engineers (numeric).
+    Ieee,
+    /// Taylor & Francis Chicago author-date.
+    TaylorAndFrancisChicagoAuthorDate,
+    /// Taylor & Francis Council of Science Editors author-date.
+    TaylorAndFrancisCouncilOfScienceEditorsAuthorDate,
+    /// Taylor & Francis National Library of Medicine.
+    TaylorAndFrancisNationalLibraryOfMedicine,
+    /// Modern Language Association 9th edition (author-page).
+    ModernLanguageAssociation,
+}
+
+impl StyleBase {
+    /// Return the embedded YAML key used to look up this base.
+    fn embedded_key(&self) -> &'static str {
+        match self {
+            StyleBase::ChicagoNotes18th => "chicago-notes-18th",
+            StyleBase::ChicagoAuthorDate18th => "chicago-author-date-18th",
+            StyleBase::ChicagoShortenedNotesBibliography => "chicago-shortened-notes-bibliography",
+            StyleBase::Apa7th => "apa-7th",
+            StyleBase::ElsevierHarvard => "elsevier-harvard",
+            StyleBase::ElsevierWithTitles => "elsevier-with-titles",
+            StyleBase::ElsevierVancouver => "elsevier-vancouver",
+            StyleBase::SpringerBasicAuthorDate => "springer-basic-author-date",
+            StyleBase::SpringerVancouverBrackets => "springer-vancouver-brackets",
+            StyleBase::SpringerBasicBrackets => "springer-basic-brackets",
+            StyleBase::AmericanMedicalAssociation => "american-medical-association",
+            StyleBase::Ieee => "ieee",
+            StyleBase::TaylorAndFrancisChicagoAuthorDate => {
+                "taylor-and-francis-chicago-author-date"
+            }
+            StyleBase::TaylorAndFrancisCouncilOfScienceEditorsAuthorDate => {
+                "taylor-and-francis-council-of-science-editors-author-date"
+            }
+            StyleBase::TaylorAndFrancisNationalLibraryOfMedicine => {
+                "taylor-and-francis-national-library-of-medicine"
+            }
+            StyleBase::ModernLanguageAssociation => "modern-language-association",
+        }
+    }
+
+    /// Return the base [`Style`] for this base.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the embedded YAML is missing or malformed.
+    pub fn base(&self) -> Style {
+        let key = self.embedded_key();
+        get_embedded_style(key)
+            .unwrap_or_else(|| panic!("StyleBase: missing embedded style for key '{key}'"))
+            .unwrap_or_else(|e| panic!("StyleBase: malformed embedded YAML for key '{key}': {e}"))
+    }
+
+    /// Return the canonical base key string (kebab-case).
+    pub fn key(&self) -> &'static str {
+        match self {
+            StyleBase::ChicagoNotes18th => "chicago-notes-18th",
+            StyleBase::ChicagoAuthorDate18th => "chicago-author-date-18th",
+            StyleBase::ChicagoShortenedNotesBibliography => "chicago-shortened-notes-bibliography",
+            StyleBase::Apa7th => "apa-7th",
+            StyleBase::ElsevierHarvard => "elsevier-harvard",
+            StyleBase::ElsevierWithTitles => "elsevier-with-titles",
+            StyleBase::ElsevierVancouver => "elsevier-vancouver",
+            StyleBase::SpringerBasicAuthorDate => "springer-basic-author-date",
+            StyleBase::SpringerVancouverBrackets => "springer-vancouver-brackets",
+            StyleBase::SpringerBasicBrackets => "springer-basic-brackets",
+            StyleBase::AmericanMedicalAssociation => "american-medical-association",
+            StyleBase::Ieee => "ieee",
+            StyleBase::TaylorAndFrancisChicagoAuthorDate => {
+                "taylor-and-francis-chicago-author-date"
+            }
+            StyleBase::TaylorAndFrancisCouncilOfScienceEditorsAuthorDate => {
+                "taylor-and-francis-council-of-science-editors-author-date"
+            }
+            StyleBase::TaylorAndFrancisNationalLibraryOfMedicine => {
+                "taylor-and-francis-national-library-of-medicine"
+            }
+            StyleBase::ModernLanguageAssociation => "modern-language-association",
+        }
+    }
+
+    /// Return all known base variants.
+    ///
+    /// Prefer this over exhaustive `match` when iterating the registry, since
+    /// [`StyleBase`] is `#[non_exhaustive]`.
+    pub fn all() -> &'static [StyleBase] {
+        &[
+            StyleBase::ChicagoNotes18th,
+            StyleBase::ChicagoAuthorDate18th,
+            StyleBase::ChicagoShortenedNotesBibliography,
+            StyleBase::Apa7th,
+            StyleBase::ElsevierHarvard,
+            StyleBase::ElsevierWithTitles,
+            StyleBase::ElsevierVancouver,
+            StyleBase::SpringerBasicAuthorDate,
+            StyleBase::SpringerVancouverBrackets,
+            StyleBase::SpringerBasicBrackets,
+            StyleBase::AmericanMedicalAssociation,
+            StyleBase::Ieee,
+            StyleBase::TaylorAndFrancisChicagoAuthorDate,
+            StyleBase::TaylorAndFrancisCouncilOfScienceEditorsAuthorDate,
+            StyleBase::TaylorAndFrancisNationalLibraryOfMedicine,
+            StyleBase::ModernLanguageAssociation,
+        ]
+    }
+
+    /// Internal resolver with loop protection.
+    pub(crate) fn resolve_with_visited(&self, visited: &mut HashSet<StyleBase>) -> Style {
+        let mut style = self.base();
+        if style.extends.is_some() {
+            style = style.into_resolved_recursive(visited);
+        }
+        style
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::{Config, PageRangeFormat};
+    use crate::{Style, StyleInfo};
+
+    #[test]
+    fn style_base_chicago_notes_base_is_valid() {
+        let style = StyleBase::ChicagoNotes18th.base();
+        let yaml = serde_yaml::to_string(&style).expect("serialization failed");
+        let back: Style = serde_yaml::from_str(&yaml).expect("deserialization failed");
+        assert!(back.info.title.is_some(), "title should be present");
+        assert!(
+            back.citation
+                .as_ref()
+                .and_then(|citation| citation.ibid.as_ref())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn style_base_chicago_author_date_base_is_valid() {
+        let style = StyleBase::ChicagoAuthorDate18th.base();
+        assert!(style.info.title.is_some(), "title should be present");
+    }
+
+    #[test]
+    fn style_base_apa_7th_base_is_valid() {
+        let style = StyleBase::Apa7th.base();
+        assert!(style.info.title.is_some(), "title should be present");
+        assert!(
+            style.extends.is_none(),
+            "apa-7th is a Tier-1 base and must not extend anything"
+        );
+        let citation = style.citation.as_ref().expect("citation should be present");
+        assert!(
+            citation.use_preset.is_none(),
+            "APA base should carry authored citation templates"
+        );
+        assert!(
+            citation.template.is_none(),
+            "APA base should not define a top-level citation template"
+        );
+        assert!(
+            citation
+                .integral
+                .as_ref()
+                .is_some_and(|i| i.template.is_some()),
+            "APA base should define an authored integral citation template"
+        );
+        assert!(
+            citation
+                .non_integral
+                .as_ref()
+                .is_some_and(|ni| ni.template.is_some()),
+            "APA base should define an authored non-integral citation template"
+        );
+
+        let bibliography = style
+            .bibliography
+            .as_ref()
+            .expect("bibliography should be present");
+        assert!(
+            bibliography.use_preset.is_none(),
+            "APA base should carry authored bibliography templates"
+        );
+        assert!(
+            bibliography.template.is_some(),
+            "APA base should define an authored bibliography template"
+        );
+        assert!(
+            bibliography
+                .type_variants
+                .as_ref()
+                .is_some_and(|variants| !variants.is_empty()),
+            "APA base should define authored bibliography type variants"
+        );
+    }
+
+    #[test]
+    fn style_base_yaml_roundtrip() {
+        let yaml = "chicago-notes-18th";
+        let base: StyleBase = serde_yaml::from_str(yaml).expect("deserialization failed");
+        assert_eq!(base, StyleBase::ChicagoNotes18th);
+
+        let back = serde_yaml::to_string(&base).expect("serialization failed");
+        assert!(back.trim() == "chicago-notes-18th");
+    }
+
+    #[test]
+    fn top_level_null_field_clears_inherited_base_value() {
+        // A style that inherits Chicago Notes but disables ibid via a
+        // top-level citation block — the canonical authoring pattern
+        // since there is no separate variant layer.
+        let yaml = r#"
+extends: chicago-notes-18th
+citation:
+  ibid: ~
+"#;
+        let style: Style = Style::from_yaml_str(yaml).expect("style parses");
+        let resolved = style.into_resolved();
+        assert!(
+            resolved
+                .citation
+                .as_ref()
+                .expect("citation present")
+                .ibid
+                .is_none(),
+            "top-level null should clear inherited ibid"
+        );
+        assert!(
+            resolved.citation.as_ref().unwrap().template.is_some(),
+            "top-level override should preserve the inherited template"
+        );
+    }
+
+    #[test]
+    fn local_style_overrides_merge_with_base() {
+        let style = Style {
+            info: StyleInfo {
+                title: Some("Taylor & Francis Test".to_string()),
+                id: Some("tf-test".into()),
+                ..Default::default()
+            },
+            extends: Some(StyleBase::ChicagoAuthorDate18th),
+            options: Some(Config {
+                page_range_format: Some(PageRangeFormat::Expanded),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let resolved = style.into_resolved();
+        let options = resolved
+            .options
+            .expect("resolved options should be present");
+        assert_eq!(options.page_range_format, Some(PageRangeFormat::Expanded));
+        assert!(
+            options.processing.is_some(),
+            "local override should preserve inherited processing"
+        );
+        assert!(
+            resolved.citation.is_some(),
+            "local override should preserve inherited citation spec"
+        );
+    }
+
+    #[test]
+    fn style_base_circular_dependency_is_handled() {
+        let mut base = StyleBase::ChicagoNotes18th.base();
+        base.extends = Some(StyleBase::ChicagoNotes18th);
+
+        let resolved = base.into_resolved();
+        assert!(resolved.extends.is_some());
+    }
+
+    #[test]
+    fn all_bases_resolve_cleanly() {
+        for base in StyleBase::all() {
+            let resolved = base.base().into_resolved();
+            assert!(
+                resolved.citation.is_some(),
+                "{} resolved citation missing",
+                base.key()
+            );
+            assert!(
+                resolved.options.is_some(),
+                "{} resolved options missing",
+                base.key()
+            );
+        }
+    }
+
+    #[test]
+    fn tier1_bases_have_no_extends_field() {
+        // Tier-1 base styles must not contain an extends: field — they ARE the root.
+        // Profile styles (Tier-2) in StyleBase may legitimately extend a base.
+        let tier1 = [
+            StyleBase::Apa7th,
+            StyleBase::ChicagoNotes18th,
+            StyleBase::ChicagoAuthorDate18th,
+            StyleBase::Ieee,
+            StyleBase::AmericanMedicalAssociation,
+            StyleBase::ModernLanguageAssociation,
+        ];
+        for base in &tier1 {
+            assert!(
+                base.base().extends.is_none(),
+                "{} is a Tier-1 base and must not have an extends: field",
+                base.key()
+            );
+        }
+    }
+
+    #[test]
+    fn turabian_pattern_disables_ibid_via_top_level_citation() {
+        // Turabian 9th ed. = Chicago Notes + ibid disabled.
+        // With no variant layer, this is expressed as a top-level citation override.
+        let yaml = r#"
+info:
+  title: "Turabian 9th"
+extends: chicago-notes-18th
+citation:
+  ibid: ~
+"#;
+        let style = Style::from_yaml_str(yaml).expect("style parses");
+        let resolved = style.into_resolved();
+        let citation = resolved.citation.expect("citation should be present");
+        assert!(citation.ibid.is_none(), "ibid should be disabled");
+        assert!(
+            citation.template.is_some(),
+            "inherited template should be preserved"
+        );
+    }
+}

--- a/docs/schemas/registry.json
+++ b/docs/schemas/registry.json
@@ -65,10 +65,46 @@
             "type": "string"
           },
           "default": []
+        },
+        "kind": {
+          "description": "Tier classification (base, profile, journal, independent).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StyleKind"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
         "id"
+      ]
+    },
+    "StyleKind": {
+      "description": "Tier classification for a style in the registry.",
+      "oneOf": [
+        {
+          "description": "Complete style that serves as an inheritance root.",
+          "type": "string",
+          "const": "base"
+        },
+        {
+          "description": "Organizational adaptation of a base style (publisher, society, standards body).",
+          "type": "string",
+          "const": "profile"
+        },
+        {
+          "description": "Pure alias pointing to a profile or base style.",
+          "type": "string",
+          "const": "journal"
+        },
+        {
+          "description": "Standalone style with no aliases and no inheritance role.",
+          "type": "string",
+          "const": "independent"
+        }
       ]
     }
   }

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7,7 +7,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.34.0"
+      "default": "0.35.0"
     },
     "info": {
       "description": "Style metadata.",
@@ -68,11 +68,11 @@
       ],
       "additionalProperties": true
     },
-    "preset": {
-      "description": "Style-level preset reference with optional variant delta overlay.\n\nWhen present, the base [`StylePreset`] is resolved and the variant\ndelta merged before any further processing. Explicit `options`,\n`citation`, and `bibliography` keys at the same document level take\nprecedence over the resolved preset.",
+    "extends": {
+      "description": "Extends a base style, with optional local overrides.\n\nWhen present, the base [`StyleBase`] is resolved and the local\noverrides are merged before any further processing. Explicit `options`,\n`citation`, and `bibliography` keys at the same document level take\nprecedence over the resolved base.",
       "anyOf": [
         {
-          "$ref": "#/$defs/StylePreset"
+          "$ref": "#/$defs/StyleBase"
         },
         {
           "type": "null"
@@ -5414,8 +5414,8 @@
         }
       ]
     },
-    "StylePreset": {
-      "description": "A named, compiled-in style preset (Level 2 of Citum's preset hierarchy).\n\nA style file declares `preset: <key>` to inherit a complete base style.\nAny top-level fields in the file (`options`, `citation`, `bibliography`,\netc.) are merged over the preset base, with local fields taking\nultimate precedence.",
+    "StyleBase": {
+      "description": "A named, compiled-in style base that serves as an inheritance root.\n\nA style file declares `extends: <key>` to inherit a complete base style.\nAny top-level fields in the file (`options`, `citation`, `bibliography`,\netc.) are merged over the base, with local fields taking\nultimate precedence.",
       "oneOf": [
         {
           "description": "Chicago Manual of Style 18th edition — notes without bibliography.",

--- a/docs/specs/STYLE_PRESET_ARCHITECTURE.md
+++ b/docs/specs/STYLE_PRESET_ARCHITECTURE.md
@@ -1,10 +1,10 @@
-# Style Preset Architecture
+# Style Base Architecture
 
 **Status:** Active
-**Version:** 1.5
-**Date:** 2026-03-19
-**Bean:** `csl26-fsjy`
-**Related:** bean `csl26-zy07` (unblocked by this spec), bean `csl26-wp6y` (follow-up policy work), `LOCALE_MESSAGES.md`
+**Version:** 2.0
+**Date:** 2026-04-20
+**Bean:** `csl26-v961`
+**Related:** bean `csl26-zy07` (unblocked by this spec), bean `csl26-wp6y` (follow-up policy work), `LOCALE_MESSAGES.md`, `STYLE_TAXONOMY.md`
 
 ## Purpose
 
@@ -15,15 +15,15 @@ configuration (`ContributorPreset`, `DatePreset`, `TitlePreset`, etc.) applied
 at the `options` key of a style file. Already implemented in
 `crates/citum-schema-style/src/presets.rs`.
 
-**Level 2 — Style presets (new).** A named, compiled-in `Style` struct
+**Level 2 — Style base inheritance (new).** A named, compiled-in `Style` struct
 representing a complete well-known style. A YAML file (or wizard output) can
-reference a style preset by name and express only the delta between itself and
-the preset, rather than duplicating the full style definition.
+reference a style base by name using the `extends:` key and express only the delta
+between itself and the base, rather than duplicating the full style definition.
 
 The motivating case is **behavioral dependents** — styles that differ from a
 parent by 2–5 rules (e.g. Turabian ≈ Chicago Notes + no ibid + footnote
 punctuation tweaks). In CSL these are full standalone files. In Citum they
-become a `preset:` declaration plus a few top-level field overrides.
+become an `extends:` declaration plus a few top-level field overrides.
 
 ---
 
@@ -44,18 +44,18 @@ them without loading a YAML file from disk.
 
 ---
 
-## §2 `StylePreset` Enum
+## §2 `StyleBase` Enum
 
-A `StylePreset` identifies a compiled-in `Style` struct by a stable key.
+A `StyleBase` identifies a compiled-in `Style` struct by a stable key.
 
 ```yaml
-# Minimal preset-backed style — inherits everything from the base
-preset: chicago-notes-18th
+# Minimal base-extended style — inherits everything from the base
+extends: chicago-notes-18th
 ```
 
 ```yaml
 # Behavioral variant — override specific fields at the top level
-preset: chicago-notes-18th
+extends: chicago-notes-18th
 citation:
   ibid: ~       # null disables ibid — Turabian 9th ed.
 options:
@@ -65,23 +65,23 @@ options:
 
 ```yaml
 # Locale variant — override locale rendering options at the top level
-preset: chicago-author-date-18th
+extends: chicago-author-date-18th
 options:
   locale-override: de-DE-chicago
   default-locale: de-DE
 ```
 
-The authoring rule is uniform: declare `preset:`, then override any fields you
+The authoring rule is uniform: declare `extends:`, then override any fields you
 need at the top level of the style file. There is no separate `variant` layer —
 top-level fields are the only override mechanism, keeping the mental model
 simple for style authors.
 
 ### Naming convention
 
-Style preset keys use `kebab-case` composed of `{short-name}-{edition}`:
+Style base keys use `kebab-case` composed of `{short-name}-{edition}`:
 
-| Preset key | `info.short_name` | `info.edition` |
-|------------|-------------------|----------------|
+| Base key | `info.short_name` | `info.edition` |
+|----------|-------------------|----------------|
 | `chicago-notes-18th` | Chicago Notes | 18th |
 | `chicago-author-date-18th` | Chicago Author-Date | 18th |
 | `apa-7th` | APA | 7th |
@@ -91,33 +91,34 @@ The key is the canonical identity. `info.short_name` and `info.edition`
 
 ### Initial set
 
-| Preset key | Base file |
-|------------|-----------|
-| `chicago-notes-18th` | `styles/preset-bases/chicago-notes-18th.yaml` |
-| `chicago-author-date-18th` | `styles/preset-bases/chicago-author-date-18th.yaml` |
-| `apa-7th` | `styles/preset-bases/apa-7th.yaml` |
+| Base key | Location |
+|----------|----------|
+| `chicago-notes-18th` | `styles/embedded/chicago-notes-18th.yaml` |
+| `chicago-author-date-18th` | `styles/embedded/chicago-author-date-18th.yaml` |
+| `apa-7th` | `styles/embedded/apa-7th.yaml` |
 
-Additional presets are added as csl26-zy07 backfills `short_name`/`edition` on
-the full style library.
+Additional bases are added as top-priority styles in the style portfolio are
+embedded. The `StyleBase` enum in `crates/citum-schema-style/src/style_base.rs`
+lists all currently available bases.
 
 ---
 
-## §3 `Style.preset` Field
+## §3 `Style.extends` Field
 
-The `preset` field on `Style` holds an optional `StylePreset` value — a plain
+The `extends` field on `Style` holds an optional `StyleBase` value — a plain
 enum that serializes to/from a kebab-case string:
 
 ```rust
 pub struct Style {
     // … existing fields …
-    pub preset: Option<StylePreset>,
+    pub extends: Option<StyleBase>,
 }
 ```
 
-When `preset` is present, the engine produces the final `Style` during
+When `extends` is present, the engine produces the final `Style` during
 processor construction by:
 
-1. Loading the preset base.
+1. Loading the base style.
 2. Merging any explicit top-level fields from the local file on top (with local
    fields taking ultimate precedence).
 
@@ -132,12 +133,12 @@ wholesale — there is no per-element merging.
 
 ## §4 Registry Location
 
-The `StylePreset` registry lives in `crates/citum-schema-style` as compiled-in
+The `StyleBase` enum lives in `crates/citum-schema-style` as compiled-in
 data, while the engine owns runtime resolution. Rationale:
 
-- Keeping the registry in the schema crate preserves the declarative contract:
+- Keeping the enum in the schema crate preserves the declarative contract:
   a `Style` is a `Style` regardless of how it was produced.
-- Letting the engine resolve preset-backed styles guarantees that every runtime
+- Letting the engine resolve base-extended styles guarantees that every runtime
   entry point observes the same effective style, even when callers load raw
   YAML or embedded styles without pre-resolving them.
 - The wizard and CLI both depend on `citum-schema-style` already; no new
@@ -147,10 +148,10 @@ data, while the engine owns runtime resolution. Rationale:
 
 ## §5 Locale Complement
 
-Style presets interact cleanly with the locale override system (LOCALE_MESSAGES.md):
+Style bases interact cleanly with the locale override system (LOCALE_MESSAGES.md):
 
 ```yaml
-preset: chicago-author-date-18th
+extends: chicago-author-date-18th
 options:
   locale-override: de-DE-chicago
 ```
@@ -159,11 +160,11 @@ The `de-DE-chicago` locale override encodes the locale-specific deviations from
 `chicago-author-date-de.csl` (German conjunctions, date order, editor verb form)
 without duplicating the style's structural template. This is expressed as a
 regular top-level `options` override — the same mechanism used for any other
-behavioral difference from the preset.
+behavioral difference from the base.
 
 This replaces the CSL pattern of language-variant style files like
 `chicago-author-date-de.csl`. German-speaking users select
-`preset: chicago-author-date-18th` and set their locale to `de-DE` (or apply
+`extends: chicago-author-date-18th` and set their locale to `de-DE` (or apply
 `locale-override: de-DE-chicago` for style-specific refinements); no separate
 German style file is needed.
 
@@ -174,81 +175,52 @@ worked example.
 
 ## §6 Wizard & CLI Implications
 
-**Style Navigator** (citum-hub): The 'Closest match' banner names a preset key
+**Style Navigator** (citum-hub): The 'Closest match' banner names a base key
 (e.g. `chicago-notes-18th`), not a file path. "Use this" loads the compiled
-preset directly into `WizardState`. A YAML file is only produced when the user
-deviates from the preset — and even then the output contains `preset:` plus
+base directly into `WizardState`. A YAML file is only produced when the user
+deviates from the base — and even then the output contains `extends:` plus
 only the overriding fields, not the full style.
 
-**CLI**: `citum render` resolves `preset` before rendering. A future
-`--preset <key>` flag would make the registry directly addressable without a
+**CLI**: `citum render` resolves `extends` before rendering. A future
+`--base <key>` flag would make the registry directly addressable without a
 style file argument, but that is out of scope for this bean.
 
-**File naming** (csl26-zy07): Once style presets exist, YAML filenames for
+**File naming** (csl26-zy07): Once style bases exist, YAML filenames for
 well-known styles should derive from `short_name` + `edition`. The rename wave
-is tracked separately and blocks on this bean's preset key shape being stable.
+is tracked separately and blocks on this bean's base key shape being stable.
 
 ---
 
 ## §7 Circular Dependency Prevention
 
-To prevent infinite recursion during preset resolution, Citum implements two
+To prevent infinite recursion during base resolution, Citum implements two
 levels of protection:
 
 1. **Resolution loop protection:** `into_resolved()` tracks visited
-   `StylePreset` variants in a `HashSet`. If a preset is encountered twice in
+   `StyleBase` variants in a `HashSet`. If a base is encountered twice in
    the same resolution chain, the recursive call is aborted and the style is
    returned as-is for that branch.
 
-2. **Base style invariant:** A `Style` that serves as the base for a
-   `StylePreset` (e.g. `styles/preset-bases/apa-7th.yaml`) **must not** itself
-   contain a `preset` field. Enforced by the `all_presets_resolve_cleanly` unit
+2. **Base style invariant:** A `Style` that serves as a base for the
+   `StyleBase` enum (e.g. `styles/embedded/apa-7th.yaml`) **must not** itself
+   contain an `extends` field. Enforced by the `all_bases_resolve_cleanly` unit
    test and documented as an authoring constraint.
 
 If a circular dependency is detected at runtime, the engine stops at the first
 repetition and renders using any fields present beyond the `preset` key,
-effectively treating the circular reference as a no-op.
+effectively treating the circular reference as a no-op. Base styles (Tier 1) must
+not contain an `extends:` field; this is enforced by the `all_bases_resolve_cleanly`
+unit test.
 
 ---
 
 ## §8 Corpus Impact
 
-`citum-analyze` now includes a corpus-savings report:
+Base-extended styles enable significant corpus savings when combined with the
+registry alias system (see `STYLE_TAXONOMY.md`). On the current CSL snapshot,
+the top opportunities are families like APA (900+ potential aliases), Elsevier
+variants (1,500+ total), and Springer templates (475+ dependent styles).
 
-```bash
-cargo run -p citum-analyze --bin citum-analyze -- \
-  styles-legacy --quantify-savings --json
-```
-
-On the March 18, 2026 snapshot of the CSL corpus bundled in this repository,
-the report produced:
-
-| Metric | Count | Interpretation |
-|--------|-------|----------------|
-| Independent CSL styles | 2,844 | Full standalone styles in the top-level `styles-legacy/` directory |
-| Dependent CSL styles | 7,987 | Clear alias/wrapper styles already pointing at an independent parent |
-| Unique dependent parents | 298 | Distinct parent families represented by those dependents |
-| Dependent alias savings | 7,987 | Lower-bound one-by-one conversions avoided by alias/preset composition |
-| High-confidence locale override savings | 11 | Independent locale variants with a matching base slug, such as `chicago-author-date-de` |
-| Possible locale override savings | 2,515 | Independent styles with `default-locale`; some are true locale variants, others are broader localized wrappers |
-| Preset wrapper opportunity | 2,140 | Independent styles with CSL `rel="template"` links, excluding the 11 high-confidence locale variants already counted above |
-| Lower-bound avoided conversions | 7,998 | `dependent alias savings + high-confidence locale override savings` |
-| Upper-bound avoided conversions | 10,138 | Lower bound plus the broader preset-wrapper opportunity bucket |
-
-These numbers are intentionally framed as **ranges**, not exact migration
-promises:
-
-- The **lower bound** is conservative and counts only the styles we can point to
-  directly as aliases or clearly locale-paired variants.
-- The **upper bound** is a heuristic estimate of the broader style-family reuse
-  opportunity unlocked by preset-backed wrappers.
-- The `possible locale override` bucket is informative context, not a direct
-  claim that every localized CSL style collapses cleanly into a locale-only
-  overlay.
-
-Top families by combined dependent + wrapper opportunity in this snapshot were
-`apa` (906), `elsevier-harvard` (715), `elsevier-with-titles` (686),
-`elsevier-vancouver` (590), and `springer-vancouver-brackets` (475).
 
 ---
 
@@ -257,43 +229,48 @@ Top families by combined dependent + wrapper opportunity in this snapshot were
 This design is intentionally shippable before every policy question is fully
 settled.
 
-- **Benchmark identity.** When a preset-backed style overrides part of its
+- **Benchmark identity.** When a base-extended style overrides part of its
   parent, the project still needs a stable rule for what comparator or oracle
   identity should govern fidelity claims.
 - **Wrapper vs independent style.** A compact override is valuable; a large
   override layer may become harder to understand than an explicit standalone
-  style. The project should define when presets are encouraged and when they
+  style. The project should define when bases are encouraged and when they
   should be avoided.
 - **Replace-only arrays.** Structural deep merge works well for nested objects,
   but arrays and template lists still replace wholesale. This is the correct
   merge rule, but it creates an authoring footgun unless the docs and examples
   stay explicit.
 
-Broader policy and authoring guidance are tracked in `csl26-wp6y`.
+Broader policy and authoring guidance are tracked in `csl26-wp6y`. The taxonomy
+and four-tier classification are documented in `STYLE_TAXONOMY.md`.
 
 ---
 
 ## §10 Acceptance Criteria
 
-- [x] `StylePreset::ChicagoNotes18th.base()` returns a `Style` that round-trips
+- [x] `StyleBase::ChicagoNotes18th.base()` returns a `Style` that round-trips
       through serde without error.
-- [x] A style YAML with `preset: chicago-notes-18th` and no other fields
-      deserializes and resolves to the same effective `Style` as the base preset.
-- [x] A style YAML with `preset: chicago-notes-18th` + `citation.ibid: ~`
+- [x] A style YAML with `extends: chicago-notes-18th` and no other fields
+      deserializes and resolves to the same effective `Style` as the base.
+- [x] A style YAML with `extends: chicago-notes-18th` + `citation.ibid: ~`
       produces a `Style` where `citation.ibid` is `None`.
-- [x] A style YAML with `preset: chicago-author-date-18th` +
+- [x] A style YAML with `extends: chicago-author-date-18th` +
       `options.page-range-format: expanded` preserves inherited option fields
       while overriding only the page-range behavior.
 - [x] `options.locale-override: de-DE-chicago` paired with
-      `preset: chicago-author-date-18th` renders `"und"` (not `"and"`) for a
+      `extends: chicago-author-date-18th` renders `"und"` (not `"and"`) for a
       multi-author citation.
-- [x] `citum.schema.json` updated to include `StylePreset`.
+- [x] `citum.schema.json` updated to include `StyleBase`.
 - [x] All existing oracle tests pass without regression.
-
 ---
 
 ## Changelog
 
+- v2.0 (2026-04-20): Renamed `StylePreset` → `StyleBase` and `preset:` →
+  `extends:` throughout the schema (breaking rename; all YAML files updated).
+  Expanded the base enum to 16 entries with full publisher and numeric styles.
+  Added `StyleKind` enum to `RegistryEntry` for four-tier taxonomy classification.
+  New spec `STYLE_TAXONOMY.md` documents the four tiers (base, profile, journal, independent).
 - v1.5 (2026-03-19): Removed `StyleVariantDelta` and `StylePresetSpec`.
   Top-level style fields are now the sole override mechanism; `Style.preset`
   holds `Option<StylePreset>` directly. Unified authoring model: declare
@@ -302,6 +279,6 @@ Broader policy and authoring guidance are tracked in `csl26-wp6y`.
   canonical runtime resolution into the engine, documented concrete preset
   base files, and added follow-up design tensions explicitly.
 - v1.3 (2026-03-18): Marked Active after implementation and CI-tooling verification.
-- v1.2 (2026-03-18): Added §9 Circular Dependency Prevention.
+- v1.2 (2026-03-18): Added §7 Circular Dependency Prevention.
 - v1.1 (2026-03-18): Updated to include Apa7th and ChicagoAuthorDate18th.
 - v1.0 (2026-03-18): Initial Draft.

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -1,0 +1,67 @@
+# Style Taxonomy
+
+**Status:** Active
+**Version:** 1.0
+**Date:** 2026-04-20
+**Bean:** `csl26-v961`
+**Related:** `STYLE_PRESET_ARCHITECTURE.md`
+
+## Purpose
+
+Define a four-tier classification for all Citum styles. The taxonomy drives registry `kind` annotations, embedding decisions, and verification strategies.
+
+## Tiers
+
+| Tier | Kind | Definition | `extends:` field | Verification |
+|------|------|------------|-----------------|--------------|
+| 1 | `base` | Complete style with full templates; serves as inheritance root | No | CSL oracle (citeproc-js) for CSL-derived; biblatex snapshot for biblatex-derived |
+| 2 | `profile` | Adapts a base for a specific organization; may override options without full templates | Optional | Delta from its base; or direct oracle if self-contained |
+| 3 | `journal` | Pure alias in the registry; no YAML file | N/A | Inherits from parent |
+| 4 | `independent` | Complete style; no aliases; no inheritance role | No | Own oracle |
+
+## Current Classification
+
+### Base Styles (Tier 1)
+
+| Style | Origin |
+|-------|--------|
+| `apa-7th` | CSL-derived |
+| `chicago-notes-18th` | CSL-derived |
+| `chicago-author-date-18th` | CSL-derived |
+| `ieee` | CSL-derived |
+| `american-medical-association` | CSL-derived |
+| `modern-language-association` | CSL-derived |
+
+### Profile Styles (Tier 2)
+
+| Style | Base | Notes |
+|-------|------|-------|
+| `chicago-shortened-notes-bibliography` | chicago-notes-18th | Chicago variant |
+| `elsevier-harvard` | — | Self-contained publisher profile |
+| `elsevier-vancouver` | — | Self-contained publisher profile |
+| `elsevier-with-titles` | — | Self-contained publisher profile |
+| `springer-basic-author-date` | — | Self-contained publisher profile |
+| `springer-basic-brackets` | — | Self-contained publisher profile |
+| `springer-vancouver-brackets` | — | Self-contained publisher profile |
+| `taylor-and-francis-chicago-author-date` | chicago-author-date-18th | Uses `extends:` |
+| `taylor-and-francis-council-of-science-editors-author-date` | — | Self-contained |
+| `taylor-and-francis-national-library-of-medicine` | — | Self-contained |
+
+### Journal / Alias Styles (Tier 3)
+
+Journal aliases are listed in `registry/default.yaml` under each entry's `aliases:` key. Each is a zero-config pointer to a profile or base style.
+
+### Independent Styles (Tier 4)
+
+Styles in `styles/*.yaml` that have no journal aliases and are not used as bases. Includes OSCOLA, MHRA variants, GOST, and similar discipline-specific styles.
+
+## Embedding Policy
+
+Only Tier 1 (base) and Tier 2 (profile) styles are embedded in the binary via `StyleBase`. Tier 3 (journal) styles resolve at runtime through the registry alias table. Tier 4 (independent) styles are loaded from disk or bundled separately.
+
+---
+
+## Changelog
+
+- v1.0 (2026-04-20): Initial spec. Defines four-tier model (base, profile, journal, independent).
+  Classifies all 16 embedded styles. Documents embedding policy.

--- a/registry/default.yaml
+++ b/registry/default.yaml
@@ -3,75 +3,91 @@ styles:
   - id: apa-7th
     aliases: [apa, taylor-and-francis-style-p]
     builtin: apa-7th
+    kind: base
     description: "APA 7th edition"
     fields: [psychology, social-science]
   - id: elsevier-harvard
     aliases: [harvard, applied-clay-science, environmental-chemistry, international-biodeterioration-and-biodegradation, accident-analysis-and-prevention, entecho, handbook-of-clinical-neurology, journal-of-economic-impact]
     builtin: elsevier-harvard
+    kind: profile
     description: "Elsevier Harvard"
     fields: [science]
   - id: elsevier-with-titles
     aliases: [firephyschem, journal-of-applied-engineering-sciences-technology, biochimica-et-biophysica-acta, cancer-biomarkers, engineered-regeneration, gait-and-posture, ios-press-books, necmettin-erbakan-universitesi-fen-ve-muhendislik-bilimleri-dergisi]
     builtin: elsevier-with-titles
+    kind: profile
     description: "Elsevier with Titles"
     fields: [science]
   - id: elsevier-vancouver
     aliases: [vancouver]
     builtin: elsevier-vancouver
+    kind: profile
     description: "Elsevier Vancouver"
     fields: [medicine]
   - id: springer-basic-author-date
     builtin: springer-basic-author-date
+    kind: profile
     description: "Springer Basic Author-Date"
     fields: [science]
   - id: springer-vancouver-brackets
     builtin: springer-vancouver-brackets
+    kind: profile
     description: "Springer Vancouver Brackets"
     fields: [science]
   - id: springer-basic-brackets
     builtin: springer-basic-brackets
+    kind: profile
     description: "Springer Basic Brackets"
     fields: [science]
   - id: american-medical-association
     aliases: [ama, acta-medica-portuguesa, ophthalmic-plastic-and-reconstructive-surgery, retina]
     builtin: american-medical-association
+    kind: base
     description: "American Medical Association"
     fields: [medicine]
   - id: ieee
     aliases: [engineering-technology-and-applied-science-research, ieee-transactions-on-medical-imaging]
     builtin: ieee
+    kind: base
     description: "Institute of Electrical and Electronics Engineers"
     fields: [engineering]
   - id: taylor-and-francis-chicago-author-date
     aliases: [annals-of-the-association-of-american-geographers]
     builtin: taylor-and-francis-chicago-author-date
+    kind: profile
     description: "Taylor & Francis Chicago Author-Date"
     fields: [humanities]
   - id: taylor-and-francis-council-of-science-editors-author-date
     builtin: taylor-and-francis-council-of-science-editors-author-date
+    kind: profile
     description: "Taylor & Francis Council of Science Editors Author-Date"
     fields: [science]
   - id: taylor-and-francis-national-library-of-medicine
     builtin: taylor-and-francis-national-library-of-medicine
+    kind: profile
     description: "Taylor & Francis National Library of Medicine"
     fields: [medicine]
   - id: chicago-author-date-18th
     aliases: [chicago-author-date, taylor-and-francis-style-f]
     builtin: chicago-author-date-18th
+    kind: base
     description: "Chicago Author-Date (standard)"
     fields: [humanities]
   - id: chicago-shortened-notes-bibliography
     aliases: [chicago]
     builtin: chicago-shortened-notes-bibliography
+    kind: profile
     description: "Chicago Shortened Notes"
     fields: [humanities]
   - id: chicago-notes-18th
     aliases: [chicago-notes]
     builtin: chicago-notes-18th
+    kind: base
     description: "Chicago Notes (without bibliography)"
     fields: [humanities]
   - id: modern-language-association
     aliases: [mla, taylor-and-francis-style-e, modern-language-association-notes]
     builtin: modern-language-association
+    kind: base
     description: "Modern Language Association"
     fields: [humanities]

--- a/scripts/lib/verification-policy.js
+++ b/scripts/lib/verification-policy.js
@@ -389,7 +389,7 @@ function localStyleOverlay(styleData) {
   }
 
   const overlay = { ...styleData };
-  delete overlay.preset;
+  delete overlay.extends;
   return overlay;
 }
 
@@ -397,11 +397,11 @@ function localStyleOverlay(styleData) {
  * Resolves a style's preset reference.
  */
 function resolveStyleData(styleData, visited = new Set()) {
-  const presetSpec = styleData?.preset;
+  const presetSpec = styleData?.extends;
   let resolved = styleData;
 
   if (presetSpec) {
-    const presetKey = typeof presetSpec === 'string' ? presetSpec : presetSpec.preset;
+    const presetKey = typeof presetSpec === 'string' ? presetSpec : presetSpec.extends;
     if (presetKey && PRESET_BASES[presetKey] && !visited.has(presetKey)) {
       const basePath = PRESET_BASES[presetKey];
       if (fs.existsSync(basePath)) {

--- a/styles/american-institute-of-aeronautics-and-astronautics.yaml
+++ b/styles/american-institute-of-aeronautics-and-astronautics.yaml
@@ -1,4 +1,4 @@
-preset: ieee
+extends: ieee
 info:
   title: American Institute of Aeronautics and Astronautics
   description: A style for AIAA

--- a/styles/american-mathematical-society-label.yaml
+++ b/styles/american-mathematical-society-label.yaml
@@ -1,4 +1,4 @@
-preset: elsevier-with-titles
+extends: elsevier-with-titles
 info:
   title: Amercian Mathematical Society (label)
   fields:

--- a/styles/american-medical-association-alphabetical.yaml
+++ b/styles/american-medical-association-alphabetical.yaml
@@ -1,4 +1,4 @@
-preset: american-medical-association
+extends: american-medical-association
 info:
   title: AMA Manual of Style 11th edition (sorted alphabetically)
   description: 'AMA Manual of Style: A Guide for Authors and Editors (11th ed.), with alphabetically sorted bibliography.'

--- a/styles/american-medical-association-no-et-al.yaml
+++ b/styles/american-medical-association-no-et-al.yaml
@@ -1,4 +1,4 @@
-preset: american-medical-association
+extends: american-medical-association
 info:
   title: AMA Manual of Style 11th edition (no "et al.")
   description: 'AMA Manual of Style: A Guide for Authors and Editors (11th ed.), without et al.'

--- a/styles/american-medical-association-no-url.yaml
+++ b/styles/american-medical-association-no-url.yaml
@@ -1,4 +1,4 @@
-preset: american-medical-association
+extends: american-medical-association
 info:
   title: AMA Manual of Style 11th edition (without URLs)
   description: 'AMA Manual of Style: A Guide for Authors and Editors (11th ed.), without URLs.'

--- a/styles/american-society-of-mechanical-engineers.yaml
+++ b/styles/american-society-of-mechanical-engineers.yaml
@@ -1,4 +1,4 @@
-preset: ieee
+extends: ieee
 info:
   title: American Society of Mechanical Engineers
   description: A style for the ASME's 23 journals

--- a/styles/elsevier-vancouver-author-date.yaml
+++ b/styles/elsevier-vancouver-author-date.yaml
@@ -1,4 +1,4 @@
-preset: elsevier-vancouver
+extends: elsevier-vancouver
 info:
   title: Elsevier - NLM/Vancouver (name-year)
   description: A style for some Elsevier journals, resembles Vancouver style, but using author-date format

--- a/styles/embedded/apa-7th.yaml
+++ b/styles/embedded/apa-7th.yaml
@@ -1,4 +1,3 @@
-preset: apa-7th
 info:
   title: American Psychological Association 7th edition
   fields:

--- a/styles/embedded/chicago-shortened-notes-bibliography.yaml
+++ b/styles/embedded/chicago-shortened-notes-bibliography.yaml
@@ -1,4 +1,4 @@
-preset: chicago-notes-18th
+extends: chicago-notes-18th
 info:
   title: Chicago Manual of Style 18th edition (shortened notes and bibliography)
   description: Chicago-style source citations (with Bluebook for legal citations), shortened author-title notes and bibliography system

--- a/styles/embedded/taylor-and-francis-chicago-author-date.yaml
+++ b/styles/embedded/taylor-and-francis-chicago-author-date.yaml
@@ -4,7 +4,7 @@ info:
   description: 'Taylor & Francis Journals adaptation of Chicago-style, author-date system, using style
     presets.'
 
-preset: chicago-author-date-18th
+extends: chicago-author-date-18th
 options:
   page-range-format: expanded
   contributors:

--- a/styles/endocrine-press.yaml
+++ b/styles/endocrine-press.yaml
@@ -1,4 +1,4 @@
-preset: american-medical-association
+extends: american-medical-association
 info:
   title: Endocrine Press
   description: The American Medical Association style  with parentheses, bold authors, and no et-al

--- a/styles/entomological-society-of-america.yaml
+++ b/styles/entomological-society-of-america.yaml
@@ -1,4 +1,4 @@
-preset: elsevier-harvard
+extends: elsevier-harvard
 info:
   title: Entomological Society of America
   fields:

--- a/styles/inter-research-science-center.yaml
+++ b/styles/inter-research-science-center.yaml
@@ -1,4 +1,4 @@
-preset: american-medical-association
+extends: american-medical-association
 info:
   title: Inter-Research Science Center
   fields:

--- a/styles/international-journal-of-wildland-fire.yaml
+++ b/styles/international-journal-of-wildland-fire.yaml
@@ -1,4 +1,4 @@
-preset: springer-basic-author-date
+extends: springer-basic-author-date
 info:
   title: International Journal of Wildland Fire
   description: "This style produces the CSIRO style used in the International Journal of Wildland Fire,\n      the Australian Journal of Botany and several other Australian journals.  It has been\n      validated for the journal, book, book chapter, report, and conference paper citation\n      styles.  This style is in the public domain."

--- a/styles/springer-basic-brackets-no-et-al.yaml
+++ b/styles/springer-basic-brackets-no-et-al.yaml
@@ -1,4 +1,4 @@
-preset: springer-basic-author-date
+extends: springer-basic-author-date
 info:
   title: Springer - Basic (numeric, brackets, no "et al.")
   description: Springer Numbered Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.

--- a/styles/the-optical-society.yaml
+++ b/styles/the-optical-society.yaml
@@ -1,4 +1,4 @@
-preset: ieee
+extends: ieee
 info:
   title: The Optical Society
   description: Common style use by OSA publications.


### PR DESCRIPTION
## Summary

- **Breaking rename**: `StylePreset` → `StyleBase`, YAML key `preset:` → `extends:` — no serde alias, all files updated
- Renames `style_preset.rs` → `style_base.rs` and `preset_detector.rs` → `base_detector.rs` in `citum-migrate`
- Adds `StyleKind` enum (`base` / `profile` / `journal` / `independent`) to `RegistryEntry`; all 16 embedded registry entries annotated
- New `docs/specs/STYLE_TAXONOMY.md` — four-tier classification (Active)
- `docs/specs/STYLE_PRESET_ARCHITECTURE.md` bumped to v2.0

## Files changed

| Area | Change |
|------|--------|
| `crates/citum-schema-style/src/style_base.rs` | Renamed from `style_preset.rs`; `StylePreset` → `StyleBase` |
| `crates/citum-schema-style/src/lib.rs` | Field renamed; serde alias removed; test fixture updated |
| `crates/citum-schema-style/src/registry.rs` | `StyleKind` enum + `RegistryEntry.kind` field |
| `crates/citum-migrate/src/base_detector.rs` | Renamed from `preset_detector.rs` |
| `crates/citum-migrate/src/passes/*.rs` + `main.rs` | `StylePreset` → `StyleBase` refs |
| `crates/citum-engine/tests/i18n.rs` | Updated import |
| `styles/embedded/*.yaml` (6 files) | `preset:` → `extends:` |
| `styles/*.yaml` (~19 files) | `preset:` → `extends:` |
| `registry/default.yaml` | `kind:` annotations on all 16 entries |
| `docs/specs/STYLE_TAXONOMY.md` | New spec (Active) |
| `docs/specs/STYLE_PRESET_ARCHITECTURE.md` | v2.0; all preset→extends/base terminology |

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run` — 1070/1070 passed
