### PR TITLE
feat(migrate): add taxonomy-aware wrapper lineage

### DIFF
--- a/.codex/agents/migration-researcher.md
+++ b/.codex/agents/migration-researcher.md
@@ -22,7 +22,11 @@ verification:
   - For Rust changes, use the repo's required verification flow.
 output_contract:
   - State the chosen cluster.
+  - State the target semantic class and implementation form.
+  - State the selected parent style when one exists.
   - Classify it as `migration-artifact`, `style-defect`, `processor-defect`, or `intentional divergence`.
+  - Preserve the config-wrapper contract for `profile + config-wrapper` targets.
+  - Accept `journal + structural-wrapper` as a valid stopping point.
   - If classified as `migration-artifact`, make at most one tightly scoped code change for that pass.
   - Report before/after evidence and note any remaining uncertainty.
 ---

--- a/.codex/skills/migrate-research/SKILL.md
+++ b/.codex/skills/migrate-research/SKILL.md
@@ -24,13 +24,19 @@ Read first:
 ## Operating Rules
 
 - Start with the smallest trustworthy evidence surface.
+- State the target semantic class and implementation form before proposing a fix.
 - Classify each cluster as `migration-artifact`, `style-defect`, `processor-defect`,
   or `intentional divergence`.
+- Record the selected parent style when the target is a known wrapper.
+- Preserve the config-wrapper contract for `profile + config-wrapper` targets.
+- Treat `journal + structural-wrapper` as a valid endpoint; do not force thin-wrapper reduction.
+- If a migration-side fix would require local templates or local `type-variants` in a profile,
+  stop and reroute or escalate instead of breaking the profile contract.
 - Stop when the cluster is clearly out of scope or converged.
 - Keep the loop bounded to one cluster per pass.
 
 ## Output
 
-Report the chosen cluster, classification, before/after evidence, exact change made if
-any, and whether the pass should continue, stop, or escalate.
-
+Report the chosen cluster, semantic class, implementation form, selected parent if any,
+classification, before/after evidence, exact change made if any, and whether the pass
+should continue, stop, or escalate.

--- a/crates/citum-migrate/README.md
+++ b/crates/citum-migrate/README.md
@@ -12,6 +12,12 @@ The migration pipeline is now output-driven first:
 
 This keeps option extraction deterministic while scaling template migration to large style corpora.
 
+When the target style is already known in the repo as a profile or journal
+wrapper, `citum-migrate` now derives that lineage from current repo truth and
+may emit `extends:`-based wrapper output instead of flattening everything into a
+standalone style. Unknown or unresolved styles still fall back to standalone
+output.
+
 ## CLI Usage
 
 ```bash

--- a/crates/citum-migrate/src/base_detector.rs
+++ b/crates/citum-migrate/src/base_detector.rs
@@ -3,11 +3,10 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-//! Detects when extracted configuration matches known style bases.
+//! Detects narrow formatting families for migration fixups.
 //!
-//! This module implements base detection for Phase 3 of the style aliasing
-//! design. When migrating CSL 1.0 styles, it compares extracted configuration
-//! to known base patterns and emits base names instead of expanded configs.
+//! This module does not determine style taxonomy or wrapper lineage. It only
+//! detects narrow formatting families used by migration-time fixups.
 //!
 //! ## Detection Strategy
 //!
@@ -23,9 +22,9 @@ use citum_schema::options::{
 };
 use citum_schema::presets::{ContributorPreset, DatePreset, TitlePreset};
 
-/// Holistic style bases that combine multiple configuration aspects.
+/// Narrow formatting families used only by migration fixups.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StyleBase {
+pub enum FixupFamily {
     Apa,
     Chicago,
     Ieee,
@@ -33,8 +32,8 @@ pub enum StyleBase {
     Harvard,
 }
 
-/// Detects the style base from a full configuration.
-pub fn detect_style_base(config: &Config) -> Option<StyleBase> {
+/// Detect the formatting family used by migration fixups from a full config.
+pub fn detect_fixup_family(config: &Config) -> Option<FixupFamily> {
     let cp = config
         .contributors
         .as_ref()
@@ -42,13 +41,29 @@ pub fn detect_style_base(config: &Config) -> Option<StyleBase> {
     let tp = config.titles.as_ref().and_then(detect_title_preset);
 
     match (cp, tp) {
-        (Some(ContributorPreset::Apa), Some(TitlePreset::Apa)) => Some(StyleBase::Apa),
-        (Some(ContributorPreset::Chicago), Some(TitlePreset::Chicago)) => Some(StyleBase::Chicago),
-        (Some(ContributorPreset::Ieee), Some(TitlePreset::Chicago)) => Some(StyleBase::Ieee),
-        (Some(ContributorPreset::Vancouver), _) => Some(StyleBase::Vancouver),
-        (Some(ContributorPreset::Harvard), _) => Some(StyleBase::Harvard),
+        (Some(ContributorPreset::Apa), Some(TitlePreset::Apa)) => Some(FixupFamily::Apa),
+        (Some(ContributorPreset::Chicago), Some(TitlePreset::Chicago)) => {
+            Some(FixupFamily::Chicago)
+        }
+        (Some(ContributorPreset::Ieee), Some(TitlePreset::Chicago)) => Some(FixupFamily::Ieee),
+        (Some(ContributorPreset::Vancouver), _) => Some(FixupFamily::Vancouver),
+        (Some(ContributorPreset::Harvard), _) => Some(FixupFamily::Harvard),
         _ => None,
     }
+}
+
+/// Backward-compatible alias for the historical fixup family name.
+#[deprecated(note = "use FixupFamily instead; this type models fixup families, not taxonomy")]
+pub type StyleBase = FixupFamily;
+
+/// Backward-compatible wrapper for the historical fixup family detector.
+#[deprecated(note = "use detect_fixup_family instead")]
+#[allow(
+    deprecated,
+    reason = "compatibility shim must preserve the historical signature"
+)]
+pub fn detect_style_base(config: &Config) -> Option<StyleBase> {
+    detect_fixup_family(config)
 }
 
 /// Detects if a `ContributorConfig` matches a known preset.

--- a/crates/citum-migrate/src/compilation.rs
+++ b/crates/citum-migrate/src/compilation.rs
@@ -145,11 +145,11 @@ pub fn compile_from_xml(
         passes::reorder::add_volume_prefix_after_serial(&mut new_bib);
     }
 
-    // Detect holistic style preset for semantic fixups
-    let style_base = base_detector::detect_style_base(options);
+    // Detect the narrow formatting family needed by migration fixups.
+    let fixup_family = base_detector::detect_fixup_family(options);
 
     if is_in_text_class && is_author_date_processing {
-        apply_author_date_bibliography_passes(&mut new_bib, options, style_base);
+        apply_author_date_bibliography_passes(&mut new_bib, options, fixup_family);
     }
 
     let type_templates_opt = if type_templates.is_empty() {
@@ -244,7 +244,7 @@ fn record_template_placements_if_enabled(
 fn apply_author_date_bibliography_passes(
     new_bib: &mut Vec<TemplateComponent>,
     options: &mut citum_schema::options::Config,
-    style_base: Option<base_detector::StyleBase>,
+    fixup_family: Option<base_detector::FixupFamily>,
 ) {
     // Detect if the style uses space prefix for volume (Elsevier pattern)
     let volume_list_has_space_prefix = new_bib.iter().any(|c| {
@@ -265,7 +265,7 @@ fn apply_author_date_bibliography_passes(
             component,
             vol_pages_delim.clone(),
             volume_list_has_space_prefix,
-            style_base,
+            fixup_family,
         );
     }
 
@@ -279,12 +279,12 @@ fn apply_author_date_bibliography_passes(
     passes::reorder::propagate_list_overrides(new_bib);
     passes::deduplicate::deduplicate_nested_lists(new_bib);
     passes::reorder::reorder_serial_components(new_bib);
-    passes::grouping::group_volume_and_issue(new_bib, options, style_base);
+    passes::grouping::group_volume_and_issue(new_bib, options, fixup_family);
     passes::reorder::reorder_pages_for_serials(new_bib);
-    passes::reorder::reorder_publisher_place_for_chicago(new_bib, style_base);
-    passes::reorder::reorder_chapters_for_apa(new_bib, style_base);
-    passes::reorder::reorder_chapters_for_chicago(new_bib, style_base);
-    passes::deduplicate::suppress_duplicate_issue_for_journals(new_bib, style_base);
+    passes::reorder::reorder_publisher_place_for_chicago(new_bib, fixup_family);
+    passes::reorder::reorder_chapters_for_apa(new_bib, fixup_family);
+    passes::reorder::reorder_chapters_for_chicago(new_bib, fixup_family);
+    passes::deduplicate::suppress_duplicate_issue_for_journals(new_bib, fixup_family);
 }
 
 #[allow(
@@ -295,7 +295,7 @@ fn apply_type_overrides(
     component: &mut TemplateComponent,
     volume_pages_delimiter: Option<citum_schema::template::DelimiterPunctuation>,
     volume_list_has_space_prefix: bool,
-    style_base: Option<base_detector::StyleBase>,
+    fixup_family: Option<base_detector::FixupFamily>,
 ) {
     if let TemplateComponent::Group(list) = component {
         for item in &mut list.group {
@@ -303,7 +303,7 @@ fn apply_type_overrides(
                 item,
                 volume_pages_delimiter.clone(),
                 volume_list_has_space_prefix,
-                style_base,
+                fixup_family,
             );
         }
     }

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -18,6 +18,8 @@ pub mod fixups;
 /// Style metadata extraction.
 pub mod info_extractor;
 mod js_runtime;
+/// Migration-time lineage and wrapper classification.
+pub mod lineage;
 /// Options extraction from CSL 1.0.
 pub mod options_extractor;
 /// Multi-pass processing pipeline.

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -1,0 +1,533 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Migration-time style lineage and wrapper classification.
+
+use citum_schema::Style;
+use citum_schema::embedded;
+use citum_schema::registry::{StyleKind, StyleRegistry};
+use serde_yaml::{Mapping, Value};
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+/// Taxonomy-level semantic class for the migration target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticClass {
+    Base,
+    Profile,
+    Journal,
+    Independent,
+    Unknown,
+}
+
+/// Current implementation form derived from the checked-in style shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImplementationForm {
+    Alias,
+    ConfigWrapper,
+    StructuralWrapper,
+    Standalone,
+    Unknown,
+}
+
+/// Migration-time lineage for one style target.
+#[derive(Debug, Clone)]
+pub struct StyleLineage {
+    /// Canonical style ID derived from the CSL filename.
+    pub style_id: String,
+    /// Semantic class from the registry or alias surface.
+    pub semantic_class: SemanticClass,
+    /// Current implementation form derived from the checked-in style.
+    pub implementation_form: ImplementationForm,
+    /// Established parent style ID, if any.
+    pub parent_style_id: Option<String>,
+    parent_style: Option<Style>,
+}
+
+/// Failure while resolving or rewriting migration lineage.
+#[derive(Debug)]
+pub enum LineageError {
+    Io(std::io::Error),
+    Yaml(serde_yaml::Error),
+}
+
+impl fmt::Display for LineageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LineageError::Io(err) => write!(f, "{err}"),
+            LineageError::Yaml(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for LineageError {}
+
+impl From<std::io::Error> for LineageError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<serde_yaml::Error> for LineageError {
+    fn from(value: serde_yaml::Error) -> Self {
+        Self::Yaml(value)
+    }
+}
+
+impl StyleLineage {
+    /// Resolve migration lineage from the CSL file path and repository root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the current style or its established parent cannot
+    /// be read or parsed from repo-owned YAML.
+    pub fn resolve(input_path: &str, repo_root: &Path) -> Result<Self, LineageError> {
+        let style_id = Path::new(input_path)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let registry = StyleRegistry::load_default();
+        let exact_entry = registry.styles.iter().find(|entry| entry.id == style_id);
+        let alias_target = registry
+            .styles
+            .iter()
+            .find(|entry| entry.aliases.iter().any(|alias| alias == &style_id));
+
+        let current_style = load_current_style(repo_root, &style_id, exact_entry)?;
+        let semantic_class = if let Some(entry) = exact_entry {
+            map_style_kind(entry.kind.as_ref())
+        } else if alias_target.is_some() {
+            SemanticClass::Journal
+        } else if let Some(style) = current_style.as_ref() {
+            if style.extends.is_some() {
+                SemanticClass::Journal
+            } else {
+                SemanticClass::Independent
+            }
+        } else {
+            SemanticClass::Unknown
+        };
+        let parent_style_id = current_style
+            .as_ref()
+            .and_then(|style| style.extends.as_ref())
+            .map(|base| base.key().to_string())
+            .or_else(|| alias_target.map(|entry| entry.id.clone()));
+        let parent_style = parent_style_id
+            .as_deref()
+            .map(|parent| load_style_by_id(repo_root, parent))
+            .transpose()?;
+
+        let implementation_form = if current_style.is_none() && alias_target.is_some() {
+            ImplementationForm::Alias
+        } else if let Some(style) = current_style.as_ref() {
+            derive_implementation_form(style)
+        } else {
+            ImplementationForm::Unknown
+        };
+
+        Ok(Self {
+            style_id,
+            semantic_class,
+            implementation_form,
+            parent_style_id,
+            parent_style,
+        })
+    }
+
+    /// Rewrite a standalone migrated style into wrapper form when the current
+    /// repo truth already establishes that relationship.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the rewritten wrapper cannot be serialized or
+    /// deserialized as a valid `Style`.
+    pub fn apply_to_migrated_style(&self, style: Style) -> Result<Style, LineageError> {
+        let Some(parent_style_id) = self.parent_style_id.as_deref() else {
+            return Ok(style);
+        };
+        let Some(parent_style) = self.parent_style.as_ref() else {
+            return Ok(style);
+        };
+
+        let exclude_template_paths = match (self.semantic_class, self.implementation_form) {
+            (
+                SemanticClass::Profile | SemanticClass::Journal,
+                ImplementationForm::ConfigWrapper,
+            ) => true,
+            (SemanticClass::Journal, ImplementationForm::StructuralWrapper) => false,
+            _ => return Ok(style),
+        };
+
+        let child = serde_yaml::to_value(&style)?;
+        let parent = serde_yaml::to_value(parent_style.clone().into_resolved())?;
+
+        let mut diff = match diff_value(&child, &parent, &mut Vec::new(), exclude_template_paths) {
+            Some(Value::Mapping(map)) => map,
+            Some(other) => {
+                let mut map = Mapping::new();
+                map.insert(Value::String("style".to_string()), other);
+                map
+            }
+            None => Mapping::new(),
+        };
+
+        diff.insert(
+            Value::String("extends".to_string()),
+            Value::String(parent_style_id.to_string()),
+        );
+
+        let mut rebuilt: Style = serde_yaml::from_value(Value::Mapping(diff))?;
+        rebuilt.raw_yaml = None;
+        Ok(rebuilt)
+    }
+}
+
+fn map_style_kind(kind: Option<&StyleKind>) -> SemanticClass {
+    match kind {
+        Some(StyleKind::Base) => SemanticClass::Base,
+        Some(StyleKind::Profile) => SemanticClass::Profile,
+        Some(StyleKind::Journal) => SemanticClass::Journal,
+        Some(StyleKind::Independent) => SemanticClass::Independent,
+        None => SemanticClass::Unknown,
+    }
+}
+
+fn load_current_style(
+    repo_root: &Path,
+    style_id: &str,
+    exact_entry: Option<&citum_schema::RegistryEntry>,
+) -> Result<Option<Style>, LineageError> {
+    let local_path = repo_root.join("styles").join(format!("{style_id}.yaml"));
+    if local_path.exists() {
+        return Ok(Some(load_style_from_path(&local_path)?));
+    }
+
+    if let Some(entry) = exact_entry
+        && let Some(name) = &entry.builtin
+        && let Some(style) = embedded::get_embedded_style(name)
+    {
+        return Ok(Some(style?));
+    }
+
+    Ok(None)
+}
+
+fn load_style_by_id(repo_root: &Path, style_id: &str) -> Result<Style, LineageError> {
+    let local_path = repo_root.join("styles").join(format!("{style_id}.yaml"));
+    if local_path.exists() {
+        return load_style_from_path(&local_path);
+    }
+
+    if let Some(style) = embedded::get_embedded_style(style_id) {
+        return Ok(style?);
+    }
+
+    let embedded_path = repo_root
+        .join("styles")
+        .join("embedded")
+        .join(format!("{style_id}.yaml"));
+    if embedded_path.exists() {
+        return load_style_from_path(&embedded_path);
+    }
+
+    Err(LineageError::Io(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!("unable to resolve parent style `{style_id}`"),
+    )))
+}
+
+fn load_style_from_path(path: &Path) -> Result<Style, LineageError> {
+    let yaml = fs::read_to_string(path)?;
+    Ok(Style::from_yaml_str(&yaml)?)
+}
+
+fn derive_implementation_form(style: &Style) -> ImplementationForm {
+    if style.extends.is_none() {
+        return ImplementationForm::Standalone;
+    }
+
+    if has_template_bearing_structure(style) {
+        ImplementationForm::StructuralWrapper
+    } else {
+        ImplementationForm::ConfigWrapper
+    }
+}
+
+fn has_template_bearing_structure(style: &Style) -> bool {
+    if style.templates.is_some() || yaml_path_present(style.raw_yaml.as_ref(), &["templates"]) {
+        return true;
+    }
+
+    TEMPLATE_BEARING_PATHS
+        .iter()
+        .any(|path| yaml_path_present(style.raw_yaml.as_ref(), path))
+}
+
+const TEMPLATE_BEARING_PATHS: [&[&str]; 9] = [
+    &["templates"],
+    &["citation", "template"],
+    &["citation", "type-variants"],
+    &["citation", "integral", "template"],
+    &["citation", "integral", "type-variants"],
+    &["citation", "non-integral", "template"],
+    &["citation", "non-integral", "type-variants"],
+    &["bibliography", "template"],
+    &["bibliography", "type-variants"],
+];
+
+fn yaml_path_present(value: Option<&Value>, path: &[&str]) -> bool {
+    let Some(mut current) = value else {
+        return false;
+    };
+    for segment in path {
+        let Value::Mapping(map) = current else {
+            return false;
+        };
+        let key = Value::String((*segment).to_string());
+        let Some(next) = map.get(&key) else {
+            return false;
+        };
+        current = next;
+    }
+    true
+}
+
+fn diff_value(
+    child: &Value,
+    parent: &Value,
+    path: &mut Vec<String>,
+    exclude_template_paths: bool,
+) -> Option<Value> {
+    if child == parent {
+        return None;
+    }
+
+    match (child, parent) {
+        (Value::Mapping(child_map), Value::Mapping(parent_map)) => {
+            let mut diff = Mapping::new();
+            for (key, child_value) in child_map {
+                let Some(segment) = key.as_str() else {
+                    diff.insert(key.clone(), child_value.clone());
+                    continue;
+                };
+                path.push(segment.to_string());
+                if exclude_template_paths && is_template_bearing_path(path) {
+                    path.pop();
+                    continue;
+                }
+
+                match parent_map.get(key) {
+                    Some(parent_value) => {
+                        if let Some(child_diff) =
+                            diff_value(child_value, parent_value, path, exclude_template_paths)
+                        {
+                            diff.insert(key.clone(), child_diff);
+                        }
+                    }
+                    None => {
+                        diff.insert(key.clone(), child_value.clone());
+                    }
+                }
+                path.pop();
+            }
+
+            if diff.is_empty() {
+                None
+            } else {
+                Some(Value::Mapping(diff))
+            }
+        }
+        _ => Some(child.clone()),
+    }
+}
+
+fn is_template_bearing_path(path: &[String]) -> bool {
+    TEMPLATE_BEARING_PATHS.iter().any(|candidate| {
+        candidate.len() == path.len()
+            && candidate
+                .iter()
+                .zip(path.iter())
+                .all(|(expected, actual)| *expected == actual)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use citum_schema::template::{
+        ContributorForm, ContributorRole, DateForm, DateVariable, SimpleVariable,
+        TemplateComponent, TemplateContributor, TemplateDate, TemplateVariable,
+    };
+    use std::path::PathBuf;
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("crate dir should have workspace root")
+            .to_path_buf()
+    }
+
+    fn minimal_migrated_style() -> Style {
+        Style {
+            info: citum_schema::StyleInfo {
+                title: Some("Migrated Test".to_string()),
+                id: Some("https://example.org/migrated-test".to_string()),
+                ..Default::default()
+            },
+            citation: Some(citum_schema::CitationSpec {
+                template: Some(vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author,
+                        form: ContributorForm::Short,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        ..Default::default()
+                    }),
+                ]),
+                ..Default::default()
+            }),
+            bibliography: Some(citum_schema::BibliographySpec {
+                template: Some(vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author,
+                        form: ContributorForm::Long,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Doi,
+                        ..Default::default()
+                    }),
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolves_embedded_profile_as_config_wrapper() {
+        let lineage =
+            StyleLineage::resolve("styles-legacy/elsevier-harvard.csl", &repo_root()).unwrap();
+
+        assert_eq!(lineage.style_id, "elsevier-harvard");
+        assert_eq!(lineage.semantic_class, SemanticClass::Profile);
+        assert_eq!(
+            lineage.implementation_form,
+            ImplementationForm::ConfigWrapper
+        );
+        assert_eq!(
+            lineage.parent_style_id.as_deref(),
+            Some("elsevier-harvard-core")
+        );
+    }
+
+    #[test]
+    fn resolves_journal_config_wrapper_from_local_style() {
+        let lineage = StyleLineage::resolve(
+            "styles-legacy/disability-and-rehabilitation.csl",
+            &repo_root(),
+        )
+        .unwrap();
+
+        assert_eq!(lineage.semantic_class, SemanticClass::Journal);
+        assert_eq!(
+            lineage.implementation_form,
+            ImplementationForm::ConfigWrapper
+        );
+        assert_eq!(
+            lineage.parent_style_id.as_deref(),
+            Some("elsevier-with-titles")
+        );
+    }
+
+    #[test]
+    fn resolves_journal_structural_wrapper_from_local_style() {
+        let lineage = StyleLineage::resolve(
+            "styles-legacy/american-society-of-mechanical-engineers.csl",
+            &repo_root(),
+        )
+        .unwrap();
+
+        assert_eq!(lineage.semantic_class, SemanticClass::Journal);
+        assert_eq!(
+            lineage.implementation_form,
+            ImplementationForm::StructuralWrapper
+        );
+        assert_eq!(lineage.parent_style_id.as_deref(), Some("ieee"));
+    }
+
+    #[test]
+    fn resolves_unknown_style_as_unknown() {
+        let lineage =
+            StyleLineage::resolve("styles-legacy/definitely-unknown-style.csl", &repo_root())
+                .unwrap();
+
+        assert_eq!(lineage.semantic_class, SemanticClass::Unknown);
+        assert_eq!(lineage.implementation_form, ImplementationForm::Unknown);
+        assert!(lineage.parent_style_id.is_none());
+    }
+
+    #[test]
+    fn config_wrapper_output_sets_extends_and_strips_templates() {
+        let lineage =
+            StyleLineage::resolve("styles-legacy/elsevier-harvard.csl", &repo_root()).unwrap();
+        let rewritten = lineage
+            .apply_to_migrated_style(minimal_migrated_style())
+            .unwrap();
+
+        assert_eq!(
+            rewritten.extends.as_ref().map(|base| base.key()),
+            Some("elsevier-harvard-core")
+        );
+        assert!(
+            rewritten
+                .citation
+                .as_ref()
+                .and_then(|citation| citation.template.as_ref())
+                .is_none(),
+            "config-wrapper profiles must not keep local citation templates"
+        );
+        assert!(
+            rewritten
+                .bibliography
+                .as_ref()
+                .and_then(|bibliography| bibliography.template.as_ref())
+                .is_none(),
+            "config-wrapper profiles must not keep local bibliography templates"
+        );
+    }
+
+    #[test]
+    fn structural_wrapper_output_keeps_extends_and_structural_deltas() {
+        let lineage = StyleLineage::resolve(
+            "styles-legacy/american-society-of-mechanical-engineers.csl",
+            &repo_root(),
+        )
+        .unwrap();
+        let rewritten = lineage
+            .apply_to_migrated_style(minimal_migrated_style())
+            .unwrap();
+
+        assert_eq!(
+            rewritten.extends.as_ref().map(|base| base.key()),
+            Some("ieee")
+        );
+        assert!(
+            rewritten
+                .citation
+                .as_ref()
+                .and_then(|citation| citation.template.as_ref())
+                .is_some(),
+            "structural wrappers should preserve local structural citation deltas"
+        );
+    }
+}

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -14,6 +14,7 @@ use citum_migrate::{
         note_citation_template_is_underfit, scrub_inferred_literal_artifacts,
         should_merge_inferred_type_template,
     },
+    lineage::StyleLineage,
     options_extractor::MigrationOptions,
     provenance::ProvenanceTracker,
     template_resolver,
@@ -25,7 +26,7 @@ use citum_schema::{
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Shorthand for the per-type template map used throughout the migration pipeline.
 type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
@@ -191,18 +192,7 @@ fn resolve_style_name_and_templates(
         .unwrap_or("unknown")
         .to_string();
 
-    let workspace_root = {
-        let style_path = std::path::Path::new(path);
-        if style_path.is_absolute() {
-            style_path
-                .ancestors()
-                .find(|p| p.join("Cargo.toml").exists())
-                .unwrap_or(style_path.parent().unwrap_or(std::path::Path::new(".")))
-                .to_path_buf()
-        } else {
-            std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
-        }
-    };
+    let workspace_root = workspace_root_for_style_path(path);
 
     let resolved = template_resolver::resolve_templates(
         path,
@@ -215,6 +205,19 @@ fn resolve_style_name_and_templates(
     );
 
     (style_name, resolved)
+}
+
+fn workspace_root_for_style_path(path: &str) -> PathBuf {
+    let style_path = Path::new(path);
+    if style_path.is_absolute() {
+        style_path
+            .ancestors()
+            .find(|p| p.join("Cargo.toml").exists())
+            .unwrap_or(style_path.parent().unwrap_or(Path::new(".")))
+            .to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    }
 }
 
 fn extract_citation_collapse(citation: &csl_legacy::model::Citation) -> Option<CitationCollapse> {
@@ -316,8 +319,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize provenance tracking if debug variable is specified
     let enable_provenance = cli.debug_variable.is_some();
     let tracker = ProvenanceTracker::new(enable_provenance);
+    let workspace_root = workspace_root_for_style_path(path);
+    let lineage = StyleLineage::resolve(path, &workspace_root)?;
 
     eprintln!("Migrating {path} to Citum...");
+    eprintln!(
+        "Resolved lineage: semantic={:?}, form={:?}, parent={}",
+        lineage.semantic_class,
+        lineage.implementation_form,
+        lineage.parent_style_id.as_deref().unwrap_or("none")
+    );
 
     let text = fs::read_to_string(path)?;
     let doc = Document::parse(&text)?;
@@ -380,7 +391,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         resolve_citation_metadata(&resolved, &legacy_style, &options, &mut new_cit);
 
     // 5. Build Style in correct format for citum_engine
-    let style = build_final_style(
+    let standalone_style = build_final_style(
         &legacy_style,
         CompiledOutput {
             options,
@@ -398,6 +409,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             citation_ibid_override,
         },
     );
+    let style = lineage.apply_to_migrated_style(standalone_style)?;
 
     output_style_and_debug(&style, cli.debug_variable.as_deref(), &tracker)?;
     Ok(())

--- a/crates/citum-migrate/src/passes/deduplicate.rs
+++ b/crates/citum-migrate/src/passes/deduplicate.rs
@@ -184,7 +184,7 @@ pub fn list_signature(list: &citum_schema::template::TemplateGroup) -> String {
 /// Suppress duplicate issue in parent-monograph lists for article-journal types.
 pub fn suppress_duplicate_issue_for_journals(
     _components: &mut [TemplateComponent],
-    _style_preset: Option<crate::base_detector::StyleBase>,
+    _fixup_family: Option<crate::base_detector::FixupFamily>,
 ) {
     // Overrides-based suppression removed as component-level overrides are deprecated.
 }

--- a/crates/citum-migrate/src/passes/grouping.rs
+++ b/crates/citum-migrate/src/passes/grouping.rs
@@ -72,7 +72,7 @@ fn group_vol_issue_and_date_top_level(
 fn group_vol_issue_issue_at_top(
     components: &mut Vec<TemplateComponent>,
     issue_idx: usize,
-    style_base: Option<crate::base_detector::StyleBase>,
+    fixup_family: Option<crate::base_detector::FixupFamily>,
     vol_issue_delimiter: DelimiterPunctuation,
 ) {
     let list_idx = components.iter().enumerate().find_map(|(idx, c)| {
@@ -113,7 +113,7 @@ fn group_vol_issue_issue_at_top(
                 issue_with_parens,
                 vol_issue_delimiter.clone(),
             )
-            && matches!(style_base, Some(crate::base_detector::StyleBase::Apa))
+            && matches!(fixup_family, Some(crate::base_detector::FixupFamily::Apa))
             && !list_contains_title(list)
         {
             list.delimiter = Some(DelimiterPunctuation::Comma);
@@ -168,7 +168,7 @@ fn group_vol_issue_both_nested(
 pub fn group_volume_and_issue(
     components: &mut Vec<TemplateComponent>,
     options: &citum_schema::options::Config,
-    style_base: Option<crate::base_detector::StyleBase>,
+    fixup_family: Option<crate::base_detector::FixupFamily>,
 ) {
     // Volume-issue spacing varies by style:
     // - APA (comma delimiter): no space, e.g., "2(2)"
@@ -213,7 +213,7 @@ pub fn group_volume_and_issue(
     }
 
     if let Some(issue_idx) = issue_pos {
-        group_vol_issue_issue_at_top(components, issue_idx, style_base, vol_issue_delimiter);
+        group_vol_issue_issue_at_top(components, issue_idx, fixup_family, vol_issue_delimiter);
     } else if vol_pos.is_none() {
         group_vol_issue_both_nested(components, vol_issue_delimiter);
     }

--- a/crates/citum-migrate/src/passes/reorder.rs
+++ b/crates/citum-migrate/src/passes/reorder.rs
@@ -134,13 +134,13 @@ pub fn reorder_pages_for_serials(components: &mut Vec<TemplateComponent>) {
 /// Reorder publisher-place for Chicago journal articles.
 pub fn reorder_publisher_place_for_chicago(
     components: &mut Vec<TemplateComponent>,
-    style_base: Option<crate::base_detector::StyleBase>,
+    fixup_family: Option<crate::base_detector::FixupFamily>,
 ) {
-    use crate::base_detector::StyleBase;
+    use crate::base_detector::FixupFamily;
     use citum_schema::template::{SimpleVariable, TitleType};
 
     // Only apply to Chicago styles
-    if !matches!(style_base, Some(StyleBase::Chicago)) {
+    if !matches!(fixup_family, Some(FixupFamily::Chicago)) {
         return;
     }
 
@@ -187,13 +187,13 @@ pub fn reorder_publisher_place_for_chicago(
 /// Reorder chapter components for APA style.
 pub fn reorder_chapters_for_apa(
     components: &mut Vec<TemplateComponent>,
-    style_base: Option<crate::base_detector::StyleBase>,
+    fixup_family: Option<crate::base_detector::FixupFamily>,
 ) {
-    use crate::base_detector::StyleBase;
+    use crate::base_detector::FixupFamily;
     use citum_schema::template::{ContributorRole, TitleType};
 
     // Only apply to APA styles
-    if !matches!(style_base, Some(StyleBase::Apa)) {
+    if !matches!(fixup_family, Some(FixupFamily::Apa)) {
         return;
     }
 
@@ -226,13 +226,13 @@ pub fn reorder_chapters_for_apa(
 /// Reorder chapter components for Chicago style.
 pub fn reorder_chapters_for_chicago(
     components: &mut Vec<TemplateComponent>,
-    style_base: Option<crate::base_detector::StyleBase>,
+    fixup_family: Option<crate::base_detector::FixupFamily>,
 ) {
-    use crate::base_detector::StyleBase;
+    use crate::base_detector::FixupFamily;
     use citum_schema::template::{ContributorRole, TitleType};
 
     // Only apply to Chicago styles
-    if !matches!(style_base, Some(StyleBase::Chicago)) {
+    if !matches!(fixup_family, Some(FixupFamily::Chicago)) {
         return;
     }
 

--- a/docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md
+++ b/docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md
@@ -15,6 +15,9 @@ Required pass fields:
 - target style
 - target cluster
 - cluster selector
+- semantic class
+- implementation form
+- selected parent, if any
 - primary oracle before and after
 - official supplemental before and after
 - cluster before and after
@@ -40,12 +43,29 @@ Every pass must classify the chosen cluster before edits:
 - `processor-defect`
 - `intentional divergence`
 
+Every pass must also classify the target style on the taxonomy axes before edits:
+
+- semantic class: `base`, `profile`, `journal`, `independent`, or `unknown`
+- implementation form: `alias`, `config-wrapper`, `structural-wrapper`, `standalone`, or `unknown`
+
+Use `unknown` when the target cannot yet be resolved safely on that taxonomy
+axis; do not force an unresolved target into an incorrect bucket.
+
 Action routing:
 
 - `migration-artifact` stays in `migrate-research`
 - `style-defect` routes to `style-evolve upgrade`
 - `processor-defect` routes to engine follow-up
 - `intentional divergence` routes to adjudication
+
+Wrapper guardrails:
+
+- `profile + config-wrapper` work must preserve the config-wrapper contract
+- if a proposed migration fix would require local templates or local
+  `type-variants` in a profile target, reroute or escalate instead of breaking
+  the profile contract
+- `journal + structural-wrapper` is a valid endpoint and must not be
+  force-reduced to a thin wrapper
 
 If a migration-side change produces no delta in the reduced cluster and no delta
 in `report-core --style-file`, stop treating the cluster as migration-owned and

--- a/docs/specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md
+++ b/docs/specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md
@@ -1,6 +1,6 @@
 # Migration Taxonomy-Aware Wrappers Specification
 
-**Status:** Draft
+**Status:** Active
 **Date:** 2026-04-23
 **Related:** `docs/specs/STYLE_TAXONOMY.md`, `docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md`, `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`
 
@@ -118,4 +118,5 @@ For `journal + structural-wrapper` targets:
 
 ## Changelog
 
+- 2026-04-23: Activated with implementation in `citum-migrate` and taxonomy-aware `migrate-research` routing.
 - 2026-04-23: Initial version.

--- a/docs/specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md
+++ b/docs/specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md
@@ -1,0 +1,121 @@
+# Migration Taxonomy-Aware Wrappers Specification
+
+**Status:** Draft
+**Date:** 2026-04-23
+**Related:** `docs/specs/STYLE_TAXONOMY.md`, `docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md`, `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`
+
+## Purpose
+
+Define how `citum-migrate` and `migrate-research` use the current Citum style
+taxonomy during migration work. Migration should derive semantic class from the
+registry, derive implementation form from the current checked-in style shape,
+and emit wrapper output only when repo truth already establishes the parent
+relationship.
+
+## Scope
+
+In scope:
+- migration-time lineage resolution for a target CSL file
+- distinction between semantic class and implementation form during migration
+- automatic `extends:` emission for established profile and journal wrappers
+- profile-contract guardrails for migration and `migrate-research`
+
+Out of scope:
+- new registry/schema fields for implementation form
+- alias generation or alias discovery
+- similarity-based parent inference for new wrappers
+
+## Design
+
+### Migration-Time Lineage
+
+For a migration target, derive:
+
+- `style_id` from the CSL filename stem
+- semantic class from `StyleRegistry::resolve(style_id).kind` when the style has
+  a canonical registry entry
+- alias-backed journal classification when `style_id` resolves only through a
+  parent entry's alias list
+- current style shape from the checked-in Citum style with the same `style_id`,
+  or from the embedded builtin style when the target is embedded
+
+Implementation form is derived locally:
+
+- `alias`: no concrete style file exists and the target resolves only as a registry alias
+- `config-wrapper`: current style has `extends:` and no local template-bearing fields
+- `structural-wrapper`: current style has `extends:` and local template-bearing fields
+- `standalone`: current style has no `extends:`
+
+### Automatic Wrapper Output
+
+`citum-migrate` starts from the migrated standalone style, then may rewrite the
+output into wrapper form.
+
+Allowed cases:
+
+- `profile + config-wrapper`
+- `journal + config-wrapper`
+- `journal + structural-wrapper`
+
+For these cases, the parent comes only from the current checked-in style's
+`extends:` value.
+
+Fallback rule:
+
+- if the current checked-in style does not establish a parent safely, keep
+  standalone output
+
+### Wrapper Emission Rules
+
+For `config-wrapper` output:
+
+- set `extends:` to the established parent
+- keep only deltas relative to the resolved parent
+- omit local template-bearing fields
+
+For `structural-wrapper` output:
+
+- set `extends:` to the established parent
+- keep structural and non-structural deltas relative to the resolved parent
+
+### Research Routing
+
+`migrate-research` must report:
+
+- target style or cluster
+- semantic class
+- implementation form
+- selected parent, if any
+- issue classification
+- before/after evidence
+- exact change made
+- continue / stop / escalate decision
+
+For `profile + config-wrapper` targets:
+
+- migration work must preserve the config-wrapper contract
+- if a proposed change requires local templates or local `type-variants`, the
+  pass must reclassify or escalate instead of breaking the profile contract
+
+For `journal + structural-wrapper` targets:
+
+- structural-wrapper is a valid endpoint and must not be force-reduced to a thin wrapper
+
+## Implementation Notes
+
+- Semantic class remains `RegistryEntry.kind`; implementation form is derived in
+  migration code and workflow logic.
+- Low-level preset extraction may remain for option compression and family-like
+  fixups, but it must not be treated as authoritative style identity.
+
+## Acceptance Criteria
+
+- [ ] `citum-migrate` derives semantic class from the registry and implementation form from current style structure.
+- [ ] Known config-wrapper profiles and journals migrate with `extends:` and without local template-bearing fields.
+- [ ] Known structural-wrapper journals preserve `extends:` plus structural deltas.
+- [ ] Unknown or unresolved styles remain standalone.
+- [ ] `migrate-research` output contracts require semantic class, implementation form, and parent reporting.
+
+## Changelog
+
+- 2026-04-23: Initial version.


### PR DESCRIPTION
## Summary
- add migration-time lineage resolution for semantic class, implementation form, and established parent styles
- make `citum-migrate` emit `extends:`-based wrapper output for known profile and journal wrappers while preserving structural wrappers
- update `migrate-research` docs/contracts to require taxonomy-aware reporting and preserve the profile contract

## Testing
- targeted unit coverage in `crates/citum-migrate/src/lineage.rs` for:
  - embedded profile -> config-wrapper resolution
  - local journal config-wrapper resolution
  - local journal structural-wrapper resolution
  - unknown style fallback
  - config-wrapper rewrite strips templates and sets `extends:`
  - structural-wrapper rewrite preserves `extends:` and structural deltas
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `./scripts/validate-frontmatter.sh --copilot-strict`
