### PR TITLE
docs: make style-evolve profile-aware

### DIFF
--- a/.claude/skills/style-evolve/SKILL.md
+++ b/.claude/skills/style-evolve/SKILL.md
@@ -47,6 +47,13 @@ Use `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` for failure classification 
 
 - Compatibility fidelity regression is never allowed unless the task explicitly chooses a documented semantic divergence from legacy CSL behavior.
 - SQI is optimization-only after fidelity is stable.
+- Before editing a style, classify it by semantic class and implementation form
+  using the shared workflow docs and `docs/specs/STYLE_TAXONOMY.md`.
+- Profile-family work may require a `create` pass for a hidden family root
+  followed by `upgrade` reduction of the public handles.
+- Journal/profile reductions must choose parents from guide-backed authority,
+  not nearest CSL or template similarity.
+- Keep waves bounded to one family or one clearly related cohort per PR.
 - For styles with configured `benchmark_runs`, run `node scripts/report-core.js --style <name>` after the primary oracle pass and treat the rich-input results as official supplemental evidence.
 - All modes must pass `../style-qa/SKILL.md` before completion.
 - If docs or beans are changed: `./scripts/check-docs-beans-hygiene.sh` must pass.

--- a/.codex/skills/style-evolve/SKILL.md
+++ b/.codex/skills/style-evolve/SKILL.md
@@ -30,6 +30,12 @@ Read first:
 
 - Keep fidelity as the hard gate.
 - Treat SQI as secondary optimization only.
+- Before editing a style, classify it by semantic class and implementation
+  form using `docs/specs/STYLE_TAXONOMY.md` and the shared workflow docs.
+- Profile-family work may require a `create` pass for a hidden family root
+  followed by `upgrade` reduction of the public handles.
+- Journal/profile reductions must choose parents from guide-backed authority,
+  not nearest CSL or template similarity.
+- Keep waves bounded to one family or one clearly related cohort per PR.
 - Do not duplicate the shared decision rules or evidence ladder here.
 - Keep this skill focused on routing and host-facing behavior.
-

--- a/docs/architecture/2026-04-23_STYLE_EVOLVE_PROFILE_ELSEVIER_WAVE.md
+++ b/docs/architecture/2026-04-23_STYLE_EVOLVE_PROFILE_ELSEVIER_WAVE.md
@@ -1,0 +1,96 @@
+# Style-Evolve Profile Elsevier Wave
+
+**Date:** 2026-04-23
+**Bean:** `csl26-u1tq`
+**Related:** `docs/specs/STYLE_TAXONOMY.md`, `docs/specs/UNIFIED_SCOPED_OPTIONS.md`, `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`
+
+## Summary
+
+This pass bundled a bounded Elsevier profile-family verification wave with the
+profile-aware `style-evolve` workflow update.
+
+The intended question was simple:
+
+- do dedicated Elsevier family roots exist
+- do the public Elsevier profile handles already resolve as true thin wrappers
+- does the shared workflow now describe how to make and verify that judgment
+
+The answer is yes on all three counts.
+
+## Current Elsevier Family Shape
+
+The repo already contains dedicated hidden family roots and public thin wrappers
+for the two target Elsevier profiles:
+
+- `styles/embedded/elsevier-harvard-core.yaml`
+- `styles/embedded/elsevier-harvard.yaml`
+- `styles/embedded/elsevier-vancouver-core.yaml`
+- `styles/embedded/elsevier-vancouver.yaml`
+
+Current wrapper shape:
+
+- both public wrappers use `extends:`
+- both wrappers limit local deltas to metadata and scoped options
+- neither wrapper carries local templates
+- neither wrapper carries local `type-variants`
+- `elsevier-harvard` changes bibliography date placement through
+  `bibliography.options.date-position`
+- `elsevier-vancouver` changes citation label wrapping and bibliography label
+  mode through scoped options only
+
+That means no YAML reduction work was required in this pass. The wave outcome is
+verification plus workflow alignment, not synthetic churn.
+
+## Evidence
+
+Authority basis:
+
+1. current Elsevier guide links embedded in the style metadata
+2. current family-root and wrapper YAML structure
+3. style-oracle and style-scoped report verification on the public handles
+4. shared-fixture parent-vs-wrapper diffs
+
+Operational classification:
+
+- `elsevier-harvard`: `profile + config-wrapper`
+- `elsevier-vancouver`: `profile + config-wrapper`
+
+Verification summary:
+
+- `node scripts/oracle-yaml.js styles/embedded/elsevier-harvard.yaml styles-legacy/elsevier-harvard.csl --json`
+  returned `18/18` citations and `34/34` bibliography
+- `node scripts/oracle-yaml.js styles/embedded/elsevier-vancouver.yaml styles-legacy/elsevier-vancouver.csl --json`
+  returned `18/18` citations and `34/34` bibliography
+- `node scripts/report-core.js --style elsevier-harvard` reported quality score
+  `0.907`
+- `node scripts/report-core.js --style elsevier-vancouver` reported quality
+  score `0.847`
+- parent-vs-wrapper rendering on the shared fixtures showed that the wrapper
+  deltas are real but bounded:
+  `elsevier-harvard` changes bibliography layout relative to the family root,
+  while `elsevier-vancouver` changes label rendering relative to the family
+  root
+
+## Decision
+
+Keep the existing Elsevier family-root and wrapper YAML unchanged.
+
+The real repo gap was not missing Elsevier roots. It was that the shared
+workflow and host wrappers did not explicitly tell agents how to:
+
+- classify semantic class vs implementation form
+- preserve the config-wrapper contract for profiles
+- accept structural journal descendants when the evidence or infrastructure
+  requires them
+- stop forcing thin reductions when current merge mechanics block them
+
+This pass addresses that workflow gap directly.
+
+## Follow-Up Boundary
+
+This pass does not widen into schema or runtime work.
+
+If a future family re-check shows that an Elsevier public handle needs more than
+scoped options and metadata, the correct action is to record the infrastructure
+constraint or author a different family base. It is not to silently treat copied
+structural YAML as authoritative.

--- a/docs/guides/STYLE_EVOLVE_WORKFLOW.md
+++ b/docs/guides/STYLE_EVOLVE_WORKFLOW.md
@@ -44,6 +44,32 @@ targeting.
 - Every iteration must assess both:
   - style-level edits
   - processor/preset/feature opportunities
+- Before editing YAML, classify the target using the shared two-axis taxonomy:
+  semantic class (`base`, `profile`, `journal`, `independent`) and
+  implementation form (`alias`, `config-wrapper`, `structural-wrapper`,
+  `standalone`).
+- Profile work must preserve the config-wrapper contract: scoped options and
+  metadata only, with no local templates, no local `type-variants`, and no
+  template-clearing `null`.
+- Journal descendants may legitimately remain structural wrappers when
+  guide-backed deltas or current merge mechanics prevent a meaningful thin
+  reduction.
+- Choose parent styles from current guide-backed authority first, not nearest
+  CSL/template similarity.
+- If guide-backed parentage is real but the current merge model still forces a
+  bulky child file, record the infrastructure constraint and stop forcing
+  compression.
+
+## Wave Guidance
+
+A style wave is a bounded cohort executed through repeated `upgrade`,
+`migrate`, or `create` passes under the shared workflow docs.
+
+- Keep one wave to one family or one clearly related cohort per PR.
+- Profile-family work may require a `create` pass for a hidden family root,
+  followed by `upgrade` passes to reduce the public handles.
+- `style-evolve` remains a three-mode public entrypoint. A wave is execution
+  scope, not a fourth mode.
 
 ## Internal Pipeline (For Maintainers)
 `/style-evolve` routes internally to:

--- a/docs/guides/STYLE_WORKFLOW_EXECUTION.md
+++ b/docs/guides/STYLE_WORKFLOW_EXECUTION.md
@@ -23,14 +23,18 @@ Out of scope:
 ## Design
 ### Shared execution order
 1. Establish the workflow mode and target scope.
-2. Establish source authority before reading implementation artifacts:
+2. Classify the target on two axes before editing:
+   semantic class (`base`, `profile`, `journal`, `independent`) and
+   implementation form (`alias`, `config-wrapper`, `structural-wrapper`,
+   `standalone`).
+3. Establish source authority before reading implementation artifacts:
    publisher guide first, then publisher house rules, then parent-style guidance.
-3. Capture the smallest trustworthy evidence surface first.
-4. Use reduced-cluster evidence before broad supplemental reruns.
-5. Classify each failure using the shared policy.
-6. Apply at most one tightly scoped fix per bounded cluster pass.
-7. Re-run the reduced evidence set, then the broader oracle or report surface.
-8. Stop when the cluster is reclassified, converged, or proven out of scope.
+4. Capture the smallest trustworthy evidence surface first.
+5. Use reduced-cluster evidence before broad supplemental reruns.
+6. Classify each failure using the shared policy.
+7. Apply at most one tightly scoped fix per bounded cluster pass.
+8. Re-run the reduced evidence set, then the broader oracle or report surface.
+9. Stop when the cluster is reclassified, converged, or proven out of scope.
 
 ### Shared verification logic
 - Fidelity is the hard gate.
@@ -38,10 +42,17 @@ Out of scope:
 - QA must reject regressions and formatting defects.
 - Supplemental rich-input evidence is confirmation, not the first debugging surface.
 - CSL structure is verification evidence, not the source of truth for wrapper thickness.
+- For `profile` targets, verify that the file still satisfies the config-wrapper
+  contract: no local templates, no local `type-variants`, and no
+  template-clearing `null`.
+- For `journal` targets, accept `structural-wrapper` as a legitimate endpoint
+  when guide-backed deltas or current merge mechanics prevent a meaningful thin
+  reduction.
 
 ### Shared output shape
 Every workflow should report:
 - target or cluster chosen
+- semantic class and implementation form
 - classification and rationale
 - before/after evidence
 - exact change made, if any
@@ -52,6 +63,20 @@ Every workflow should report:
 - `style-defect` routes to style-local YAML repair.
 - `processor-defect` routes to processor or engine follow-up.
 - `intentional divergence` is recorded and excluded from fix counts.
+- If parentage is guide-backed but current merge semantics still force a bulky
+  wrapper, escalate as an infrastructure constraint rather than preserving or
+  reintroducing duplicated structure as if it were authority.
+
+## Waves
+
+A style wave is a bounded cohort executed through repeated `upgrade`,
+`migrate`, or `create` passes under this same execution flow.
+
+- Keep one wave to one family or one clearly related cohort per PR.
+- For profile-family work, it is valid to use `create` to author a hidden family
+  root first and then `upgrade` to reduce the public handles.
+- Do not add a separate public "wave" command surface; waves are an execution
+  pattern, not a new mode.
 
 ## Implementation Notes
 - Use this guide as the canonical place for the evidence ladder and convergence language currently repeated across style workflows.
@@ -63,4 +88,7 @@ Every workflow should report:
 - [x] The shared output contract is expressed here in host-neutral terms.
 
 ## Changelog
+- 2026-04-23: Added explicit semantic-class vs implementation-form
+  classification, profile-contract verification, journal structural-wrapper
+  acceptance, and bounded-wave guidance.
 - 2026-04-04: Initial version.

--- a/docs/policies/STYLE_WORKFLOW_DECISION_RULES.md
+++ b/docs/policies/STYLE_WORKFLOW_DECISION_RULES.md
@@ -15,6 +15,16 @@ Style-authority decisions for existing journals must follow this order:
 4. CSL implementation evidence
 5. existing Citum YAML structure
 
+Before editing YAML, shared style workflows must classify the target on two
+axes:
+1. semantic class: `base`, `profile`, `journal`, or `independent`
+2. implementation form: `alias`, `config-wrapper`, `structural-wrapper`, or
+   `standalone`
+
+This classification is operational, not cosmetic. It determines whether the
+style should be reduced to a thin wrapper, kept structural, or left
+self-contained.
+
 ## Rationale
 Style work in Citum repeatedly follows the same decision logic: determine whether the defect belongs in YAML, migration, engine behavior, or adjudication, then route the work accordingly. Putting that logic in one policy keeps the Claude and Codex wrappers thin and reduces drift between hosts.
 
@@ -23,16 +33,33 @@ Style work in Citum repeatedly follows the same decision logic: determine whethe
 - `migration-artifact` stays in migration-focused work.
 - `processor-defect` routes to engine or processor follow-up.
 - `intentional divergence` is recorded and excluded from fix counts.
+- `profile` means both a semantic relationship and a config-wrapper contract.
+  Profile work must preserve that contract: local metadata and scoped options
+  are allowed, but local templates, local `type-variants`, and
+  template-clearing `null` values are not.
+- `journal` is semantic only. A journal descendant may legitimately be an
+  `alias`, `config-wrapper`, or `structural-wrapper` depending on the evidence
+  and the current infrastructure.
 - If a publisher guide says a journal follows a known parent style with a few house tweaks, treat the parent preset as the baseline and keep only the documented deltas.
 - Treat CSL XML and migrated standalone YAML as implementation evidence, not the canonical authority for wrapper thickness.
 - If a guide-confirmed parent-plus-deltas relationship cannot yet be expressed compactly because preset merge semantics are too coarse, record that as an infrastructure constraint instead of preserving CSL duplication as the source of truth.
+- If guide-backed parentage is real but the current merge mechanics still force
+  a bulky child file, stop forcing compression. Record the infrastructure
+  constraint and keep the style structural until the override model improves.
 - If the same scenario fails with identical output after two distinct approaches, stop iterating on that scenario and reclassify it.
 - If a registered divergence explains the failure, record the divergence ID instead of treating it as a fresh bug.
+- A style wave is a bounded cohort executed through repeated `upgrade`,
+  `migrate`, or `create` passes under these same rules. Keep waves scoped to one
+  family or one clearly related cohort per PR.
 
 ## Exceptions
 - Host-specific routing, model choice, and permission semantics stay in the wrapper files.
 - Rich-input evidence ordering and per-skill output phrasing live in the execution guide.
 
 ## Changelog
+- v1.2 (2026-04-23): Added the two-axis taxonomy as an operational workflow
+  rule, made the config-wrapper profile contract explicit, clarified that
+  journal descendants may remain structural, and added the infrastructure-stop
+  rule for guide-backed wrappers blocked by current merge mechanics.
 - v1.1 (2026-04-19): Added explicit source-of-truth ordering for preset-wrapper work and clarified that CSL artifacts are verification evidence, not authority.
 - v1.0 (2026-04-04): Established shared style-workflow decision rules.


### PR DESCRIPTION
## Summary
- make the shared style workflow explicitly profile-aware
- correct the PR framing so true profile validity comes from guide-backed authority plus the config-wrapper contract, not from citeproc parity
- add a draft follow-up spec for documentary-primary verification of marked profile wrappers, piloted on Elsevier

## What changed
- added the semantic-class vs implementation-form classification step to the shared style workflow
- made the config-wrapper profile contract explicit and documented the stop rule for guide-backed wrappers blocked by current merge mechanics
- changed workflow language so fidelity means fidelity to the declared primary authority, not implicitly to citeproc-js
- updated the Elsevier proof-wave note so current CSL parity is treated as corroborating evidence rather than the reason the profiles are valid
- added a draft spec for documentary-primary profile verification using curated guide-backed fixtures, with `elsevier-harvard` and `elsevier-vancouver` as the first pilot

## Follow-up Spec
- `docs/specs/PROFILE_DOCUMENTARY_VERIFICATION.md`
- defines documentary-primary verification for true `profile + config-wrapper` styles
- keeps documentary-primary opt-in per style via verification policy
- uses curated rendered fixtures as the primary release gate
- keeps `citeproc-js` as secondary drift/conflict evidence rather than the failure-by-default authority for marked profile pilots

## Verification
- `./scripts/validate-frontmatter.sh --copilot-strict`
- `./scripts/check-docs-beans-hygiene.sh`
- `node scripts/oracle-yaml.js styles/embedded/elsevier-harvard.yaml styles-legacy/elsevier-harvard.csl --json`
- `node scripts/oracle-yaml.js styles/embedded/elsevier-vancouver.yaml styles-legacy/elsevier-vancouver.csl --json`
- `node scripts/report-core.js --style elsevier-harvard`
- `node scripts/report-core.js --style elsevier-vancouver`
- shared-fixture parent-vs-wrapper diffs for `elsevier-harvard` and `elsevier-vancouver`
