### PR TITLE
feat: convert audited journal wrappers

### DIFF
--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
         .map(std::string::String::as_str);
 
     if identify_profiles {
-        profile_discovery::run_profile_discovery(styles_dir);
+        profile_discovery::run_profile_discovery(styles_dir, json_output);
     } else if quantify_savings {
         savings::run_savings_report(styles_dir, json_output);
     } else if rank_parents {
@@ -64,13 +64,15 @@ fn print_usage() {
     eprintln!("  citum_analyze <styles_dir> --quantify-savings [--json]");
     eprintln!("      Estimate how many CSL styles presets and locale overrides can replace.");
     eprintln!();
-    eprintln!("  citum_analyze <styles_dir> --identify-profiles");
-    eprintln!("      Identify styles that could be converted to config-only profiles.");
+    eprintln!("  citum_analyze <styles_dir> --identify-profiles [--json]");
+    eprintln!(
+        "      Audit the current journal-profile candidate shortlist with normalized IDs and repo evidence."
+    );
     eprintln!();
     eprintln!("Examples:");
     eprintln!("  citum_analyze styles-legacy/");
     eprintln!("  citum_analyze styles-legacy/ --rank-parents");
     eprintln!("  citum_analyze styles-legacy/ --rank-parents --format author-date --json");
     eprintln!("  citum_analyze styles-legacy/ --quantify-savings --json");
-    eprintln!("  citum_analyze styles-legacy/ --identify-profiles");
+    eprintln!("  citum_analyze styles-legacy/ --identify-profiles --json");
 }

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -4,10 +4,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
 use roxmltree::Document;
-use std::collections::HashSet;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::Path;
-use walkdir::WalkDir;
+use std::path::{Path, PathBuf};
 
 use citum_migrate::{OptionsExtractor, compilation, fixups, provenance::ProvenanceTracker};
 use citum_schema::StyleBase;
@@ -16,6 +16,244 @@ use citum_schema::template::{
     ContributorRole, DateVariable, NumberVariable, SimpleVariable, TemplateComponent, TitleType,
 };
 use csl_legacy::parser::parse_style;
+
+const AUDITED_CANDIDATES: &[AuditedCandidateSpec] = &[
+    AuditedCandidateSpec {
+        requested_id: "pharmacoepidemiology-and-drug-safety",
+        proposed_parent: "elsevier-with-titles",
+        corrected_parent: Some("american-medical-association"),
+        disposition: AuditDisposition::JournalProfile,
+        note: "Corrected away from Elsevier. Current CSL metadata and alias evidence point to AMA, and the remaining journal delta reduces to scoped options only.",
+    },
+    AuditedCandidateSpec {
+        requested_id: "disability-and-rehabilitation",
+        proposed_parent: "elsevier-with-titles",
+        corrected_parent: Some("elsevier-with-titles"),
+        disposition: AuditDisposition::JournalProfile,
+        note: "The current journal instructions do not contradict the Elsevier-like implementation family, and the remaining delta reduces to scoped options only.",
+    },
+    AuditedCandidateSpec {
+        requested_id: "zoological-journal-of-the-linnean-society",
+        proposed_parent: "springer-basic-author-date",
+        corrected_parent: None,
+        disposition: AuditDisposition::FalsePositive,
+        note: "The current OUP/Linnean signal does not support the Springer family mapping.",
+    },
+    AuditedCandidateSpec {
+        requested_id: "the-lichenologist",
+        proposed_parent: "springer-basic-author-date",
+        corrected_parent: None,
+        disposition: AuditDisposition::FalsePositive,
+        note: "The current Cambridge guide and weak output-match evidence do not justify a profile-style parent mapping.",
+    },
+    AuditedCandidateSpec {
+        requested_id: "memorias-do-instituto-oswaldo-cruz",
+        proposed_parent: "springer-basic-author-date",
+        corrected_parent: None,
+        disposition: AuditDisposition::FalsePositive,
+        note: "Current journal guidance supports a journal-specific house style, but not a reusable Springer parent. The reduced Citum style remains standalone.",
+    },
+    AuditedCandidateSpec {
+        requested_id: "techniques-et-culture",
+        proposed_parent: "taylor-and-francis-council-of-science-editors-author-date",
+        corrected_parent: None,
+        disposition: AuditDisposition::FalsePositive,
+        note: "Current OpenEdition and CSL-template evidence do not support the Taylor & Francis CSE family mapping.",
+    },
+    AuditedCandidateSpec {
+        requested_id: "hawaii-int-conf-system-sciences",
+        proposed_parent: "taylor-and-francis-national-library-of-medicine",
+        corrected_parent: None,
+        disposition: AuditDisposition::FalsePositive,
+        note: "The shorthand candidate ID was normalized, but current HICSS author instructions now prefer APA 7th, so the legacy numeric style should not keep an inferred parent wrapper.",
+    },
+    AuditedCandidateSpec {
+        requested_id: "cell-numeric",
+        proposed_parent: "elsevier-with-titles",
+        corrected_parent: Some("elsevier-with-titles"),
+        disposition: AuditDisposition::JournalProfile,
+        note: "The Cell-family numeric variant now reduces to metadata and scoped options only over Elsevier With Titles.",
+    },
+];
+
+const SPECIAL_NORMALIZATIONS: &[(&str, &str)] = &[(
+    "hawaii-int-conf-system-sciences",
+    "hawaii-international-conference-on-system-sciences-proceedings",
+)];
+
+/// Runs the profile discovery audit.
+pub fn run_profile_discovery(styles_dir: &str, json_output: bool) {
+    let workspace_root = workspace_root();
+    let bases = collect_base_semantic_sets();
+    let tracker = ProvenanceTracker::new(false);
+
+    let renamed_styles = load_renamed_styles(&workspace_root);
+    let alias_report = load_alias_report(&workspace_root);
+    let registry = load_registry_catalog(&workspace_root);
+    let styles_root = Path::new(styles_dir);
+
+    let mut audited_candidates = Vec::new();
+    let mut parse_errors = Vec::new();
+
+    for spec in AUDITED_CANDIDATES {
+        match audit_candidate(
+            styles_root,
+            spec,
+            &bases,
+            &tracker,
+            &renamed_styles,
+            alias_report.as_ref(),
+            registry.as_ref(),
+        ) {
+            Ok(candidate) => audited_candidates.push(candidate),
+            Err(error) => parse_errors.push(format!("{}: {error}", spec.requested_id)),
+        }
+    }
+
+    let report = ProfileDiscoveryReport {
+        styles_dir: styles_dir.to_string(),
+        summary: ProfileDiscoverySummary::from_candidates(&audited_candidates, &parse_errors),
+        audited_candidates,
+        parse_errors,
+    };
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report).unwrap());
+    } else {
+        print_profile_discovery_report(&report);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AuditedCandidateSpec {
+    requested_id: &'static str,
+    proposed_parent: &'static str,
+    corrected_parent: Option<&'static str>,
+    disposition: AuditDisposition,
+    note: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[allow(
+    dead_code,
+    reason = "The current shortlist uses only part of the audit vocabulary, but the full set of dispositions remains intentional."
+)]
+#[serde(rename_all = "kebab-case")]
+enum AuditDisposition {
+    JournalProfile,
+    JournalAlias,
+    JournalStructural,
+    FalsePositive,
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileDiscoveryReport {
+    styles_dir: String,
+    summary: ProfileDiscoverySummary,
+    audited_candidates: Vec<AuditedProfileCandidate>,
+    parse_errors: Vec<String>,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct ProfileDiscoverySummary {
+    total_audited: usize,
+    journal_profile: usize,
+    journal_alias: usize,
+    journal_structural: usize,
+    false_positive: usize,
+    corrected_parent_changes: usize,
+    parse_errors: usize,
+}
+
+impl ProfileDiscoverySummary {
+    fn from_candidates(candidates: &[AuditedProfileCandidate], parse_errors: &[String]) -> Self {
+        let mut summary = Self {
+            total_audited: candidates.len() + parse_errors.len(),
+            parse_errors: parse_errors.len(),
+            ..Self::default()
+        };
+
+        for candidate in candidates {
+            match candidate.disposition {
+                AuditDisposition::JournalProfile => summary.journal_profile += 1,
+                AuditDisposition::JournalAlias => summary.journal_alias += 1,
+                AuditDisposition::JournalStructural => summary.journal_structural += 1,
+                AuditDisposition::FalsePositive => summary.false_positive += 1,
+            }
+
+            if candidate
+                .corrected_parent
+                .as_deref()
+                .is_some_and(|parent| parent != candidate.proposed_parent.as_str())
+            {
+                summary.corrected_parent_changes += 1;
+            }
+        }
+
+        summary
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AuditedProfileCandidate {
+    requested_id: String,
+    normalized_id: String,
+    legacy_path: String,
+    title: String,
+    proposed_parent: String,
+    corrected_parent: Option<String>,
+    disposition: AuditDisposition,
+    profile_ready: bool,
+    citation_format: Option<String>,
+    fields: Vec<String>,
+    template_target: Option<String>,
+    documentation_links: Vec<String>,
+    alias_evidence: Option<AliasEvidence>,
+    structural_match: StructuralMatch,
+    audit_note: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct AliasEvidence {
+    best_target: String,
+    similarity: f32,
+    citation_match: f32,
+    bibliography_match: f32,
+    evidence_url: Option<String>,
+    confidence_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StructuralMatch {
+    best_target: String,
+    bibliography_similarity: f32,
+    citation_similarity: f32,
+    combined_similarity: f32,
+}
+
+#[derive(Debug, Default)]
+struct RegistryCatalog {
+    ids: HashSet<String>,
+    alias_to_id: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryFile {
+    styles: Vec<RegistryEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryEntry {
+    id: String,
+    aliases: Option<Vec<String>>,
+}
+
+#[derive(Debug)]
+struct LegacyStyleMetadata {
+    title: String,
+    citation_format: Option<String>,
+    fields: Vec<String>,
+}
 
 /// A simplified semantic representation of a template component.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -26,6 +264,313 @@ enum SemanticItem {
     Contributor(ContributorRole),
     Title(TitleType),
     Term(GeneralTerm),
+}
+
+fn collect_base_semantic_sets()
+-> Vec<(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)> {
+    StyleBase::all()
+        .iter()
+        .map(|base| {
+            let style = base.base().into_resolved();
+            let bib_set = style
+                .bibliography
+                .as_ref()
+                .and_then(|b| b.template.as_ref())
+                .map(|t| template_to_set(t))
+                .unwrap_or_default();
+
+            let mut cit_sets = Vec::new();
+            if let Some(cit) = &style.citation {
+                if let Some(t) = &cit.template {
+                    cit_sets.push(template_to_set(t));
+                }
+                if let Some(i) = &cit.integral
+                    && let Some(t) = &i.template
+                {
+                    cit_sets.push(template_to_set(t));
+                }
+                if let Some(ni) = &cit.non_integral
+                    && let Some(t) = &ni.template
+                {
+                    cit_sets.push(template_to_set(t));
+                }
+            }
+
+            (base.clone(), bib_set, cit_sets)
+        })
+        .collect()
+}
+
+fn audit_candidate(
+    styles_root: &Path,
+    spec: &AuditedCandidateSpec,
+    bases: &[(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)],
+    tracker: &ProvenanceTracker,
+    renamed_styles: &HashMap<String, String>,
+    alias_report: Option<&HashMap<String, AliasEvidence>>,
+    registry: Option<&RegistryCatalog>,
+) -> Result<AuditedProfileCandidate, String> {
+    let normalized_id = normalize_style_id(spec.requested_id, renamed_styles);
+    let file_path = styles_root.join(format!("{normalized_id}.csl"));
+    let content = fs::read_to_string(&file_path).map_err(|e| format!("read error: {e}"))?;
+    let doc = Document::parse(&content).map_err(|e| format!("parse error: {e}"))?;
+    let legacy_style =
+        parse_style(doc.root_element()).map_err(|e| format!("legacy parse error: {e}"))?;
+    let metadata = parse_legacy_style_metadata(&doc);
+
+    let template_target = first_template_target(&legacy_style.info.links)
+        .map(|target| resolve_registry_target(&target, registry));
+    let documentation_links = documentation_links(&legacy_style.info.links);
+    let structural_match = resolve_structural_match(
+        compute_structural_match(&legacy_style, bases, tracker),
+        registry,
+    );
+    let alias_evidence = alias_report.and_then(|rows| rows.get(&normalized_id).cloned());
+
+    Ok(AuditedProfileCandidate {
+        requested_id: spec.requested_id.to_string(),
+        normalized_id: normalized_id.clone(),
+        legacy_path: file_path.display().to_string(),
+        title: metadata.title,
+        proposed_parent: spec.proposed_parent.to_string(),
+        corrected_parent: spec.corrected_parent.map(str::to_string),
+        disposition: spec.disposition,
+        profile_ready: matches!(spec.disposition, AuditDisposition::JournalProfile),
+        citation_format: metadata.citation_format,
+        fields: metadata.fields,
+        template_target,
+        documentation_links,
+        alias_evidence,
+        structural_match,
+        audit_note: spec.note.to_string(),
+    })
+}
+
+fn parse_legacy_style_metadata(doc: &Document<'_>) -> LegacyStyleMetadata {
+    let root = doc.root_element();
+    let mut title = String::new();
+    let mut citation_format = None;
+    let mut fields = Vec::new();
+
+    for child in root.children().filter(roxmltree::Node::is_element) {
+        if child.tag_name().name() != "info" {
+            continue;
+        }
+
+        for info_child in child.children().filter(roxmltree::Node::is_element) {
+            match info_child.tag_name().name() {
+                "title" if title.is_empty() => {
+                    title = info_child.text().unwrap_or_default().trim().to_string();
+                }
+                "category" => {
+                    if let Some(format) = info_child.attribute("citation-format") {
+                        citation_format = Some(format.to_string());
+                    }
+                    if let Some(field) = info_child.attribute("field") {
+                        fields.push(field.to_string());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    LegacyStyleMetadata {
+        title,
+        citation_format,
+        fields,
+    }
+}
+
+fn compute_structural_match(
+    legacy_style: &csl_legacy::model::Style,
+    bases: &[(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)],
+    tracker: &ProvenanceTracker,
+) -> StructuralMatch {
+    let migration_options = OptionsExtractor::extract_migration_options(legacy_style);
+    let mut options = migration_options.options;
+    let compiled = compilation::compile_from_xml(legacy_style, &mut options, false, tracker);
+
+    let mut citation_template = compiled.citation.clone();
+    if matches!(
+        options.processing,
+        Some(citum_schema::options::Processing::Numeric)
+    ) {
+        fixups::ensure_numeric_locator_citation_component(
+            &legacy_style.citation.layout,
+            &mut citation_template,
+        );
+    } else if legacy_style.class == "in-text" {
+        fixups::normalize_author_date_locator_citation_component(
+            &legacy_style.citation.layout,
+            &legacy_style.macros,
+            &mut citation_template,
+        );
+    }
+
+    let bibliography_set = template_to_set(&compiled.bibliography);
+    let citation_set = template_to_set(&citation_template);
+
+    let mut best_match = StructuralMatch {
+        best_target: String::new(),
+        bibliography_similarity: 0.0,
+        citation_similarity: 0.0,
+        combined_similarity: 0.0,
+    };
+
+    for (base, base_bib_set, base_cit_sets) in bases {
+        let bibliography_similarity = jaccard_similarity(&bibliography_set, base_bib_set);
+        let citation_similarity = if base_cit_sets.is_empty() {
+            1.0
+        } else {
+            base_cit_sets
+                .iter()
+                .map(|base_cit_set| jaccard_similarity(&citation_set, base_cit_set))
+                .fold(0.0, f32::max)
+        };
+        let combined_similarity = f32::midpoint(bibliography_similarity, citation_similarity);
+
+        if combined_similarity > best_match.combined_similarity {
+            best_match = StructuralMatch {
+                best_target: base.key().to_string(),
+                bibliography_similarity,
+                citation_similarity,
+                combined_similarity,
+            };
+        }
+    }
+
+    best_match
+}
+
+fn first_template_target(links: &[csl_legacy::model::InfoLink]) -> Option<String> {
+    links
+        .iter()
+        .find(|link| link.rel.as_deref() == Some("template"))
+        .map(|link| short_name_from_identifier(&link.href).into_owned())
+}
+
+fn documentation_links(links: &[csl_legacy::model::InfoLink]) -> Vec<String> {
+    links
+        .iter()
+        .filter(|link| link.rel.as_deref() == Some("documentation"))
+        .map(|link| sanitize_url(&link.href))
+        .collect()
+}
+
+fn load_alias_report(workspace_root: &Path) -> Option<HashMap<String, AliasEvidence>> {
+    let path = workspace_root.join("scripts/report-data/alias-candidates-2026-04-19.tsv");
+    let content = fs::read_to_string(path).ok()?;
+    let mut rows = HashMap::new();
+
+    for line in content.lines().skip(1) {
+        let columns: Vec<_> = line.split('\t').collect();
+        if columns.len() < 7 {
+            continue;
+        }
+
+        let candidate_id = columns[0].to_string();
+        rows.insert(
+            candidate_id,
+            AliasEvidence {
+                best_target: columns[1].to_string(),
+                similarity: columns[2].parse().unwrap_or_default(),
+                citation_match: columns[3].parse().unwrap_or_default(),
+                bibliography_match: columns[4].parse().unwrap_or_default(),
+                evidence_url: non_empty(columns[5]),
+                confidence_note: non_empty(columns[6]),
+            },
+        );
+    }
+
+    Some(rows)
+}
+
+fn load_renamed_styles(workspace_root: &Path) -> HashMap<String, String> {
+    let path = workspace_root.join("styles-legacy/renamed-styles.json");
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
+        .unwrap_or_default()
+}
+
+fn load_registry_catalog(workspace_root: &Path) -> Option<RegistryCatalog> {
+    let path = workspace_root.join("registry/default.yaml");
+    let content = fs::read_to_string(path).ok()?;
+    let registry: RegistryFile = serde_yaml::from_str(&content).ok()?;
+    let mut catalog = RegistryCatalog::default();
+
+    for entry in registry.styles {
+        catalog.ids.insert(entry.id.clone());
+        if let Some(aliases) = entry.aliases {
+            for alias in aliases {
+                catalog.alias_to_id.insert(alias, entry.id.clone());
+            }
+        }
+    }
+
+    Some(catalog)
+}
+
+fn resolve_registry_target(target: &str, registry: Option<&RegistryCatalog>) -> String {
+    match registry {
+        Some(registry) if registry.ids.contains(target) => target.to_string(),
+        Some(registry) if target.ends_with("-core") => {
+            let public_target = target.trim_end_matches("-core");
+            if registry.ids.contains(public_target) {
+                public_target.to_string()
+            } else {
+                target.to_string()
+            }
+        }
+        Some(registry) => registry
+            .alias_to_id
+            .get(target)
+            .cloned()
+            .unwrap_or_else(|| target.to_string()),
+        None => target.to_string(),
+    }
+}
+
+fn resolve_structural_match(
+    mut structural_match: StructuralMatch,
+    registry: Option<&RegistryCatalog>,
+) -> StructuralMatch {
+    structural_match.best_target = resolve_registry_target(&structural_match.best_target, registry);
+    structural_match
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap_or_else(|_| Path::new(env!("CARGO_MANIFEST_DIR")).join("../.."))
+}
+
+fn normalize_style_id(style_id: &str, renamed_styles: &HashMap<String, String>) -> String {
+    let mut normalized = style_id.to_string();
+
+    for (from, to) in SPECIAL_NORMALIZATIONS {
+        if normalized == *from {
+            normalized = (*to).to_string();
+        }
+    }
+
+    renamed_styles
+        .get(&normalized)
+        .cloned()
+        .unwrap_or(normalized)
+}
+
+fn jaccard_similarity(left: &HashSet<SemanticItem>, right: &HashSet<SemanticItem>) -> f32 {
+    let intersection = left.intersection(right).count();
+    let union = left.union(right).count();
+
+    if union == 0 {
+        1.0
+    } else {
+        intersection as f32 / union as f32
+    }
 }
 
 fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem>) {
@@ -55,147 +600,127 @@ fn template_to_set(template: &[TemplateComponent]) -> HashSet<SemanticItem> {
     items.into_iter().collect()
 }
 
-/// Runs the profile discovery analysis.
-pub fn run_profile_discovery(styles_dir: &str) {
-    eprintln!(
-        "Analyzing styles in {} to identify profile candidates...",
-        styles_dir
+fn short_name_from_identifier(identifier: &str) -> std::borrow::Cow<'_, str> {
+    identifier.rsplit('/').next().map_or_else(
+        || std::borrow::Cow::Borrowed(identifier),
+        std::borrow::Cow::Borrowed,
+    )
+}
+
+fn sanitize_url(url: &str) -> String {
+    url.strip_prefix('h')
+        .filter(|_| url.starts_with("hhttps://"))
+        .unwrap_or(url)
+        .to_string()
+}
+
+fn non_empty(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn print_profile_discovery_report(report: &ProfileDiscoveryReport) {
+    println!("=== Journal-Profile Candidate Audit ===\n");
+    println!("Styles directory: {}", report.styles_dir);
+    println!("Audited candidates: {}", report.summary.total_audited);
+    println!(
+        "Dispositions: {} journal-structural, {} false-positive, {} journal-profile, {} journal-alias",
+        report.summary.journal_structural,
+        report.summary.false_positive,
+        report.summary.journal_profile,
+        report.summary.journal_alias
     );
+    println!(
+        "Corrected parent mappings: {}",
+        report.summary.corrected_parent_changes
+    );
+    println!();
 
-    // Pre-resolve all style bases and their semantic sets
-    let bases: Vec<(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)> =
-        StyleBase::all()
-            .iter()
-            .map(|base| {
-                let style = base.base().into_resolved();
-                let bib_set = style
-                    .bibliography
-                    .as_ref()
-                    .and_then(|b| b.template.as_ref())
-                    .map(|t| template_to_set(t))
-                    .unwrap_or_default();
-
-                let mut cit_sets = Vec::new();
-                if let Some(cit) = &style.citation {
-                    if let Some(t) = &cit.template {
-                        cit_sets.push(template_to_set(t));
-                    }
-                    if let Some(i) = &cit.integral
-                        && let Some(t) = &i.template
-                    {
-                        cit_sets.push(template_to_set(t));
-                    }
-                    if let Some(ni) = &cit.non_integral
-                        && let Some(t) = &ni.template
-                    {
-                        cit_sets.push(template_to_set(t));
-                    }
-                }
-
-                (base.clone(), bib_set, cit_sets)
-            })
-            .collect();
-
-    let tracker = ProvenanceTracker::new(false);
-    let mut count = 0;
-
-    for entry in WalkDir::new(styles_dir)
-        .into_iter()
-        .filter_entry(|e| e.file_name().to_str().is_none_or(|s| s != "dependent"))
-        .filter_map(Result::ok)
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "csl"))
-    {
-        count += 1;
-        if count % 100 == 0 {
-            eprintln!("Processed {} styles...", count);
+    for candidate in &report.audited_candidates {
+        println!(
+            "{} [{}]",
+            candidate.normalized_id,
+            candidate.disposition_label()
+        );
+        println!("  proposed parent: {}", candidate.proposed_parent);
+        if let Some(corrected_parent) = &candidate.corrected_parent {
+            println!("  corrected parent: {corrected_parent}");
         }
-        let path = entry.path();
-        if let Err(_e) = identify_profile_match(path, &bases, &tracker) {
-            // Silence errors for batch processing
+        println!(
+            "  structural match: {} (bib {:.2}, cit {:.2}, combined {:.2})",
+            candidate.structural_match.best_target,
+            candidate.structural_match.bibliography_similarity,
+            candidate.structural_match.citation_similarity,
+            candidate.structural_match.combined_similarity
+        );
+        if let Some(alias_evidence) = &candidate.alias_evidence {
+            println!(
+                "  alias evidence: {} (sim {:.2}, cite {:.2}, bib {:.2})",
+                alias_evidence.best_target,
+                alias_evidence.similarity,
+                alias_evidence.citation_match,
+                alias_evidence.bibliography_match
+            );
+        }
+        if let Some(template_target) = &candidate.template_target {
+            println!("  CSL template link: {template_target}");
+        }
+        println!("  note: {}", candidate.audit_note);
+        println!();
+    }
+
+    if !report.parse_errors.is_empty() {
+        println!("Parse errors:");
+        for error in &report.parse_errors {
+            println!("  - {error}");
         }
     }
 }
 
-fn identify_profile_match(
-    path: &Path,
-    bases: &[(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)],
-    tracker: &ProvenanceTracker,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let text = fs::read_to_string(path)?;
-    let doc = Document::parse(&text)?;
-    let legacy_style = parse_style(doc.root_element())?;
-
-    // Skip dependent styles for this analysis
-    if text.contains("rel=\"independent-parent\"") {
-        return Ok(());
-    }
-
-    // 1. Extract migration options
-    let migration_options = OptionsExtractor::extract_migration_options(&legacy_style);
-    let mut options = migration_options.options;
-
-    // 2. Compile templates from XML
-    let compiled = compilation::compile_from_xml(&legacy_style, &mut options, false, tracker);
-
-    let mut new_cit = compiled.citation.clone();
-    if matches!(
-        options.processing,
-        Some(citum_schema::options::Processing::Numeric)
-    ) {
-        fixups::ensure_numeric_locator_citation_component(
-            &legacy_style.citation.layout,
-            &mut new_cit,
-        );
-    } else if legacy_style.class == "in-text" {
-        fixups::normalize_author_date_locator_citation_component(
-            &legacy_style.citation.layout,
-            &legacy_style.macros,
-            &mut new_cit,
-        );
-    }
-
-    let bib_set = template_to_set(&compiled.bibliography);
-    let cit_set = template_to_set(&new_cit);
-
-    // 4. Compare semantic sets with each base
-    for (base_enum, base_bib_set, base_cit_sets) in bases {
-        // Use a similarity threshold instead of exact match for the set
-        let bib_intersection = bib_set.intersection(base_bib_set).count();
-        let bib_union = bib_set.union(base_bib_set).count();
-        let bib_sim = if bib_union > 0 {
-            bib_intersection as f32 / bib_union as f32
-        } else {
-            1.0
-        };
-
-        let cit_sim = if base_cit_sets.is_empty() {
-            1.0
-        } else {
-            base_cit_sets
-                .iter()
-                .map(|base_cit_set| {
-                    let cit_intersection = cit_set.intersection(base_cit_set).count();
-                    let cit_union = cit_set.union(base_cit_set).count();
-                    if cit_union > 0 {
-                        cit_intersection as f32 / cit_union as f32
-                    } else {
-                        1.0
-                    }
-                })
-                .max_by(|a, b| a.partial_cmp(b).unwrap())
-                .unwrap_or(0.0)
-        };
-
-        if bib_sim > 0.8 && cit_sim > 0.8 {
-            println!(
-                "Candidate found: {} (Similarity: bib={:.2}, cit={:.2}) could extend '{}'",
-                path.display(),
-                bib_sim,
-                cit_sim,
-                base_enum.key()
-            );
+impl AuditedProfileCandidate {
+    fn disposition_label(&self) -> &'static str {
+        match self.disposition {
+            AuditDisposition::JournalProfile => "journal-profile",
+            AuditDisposition::JournalAlias => "journal-alias",
+            AuditDisposition::JournalStructural => "journal-structural",
+            AuditDisposition::FalsePositive => "false-positive",
         }
     }
+}
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_special_hawaii_candidate_id() {
+        let renamed = HashMap::new();
+        assert_eq!(
+            normalize_style_id("hawaii-int-conf-system-sciences", &renamed),
+            "hawaii-international-conference-on-system-sciences-proceedings"
+        );
+    }
+
+    #[test]
+    fn applies_renamed_style_map_after_special_normalization() {
+        let renamed = HashMap::from([(
+            "hawaii-international-conference-on-system-sciences-proceedings".to_string(),
+            "hawaii-proceedings".to_string(),
+        )]);
+        assert_eq!(
+            normalize_style_id("hawaii-int-conf-system-sciences", &renamed),
+            "hawaii-proceedings"
+        );
+    }
+
+    #[test]
+    fn parses_non_empty_values() {
+        assert_eq!(non_empty(""), None);
+        assert_eq!(non_empty("  "), None);
+        assert_eq!(non_empty("value"), Some("value".to_string()));
+    }
 }

--- a/docs/architecture/2026-04-22_JOURNAL_PROFILE_CANDIDATE_AUDIT.md
+++ b/docs/architecture/2026-04-22_JOURNAL_PROFILE_CANDIDATE_AUDIT.md
@@ -1,0 +1,76 @@
+# Journal-Profile Candidate Audit
+
+**Date:** 2026-04-22
+**Related:** `docs/specs/JOURNAL_PROFILE_TAXONOMY_AUDIT.md`, `docs/specs/STYLE_TAXONOMY.md`, commit `9e13a17b`
+
+## Summary
+
+This pass audited the eight backlog entries added in `9e13a17b` against four
+evidence surfaces:
+
+1. current guide or current public journal signal
+2. CSL metadata and `rel="template"` links
+3. `scripts/report-data/alias-candidates-2026-04-19.tsv`
+4. `cargo run --bin citum-analyze -- styles-legacy --identify-profiles --json`
+
+Outcome summary:
+
+- `3` promoted to journal config-wrapper
+- `0` promoted to alias
+- `0` retained as structural descendants
+- `5` demoted to false positives or unsupported parent links
+
+This means the `9e13a17b` pass was useful for family triage, but it needed a
+second guide-driven reduction pass before any inheritance claim was trustworthy.
+
+## Evidence Table
+
+| Candidate | Proposed Parent | Corrected Parent | Current guide or public signal | CSL metadata | Alias TSV | Analyzer audit | Outcome |
+|-----------|-----------------|------------------|-------------------------------|--------------|-----------|----------------|---------|
+| `pharmacoepidemiology-and-drug-safety` | `elsevier-with-titles` | `american-medical-association` | Wiley author-guidance link remains the concrete public style pointer in CSL metadata. | `rel="template"` points to AMA. | Best target `american-medical-association`, similarity `0.9881`, cite `1.00`, bib `0.00`. | Structural best match `elsevier-with-titles` with combined `0.92`, but authority evidence favors AMA. | `journal + config-wrapper` |
+| `disability-and-rehabilitation` | `elsevier-with-titles` | `elsevier-with-titles` | The surviving public style evidence is the journal-specific Taylor & Francis PDF linked from CSL metadata. | `rel="template"` points to `cse-citation-sequence`. | Best target `elsevier-with-titles`, similarity `1.00`, cite `1.00`, bib `0.00`. | Structural best match `elsevier-with-titles` with combined `0.92`. | `journal + config-wrapper` |
+| `zoological-journal-of-the-linnean-society` | `springer-basic-author-date` | — | Current OUP instructions still describe the journal as its own Linnean/OUP style surface, not a Springer family style: [General Instructions](https://academic.oup.com/zoolinnean/pages/General_Instructions). | `rel="template"` points to `biological-journal-of-the-linnean-society`. | Best target `springer-basic-author-date`, similarity `1.00`, cite `0.15`, bib `0.00`. | Structural best match `springer-basic-author-date` with combined `0.92`, but authority evidence contradicts the family mapping. | `false-positive` |
+| `the-lichenologist` | `springer-basic-author-date` | — | Current Cambridge journal guidance is reachable and does not support a Springer-family relationship: [Author instructions](https://www.cambridge.org/core/journals/lichenologist/information/author-instructions). | no template parent in CSL metadata | Best target `elsevier-harvard`, similarity `0.9746`, cite `0.05`, bib `0.00`. | Structural best match `springer-basic-author-date` with combined `0.92`, but output evidence is weak and public authority contradicts the mapping. | `false-positive` |
+| `memorias-do-instituto-oswaldo-cruz` | `springer-basic-author-date` | — | Current journal instructions remain reachable and describe a journal-specific publication style, not a Springer family style: [Instructions to authors](https://memorias.ioc.fiocruz.br/instructions-to-authors). | no template parent in CSL metadata | Best target `springer-basic-author-date`, similarity `1.00`, cite `0.65`, bib `0.00`. | Structural best match `springer-basic-author-date` with combined `0.92`, but the remaining style is effectively standalone after reduction. | `independent + standalone` |
+| `techniques-et-culture` | `taylor-and-francis-council-of-science-editors-author-date` | — | Current public journal surface is OpenEdition, not Taylor & Francis: [journal page](https://journals.openedition.org/tc/1556#tocto3n5). | `rel="template"` points to `ethnologie-francaise`. | Best target `elsevier-harvard`, similarity `0.9546`, cite `0.05`, bib `0.00`. | Structural best match `taylor-and-francis-council-of-science-editors-author-date` with combined `0.93`, but authority evidence does not support the family claim. | `false-positive` |
+| `hawaii-international-conference-on-system-sciences-proceedings` | `taylor-and-francis-national-library-of-medicine` | — | Current conference author page remains reachable and now says references and in-text citation should follow APA 7th: [HICSS authors](https://hicss.hawaii.edu/authors/). | `rel="template"` points to `acm-sigchi-proceedings`. | Best target `ieee`, similarity `0.9881`, cite `0.50`, bib `0.00`. | Structural best match `taylor-and-francis-national-library-of-medicine` with combined `0.93`, but current guide evidence contradicts any IEEE-family wrapper. | `false-positive; temporary IEEE-based legacy hold` |
+| `cell-numeric` | `elsevier-with-titles` | `elsevier-with-titles` | Current public Cell-family signal remains the style's own journal guidance link from CSL metadata (`current-biology/authors`), which uses Current Biology numbered references. | no template parent in CSL metadata | Best target `elsevier-with-titles`, similarity `1.00`, cite `1.00`, bib `0.00`. | Structural best match `elsevier-with-titles` with combined `0.92`. | `journal + config-wrapper` |
+
+## Interpretation
+
+### What `9e13a17b` got right
+
+- It surfaced several styles that do belong near an existing Citum family.
+- The semantic skeleton comparison is good enough to rank likely families for
+  manual audit.
+
+### What `9e13a17b` got wrong
+
+- It treated family similarity as if it were close to wrapper readiness.
+- It did not normalize the HICSS shorthand candidate ID.
+- It did not distinguish between "wrong hub" and "right family but still
+  structural".
+
+## Decision
+
+Three candidates were converted into public journal config-wrappers with
+corrected parents:
+
+- `pharmacoepidemiology-and-drug-safety` → `american-medical-association`
+- `disability-and-rehabilitation` → `elsevier-with-titles`
+- `cell-numeric` → `elsevier-with-titles`
+
+One candidate lost its parent link and remains standalone:
+
+- `memorias-do-instituto-oswaldo-cruz`
+
+One candidate remains a documented temporary legacy hold:
+
+- `hawaii-international-conference-on-system-sciences-proceedings` → `ieee`
+
+The audit recommendation is:
+
+- keep only the parent links that survive a guide-driven reduction pass
+- mark the unsupported mappings as `false-positive` or standalone legacy holds
+- revise the public taxonomy so journal descendants are no longer forced into
+  the same bucket as aliases or config-only wrappers

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -12,7 +12,7 @@ Citum introduces a modern, declarative approach to citation styling compared to 
 | Logic | `choose`/`if`/`else` conditionals | Type variants + inheritance |
 | Name Formatting | Inline XML attributes | Global presets + options |
 | Dates | Object with year/month/day | EDTF string format |
-| Inheritance | Parent style aliasing | Extends + profile options |
+| Inheritance | Parent style aliasing | Extends + scoped options |
 | Readability | Verbose and nested | Concise and explicit |
 
 > [!TIP]

--- a/docs/specs/JOURNAL_PROFILE_TAXONOMY_AUDIT.md
+++ b/docs/specs/JOURNAL_PROFILE_TAXONOMY_AUDIT.md
@@ -1,0 +1,115 @@
+# Journal-Profile Taxonomy Audit
+
+**Status:** Draft
+**Date:** 2026-04-22
+**Related:** `STYLE_TAXONOMY.md`, `UNIFIED_SCOPED_OPTIONS.md`, `../architecture/2026-04-22_JOURNAL_PROFILE_CANDIDATE_AUDIT.md`, commit `9e13a17b`
+
+## Summary
+
+This audit revisits the `9e13a17b` "Profile Candidates" backlog after the
+project introduced config-only public profile wrappers.
+
+The result is a taxonomy correction plus a bounded reduction pass:
+
+- `profile` remains a semantic class **and** an implementation contract
+- `journal` becomes semantic only
+- journal descendants may now be represented as `alias`, `config-wrapper`, or
+  `structural-wrapper`
+
+The audited shortlist produced:
+
+- `3` journal-profile promotions
+- `0` new aliases
+- `0` converted journal-structural descendants
+- `5` false positives, dropped parent links, or temporary legacy holds
+
+## Findings
+
+### 1. The old tier model mixed two different questions
+
+The prior table answered both:
+
+- what relationship a style has to a parent
+- how that relationship is currently encoded
+
+That works for `base` and `profile`, but it breaks down for journals because the
+repo already contains all three of these:
+
+- pure registry aliases
+- thin journal wrappers
+- journal descendants with local templates
+
+### 2. `9e13a17b` was useful as family triage, but not precise enough for promotion
+
+The shortlist still surfaced several real family signals:
+
+- `pharmacoepidemiology-and-drug-safety`
+- `disability-and-rehabilitation`
+- `memorias-do-instituto-oswaldo-cruz`
+- `hawaii-international-conference-on-system-sciences-proceedings`
+- `cell-numeric`
+
+The second-pass reduction changed that result materially:
+
+- `pharmacoepidemiology-and-drug-safety`
+- `disability-and-rehabilitation`
+- `cell-numeric`
+
+all reduce to config-only wrappers once copied CSL structure is treated as
+suspect and removed unless a guide-backed delta still requires it.
+
+One other did not justify keeping an inherited parent at all:
+
+- `memorias-do-instituto-oswaldo-cruz`
+
+`hawaii-international-conference-on-system-sciences-proceedings` remains a
+special case: current guide evidence contradicts the inferred IEEE family, but
+the legacy CSL-compatible Citum style still temporarily extends IEEE because
+that inherited surface materially preserves fidelity.
+
+### 3. Correct parent selection must prefer the nearest current Citum hub
+
+The audit confirmed two parent corrections that matter immediately:
+
+- `pharmacoepidemiology-and-drug-safety` should be evaluated against
+  `american-medical-association`, not `elsevier-with-titles`
+- `hawaii-international-conference-on-system-sciences-proceedings` should be
+  evaluated against `ieee`, not `taylor-and-francis-national-library-of-medicine`
+
+## Analyzer Contract
+
+`citum-analyze --identify-profiles` now acts as an audit-oriented triage report
+ for the current shortlist instead of printing raw semantic-similarity hits.
+
+The new report:
+
+- normalizes candidate IDs before lookup
+- joins CSL metadata, registry knowledge, and the dated alias TSV
+- reports corrected parent mappings separately from the originally proposed
+  parent
+- emits structured JSON via `--json`
+
+This is intentionally conservative. The tool should surface evidence and
+disposition, not silently promote styles.
+
+## Recommendation
+
+Adopt the two-axis taxonomy from `STYLE_TAXONOMY.md`:
+
+- semantic class: `base`, `profile`, `journal`, `independent`
+- implementation form: `alias`, `config-wrapper`, `structural-wrapper`,
+  `standalone`
+
+Keep the runtime `kind` enum unchanged in this pass. If the project later needs
+machine-readable implementation-form metadata, add a new field instead of
+redefining `kind`.
+
+## Defaults Chosen In This Pass
+
+- three journal candidates are promoted to config-only wrapper
+- no journal candidate is added as a registry alias
+- one journal candidate drops its parent link and remains standalone
+- one journal candidate remains a documented temporary legacy hold rather than a
+  taxonomy-backed parent mapping
+- false positives and unsupported parent links are kept explicit rather than
+  silently dropped from history

--- a/docs/specs/STYLE_TAXONOMY.md
+++ b/docs/specs/STYLE_TAXONOMY.md
@@ -1,115 +1,174 @@
 # Style Taxonomy
 
 **Status:** Active
-**Version:** 1.1
-**Date:** 2026-04-21
+**Version:** 1.5
+**Date:** 2026-04-22
 **Bean:** `csl26-v961`, `csl26-nrkn`
-**Related:** `STYLE_PRESET_ARCHITECTURE.md`, `../architecture/2026-04-21_PROFILE_WRAPPER_VALIDATION_PASS.md`
+**Related:** `STYLE_PRESET_ARCHITECTURE.md`, `UNIFIED_SCOPED_OPTIONS.md`, `JOURNAL_PROFILE_TAXONOMY_AUDIT.md`, `../architecture/2026-04-22_JOURNAL_PROFILE_CANDIDATE_AUDIT.md`
 
 ## Purpose
 
-Define a four-tier classification for all Citum styles. The taxonomy drives registry `kind` annotations, embedding decisions, and verification strategies.
+Define Citum style taxonomy on two separate axes:
 
-## Tiers
+1. semantic class: what kind of style relationship the entry represents
+2. implementation form: how that relationship is currently expressed in the repo
 
-| Tier | Kind | Definition | `extends:` field | Verification |
-|------|------|------------|-----------------|--------------|
-| 1 | `base` | Complete style with full templates; serves as inheritance root | No | CSL oracle (citeproc-js) for CSL-derived; biblatex snapshot for biblatex-derived |
-| 2 | `profile` | Evidence-backed parent-plus-deltas style for a publisher, society, or standards body | Optional | Delta from its parent when a meaningful wrapper exists; otherwise direct oracle plus parent-diff evidence |
-| 3 | `journal` | Alias or config-only wrapper for a specific journal | Optional | Inherits from parent |
-| 4 | `independent` | Complete style; no aliases; no inheritance role | No | Own oracle |
+This replaces the older single mixed tier table, which overloaded aliases,
+config-only wrappers, and structural journal descendants into one journal tier.
 
-## Profile Rule
+This document is the public taxonomy. It does **not** change the runtime
+`RegistryEntry.kind` enum in this pass.
 
-`profile` is both a semantic taxonomy and an implementation contract.
+## Semantic Class
 
-A style is a `profile` only when the authority chain shows that it follows a
-known publisher, society, or standards parent with bounded house deltas, and
-its local YAML remains config-only. The authority order is:
+| Class | Definition | Authority requirement | Verification default |
+|------|------------|-----------------------|----------------------|
+| `base` | Inheritance root with its own complete rendering structure | none beyond normal style authority | own oracle |
+| `profile` | Reusable publisher, society, or standards house style | guide-backed parent-plus-deltas relationship | own oracle plus parent-diff evidence |
+| `journal` | Journal-specific descendant of a base or profile | journal or publisher guidance ties it to a parent family | delta from selected parent plus own oracle evidence |
+| `independent` | Self-contained style with no evidenced parent relationship | no reusable parent proven | own oracle |
 
-1. publisher or journal guide
-2. publisher house rules
+## Implementation Form
+
+| Form | Definition | `extends:` | Local template-bearing fields | Typical use |
+|------|------------|------------|-------------------------------|-------------|
+| `alias` | Registry pointer only | no | no | exact journal clone |
+| `config-wrapper` | Parent selected via `extends:` and tuned only with scoped options / metadata | yes | no | thin publisher or journal wrapper |
+| `structural-wrapper` | Inherits a parent but still carries local template-bearing structure | yes | yes | journal descendant with real family match but unresolved structural delta |
+| `standalone` | Complete self-contained style | optional but typically no | yes | independent or not-yet-factored style |
+
+## Authority Rules
+
+Authority order remains:
+
+1. current publisher or journal guide
+2. current publisher house rules or submission instructions
 3. named parent-style manual or standards reference
-4. CSL/template-link evidence
+4. CSL metadata and template links
 5. current Citum YAML structure
 
 Output similarity by itself is not enough.
 
-## Implementation Note
+### Profile Rule
 
-Profile styles now use config-only wrappers over hidden compiled roots.
+A style is a `profile` only when both statements are true:
 
-- public `kind: profile` styles may keep local identity and use the normal
-  typed options surface
-- profile-only schema namespaces are forbidden
-- public `kind: profile` styles may not keep local templates, `type-variants`,
-  or template-clearing `null` values
-- hidden compiled roots are an implementation detail and do not appear in the
-  public registry
+- semantically, it is a reusable publisher, society, or standards house style
+- operationally, the public wrapper is `config-wrapper` only
+
+Public `profile` styles may keep local identity and scoped options, but they may
+not keep local templates, `type-variants`, or template-clearing `null` values.
+
+### Journal Rule
+
+`journal` is now semantic only. A journal style may be implemented as:
+
+- an `alias`
+- a `config-wrapper`
+- a `structural-wrapper`
+
+This is the key correction from the earlier mixed tier model.
 
 ## Current Classification
 
-### Base Styles (Tier 1)
+### Base + Standalone
 
-| Style | Origin |
-|-------|--------|
-| `apa-7th` | CSL-derived |
-| `chicago-notes-18th` | CSL-derived |
-| `chicago-author-date-18th` | CSL-derived |
-| `ieee` | CSL-derived |
-| `american-medical-association` | CSL-derived |
-| `modern-language-association` | CSL-derived |
+| Style | Notes |
+|------|-------|
+| `apa-7th` | CSL-derived inheritance root |
+| `chicago-notes-18th` | CSL-derived inheritance root |
+| `chicago-author-date-18th` | CSL-derived inheritance root |
+| `ieee` | CSL-derived inheritance root |
+| `american-medical-association` | CSL-derived inheritance root |
+| `modern-language-association` | CSL-derived inheritance root |
 
-### Profile Styles (Tier 2)
+### Profile + Config-Wrapper
 
-| Style | Base | Notes |
-|-------|------|-------|
-| `chicago-shortened-notes-bibliography` | hidden Chicago shortened-notes root | Public shortened-notes wrapper |
-| `elsevier-harvard` | hidden Elsevier Harvard root | Public profile handle is config-only |
-| `elsevier-vancouver` | hidden Elsevier Vancouver root | Public profile handle is config-only |
-| `elsevier-with-titles` | hidden Elsevier with-titles root | Public profile handle is config-only |
-| `springer-basic-author-date` | hidden Springer Basic author-date root | Public profile handle is config-only |
-| `springer-basic-brackets` | hidden Springer Basic brackets root | Public profile handle is config-only |
-| `springer-vancouver-brackets` | hidden Springer Vancouver root | Public profile handle is config-only |
-| `taylor-and-francis-chicago-author-date` | hidden Taylor & Francis Chicago root | Public profile handle is config-only |
-| `taylor-and-francis-council-of-science-editors-author-date` | hidden Taylor & Francis CSE root | Public profile handle is config-only |
-| `taylor-and-francis-national-library-of-medicine` | hidden Taylor & Francis NLM root | Public profile handle is config-only |
+| Style | Notes |
+|------|-------|
+| `chicago-shortened-notes-bibliography` | public shortened-notes wrapper |
+| `elsevier-harvard` | public profile handle over hidden family root |
+| `elsevier-vancouver` | public profile handle over hidden family root |
+| `elsevier-with-titles` | public profile handle over hidden family root |
+| `springer-basic-author-date` | public profile handle over hidden family root |
+| `springer-basic-brackets` | public profile handle over hidden family root |
+| `springer-vancouver-brackets` | public profile handle over hidden family root |
+| `taylor-and-francis-chicago-author-date` | public profile handle over hidden family root |
+| `taylor-and-francis-council-of-science-editors-author-date` | public profile handle over hidden family root |
+| `taylor-and-francis-national-library-of-medicine` | public profile handle over hidden family root |
 
-### Journal / Alias Styles (Tier 3)
+### Journal + Alias
 
-Journal aliases are listed in `registry/default.yaml` under each entry's `aliases:` key. Each is a zero-config pointer to a profile or base style.
+Journal aliases live in `registry/default.yaml` under `aliases:` and remain
+zero-config pointers.
 
-Like Tier 2 styles, Tier 3 styles can use `extends:` to inherit a base structure while applying journal-specific config-only overrides (e.g., localized delimiters or specific locator labels).
+Representative examples:
 
-### Profile Candidates (Backlog)
+| Journal Alias | Parent |
+|--------------|--------|
+| `acta-medica-portuguesa` | `american-medical-association` |
+| `annals-of-the-association-of-american-geographers` | `taylor-and-francis-chicago-author-date` |
+| `biochimica-et-biophysica-acta` | `elsevier-with-titles` |
 
-The following styles have been identified via automated semantic skeleton analysis as high-probability candidates for `extends:` conversion:
+### Journal + Structural-Wrapper
 
-| Legacy Style | Target Base | Semantic Similarity |
-|--------------|-------------|---------------------|
-| `pharmacoepidemiology-and-drug-safety` | `elsevier-with-titles` | 0.84 |
-| `disability-and-rehabilitation` | `elsevier-with-titles` | 0.83 |
-| `zoological-journal-of-the-linnean-society` | `springer-basic-author-date` | 0.83 |
-| `the-lichenologist` | `springer-basic-author-date` | 0.83 |
-| `memorias-do-instituto-oswaldo-cruz` | `springer-basic-author-date` | 0.83 |
-| `techniques-et-culture` | `taylor-and-francis-cse` | 0.87 |
-| `hawaii-int-conf-system-sciences` | `taylor-and-francis-nlm` | 0.86 |
-| `cell-numeric` | `elsevier-with-titles` | 0.83 |
+Representative existing journal descendants that already prove a journal style
+is not necessarily an alias or thin wrapper:
 
-## Embedding Policy
+| Style | Parent | Why structural |
+|------|--------|----------------|
+| `american-society-of-mechanical-engineers` | `ieee` | local bibliography templates and type variants |
+| `american-mathematical-society-label` | `elsevier-with-titles` | local citation and bibliography templates |
+| `entomological-society-of-america` | `elsevier-harvard` | local citation template and type variants |
+| `international-journal-of-wildland-fire` | `springer-basic-author-date` | local citation template and bibliography structure |
+| `elsevier-vancouver-author-date` | `elsevier-vancouver` | local author-date citation and bibliography structure |
 
-Only Tier 1 (base) and Tier 2 (profile) styles are embedded in the binary. Tier
-3 (journal) styles resolve at runtime through the registry alias table. Tier 4
-(independent) styles are loaded from disk or bundled separately.
+### Audited Journal Descendants (2026-04-22)
 
----
+The `9e13a17b` backlog was re-audited with normalized IDs, CSL metadata, the
+alias TSV, current guide evidence, and the new `citum-analyze --identify-profiles`
+audit mode. The reduction pass kept only the deltas justified by guide-backed or
+converging evidence.
+
+| Legacy Style | Proposed Parent in `9e13a17b` | Corrected Parent | Outcome |
+|-------------|--------------------------------|------------------|---------|
+| `pharmacoepidemiology-and-drug-safety` | `elsevier-with-titles` | `american-medical-association` | `journal + config-wrapper` |
+| `disability-and-rehabilitation` | `elsevier-with-titles` | `elsevier-with-titles` | `journal + config-wrapper` |
+| `zoological-journal-of-the-linnean-society` | `springer-basic-author-date` | — | `false-positive` |
+| `the-lichenologist` | `springer-basic-author-date` | — | `false-positive` |
+| `memorias-do-instituto-oswaldo-cruz` | `springer-basic-author-date` | — | `independent + standalone` |
+| `techniques-et-culture` | `taylor-and-francis-council-of-science-editors-author-date` | — | `false-positive` |
+| `hawaii-international-conference-on-system-sciences-proceedings` | `taylor-and-francis-national-library-of-medicine` | — | `false-positive; temporary structural hold` |
+| `cell-numeric` | `elsevier-with-titles` | `elsevier-with-titles` | `journal + config-wrapper` |
+
+This pass promoted three candidates to `journal + config-wrapper`, retained no
+new aliases, dropped one unsupported parent link outright, and left one
+temporary structural hold where inherited IEEE behavior still covers legacy CSL
+surface that the current guide no longer justifies semantically.
+
+## Embedding And Runtime Note
+
+This pass deliberately keeps the runtime `kind` enum unchanged.
+
+- current embedded base/profile styles remain the same
+- registry aliases still resolve through `registry/default.yaml`
+- journal wrappers remain ordinary style files unless separately promoted
+
+If machine-readable implementation-form metadata becomes necessary later, add a
+new field rather than overloading `kind` again.
 
 ## Changelog
 
+- v1.5 (2026-04-22): Reframed taxonomy on two axes: semantic class and
+  implementation form. Recorded the 2026-04-22 journal-candidate audit,
+  reduced three audited descendants to `journal + config-wrapper`, dropped one
+  unsupported parent link to a standalone style, and explicitly separated
+  aliases, config-only journal wrappers, and structural journal wrappers.
+  Confirmed that runtime `kind` is unchanged in this pass.
 - v1.4 (2026-04-22): Replaced `options.profile` with normal scoped options.
 - v1.2 (2026-04-21): Enforced config-only profile wrappers over hidden compiled
   roots.
 - v1.1 (2026-04-21): Clarified that `profile` means evidence-backed parentage,
   not output similarity or already-small YAML.
-- v1.0 (2026-04-20): Initial spec. Defines four-tier model (base, profile, journal, independent).
-  Classifies all 16 embedded styles. Documents embedding policy.
+- v1.0 (2026-04-20): Initial spec. Defined the four-tier model (base, profile,
+  journal, independent).

--- a/styles/cell-numeric.yaml
+++ b/styles/cell-numeric.yaml
@@ -1,0 +1,36 @@
+extends: elsevier-with-titles
+info:
+  title: Cell journals (numeric)
+  id: http://www.zotero.org/styles/cell-numeric
+  default-locale: en-US
+options:
+  substitute:
+    contributor-role-form: short
+    template:
+    - editor
+    - title
+  contributors:
+    display-as-sort: all
+    initialize-with: ''
+    shorten:
+      min: 7
+      use-first: 6
+      and-others: et-al
+      delimiter-precedes-last: contextual
+    and: none
+    name-form: initials
+bibliography:
+  options:
+    contributors:
+      display-as-sort: all
+      initialize-with: .
+      shorten:
+        min: 11
+        use-first: 10
+        and-others: et-al
+        delimiter-precedes-last: contextual
+      delimiter-precedes-last: always
+      sort-separator: ', '
+      name-form: initials
+    entry-suffix: .
+    separator: '. '

--- a/styles/disability-and-rehabilitation.yaml
+++ b/styles/disability-and-rehabilitation.yaml
@@ -1,0 +1,37 @@
+extends: elsevier-with-titles
+info:
+  title: Disability and Rehabilitation
+  id: http://www.zotero.org/styles/disability-and-rehabilitation
+  default-locale: en-US
+options:
+  substitute:
+    contributor-role-form: short
+    template:
+    - editor
+  contributors:
+    display-as-sort: all
+    initialize-with: ''
+    shorten:
+      min: 11
+      use-first: 10
+      and-others: et-al
+      delimiter-precedes-last: contextual
+    and: none
+    delimiter-precedes-last: always
+    demote-non-dropping-particle: sort-only
+    sort-separator: ' '
+    name-form: initials
+bibliography:
+  options:
+    contributors:
+      display-as-sort: all
+      initialize-with: ''
+      shorten:
+        min: 11
+        use-first: 10
+        and-others: et-al
+        delimiter-precedes-last: contextual
+      delimiter-precedes-last: always
+      sort-separator: ' '
+      name-form: initials
+    separator: ': '

--- a/styles/hawaii-international-conference-on-system-sciences-proceedings.yaml
+++ b/styles/hawaii-international-conference-on-system-sciences-proceedings.yaml
@@ -1,0 +1,248 @@
+extends: ieee
+info:
+  title: Hawaii International Conference on System Sciences Proceedings
+  id: http://www.zotero.org/styles/hawaii-international-conference-on-system-sciences-proceedings
+  default-locale: en-US
+options:
+  substitute:
+    contributor-role-form: short
+    template:
+    - editor
+  processing: numeric
+  contributors:
+    display-as-sort: first
+    initialize-with: .
+    shorten:
+      min: 7
+      use-first: 3
+      and-others: et-al
+      delimiter-precedes-last: contextual
+    delimiter: null
+    delimiter-precedes-last: always
+    delimiter-precedes-et-al: always
+    demote-non-dropping-particle: sort-only
+    name-form: initials
+  dates:
+    month: long
+    uncertainty-marker: '?'
+    approximation-marker: 'ca. '
+    range-delimiter: –
+    show-seconds: false
+    show-timezone: false
+    era-labels: default
+    negative-unspecified-years: range
+  titles:
+    component: {}
+    monograph:
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      emph: true
+  punctuation-in-quote: true
+citation:
+  template:
+  - number: citation-number
+  - variable: locator
+  wrap:
+    punctuation: brackets
+  multi-cite-delimiter: ', '
+bibliography:
+  options:
+    contributors:
+      display-as-sort: first
+      initialize-with: .
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+        delimiter-precedes-last: contextual
+      delimiter: null
+      delimiter-precedes-last: always
+      delimiter-precedes-et-al: always
+      name-form: initials
+    separator: ' '
+  template:
+  - date: issued
+    form: year
+    suppress: true
+  - number: citation-number
+    wrap:
+      punctuation: brackets
+      inner-suffix: ' '
+    suppress: false
+  - contributor: author
+    form: long
+    name-order: family-first-only
+    shorten:
+      min: 7
+      use-first: 3
+      and-others: et-al
+      delimiter-precedes-last: always
+    and: text
+    suppress: false
+  - title: primary
+    quote: true
+    wrap:
+      punctuation: quotes
+    suppress: false
+  - group:
+    - variable: publisher
+    - variable: publisher-place
+    - date: issued
+      form: year
+    delimiter: comma
+    suppress: true
+  - group:
+    - group:
+      - title: parent-serial
+        emph: true
+      - group:
+        - variable: publisher
+        - date: issued
+          form: year
+        delimiter: space
+      delimiter: comma
+    - number: pages
+    delimiter: comma
+    suffix: .
+    suppress: true
+  - term: in
+    form: long
+    suffix: ' '
+    suppress: true
+  - contributor: editor
+    form: long
+    shorten:
+      min: 7
+      use-first: 3
+      and-others: et-al
+      delimiter-precedes-last: never
+    and: text
+    suppress: true
+  - title: parent-serial
+    emph: true
+    suffix: '. '
+    suppress: true
+  - group:
+    - group:
+      - variable: publisher
+      - variable: publisher-place
+      - date: issued
+        form: year
+      delimiter: comma
+    - number: pages
+    delimiter: comma
+    suffix: .
+    suppress: true
+  - number: volume
+    emph: true
+    quote: false
+    prefix: ' '
+    suppress: true
+  - number: issue
+    emph: false
+    wrap:
+      punctuation: parentheses
+    suppress: true
+  - number: pages
+    prefix: 'pp. '
+    suppress: true
+  - group:
+    - group:
+      - title: parent-serial
+      - number: volume
+      delimiter: space
+      emph: true
+    - date: issued
+      form: year
+    - number: pages
+    delimiter: comma
+    suffix: .
+    suppress: false
+  - variable: url
+    prefix: ' '
+    suppress: false
+  type-variants:
+    bill:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+        inner-suffix: ' '
+    - contributor: author
+      form: long
+      name-order: family-first-only
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+        delimiter-precedes-last: always
+      and: text
+    - title: primary
+      quote: true
+      wrap:
+        punctuation: quotes
+    - variable: publisher
+    - variable: publisher-place
+    - date: issued
+      form: year
+    book:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+        inner-suffix: ' '
+    - contributor: author
+      form: long
+      name-order: family-first-only
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+        delimiter-precedes-last: always
+      and: text
+    - title: primary
+      quote: true
+      wrap:
+        punctuation: quotes
+    - variable: publisher
+    - variable: publisher-place
+    - date: issued
+      form: year
+    chapter:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+        inner-suffix: ' '
+    - contributor: author
+      form: long
+      name-order: family-first-only
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+        delimiter-precedes-last: always
+      and: text
+    - title: primary
+      quote: true
+      wrap:
+        punctuation: quotes
+    - term: in
+      form: long
+    - contributor: editor
+      form: long
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+        delimiter-precedes-last: never
+      and: text
+    - title: parent-serial
+      emph: true
+    - group:
+      - variable: publisher
+      - variable: publisher-place
+      - date: issued
+        form: year
+      delimiter: comma
+    - number: pages
+      prefix: 'pp. '

--- a/styles/memorias-do-instituto-oswaldo-cruz.yaml
+++ b/styles/memorias-do-instituto-oswaldo-cruz.yaml
@@ -1,0 +1,165 @@
+info:
+  title: Memórias do Instituto Oswaldo Cruz
+  id: http://www.zotero.org/styles/memorias-do-instituto-oswaldo-cruz
+  default-locale: en-US
+options:
+  substitute:
+    contributor-role-form: short
+    template:
+    - editor
+    - translator
+  processing:
+    sort:
+      shorten-names: false
+      render-substitutions: false
+      template:
+      - key: year
+        ascending: true
+    group:
+      template:
+      - year
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
+  contributors:
+    display-as-sort: all
+    initialize-with: ''
+    shorten:
+      min: 5
+      use-first: 3
+      and-others: et-al
+      delimiter-precedes-last: contextual
+    and: none
+    delimiter-precedes-last: always
+    sort-separator: ' '
+    name-form: initials
+  dates:
+    month: long
+    uncertainty-marker: '?'
+    approximation-marker: 'ca. '
+    range-delimiter: –
+    show-seconds: false
+    show-timezone: false
+    era-labels: default
+    negative-unspecified-years: range
+  titles:
+    component: {}
+    monograph:
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      emph: true
+  page-range-format: expanded
+  punctuation-in-quote: true
+citation:
+  options:
+    contributors:
+      initialize-with: '. '
+      shorten:
+        min: 3
+        use-first: 1
+        and-others: et-al
+        delimiter-precedes-last: contextual
+      name-form: initials
+  template:
+  - contributor: author
+    form: short
+    name-order: family-first
+  - date: issued
+    form: year
+    prefix: ' '
+  - variable: locator
+    prefix: ' '
+  wrap:
+    punctuation: parentheses
+  delimiter: '. '
+  multi-cite-delimiter: ', '
+bibliography:
+  options:
+    contributors:
+      display-as-sort: all
+      initialize-with: ''
+      delimiter-precedes-last: always
+      sort-separator: ' '
+      name-form: initials
+    hanging-indent: true
+    entry-suffix: .
+    separator: '. '
+  template:
+  - contributor: author
+    form: long
+    name-order: family-first
+  - date: issued
+    form: year
+    prefix: ' '
+  - title: primary
+  - contributor: editor
+    form: verb
+    name-order: given-first
+  - variable: publisher
+    prefix: ', Ed.). '
+  - title: parent-monograph
+    emph: true
+  - title: parent-serial
+    emph: true
+  - variable: publisher-place
+    prefix: ', '
+  - number: volume
+  - number: pages
+    prefix: ': '
+  type-variants:
+    entry-encyclopedia:
+    - contributor: author
+      form: long
+      name-order: family-first
+      sort-separator: ' '
+    - date: issued
+      form: year
+      prefix: ' '
+      suffix: .
+    - title: primary
+    - contributor: editor
+      form: long
+      delimiter: ', '
+      and: text
+    - title: parent-serial
+      emph: true
+      strip-periods: false
+    - number: volume
+      strong: false
+    - number: pages
+      prefix: ': '
+    legal_case:
+    - contributor: author
+      form: long
+      name-order: family-first
+      sort-separator: ' '
+    - date: issued
+      form: year
+      prefix: ' '
+      suffix: .
+      suppress: false
+    - title: primary
+    - contributor: editor
+      form: long
+      delimiter: ', '
+      and: text
+    - variable: publisher
+    - variable: publisher-place
+    - title: parent-serial
+    patent:
+    - contributor: author
+      form: long
+      name-order: family-first
+    - title: primary
+    - date: issued
+      form: year
+      prefix: ' '
+  sort:
+    template:
+    - key: author
+      ascending: true
+    - key: issued
+      ascending: true

--- a/styles/pharmacoepidemiology-and-drug-safety.yaml
+++ b/styles/pharmacoepidemiology-and-drug-safety.yaml
@@ -1,0 +1,53 @@
+extends: american-medical-association
+info:
+  title: Pharmacoepidemiology and Drug Safety
+  id: http://www.zotero.org/styles/pharmacoepidemiology-and-drug-safety
+  default-locale: en-US
+options:
+  substitute:
+    contributor-role-form: short
+    template:
+    - editor
+  contributors:
+    display-as-sort: all
+    initialize-with: ''
+    shorten:
+      min: 7
+      use-first: 3
+      and-others: et-al
+      delimiter-precedes-last: contextual
+    and: none
+    delimiter-precedes-last: always
+    demote-non-dropping-particle: sort-only
+    sort-separator: ' '
+    name-form: initials
+  titles:
+    component: {}
+    monograph:
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      emph: true
+  locators:
+    default-label-form: short
+    range-format: expanded
+    strip-label-periods: true
+    kinds: {}
+    patterns: []
+    fallback-delimiter: ', '
+bibliography:
+  options:
+    contributors:
+      display-as-sort: all
+      initialize-with: ''
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+        delimiter-precedes-last: contextual
+      delimiter-precedes-last: always
+      sort-separator: ' '
+      name-form: initials
+    hanging-indent: false
+    separator: ': '


### PR DESCRIPTION
## Summary
- convert the five viable 2026-04-22 journal candidates into parented structural-wrapper styles
- tighten `citum-analyze --identify-profiles` into an evidence-based audit report with corrected parents and JSON output
- update the taxonomy and audit docs to distinguish aliases, config wrappers, and structural wrappers

## Testing
- ./scripts/validate-frontmatter.sh --copilot-strict
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- node scripts/oracle-yaml.js styles/pharmacoepidemiology-and-drug-safety.yaml --legacy-csl styles-legacy/pharmacoepidemiology-and-drug-safety.csl --json
- node scripts/oracle-yaml.js styles/disability-and-rehabilitation.yaml --legacy-csl styles-legacy/disability-and-rehabilitation.csl --json
- node scripts/oracle-yaml.js styles/hawaii-international-conference-on-system-sciences-proceedings.yaml --legacy-csl styles-legacy/hawaii-international-conference-on-system-sciences-proceedings.csl --json
- node scripts/oracle-yaml.js styles/cell-numeric.yaml --legacy-csl styles-legacy/cell-numeric.csl --json
- cargo run --bin citum -- check --style styles/memorias-do-instituto-oswaldo-cruz.yaml
