### PR TITLE
chore(beans): hygiene pass + production readiness hierarchy

### DIFF
--- a/.beans/archive/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
+++ b/.beans/archive/csl26-3j0c--engine-render-original-publisher-and-original-plac.md
@@ -1,11 +1,11 @@
 ---
 # csl26-3j0c
 title: 'engine: render original-publisher and original-place for reprints'
-status: done
+status: completed
 type: feature
 priority: normal
 created_at: 2026-04-11T11:34:06Z
-updated_at: 2026-04-14T13:18:35Z
+updated_at: 2026-04-24T12:13:54Z
 ---
 
 Chicago 18th §14.16 reprint pattern: '(original-year) current-year. Title. Original Publisher. Note. Current Publisher'. CSL fields original-publisher and original-publisher-place are not yet mapped from CSL JSON to Citum's original WorkRelation, so they silently drop. 7 chicago-zotero-bibliography benchmark items fail on this pattern (date already fixed by csl26-tpmn engine fix, but original-publisher and edition text still differ).

--- a/.beans/archive/csl26-7b28--refine-renderernew-bundle-params-into-rendererreso.md
+++ b/.beans/archive/csl26-7b28--refine-renderernew-bundle-params-into-rendererreso.md
@@ -1,10 +1,11 @@
 ---
 # csl26-7b28
 title: 'Refine Renderer::new: bundle params into RendererResources'
-status: done
+status: completed
 type: task
+priority: normal
 created_at: 2026-03-17T00:21:43Z
-updated_at: 2026-03-17T00:21:43Z
+updated_at: 2026-04-24T12:13:54Z
 ---
 
 Remove #[allow(clippy::too_many_arguments)] from Renderer::new by bundling style/bibliography/locale/config into RendererResources<'a>. Reduces from 8 params to 5. Update 6 call sites (4 production, 2 tests).

--- a/.beans/archive/csl26-date--evaluate-created-vs-issued.md
+++ b/.beans/archive/csl26-date--evaluate-created-vs-issued.md
@@ -1,11 +1,11 @@
 ---
 # csl26-date
-title: 'Evaluate created vs issued dates for unpublished documents'
-status: todo
+title: Evaluate created vs issued dates for unpublished documents
+status: completed
 type: task
 priority: medium
 created_at: 2026-04-08T12:00:00Z
-updated_at: 2026-04-08T12:00:00Z
+updated_at: 2026-04-24T12:13:58Z
 ---
 
 # Evaluate `created` vs `issued` dates for unpublished documents
@@ -29,3 +29,5 @@ Adapters could decide: “when exporting Citum → CSL, map `created` or `publis
 
 ## Next Steps
 Evaluate whether `created` plus a small set of more specific date roles (`published`, `recorded`, etc.) fit cleanly into the rest of the current Citum date model, and consider proposing a schema migration to support these new date fields.
+
+## Summary of Changes\n\nEvaluation was completed and implemented: `created` + `issued` date fields added to all reference types with `csl_issued_date()` compat accessor. See date model implementation on main.

--- a/.beans/archive/csl26-fk0w--pre-release-style-engine-co-evolution-wave.md
+++ b/.beans/archive/csl26-fk0w--pre-release-style-engine-co-evolution-wave.md
@@ -1,11 +1,11 @@
 ---
 # csl26-fk0w
 title: Pre-release style + engine co-evolution wave
-status: done
+status: completed
 type: epic
 priority: normal
 created_at: 2026-03-16T10:34:43Z
-updated_at: 2026-03-27T20:14:04Z
+updated_at: 2026-04-24T12:13:54Z
 ---
 
 Track A: engine fixes for cross-portfolio gaps (volume-pages, DOI suppression, editor name-order). Track B: upgrade outlier styles (springer-physics-brackets, royal-society-of-chemistry, MLA). Track C: promote chicago-author-date from experimental. PR branch: style-evolve-pre-release-wave.

--- a/.beans/archive/csl26-lb46--fix-schema-pre-10-major-bump-guard.md
+++ b/.beans/archive/csl26-lb46--fix-schema-pre-10-major-bump-guard.md
@@ -1,10 +1,11 @@
 ---
 # csl26-lb46
 title: 'fix: schema pre-1.0 major bump guard'
-status: done
+status: completed
 type: bug
+priority: normal
 created_at: 2026-03-25T06:17:03Z
-updated_at: 2026-03-25T06:17:03Z
+updated_at: 2026-04-24T12:13:54Z
 ---
 
 bump_version() in prepare-release-artifacts.py has no pre-1.0 guard. Schema-Bump: major on feat(template-v2) caused 0.12.0 → 1.0.0 instead of 0.13.0. Fix: treat major as minor when current major==0. Also revert STYLE_SCHEMA_VERSION and docs/schemas/style.json to 0.13.0, update SCHEMA_VERSIONING.md, and regenerate schema JSONs.

--- a/.beans/archive/csl26-pszh--schema-defaults-review.md
+++ b/.beans/archive/csl26-pszh--schema-defaults-review.md
@@ -1,10 +1,11 @@
 ---
 # csl26-pszh
 title: Schema defaults review
-status: done
+status: completed
 type: task
+priority: normal
 created_at: 2026-03-16T18:14:56Z
-updated_at: 2026-03-16T18:14:56Z
+updated_at: 2026-04-24T12:13:54Z
 ---
 
 Encode hidden engine fallbacks in the schema, fix Option<bool> inconsistency on semantic_classes, and correct a wrong doc comment on entry_suffix. PR branch: fix/schema-defaults.

--- a/.beans/archive/csl26-vepq--add-confirm-web-flag-to-find-alias-candidatesjs.md
+++ b/.beans/archive/csl26-vepq--add-confirm-web-flag-to-find-alias-candidatesjs.md
@@ -1,10 +1,11 @@
 ---
 # csl26-vepq
 title: Add --confirm-web flag to find-alias-candidates.js
-status: done
+status: completed
 type: feature
+priority: normal
 created_at: 2026-04-19T13:11:05Z
-updated_at: 2026-04-19T13:11:05Z
+updated_at: 2026-04-24T12:13:54Z
 ---
 
 Enhance the alias discovery script with a --confirm-web flag that fires a web search per candidate above the similarity threshold (e.g. '"<journal name>" citation style author guidelines'). Attach the best evidence URL and a confidence note to the TSV output so reviewers have citable confirmation without manual lookup. Candidate search backend: Perplexity or DuckDuckGo API. See docs/guides/ALIAS_DISCOVERY.md#web-confirmation-planned-enhancement.

--- a/.beans/archive/csl26-zt6c--improve-beans-next-dependency-aware-ranking.md
+++ b/.beans/archive/csl26-zt6c--improve-beans-next-dependency-aware-ranking.md
@@ -1,11 +1,11 @@
 ---
 # csl26-zt6c
 title: 'Improve /beans next: dependency-aware ranking'
-status: done
+status: completed
 type: task
 priority: high
 created_at: 2026-03-06T13:47:09Z
-updated_at: 2026-03-06T13:50:10Z
+updated_at: 2026-04-24T12:13:54Z
 ---
 
 Improve the citum-bean next script and beans SKILL.md so /beans next can be trusted without manual override.

--- a/.beans/archive/csl26-zuyb--track-toasty.md
+++ b/.beans/archive/csl26-zuyb--track-toasty.md
@@ -1,14 +1,16 @@
 ---
 # csl26-zuyb
 title: track toasty
-status: todo
+status: scrapped
 type: task
 priority: normal
 created_at: 2026-02-28T14:05:01Z
-updated_at: 2026-02-28T14:06:22Z
+updated_at: 2026-04-24T12:14:01Z
 ---
 
 This is an experimental project from Tokio.
 Might be useful for the server crates at some point.
 
 https://github.com/tokio-rs/toasty
+
+## Reasons for Scrapping\n\nNot an actionable task — just a library bookmark. If toasty becomes relevant, open a concrete bean at that time.

--- a/.beans/archive/csl26-zy07--styleinfo-add-short-name-edition-fields-convert-tu.md
+++ b/.beans/archive/csl26-zy07--styleinfo-add-short-name-edition-fields-convert-tu.md
@@ -1,11 +1,11 @@
 ---
 # csl26-zy07
 title: 'StyleInfo: add short_name + edition fields, convert Turabian and APA 6th'
-status: done
+status: completed
 type: feature
 priority: normal
 created_at: 2026-03-17T10:25:53Z
-updated_at: 2026-03-22T22:37:00Z
+updated_at: 2026-04-24T12:13:54Z
 blocked_by:
     - csl26-fsjy
 ---

--- a/.beans/csl26-7edf--add-dedicated-partsupplementprinting-number-fields.md
+++ b/.beans/csl26-7edf--add-dedicated-partsupplementprinting-number-fields.md
@@ -5,7 +5,8 @@ status: todo
 type: feature
 priority: deferred
 created_at: 2026-03-05T15:22:41Z
-updated_at: 2026-03-05T15:24:42Z
+updated_at: 2026-04-24T12:14:10Z
+parent: csl26-li63
 ---
 
 Tentative conclusion from PR #285 analysis:

--- a/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
+++ b/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
@@ -5,7 +5,8 @@ status: todo
 type: task
 priority: deferred
 created_at: 2026-02-24T17:28:17Z
-updated_at: 2026-03-22T14:28:01Z
+updated_at: 2026-04-24T12:14:43Z
+parent: csl26-li63
 blocked_by:
     - csl26-yipx
 ---

--- a/.beans/csl26-mlc2--design-locale-backed-archive-hierarchy-labels.md
+++ b/.beans/csl26-mlc2--design-locale-backed-archive-hierarchy-labels.md
@@ -5,7 +5,10 @@ status: todo
 type: feature
 priority: normal
 created_at: 2026-04-23T15:08:48Z
-updated_at: 2026-04-23T15:08:48Z
+updated_at: 2026-04-24T12:14:13Z
+parent: csl26-li63
+blocked_by:
+    - csl26-y3kj
 ---
 
 Scope the deferred localization work for archival container labels introduced by csl26-jgt4. Define where archive hierarchy labels belong in the locale model, how singular/plural and short forms work, and when the engine should add labels versus requiring styles to render them explicitly.

--- a/.beans/csl26-registry-distributed-reconsideration.md
+++ b/.beans/csl26-registry-distributed-reconsideration.md
@@ -1,9 +1,14 @@
 ---
+# csl26
 title: Reconsider distributed registry architecture
-status: todo
+status: draft
+type: task
 priority: low
-tags: [registry, architecture]
+tags:
+    - registry
+    - architecture
 created_at: 2026-04-23T00:00:00Z
+updated_at: 2026-04-24T12:14:01Z
 ---
 
 # Objective

--- a/.beans/csl26-suz3--djot-as-default-markup-for-annotations-and-referen.md
+++ b/.beans/csl26-suz3--djot-as-default-markup-for-annotations-and-referen.md
@@ -5,7 +5,8 @@ status: in-progress
 type: feature
 priority: normal
 created_at: 2026-03-02T20:10:22Z
-updated_at: 2026-03-09T20:25:41Z
+updated_at: 2026-04-24T12:14:10Z
+parent: csl26-li63
 ---
 
 Implement djot inline markup support for annotation rendering and reference fields (note, abstract). Document math policy (Unicode-only) and title markup cases. See dplan output for full architecture.

--- a/.beans/csl26-y3kj--support-gender-on-locale-term-singlemultiple-forms.md
+++ b/.beans/csl26-y3kj--support-gender-on-locale-term-singlemultiple-forms.md
@@ -5,7 +5,8 @@ status: todo
 type: feature
 priority: low
 created_at: 2026-03-09T22:28:26Z
-updated_at: 2026-03-09T23:06:36Z
+updated_at: 2026-04-24T12:14:09Z
+parent: csl26-li63
 ---
 
 ## Context

--- a/.beans/csl26-yipx--wire-styleversion-to-schema-validation-in-csln-che.md
+++ b/.beans/csl26-yipx--wire-styleversion-to-schema-validation-in-csln-che.md
@@ -5,7 +5,8 @@ status: todo
 type: feature
 priority: normal
 created_at: 2026-02-24T17:28:12Z
-updated_at: 2026-02-24T17:28:12Z
+updated_at: 2026-04-24T12:14:43Z
+parent: csl26-li63
 ---
 
 Style.version exists as a string field but is completely ignored at parse time. Add a SchemaVersion struct that parses the X.Y string into (major, minor) integers. Wire it into the `citum check` command to: (1) emit version info in structured JSON output, (2) reject styles where major > current supported major with a clear error message, (3) warn (but succeed) when minor > current supported minor. This gives us the gating mechanism before we need it and makes `citum check` useful for tooling. No behavior change for existing valid styles.


### PR DESCRIPTION
## Summary

- Archive 8 beans stuck in non-standard `done` status
- Scrap `csl26-zuyb` (toasty bookmark — not actionable)
- Complete + archive `csl26-date` (created/issued eval resolved by date model impl)
- Demote `csl26` distributed registry rethink to `draft` (future research)
- Wire `csl26-li63` (Production Readiness milestone) as parent for six pre-stability items
- Set dependency order: `mlc2` blocked-by `y3kj`; `fuw7` blocked-by `yipx`

## Production Readiness Children (csl26-li63)

| Bean | Title | State |
|------|-------|-------|
| csl26-y3kj | MaybeGendered locale terms | ready |
| csl26-7edf | part/supplement/printing number fields | ready |
| csl26-yipx | wire Style.version to schema validation | ready |
| csl26-mlc2 | archive hierarchy labels | blocked by y3kj |
| csl26-fuw7 | versioning policy docs | blocked by yipx |
| csl26-suz3 | Djot note/abstract phase 2 | in-progress |

`beans list --ready` now surfaces production readiness items in the right order.
No code changes.
