### PR TITLE
feat(analyze): add automated profile candidate discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
 name = "citum-analyze"
 version = "0.24.0"
 dependencies = [
+ "citum-migrate",
  "citum-schema",
  "csl-legacy",
  "roxmltree",

--- a/crates/citum-analyze/Cargo.toml
+++ b/crates/citum-analyze/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/batch_test.rs"
 [dependencies]
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 citum_schema = { package = "citum-schema", path = "../citum-schema" }
+citum_migrate = { package = "citum-migrate", path = "../citum-migrate" }
 roxmltree = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -10,6 +10,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! and identify patterns for guiding migration development.
 
 mod analyzer;
+mod profile_discovery;
 mod ranker;
 mod savings;
 
@@ -27,6 +28,7 @@ fn main() {
     let json_output = args.contains(&"--json".to_string());
     let rank_parents = args.contains(&"--rank-parents".to_string());
     let quantify_savings = args.contains(&"--quantify-savings".to_string());
+    let identify_profiles = args.contains(&"--identify-profiles".to_string());
 
     // Check for format filter (--format author-date, --format numeric, etc.)
     let format_filter = args
@@ -35,7 +37,9 @@ fn main() {
         .and_then(|i| args.get(i + 1))
         .map(std::string::String::as_str);
 
-    if quantify_savings {
+    if identify_profiles {
+        profile_discovery::run_profile_discovery(styles_dir, json_output);
+    } else if quantify_savings {
         savings::run_savings_report(styles_dir, json_output);
     } else if rank_parents {
         ranker::run_parent_ranker(styles_dir, json_output, format_filter);
@@ -60,9 +64,13 @@ fn print_usage() {
     eprintln!("  citum_analyze <styles_dir> --quantify-savings [--json]");
     eprintln!("      Estimate how many CSL styles presets and locale overrides can replace.");
     eprintln!();
+    eprintln!("  citum_analyze <styles_dir> --identify-profiles");
+    eprintln!("      Identify styles that could be converted to config-only profiles.");
+    eprintln!();
     eprintln!("Examples:");
     eprintln!("  citum_analyze styles-legacy/");
     eprintln!("  citum_analyze styles-legacy/ --rank-parents");
     eprintln!("  citum_analyze styles-legacy/ --rank-parents --format author-date --json");
     eprintln!("  citum_analyze styles-legacy/ --quantify-savings --json");
+    eprintln!("  citum_analyze styles-legacy/ --identify-profiles");
 }

--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
         .map(std::string::String::as_str);
 
     if identify_profiles {
-        profile_discovery::run_profile_discovery(styles_dir, json_output);
+        profile_discovery::run_profile_discovery(styles_dir);
     } else if quantify_savings {
         savings::run_savings_report(styles_dir, json_output);
     } else if rank_parents {

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -3,23 +3,17 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
+use roxmltree::Document;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
-use roxmltree::Document;
-use std::collections::HashSet;
 
+use citum_migrate::{OptionsExtractor, compilation, fixups, provenance::ProvenanceTracker};
 use citum_schema::StyleBase;
-use citum_schema::template::{
-    TemplateComponent,
-    SimpleVariable, NumberVariable, DateVariable, ContributorRole, TitleType
-};
 use citum_schema::locale::GeneralTerm;
-use citum_migrate::{
-    OptionsExtractor,
-    compilation,
-    fixups,
-    provenance::ProvenanceTracker,
+use citum_schema::template::{
+    ContributorRole, DateVariable, NumberVariable, SimpleVariable, TemplateComponent, TitleType,
 };
 use csl_legacy::parser::parse_style;
 
@@ -39,7 +33,9 @@ fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem
         TemplateComponent::Variable(v) => items.push(SemanticItem::Variable(v.variable.clone())),
         TemplateComponent::Number(n) => items.push(SemanticItem::Number(n.number.clone())),
         TemplateComponent::Date(d) => items.push(SemanticItem::Date(d.date.clone())),
-        TemplateComponent::Contributor(c) => items.push(SemanticItem::Contributor(c.contributor.clone())),
+        TemplateComponent::Contributor(c) => {
+            items.push(SemanticItem::Contributor(c.contributor.clone()));
+        }
         TemplateComponent::Title(t) => items.push(SemanticItem::Title(t.title.clone())),
         TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term)),
         TemplateComponent::Group(g) => {
@@ -60,37 +56,45 @@ fn template_to_set(template: &[TemplateComponent]) -> HashSet<SemanticItem> {
 }
 
 /// Runs the profile discovery analysis.
-pub fn run_profile_discovery(styles_dir: &str, _json_output: bool) {
-    eprintln!("Analyzing styles in {} to identify profile candidates...", styles_dir);
+pub fn run_profile_discovery(styles_dir: &str) {
+    eprintln!(
+        "Analyzing styles in {} to identify profile candidates...",
+        styles_dir
+    );
 
     // Pre-resolve all style bases and their semantic sets
-    let bases: Vec<(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)> = StyleBase::all()
-        .iter()
-        .map(|base| {
-            let style = base.base().into_resolved();
-            let bib_set = style.bibliography.as_ref()
-                .and_then(|b| b.template.as_ref())
-                .map(|t| template_to_set(t))
-                .unwrap_or_default();
-            
-            let mut cit_sets = Vec::new();
-            if let Some(cit) = &style.citation {
-                if let Some(t) = &cit.template {
-                    cit_sets.push(template_to_set(t));
-                }
-                if let Some(i) = &cit.integral
-                    && let Some(t) = &i.template {
+    let bases: Vec<(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)> =
+        StyleBase::all()
+            .iter()
+            .map(|base| {
+                let style = base.base().into_resolved();
+                let bib_set = style
+                    .bibliography
+                    .as_ref()
+                    .and_then(|b| b.template.as_ref())
+                    .map(|t| template_to_set(t))
+                    .unwrap_or_default();
+
+                let mut cit_sets = Vec::new();
+                if let Some(cit) = &style.citation {
+                    if let Some(t) = &cit.template {
                         cit_sets.push(template_to_set(t));
-                }
-                if let Some(ni) = &cit.non_integral
-                    && let Some(t) = &ni.template {
+                    }
+                    if let Some(i) = &cit.integral
+                        && let Some(t) = &i.template
+                    {
                         cit_sets.push(template_to_set(t));
+                    }
+                    if let Some(ni) = &cit.non_integral
+                        && let Some(t) = &ni.template
+                    {
+                        cit_sets.push(template_to_set(t));
+                    }
                 }
-            }
-            
-            (base.clone(), bib_set, cit_sets)
-        })
-        .collect();
+
+                (base.clone(), bib_set, cit_sets)
+            })
+            .collect();
 
     let tracker = ProvenanceTracker::new(false);
     let mut count = 0;
@@ -131,18 +135,23 @@ fn identify_profile_match(
     let mut options = migration_options.options;
 
     // 2. Compile templates from XML
-    let compiled = compilation::compile_from_xml(
-        &legacy_style,
-        &mut options,
-        false,
-        tracker,
-    );
+    let compiled = compilation::compile_from_xml(&legacy_style, &mut options, false, tracker);
 
     let mut new_cit = compiled.citation.clone();
-    if matches!(options.processing, Some(citum_schema::options::Processing::Numeric)) {
-        fixups::ensure_numeric_locator_citation_component(&legacy_style.citation.layout, &mut new_cit);
+    if matches!(
+        options.processing,
+        Some(citum_schema::options::Processing::Numeric)
+    ) {
+        fixups::ensure_numeric_locator_citation_component(
+            &legacy_style.citation.layout,
+            &mut new_cit,
+        );
     } else if legacy_style.class == "in-text" {
-        fixups::normalize_author_date_locator_citation_component(&legacy_style.citation.layout, &legacy_style.macros, &mut new_cit);
+        fixups::normalize_author_date_locator_citation_component(
+            &legacy_style.citation.layout,
+            &legacy_style.macros,
+            &mut new_cit,
+        );
     }
 
     let bib_set = template_to_set(&compiled.bibliography);
@@ -153,16 +162,28 @@ fn identify_profile_match(
         // Use a similarity threshold instead of exact match for the set
         let bib_intersection = bib_set.intersection(base_bib_set).count();
         let bib_union = bib_set.union(base_bib_set).count();
-        let bib_sim = if bib_union > 0 { bib_intersection as f32 / bib_union as f32 } else { 1.0 };
+        let bib_sim = if bib_union > 0 {
+            bib_intersection as f32 / bib_union as f32
+        } else {
+            1.0
+        };
 
         let cit_sim = if base_cit_sets.is_empty() {
-             1.0
+            1.0
         } else {
-             base_cit_sets.iter().map(|base_cit_set| {
-                 let cit_intersection = cit_set.intersection(base_cit_set).count();
-                 let cit_union = cit_set.union(base_cit_set).count();
-                 if cit_union > 0 { cit_intersection as f32 / cit_union as f32 } else { 1.0 }
-             }).max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap_or(0.0)
+            base_cit_sets
+                .iter()
+                .map(|base_cit_set| {
+                    let cit_intersection = cit_set.intersection(base_cit_set).count();
+                    let cit_union = cit_set.union(base_cit_set).count();
+                    if cit_union > 0 {
+                        cit_intersection as f32 / cit_union as f32
+                    } else {
+                        1.0
+                    }
+                })
+                .max_by(|a, b| a.partial_cmp(b).unwrap())
+                .unwrap_or(0.0)
         };
 
         if bib_sim > 0.8 && cit_sim > 0.8 {

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -1,0 +1,182 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+use std::fs;
+use std::path::Path;
+use walkdir::WalkDir;
+use roxmltree::Document;
+use std::collections::HashSet;
+
+use citum_schema::StyleBase;
+use citum_schema::template::{
+    TemplateComponent,
+    SimpleVariable, NumberVariable, DateVariable, ContributorRole, TitleType
+};
+use citum_schema::locale::GeneralTerm;
+use citum_migrate::{
+    OptionsExtractor,
+    compilation,
+    fixups,
+    provenance::ProvenanceTracker,
+};
+use csl_legacy::parser::parse_style;
+
+/// A simplified semantic representation of a template component.
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+enum SemanticItem {
+    Variable(SimpleVariable),
+    Number(NumberVariable),
+    Date(DateVariable),
+    Contributor(ContributorRole),
+    Title(TitleType),
+    Term(GeneralTerm),
+}
+
+fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem>) {
+    match component {
+        TemplateComponent::Variable(v) => items.push(SemanticItem::Variable(v.variable.clone())),
+        TemplateComponent::Number(n) => items.push(SemanticItem::Number(n.number.clone())),
+        TemplateComponent::Date(d) => items.push(SemanticItem::Date(d.date.clone())),
+        TemplateComponent::Contributor(c) => items.push(SemanticItem::Contributor(c.contributor.clone())),
+        TemplateComponent::Title(t) => items.push(SemanticItem::Title(t.title.clone())),
+        TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term.clone())),
+        TemplateComponent::Group(g) => {
+            for child in &g.group {
+                to_semantic_items(child, items);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn template_to_set(template: &[TemplateComponent]) -> HashSet<SemanticItem> {
+    let mut items = Vec::new();
+    for component in template {
+        to_semantic_items(component, &mut items);
+    }
+    items.into_iter().collect()
+}
+
+/// Runs the profile discovery analysis.
+pub fn run_profile_discovery(styles_dir: &str, _json_output: bool) {
+    eprintln!("Analyzing styles in {} to identify profile candidates...", styles_dir);
+
+    // Pre-resolve all style bases and their semantic sets
+    let bases: Vec<(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)> = StyleBase::all()
+        .iter()
+        .map(|base| {
+            let style = base.base().into_resolved();
+            let bib_set = style.bibliography.as_ref()
+                .and_then(|b| b.template.as_ref())
+                .map(|t| template_to_set(t))
+                .unwrap_or_default();
+            
+            let mut cit_sets = Vec::new();
+            if let Some(cit) = &style.citation {
+                if let Some(t) = &cit.template {
+                    cit_sets.push(template_to_set(t));
+                }
+                if let Some(i) = &cit.integral {
+                    if let Some(t) = &i.template {
+                        cit_sets.push(template_to_set(t));
+                    }
+                }
+                if let Some(ni) = &cit.non_integral {
+                    if let Some(t) = &ni.template {
+                        cit_sets.push(template_to_set(t));
+                    }
+                }
+            }
+            
+            (base.clone(), bib_set, cit_sets)
+        })
+        .collect();
+
+    let tracker = ProvenanceTracker::new(false);
+    let mut count = 0;
+
+    for entry in WalkDir::new(styles_dir)
+        .into_iter()
+        .filter_entry(|e| !e.file_name().to_str().is_some_and(|s| s == "dependent"))
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "csl"))
+    {
+        count += 1;
+        if count % 100 == 0 {
+            eprintln!("Processed {} styles...", count);
+        }
+        let path = entry.path();
+        if let Err(_e) = identify_profile_match(path, &bases, &tracker) {
+            // Silence errors for batch processing
+        }
+    }
+}
+
+fn identify_profile_match(
+    path: &Path,
+    bases: &[(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)],
+    tracker: &ProvenanceTracker,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let text = fs::read_to_string(path)?;
+    let doc = Document::parse(&text)?;
+    let legacy_style = parse_style(doc.root_element())?;
+
+    // Skip dependent styles for this analysis
+    if text.contains("rel=\"independent-parent\"") {
+        return Ok(());
+    }
+
+    // 1. Extract migration options
+    let migration_options = OptionsExtractor::extract_migration_options(&legacy_style);
+    let mut options = migration_options.options;
+
+    // 2. Compile templates from XML
+    let compiled = compilation::compile_from_xml(
+        &legacy_style,
+        &mut options,
+        false,
+        tracker,
+    );
+
+    let mut new_cit = compiled.citation.clone();
+    if matches!(options.processing, Some(citum_schema::options::Processing::Numeric)) {
+        fixups::ensure_numeric_locator_citation_component(&legacy_style.citation.layout, &mut new_cit);
+    } else if legacy_style.class == "in-text" {
+        fixups::normalize_author_date_locator_citation_component(&legacy_style.citation.layout, &legacy_style.macros, &mut new_cit);
+    }
+
+    let bib_set = template_to_set(&compiled.bibliography);
+    let cit_set = template_to_set(&new_cit);
+
+    // 4. Compare semantic sets with each base
+    for (base_enum, base_bib_set, base_cit_sets) in bases {
+        // Use a similarity threshold instead of exact match for the set
+        let bib_intersection = bib_set.intersection(base_bib_set).count();
+        let bib_union = bib_set.union(base_bib_set).count();
+        let bib_sim = if bib_union > 0 { bib_intersection as f32 / bib_union as f32 } else { 1.0 };
+
+        let cit_sim = if base_cit_sets.is_empty() {
+             1.0
+        } else {
+             base_cit_sets.iter().map(|base_cit_set| {
+                 let cit_intersection = cit_set.intersection(base_cit_set).count();
+                 let cit_union = cit_set.union(base_cit_set).count();
+                 if cit_union > 0 { cit_intersection as f32 / cit_union as f32 } else { 1.0 }
+             }).max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap_or(0.0)
+        };
+
+        if bib_sim > 0.8 && cit_sim > 0.8 {
+            println!(
+                "Candidate found: {} (Similarity: bib={:.2}, cit={:.2}) could extend '{}'",
+                path.display(),
+                bib_sim,
+                cit_sim,
+                base_enum.key()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -41,7 +41,7 @@ fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem
         TemplateComponent::Date(d) => items.push(SemanticItem::Date(d.date.clone())),
         TemplateComponent::Contributor(c) => items.push(SemanticItem::Contributor(c.contributor.clone())),
         TemplateComponent::Title(t) => items.push(SemanticItem::Title(t.title.clone())),
-        TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term.clone())),
+        TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term)),
         TemplateComponent::Group(g) => {
             for child in &g.group {
                 to_semantic_items(child, items);
@@ -78,15 +78,13 @@ pub fn run_profile_discovery(styles_dir: &str, _json_output: bool) {
                 if let Some(t) = &cit.template {
                     cit_sets.push(template_to_set(t));
                 }
-                if let Some(i) = &cit.integral {
-                    if let Some(t) = &i.template {
+                if let Some(i) = &cit.integral
+                    && let Some(t) = &i.template {
                         cit_sets.push(template_to_set(t));
-                    }
                 }
-                if let Some(ni) = &cit.non_integral {
-                    if let Some(t) = &ni.template {
+                if let Some(ni) = &cit.non_integral
+                    && let Some(t) = &ni.template {
                         cit_sets.push(template_to_set(t));
-                    }
                 }
             }
             
@@ -99,7 +97,7 @@ pub fn run_profile_discovery(styles_dir: &str, _json_output: bool) {
 
     for entry in WalkDir::new(styles_dir)
         .into_iter()
-        .filter_entry(|e| !e.file_name().to_str().is_some_and(|s| s == "dependent"))
+        .filter_entry(|e| e.file_name().to_str().is_none_or(|s| s != "dependent"))
         .filter_map(Result::ok)
         .filter(|e| e.path().extension().is_some_and(|ext| ext == "csl"))
     {

--- a/crates/citum-migrate/src/compilation.rs
+++ b/crates/citum-migrate/src/compilation.rs
@@ -1,0 +1,304 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Unified compilation pipeline from CSL 1.0 to Citum templates.
+
+use citum_schema::template::{TemplateComponent, TypeSelector};
+use crate::{
+    Compressor, MacroInliner, TemplateCompiler, Upsampler,
+    analysis, base_detector, passes,
+    provenance::ProvenanceTracker,
+};
+
+/// Shorthand for the per-type template map used throughout the migration pipeline.
+pub type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
+
+/// Output from the XML compilation pipeline.
+#[derive(Debug, Clone)]
+pub struct XmlCompilationOutput {
+    /// Base bibliography template.
+    pub bibliography: Vec<TemplateComponent>,
+    /// Type-specific bibliography variants.
+    pub type_templates: Option<TypeTemplateMap>,
+    /// Base citation template.
+    pub citation: Vec<TemplateComponent>,
+    /// Position-specific citation overrides.
+    pub citation_overrides: CitationPositionOverrides,
+}
+
+/// Position-specific citation overrides.
+#[derive(Debug, Clone, Default)]
+pub struct CitationPositionOverrides {
+    /// Subsequent citation override.
+    pub subsequent: Option<Vec<TemplateComponent>>,
+    /// Ibid citation override.
+    pub ibid: Option<Vec<TemplateComponent>>,
+}
+
+/// Run the full XML compilation pipeline for bibliography and citation templates.
+/// This is the fallback when no hand-authored or inferred template is available.
+pub fn compile_from_xml(
+    legacy_style: &csl_legacy::model::Style,
+    options: &mut citum_schema::options::Config,
+    enable_provenance: bool,
+    tracker: &ProvenanceTracker,
+) -> XmlCompilationOutput {
+    // Extract author suffix before macro inlining (will be lost during inlining)
+    let author_suffix = if let Some(ref bib) = legacy_style.bibliography {
+        analysis::bibliography::extract_author_suffix(&bib.layout)
+    } else {
+        None
+    };
+
+    // Extract bibliography-specific 'and' setting (may differ from citation)
+    let bib_and = analysis::bibliography::extract_bibliography_and(legacy_style);
+
+    // 1. Deconstruction
+    let inliner = if enable_provenance {
+        MacroInliner::with_provenance(legacy_style, tracker.clone())
+    } else {
+        MacroInliner::new(legacy_style)
+    };
+    let flattened_bib = inliner
+        .inline_bibliography(legacy_style)
+        .unwrap_or_default();
+    let flattened_cit = inliner.inline_citation(legacy_style);
+
+    // 2. Semantic Upsampling
+    let mut upsampler = if enable_provenance {
+        Upsampler::with_provenance(tracker.clone())
+    } else {
+        Upsampler::new()
+    };
+
+    // Set citation-specific thresholds for citation upsampling
+    upsampler.et_al_min = legacy_style.citation.et_al_min;
+    upsampler.et_al_use_first = legacy_style.citation.et_al_use_first;
+    let citation_position_nodes = upsampler.extract_citation_position_templates(&flattened_cit);
+    
+    // We don't print to stderr here to keep the library quiet, 
+    // but the flag is available if the caller wants it.
+    
+    let raw_cit = citation_position_nodes
+        .first
+        .clone()
+        .unwrap_or_else(|| upsampler.upsample_nodes(&flattened_cit));
+
+    // Set bibliography-specific thresholds for bibliography upsampling
+    if let Some(ref bib) = legacy_style.bibliography {
+        upsampler.et_al_min = bib.et_al_min;
+        upsampler.et_al_use_first = bib.et_al_use_first;
+    }
+    let raw_bib = upsampler.upsample_nodes(&flattened_bib);
+
+    // 3. Compression (Pattern Recognition)
+    let compressor = Compressor;
+    let csln_bib = compressor.compress_nodes(raw_bib.clone());
+    let csln_cit = compressor.compress_nodes(raw_cit.clone());
+
+    // 4. Template Compilation
+    let template_compiler = TemplateCompiler;
+
+    // Detect if this is a numeric style
+    let is_numeric = matches!(
+        options.processing,
+        Some(citum_schema::options::Processing::Numeric)
+    );
+
+    let (mut new_bib, type_templates) =
+        template_compiler.compile_bibliography_with_types(&csln_bib, is_numeric);
+    let new_cit = template_compiler.compile_citation(&csln_cit);
+    
+    let citation_position_overrides = CitationPositionOverrides {
+        subsequent: compile_citation_position_override(
+            &template_compiler,
+            &compressor,
+            citation_position_nodes.subsequent,
+        ),
+        ibid: compile_citation_position_override(
+            &template_compiler,
+            &compressor,
+            citation_position_nodes.ibid,
+        ),
+    };
+
+    record_template_placements_if_enabled(&new_bib, enable_provenance, tracker);
+// Apply author suffix extracted from original CSL (lost during macro inlining)
+analysis::bibliography::apply_author_suffix(&mut new_bib, author_suffix);
+
+// Apply bibliography-specific 'and' setting (may differ from citation)
+analysis::bibliography::apply_bibliography_and(&mut new_bib, bib_and);
+
+// For author-date styles with in-text class, apply standard formatting.
+let is_in_text_class = legacy_style.class == "in-text";
+let is_author_date_processing = matches!(
+    options.processing,
+    Some(citum_schema::options::Processing::AuthorDate)
+);
+
+// Apply to all in-text styles (both author-date and numeric)
+if is_in_text_class {
+    passes::reorder::add_volume_prefix_after_serial(&mut new_bib);
+}
+
+
+    // Detect holistic style preset for semantic fixups
+    let style_base = base_detector::detect_style_base(options);
+
+    if is_in_text_class && is_author_date_processing {
+        apply_author_date_bibliography_passes(&mut new_bib, options, style_base);
+    }
+
+    let type_templates_opt = if type_templates.is_empty() {
+        None
+    } else {
+        Some(type_templates)
+    };
+
+    XmlCompilationOutput {
+        bibliography: new_bib,
+        type_templates: type_templates_opt,
+        citation: new_cit,
+        citation_overrides: citation_position_overrides,
+    }
+}
+
+fn compile_citation_position_override(
+    compiler: &TemplateCompiler,
+    compressor: &Compressor,
+    nodes: Option<Vec<citum_schema::CslnNode>>,
+) -> Option<Vec<TemplateComponent>> {
+    let nodes = nodes?;
+    let compressed = compressor.compress_nodes(nodes);
+    let compiled = compiler.compile_citation(&compressed);
+    if compiled.is_empty() {
+        None
+    } else {
+        Some(compiled)
+    }
+}
+
+fn record_template_placements_if_enabled(
+    new_bib: &[TemplateComponent],
+    enable_provenance: bool,
+    tracker: &ProvenanceTracker,
+) {
+    if !enable_provenance {
+        return;
+    }
+    for (index, component) in new_bib.iter().enumerate() {
+        match component {
+            TemplateComponent::Variable(v) => {
+                let var_name = format!("{:?}", v.variable).to_lowercase();
+                tracker.record_template_placement(
+                    &var_name,
+                    index,
+                    "bibliography.template",
+                    "Variable",
+                );
+            }
+            TemplateComponent::Number(n) => {
+                let var_name = format!("{:?}", n.number).to_lowercase();
+                tracker.record_template_placement(
+                    &var_name,
+                    index,
+                    "bibliography.template",
+                    "Number",
+                );
+            }
+            TemplateComponent::Date(d) => {
+                let var_name = format!("{:?}", d.date).to_lowercase();
+                tracker.record_template_placement(
+                    &var_name,
+                    index,
+                    "bibliography.template",
+                    "Date",
+                );
+            }
+            TemplateComponent::Title(t) => {
+                let var_name = format!("{:?}", t.title).to_lowercase();
+                tracker.record_template_placement(
+                    &var_name,
+                    index,
+                    "bibliography.template",
+                    "Title",
+                );
+            }
+            TemplateComponent::Contributor(_) => {
+                tracker.record_template_placement(
+                    "contributor",
+                    index,
+                    "bibliography.template",
+                    "Contributor",
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn apply_author_date_bibliography_passes(
+    new_bib: &mut Vec<TemplateComponent>,
+    options: &mut citum_schema::options::Config,
+    style_base: Option<base_detector::StyleBase>,
+) {
+    // Detect if the style uses space prefix for volume (Elsevier pattern)
+    let volume_list_has_space_prefix = new_bib.iter().any(|c| {
+        if let TemplateComponent::Group(list) = c {
+            let has_volume = list.group.iter().any(|item| {
+                matches!(item, TemplateComponent::Number(n) if n.number == citum_schema::template::NumberVariable::Volume)
+            });
+            if has_volume {
+                return list.rendering.prefix.as_deref() == Some(" ");
+            }
+        }
+        false
+    });
+
+    let vol_pages_delim = options.volume_pages_delimiter.clone();
+    for component in &mut *new_bib {
+        apply_type_overrides(
+            component,
+            vol_pages_delim.clone(),
+            volume_list_has_space_prefix,
+            style_base,
+        );
+    }
+
+    passes::reorder::move_access_components_to_end(new_bib);
+    passes::reorder::unsuppress_for_type(new_bib, "chapter");
+    passes::reorder::unsuppress_for_type(new_bib, "paper-conference");
+    passes::reorder::unsuppress_for_type(new_bib, "thesis");
+    passes::reorder::unsuppress_for_type(new_bib, "document");
+    passes::deduplicate::deduplicate_titles_in_lists(new_bib);
+    passes::deduplicate::deduplicate_variables_cross_lists(new_bib);
+    passes::reorder::propagate_list_overrides(new_bib);
+    passes::deduplicate::deduplicate_nested_lists(new_bib);
+    passes::reorder::reorder_serial_components(new_bib);
+    passes::grouping::group_volume_and_issue(new_bib, options, style_base);
+    passes::reorder::reorder_pages_for_serials(new_bib);
+    passes::reorder::reorder_publisher_place_for_chicago(new_bib, style_base);
+    passes::reorder::reorder_chapters_for_apa(new_bib, style_base);
+    passes::reorder::reorder_chapters_for_chicago(new_bib, style_base);
+    passes::deduplicate::suppress_duplicate_issue_for_journals(new_bib, style_base);
+}
+
+fn apply_type_overrides(
+    component: &mut TemplateComponent,
+    _volume_pages_delimiter: Option<citum_schema::template::DelimiterPunctuation>,
+    _volume_list_has_space_prefix: bool,
+    _style_base: Option<base_detector::StyleBase>,
+) {
+    if let TemplateComponent::Group(list) = component {
+        for item in &mut list.group {
+            apply_type_overrides(
+                item,
+                _volume_pages_delimiter.clone(),
+                _volume_list_has_space_prefix,
+                _style_base,
+            );
+        }
+    }
+}

--- a/crates/citum-migrate/src/compilation.rs
+++ b/crates/citum-migrate/src/compilation.rs
@@ -285,19 +285,23 @@ fn apply_author_date_bibliography_passes(
     passes::deduplicate::suppress_duplicate_issue_for_journals(new_bib, style_base);
 }
 
+#[allow(
+    clippy::only_used_in_recursion,
+    reason = "params propagated for future type-override logic"
+)]
 fn apply_type_overrides(
     component: &mut TemplateComponent,
-    _volume_pages_delimiter: Option<citum_schema::template::DelimiterPunctuation>,
-    _volume_list_has_space_prefix: bool,
-    _style_base: Option<base_detector::StyleBase>,
+    volume_pages_delimiter: Option<citum_schema::template::DelimiterPunctuation>,
+    volume_list_has_space_prefix: bool,
+    style_base: Option<base_detector::StyleBase>,
 ) {
     if let TemplateComponent::Group(list) = component {
         for item in &mut list.group {
             apply_type_overrides(
                 item,
-                _volume_pages_delimiter.clone(),
-                _volume_list_has_space_prefix,
-                _style_base,
+                volume_pages_delimiter.clone(),
+                volume_list_has_space_prefix,
+                style_base,
             );
         }
     }

--- a/crates/citum-migrate/src/compilation.rs
+++ b/crates/citum-migrate/src/compilation.rs
@@ -5,12 +5,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Unified compilation pipeline from CSL 1.0 to Citum templates.
 
-use citum_schema::template::{TemplateComponent, TypeSelector};
 use crate::{
-    Compressor, MacroInliner, TemplateCompiler, Upsampler,
-    analysis, base_detector, passes,
+    Compressor, MacroInliner, TemplateCompiler, Upsampler, analysis, base_detector, passes,
     provenance::ProvenanceTracker,
 };
+use citum_schema::template::{TemplateComponent, TypeSelector};
 
 /// Shorthand for the per-type template map used throughout the migration pipeline.
 pub type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
@@ -26,6 +25,8 @@ pub struct XmlCompilationOutput {
     pub citation: Vec<TemplateComponent>,
     /// Position-specific citation overrides.
     pub citation_overrides: CitationPositionOverrides,
+    /// Whether citation position branches could not be migrated cleanly.
+    pub unsupported_mixed_conditions: bool,
 }
 
 /// Position-specific citation overrides.
@@ -77,10 +78,11 @@ pub fn compile_from_xml(
     upsampler.et_al_min = legacy_style.citation.et_al_min;
     upsampler.et_al_use_first = legacy_style.citation.et_al_use_first;
     let citation_position_nodes = upsampler.extract_citation_position_templates(&flattened_cit);
-    
-    // We don't print to stderr here to keep the library quiet, 
+    let unsupported_mixed_conditions = citation_position_nodes.unsupported_mixed_conditions;
+
+    // We don't print to stderr here to keep the library quiet,
     // but the flag is available if the caller wants it.
-    
+
     let raw_cit = citation_position_nodes
         .first
         .clone()
@@ -110,7 +112,7 @@ pub fn compile_from_xml(
     let (mut new_bib, type_templates) =
         template_compiler.compile_bibliography_with_types(&csln_bib, is_numeric);
     let new_cit = template_compiler.compile_citation(&csln_cit);
-    
+
     let citation_position_overrides = CitationPositionOverrides {
         subsequent: compile_citation_position_override(
             &template_compiler,
@@ -125,24 +127,23 @@ pub fn compile_from_xml(
     };
 
     record_template_placements_if_enabled(&new_bib, enable_provenance, tracker);
-// Apply author suffix extracted from original CSL (lost during macro inlining)
-analysis::bibliography::apply_author_suffix(&mut new_bib, author_suffix);
+    // Apply author suffix extracted from original CSL (lost during macro inlining)
+    analysis::bibliography::apply_author_suffix(&mut new_bib, author_suffix);
 
-// Apply bibliography-specific 'and' setting (may differ from citation)
-analysis::bibliography::apply_bibliography_and(&mut new_bib, bib_and);
+    // Apply bibliography-specific 'and' setting (may differ from citation)
+    analysis::bibliography::apply_bibliography_and(&mut new_bib, bib_and);
 
-// For author-date styles with in-text class, apply standard formatting.
-let is_in_text_class = legacy_style.class == "in-text";
-let is_author_date_processing = matches!(
-    options.processing,
-    Some(citum_schema::options::Processing::AuthorDate)
-);
+    // For author-date styles with in-text class, apply standard formatting.
+    let is_in_text_class = legacy_style.class == "in-text";
+    let is_author_date_processing = matches!(
+        options.processing,
+        Some(citum_schema::options::Processing::AuthorDate)
+    );
 
-// Apply to all in-text styles (both author-date and numeric)
-if is_in_text_class {
-    passes::reorder::add_volume_prefix_after_serial(&mut new_bib);
-}
-
+    // Apply to all in-text styles (both author-date and numeric)
+    if is_in_text_class {
+        passes::reorder::add_volume_prefix_after_serial(&mut new_bib);
+    }
 
     // Detect holistic style preset for semantic fixups
     let style_base = base_detector::detect_style_base(options);
@@ -162,6 +163,7 @@ if is_in_text_class {
         type_templates: type_templates_opt,
         citation: new_cit,
         citation_overrides: citation_position_overrides,
+        unsupported_mixed_conditions,
     }
 }
 

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -16,6 +16,8 @@ pub mod fixups;
 /// Style metadata extraction.
 pub mod info_extractor;
 mod js_runtime;
+/// Unified compilation pipeline.
+pub mod compilation;
 /// Options extraction from CSL 1.0.
 pub mod options_extractor;
 /// Multi-pass processing pipeline.

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 pub mod analysis;
 /// Base detector for style classification.
 pub mod base_detector;
+/// Unified compilation pipeline.
+pub mod compilation;
 /// YAML/template compressor for reducing style size.
 pub mod compressor;
 /// Debug output formatting.
@@ -16,8 +18,6 @@ pub mod fixups;
 /// Style metadata extraction.
 pub mod info_extractor;
 mod js_runtime;
-/// Unified compilation pipeline.
-pub mod compilation;
 /// Options extraction from CSL 1.0.
 pub mod options_extractor;
 /// Multi-pass processing pipeline.

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -1,8 +1,7 @@
 #![allow(missing_docs, reason = "bin")]
 
 use citum_migrate::{
-    OptionsExtractor,
-    analysis,
+    OptionsExtractor, analysis,
     compilation::{self, XmlCompilationOutput as XmlFallback},
     debug_output::DebugOutputFormatter,
     fixups::{
@@ -21,9 +20,7 @@ use citum_migrate::{
 };
 use citum_schema::{
     BibliographySpec, CitationCollapse, CitationSpec, Style, StyleInfo,
-    template::{
-        TemplateComponent, TypeSelector, WrapPunctuation,
-    },
+    template::{TemplateComponent, TypeSelector, WrapPunctuation},
 };
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
@@ -353,6 +350,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         enable_provenance,
         &tracker,
     ));
+
+    if let Some(ref fallback) = xml_fallback
+        && fallback.unsupported_mixed_conditions
+    {
+        eprintln!(
+            "Warning: citation position branches could not be migrated cleanly for style {}. Falling back to base citation template only.",
+            legacy_style.info.id
+        );
+    }
 
     log_template_sources(&resolved);
 
@@ -1405,7 +1411,8 @@ mod tests {
             "fallback content from sibling chooses should remain in the base citation template"
         );
 
-        let subsequent_template = out.citation_overrides
+        let subsequent_template = out
+            .citation_overrides
             .subsequent
             .expect("subsequent branch should be migrated");
         assert!(
@@ -1421,7 +1428,8 @@ mod tests {
             "sibling choose fallback content should remain in the subsequent override"
         );
 
-        let ibid_template = out.citation_overrides
+        let ibid_template = out
+            .citation_overrides
             .ibid
             .expect("ibid branch should be migrated");
         assert!(

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -1,8 +1,9 @@
 #![allow(missing_docs, reason = "bin")]
 
 use citum_migrate::{
-    Compressor, MacroInliner, OptionsExtractor, TemplateCompiler, Upsampler, analysis,
-    base_detector,
+    OptionsExtractor,
+    analysis,
+    compilation::{self, XmlCompilationOutput as XmlFallback},
     debug_output::DebugOutputFormatter,
     fixups::{
         citation_template_has_citation_number, citation_template_is_author_year_only,
@@ -14,14 +15,14 @@ use citum_migrate::{
         note_citation_template_is_underfit, scrub_inferred_literal_artifacts,
         should_merge_inferred_type_template,
     },
-    passes,
+    options_extractor::MigrationOptions,
     provenance::ProvenanceTracker,
     template_resolver,
 };
 use citum_schema::{
     BibliographySpec, CitationCollapse, CitationSpec, Style, StyleInfo,
     template::{
-        DelimiterPunctuation, NumberVariable, TemplateComponent, TypeSelector, WrapPunctuation,
+        TemplateComponent, TypeSelector, WrapPunctuation,
     },
 };
 use csl_legacy::parser::parse_style;
@@ -31,14 +32,6 @@ use std::path::PathBuf;
 
 /// Shorthand for the per-type template map used throughout the migration pipeline.
 type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
-
-/// Output from the XML compilation fallback pipeline.
-type XmlFallback = (
-    Vec<TemplateComponent>,
-    Option<TypeTemplateMap>,
-    Vec<TemplateComponent>,
-    CitationPositionOverrides,
-);
 
 struct CliArgs {
     path: String,
@@ -227,57 +220,6 @@ fn resolve_style_name_and_templates(
     (style_name, resolved)
 }
 
-/// Extracts migration options and contributor configuration overrides.
-///
-/// Returns the options Config, citation contributor overrides,
-/// bibliography contributor overrides, and a flag indicating if
-/// citation has scope shorten.
-fn extract_migration_options(
-    legacy_style: &csl_legacy::model::Style,
-) -> (
-    citum_schema::options::Config,
-    Option<citum_schema::BibliographyOptions>,
-    Option<citum_schema::options::ContributorConfig>,
-    Option<citum_schema::options::ContributorConfig>,
-    bool,
-) {
-    let mut options = OptionsExtractor::extract(legacy_style);
-    apply_preset_extractions(&mut options);
-    let bibliography_options =
-        citum_migrate::options_extractor::bibliography::extract_bibliography_config(legacy_style)
-            .map(|config| citum_schema::BibliographyOptions {
-                article_journal: config.article_journal,
-                subsequent_author_substitute: config.subsequent_author_substitute,
-                subsequent_author_substitute_rule: config.subsequent_author_substitute_rule,
-                hanging_indent: config.hanging_indent,
-                entry_suffix: config.entry_suffix,
-                separator: config.separator,
-                suppress_period_after_url: config.suppress_period_after_url,
-                compound_numeric: config.compound_numeric,
-                ..Default::default()
-            });
-    let citation_contributor_overrides =
-        citum_migrate::options_extractor::contributors::extract_citation_contributor_overrides(
-            legacy_style,
-        );
-    let bibliography_contributor_overrides =
-        citum_migrate::options_extractor::contributors::extract_bibliography_contributor_overrides(
-            legacy_style,
-        );
-    let citation_has_scope_shorten = citation_contributor_overrides
-        .as_ref()
-        .and_then(|contributors| contributors.shorten.as_ref())
-        .is_some();
-
-    (
-        options,
-        bibliography_options,
-        citation_contributor_overrides,
-        bibliography_contributor_overrides,
-        citation_has_scope_shorten,
-    )
-}
-
 fn extract_citation_collapse(citation: &csl_legacy::model::Citation) -> Option<CitationCollapse> {
     match citation.collapse.as_deref() {
         Some("citation-number") => Some(CitationCollapse::CitationNumber),
@@ -385,13 +327,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let legacy_style = parse_style(doc.root_element())?;
 
     // 0. Extract global options (new Citum Config)
-    let (
+    let MigrationOptions {
         mut options,
         mut bibliography_options,
         citation_contributor_overrides,
         bibliography_contributor_overrides,
         citation_has_scope_shorten,
-    ) = extract_migration_options(&legacy_style);
+    } = OptionsExtractor::extract_migration_options(&legacy_style);
 
     // Resolve template: try hand-authored, cached inferred, or live inference
     // before falling back to the XML compiler pipeline.
@@ -405,7 +347,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         citation_has_scope_shorten,
     );
 
-    let xml_fallback = Some(compile_from_xml(
+    let xml_fallback = Some(compilation::compile_from_xml(
         &legacy_style,
         &mut options,
         enable_provenance,
@@ -518,84 +460,120 @@ fn bibliography_sort_matches_processing_default(
         .is_some_and(|preset| preset.group_sort() == *sort)
 }
 
-#[derive(Debug, Clone, Default)]
-struct CitationPositionOverrides {
-    subsequent: Option<Vec<TemplateComponent>>,
-    ibid: Option<Vec<TemplateComponent>>,
-}
-
-fn compile_citation_position_override(
-    compiler: &TemplateCompiler,
-    compressor: &Compressor,
-    nodes: Option<Vec<citum_schema::CslnNode>>,
-) -> Option<Vec<TemplateComponent>> {
-    let nodes = nodes?;
-    let compressed = compressor.compress_nodes(nodes);
-    let compiled = compiler.compile_citation(&compressed);
-    if compiled.is_empty() {
-        None
-    } else {
-        Some(compiled)
-    }
-}
-
-fn record_template_placements_if_enabled(
-    new_bib: &[TemplateComponent],
-    enable_provenance: bool,
-    tracker: &ProvenanceTracker,
-) {
-    if !enable_provenance {
-        return;
-    }
-    for (index, component) in new_bib.iter().enumerate() {
-        match component {
-            TemplateComponent::Variable(v) => {
-                let var_name = format!("{:?}", v.variable).to_lowercase();
-                tracker.record_template_placement(
-                    &var_name,
-                    index,
-                    "bibliography.template",
-                    "Variable",
-                );
-            }
-            TemplateComponent::Number(n) => {
-                let var_name = format!("{:?}", n.number).to_lowercase();
-                tracker.record_template_placement(
-                    &var_name,
-                    index,
-                    "bibliography.template",
-                    "Number",
-                );
-            }
-            TemplateComponent::Date(d) => {
-                let var_name = format!("{:?}", d.date).to_lowercase();
-                tracker.record_template_placement(
-                    &var_name,
-                    index,
-                    "bibliography.template",
-                    "Date",
-                );
-            }
-            TemplateComponent::Title(t) => {
-                let var_name = format!("{:?}", t.title).to_lowercase();
-                tracker.record_template_placement(
-                    &var_name,
-                    index,
-                    "bibliography.template",
-                    "Title",
-                );
-            }
-            TemplateComponent::Contributor(_) => {
-                tracker.record_template_placement(
-                    "contributor",
-                    index,
-                    "bibliography.template",
-                    "Contributor",
-                );
-            }
-            _ => {}
+fn log_template_sources(resolved: &template_resolver::ResolvedTemplates) {
+    if let Some(ref resolved_bib) = resolved.bibliography {
+        eprintln!("Using {} bibliography template", resolved_bib.source);
+        if let Some(conf) = resolved_bib.confidence {
+            eprintln!("  bibliography confidence: {:.0}%", conf * 100.0);
         }
+    } else {
+        eprintln!(
+            "Using {} bibliography template",
+            template_resolver::TemplateSource::XmlCompiled
+        );
     }
+
+    if let Some(ref resolved_cit) = resolved.citation {
+        eprintln!("Using {} citation template", resolved_cit.source);
+        if let Some(conf) = resolved_cit.confidence {
+            eprintln!("  citation confidence: {:.0}%", conf * 100.0);
+        }
+    } else {
+        eprintln!(
+            "Using {} citation template",
+            template_resolver::TemplateSource::XmlCompiled
+        );
+    }
+}
+
+fn select_and_process_bibliography_template(
+    resolved: &template_resolver::ResolvedTemplates,
+    xml_fallback: &Option<XmlFallback>,
+    legacy_style: &csl_legacy::model::Style,
+) -> (Vec<TemplateComponent>, Option<TypeTemplateMap>, bool) {
+    let (mut new_bib, mut type_templates, inferred_bib_source) =
+        if let Some(ref resolved_bib) = resolved.bibliography {
+            let inferred_bib = matches!(
+                resolved_bib.source,
+                template_resolver::TemplateSource::InferredCached(_)
+                    | template_resolver::TemplateSource::InferredLive
+            );
+
+            let merged_type_templates = if inferred_bib {
+                xml_fallback
+                    .as_ref()
+                    .and_then(|out| out.type_templates.clone())
+                    .map(|type_templates| {
+                        type_templates
+                            .into_iter()
+                            .filter(|(selector, type_template)| {
+                                selector.type_names().iter().any(|type_name| {
+                                    should_merge_inferred_type_template(
+                                        type_name,
+                                        &resolved_bib.template,
+                                        type_template,
+                                    )
+                                })
+                            })
+                            .collect::<indexmap::IndexMap<_, _>>()
+                    })
+                    .filter(|m| !m.is_empty())
+            } else {
+                None
+            };
+
+            (
+                resolved_bib.template.clone(),
+                merged_type_templates,
+                inferred_bib,
+            )
+        } else {
+            let out = xml_fallback
+                .as_ref()
+                .expect("XML fallback must exist when bibliography is unresolved");
+            (out.bibliography.clone(), out.type_templates.clone(), false)
+        };
+
+    if inferred_bib_source {
+        postprocess_inferred_bibliography(&mut new_bib, &mut type_templates, legacy_style);
+    }
+
+    (new_bib, type_templates, inferred_bib_source)
+}
+
+fn select_citation_template(
+    resolved: &template_resolver::ResolvedTemplates,
+    xml_fallback: &Option<XmlFallback>,
+    inferred_bib_source: bool,
+    legacy_style: &csl_legacy::model::Style,
+    type_templates: &mut Option<TypeTemplateMap>,
+) -> (
+    Vec<TemplateComponent>,
+    Option<Vec<TemplateComponent>>,
+    Option<Vec<TemplateComponent>>,
+) {
+    let mut citation_subsequent_override: Option<Vec<TemplateComponent>> = None;
+    let mut citation_ibid_override: Option<Vec<TemplateComponent>> = None;
+    let new_cit = if let Some(ref resolved_cit) = resolved.citation {
+        resolved_cit.template.clone()
+    } else {
+        let out = xml_fallback
+            .as_ref()
+            .expect("XML fallback must exist when citation is unresolved");
+        citation_subsequent_override = out.citation_overrides.subsequent.clone();
+        citation_ibid_override = out.citation_overrides.ibid.clone();
+        out.citation.clone()
+    };
+
+    if inferred_bib_source {
+        ensure_personal_communication_omitted(legacy_style, &new_cit, type_templates);
+    }
+
+    (
+        new_cit,
+        citation_subsequent_override,
+        citation_ibid_override,
+    )
 }
 
 fn override_bibliography_options_if_inferred(
@@ -603,9 +581,6 @@ fn override_bibliography_options_if_inferred(
     legacy_style: &csl_legacy::model::Style,
     options: &mut Option<citum_schema::BibliographyOptions>,
 ) {
-    // Override bibliography options with inferred values when available.
-    // The XML options extractor often gets the wrong delimiter because it reads group
-    // delimiters rather than rendered output.
     if let Some(ref resolved_bib) = resolved.bibliography {
         let is_inferred_source = matches!(
             resolved_bib.source,
@@ -652,7 +627,6 @@ fn resolve_citation_metadata(
         &legacy_style.macros,
     );
 
-    // Output-driven citation metadata is higher fidelity than XML analysis when available.
     if let Some(ref resolved_cit) = resolved.citation {
         if let Some(ref wrap) = resolved_cit.wrap {
             citation_wrap = Some(wrap.clone());
@@ -664,9 +638,6 @@ fn resolve_citation_metadata(
         }
     }
 
-    // Numeric citation fixups informed by migration quality runs:
-    // - Keep locator labels when legacy style has a citation-locator macro.
-    // - Preserve per-item wrapping for grouped numeric layouts (e.g., IEEE).
     if matches!(
         options.processing,
         Some(citum_schema::options::Processing::Numeric)
@@ -703,9 +674,6 @@ fn postprocess_inferred_bibliography(
     type_templates: &mut Option<TypeTemplateMap>,
     legacy_style: &csl_legacy::model::Style,
 ) {
-    // Output-driven inference can leak literal sample years into prefixes
-    // (e.g., " 2023 " in titles, "; 2006; " in page prefixes).
-    // Strip those artifacts while keeping component structure intact.
     for component in &mut *new_bib {
         scrub_inferred_literal_artifacts(component);
     }
@@ -872,7 +840,6 @@ fn validate_and_normalize_inferred_citations(
     style_name: &str,
     citation_has_scope_shorten: bool,
 ) {
-    // Validate inferred citation templates
     if let Some(resolved_cit) = resolved.citation.as_ref() {
         let is_inferred_source = matches!(
             resolved_cit.source,
@@ -904,7 +871,6 @@ fn validate_and_normalize_inferred_citations(
         }
     }
 
-    // Normalize author-year citations
     let should_normalize = legacy_style.class == "note"
         || matches!(
             options.processing,
@@ -927,7 +893,6 @@ fn validate_and_normalize_inferred_citations(
         }
     }
 
-    // Normalize in-text author-date citations
     if legacy_style.class == "in-text"
         && let Some(resolved_cit) = resolved.citation.as_mut()
     {
@@ -952,378 +917,11 @@ fn validate_and_normalize_inferred_citations(
     }
 }
 
-fn apply_author_date_bibliography_passes(
-    new_bib: &mut Vec<TemplateComponent>,
-    options: &mut citum_schema::options::Config,
-    style_base: Option<base_detector::StyleBase>,
-) {
-    // Detect if the style uses space prefix for volume (Elsevier pattern)
-    let volume_list_has_space_prefix = new_bib.iter().any(|c| {
-        if let TemplateComponent::Group(list) = c {
-            let has_volume = list.group.iter().any(|item| {
-                matches!(item, TemplateComponent::Number(n) if n.number == NumberVariable::Volume)
-            });
-            if has_volume {
-                // Check if the List has a space-only prefix
-                return list.rendering.prefix.as_deref() == Some(" ");
-            }
-        }
-        false
-    });
-
-    // Add type-specific overrides (recursively to handle nested Lists)
-    // Pass the extracted volume-pages delimiter for journal article pages
-    let vol_pages_delim = options.volume_pages_delimiter.clone();
-    for component in &mut *new_bib {
-        apply_type_overrides(
-            component,
-            vol_pages_delim.clone(),
-            volume_list_has_space_prefix,
-            style_base,
-        );
-    }
-
-    // Move DOI/URL to the end of the bibliography template.
-    passes::reorder::move_access_components_to_end(new_bib);
-
-    // Ensure publisher and publisher-place are unsuppressed for chapters
-    passes::reorder::unsuppress_for_type(new_bib, "chapter");
-    passes::reorder::unsuppress_for_type(new_bib, "paper-conference");
-    passes::reorder::unsuppress_for_type(new_bib, "thesis");
-    passes::reorder::unsuppress_for_type(new_bib, "document");
-
-    // Remove duplicate titles from Lists that already appear at top level.
-    passes::deduplicate::deduplicate_titles_in_lists(new_bib);
-
-    // Suppress variables that appear in multiple sibling lists (enforce variable-once rule).
-    passes::deduplicate::deduplicate_variables_cross_lists(new_bib);
-
-    // Propagate type-specific overrides within Lists.
-    passes::reorder::propagate_list_overrides(new_bib);
-
-    // Remove duplicate nested Lists that have identical contents.
-    passes::deduplicate::deduplicate_nested_lists(new_bib);
-
-    // Reorder serial components: container-title before volume.
-    passes::reorder::reorder_serial_components(new_bib);
-
-    // Combine volume and issue into a grouped structure: volume(issue)
-    passes::grouping::group_volume_and_issue(new_bib, options, style_base);
-
-    // Move pages to after the container-title/volume List for serial types.
-    passes::reorder::reorder_pages_for_serials(new_bib);
-
-    // Reorder publisher-place for Chicago journal articles.
-    passes::reorder::reorder_publisher_place_for_chicago(new_bib, style_base);
-
-    // Reorder chapters for APA: "In " prefix + editors before book title
-    passes::reorder::reorder_chapters_for_apa(new_bib, style_base);
-
-    // Reorder chapters for Chicago: "In" prefix + book title before editors
-    passes::reorder::reorder_chapters_for_chicago(new_bib, style_base);
-
-    // Fix Chicago issue placement
-    passes::deduplicate::suppress_duplicate_issue_for_journals(new_bib, style_base);
-}
-
-/// Run the full XML compilation pipeline for bibliography and citation templates.
-/// This is the fallback when no hand-authored or inferred template is available.
-fn compile_from_xml(
-    legacy_style: &csl_legacy::model::Style,
-    options: &mut citum_schema::options::Config,
-    enable_provenance: bool,
-    tracker: &citum_migrate::provenance::ProvenanceTracker,
-) -> XmlFallback {
-    // Extract author suffix before macro inlining (will be lost during inlining)
-    let author_suffix = if let Some(ref bib) = legacy_style.bibliography {
-        analysis::bibliography::extract_author_suffix(&bib.layout)
-    } else {
-        None
-    };
-
-    // Extract bibliography-specific 'and' setting (may differ from citation)
-    let bib_and = analysis::bibliography::extract_bibliography_and(legacy_style);
-
-    // 1. Deconstruction
-    let inliner = if enable_provenance {
-        MacroInliner::with_provenance(legacy_style, tracker.clone())
-    } else {
-        MacroInliner::new(legacy_style)
-    };
-    let flattened_bib = inliner
-        .inline_bibliography(legacy_style)
-        .unwrap_or_default();
-    let flattened_cit = inliner.inline_citation(legacy_style);
-
-    // 2. Semantic Upsampling
-    let mut upsampler = if enable_provenance {
-        Upsampler::with_provenance(tracker.clone())
-    } else {
-        Upsampler::new()
-    };
-
-    // Set citation-specific thresholds for citation upsampling
-    upsampler.et_al_min = legacy_style.citation.et_al_min;
-    upsampler.et_al_use_first = legacy_style.citation.et_al_use_first;
-    let citation_position_nodes = upsampler.extract_citation_position_templates(&flattened_cit);
-    if citation_position_nodes.unsupported_mixed_conditions {
-        eprintln!(
-            "Warning: citation position branches could not be migrated cleanly for style {}. Falling back to base citation template only.",
-            legacy_style.info.id
-        );
-    }
-    let raw_cit = citation_position_nodes
-        .first
-        .clone()
-        .unwrap_or_else(|| upsampler.upsample_nodes(&flattened_cit));
-
-    // Set bibliography-specific thresholds for bibliography upsampling
-    if let Some(ref bib) = legacy_style.bibliography {
-        upsampler.et_al_min = bib.et_al_min;
-        upsampler.et_al_use_first = bib.et_al_use_first;
-    }
-    let raw_bib = upsampler.upsample_nodes(&flattened_bib);
-
-    // 3. Compression (Pattern Recognition)
-    let compressor = Compressor;
-    let csln_bib = compressor.compress_nodes(raw_bib.clone());
-    let csln_cit = compressor.compress_nodes(raw_cit.clone());
-
-    // 4. Template Compilation
-    let template_compiler = TemplateCompiler;
-
-    // Detect if this is a numeric style
-    let is_numeric = matches!(
-        options.processing,
-        Some(citum_schema::options::Processing::Numeric)
-    );
-
-    let (mut new_bib, type_templates) =
-        template_compiler.compile_bibliography_with_types(&csln_bib, is_numeric);
-    let new_cit = template_compiler.compile_citation(&csln_cit);
-    let citation_position_overrides = CitationPositionOverrides {
-        subsequent: compile_citation_position_override(
-            &template_compiler,
-            &compressor,
-            citation_position_nodes.subsequent,
-        ),
-        ibid: compile_citation_position_override(
-            &template_compiler,
-            &compressor,
-            citation_position_nodes.ibid,
-        ),
-    };
-
-    record_template_placements_if_enabled(&new_bib, enable_provenance, tracker);
-
-    // Apply author suffix extracted from original CSL (lost during macro inlining)
-    analysis::bibliography::apply_author_suffix(&mut new_bib, author_suffix);
-
-    // Apply bibliography-specific 'and' setting (may differ from citation)
-    analysis::bibliography::apply_bibliography_and(&mut new_bib, bib_and);
-
-    // For author-date styles with in-text class, apply standard formatting.
-    // Note styles (class="note") should NOT have these transformations applied.
-    let is_in_text_class = legacy_style.class == "in-text";
-    let is_author_date_processing = matches!(
-        options.processing,
-        Some(citum_schema::options::Processing::AuthorDate)
-    );
-
-    // Apply to all in-text styles (both author-date and numeric)
-    if is_in_text_class {
-        // Add space prefix to volume when it follows parent-serial directly.
-        // This handles numeric styles where journal and volume are siblings, not in a List.
-        passes::reorder::add_volume_prefix_after_serial(&mut new_bib);
-    }
-
-    // Detect holistic style preset for semantic fixups
-    let style_base = base_detector::detect_style_base(options);
-    if let Some(base) = style_base {
-        eprintln!("Detected style base: {base:?}");
-    }
-
-    if is_in_text_class && is_author_date_processing {
-        apply_author_date_bibliography_passes(&mut new_bib, options, style_base);
-    }
-
-    let type_templates_opt = if type_templates.is_empty() {
-        None
-    } else {
-        Some(type_templates)
-    };
-
-    (
-        new_bib,
-        type_templates_opt,
-        new_cit,
-        citation_position_overrides,
-    )
-}
-
-fn log_template_sources(resolved: &template_resolver::ResolvedTemplates) {
-    if let Some(ref resolved_bib) = resolved.bibliography {
-        eprintln!("Using {} bibliography template", resolved_bib.source);
-        if let Some(conf) = resolved_bib.confidence {
-            eprintln!("  bibliography confidence: {:.0}%", conf * 100.0);
-        }
-    } else {
-        eprintln!(
-            "Using {} bibliography template",
-            template_resolver::TemplateSource::XmlCompiled
-        );
-    }
-
-    if let Some(ref resolved_cit) = resolved.citation {
-        eprintln!("Using {} citation template", resolved_cit.source);
-        if let Some(conf) = resolved_cit.confidence {
-            eprintln!("  citation confidence: {:.0}%", conf * 100.0);
-        }
-    } else {
-        eprintln!(
-            "Using {} citation template",
-            template_resolver::TemplateSource::XmlCompiled
-        );
-    }
-}
-
-fn select_and_process_bibliography_template(
-    resolved: &template_resolver::ResolvedTemplates,
-    xml_fallback: &Option<XmlFallback>,
-    legacy_style: &csl_legacy::model::Style,
-) -> (Vec<TemplateComponent>, Option<TypeTemplateMap>, bool) {
-    let (mut new_bib, mut type_templates, inferred_bib_source) =
-        if let Some(ref resolved_bib) = resolved.bibliography {
-            let inferred_bib = matches!(
-                resolved_bib.source,
-                template_resolver::TemplateSource::InferredCached(_)
-                    | template_resolver::TemplateSource::InferredLive
-            );
-
-            let merged_type_templates = if inferred_bib {
-                xml_fallback
-                    .as_ref()
-                    .and_then(|(_, type_templates, _, _)| type_templates.clone())
-                    .map(|type_templates| {
-                        type_templates
-                            .into_iter()
-                            .filter(|(selector, type_template)| {
-                                selector.type_names().iter().any(|type_name| {
-                                    should_merge_inferred_type_template(
-                                        type_name,
-                                        &resolved_bib.template,
-                                        type_template,
-                                    )
-                                })
-                            })
-                            .collect::<indexmap::IndexMap<_, _>>()
-                    })
-                    .filter(|m| !m.is_empty())
-            } else {
-                None
-            };
-
-            (
-                resolved_bib.template.clone(),
-                merged_type_templates,
-                inferred_bib,
-            )
-        } else {
-            let (new_bib, type_templates, _, _) = xml_fallback
-                .as_ref()
-                .expect("XML fallback must exist when bibliography is unresolved");
-            (new_bib.clone(), type_templates.clone(), false)
-        };
-
-    if inferred_bib_source {
-        postprocess_inferred_bibliography(&mut new_bib, &mut type_templates, legacy_style);
-    }
-
-    (new_bib, type_templates, inferred_bib_source)
-}
-
-fn select_citation_template(
-    resolved: &template_resolver::ResolvedTemplates,
-    xml_fallback: &Option<XmlFallback>,
-    inferred_bib_source: bool,
-    legacy_style: &csl_legacy::model::Style,
-    type_templates: &mut Option<TypeTemplateMap>,
-) -> (
-    Vec<TemplateComponent>,
-    Option<Vec<TemplateComponent>>,
-    Option<Vec<TemplateComponent>>,
-) {
-    let mut citation_subsequent_override: Option<Vec<TemplateComponent>> = None;
-    let mut citation_ibid_override: Option<Vec<TemplateComponent>> = None;
-    let new_cit = if let Some(ref resolved_cit) = resolved.citation {
-        resolved_cit.template.clone()
-    } else {
-        let (_, _, new_cit, citation_overrides) = xml_fallback
-            .as_ref()
-            .expect("XML fallback must exist when citation is unresolved");
-        citation_subsequent_override = citation_overrides.subsequent.clone();
-        citation_ibid_override = citation_overrides.ibid.clone();
-        new_cit.clone()
-    };
-
-    if inferred_bib_source {
-        ensure_personal_communication_omitted(legacy_style, &new_cit, type_templates);
-    }
-
-    (
-        new_cit,
-        citation_subsequent_override,
-        citation_ibid_override,
-    )
-}
-
-#[allow(
-    clippy::only_used_in_recursion,
-    reason = "params propagated for future type-override logic"
-)]
-fn apply_type_overrides(
-    component: &mut TemplateComponent,
-    volume_pages_delimiter: Option<DelimiterPunctuation>,
-    volume_list_has_space_prefix: bool,
-    style_base: Option<base_detector::StyleBase>,
-) {
-    if let TemplateComponent::Group(list) = component {
-        for item in &mut list.group {
-            apply_type_overrides(
-                item,
-                volume_pages_delimiter.clone(),
-                volume_list_has_space_prefix,
-                style_base,
-            );
-        }
-    }
-}
-
 fn relax_inferred_bibliography_date_suppression(template: &mut [TemplateComponent]) {
     for component in template {
         if let TemplateComponent::Group(list) = component {
             relax_inferred_bibliography_date_suppression(&mut list.group);
         }
-    }
-}
-
-fn apply_preset_extractions(options: &mut citum_schema::options::Config) {
-    if let Some(contributors) = options.contributors.clone()
-        && let Some(preset) = base_detector::detect_contributor_preset(&contributors)
-    {
-        options.contributors = Some(preset.config());
-    }
-
-    if let Some(titles) = options.titles.clone()
-        && let Some(preset) = base_detector::detect_title_preset(&titles)
-    {
-        options.titles = Some(preset.config());
-    }
-
-    if let Some(dates) = options.dates.clone()
-        && let Some(preset) = base_detector::detect_date_preset(&dates)
-    {
-        options.dates = Some(preset.config());
     }
 }
 
@@ -1792,23 +1390,22 @@ mod tests {
 
         let mut options = citum_schema::options::Config::default();
         let tracker = ProvenanceTracker::new(false);
-        let (_, _, citation_template, citation_overrides) =
-            compile_from_xml(&legacy_style, &mut options, false, &tracker);
+        let out = compilation::compile_from_xml(&legacy_style, &mut options, false, &tracker);
 
         assert!(
-            citation_template
+            out.citation
                 .iter()
                 .any(|component| matches!(component, TemplateComponent::Title(_))),
             "explicit first-position branch should become part of the base citation template"
         );
         assert!(
-            citation_template
+            out.citation
                 .iter()
                 .any(|component| matches!(component, TemplateComponent::Date(_))),
             "fallback content from sibling chooses should remain in the base citation template"
         );
 
-        let subsequent_template = citation_overrides
+        let subsequent_template = out.citation_overrides
             .subsequent
             .expect("subsequent branch should be migrated");
         assert!(
@@ -1824,7 +1421,7 @@ mod tests {
             "sibling choose fallback content should remain in the subsequent override"
         );
 
-        let ibid_template = citation_overrides
+        let ibid_template = out.citation_overrides
             .ibid
             .expect("ibid branch should be migrated");
         assert!(
@@ -1884,21 +1481,20 @@ mod tests {
 
         let mut options = citum_schema::options::Config::default();
         let tracker = ProvenanceTracker::new(false);
-        let (_, _, citation_template, citation_overrides) =
-            compile_from_xml(&legacy_style, &mut options, false, &tracker);
+        let out = compilation::compile_from_xml(&legacy_style, &mut options, false, &tracker);
 
         assert!(
-            citation_template
+            out.citation
                 .iter()
                 .any(|component| matches!(component, TemplateComponent::Title(_))),
             "base citation template should still contain the first-citation title"
         );
         assert!(
-            citation_overrides.subsequent.is_some(),
+            out.citation_overrides.subsequent.is_some(),
             "mixed note trees should now emit a subsequent override"
         );
         assert!(
-            citation_overrides
+            out.citation_overrides
                 .subsequent
                 .as_ref()
                 .is_some_and(|template| template
@@ -1938,15 +1534,14 @@ mod tests {
 
         let mut options = citum_schema::options::Config::default();
         let tracker = ProvenanceTracker::new(false);
-        let (_, _, citation_template, citation_overrides) =
-            compile_from_xml(&legacy_style, &mut options, false, &tracker);
+        let out = compilation::compile_from_xml(&legacy_style, &mut options, false, &tracker);
 
         assert!(
-            !citation_template.is_empty(),
+            !out.citation.is_empty(),
             "unsupported trees must still compile a base citation template"
         );
         assert!(
-            citation_overrides.subsequent.is_none() && citation_overrides.ibid.is_none(),
+            out.citation_overrides.subsequent.is_none() && out.citation_overrides.ibid.is_none(),
             "unsupported trees should not emit partial position overrides"
         );
     }

--- a/crates/citum-migrate/src/options_extractor/mod.rs
+++ b/crates/citum-migrate/src/options_extractor/mod.rs
@@ -19,10 +19,62 @@ mod tests;
 use citum_schema::options::{Config, Substitute, SubstituteConfig};
 use csl_legacy::model::Style;
 
-/// Extracts global configuration options from a CSL 1.0 style.
+/// The full set of configuration and flags extracted from a CSL 1.0 style.
+pub struct MigrationOptions {
+    /// The global configuration.
+    pub options: Config,
+    /// Bibliography-specific options.
+    pub bibliography_options: Option<citum_schema::BibliographyOptions>,
+    /// Citation-scoped contributor overrides.
+    pub citation_contributor_overrides: Option<citum_schema::options::ContributorConfig>,
+    /// Bibliography-scoped contributor overrides.
+    pub bibliography_contributor_overrides: Option<citum_schema::options::ContributorConfig>,
+    /// Whether the citation has a scoped shorten option.
+    pub citation_has_scope_shorten: bool,
+}
+
+/// Extracts global style options from a CSL 1.0 structure into Citum Config.
 pub struct OptionsExtractor;
 
 impl OptionsExtractor {
+    /// Extracts a full set of migration options from the given CSL 1.0 style.
+    pub fn extract_migration_options(style: &Style) -> MigrationOptions {
+        let mut options = Self::extract(style);
+        Self::apply_preset_extractions(&mut options);
+
+        let bibliography_options =
+            self::bibliography::extract_bibliography_config(style)
+                .map(|config| citum_schema::BibliographyOptions {
+                    article_journal: config.article_journal,
+                    subsequent_author_substitute: config.subsequent_author_substitute,
+                    subsequent_author_substitute_rule: config.subsequent_author_substitute_rule,
+                    hanging_indent: config.hanging_indent,
+                    entry_suffix: config.entry_suffix,
+                    separator: config.separator,
+                    suppress_period_after_url: config.suppress_period_after_url,
+                    compound_numeric: config.compound_numeric,
+                    ..Default::default()
+                });
+
+        let citation_contributor_overrides =
+            self::contributors::extract_citation_contributor_overrides(style);
+        let bibliography_contributor_overrides =
+            self::contributors::extract_bibliography_contributor_overrides(style);
+        
+        let citation_has_scope_shorten = citation_contributor_overrides
+            .as_ref()
+            .and_then(|contributors| contributors.shorten.as_ref())
+            .is_some();
+
+        MigrationOptions {
+            options,
+            bibliography_options,
+            citation_contributor_overrides,
+            bibliography_contributor_overrides,
+            citation_has_scope_shorten,
+        }
+    }
+
     /// Extract a Config from the given CSL 1.0 style.
     pub fn extract(style: &Style) -> Config {
         Config {
@@ -110,6 +162,27 @@ impl OptionsExtractor {
                 CslNode::Names(n) => Self::collect_macro_refs_from_nodes(&n.children, macros),
                 _ => {}
             }
+        }
+    }
+
+    fn apply_preset_extractions(options: &mut Config) {
+        use crate::base_detector;
+        if let Some(contributors) = options.contributors.clone()
+            && let Some(preset) = base_detector::detect_contributor_preset(&contributors)
+        {
+            options.contributors = Some(preset.config());
+        }
+
+        if let Some(titles) = options.titles.clone()
+            && let Some(preset) = base_detector::detect_title_preset(&titles)
+        {
+            options.titles = Some(preset.config());
+        }
+
+        if let Some(dates) = options.dates.clone()
+            && let Some(preset) = base_detector::detect_date_preset(&dates)
+        {
+            options.dates = Some(preset.config());
         }
     }
 }

--- a/crates/citum-migrate/src/options_extractor/mod.rs
+++ b/crates/citum-migrate/src/options_extractor/mod.rs
@@ -43,8 +43,8 @@ impl OptionsExtractor {
         Self::apply_preset_extractions(&mut options);
 
         let bibliography_options =
-            self::bibliography::extract_bibliography_config(style)
-                .map(|config| citum_schema::BibliographyOptions {
+            self::bibliography::extract_bibliography_config(style).map(|config| {
+                citum_schema::BibliographyOptions {
                     article_journal: config.article_journal,
                     subsequent_author_substitute: config.subsequent_author_substitute,
                     subsequent_author_substitute_rule: config.subsequent_author_substitute_rule,
@@ -54,13 +54,14 @@ impl OptionsExtractor {
                     suppress_period_after_url: config.suppress_period_after_url,
                     compound_numeric: config.compound_numeric,
                     ..Default::default()
-                });
+                }
+            });
 
         let citation_contributor_overrides =
             self::contributors::extract_citation_contributor_overrides(style);
         let bibliography_contributor_overrides =
             self::contributors::extract_bibliography_contributor_overrides(style);
-        
+
         let citation_has_scope_shorten = citation_contributor_overrides
             .as_ref()
             .and_then(|contributors| contributors.shorten.as_ref())

--- a/crates/citum-migrate/src/passes/reorder.rs
+++ b/crates/citum-migrate/src/passes/reorder.rs
@@ -312,7 +312,6 @@ pub fn add_volume_prefix_after_serial(components: &mut [TemplateComponent]) {
             && let Some(TemplateComponent::Number(num)) = components.get_mut(i)
             && num.number == NumberVariable::Volume
         {
-            eprintln!("DEBUG: Adding space prefix to volume after parent-serial");
             // Add space prefix if not already present
             if num.rendering.prefix.is_none() {
                 num.rendering.prefix = Some(" ".to_string());

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -612,7 +612,7 @@ pub struct TemplateDate {
 }
 
 /// Date variables.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum DateVariable {
@@ -664,7 +664,7 @@ pub struct TemplateTitle {
 }
 
 /// Types of titles.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
@@ -919,7 +919,7 @@ pub struct TemplateVariable {
 /// also present in [`NumberVariable`]. For example, `variable: volume` keeps the
 /// source value as plain text, while `number: volume` opts into numeric
 /// formatting behavior.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -612,7 +612,7 @@ pub struct TemplateDate {
 }
 
 /// Date variables.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum DateVariable {
@@ -664,7 +664,7 @@ pub struct TemplateTitle {
 }
 
 /// Types of titles.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
@@ -919,7 +919,7 @@ pub struct TemplateVariable {
 /// also present in [`NumberVariable`]. For example, `variable: volume` keeps the
 /// source value as plain text, while `number: volume` opts into numeric
 /// formatting behavior.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -79,9 +79,22 @@ Profile styles now use config-only wrappers over hidden compiled roots.
 
 Journal aliases are listed in `registry/default.yaml` under each entry's `aliases:` key. Each is a zero-config pointer to a profile or base style.
 
-### Independent Styles (Tier 4)
+Like Tier 2 styles, Tier 3 styles can use `extends:` to inherit a base structure while applying journal-specific config-only overrides (e.g., localized delimiters or specific locator labels).
 
-Styles in `styles/*.yaml` that have no journal aliases and are not used as bases. Includes OSCOLA, MHRA variants, GOST, and similar discipline-specific styles.
+### Profile Candidates (Backlog)
+
+The following styles have been identified via automated semantic skeleton analysis as high-probability candidates for `extends:` conversion:
+
+| Legacy Style | Target Base | Semantic Similarity |
+|--------------|-------------|---------------------|
+| `pharmacoepidemiology-and-drug-safety` | `elsevier-with-titles` | 0.84 |
+| `disability-and-rehabilitation` | `elsevier-with-titles` | 0.83 |
+| `zoological-journal-of-the-linnean-society` | `springer-basic-author-date` | 0.83 |
+| `the-lichenologist` | `springer-basic-author-date` | 0.83 |
+| `memorias-do-instituto-oswaldo-cruz` | `springer-basic-author-date` | 0.83 |
+| `techniques-et-culture` | `taylor-and-francis-cse` | 0.87 |
+| `hawaii-int-conf-system-sciences` | `taylor-and-francis-nlm` | 0.86 |
+| `cell-numeric` | `elsevier-with-titles` | 0.83 |
 
 ## Embedding Policy
 

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -16,7 +16,7 @@ Define a four-tier classification for all Citum styles. The taxonomy drives regi
 |------|------|------------|-----------------|--------------|
 | 1 | `base` | Complete style with full templates; serves as inheritance root | No | CSL oracle (citeproc-js) for CSL-derived; biblatex snapshot for biblatex-derived |
 | 2 | `profile` | Evidence-backed parent-plus-deltas style for a publisher, society, or standards body | Optional | Delta from its parent when a meaningful wrapper exists; otherwise direct oracle plus parent-diff evidence |
-| 3 | `journal` | Pure alias in the registry; no YAML file | N/A | Inherits from parent |
+| 3 | `journal` | Alias or config-only wrapper for a specific journal | Optional | Inherits from parent |
 | 4 | `independent` | Complete style; no aliases; no inheritance role | No | Own oracle |
 
 ## Profile Rule


### PR DESCRIPTION
This PR implements a profile discovery tool to identify CSL styles that are structural candidates for conversion to Citum 'extends:' profiles.

### Changes:
- **citum-migrate**: Refactored the XML compilation pipeline into a reusable library module (`compilation.rs`).
- **citum-analyze**: Added `--identify-profiles` flag using semantic skeleton matching (Jaccard similarity on template items).
- **citum-schema-style**: Added `Eq`, `Hash`, and `Ord` to core template enums for set-based analysis.
- **docs**: Updated `STYLE_TAXONOMY.md` with the identified candidate backlog and clarified Tier 3 inheritance.

### Findings:
Initial run on the independent legacy corpus identified 35+ high-probability candidates with >0.8 semantic similarity to existing bases (Elsevier, Springer, T&F).