### PR TITLE
refactor(schema): clarify profile preset slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "typst",
  "typst-kit",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -863,7 +863,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -581,9 +581,9 @@ fn validate_profile_capabilities(
     )?;
     validate_axis(
         base,
-        "name-list-profile",
-        profile.name_list_profile.as_ref(),
-        capabilities.name_list_profile,
+        "contributor-preset",
+        profile.contributor_preset.as_ref(),
+        capabilities.contributor_preset,
     )?;
     validate_axis(
         base,
@@ -2051,6 +2051,23 @@ options:
     }
 
     #[test]
+    fn profile_rejects_removed_name_list_profile_axis() {
+        let yaml = r#"
+info:
+  id: elsevier-harvard
+extends: elsevier-harvard-core
+options:
+  profile:
+    name-list-profile: springer
+"#;
+        let err = Style::from_yaml_str(yaml).expect_err("removed profile axis must fail");
+        assert!(
+            err.to_string()
+                .contains("unknown field `name-list-profile`")
+        );
+    }
+
+    #[test]
     fn profile_reports_unsupported_axis_and_value_separately() {
         let unsupported_axis = Style::from_yaml_str(
             r#"
@@ -2168,6 +2185,53 @@ options:
                 .as_deref(),
             Some("———")
         );
+    }
+
+    #[test]
+    fn profile_contributor_preset_applies_supported_slot() {
+        let resolved = Style::from_yaml_str(
+            r#"
+info:
+  id: springer-basic-author-date
+extends: springer-basic-author-date-core
+options:
+  profile:
+    contributor-preset: springer
+"#,
+        )
+        .unwrap()
+        .try_into_resolved()
+        .expect("supported profile contributor preset should resolve");
+
+        assert_eq!(
+            resolved
+                .options
+                .as_ref()
+                .and_then(|options| options.contributors.clone()),
+            Some(crate::presets::ContributorPreset::Springer.config())
+        );
+    }
+
+    #[test]
+    fn profile_contributor_preset_rejects_unsupported_value() {
+        let err = Style::from_yaml_str(
+            r#"
+info:
+  id: springer-basic-author-date
+extends: springer-basic-author-date-core
+options:
+  profile:
+    contributor-preset: ieee
+"#,
+        )
+        .unwrap()
+        .try_into_resolved()
+        .expect_err("unsupported contributor preset should be rejected");
+
+        assert!(matches!(
+            err,
+            ResolutionError::UnsupportedProfileValue { axis, .. } if axis == "contributor-preset"
+        ));
     }
 
     #[test]

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -41,9 +41,8 @@ pub use processing::{
     ProcessingCustom, Sort, SortEntry, SortKey, SortSpec,
 };
 pub use profile::{
-    BibliographyLabelMode, CitationGroupDelimiter, DatePosition, NameListProfile,
-    ProfileAxisCapabilities, ProfileConfig, ProfileWrap, RepeatedAuthorRendering, TitleTerminator,
-    VolumePagesDelimiter,
+    BibliographyLabelMode, CitationGroupDelimiter, DatePosition, ProfileAxisCapabilities,
+    ProfileConfig, ProfileWrap, RepeatedAuthorRendering, TitleTerminator, VolumePagesDelimiter,
 };
 pub use substitute::{Substitute, SubstituteConfig, SubstituteKey};
 

--- a/crates/citum-schema-style/src/options/profile.rs
+++ b/crates/citum-schema-style/src/options/profile.rs
@@ -39,9 +39,9 @@ pub struct ProfileConfig {
     /// Terminator applied to primary-title bibliography components.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title_terminator: Option<TitleTerminator>,
-    /// Contributor-list preset for this profile family.
+    /// Profile-scoped contributor preset slot for this family of wrappers.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name_list_profile: Option<NameListProfile>,
+    pub contributor_preset: Option<ContributorPreset>,
     /// Repeated-author rendering mode for bibliographies.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repeated_author_rendering: Option<RepeatedAuthorRendering>,
@@ -60,7 +60,7 @@ impl ProfileConfig {
             date_position,
             volume_pages_delimiter,
             title_terminator,
-            name_list_profile,
+            contributor_preset,
             repeated_author_rendering,
         );
     }
@@ -98,9 +98,8 @@ impl ProfileConfig {
         if let Some(terminator) = self.title_terminator {
             apply_title_terminator(style.bibliography.as_mut(), terminator);
         }
-        if let Some(profile) = self.name_list_profile {
-            style.options.get_or_insert_default().contributors =
-                Some(profile.into_preset().config());
+        if let Some(preset) = self.contributor_preset {
+            style.options.get_or_insert_default().contributors = Some(preset.config());
         }
         if let Some(repeated) = self.repeated_author_rendering {
             let bib_opts = style
@@ -247,35 +246,6 @@ impl TitleTerminator {
             TitleTerminator::Period => Some("."),
             TitleTerminator::Comma => Some(","),
             TitleTerminator::None => None,
-        }
-    }
-}
-
-/// Named contributor-list presets exposed through profile config.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum NameListProfile {
-    /// APA-like inversion and symbol conjunction.
-    Apa,
-    /// Chicago-style given-name rendering.
-    Chicago,
-    /// Harvard family-first rendering.
-    Harvard,
-    /// Springer/biology family-first numeric rendering.
-    Springer,
-    /// Vancouver-style numeric contributor rendering.
-    Vancouver,
-}
-
-impl NameListProfile {
-    fn into_preset(self) -> ContributorPreset {
-        match self {
-            NameListProfile::Apa => ContributorPreset::Apa,
-            NameListProfile::Chicago => ContributorPreset::Chicago,
-            NameListProfile::Harvard => ContributorPreset::Harvard,
-            NameListProfile::Springer => ContributorPreset::Springer,
-            NameListProfile::Vancouver => ContributorPreset::Vancouver,
         }
     }
 }
@@ -531,8 +501,8 @@ pub struct ProfileAxisCapabilities {
     pub volume_pages_delimiter: &'static [VolumePagesDelimiter],
     /// Whether the base supports title-terminator.
     pub title_terminator: &'static [TitleTerminator],
-    /// Whether the base supports name-list-profile.
-    pub name_list_profile: &'static [NameListProfile],
+    /// Which contributor presets the base exposes through a profile slot.
+    pub contributor_preset: &'static [ContributorPreset],
     /// Whether the base supports repeated-author-rendering.
     pub repeated_author_rendering: &'static [RepeatedAuthorRendering],
 }
@@ -547,7 +517,7 @@ impl ProfileAxisCapabilities {
         date_position: &[],
         volume_pages_delimiter: &[],
         title_terminator: &[],
-        name_list_profile: &[],
+        contributor_preset: &[],
         repeated_author_rendering: &[],
     };
 }

--- a/crates/citum-schema-style/src/presets.rs
+++ b/crates/citum-schema-style/src/presets.rs
@@ -43,7 +43,7 @@ use std::collections::HashMap;
 /// Each preset encodes the contributor formatting conventions for a major citation
 /// style or style family. Use doc comments to describe the visual behavior so
 /// style authors can choose the right preset without knowing style guide names.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -13,10 +13,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use crate::Style;
 use crate::embedded::get_embedded_style;
 use crate::options::{
-    BibliographyLabelMode, CitationGroupDelimiter, DatePosition, NameListProfile,
-    ProfileAxisCapabilities, ProfileWrap, RepeatedAuthorRendering, TitleTerminator,
-    VolumePagesDelimiter,
+    BibliographyLabelMode, CitationGroupDelimiter, DatePosition, ProfileAxisCapabilities,
+    ProfileWrap, RepeatedAuthorRendering, TitleTerminator, VolumePagesDelimiter,
 };
+use crate::presets::ContributorPreset;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -124,12 +124,12 @@ const TITLE_TERMINATORS: &[TitleTerminator] = &[
     TitleTerminator::Comma,
     TitleTerminator::None,
 ];
-const NAME_LIST_PROFILES: &[NameListProfile] = &[
-    NameListProfile::Apa,
-    NameListProfile::Chicago,
-    NameListProfile::Harvard,
-    NameListProfile::Springer,
-    NameListProfile::Vancouver,
+const CONTRIBUTOR_PRESET_PROFILES: &[ContributorPreset] = &[
+    ContributorPreset::Apa,
+    ContributorPreset::Chicago,
+    ContributorPreset::Harvard,
+    ContributorPreset::Springer,
+    ContributorPreset::Vancouver,
 ];
 const REPEATED_AUTHOR_RENDERINGS: &[RepeatedAuthorRendering] = &[
     RepeatedAuthorRendering::Full,
@@ -144,7 +144,7 @@ const AUTHOR_DATE_PROFILE_CAPABILITIES: ProfileAxisCapabilities = ProfileAxisCap
     date_position: DATE_POSITIONS,
     volume_pages_delimiter: VOLUME_PAGES_DELIMITERS,
     title_terminator: TITLE_TERMINATORS,
-    name_list_profile: NAME_LIST_PROFILES,
+    contributor_preset: CONTRIBUTOR_PRESET_PROFILES,
     repeated_author_rendering: REPEATED_AUTHOR_RENDERINGS,
 };
 const NUMERIC_PROFILE_CAPABILITIES: ProfileAxisCapabilities = ProfileAxisCapabilities {
@@ -155,7 +155,7 @@ const NUMERIC_PROFILE_CAPABILITIES: ProfileAxisCapabilities = ProfileAxisCapabil
     date_position: DATE_POSITIONS,
     volume_pages_delimiter: VOLUME_PAGES_DELIMITERS,
     title_terminator: TITLE_TERMINATORS,
-    name_list_profile: NAME_LIST_PROFILES,
+    contributor_preset: CONTRIBUTOR_PRESET_PROFILES,
     repeated_author_rendering: REPEATED_AUTHOR_RENDERINGS,
 };
 const NOTE_PROFILE_CAPABILITIES: ProfileAxisCapabilities = ProfileAxisCapabilities {
@@ -166,7 +166,7 @@ const NOTE_PROFILE_CAPABILITIES: ProfileAxisCapabilities = ProfileAxisCapabiliti
     date_position: DATE_POSITIONS,
     volume_pages_delimiter: VOLUME_PAGES_DELIMITERS,
     title_terminator: TITLE_TERMINATORS,
-    name_list_profile: NAME_LIST_PROFILES,
+    contributor_preset: CONTRIBUTOR_PRESET_PROFILES,
     repeated_author_rendering: REPEATED_AUTHOR_RENDERINGS,
 };
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -1157,7 +1157,8 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                     instead of spelling out every field. At the style level,
                     <code class="text-xs bg-slate-100 px-1 rounded">extends:</code>
                     lets a thin wrapper inherit all templates from a named
-                    base style, then tune behaviour along declared axes via
+                    base style, then tune behaviour through wrapper-only
+                    behaviour axes and preset slots via
                     <code class="text-xs bg-slate-100 px-1 rounded">options.profile:</code>.
                 </p>
             </div>
@@ -1200,21 +1201,22 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </div>
                 <div class="bg-slate-900 p-6 overflow-x-auto">
                     <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-slate-500"># Tune declared axes on an inherited base — no templates required</span>
+<span class="text-slate-500"># Preset slot: ask the base to use a contributor preset — no templates required</span>
 <span class="text-indigo-400">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span>
 <span class="text-indigo-400">options</span>:
   <span class="text-primary">profile</span>:
-    <span class="text-primary">name-list-profile</span>: <span class="text-emerald-400">springer</span>
+    <span class="text-primary">contributor-preset</span>: <span class="text-emerald-400">springer</span>
     <span class="text-primary">date-position</span>: <span class="text-emerald-400">after-author</span>
 
-<span class="text-slate-500"># Numeric variant: bracket labels + numeric bibliography</span>
+<span class="text-slate-500"># Behavior axes: bracket labels + numeric bibliography</span>
 <span class="text-indigo-400">extends</span>: <span class="text-emerald-400">elsevier-vancouver-core</span>
 <span class="text-indigo-400">options</span>:
   <span class="text-primary">profile</span>:
     <span class="text-primary">citation-label-wrap</span>: <span class="text-emerald-400">brackets</span>
     <span class="text-primary">bibliography-label-mode</span>: <span class="text-emerald-400">numeric</span>
 
-<span class="text-slate-500"># Supported axes: date-position | name-list-profile | citation-label-wrap | bibliography-label-mode</span>
+<span class="text-slate-500"># Profile fields fall into two categories: behavior axes and preset slots.</span>
+<span class="text-slate-500"># Supported fields here: date-position | contributor-preset | citation-label-wrap | bibliography-label-mode</span>
 <span class="text-slate-500"># Unsupported axes are rejected at load time.</span></pre>
                 </div>
             </div>

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -229,22 +229,73 @@ extends: springer-basic-author-date-core
 
 ## [tune] Profile Options
 
-When a style uses `extends:`, it may tune behaviour along axes the base style
-explicitly supports via `options.profile:`. Unsupported axes are rejected at
-load time.
+When a style uses `extends:`, it may tune behaviour through
+`options.profile:`. Unsupported fields are rejected at load time.
 
-| Axis | Values | Effect |
-|---|---|---|
-| `date-position` | `after-author`, `after-title` | Where the year appears in a bibliography entry |
-| `name-list-profile` | `apa`, `chicago`, `springer`, `vancouver` | Name-list truncation and formatting rules |
-| `citation-label-wrap` | `brackets`, `parentheses` | Delimiter around in-text citation labels |
-| `bibliography-label-mode` | `numeric`, `alpha` | Label format in the bibliography |
+**Two different places to configure a style**
+
+- `options.*` configures a style directly. Use this for normal, standalone
+  styles.
+- `options.profile.*` configures a style through an inherited base. Use this
+  only when the style has `extends:`.
+
+In plain terms:
+
+- if you are authoring a full style, edit `options`
+- if you are authoring a thin wrapper over a base style, edit `options.profile`
+
+`options.profile` exists so a base style can expose a small, safe set of
+allowed changes without letting the wrapper rewrite templates.
+
+**Why not always use `options.*`?**
+
+Because a profile is not a full style. It is a constrained child of a base
+style. The base decides which knobs a profile may change. That keeps wrapper
+styles simple, keeps inheritance predictable, and makes GUI authoring possible:
+the UI can show only the controls the base supports.
+
+`options.profile` has two kinds of fields:
+
+### Behavior axes
+
+Use these for wrapper-only adjustments to inherited structure.
+
+- `date-position`
+- `citation-label-wrap`
+- `bibliography-label-mode`
+
+### Preset slots
+
+Use these when the base allows the profile to choose from an existing preset
+family.
+
+- `contributor-preset`
+
+A preset slot is not a different preset system. It is a profile-safe way for a
+wrapper to select one of the preset families the base exposes.
+
+**Allowed values for the common profile fields**
+
+| Field | Allowed values | Use when | Example value |
+|---|---|---|---|
+| `date-position` | `after-author`, `after-title`, `terminal` | the wrapper should move the year within bibliography entries | `after-author` |
+| `contributor-preset` | base-supported contributor presets such as `apa`, `chicago`, `springer`, `vancouver` | the wrapper should switch contributor formatting to a base-supported preset | `springer` |
+| `citation-label-wrap` | `none`, `parentheses`, `brackets`, `superscript` | the wrapper should change citation label punctuation | `brackets` |
+| `bibliography-label-mode` | `none`, `numeric`, `author-date` | the wrapper should change bibliography label display | `numeric` |
 
 ```yaml
+# Standalone style: configure the style directly
+options:
+  contributors: springer
+  dates: short
+```
+
+```yaml
+# Profile wrapper: configure the inherited base through its profile contract
 extends: springer-basic-author-date-core
 options:
   profile:
-    name-list-profile: springer
+    contributor-preset: springer
     date-position: after-author
 ```
 
@@ -256,9 +307,17 @@ options:
     bibliography-label-mode: numeric
 ```
 
-> [!NOTE]
-> Profile options are the only way to vary behaviour in an `extends:` style.
-> Structural template changes require a new base style or an independent style.
+> [!TIP]
+> **Beginner rule**
+>
+> Ask this first:
+>
+> - does this file use `extends:`?
+>   - no: use `options.*`
+>   - yes: use `options.profile.*`
+>
+> If you need to change templates or `type-variants`, you are no longer making
+> a profile. You need a new base style or an independent style.
 
 ## [category] Type Variants
 
@@ -495,7 +554,7 @@ info:
 extends: springer-basic-author-date-core
 options:
   profile:
-    name-list-profile: springer
+    contributor-preset: springer
     date-position: after-author
 ```
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -4383,11 +4383,11 @@
             }
           ]
         },
-        "name-list-profile": {
-          "description": "Contributor-list preset for this profile family.",
+        "contributor-preset": {
+          "description": "Profile-scoped contributor preset slot for this family of wrappers.",
           "anyOf": [
             {
-              "$ref": "#/$defs/NameListProfile"
+              "$ref": "#/$defs/ContributorPreset"
             },
             {
               "type": "null"
@@ -4530,36 +4530,6 @@
           "description": "No terminator.",
           "type": "string",
           "const": "none"
-        }
-      ]
-    },
-    "NameListProfile": {
-      "description": "Named contributor-list presets exposed through profile config.",
-      "oneOf": [
-        {
-          "description": "APA-like inversion and symbol conjunction.",
-          "type": "string",
-          "const": "apa"
-        },
-        {
-          "description": "Chicago-style given-name rendering.",
-          "type": "string",
-          "const": "chicago"
-        },
-        {
-          "description": "Harvard family-first rendering.",
-          "type": "string",
-          "const": "harvard"
-        },
-        {
-          "description": "Springer/biology family-first numeric rendering.",
-          "type": "string",
-          "const": "springer"
-        },
-        {
-          "description": "Vancouver-style numeric contributor rendering.",
-          "type": "string",
-          "const": "vancouver"
         }
       ]
     },

--- a/docs/specs/CONFIG_ONLY_PROFILE_OVERRIDES.md
+++ b/docs/specs/CONFIG_ONLY_PROFILE_OVERRIDES.md
@@ -128,37 +128,61 @@ options:
   profile:
     citation-label-wrap: brackets
     bibliography-label-mode: numeric
+    contributor-preset: springer
     date-position: after-author
     volume-pages-delimiter: colon
 ```
 
-`options.profile` is a strongly typed struct, not a free-form map. New fields
-may be added only when all of the following are true:
+`options.profile` is a strongly typed struct, not a free-form map. It is also
+not just a bag of small formatting tweaks. It is the complete, capability-gated
+variation contract for config-only profile wrappers.
+
+Fields under `options.profile` fall into exactly two categories:
+
+- **behavior axes**: wrapper-only adjustments to inherited structure
+- **preset slots**: wrapper-only selection of an existing preset family, if the
+  chosen base explicitly exposes that slot
+
+This distinction is normative:
+
+- `options.contributors: springer` configures the style directly through the
+  normal global options surface
+- `options.profile.contributor-preset: springer` asks the selected base to
+  switch contributor behavior through a declared wrapper contract
+
+New fields may be added only when all of the following are true:
 
 - the variation has stable rendering semantics
 - the variation appears across multiple styles or a large family, not one file
 - the variation is explainable without referencing hidden template structure
-- the axis is orthogonal to existing profile axes where practical
+- the field is either a stable behavior axis or a clearly named preset slot
+- the field is orthogonal to existing profile fields where practical
 
 The initial option families for this model are:
 
-- citation label presentation
-  - `citation-label-wrap`: `none | parentheses | brackets | superscript`
-  - `citation-group-delimiter`: `comma | semicolon | space`
-- bibliography label presentation
-  - `bibliography-label-mode`: `none | numeric | author-date`
-  - `bibliography-label-wrap`: `none | parentheses | brackets`
-- entry sequencing and punctuation
-  - `date-position`: `after-author | after-title | terminal`
-  - `volume-pages-delimiter`: `comma | colon | space`
-  - `title-terminator`: `period | comma | none`
-- contributor list behavior
-  - `name-list-profile`: references existing typed contributor presets
-  - `repeated-author-rendering`: `full | dash | dash-with-space`
+- behavior axes
+  - citation label presentation
+    - `citation-label-wrap`: `none | parentheses | brackets | superscript`
+    - `citation-group-delimiter`: `comma | semicolon | space`
+  - bibliography label presentation
+    - `bibliography-label-mode`: `none | numeric | author-date`
+    - `bibliography-label-wrap`: `none | parentheses | brackets`
+  - entry sequencing and punctuation
+    - `date-position`: `after-author | after-title | terminal`
+    - `volume-pages-delimiter`: `comma | colon | space`
+    - `title-terminator`: `period | comma | none`
+  - bibliography repetition
+    - `repeated-author-rendering`: `full | dash | dash-with-space`
+- preset slots
+  - `contributor-preset`: any base-supported `ContributorPreset` value
 
 This list is intentionally bounded. If a proposed option needs to describe a
 whole template fragment rather than a stable behavior axis, it does not belong
 in `options.profile`.
+
+Misleading effect-named fields are forbidden. If a field selects a larger
+preset family, the field name must describe that full semantic scope rather
+than only one visible side effect.
 
 The default policy is conservative: the first implementation should cover only
 the small set of recurring axes already evidenced by current Springer,
@@ -174,7 +198,8 @@ This keeps profile authoring explicit:
 
 - a style cannot silently request a knob that its base ignores
 - two family bases can support different subsets of the shared profile options
-- base authors must declare which behavior axes are part of the base contract
+- base authors must declare which behavior axes and preset slots are part of
+  the base contract
 
 The capability list is runtime metadata in `StyleBase`, not user-authored YAML.
 Schema validation ensures shape; base capability validation ensures semantic
@@ -186,8 +211,8 @@ Conceptually, a base capability declaration looks like:
 profile-capabilities:
   citation-label-wrap:
     values: [none, parentheses, brackets]
-  bibliography-label-mode:
-    values: [none, numeric]
+  contributor-preset:
+    values: [apa, chicago, springer]
 ```
 
 This is illustrative only. The actual source of truth is compiled metadata, not
@@ -262,6 +287,7 @@ info:
 extends: springer-basic-core
 options:
   profile:
+    contributor-preset: springer
     bibliography-label-mode: none
     date-position: after-author
 ```

--- a/docs/specs/STYLE_PRESET_ARCHITECTURE.md
+++ b/docs/specs/STYLE_PRESET_ARCHITECTURE.md
@@ -25,6 +25,12 @@ parent by 2–5 rules (e.g. Turabian ≈ Chicago Notes + no ibid + footnote
 punctuation tweaks). In CSL these are full standalone files. In Citum they
 become an `extends:` declaration plus a few top-level field overrides.
 
+For config-only profile wrappers, those deltas now live under
+`options.profile`. That surface is intentionally narrower than ordinary
+`options.*`: it contains wrapper-only behavior axes plus explicitly named
+profile-scoped preset slots such as `contributor-preset`, and each field is
+capability-gated by the selected base.
+
 ---
 
 ## §1 Problem Statement

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -40,6 +40,8 @@ Output similarity by itself is not enough.
 Profile styles now use config-only wrappers over hidden compiled roots.
 
 - public `kind: profile` styles may keep local identity and `options.profile`
+- `options.profile` is the full wrapper contract and may contain both behavior
+  axes and explicitly named preset slots
 - public `kind: profile` styles may not keep local templates, `type-variants`,
   or template-clearing `null` values
 - hidden compiled roots are an implementation detail and do not appear in the
@@ -91,6 +93,8 @@ Only Tier 1 (base) and Tier 2 (profile) styles are embedded in the binary. Tier
 
 ## Changelog
 
+- v1.3 (2026-04-21): Clarified that `options.profile` may contain both
+  behavior axes and profile-scoped preset slots.
 - v1.2 (2026-04-21): Enforced config-only profile wrappers over hidden compiled
   roots.
 - v1.1 (2026-04-21): Clarified that `profile` means evidence-backed parentage,

--- a/styles/embedded/springer-basic-author-date.yaml
+++ b/styles/embedded/springer-basic-author-date.yaml
@@ -4,5 +4,5 @@ info:
 extends: springer-basic-author-date-core
 options:
   profile:
-    name-list-profile: springer
+    contributor-preset: springer
     date-position: after-author

--- a/styles/embedded/taylor-and-francis-chicago-author-date.yaml
+++ b/styles/embedded/taylor-and-francis-chicago-author-date.yaml
@@ -5,5 +5,5 @@ info:
 extends: taylor-and-francis-chicago-author-date-core
 options:
   profile:
-    name-list-profile: chicago
+    contributor-preset: chicago
     date-position: after-author

--- a/styles/embedded/taylor-and-francis-council-of-science-editors-author-date.yaml
+++ b/styles/embedded/taylor-and-francis-council-of-science-editors-author-date.yaml
@@ -6,5 +6,5 @@ info:
 extends: taylor-and-francis-council-of-science-editors-author-date-core
 options:
   profile:
-    name-list-profile: vancouver
+    contributor-preset: vancouver
     date-position: after-author


### PR DESCRIPTION
## Summary
- rename `options.profile.name-list-profile` to `options.profile.contributor-preset`
- reuse `ContributorPreset` directly for profile capability metadata and validation
- clarify the active spec and author docs so `options.profile` is described as profile-wrapper-only behavior axes plus preset slots

## Testing
- `./scripts/validate-frontmatter.sh --copilot-strict`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`