### PR TITLE
docs(styles): validate profile wrapper taxonomy

### DIFF
--- a/.beans/archive/csl26-nrkn--validate-publisher-family-bases-before-profile-wra.md
+++ b/.beans/archive/csl26-nrkn--validate-publisher-family-bases-before-profile-wra.md
@@ -1,7 +1,7 @@
 ---
 # csl26-nrkn
 title: Validate publisher-family bases before profile-wrapper conversion
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - taxonomy
     - verification
 created_at: 2026-04-21T12:14:46Z
-updated_at: 2026-04-21T12:14:46Z
+updated_at: 2026-04-21T13:40:00Z
 ---
 
 Evaluate the embedded publisher/profile styles that were tentatively remapped to
@@ -63,13 +63,13 @@ Classify each style as exactly one of:
 - independent/self-contained style
 
 ## Tasks
-- [ ] Build a per-style evidence table using the authority order above.
-- [ ] Record the current publisher-guide relationship, if any, for each candidate profile.
-- [ ] Record the CSL template-link or named-parent evidence for each candidate profile.
-- [ ] Re-run reduced citation/bibliography fixture comparisons for each style against its candidate base or family base.
-- [ ] Decide the classification for each candidate style.
-- [ ] Update the taxonomy wording so `profile` means guide-backed parent-plus-deltas, not output-similar-to-an-existing-base.
-- [ ] Split any required implementation into narrower beans if new bases or converter work are needed.
+- [x] Build a per-style evidence table using the authority order above.
+- [x] Record the current publisher-guide relationship, if any, for each candidate profile.
+- [x] Record the CSL template-link or named-parent evidence for each candidate profile.
+- [x] Re-run reduced citation/bibliography fixture comparisons for each style against its candidate base or family base.
+- [x] Decide the classification for each candidate style.
+- [x] Update the taxonomy wording so `profile` means guide-backed parent-plus-deltas, not output-similar-to-an-existing-base.
+- [x] Split any required implementation into narrower beans if new bases or converter work are needed.
 
 ## Acceptance
 - there is a per-style evidence table covering all candidate profiles
@@ -77,6 +77,17 @@ Classify each style as exactly one of:
 - no style is converted to a thin wrapper unless reduced YAML reproduces current
   accepted behavior on the chosen verification surface
 - taxonomy language is tightened to prevent future output-similarity shortcuts
+
+## Result
+
+Completed in `docs/architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md`.
+
+- All candidate styles remain taxonomy `profile`.
+- No new wrapper conversion was landed in this pass.
+- Follow-up beans created:
+  `csl26-u1tq`,
+  `csl26-r4dm`,
+  `csl26-xt7k`.
 
 ## Stop-Loss Rule
 - do not reland the reverted branch-local `extends:` mappings just because they

--- a/.beans/csl26-r4dm--author-standards-backed-cse-and-nlm-family-bases-fo.md
+++ b/.beans/csl26-r4dm--author-standards-backed-cse-and-nlm-family-bases-fo.md
@@ -1,0 +1,47 @@
+---
+# csl26-r4dm
+title: Author standards-backed CSE and NLM family bases for publisher profiles
+status: todo
+type: task
+priority: normal
+tags:
+    - styles
+    - taxonomy
+    - standards
+created_at: 2026-04-21T13:31:00Z
+updated_at: 2026-04-21T13:31:00Z
+---
+
+`csl26-nrkn` confirmed that the Taylor & Francis and Springer CSE/NLM variants
+have real standards-backed parentage, but today they still sit on public profile
+handles or on generic standards styles that are too far away for safe direct
+collapse.
+
+## Goal
+
+Create explicit CSE/NLM family bases for publisher-backed wrappers so those
+profiles stop carrying standards-root behavior implicitly.
+
+## Tasks
+
+- [ ] Decide the required base set for `cse-name-year`,
+      `nlm-citation-sequence`, and `nlm-citation-sequence-brackets` derived
+      publisher profiles.
+- [ ] Author the dedicated family base YAML needed by:
+      `taylor-and-francis-council-of-science-editors-author-date`,
+      `taylor-and-francis-national-library-of-medicine`, and
+      `springer-vancouver-brackets`.
+- [ ] Re-run shared-fixture comparisons against the authored family bases.
+- [ ] Convert public profiles to `extends:` wrappers only after parity is
+      proven on the accepted verification surface.
+
+## Acceptance
+
+- standards-backed family base(s) exist where the authority chain requires them
+- public publisher profiles no longer need to impersonate standards roots
+- wrapper reductions are evidence-stable before landing
+
+## Related
+
+- csl26-nrkn
+- csl26-wp6y

--- a/.beans/csl26-u1tq--author-dedicated-elsevier-family-bases-for-harvard-an.md
+++ b/.beans/csl26-u1tq--author-dedicated-elsevier-family-bases-for-harvard-an.md
@@ -1,0 +1,45 @@
+---
+# csl26-u1tq
+title: Author dedicated Elsevier family bases for Harvard and Vancouver profiles
+status: todo
+type: task
+priority: normal
+tags:
+    - styles
+    - taxonomy
+    - bases
+created_at: 2026-04-21T13:30:00Z
+updated_at: 2026-04-21T13:30:00Z
+---
+
+`csl26-nrkn` confirmed that `elsevier-harvard` and `elsevier-vancouver` are
+real publisher-family profiles, but not safely reducible to today's existing
+general bases.
+
+## Goal
+
+Create explicit Elsevier family inheritance roots so the public style handles can
+become true parent-plus-deltas wrappers instead of carrying family-root behavior
+themselves.
+
+## Tasks
+
+- [ ] Decide whether Elsevier needs one author-date family base and one numeric
+      family base, or a more granular split.
+- [ ] Author the dedicated family base YAML files from publisher-guide evidence.
+- [ ] Re-check `elsevier-harvard` and `elsevier-vancouver` against the new bases
+      on the shared fixture surface.
+- [ ] Convert the public profiles to `extends:` wrappers only if the reduced
+      form preserves current accepted behavior.
+
+## Acceptance
+
+- explicit Elsevier family base(s) exist in the repo
+- public Elsevier profile handles no longer need to act as family roots
+- wrapper reductions are landed only when parity is proven
+
+## Related
+
+- csl26-nrkn
+- csl26-ocdt
+- csl26-wp6y

--- a/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
+++ b/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
@@ -9,7 +9,7 @@ tags:
     - taxonomy
     - springer
 created_at: 2026-04-21T13:32:00Z
-updated_at: 2026-04-21T14:20:00Z
+updated_at: 2026-04-21T15:35:00Z
 ---
 
 `csl26-nrkn` confirmed that `springer-basic-brackets` has real parentage to
@@ -19,6 +19,8 @@ carry almost the whole file because bibliography templates and many
 the current merge contract, objects deep-merge, but arrays and explicit `null`
 replace inherited content wholesale, so a localized child change can force
 nearly complete restatement of the inherited bibliography block.
+
+Alternative design draft: `docs/specs/CONFIG_ONLY_PROFILE_OVERRIDES.md`.
 
 ## Goal
 

--- a/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
+++ b/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
@@ -1,0 +1,45 @@
+---
+# csl26-xt7k
+title: Split Springer Basic family-root behavior from public wrappers
+status: todo
+type: task
+priority: normal
+tags:
+    - styles
+    - taxonomy
+    - springer
+created_at: 2026-04-21T13:32:00Z
+updated_at: 2026-04-21T13:32:00Z
+---
+
+`csl26-nrkn` confirmed that `springer-basic-brackets` has real parentage to
+`springer-basic-author-date`, but the current `extends:` delta still has to
+carry almost the whole file because bibliography arrays replace wholesale.
+
+## Goal
+
+Separate the Springer Basic family root from the public author-date and numeric
+profiles, then reduce `springer-basic-brackets` to a meaningful wrapper.
+
+## Tasks
+
+- [ ] Decide whether the project needs a dedicated hidden Springer Basic family
+      root instead of reusing the public `springer-basic-author-date` handle.
+- [ ] Define the minimum bibliography/type-variant delta required by
+      `springer-basic-brackets`.
+- [ ] If current merge semantics remain too coarse, scope the smallest
+      infrastructure follow-up that would make the wrapper meaningfully smaller.
+- [ ] Land the wrapper conversion only when the reduced YAML is materially
+      smaller and preserves current accepted output.
+
+## Acceptance
+
+- the family-root contract for Springer Basic is explicit
+- `springer-basic-brackets` is either a meaningful wrapper or has a concrete
+  infrastructure blocker bean attached
+
+## Related
+
+- csl26-nrkn
+- csl26-ocdt
+- csl26-wp6y

--- a/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
+++ b/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
@@ -9,17 +9,22 @@ tags:
     - taxonomy
     - springer
 created_at: 2026-04-21T13:32:00Z
-updated_at: 2026-04-21T13:32:00Z
+updated_at: 2026-04-21T14:20:00Z
 ---
 
 `csl26-nrkn` confirmed that `springer-basic-brackets` has real parentage to
 `springer-basic-author-date`, but the current `extends:` delta still has to
-carry almost the whole file because bibliography arrays replace wholesale.
+carry almost the whole file because bibliography templates and many
+`type-variants` are expressed through replace-whole array/map structures. Under
+the current merge contract, objects deep-merge, but arrays and explicit `null`
+replace inherited content wholesale, so a localized child change can force
+nearly complete restatement of the inherited bibliography block.
 
 ## Goal
 
 Separate the Springer Basic family root from the public author-date and numeric
-profiles, then reduce `springer-basic-brackets` to a meaningful wrapper.
+profiles, then reduce `springer-basic-brackets` to a meaningful wrapper or
+explicitly scope the inheritance-model follow-up needed to make that possible.
 
 ## Tasks
 
@@ -27,16 +32,21 @@ profiles, then reduce `springer-basic-brackets` to a meaningful wrapper.
       root instead of reusing the public `springer-basic-author-date` handle.
 - [ ] Define the minimum bibliography/type-variant delta required by
       `springer-basic-brackets`.
-- [ ] If current merge semantics remain too coarse, scope the smallest
-      infrastructure follow-up that would make the wrapper meaningfully smaller.
+- [ ] Decide whether the project should add finer-grained inheritance/override
+      mechanics for bibliography/type-variant structures, or keep the current
+      merge semantics and accept larger wrapper YAML for this family.
+- [ ] If the current merge model remains in place, scope the smallest
+      infrastructure follow-up bean that would change the merge/override model
+      enough to make the wrapper materially smaller.
 - [ ] Land the wrapper conversion only when the reduced YAML is materially
       smaller and preserves current accepted output.
 
 ## Acceptance
 
 - the family-root contract for Springer Basic is explicit
-- `springer-basic-brackets` is either a meaningful wrapper or has a concrete
-  infrastructure blocker bean attached
+- `springer-basic-brackets` is either a materially smaller wrapper under the
+  current model or has a concrete infrastructure bean that changes the
+  bibliography/type-variant merge/override model
 
 ## Related
 

--- a/docs/architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md
+++ b/docs/architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md
@@ -24,8 +24,11 @@ Two outcomes matter:
   guide-backed.
 - No new `extends:` conversion was landed in this pass. The only plausible
   existing-base conversion (`springer-basic-brackets` → `springer-basic-author-date`)
-  still requires almost the whole file under current merge semantics, so it does
-  not yet meet the tightened meaning of a thin profile.
+  still requires almost the whole file under the current merge contract, so it
+  does not yet meet the tightened meaning of a thin profile. The blocker here
+  is not uncertainty about parentage; it is that bibliography/type-variant
+  deltas live in replace-whole structures, so a child style cannot express a
+  small localized override without restating most of the inherited block.
 
 ## Method
 
@@ -43,6 +46,11 @@ Two outcomes matter:
   `cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -c tests/fixtures/citations-expanded.json --mode both --show-keys`.
 - The parent comparison counts below are changed output lines between the current
   style and the most plausible current parent candidate on that shared surface.
+- Where this document says “current merge semantics,” it refers to the existing
+  `extends:` contract: objects deep-merge, but arrays and explicit `null`
+  values replace inherited content wholesale. That rule is simple and valid, but
+  it means some bibliography/template deltas cannot be expressed as genuinely
+  small wrappers today.
 
 ## Evidence Table
 
@@ -51,7 +59,7 @@ Two outcomes matter:
 | `elsevier-harvard` | Biological Conservation still uses author-year reference instructions in its current guide. | CSL `rel: template` points to `ecology-letters`; no current Citum `ecology-letters` base exists. | `18/18` citations, `34/34` bibliography | `75` changed lines vs `apa-7th` | `thin profile on a new publisher/standards base` | Keep self-contained; do not remap to APA. Follow-up: `csl26-u1tq`. |
 | `elsevier-vancouver` | Current Energy guide remains the journal authority; the embedded metadata still points to that guide. | Style identity is Elsevier NLM/Vancouver; there is no dedicated Elsevier numeric family base in Citum. | `18/18` citations, `34/34` bibliography | `106` changed lines vs `styles/nlm-citation-sequence.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; do not collapse directly to the repo NLM style. Follow-up: `csl26-u1tq`. |
 | `springer-basic-author-date` | Springer Nature still documents a distinct “Basic style” and says it is based on Harvard style plus CBE recommendations. | Springer’s current guidance treats Basic as its own house style rather than as APA or Chicago. | `18/18` citations, `34/34` bibliography | `79` changed lines vs `apa-7th` | `thin profile on a new publisher/standards base` | Keep self-contained public style; dedicated Springer family root is follow-up work. Follow-up: `csl26-xt7k`. |
-| `springer-basic-brackets` | Springer Nature still treats this as part of the same Basic house-style family. | CSL `rel: template` points to `springer-basic-author-date`. | `18/18` citations, `34/34` bibliography | `92` changed lines vs `springer-basic-author-date` | `thin profile on an existing base` | Do not land an `extends:` rewrite yet. A mechanically derived delta still carries roughly `340/344` lines and remains too bulky to count as a meaningful thin wrapper under current merge semantics. Follow-up: `csl26-xt7k`. |
+| `springer-basic-brackets` | Springer Nature still treats this as part of the same Basic house-style family. | CSL `rel: template` points to `springer-basic-author-date`. | `18/18` citations, `34/34` bibliography | `92` changed lines vs `springer-basic-author-date` | `thin profile on an existing base` | Do not land an `extends:` rewrite yet. Parentage is clear, but the current merge model only deep-merges objects; bibliography/type-variant arrays still replace wholesale. That makes the child delta too large to count as a meaningful thin wrapper, so the documented outcome is “keep taxonomy as profile; defer wrapper compression to follow-up design/work.” Follow-up: `csl26-xt7k`. |
 | `springer-vancouver-brackets` | Springer Nature’s current guide says “Vancouver style” is based on NLM `Citing Medicine`. | House style is Springer-specific Vancouver, not generic IEEE or AMA. | `18/18` citations, `34/34` bibliography | `70` changed lines vs `styles/nlm-citation-sequence-brackets.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; it still needs a dedicated Springer/NLM family split rather than direct remap. Follow-up: `csl26-r4dm`. |
 | `taylor-and-francis-council-of-science-editors-author-date` | Taylor & Francis currently publishes a dedicated CSE-9 author-date reference guide. | The guide names CSE directly; CSL `rel: template` points to `cse-name-year`. | `18/18` citations, `33/34` bibliography | `84` changed lines vs `styles/cse-name-year.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; parentage is real, but the missing standards/publisher base should be authored explicitly. Follow-up: `csl26-r4dm`. |
 | `taylor-and-francis-national-library-of-medicine` | Taylor & Francis currently publishes a dedicated NLM brackets guide. | The guide and CSL metadata both point to NLM-with-brackets rather than AMA. | `18/18` citations, `34/34` bibliography | `36` changed lines vs `styles/nlm-citation-sequence-brackets.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; do not force it onto AMA or the current generic NLM style. Follow-up: `csl26-r4dm`. |
@@ -63,7 +71,9 @@ Two outcomes matter:
 - No candidate was reclassified to `independent`.
 - No new wrapper conversion was landed in this bean.
 - `springer-basic-brackets` is the only strong existing-base relationship in the
-  current repo, but current merge semantics still force a nearly full-file delta.
+  current repo, but the current merge model still forces a nearly full-file
+  delta because bibliography/type-variant overrides are expressed through
+  replace-whole structures rather than fine-grained inherited edits.
 - The Elsevier, Springer-family-root, CSE, and NLM cases should be handled by
   explicit follow-up base-authoring work rather than by forcing these public
   styles onto today’s Tier-1 bases.

--- a/docs/architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md
+++ b/docs/architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md
@@ -1,0 +1,79 @@
+# Profile Wrapper Validation Pass
+
+**Date:** 2026-04-21
+**Bean:** `csl26-nrkn`
+**Related:** `docs/specs/STYLE_TAXONOMY.md`, `docs/architecture/PRESET_WRAPPER_AUTHORITY_PASS_2026-04-19.md`, `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`
+
+## Summary
+
+This pass re-checked the embedded publisher/profile styles that had been
+directionally grouped during the style-taxonomy rename work.
+
+The governing decision rule stayed the same:
+
+1. publisher or journal guide
+2. publisher house rules
+3. named parent-style manual or standards reference
+4. CSL/template-link evidence
+5. current Citum YAML structure
+
+Two outcomes matter:
+
+- `profile` can stay the correct taxonomy even when the current public YAML is
+  still self-contained, as long as the parent-plus-deltas relationship is
+  guide-backed.
+- No new `extends:` conversion was landed in this pass. The only plausible
+  existing-base conversion (`springer-basic-brackets` → `springer-basic-author-date`)
+  still requires almost the whole file under current merge semantics, so it does
+  not yet meet the tightened meaning of a thin profile.
+
+## Method
+
+- Live source review used current publisher/manual pages where they were
+  directly reachable:
+  [Biological Conservation guide](https://www.sciencedirect.com/journal/biological-conservation/publish/guide-for-authors),
+  [Energy guide](https://www.sciencedirect.com/journal/energy/publish/guide-for-authors),
+  [Springer Nature manuscript guidelines](https://www.springernature.com/gp/authors/publish-a-book/manuscript-guidelines),
+  [Taylor & Francis CSE guide](https://www.tandf.co.uk/journals/authors/style/reference/tf_CSE.pdf),
+  [Taylor & Francis NLM guide](https://files.taylorandfrancis.com/tf_NLM.pdf),
+  [Chicago/Turabian notes and bibliography quick guide](https://www.chicagomanualofstyle.org/turabian/turabian-notes-and-bibliography-citation-quick-guide.html%26nbsp).
+- Oracle verification used `node scripts/oracle-yaml.js styles/embedded/<style>.yaml --json`
+  after repairing the broken `resolveStyleData` import in this PR.
+- Parent/base comparison used direct Citum output diffs on the shared fixture:
+  `cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -c tests/fixtures/citations-expanded.json --mode both --show-keys`.
+- The parent comparison counts below are changed output lines between the current
+  style and the most plausible current parent candidate on that shared surface.
+
+## Evidence Table
+
+| Style | Guide / live relationship | Parent or template evidence | Current verification | Parent comparison | Classification | PR action |
+| --- | --- | --- | --- | --- | --- | --- |
+| `elsevier-harvard` | Biological Conservation still uses author-year reference instructions in its current guide. | CSL `rel: template` points to `ecology-letters`; no current Citum `ecology-letters` base exists. | `18/18` citations, `34/34` bibliography | `75` changed lines vs `apa-7th` | `thin profile on a new publisher/standards base` | Keep self-contained; do not remap to APA. Follow-up: `csl26-u1tq`. |
+| `elsevier-vancouver` | Current Energy guide remains the journal authority; the embedded metadata still points to that guide. | Style identity is Elsevier NLM/Vancouver; there is no dedicated Elsevier numeric family base in Citum. | `18/18` citations, `34/34` bibliography | `106` changed lines vs `styles/nlm-citation-sequence.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; do not collapse directly to the repo NLM style. Follow-up: `csl26-u1tq`. |
+| `springer-basic-author-date` | Springer Nature still documents a distinct “Basic style” and says it is based on Harvard style plus CBE recommendations. | Springer’s current guidance treats Basic as its own house style rather than as APA or Chicago. | `18/18` citations, `34/34` bibliography | `79` changed lines vs `apa-7th` | `thin profile on a new publisher/standards base` | Keep self-contained public style; dedicated Springer family root is follow-up work. Follow-up: `csl26-xt7k`. |
+| `springer-basic-brackets` | Springer Nature still treats this as part of the same Basic house-style family. | CSL `rel: template` points to `springer-basic-author-date`. | `18/18` citations, `34/34` bibliography | `92` changed lines vs `springer-basic-author-date` | `thin profile on an existing base` | Do not land an `extends:` rewrite yet. A mechanically derived delta still carries roughly `340/344` lines and remains too bulky to count as a meaningful thin wrapper under current merge semantics. Follow-up: `csl26-xt7k`. |
+| `springer-vancouver-brackets` | Springer Nature’s current guide says “Vancouver style” is based on NLM `Citing Medicine`. | House style is Springer-specific Vancouver, not generic IEEE or AMA. | `18/18` citations, `34/34` bibliography | `70` changed lines vs `styles/nlm-citation-sequence-brackets.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; it still needs a dedicated Springer/NLM family split rather than direct remap. Follow-up: `csl26-r4dm`. |
+| `taylor-and-francis-council-of-science-editors-author-date` | Taylor & Francis currently publishes a dedicated CSE-9 author-date reference guide. | The guide names CSE directly; CSL `rel: template` points to `cse-name-year`. | `18/18` citations, `33/34` bibliography | `84` changed lines vs `styles/cse-name-year.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; parentage is real, but the missing standards/publisher base should be authored explicitly. Follow-up: `csl26-r4dm`. |
+| `taylor-and-francis-national-library-of-medicine` | Taylor & Francis currently publishes a dedicated NLM brackets guide. | The guide and CSL metadata both point to NLM-with-brackets rather than AMA. | `18/18` citations, `34/34` bibliography | `36` changed lines vs `styles/nlm-citation-sequence-brackets.yaml` | `thin profile on a new publisher/standards base` | Keep self-contained; do not force it onto AMA or the current generic NLM style. Follow-up: `csl26-r4dm`. |
+| `chicago-shortened-notes-bibliography` | Chicago/Turabian still defines notes-and-bibliography with shortened subsequent notes. | The current YAML already extends `chicago-notes-18th`; this remains the control case. | `34/34` citations, `32/33` bibliography | `61` changed lines vs `chicago-notes-18th` | `thin profile on an existing base` | No taxonomy change needed; keep as the proven control wrapper. |
+
+## Decisions
+
+- All eight candidate styles remain `profile` in registry taxonomy.
+- No candidate was reclassified to `independent`.
+- No new wrapper conversion was landed in this bean.
+- `springer-basic-brackets` is the only strong existing-base relationship in the
+  current repo, but current merge semantics still force a nearly full-file delta.
+- The Elsevier, Springer-family-root, CSE, and NLM cases should be handled by
+  explicit follow-up base-authoring work rather than by forcing these public
+  styles onto today’s Tier-1 bases.
+
+## Follow-Up Beans
+
+- `csl26-u1tq` — author dedicated Elsevier family bases for Harvard and
+  Vancouver public profiles.
+- `csl26-r4dm` — author standards-backed CSE/NLM family bases for Taylor &
+  Francis and Springer publisher profiles.
+- `csl26-xt7k` — split Springer Basic family-root behavior from public wrappers
+  and reduce `springer-basic-brackets` once the inherited bibliography delta is
+  meaningfully smaller than the current file.

--- a/docs/architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md
+++ b/docs/architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md
@@ -39,7 +39,7 @@ Two outcomes matter:
   [Springer Nature manuscript guidelines](https://www.springernature.com/gp/authors/publish-a-book/manuscript-guidelines),
   [Taylor & Francis CSE guide](https://www.tandf.co.uk/journals/authors/style/reference/tf_CSE.pdf),
   [Taylor & Francis NLM guide](https://files.taylorandfrancis.com/tf_NLM.pdf),
-  [Chicago/Turabian notes and bibliography quick guide](https://www.chicagomanualofstyle.org/turabian/turabian-notes-and-bibliography-citation-quick-guide.html%26nbsp).
+  [Chicago/Turabian notes and bibliography quick guide](https://www.chicagomanualofstyle.org/turabian/turabian-notes-and-bibliography-citation-quick-guide.html).
 - Oracle verification used `node scripts/oracle-yaml.js styles/embedded/<style>.yaml --json`
   after repairing the broken `resolveStyleData` import in this PR.
 - Parent/base comparison used direct Citum output diffs on the shared fixture:

--- a/docs/specs/CONFIG_ONLY_PROFILE_OVERRIDES.md
+++ b/docs/specs/CONFIG_ONLY_PROFILE_OVERRIDES.md
@@ -1,0 +1,345 @@
+# Config-Only Profile Overrides Specification
+
+**Status:** Draft
+**Date:** 2026-04-21
+**Related:** `TEMPLATE_V2.md`, `STYLE_PRESET_ARCHITECTURE.md`, `STYLE_TAXONOMY.md`, bean `csl26-xt7k`, bean `csl26-nrkn`
+
+## Purpose
+
+This specification defines an alternative to Citum's current `extends:`
+contract for style profiles. Under this model, a profile still selects a
+guide-backed base style, but it may not merge or replace template-bearing
+structures. Instead, all supported variation must be expressed through
+explicit, typed configuration options. Any guide-backed child that still needs
+structural template changes becomes a new base or an independent style rather
+than a merged wrapper.
+
+This draft extends the same simplification direction already taken in
+`TEMPLATE_V2.md` and PR 426 ("template simplification"), where per-component
+template override machinery was removed in favor of spec-level `type-variants`
+and style-level configuration. The question here is whether the same principle
+should apply one level higher, at style inheritance boundaries.
+
+## Scope
+
+In scope:
+
+- the resolution contract for styles that declare `extends:`
+- schema and validation changes needed to make profile overrides config-only
+- the typed option surface required to absorb recurring family-level variation
+- taxonomy and registry implications of removing template merging from profiles
+
+Out of scope:
+
+- arbitrary structural parameterization of templates
+- generic stringly-typed profile maps or plugin-style option bags
+- preserving current bulky profiles as profiles if they still require template
+  edits
+- implementation of this design in the current PR
+
+## Design
+
+### 0. Terms
+
+**Template-bearing field** means any field whose schema type is `Template`, or
+any container/variant type that can contain one or more `Template` values.
+Profiles must not override template-bearing fields.
+
+This rule applies both to the currently known paths listed below and to any
+future schema field that is typed as `Template` or can contain `Template`
+values indirectly. New template-bearing fields are non-overridable by profiles
+unless a future spec explicitly changes that rule.
+
+### 1. Profile Contract
+
+Under this model, `extends:` remains the way a style selects a guide-backed
+base, but the meaning of a profile changes:
+
+- a `base` owns complete citation and bibliography templates
+- a `profile` inherits those templates intact
+- a `profile` may override local identity/metadata plus `options.profile`
+- a `profile` may not override any template-bearing field
+
+In practical terms, a profile must not supply local values for:
+
+- top-level `templates`
+- `citation.template`
+- `citation.integral.template`
+- `citation.non-integral.template`
+- `citation.type-variants`
+- `citation.integral.type-variants`
+- `citation.non-integral.type-variants`
+- `bibliography.template`
+- `bibliography.type-variants`
+- any future template-bearing field
+
+If a publisher or standards child style requires one of those edits, the style
+stops being a profile under this model. The correct fix is to:
+
+1. author a new family base, if the child represents a reusable structural
+   branch, or
+2. keep the style independent, if the structural change is one-off
+
+### 1.1 Local Identity vs. Inherited Structure
+
+A profile remains a distinct public style handle. It keeps its own local
+`info.id`, title, summary, and other user-facing metadata even though it
+inherits rendering structure from the base.
+
+The inheritance rule is therefore:
+
+- identity is local to the profile
+- rendering structure is inherited from the base
+- profile-local metadata does not imply permission to override template-bearing
+  fields
+
+### 2. Resolution Semantics
+
+`Style::into_resolved()` becomes a metadata-and-config overlay operation, not a
+general structural merge.
+
+Resolution order:
+
+1. Load the selected base style.
+2. Overlay profile-local identity/metadata fields.
+3. Overlay `options.profile` values.
+4. Validate that the profile did not supply forbidden template-bearing fields.
+5. Validate that the selected base supports every requested profile option.
+6. Return the effective style with the base templates unchanged.
+
+This removes the current deep-merge/replace-wholesale behavior for profile
+template subtrees entirely. Explicit `null` remains valid only for allowed
+config fields; it is not a legal way to clear inherited templates or inherited
+type variants in a profile.
+
+For `options.profile`, overlay semantics are per-leaf rather than replace-whole
+for nested structs. Attempting to clear a template-bearing field with `null`, or
+using `null` in a way that violates the profile-axis schema, is a validation
+error rather than a silently ignored request.
+
+### 3. Typed Profile Options
+
+To replace template edits, Citum adds a dedicated typed configuration surface
+under `options.profile`.
+
+```yaml
+extends: springer-basic-core
+options:
+  profile:
+    citation-label-wrap: brackets
+    bibliography-label-mode: numeric
+    date-position: after-author
+    volume-pages-delimiter: colon
+```
+
+`options.profile` is a strongly typed struct, not a free-form map. New fields
+may be added only when all of the following are true:
+
+- the variation has stable rendering semantics
+- the variation appears across multiple styles or a large family, not one file
+- the variation is explainable without referencing hidden template structure
+- the axis is orthogonal to existing profile axes where practical
+
+The initial option families for this model are:
+
+- citation label presentation
+  - `citation-label-wrap`: `none | parentheses | brackets | superscript`
+  - `citation-group-delimiter`: `comma | semicolon | space`
+- bibliography label presentation
+  - `bibliography-label-mode`: `none | numeric | author-date`
+  - `bibliography-label-wrap`: `none | parentheses | brackets`
+- entry sequencing and punctuation
+  - `date-position`: `after-author | after-title | terminal`
+  - `volume-pages-delimiter`: `comma | colon | space`
+  - `title-terminator`: `period | comma | none`
+- contributor list behavior
+  - `name-list-profile`: references existing typed contributor presets
+  - `repeated-author-rendering`: `full | dash | dash-with-space`
+
+This list is intentionally bounded. If a proposed option needs to describe a
+whole template fragment rather than a stable behavior axis, it does not belong
+in `options.profile`.
+
+The default policy is conservative: the first implementation should cover only
+the small set of recurring axes already evidenced by current Springer,
+Elsevier, and Taylor & Francis family analysis. Broader axis mining is follow-
+up work, not part of the initial contract.
+
+### 4. Base Capabilities
+
+Every embedded base exposes the set of `options.profile` axes it supports.
+Loading a profile with an unsupported axis is a validation error.
+
+This keeps profile authoring explicit:
+
+- a style cannot silently request a knob that its base ignores
+- two family bases can support different subsets of the shared profile options
+- base authors must declare which behavior axes are part of the base contract
+
+The capability list is runtime metadata in `StyleBase`, not user-authored YAML.
+Schema validation ensures shape; base capability validation ensures semantic
+fit.
+
+Conceptually, a base capability declaration looks like:
+
+```yaml
+profile-capabilities:
+  citation-label-wrap:
+    values: [none, parentheses, brackets]
+  bibliography-label-mode:
+    values: [none, numeric]
+```
+
+This is illustrative only. The actual source of truth is compiled metadata, not
+raw YAML.
+
+Validation distinguishes three error cases:
+
+- the engine does not recognize the requested profile axis
+- the selected base does not support that axis
+- the base supports the axis, but not the requested value
+
+### 5. Family Roots and Public Handles
+
+This model prefers hidden family roots over public-to-public chaining.
+
+Example:
+
+- `springer-basic-core` is a hidden embedded base
+- `springer-basic-author-date` extends `springer-basic-core` with profile
+  options only
+- `springer-basic-brackets` extends `springer-basic-core` with profile options
+  only
+
+The same pattern applies to Elsevier and Taylor & Francis families where the
+house style is real but the public handles represent sibling guide profiles.
+
+This is a deliberate consequence of removing template merging from profiles:
+the system needs more reusable structural roots, but it no longer needs child
+styles to restate large template blocks just to tweak punctuation or label
+mode.
+
+The normative preference is:
+
+- public profiles should extend hidden family roots
+- public-to-public `extends:` chains should be avoided
+- a public-to-public chain needs an explicit documented exception
+
+Migration consequence: some currently bulky "semantic profiles" will need to be
+split into a hidden `*-core` base plus public config-only siblings if the
+project adopts this model.
+
+### 6. Taxonomy and Registry Consequences
+
+If this model is adopted, the taxonomy definition of `profile` becomes stricter
+than the current one:
+
+- `profile` means guide-backed parentage plus config-only delta
+- a style with real parentage but structural template edits is not a profile in
+  implementation or taxonomy
+- those structurally distinct children become either `base` or `independent`
+
+Normative taxonomy summary:
+
+- `profile`: declares `extends:`, has guide-backed parentage, and defines no
+  template-bearing local fields
+- `base`: owns templates and is intended for reuse by other styles
+- `independent`: owns templates and does not declare `extends:`
+
+The practical result is:
+
+- fewer bulky "semantic profiles"
+- more family bases
+- a clearer split between parametric variation and structural variation
+
+### 7. Authoring Examples
+
+Minimal sibling profiles:
+
+```yaml
+info:
+  id: springer-basic-author-date
+extends: springer-basic-core
+options:
+  profile:
+    bibliography-label-mode: none
+    date-position: after-author
+```
+
+```yaml
+info:
+  id: springer-basic-brackets
+extends: springer-basic-core
+options:
+  profile:
+    citation-label-wrap: brackets
+    bibliography-label-mode: numeric
+    volume-pages-delimiter: colon
+```
+
+Invalid profile under this model:
+
+```yaml
+extends: springer-basic-core
+bibliography:
+  type-variants:
+    article-journal:
+      - text: "not allowed here"
+```
+
+That file must either become a new base or remain independent.
+
+Invalid profile using `null` as a template-clearing mechanism:
+
+```yaml
+extends: springer-basic-core
+bibliography:
+  template: ~
+```
+
+This is also invalid. Profiles may not clear inherited template-bearing fields.
+
+## Implementation Notes
+
+This design is intentionally simpler than the current profile merge model, but
+the simplification moves work rather than eliminating it.
+
+- Resolver complexity drops because profile resolution no longer merges
+  template subtrees or relies on replace-whole array behavior.
+- Schema and engine complexity rise because recurring wrapper differences must
+  become first-class typed options.
+- Family-root authoring becomes more important because structurally distinct
+  siblings can no longer piggyback on public bases through template deltas.
+- Registry validation becomes more important because claimed taxonomy must match
+  actual structure.
+
+Historically, this aligns more closely with the project's January 31, 2026
+style-reuse direction, which favored presets/configuration and self-describing
+styles over deep alias chains. It also follows the same simplification logic as
+Template V2 and PR 426, which removed per-component template overrides instead
+of preserving a more flexible but harder-to-reason-about merge model. The key
+difference is that this draft applies that rule at the style-profile boundary
+rather than inside a single template tree.
+
+## Acceptance Criteria
+
+- [ ] Profiles that declare `extends:` and also provide template-bearing fields
+      fail validation with a clear error.
+- [ ] Profiles that use `null` to clear template-bearing fields fail validation
+      with a clear error.
+- [ ] `Style::into_resolved()` for profiles becomes a metadata/config overlay
+      operation; no profile path performs structural template merging.
+- [ ] `options.profile` is a typed schema surface with documented initial axes
+      and no generic string map escape hatch.
+- [ ] Each embedded base declares which profile axes it supports, and
+      unsupported axes are rejected at load time.
+- [ ] Validation distinguishes unknown axis, unsupported axis, and unsupported
+      value errors.
+- [ ] Taxonomy and registry rules define `profile` as config-only and require
+      structural children to become new bases or independent styles.
+- [ ] Linting/validation rejects any style classified as a `profile` when its
+      structure includes template-bearing local fields.
+
+## Changelog
+
+- 2026-04-21: Initial draft.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -59,3 +59,4 @@ to make sure the document should be a spec rather than architecture or policy.
 | [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md) | ICU MF1 parameterized message system replacing flat YAML term files |
 | [`ORIGINAL_PUBLICATION_RELATION_SUPPORT.md`](./ORIGINAL_PUBLICATION_RELATION_SUPPORT.md) | Universal original publication metadata support across all types |
 | [`EMBEDDED_JS_TEMPLATE_INFERENCE.md`](./EMBEDDED_JS_TEMPLATE_INFERENCE.md) | Embedded `deno_core` live inference backend for `citum-migrate` |
+| [`CONFIG_ONLY_PROFILE_OVERRIDES.md`](./CONFIG_ONLY_PROFILE_OVERRIDES.md) | Draft alternative where `extends:` profiles are config-only and never merge templates |

--- a/docs/specs/STYLE_PRESET_ARCHITECTURE.md
+++ b/docs/specs/STYLE_PRESET_ARCHITECTURE.md
@@ -129,6 +129,10 @@ boundary for all callers (CLI, tests, FFI, and embedded integrations).
 arrays, and explicit `null` values replace inherited values. Arrays replace
 wholesale — there is no per-element merging.
 
+This preserves a simple and predictable contract, but it also means some
+evidence-backed child styles remain bulky until more granular override
+mechanisms exist for bibliography/template structures.
+
 ---
 
 ## §4 Registry Location

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -44,8 +44,23 @@ ideally suggest.
 That can happen for two reasons:
 
 - the correct family root is not yet authored as a distinct Citum base
-- current merge semantics still require large bibliography or type-variant
-  replacements even when the parent relationship is real
+- the current `extends:` merge contract makes some child deltas expensive to
+  express even when the parent relationship is real
+
+This second point is a real limitation of the current authoring model, not just
+an observation about file size. As documented in `STYLE_PRESET_ARCHITECTURE.md`,
+objects deep-merge, but arrays and explicit `null` values replace inherited
+content wholesale. In practice, bibliography templates and many
+`type-variants` contain nested arrays or replace-whole structures, so changing
+one child-specific component can force the child style to restate most of the
+inherited block.
+
+That is why taxonomy `profile` and “thin wrapper in YAML” can diverge. A style
+can have valid evidence-backed parentage and still remain bulky because the
+current inheritance model cannot express the delta compactly enough. This does
+not mean the current merge behavior is wrong; it means wrapper compression may
+require follow-up design work when the project wants more compact
+parent-plus-delta authoring.
 
 For that reason, a style may remain `kind: profile` in `registry/default.yaml`
 while still carrying self-contained YAML today. Conversely, the presence of a
@@ -74,7 +89,7 @@ style is Tier 1 `base`.
 | `elsevier-vancouver` | pending dedicated Elsevier numeric/NLM base | Public profile handle currently carries family-root behavior |
 | `elsevier-with-titles` | pending dedicated Elsevier numeric-with-titles base | Public profile handle currently carries family-root behavior |
 | `springer-basic-author-date` | pending dedicated Springer Basic family base | Public profile handle currently carries family-root behavior |
-| `springer-basic-brackets` | springer-basic-author-date | Evidence-backed child of the Springer Basic author-date profile; still bulky under current merge semantics |
+| `springer-basic-brackets` | springer-basic-author-date | Evidence-backed child of the Springer Basic author-date profile; still bulky because current merge rules force large bibliography/type-variant restatement |
 | `springer-vancouver-brackets` | pending dedicated Springer Vancouver/NLM family base | Public profile handle currently carries family-root behavior |
 | `taylor-and-francis-chicago-author-date` | chicago-author-date-18th | Guide-backed Chicago derivative; uses `extends:` |
 | `taylor-and-francis-council-of-science-editors-author-date` | pending dedicated CSE family base | Standards-backed public profile still carried as self-contained YAML |

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -87,7 +87,7 @@ style is Tier 1 `base`.
 | `chicago-shortened-notes-bibliography` | chicago-notes-18th | Proven shortened-notes wrapper |
 | `elsevier-harvard` | pending dedicated Elsevier author-date base | Public profile handle currently carries family-root behavior |
 | `elsevier-vancouver` | pending dedicated Elsevier numeric/NLM base | Public profile handle currently carries family-root behavior |
-| `elsevier-with-titles` | pending dedicated Elsevier numeric-with-titles base | Public profile handle currently carries family-root behavior |
+| `elsevier-with-titles` | — | Self-contained publisher profile |
 | `springer-basic-author-date` | pending dedicated Springer Basic family base | Public profile handle currently carries family-root behavior |
 | `springer-basic-brackets` | springer-basic-author-date | Evidence-backed child of the Springer Basic author-date profile; still bulky because current merge rules force large bibliography/type-variant restatement |
 | `springer-vancouver-brackets` | pending dedicated Springer Vancouver/NLM family base | Public profile handle currently carries family-root behavior |

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -1,10 +1,10 @@
 # Style Taxonomy
 
 **Status:** Active
-**Version:** 1.0
-**Date:** 2026-04-20
-**Bean:** `csl26-v961`
-**Related:** `STYLE_PRESET_ARCHITECTURE.md`
+**Version:** 1.1
+**Date:** 2026-04-21
+**Bean:** `csl26-v961`, `csl26-nrkn`
+**Related:** `STYLE_PRESET_ARCHITECTURE.md`, `../architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md`
 
 ## Purpose
 
@@ -15,9 +15,42 @@ Define a four-tier classification for all Citum styles. The taxonomy drives regi
 | Tier | Kind | Definition | `extends:` field | Verification |
 |------|------|------------|-----------------|--------------|
 | 1 | `base` | Complete style with full templates; serves as inheritance root | No | CSL oracle (citeproc-js) for CSL-derived; biblatex snapshot for biblatex-derived |
-| 2 | `profile` | Adapts a base for a specific organization; may override options without full templates | Optional | Delta from its base; or direct oracle if self-contained |
+| 2 | `profile` | Evidence-backed parent-plus-deltas style for a publisher, society, or standards body | Optional | Delta from its parent when a meaningful wrapper exists; otherwise direct oracle plus parent-diff evidence |
 | 3 | `journal` | Pure alias in the registry; no YAML file | N/A | Inherits from parent |
 | 4 | `independent` | Complete style; no aliases; no inheritance role | No | Own oracle |
+
+## Profile Rule
+
+`profile` is a semantic taxonomy, not a claim that the current YAML is already a
+small `extends:` wrapper.
+
+A style is a `profile` when the authority chain shows that it follows a known
+publisher, society, or standards parent with bounded house deltas. The authority
+order is:
+
+1. publisher or journal guide
+2. publisher house rules
+3. named parent-style manual or standards reference
+4. CSL/template-link evidence
+5. current Citum YAML structure
+
+Output similarity by itself is not enough.
+
+## Implementation Note
+
+Some public profile styles still remain bulkier than their taxonomy label would
+ideally suggest.
+
+That can happen for two reasons:
+
+- the correct family root is not yet authored as a distinct Citum base
+- current merge semantics still require large bibliography or type-variant
+  replacements even when the parent relationship is real
+
+For that reason, a style may remain `kind: profile` in `registry/default.yaml`
+while still carrying self-contained YAML today. Conversely, the presence of a
+compiled `StyleBase` key is an implementation detail, not taxonomic proof that a
+style is Tier 1 `base`.
 
 ## Current Classification
 
@@ -36,16 +69,16 @@ Define a four-tier classification for all Citum styles. The taxonomy drives regi
 
 | Style | Base | Notes |
 |-------|------|-------|
-| `chicago-shortened-notes-bibliography` | chicago-notes-18th | Chicago variant |
-| `elsevier-harvard` | — | Self-contained publisher profile |
-| `elsevier-vancouver` | — | Self-contained publisher profile |
-| `elsevier-with-titles` | — | Self-contained publisher profile |
-| `springer-basic-author-date` | — | Self-contained publisher profile |
-| `springer-basic-brackets` | — | Self-contained publisher profile |
-| `springer-vancouver-brackets` | — | Self-contained publisher profile |
-| `taylor-and-francis-chicago-author-date` | chicago-author-date-18th | Uses `extends:` |
-| `taylor-and-francis-council-of-science-editors-author-date` | — | Self-contained |
-| `taylor-and-francis-national-library-of-medicine` | — | Self-contained |
+| `chicago-shortened-notes-bibliography` | chicago-notes-18th | Proven shortened-notes wrapper |
+| `elsevier-harvard` | pending dedicated Elsevier author-date base | Public profile handle currently carries family-root behavior |
+| `elsevier-vancouver` | pending dedicated Elsevier numeric/NLM base | Public profile handle currently carries family-root behavior |
+| `elsevier-with-titles` | pending dedicated Elsevier numeric-with-titles base | Public profile handle currently carries family-root behavior |
+| `springer-basic-author-date` | pending dedicated Springer Basic family base | Public profile handle currently carries family-root behavior |
+| `springer-basic-brackets` | springer-basic-author-date | Evidence-backed child of the Springer Basic author-date profile; still bulky under current merge semantics |
+| `springer-vancouver-brackets` | pending dedicated Springer Vancouver/NLM family base | Public profile handle currently carries family-root behavior |
+| `taylor-and-francis-chicago-author-date` | chicago-author-date-18th | Guide-backed Chicago derivative; uses `extends:` |
+| `taylor-and-francis-council-of-science-editors-author-date` | pending dedicated CSE family base | Standards-backed public profile still carried as self-contained YAML |
+| `taylor-and-francis-national-library-of-medicine` | pending dedicated NLM family base | Standards-backed public profile still carried as self-contained YAML |
 
 ### Journal / Alias Styles (Tier 3)
 
@@ -57,11 +90,16 @@ Styles in `styles/*.yaml` that have no journal aliases and are not used as bases
 
 ## Embedding Policy
 
-Only Tier 1 (base) and Tier 2 (profile) styles are embedded in the binary via `StyleBase`. Tier 3 (journal) styles resolve at runtime through the registry alias table. Tier 4 (independent) styles are loaded from disk or bundled separately.
+Only Tier 1 (base) and Tier 2 (profile) styles are embedded in the binary. Tier
+3 (journal) styles resolve at runtime through the registry alias table. Tier 4
+(independent) styles are loaded from disk or bundled separately.
 
 ---
 
 ## Changelog
 
+- v1.1 (2026-04-21): Clarified that `profile` means evidence-backed parentage,
+  not output similarity or already-small YAML. Recorded the semantic vs
+  implementation distinction for bulky public profiles.
 - v1.0 (2026-04-20): Initial spec. Defines four-tier model (base, profile, journal, independent).
   Classifies all 16 embedded styles. Documents embedding policy.

--- a/scripts/oracle-yaml.js
+++ b/scripts/oracle-yaml.js
@@ -28,8 +28,8 @@ const { toCiteprocItem } = require('./lib/citeproc-locators');
 const {
   PROJECT_ROOT,
   resolveYamlVerificationPlan,
-  resolveStyleData,
 } = require('./lib/style-verification');
+const { resolveStyleData } = require('./lib/verification-policy');
 
 function parseArgs(argv = process.argv.slice(2)) {
   const options = {


### PR DESCRIPTION
## Summary
- close `csl26-nrkn` with a dated profile-wrapper evidence pass
- tighten `STYLE_TAXONOMY.md` so `profile` means guide-backed parentage rather than output similarity
- fix `scripts/oracle-yaml.js` and add follow-up beans for the remaining family-base work

## Verification
- `node --test scripts/oracle-yaml.test.js`
- `./scripts/validate-frontmatter.sh --copilot-strict`
- `node scripts/oracle-yaml.js styles/embedded/elsevier-harvard.yaml --json`
- `node scripts/oracle-yaml.js styles/embedded/chicago-shortened-notes-bibliography.yaml --json`
- direct `citum render refs` parent/base diffs on `tests/fixtures/references-expanded.json` + `tests/fixtures/citations-expanded.json`
