### PR TITLE
fix(styles): close AMA rich fixture wave

### DIFF
--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -32,15 +32,17 @@
 **Strict 100% bibliography match (top 10):** 10/10 styles
 
 Current maintained portfolio status:
-- `node scripts/report-core.js` reports `147` styles at fidelity `1.0`.
+- `node scripts/report-core.js` reports `154` styles at fidelity `1.0`.
 - Case-aware scoring is now the default oracle mode.
 - `report-core` exposes `caseMismatchesOverall` and per-style `caseMismatches`.
 - `report-core` also exposes supplemental rich benchmark evidence for configured styles.
+- `american-medical-association` now publishes supplemental AMA 11 rich
+  bibliography evidence (`71/71`).
 - Title/text-case regressions across shipped core styles are reduced to `0`.
 - One remaining case-only mismatch (`american-mathematical-society-label`) is a
   citation-label acronym issue, not a title-rendering delta.
 - `node scripts/check-core-quality.js` passes against
-  `scripts/report-data/core-quality-baseline.json` with `warnings=0`.
+  `scripts/report-data/core-quality-baseline.json` with `warnings=5`.
 
 ## Style Family Breakdown
 

--- a/docs/architecture/2026-04-24_AMA_LOWER_RANKED_RICH_WAVE.md
+++ b/docs/architecture/2026-04-24_AMA_LOWER_RANKED_RICH_WAVE.md
@@ -1,0 +1,37 @@
+# AMA Lower-Ranked Rich Wave
+
+**Date:** 2026-04-24
+**Status:** Completed
+
+## Summary
+
+This style-evolve wave kept the lower-ranked work scoped to the American Medical
+Association family and paired it with the first official AMA rich-input
+benchmark.
+
+## Changes
+
+- `american-medical-association` now has the supplemental
+  `ama-zotero-bibliography` benchmark using
+  `tests/fixtures/test-items-library/ama-11th.json`.
+- The AMA 11 rich bibliography benchmark is fully clean at `71/71`.
+- Existing lower-ranked AMA variants now retain their accepted citation
+  behavior and reach full bibliography parity:
+  - `american-medical-association-alphabetical`: `17/18` citations, `34/34`
+    bibliography
+  - `american-medical-association-no-et-al`: `18/18` citations, `34/34`
+    bibliography
+  - `american-medical-association-no-url`: `18/18` citations, `34/34`
+    bibliography
+
+## Decisions
+
+- `american-medical-association-no-url-alphabetical` was not added in this wave.
+  Its current legacy comparison remains below the existing maintained variants
+  at `17/18` citations and `32/34` bibliography.
+- Bracket and parenthesis AMA variants remain out of scope because the alias
+  report shows citation-shape differences from the base AMA style.
+- The remaining `american-medical-association-alphabetical` citation mismatch is
+  a numeric citation-number ordering issue for the `webpage-single` scenario.
+  Bibliography output is clean, so this wave preserves the existing citation
+  behavior rather than forcing a broad processor change into a style PR.

--- a/scripts/report-data/verification-policy.yaml
+++ b/scripts/report-data/verification-policy.yaml
@@ -131,6 +131,16 @@ styles:
         refs_fixture: tests/fixtures/test-items-library/apa-test.json
         scope: bibliography
         count_toward_fidelity: false
+  american-medical-association:
+    secondary:
+      - biblatex
+    benchmark_runs:
+      - id: ama-zotero-bibliography
+        label: AMA Zotero bibliography
+        runner: citeproc-oracle
+        refs_fixture: tests/fixtures/test-items-library/ama-11th.json
+        scope: bibliography
+        count_toward_fidelity: false
   ieee:
     secondary:
       - biblatex

--- a/styles/american-medical-association-alphabetical.yaml
+++ b/styles/american-medical-association-alphabetical.yaml
@@ -202,24 +202,18 @@ bibliography:
         use-first: 3
     - title: primary
       prefix: ' '
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-      prefix: '. 2013:'
-    - variable: doi
-    - variable: url
+    - delimiter: none
+      group:
+      - term: online
+        prefix: 'Published '
+        suffix: ' '
+      - date: issued
+        form: month-day
+      - date: issued
+        form: year
+        prefix: ', '
+    - variable: patent-number
+      prefix: ':'
   template:
   - contributor: author
     form: long

--- a/styles/american-medical-association-no-et-al.yaml
+++ b/styles/american-medical-association-no-et-al.yaml
@@ -174,24 +174,18 @@ bibliography:
       name-order: family-first
     - title: primary
       prefix: ' '
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: '; 2006:'
-    - variable: doi
-    - variable: url
+    - delimiter: none
+      group:
+      - term: online
+        prefix: 'Published '
+        suffix: ' '
+      - date: issued
+        form: month-day
+      - date: issued
+        form: year
+        prefix: ', '
+    - variable: patent-number
+      prefix: ':'
   template:
   - contributor: author
     form: long

--- a/styles/american-medical-association-no-url.yaml
+++ b/styles/american-medical-association-no-url.yaml
@@ -184,6 +184,31 @@ bibliography:
     - variable: publisher
     - number: pages
       prefix: '; 2006:'
+    dataset:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - title: primary
+      prefix: ' '
+    - term: online
+      prefix: 'Published '
+      suffix: ' '
+    - date: issued
+      form: year
+    webpage:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - title: primary
+      prefix: ' '
+    - date: issued
+      form: year
     patent:
     - contributor: author
       form: long
@@ -193,22 +218,18 @@ bibliography:
         use-first: 3
     - title: primary
       prefix: ' '
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: '; 2006:'
+    - delimiter: none
+      group:
+      - term: online
+        prefix: 'Published '
+        suffix: ' '
+      - date: issued
+        form: month-day
+      - date: issued
+        form: year
+        prefix: ', '
+    - variable: patent-number
+      prefix: ':'
   template:
   - contributor: author
     form: long

--- a/styles/embedded/american-medical-association.yaml
+++ b/styles/embedded/american-medical-association.yaml
@@ -66,6 +66,7 @@ bibliography:
         and-others: et-al
     - title: primary
     - title: parent-serial
+      form: short
     - delimiter: none
       group:
       - date: issued
@@ -75,6 +76,9 @@ bibliography:
       - number: issue
         wrap:
           punctuation: parentheses
+      - number: supplement-number
+        prefix: "(suppl "
+        suffix: ")"
       - number: pages
         prefix: ":"
     - variable: doi
@@ -138,6 +142,14 @@ bibliography:
     - date: issued
       form: year
       prefix: ", "
+    - date: accessed
+      form: month-day
+      prefix: "Accessed "
+    - date: accessed
+      form: year
+      prefix: ", "
+      suffix: ". "
+    - variable: url
     entry-encyclopedia:
     - contributor: author
       form: long
@@ -214,8 +226,19 @@ bibliography:
       form: long
       name-order: family-first
     - title: primary
+      text-case: title
+    - variable: publisher
+      suffix: "; "
     - date: issued
       form: year
+    - date: accessed
+      form: month-day
+      prefix: "Accessed "
+    - date: accessed
+      form: year
+      prefix: ", "
+      suffix: ". "
+    - variable: url
     broadcast:
     - contributor: author
       form: long
@@ -234,6 +257,14 @@ bibliography:
         prefix: ", "
       - variable: number
         prefix: ":"
+    - date: accessed
+      form: month-day
+      prefix: "Accessed "
+    - date: accessed
+      form: year
+      prefix: ", "
+      suffix: ". "
+    - variable: url
     [interview, personal-communication]:
     - contributor: author
       form: long

--- a/tests/fixtures/coverage-manifest.json
+++ b/tests/fixtures/coverage-manifest.json
@@ -421,6 +421,27 @@
       "notes": "Diagnostic supplemental APA benchmark kept visible in reporting without contributing to the headline fidelity total."
     },
     {
+      "fixture": "tests/fixtures/test-items-library/ama-11th.json",
+      "domain": "scientific",
+      "kind": "references",
+      "reference_types": [
+        "broad Zotero AMA 11 bibliography corpus"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "AMA supplemental bibliography coverage",
+        "large-corpus ordering and missing-entry drift",
+        "style-evolve reduced-cluster targeting"
+      ],
+      "used_by": [
+        "scripts/report-core.js",
+        "scripts/extract-rich-benchmark-cluster.js",
+        "scripts/oracle.js"
+      ],
+      "ci_status": "required",
+      "notes": "Official supplemental AMA bibliography benchmark used by `american-medical-association` rich-input reporting."
+    },
+    {
       "fixture": "tests/fixtures/references-physics-numeric.json",
       "domain": "core",
       "kind": "references",


### PR DESCRIPTION
## Summary
- add official supplemental AMA 11 bibliography benchmark reporting
- close AMA rich bibliography output at 71/71 for the base AMA style
- repair lower-ranked AMA variant bibliography branches for patent, no-url dataset, and webpage cases
- document the wave decisions, including deferring `american-medical-association-no-url-alphabetical`

## Test Plan
- `node scripts/report-core.js --style american-medical-association`
- `node scripts/report-core.js --style american-medical-association-alphabetical`
- `node scripts/report-core.js --style american-medical-association-no-et-al`
- `node scripts/report-core.js --style american-medical-association-no-url`
- `node scripts/check-testing-infra.js`
- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict`
- `node scripts/report-core.js > /tmp/core-report-ama-wave.json && node scripts/check-core-quality.js --report /tmp/core-report-ama-wave.json --baseline scripts/report-data/core-quality-baseline.json`
