### PR TITLE
feat(locales): complete MF2 wiring for es-ES + author guide

### DIFF
--- a/.beans/archive/csl26-70wn--complete-mf2-locale-wiring-diagnosis-and-fixes.md
+++ b/.beans/archive/csl26-70wn--complete-mf2-locale-wiring-diagnosis-and-fixes.md
@@ -1,0 +1,40 @@
+---
+# csl26-70wn
+title: Complete MF2 locale wiring diagnosis and fixes
+status: completed
+type: task
+priority: high
+created_at: 2026-04-25T10:51:42Z
+updated_at: 2026-04-25T10:59:15Z
+---
+
+Diagnostic-fix wave: complete es-ES to schema v2, publish locale authoring guide, refresh csl26-li63 body, and open follow-up beans. Phase A investigation confirmed engine MF2 wiring was already in place for count-based messages, but gender-aware MF2 role labels still need a separate follow-up.
+
+## Background
+
+MF2 locale-message support shipped in spec `docs/specs/LOCALE_MESSAGES.md` v1.3. Initial diagnosis suspected the engine was unwired, but Phase A exploration found the call sites already in place — `resolved_locator_term` and `resolved_role_term` in `crates/citum-engine/src/values/{locator,number,contributor/labels}.rs` consult the `messages:` map first and fall back to the legacy `terms:` / `roles:` / `locators:` maps. The visible symptoms came from elsewhere: four of five locale files have full v2 messages blocks, but `es-ES` declared `message-syntax: mf2` while shipping no messages block; no agent guidance referenced the v2 path. A later review clarified that `MaybeGendered<T>` is live for legacy term maps, while the MF2 path still lacks `$gender` arguments and multi-selector `.match` support.
+
+## Todos
+
+- [x] Phase B: add messages:, date-formats:, grammar-options:, legacy-term-aliases: blocks to locales/es-ES.yaml (excluding role.* messages until MF2 can express gender x plural role-label matrices)
+- [x] Phase C: write docs/guides/AUTHORING_LOCALES.md
+- [x] Phase C: add locale-authoring pointer to CLAUDE.md
+- [x] Phase D: refresh csl26-li63 body with structured status snapshot
+- [x] Phase A: verified MF2 is already wired (resolved_locator_term/resolved_role_term in engine; no work needed)
+- [x] Commit and open PR
+
+## Summary of Changes
+
+- `locales/es-ES.yaml`: added `messages:`, `date-formats:`, `grammar-options:`, `legacy-term-aliases:` blocks. Plural-dispatched locator labels (page, chapter, volume, section) now route through MF2. Role labels intentionally omitted because `roles:` already supports `MaybeGendered<T>`, while MF2 role-label messages cannot yet receive `$gender` or match on both `$gender` and `$count`. Issue locator labels stay in the legacy `locators:` map because `Locale::locator_message_id` does not yet route `LocatorType::Issue` through MF2.
+- `docs/guides/AUTHORING_LOCALES.md`: new authoring guide covering when to add MF2 entries, the supported subset, the interim gender limitation, required v2 blocks, and verification commands.
+- `CLAUDE.md`: added "Authoring Locales" pointer with the interim gender limitation summary.
+- `.beans/csl26-li63--production-readiness.md`: replaced one-line stub with structured acceptance-criteria list keyed to existing children.
+
+Phase A (count-based engine wiring) was confirmed already complete during exploration — `resolved_locator_term` / `resolved_role_term` are wired in `crates/citum-engine/src/values/{locator,number,contributor/labels}.rs`. Gender-aware MF2 role-label migration remains a separate follow-up (`csl26-vm2g`).
+
+## Verification
+
+- `cargo fmt --check` clean
+- `cargo clippy --all-targets --all-features -- -D warnings` clean
+- `cargo nextest run`: 1090 / 1090 passing
+- `scripts/check-core-quality.js`: gate passed (154 styles, fidelity 1.0 on the gated set; 5 pre-existing concision warnings unchanged)

--- a/.beans/csl26-li63--production-readiness.md
+++ b/.beans/csl26-li63--production-readiness.md
@@ -5,7 +5,43 @@ status: todo
 type: milestone
 priority: normal
 created_at: 2026-02-07T07:40:14Z
-updated_at: 2026-02-07T07:40:14Z
+updated_at: 2026-04-25T10:57:30Z
 ---
 
-Tooling, testing infrastructure, documentation, and performance optimization for production use.
+Tooling, testing infrastructure, documentation, and performance
+optimization for the first public release.
+
+## Acceptance criteria
+
+The release goes out when each line below is checked. This list is the
+working definition of "production ready" for citum-core; it intentionally
+excludes web-platform work (citum-hub) and bindings (citum-labs).
+
+- [x] JSON schema generation for references, citations, locales (csl26-n79w)
+- [x] Core vs. Community Style Split (csl26-tb4i)
+- [x] Server mode evaluation (csl26-kpv4)
+- [ ] Versioning policy doc committed before first public release (csl26-fuw7)
+- [ ] Style.version wired to schema validation in `citum check` (csl26-yipx)
+- [ ] Style-structure lint hard-fail rollout (csl26-egzd)
+- [ ] Dedicated part / supplement / printing number fields (csl26-7edf)
+- [ ] User style + locale store (citum_store) — csl26-erwz
+- [ ] Djot as default markup for annotations / reference fields (csl26-suz3, in-progress)
+- [ ] MaybeGendered<T> on locale terms (csl26-y3kj) — core model is live;
+      gender-aware MF2 role-label migration remains follow-up work
+- [ ] Gender-aware MF2 role labels with multi-selector `.match` support
+      (csl26-vm2g)
+- [ ] Locale-backed archive hierarchy labels (csl26-mlc2)
+
+## Strategic pointers
+
+- Roadmap and phase sequencing: [docs/architecture/ROADMAP.md](../docs/architecture/ROADMAP.md)
+- Live style fidelity: [docs/TIER_STATUS.md](../docs/TIER_STATUS.md)
+- Portfolio gate: `scripts/report-data/core-quality-baseline.json`
+- Locale authoring (MF2): [docs/guides/AUTHORING_LOCALES.md](../docs/guides/AUTHORING_LOCALES.md)
+
+## Notes
+
+- The bean body was refreshed 2026-04-25 from a one-liner to the structured
+  status above. Children list is authoritative — this body summarises but
+  doesn't add new scope. Update the checkboxes when child beans land,
+  not the prose.

--- a/.beans/csl26-qrpo--swap-mf2-parser-for-icu4x-icu-message-format-when.md
+++ b/.beans/csl26-qrpo--swap-mf2-parser-for-icu4x-icu-message-format-when.md
@@ -5,7 +5,7 @@ status: todo
 type: task
 priority: deferred
 created_at: 2026-03-22T12:45:31Z
-updated_at: 2026-03-22T13:27:25Z
+updated_at: 2026-04-25T00:00:00Z
 ---
 
 The current Mf2MessageEvaluator in crates/citum-schema-style/src/locale/message.rs is a
@@ -19,3 +19,7 @@ No locale files or call sites change. MF2 syntax is identical between implementa
 
 Blocked by: ICU4X icu_message_format reaching stable release.
 Tracking issue: https://github.com/unicode-org/icu4x/issues/3028
+
+As of 2026-04-25, unicode-org/icu4x#7884 is an open in-progress MF2
+implementation PR. Treat it as useful upstream signal, not an available
+dependency for Citum branch work.

--- a/.beans/csl26-vm2g--support-gender-aware-mf2-role-labels.md
+++ b/.beans/csl26-vm2g--support-gender-aware-mf2-role-labels.md
@@ -1,0 +1,47 @@
+---
+# csl26-vm2g
+title: Support gender-aware MF2 role labels
+status: todo
+type: feature
+priority: normal
+created_at: 2026-04-25T00:00:00Z
+updated_at: 2026-04-25T00:00:00Z
+parent: csl26-li63
+---
+
+Add the MF2 evaluator and call-site support needed to migrate gendered
+contributor role labels for gendered locales from `roles:` to `messages:`
+without losing the `MaybeGendered<T>` behavior that is already live in legacy
+term maps.
+
+## Todos
+
+- [ ] Pass both `$count` and `$gender` into `MessageArgs` from
+      `resolved_role_term`, `resolved_role_term_neutral`,
+      `resolved_locator_term`, and `resolved_general_term` where applicable.
+- [ ] Map `GrammaticalGender` to stable MF2 selector keys:
+      `masculine`, `feminine`, `neuter`, `common`.
+- [ ] Extend the custom evaluator and CLI MF2 linting to support
+      multi-selector `.match` while preserving existing one-selector messages.
+- [ ] Migrate a first confirmed gendered locale's `role.editor.*` and
+      `role.translator.*` matrices using existing `roles:` strings as the
+      source of truth.
+- [ ] Add French and Arabic migrations only after locale content and tests are
+      confirmed for those languages.
+- [ ] Keep `roles:` as fallback until every migrated role/form has tests and
+      fallback deprecation is intentional.
+
+## Verification
+
+- Unit tests for multi-selector matching, wildcard fallback, missing gender
+  fallback, and existing count-only messages.
+- Locale tests for feminine singular, feminine plural, masculine plural, and
+  mixed/common role labels through MF2.
+- Engine tests proving `roles:` fallback still works when an MF2 message is
+  absent or cannot evaluate.
+
+## Notes
+
+Do not depend on ICU4X MF2 support for this task. The ICU4X implementation is
+tracked separately and can replace the evaluator later through the existing
+`MessageEvaluator` trait.

--- a/.beans/csl26-y3kj--support-gender-on-locale-term-singlemultiple-forms.md
+++ b/.beans/csl26-y3kj--support-gender-on-locale-term-singlemultiple-forms.md
@@ -1,11 +1,11 @@
 ---
 # csl26-y3kj
 title: Add MaybeGendered<T> to locale term model
-status: todo
+status: in-progress
 type: feature
 priority: low
 created_at: 2026-03-09T22:28:26Z
-updated_at: 2026-04-24T12:14:09Z
+updated_at: 2026-04-25T00:00:00Z
 parent: csl26-li63
 ---
 
@@ -31,10 +31,17 @@ See `docs/specs/GENDERED_LOCALE_TERMS.md`
 ## Todos
 
 - [x] Create spec doc (docs/specs/GENDERED_LOCALE_TERMS.md)
-- [ ] Add `MaybeGendered<T>` and `TermGender` to citum-schema locale types
-- [ ] Change `SimpleTerm.long/short` to `MaybeGendered<String>`
-- [ ] Change `SingularPlural.singular/plural` to `MaybeGendered<String>`
-- [ ] Add `Gendered` variant to `RawTermValue` for YAML deserialization
-- [ ] Update `Locale::role_term`, `locator_term`, `general_term` to accept `Option<TermGender>`
-- [ ] Pass gender context through engine term rendering
+- [x] Add `MaybeGendered<T>` and `GrammaticalGender` to citum-schema locale types
+- [x] Change `SimpleTerm.long/short` to `MaybeGendered<String>`
+- [x] Change `SingularPlural.singular/plural` to `MaybeGendered<String>`
+- [x] Add gendered raw term parsing for YAML deserialization
+- [x] Update `Locale::role_term`, `locator_term`, `general_term` to accept `Option<GrammaticalGender>`
+- [x] Pass gender context through engine term rendering for legacy term-map lookup
 - [ ] Snapshot tests: French gendered editor, Arabic gendered ordinal
+
+## Notes
+
+The `MaybeGendered<T>` term-map model is live. This bean no longer tracks
+MessageFormat 2 role-label migration; that is split to `csl26-vm2g`, which must
+add `$gender` plumbing and multi-selector `.match` support before gendered role
+labels can move from `roles:` to `messages:`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,21 @@ Hybrid: XML pipeline for options extraction + LLM-authored templates for top par
 Use `./scripts/prep-migration.sh` + `/style-evolve migrate` for hand-authoring. See
 `docs/TIER_STATUS.md` for live fidelity metrics.
 
+## Authoring Locales
+
+Locale files in `locales/` use schema v2 with MessageFormat 2 (MF2)
+parameterized messages. The MF2 path is **live in the engine** —
+`resolved_locator_term` and `resolved_role_term` consult `messages:` first and
+fall back to the legacy `terms:` / `roles:` / `locators:` maps.
+
+When editing or creating a locale, see
+[docs/guides/AUTHORING_LOCALES.md](./docs/guides/AUTHORING_LOCALES.md). Key
+gotcha: `MaybeGendered<T>` is live in the legacy locale maps, but MF2 role and
+locator lookup currently passes `$count` only and the custom evaluator supports
+one selector per `.match`. Keep gendered role labels in `roles:` until the
+gender-aware MF2 follow-up adds `$gender` plumbing and multi-selector support.
+Spec: [docs/specs/LOCALE_MESSAGES.md](./docs/specs/LOCALE_MESSAGES.md).
+
 ## Design Principles
 
 [docs/architecture/DESIGN_PRINCIPLES.md](./docs/architecture/DESIGN_PRINCIPLES.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "typst",
  "typst-kit",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "axum",
  "citum-engine",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -899,7 +899,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -510,6 +510,10 @@ struct RenderRefsArgs {
     #[arg(short, long, required = true)]
     style: String,
 
+    /// Locale ID (e.g. "es-ES", "fr-FR") to override the style's default locale
+    #[arg(short = 'L', long)]
+    locale: Option<String>,
+
     /// Path(s) to citations input files (repeat for multiple)
     #[arg(short = 'c', long, action = ArgAction::Append)]
     citations: Vec<PathBuf>,
@@ -1692,7 +1696,13 @@ fn run_render_doc(args: RenderDocArgs) -> Result<(), Box<dyn Error>> {
         );
     }
 
-    let processor = create_processor(style_obj, bibliography, &args.style, args.no_semantics)?;
+    let processor = create_processor(
+        style_obj,
+        bibliography,
+        &args.style,
+        args.no_semantics,
+        None,
+    )?;
 
     let doc_content = fs::read_to_string(&args.input)?;
     let output = match args.input_format {
@@ -1758,7 +1768,13 @@ fn run_render_refs(args: RenderRefsArgs) -> Result<(), Box<dyn Error>> {
         format: AnnotationFormat::Djot,
     };
 
-    let processor = create_processor(style_obj, bibliography, &args.style, args.no_semantics)?;
+    let processor = create_processor(
+        style_obj,
+        bibliography,
+        &args.style,
+        args.no_semantics,
+        args.locale.as_deref(),
+    )?;
 
     let style_name = {
         let path = Path::new(&args.style);
@@ -1796,18 +1812,23 @@ fn run_render_refs(args: RenderRefsArgs) -> Result<(), Box<dyn Error>> {
 
 /// Construct a [`Processor`] from a style, bibliography, and optional locale.
 ///
-/// When the style declares a `default_locale`, the locale is resolved first
-/// from disk (for file-based styles) and then from embedded data, falling back
-/// to the hardcoded `en-US` defaults.
+/// When `locale_override` is supplied it takes precedence over the style's
+/// `default_locale`. Otherwise the locale is resolved first from disk (for
+/// file-based styles) and then from embedded data, falling back to the
+/// hardcoded `en-US` defaults.
 fn create_processor(
     style: Style,
     loaded: LoadedBibliography,
     style_input: &str,
     no_semantics: bool,
+    locale_override: Option<&str>,
 ) -> Result<Processor, Box<dyn Error>> {
     let LoadedBibliography { references, sets } = loaded;
     let compound_sets = sets.unwrap_or_default();
-    if let Some(ref locale_id) = style.info.default_locale {
+    let effective_locale = locale_override
+        .map(str::to_owned)
+        .or_else(|| style.info.default_locale.clone());
+    if let Some(ref locale_id) = effective_locale {
         let path = Path::new(style_input);
         let mut locale = if path.exists() && path.is_file() {
             // File-based style: search for locale on disk, fall back to embedded.
@@ -1822,10 +1843,22 @@ fn create_processor(
             // Builtin style: use embedded locale directly.
             load_locale_builtin(locale_id)
         };
-        if let Some(override_id) = style
-            .options
-            .as_ref()
-            .and_then(|options| options.locale_override.as_deref())
+        if locale_override.is_some() && locale.locale != *locale_id {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("locale not found: '{locale_id}'"),
+            )
+            .into());
+        }
+        if let Some(override_id) = locale_override
+            .is_none()
+            .then(|| {
+                style
+                    .options
+                    .as_ref()
+                    .and_then(|options| options.locale_override.as_deref())
+            })
+            .flatten()
         {
             let locale_override = if path.exists() && path.is_file() {
                 load_locale_override_for_file_style(override_id, style_input)?
@@ -3617,6 +3650,7 @@ grammar-options:
             loaded,
             style_path.to_str().expect("utf-8 path"),
             false,
+            None,
         )
         .expect("processor should apply locale override");
 
@@ -3638,7 +3672,7 @@ grammar-options:
         };
 
         let processor =
-            create_processor(style, loaded, "chicago", false).expect("processor should load");
+            create_processor(style, loaded, "chicago", false, None).expect("processor should load");
 
         assert_eq!(processor.locale.locale, "en-US");
         assert_eq!(
@@ -3652,6 +3686,59 @@ grammar-options:
         assert_eq!(
             processor.locale.grammar_options.page_range_delimiter,
             "\u{2013}"
+        );
+    }
+
+    #[test]
+    fn test_create_processor_locale_arg_overrides_style_default() {
+        let style = citum_schema::embedded::get_embedded_style("apa")
+            .expect("embedded style should exist")
+            .expect("embedded style should parse");
+        let loaded = LoadedBibliography {
+            references: Bibliography::new(),
+            sets: None,
+        };
+
+        let processor = create_processor(style, loaded, "apa", false, Some("es-ES"))
+            .expect("processor should load with locale override");
+
+        assert_eq!(processor.locale.locale, "es-ES");
+    }
+
+    #[test]
+    fn test_create_processor_locale_arg_skips_style_locale_override() {
+        let style = citum_schema::embedded::get_embedded_style("chicago")
+            .expect("embedded style should exist")
+            .expect("embedded style should parse");
+        let loaded = LoadedBibliography {
+            references: Bibliography::new(),
+            sets: None,
+        };
+
+        let processor = create_processor(style, loaded, "chicago", false, Some("es-ES"))
+            .expect("processor should load requested locale");
+
+        assert_eq!(processor.locale.locale, "es-ES");
+        assert!(!processor.locale.grammar_options.serial_comma);
+        assert_eq!(processor.locale.grammar_options.open_quote, "«");
+    }
+
+    #[test]
+    fn test_create_processor_locale_arg_rejects_unknown_locale() {
+        let style = citum_schema::embedded::get_embedded_style("apa")
+            .expect("embedded style should exist")
+            .expect("embedded style should parse");
+        let loaded = LoadedBibliography {
+            references: Bibliography::new(),
+            sets: None,
+        };
+
+        let err = create_processor(style, loaded, "apa", false, Some("zz-ZZ"))
+            .expect_err("unknown explicit locale should error");
+
+        assert!(
+            err.to_string().contains("locale not found: 'zz-ZZ'"),
+            "unexpected error: {err}"
         );
     }
 

--- a/docs/guides/AUTHORING_LOCALES.md
+++ b/docs/guides/AUTHORING_LOCALES.md
@@ -1,0 +1,197 @@
+# Authoring Locales
+
+This guide tells you when and how to add MessageFormat 2 (MF2) entries to a
+Citum locale file in `locales/`. It is the practical companion to
+[`docs/specs/LOCALE_MESSAGES.md`](../specs/LOCALE_MESSAGES.md).
+
+## Status
+
+- MF2 evaluator: live in `crates/citum-schema-style/src/locale/message.rs`.
+- Engine call sites: live. `resolved_locator_term` and `resolved_role_term`
+  are wired in `crates/citum-engine/src/values/{locator,number,contributor/labels}.rs`
+  and consult the `messages:` map first, falling back to the legacy `terms:` /
+  `roles:` / `locators:` maps.
+- Gendered term values: live through `MaybeGendered<T>` in the legacy locale
+  maps. This is separate from MF2 selector support.
+- Coverage as of writing: `en-US`, `de-DE`, `fr-FR`, `tr-TR`, `es-ES` carry
+  v2 `messages:` blocks. Adding new locales should follow the same shape.
+
+If a `messages:` block is absent or empty, the engine silently uses the legacy
+maps. There is no per-locale fallback alarm — author intent is signalled by
+`evaluation.message-syntax: mf2` in the locale header.
+
+## When to add a `messages:` entry
+
+Author a v2 `messages:` entry whenever the rendered text depends on a
+**parameter** that the legacy term tables can't carry compositionally:
+
+| Pattern | Example | Use MF2? |
+|---------|---------|----------|
+| Plural-dependent abbreviation | `p.` vs `pp.` | **Yes** — `.match {$count :plural}` |
+| Plural-dependent long form | `chapter` vs `chapters` | **Yes** |
+| Plural-dependent verb | "with guest" vs "with guests" | **Yes** |
+| Compositional pattern | `{$start}–{$end}` for page ranges | **Yes** |
+| URL-bearing message | "retrieved from {$url}" | **Yes** |
+| Static label | `term.and: "and"` | Optional — works either way |
+| Gender-dependent label | Spanish `editor / editora`, French `éditeur / éditrice` | **Not yet** — see "Gender" below |
+
+The rule of thumb: if the message body would contain `{` (variable
+substitution or `.match` block), MF2 is the correct home. If it's a bare
+string, both paths render identically; MF2 is preferred when authoring a new
+locale for consistency with the v2 schema.
+
+## Required block when `message-syntax: mf2`
+
+A v2-aware locale should ship the following four blocks at the bottom of the
+file, after `terms:`, `roles:`, and `locators:`:
+
+```yaml
+messages:
+  # plural-dispatched and parameterized strings — see catalog below
+date-formats:
+  numeric-short: "..."
+  textual-long: "..."
+  textual-full: "..."
+  bib-default: "..."
+  year-only: "yyyy"
+  iso: "yyyy-MM-dd"
+grammar-options:
+  punctuation-in-quote: false
+  open-quote: "..."
+  close-quote: "..."
+  serial-comma: false
+  page-range-delimiter: "..."
+legacy-term-aliases:
+  # bridge old engine keys to new message IDs
+```
+
+Use `locales/en-US.yaml`, `fr-FR.yaml`, or `de-DE.yaml` as references for
+gender-invariant messages. `es-ES.yaml` is the current concrete example of a
+locale that carries MF2 messages while keeping gendered role labels in `roles:`
+until MF2 can dispatch on both `$gender` and `$count` in one message. The same
+limitation applies to other gendered locales, including French and Arabic.
+
+## Message ID catalog (frequently used)
+
+| ID | Variables | Notes |
+|----|-----------|-------|
+| `term.page-label`, `term.page-label-long` | `$count` | `p./pp.` and `page/pages` equivalents |
+| `term.chapter-label`, `term.chapter-label-long` | `$count` | |
+| `term.volume-label`, `term.volume-label-long` | `$count` | |
+| `term.section-label`, `term.section-label-long` | `$count` | |
+| `term.figure-label` | `$count` | |
+| `term.note-label`, `term.note-label-long` | `$count` | |
+| `term.and`, `term.and-symbol`, `term.et-al`, `term.and-others` | none | Conjunctions |
+| `term.accessed`, `term.retrieved`, `term.no-date`, `term.no-date-long`, `term.forthcoming`, `term.circa`, `term.circa-long` | none | Date and access labels |
+| `role.editor.label`, `role.editor.label-long`, `role.editor.verb` | `$count` (label only today) | Avoid for gender-aware locales until multi-selector MF2 lands |
+| `role.translator.label`, `role.translator.label-long`, `role.translator.verb` | `$count` (label only today) | Avoid for gender-aware locales until multi-selector MF2 lands |
+| `role.guest.label`, `role.guest.label-long`, `role.guest.verb` | `$count` | |
+| `pattern.page-range` | `$start`, `$end` | Spec'd; not yet consumed by the engine |
+| `pattern.retrieved-from`, `pattern.available-at` | `$url` | Spec'd; not yet consumed by the engine |
+| `date.open-ended` | none | "present" / "heute" / "presente" |
+
+> **Note on `pattern.*` messages.** No engine call site currently passes
+> `$start` / `$end` / `$url` into the evaluator. These IDs are reserved by
+> the spec and locales already author them, but consumers will land in a
+> separate change. Author them in new locales for forward-compatibility,
+> but don't expect them to render today.
+
+The `legacy-term-aliases:` map bridges single-word legacy keys (e.g. `page`,
+`et_al`, `editor`) to message IDs so styles authored against the v1 vocabulary
+keep rendering. Mirror the en-US shape.
+
+## Gender — interim limitation
+
+`MaybeGendered<T>` is already live for locale term maps. The `roles:`,
+`locators:`, and `terms:` fallback paths can store and resolve gendered values
+for locales that need them, such as Spanish role nouns, French role nouns, and
+Arabic gendered ordinals, using the requested gender from contributor data or
+an explicit template override.
+
+The MF2 path is not equivalent yet. `resolved_role_term` and
+`resolved_locator_term` currently pass `$count` into MF2 evaluation, but they do
+not pass `$gender`. The custom evaluator also supports only one selector per
+`.match`, so a full `$gender` x `$count` role-label matrix cannot be authored
+reliably today.
+
+For this branch:
+
+- Locale files for languages with role-label gender variants keep those labels
+  in `roles:`. Do not add `role.editor.label`,
+  `role.editor.label-long`, `role.translator.label`, or
+  `role.translator.label-long` MF2 entries for those locales yet.
+- This is an implementation gap, not the desired final architecture. MF2 should
+  become the home for gender x plural role labels after multi-selector support
+  lands.
+- Gender-invariant role messages are safe in `messages:`.
+- Gender-invariant locator and general terms are safe in `messages:`.
+
+The follow-up is to pass gender into `MessageArgs`, support multi-selector
+`.match`, and then migrate gendered role labels from `roles:` to MF2 with tests.
+
+## Runtime locale selection
+
+Styles can declare a default locale, but that is not the only intended source
+of locale choice. `citum render refs --locale <locale-id>` is a user-facing
+per-invocation override for choosing any available locale at render time; the
+verification command below uses it as a smoke test because it exercises that
+same runtime selection path. Persistent user default locale configuration is
+tracked separately in the user style and locale store work (`csl26-erwz`).
+
+## MF2 syntax cheat sheet
+
+```yaml
+# Static string
+term.and: "and"
+
+# Variable substitution
+pattern.retrieved-from: "retrieved from {$url}"
+
+# Plural dispatch (one / wildcard only)
+term.page-label: |
+  .match {$count :plural}
+  when one {p.}
+  when * {pp.}
+
+# Select dispatch (arbitrary keys, one selector only today)
+some.gendered: |
+  .match {$gender :select}
+  when masculine {él}
+  when feminine {ella}
+  when * {elle}
+```
+
+The current evaluator supports only `one` and `*` plural categories. Full
+CLDR categories (`zero`, `two`, `few`, `many`) and multi-selector `.match`
+blocks require follow-up evaluator work. ICU4X MF2 support is tracked, but not
+treated as available in this branch.
+
+## Verification
+
+After editing a locale, run:
+
+```bash
+# 1. Schema check — ensures parse + evaluator setup is sound
+cargo nextest run -p citum-engine -E 'test(locale) + test(spanish) + test(es_es) + test(german) + test(french)'
+
+# 2. Portfolio gate — guards against accidental breakage of style fidelity
+node scripts/report-core.js > /tmp/r.json && \
+  node scripts/check-core-quality.js \
+  --report /tmp/r.json \
+  --baseline scripts/report-data/core-quality-baseline.json
+
+# 3. Smoke test against a real style
+cargo run --bin citum -- render refs \
+  -b tests/fixtures/references-expanded.json \
+  -s styles/apa-7th.yaml --locale <your-locale>
+```
+
+A future `citum locale lint <file>` (spec §8) will short-circuit the first
+two — not yet shipped.
+
+## Related
+
+- Spec: [docs/specs/LOCALE_MESSAGES.md](../specs/LOCALE_MESSAGES.md)
+- Gender model: [docs/specs/GENDERED_LOCALE_TERMS.md](../specs/GENDERED_LOCALE_TERMS.md)
+- ICU4X migration: bean `csl26-qrpo`
+- Gender-aware MF2 role labels: follow-up bean for multi-selector `.match`

--- a/locales/es-ES.yaml
+++ b/locales/es-ES.yaml
@@ -215,3 +215,97 @@ terms:
     long: et al.
   "no date":
     long: s. f.
+
+messages:
+  # Locator labels
+  term.page-label: |
+    .match {$count :plural}
+    when one {p.}
+    when * {pp.}
+  term.page-label-long: |
+    .match {$count :plural}
+    when one {página}
+    when * {páginas}
+  term.chapter-label: |
+    .match {$count :plural}
+    when one {cap.}
+    when * {caps.}
+  term.chapter-label-long: |
+    .match {$count :plural}
+    when one {capítulo}
+    when * {capítulos}
+  term.volume-label: |
+    .match {$count :plural}
+    when one {vol.}
+    when * {vols.}
+  term.volume-label-long: |
+    .match {$count :plural}
+    when one {volumen}
+    when * {volúmenes}
+  term.section-label: |
+    .match {$count :plural}
+    when one {§}
+    when * {§§}
+  term.section-label-long: |
+    .match {$count :plural}
+    when one {sección}
+    when * {secciones}
+  # Issue locator labels (n.º / n.os, número / números) live in the
+  # `locators:` map above — Locale::locator_message_id does not yet route
+  # LocatorType::Issue through MF2.
+  # Conjunctions and connectors
+  term.and: "y"
+  term.and-symbol: "&"
+  term.et-al: "et al."
+  term.and-others: "y otros"
+  # Date and access terms
+  term.accessed: "consultado"
+  term.retrieved: "recuperado"
+  term.no-date: "s. f."
+  term.no-date-long: "sin fecha"
+  term.forthcoming: "en prensa"
+  term.circa: "ca."
+  term.circa-long: "hacia"
+  # Role labels: omitted intentionally for Spanish in this branch.
+  #
+  # MaybeGendered<T> is live in the `roles:` map above, but the current MF2
+  # dispatch path passes `$count` only and the custom evaluator supports one
+  # selector per `.match`. Adding `role.editor.label` / `role.translator.label`
+  # here would bypass the gender-aware `roles:` fallback before MF2 can express
+  # the full gender x plural matrix.
+  #
+  # Revisit when the gender-aware MF2 follow-up adds `$gender` plumbing and
+  # multi-selector `.match` support.
+  # Compositional patterns
+  pattern.page-range: "{$start}–{$end}"
+  pattern.retrieved-from: "recuperado de {$url}"
+  pattern.available-at: "disponible en {$url}"
+  date.open-ended: "presente"
+
+date-formats:
+  numeric-short: "d/M/yyyy"
+  textual-long: "MMMM yyyy"
+  textual-full: "d 'de' MMMM 'de' yyyy"
+  bib-default: "d 'de' MMMM 'de' yyyy"
+  year-only: "yyyy"
+  iso: "yyyy-MM-dd"
+
+grammar-options:
+  punctuation-in-quote: false
+  nbsp-before-colon: false
+  open-quote: "«"
+  close-quote: "»"
+  open-inner-quote: "“"
+  close-inner-quote: "”"
+  serial-comma: false
+  page-range-delimiter: "–"
+
+legacy-term-aliases:
+  page: term.page-label
+  pages: term.page-label
+  et_al: term.et-al
+  and: term.and
+  accessed: term.accessed
+  retrieved: term.retrieved
+  no_date: term.no-date
+  "no date": term.no-date


### PR DESCRIPTION
## Summary

This PR makes locale/MF2 authoring exercise the live locale-message path and documents the current boundary between MF2 messages and gendered term-map lookup.

The final shape is intentionally conservative:

1. `citum render refs` now accepts `--locale/-L` as a user-facing per-invocation locale selector. The same flag is also useful for locale smoke tests because it bypasses a style's default locale directly.
2. `locales/es-ES.yaml` is the concrete locale completed in this PR: it now has schema-v2 support blocks and count-based MF2 messages for safe locator/general terms.
3. Gendered role labels for locales such as Spanish, French, and Arabic stay in `roles:` for now because `MaybeGendered<T>` is live there, while the current MF2 evaluator does not yet support `$gender × $count` matrices.
4. The authoring guide, `CLAUDE.md`, and beans now describe that as an interim implementation limitation, not as the desired final architecture.

## What changed

- `feat(cli): add locale override to render refs`
  - Adds `--locale/-L` to `citum render refs` for per-invocation locale selection.
  - Leaves `render doc` behavior unchanged.
  - Treats explicit `--locale` as the user-selected locale: it overrides the style default, skips style-level locale overrides, and errors if the requested locale cannot be loaded.
  - Adds tests proving the CLI locale override wins over the style default locale, skips style locale overrides, and rejects unknown explicit locales.
  - Includes the required patch workspace version bump and `Version-Bump: patch` footer because this commit changes the publishable CLI crate.

- `feat(locales): add es-ES MF2 authoring guidance`
  - Adds `messages:`, `date-formats:`, `grammar-options:`, and `legacy-term-aliases:` to `locales/es-ES.yaml`.
  - Adds `docs/guides/AUTHORING_LOCALES.md` and a `CLAUDE.md` pointer for locale authors.
  - Documents that `MaybeGendered<T>` is live in legacy term maps, but current MF2 role/locator resolution passes `$count` only and supports one selector per `.match`.
  - Adds `csl26-vm2g` as the follow-up for gender-aware MF2 role labels and multi-selector `.match` support across gendered locales.
  - Updates related beans so `csl26-y3kj` no longer stands in for the missing MF2 role-label work.

## Copilot review resolution

- `term.issue-label` / `term.issue-label-long`: accepted. These IDs are not wired by the current locator resolver, so the PR no longer presents them as exercised MF2 messages in the guide or `es-ES` locale content.
- Pattern MF2 IDs such as `pattern.page-range`: accepted as a documentation boundary. They remain documented as spec'd but not yet consumed by the engine, so locale authors can distinguish current runtime behavior from planned schema surface.
- Archived bean contradictions and stale paths: accepted. The archived diagnosis now says Phase A confirmed count-based engine wiring already exists, uses `crates/citum-engine/...` paths, and has a completed checklist.
- Workspace version bump: kept after CI validation. Although the initial intent was to avoid a release bump, the branch changes `crates/citum-cli`, and the PR hygiene gate requires the patch workspace version bump plus `Version-Bump: patch` on the CLI commit.
- `--locale` plus style locale overrides: accepted. Explicit CLI locale selection now suppresses style-level locale overrides so a requested locale is not mixed with a style-specific override for another locale.
- Unknown explicit `--locale`: accepted. A user-supplied locale ID now errors if it resolves to the fallback `en-US` instead of silently rendering with the wrong locale.

## Test plan

- [x] `cargo fmt --check`
- [x] `git diff --check origin/main...HEAD`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
- [x] `node scripts/report-core.js > /tmp/r.json && node scripts/check-core-quality.js --report /tmp/r.json --baseline scripts/report-data/core-quality-baseline.json`

## Out of scope

- Persistent user default locale/configuration; tracked in `csl26-erwz`.
- Full gender-aware MF2 role-label migration.
- Multi-selector `.match` support in the custom MF2 evaluator.
- Depending on ICU4X MF2 support