### PR TITLE
chore(beans): close csl26-jgt4

### DIFF
--- a/.beans/archive/csl26-jgt4--archival-and-unpublished-source-support.md
+++ b/.beans/archive/csl26-jgt4--archival-and-unpublished-source-support.md
@@ -1,21 +1,21 @@
 ---
 # csl26-jgt4
 title: Archival and unpublished source support
-status: in-progress
+status: completed
 type: feature
 created_at: 2026-03-28T21:04:14Z
-updated_at: 2026-03-29T00:00:00Z
+updated_at: 2026-04-23T15:08:22Z
 ---
 
 Introduce ArchiveInfo and EprintInfo structs to model archival citations and preprints properly. Resolves the legacy `archive_location` semantic collision (shelfmark vs. city) by introducing spec-aligned SimpleVariables `archive-location` (shelfmark) and `archive-place` (city), adds `archive-collection`/`archive-url` fields, and adds `MonographType::Preprint` replacing the arXiv medium-hack. Spec: docs/specs/ARCHIVAL_UNPUBLISHED_SUPPORT.md
 
 2026-03-29 follow-up: completed the public communication pass after merge. The checked-in archival demo now shows canonical structured `archive-info` hierarchy fields (`collection-id`, `series`, `box`, `folder`, `item`) instead of collapsing them into `location`, the demo style renders the corresponding `archive-*` variables directly, the examples page explains that `location` is a display override / legacy fallback, and the style author guide now points authors to `archive-box` / `archive-folder` / `archive-item` for structured archival layouts.
 
-Open follow-up keeping this bean in progress: locale-backed labels for structured archival hierarchy components are not implemented yet. Current examples use style-authored English prefixes such as `Series`, `Box`, `Folder`, and `Item`. Before claiming engine-added localized labels for these fields, decide whether archival container labels belong in locale general terms, locator-style terms, or a dedicated archival term family; define singular/plural behavior (`box`/`boxes`, `folder`/`folders`, `item`/`items`), short-form abbreviations, and the conditions under which the engine should add labels versus styles rendering them explicitly.
+2026-04-23 closure: the archival/eprint implementation this bean tracked is now complete on `main`, so this bean is closed. The remaining locale-backed label design for structured archival hierarchy components is intentionally deferred to follow-up bean `csl26-mlc2`. That follow-up will decide whether archival container labels belong in locale general terms, locator-style terms, or a dedicated archival term family; define singular/plural behavior (`box`/`boxes`, `folder`/`folders`, `item`/`items`) and short-form abbreviations; and specify when the engine should add labels versus styles rendering them explicitly.
 
 ## Summary of Changes
 
 - Added checked-in examples and docs guidance that use canonical structured `archive-info` hierarchy fields.
 - Added rendering coverage for both canonical structured hierarchy output and legacy `archive-location` fallback behavior.
 - Corrected `archive_location()` lookup so structured `archive-info.location` is preferred before legacy flat `archive_location`.
-- Recorded the unresolved locale-label design work as explicit follow-up on this bean.
+- Deferred locale-backed archival hierarchy labels to follow-up bean `csl26-mlc2`.

--- a/.beans/csl26-mlc2--design-locale-backed-archive-hierarchy-labels.md
+++ b/.beans/csl26-mlc2--design-locale-backed-archive-hierarchy-labels.md
@@ -1,0 +1,24 @@
+---
+# csl26-mlc2
+title: Design locale-backed archive hierarchy labels
+status: todo
+type: feature
+priority: normal
+created_at: 2026-04-23T15:08:48Z
+updated_at: 2026-04-23T15:08:48Z
+---
+
+Scope the deferred localization work for archival container labels introduced by csl26-jgt4. Define where archive hierarchy labels belong in the locale model, how singular/plural and short forms work, and when the engine should add labels versus requiring styles to render them explicitly.
+
+Related: csl26-jgt4, docs/specs/ARCHIVAL_UNPUBLISHED_SUPPORT.md
+
+Target variables and behaviors:
+- archive-box
+- archive-folder
+- archive-item
+- related archival container labels such as collection/series when engine-backed labels are desired
+
+Expected outcome:
+- decision on locale term family placement
+- explicit singular/plural and abbreviation rules
+- engine-backed rendering plan and acceptance tests for localized archival labels


### PR DESCRIPTION
## Summary
- archive `csl26-jgt4` now that the archival and eprint work it tracked is already landed on `main`
- add follow-up bean `csl26-mlc2` for the deferred locale-backed archive hierarchy label design
- keep this PR limited to bean state normalization with no Rust, schema, or style behavior changes

## Context
The archival/eprint implementation from `csl26-jgt4` is already present on `main`. This PR closes the tracking bean, archives it per project bean lifecycle policy, and carries the unresolved localization design work into a separate follow-up bean.

## Testing
- `./scripts/check-docs-beans-hygiene.sh`