### PR TITLE
ci(workflows): fix compat report actions

### DIFF
--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -11,6 +11,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   report:
     name: Generate and Deploy Docs
@@ -27,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -46,7 +49,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -55,7 +58,7 @@ jobs:
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
-          additional-cache-directories: /home/runner/.cache/sccache
+          cache-directories: /home/runner/.cache/sccache
 
       - name: Configure environment
         run: |
@@ -64,9 +67,6 @@ jobs:
 
       - name: Install Node dependencies
         run: npm install --prefix scripts
-
-      - name: Build Rust workspace
-        run: cargo build --all-features
 
       - name: Generate compatibility report
         run: node scripts/report-core.js --all-features --output-html docs/compat.html > /tmp/core-report.json
@@ -82,7 +82,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs
 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -20,6 +20,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy:
     environment:
@@ -33,7 +36,7 @@ jobs:
       SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore published compatibility report
         if: ${{ !inputs.refresh_compat }}
@@ -59,7 +62,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -68,7 +71,7 @@ jobs:
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
-          additional-cache-directories: /home/runner/.cache/sccache
+          cache-directories: /home/runner/.cache/sccache
 
       - name: Configure environment
         run: |
@@ -77,10 +80,6 @@ jobs:
 
       - name: Install Node dependencies
         run: npm install --prefix scripts
-
-      - name: Build Rust workspace
-        if: ${{ inputs.refresh_compat }}
-        run: cargo build --all-features
 
       - name: Build documentation guides
         run: npm run build:docs --prefix scripts
@@ -100,7 +99,7 @@ jobs:
         uses: actions/configure-pages@v5
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './docs'
       

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -30,7 +30,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -44,7 +44,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 


### PR DESCRIPTION
## Summary
- remove the redundant full-workspace build from Compat Report and Deploy Documentation refresh path
- update checkout/setup-node/upload-pages-artifact to current majors used for Node 24 runtime support
- fix rust-cache sccache directory inputs and opt Pages workflows into Node 24 for JavaScript actions

## Validation
- parsed edited workflow YAML locally with Ruby YAML.load_file
- reviewed resulting workflow diff for action pins, cache keys, and removed prebuild step