### PR TITLE
docs(verification): define documentary-primary profile follow-up

### DIFF
--- a/docs/architecture/2026-04-23_STYLE_EVOLVE_PROFILE_ELSEVIER_WAVE.md
+++ b/docs/architecture/2026-04-23_STYLE_EVOLVE_PROFILE_ELSEVIER_WAVE.md
@@ -17,6 +17,10 @@ The intended question was simple:
 
 The answer is yes on all three counts.
 
+The key qualification is that current citeproc parity is corroborating evidence,
+not the reason these styles qualify as profiles. Their validity comes from
+guide-backed family authority plus the `profile + config-wrapper` contract.
+
 ## Current Elsevier Family Shape
 
 The repo already contains dedicated hidden family roots and public thin wrappers
@@ -47,8 +51,9 @@ Authority basis:
 
 1. current Elsevier guide links embedded in the style metadata
 2. current family-root and wrapper YAML structure
-3. style-oracle and style-scoped report verification on the public handles
-4. shared-fixture parent-vs-wrapper diffs
+3. guide-backed `profile + config-wrapper` classification
+4. style-oracle and style-scoped report verification on the public handles
+5. shared-fixture parent-vs-wrapper diffs
 
 Operational classification:
 
@@ -71,9 +76,19 @@ Verification summary:
   while `elsevier-vancouver` changes label rendering relative to the family
   root
 
+These results show that the wrappers do not currently conflict with the legacy
+CSL comparison surface. They are supporting evidence only. The styles would
+still remain valid profiles if a future guide-backed scoped-option delta
+diverged from CSL, provided the wrapper contract and authority basis still
+held.
+
 ## Decision
 
 Keep the existing Elsevier family-root and wrapper YAML unchanged.
+
+Elsevier profiles are valid because they are guide-backed
+`profile + config-wrapper` wrappers over real family roots. Current citeproc
+parity supports that conclusion, but does not define it.
 
 The real repo gap was not missing Elsevier roots. It was that the shared
 workflow and host wrappers did not explicitly tell agents how to:
@@ -94,3 +109,15 @@ If a future family re-check shows that an Elsevier public handle needs more than
 scoped options and metadata, the correct action is to record the infrastructure
 constraint or author a different family base. It is not to silently treat copied
 structural YAML as authoritative.
+
+If a future guide-backed scoped-option delta diverges from CSL, that should
+trigger verification-policy follow-up rather than profile reclassification.
+
+## Follow-Up Spec
+
+The normative follow-up contract for documentary-primary profile verification
+now lives in [`docs/specs/PROFILE_DOCUMENTARY_VERIFICATION.md`](../specs/PROFILE_DOCUMENTARY_VERIFICATION.md).
+
+This PR does not yet implement documentary-primary comparator support in the
+verification tooling. It only corrects the branch framing so profile validity is
+not defined by citeproc parity.

--- a/docs/guides/STYLE_EVOLVE_WORKFLOW.md
+++ b/docs/guides/STYLE_EVOLVE_WORKFLOW.md
@@ -38,7 +38,7 @@ targeting.
 ```
 
 ## Quality Policy
-- Fidelity is the hard gate.
+- Fidelity to the declared primary authority is the hard gate.
 - SQI is a secondary optimization metric.
 - For styles with configured `benchmark_runs`, official rich-input evidence is auto-run as supplemental advisory output.
 - Every iteration must assess both:
@@ -59,6 +59,8 @@ targeting.
 - If guide-backed parentage is real but the current merge model still forces a
   bulky child file, record the infrastructure constraint and stop forcing
   compression.
+- True profiles may use documentary-primary verification when the verification
+  policy says so.
 
 ## Wave Guidance
 

--- a/docs/guides/STYLE_WORKFLOW_EXECUTION.md
+++ b/docs/guides/STYLE_WORKFLOW_EXECUTION.md
@@ -37,7 +37,7 @@ Out of scope:
 9. Stop when the cluster is reclassified, converged, or proven out of scope.
 
 ### Shared verification logic
-- Fidelity is the hard gate.
+- Fidelity to the declared primary authority is the hard gate.
 - SQI or other secondary metrics are advisory unless a workflow explicitly promotes them.
 - QA must reject regressions and formatting defects.
 - Supplemental rich-input evidence is confirmation, not the first debugging surface.

--- a/docs/reference/SQI.md
+++ b/docs/reference/SQI.md
@@ -6,7 +6,7 @@ Use SQI to improve style maintainability only after fidelity is correct.
 
 ## Priority Order
 
-1. Fidelity (hard gate): output must match the citeproc-js oracle.
+1. Fidelity (hard gate): output must match the style's declared primary authority.
 2. SQI (secondary): choose cleaner, more robust style definitions when fidelity is comparable.
 
 Never accept an SQI gain that causes a fidelity regression.

--- a/docs/specs/PROFILE_DOCUMENTARY_VERIFICATION.md
+++ b/docs/specs/PROFILE_DOCUMENTARY_VERIFICATION.md
@@ -1,0 +1,173 @@
+# Profile Documentary Verification Specification
+
+**Status:** Draft
+**Date:** 2026-04-23
+**Related:** `UNIFIED_SCOPED_OPTIONS.md`, `STYLE_TAXONOMY.md`, `../architecture/MULTI_AUTHORITY_STYLE_VERIFICATION_PLAN_2026-03-07.md`, bean `csl26-u1tq`
+
+## Purpose
+
+Define the verification model for true `profile + config-wrapper` styles when
+publisher or journal documentation is a better primary authority than the
+corresponding CSL renderer.
+
+This specification introduces documentary-primary verification as an opt-in
+policy for marked profile wrappers. The first implementation wave pilots the
+model on `elsevier-harvard` and `elsevier-vancouver`.
+
+## Scope
+
+In scope:
+
+- primary-authority verification for styles already classified as
+  `profile + config-wrapper`
+- policy metadata required to mark a profile as documentary-primary
+- comparator behavior for documentary-primary reports and checks
+- curated rendered fixture requirements for the Elsevier pilot
+- release-gate semantics when documentary evidence and citeproc-js disagree
+
+Out of scope:
+
+- changing the global default authority away from `citeproc-js`
+- applying documentary-primary verification to journals, structural wrappers, or
+  standalone styles in this wave
+- reclassifying `elsevier-with-titles` or non-Elsevier profile families
+- changing style YAML schema or widening what profiles are allowed to override
+
+## Design
+
+### 1. Eligibility
+
+This model applies only to styles that are already valid `profile +
+config-wrapper` wrappers.
+
+A style may be documentary-primary only when all of the following are true:
+
+- it is semantically classified as a `profile`
+- it is operationally a `config-wrapper`
+- it keeps the config-wrapper contract:
+  no local templates, no local `type-variants`, and no template-clearing `null`
+- current publisher, society, standards, or journal guidance provides a better
+  authority basis for the wrapper delta than the corresponding CSL renderer
+
+If a style stops satisfying the config-wrapper contract, it must be reclassified
+before it can use documentary-primary verification.
+
+### 2. Authority Model
+
+Documentary-primary verification is opt-in per style. It is not the new global
+default.
+
+For a marked documentary-primary profile:
+
+- curated documentary fixtures are the primary release gate
+- `citeproc-js` remains a secondary comparison source
+- a citeproc mismatch is not a release failure by itself
+- citeproc drift still appears in reports for adjudication and conflict review
+
+This means fidelity is defined as fidelity to the declared primary authority,
+not universal parity with the nearest CSL ancestor.
+
+### 3. Verification Policy Metadata
+
+The follow-up implementation must support the following policy shape in
+`scripts/report-data/verification-policy.yaml` for marked pilot styles:
+
+- `authority: documentary`
+- `authority_id: <fixture-set-id>`
+- `secondary: [citeproc-js]`
+- `scopes: [citation, bibliography]`
+- optional `note` explaining why documentary authority overrides CSL for that
+  profile
+
+The `authority_id` identifies the curated documentary fixture set used by the
+documentary comparator.
+
+### 4. Comparator Behavior
+
+The reporting and oracle layer must add a documentary comparator path.
+
+That path must:
+
+- load curated expected citation and bibliography outputs from documentary
+  snapshot or fixture files
+- compare Citum output against those documentary expectations for the declared
+  scopes
+- report documentary-primary pass/fail separately from citeproc secondary drift
+- keep citeproc mismatches visible in reports
+- preserve adjusted-divergence handling for citeproc secondary comparisons
+  without letting those adjustments redefine documentary pass/fail
+
+Documentary-primary pass/fail and citeproc secondary-drift reporting must be
+distinct outputs, not a single conflated fidelity result.
+
+### 5. Fixture Model
+
+Use curated rendered fixtures as the primary authority form.
+
+For the Elsevier pilot, create one documentary fixture set for each profile:
+
+- `elsevier-harvard`
+- `elsevier-vancouver`
+
+Each set must contain expected citation and bibliography outputs for the
+guide-backed deltas that justify the wrapper.
+
+Minimum coverage for the pilot:
+
+- `elsevier-harvard`: bibliography cases that prove
+  `bibliography.options.date-position`
+- `elsevier-vancouver`: citation and bibliography cases that prove label-wrap
+  and bibliography label-mode behavior
+
+The pilot fixture sets must be explicit enough that a passing result means the
+documented wrapper effect is actually being verified, not merely inferred from
+unrelated baseline fixtures.
+
+### 6. Elsevier Pilot Scope
+
+The first implementation wave is limited to:
+
+- `elsevier-harvard`
+- `elsevier-vancouver`
+
+Do not widen this wave to:
+
+- `elsevier-with-titles`
+- Springer profiles
+- Taylor & Francis profiles
+- journal wrappers
+- a portfolio-wide documentary-primary rollout
+
+The pilot exists to prove the policy and comparator model before broader
+adoption.
+
+## Implementation Notes
+
+- The policy layer already accepts `documentary` as an authority kind; the main
+  missing piece is the actual documentary comparator path in reporting/oracle
+  tooling.
+- Existing citeproc-based reports remain valuable as secondary drift evidence
+  and should stay visible to maintainers.
+- The pilot should favor small curated fixture sets over a broad but weak
+  documentary corpus.
+
+## Acceptance Criteria
+
+- [ ] Marked documentary-primary profiles pass/fail against curated documentary
+      fixtures.
+- [ ] Reports show documentary as the primary authority and citeproc-js as a
+      secondary source for the pilot styles.
+- [ ] Citeproc mismatches remain visible in reports but do not fail CI when
+      documentary authority passes.
+- [ ] Styles not explicitly marked documentary-primary keep their current
+      authority behavior.
+- [ ] A profile that violates the config-wrapper contract cannot be
+      documentary-primary without first being reclassified.
+- [ ] The Elsevier pilot includes separate documentary fixture sets for
+      `elsevier-harvard` and `elsevier-vancouver`.
+- [ ] Pilot fixtures cover the exact scoped-option effects that justify the
+      wrappers.
+
+## Changelog
+
+- 2026-04-23: Initial draft.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -61,3 +61,4 @@ to make sure the document should be a spec rather than architecture or policy.
 | [`EMBEDDED_JS_TEMPLATE_INFERENCE.md`](./EMBEDDED_JS_TEMPLATE_INFERENCE.md) | Embedded `deno_core` live inference backend for `citum-migrate` |
 | [`CONFIG_ONLY_PROFILE_OVERRIDES.md`](./CONFIG_ONLY_PROFILE_OVERRIDES.md) | Superseded profile-specific wrapper contract |
 | [`UNIFIED_SCOPED_OPTIONS.md`](./UNIFIED_SCOPED_OPTIONS.md) | Breaking replacement for `options.profile` using normal scoped options |
+| [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Documentary-primary verification model for true profile wrappers |


### PR DESCRIPTION
## Summary
- correct the authority framing left implicit in the merged profile-aware workflow PR
- state clearly that true profile validity comes from guide-backed authority plus the config-wrapper contract, not from citeproc parity
- add a draft follow-up spec for documentary-primary verification of marked profile wrappers, piloted on Elsevier

## What changed
- updated workflow/reference docs so fidelity means fidelity to the declared primary authority
- revised the Elsevier proof-wave note so current CSL parity is corroborating evidence rather than the reason the profiles qualify as profiles
- added `docs/specs/PROFILE_DOCUMENTARY_VERIFICATION.md` as the normative follow-up spec for documentary-primary profile verification
- indexed the new spec in `docs/specs/README.md`

## Why this is separate
The earlier PR was already merged before these follow-up docs/spec changes were committed. This PR cleanly carries the leftover work as its own reviewable follow-up instead of mutating the merged branch history.

## Verification
- `./scripts/validate-frontmatter.sh --copilot-strict`
- `./scripts/check-docs-beans-hygiene.sh`
