### PR TITLE
chore(rust): add advisory review smell audit

### DIFF
--- a/.claude/skills/rust-pro/SKILL.md
+++ b/.claude/skills/rust-pro/SKILL.md
@@ -98,6 +98,22 @@ Expert Rust developer mastering Rust 1.75+ features, advanced type system usage,
 - Include performance deltas in commit messages for optimization work
 - See CLAUDE.md "Verification Requirements" for full policy
 
+**Project-Specific String Ownership Review:**
+- Raw `.to_string()` counts are not quality metrics. Review categorized
+  production and hot-path findings instead.
+- Prefer borrowed `&str` values for lookups, comparisons, parser decisions, and
+  short-lived branching.
+- Allocate `String` values at real ownership boundaries: serde/schema data,
+  FFI, stored model fields, and returned rendered output.
+- Do not allocate short strings only to satisfy a comparison API, especially in
+  citation rendering, bibliography processing, name/date formatting, locale
+  lookup, or substitution logic.
+- Use `python3 scripts/audit-rust-review-smells.py --changed` during Rust PR
+  work and treat findings as advisory prompts for review, not automatic rewrite
+  instructions.
+- Do not perform broad hot-path allocation cleanup without before/after
+  benchmarks and a clear behavioral no-op argument.
+
 ### Unsafe Code & FFI
 - Safe abstractions over unsafe code
 - Foreign Function Interface (FFI) with C libraries

--- a/.claude/skills/test-coverage/SKILL.md
+++ b/.claude/skills/test-coverage/SKILL.md
@@ -24,6 +24,22 @@ always one of two things:
 
 Use the audit script and this checklist before declaring something tested.
 
+## Anti-overfitting rule
+
+Passing tests are not enough. A new or changed test must make an independent
+claim about behavior:
+
+- Prefer expected values from a fixture, citeproc oracle output, a spec, a
+  registered divergence, or a literal behavior contract.
+- Do not derive `expected` from `actual`, `result`, `rendered`, or other output
+  produced by the code under test.
+- For behavior fixes, confirm the test would fail on the old behavior when
+  practical. If that is not practical, say why in the PR or final report.
+- Avoid changing exact assertions into `contains` assertions unless the behavior
+  is intentionally partial, order-insensitive, or format-agnostic.
+- If a fixture changes, state which missing shape it adds and which scenario
+  exercises that shape.
+
 ## Test Style
 
 Before writing a test, pick the right style (full rule in
@@ -44,6 +60,7 @@ single-scenario integration tests.
 ```bash
 python scripts/audit-coverage.py          # text report
 python scripts/audit-coverage.py --json   # machine-readable
+python3 scripts/audit-rust-review-smells.py --changed
 ```
 
 ## Pre-test checklist
@@ -56,15 +73,22 @@ Before implementing or claiming a feature is tested, answer these questions:
 - [ ] Does the fixture have an item with those fields populated?
 - [ ] If testing citation rendering: does `citations-expanded.json` reference
       an item of the relevant type?
+- [ ] What independent source defines the expected result: fixture, oracle,
+      spec, divergence register, or literal behavior contract?
 - [ ] Run `cargo nextest run` — do the tests actually exercise the path?
 
 ## Post-test checklist
 
 After writing tests:
 
+- [ ] Would the test fail against the old behavior, or is the exception
+      documented?
+- [ ] Are expected values independent of the actual output under test?
 - [ ] Did you add fixture items if shapes were missing?
 - [ ] Did you add citation scenarios if types were missing from
       `citations-expanded.json`?
+- [ ] Did `python3 scripts/audit-rust-review-smells.py --changed` produce only
+      reviewed advisory findings?
 - [ ] Does `cargo nextest run` pass cleanly?
 - [ ] If the feature touches oracle-level behavior: run
       `./scripts/workflow-test.sh styles-legacy/apa.csl` to sanity-check

--- a/.codex/agents/rust-implementer.md
+++ b/.codex/agents/rust-implementer.md
@@ -18,6 +18,8 @@ verification:
   - Run repo-required Rust verification for `.rs`, `Cargo.toml`, or `Cargo.lock` changes.
   - If `crates/citum-cli/` or `crates/citum-schema*/` changed, regenerate schemas as required by the repo.
   - Add or update targeted tests when the change affects behavior.
+  - For behavior fixes, confirm the new or changed test would fail against the old behavior, or state why that cannot be reproduced.
+  - Run `python3 scripts/audit-rust-review-smells.py --changed` for Rust changes and review any advisory findings before closing.
 output_contract:
   - Summarize the root change in a few lines.
   - Report exact verification performed and whether it passed.

--- a/.codex/skills/rust-simplify/SKILL.md
+++ b/.codex/skills/rust-simplify/SKILL.md
@@ -22,12 +22,19 @@ Read first:
 
 - Reduce duplication and nested control flow.
 - Prefer idiomatic Rust and explicit error handling.
+- Review suspicious string ownership patterns. Prefer borrowed `&str` for lookup
+  and comparison work, and allocate `String` values at real ownership boundaries.
+- Do not perform broad allocation churn in hot paths without benchmark evidence.
 - Add or update tests when behavior changes.
+- When tests change, keep expected values independent of current implementation
+  output and confirm behavior changes would have failed before the fix when
+  practical.
 - Keep the scope to one focused file or one tightly related cluster.
 
 ## Verification
 
 - Run the repo-required Rust checks for any `.rs`, `Cargo.toml`, or `Cargo.lock` change.
+- Run `python3 scripts/audit-rust-review-smells.py --changed` for Rust cleanup
+  passes and review the advisory findings.
 - Regenerate schemas if the touched files require it.
 - Report the exact checks you ran and the result.
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate commit messages
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          while IFS= read -r sha; do
+            git log -1 --format="%B" "$sha" > /tmp/citum_commit_msg.txt
+            if ! bash .githooks/commit-msg /tmp/citum_commit_msg.txt; then
+              echo "Commit $sha has invalid message" >&2
+              exit 1
+            fi
+          done < <(git log --format="%H" "${base}..HEAD")
+
       - name: Install beans CLI
         run: |
           curl -fsSL \

--- a/crates/citum-analyze/src/batch_test.rs
+++ b/crates/citum-analyze/src/batch_test.rs
@@ -13,37 +13,31 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use walkdir::WalkDir;
 
-#[allow(
-    clippy::too_many_lines,
-    reason = "test functions naturally exceed 100 lines"
-)]
-fn main() {
-    let args: Vec<String> = env::args().collect();
+struct CliArgs {
+    styles_dir: String,
+    verbose: bool,
+    json_output: bool,
+    sample_size: Option<usize>,
+}
 
-    if args.len() < 2 {
-        eprintln!("Usage: citum_batch_test <styles_dir> [--verbose] [--sample N]");
-        eprintln!();
-        eprintln!("Options:");
-        eprintln!("  --verbose    Show individual style results");
-        eprintln!("  --sample N   Only test N random styles");
-        eprintln!("  --json       Output as JSON");
-        std::process::exit(1);
+fn parse_cli(args: &[String]) -> CliArgs {
+    CliArgs {
+        styles_dir: args[1].clone(),
+        verbose: args.iter().any(|a| a == "--verbose"),
+        json_output: args.iter().any(|a| a == "--json"),
+        sample_size: args
+            .iter()
+            .position(|a| a == "--sample")
+            .and_then(|i| args.get(i + 1))
+            .and_then(|s| s.parse().ok()),
     }
+}
 
-    let styles_dir = &args[1];
-    let verbose = args.contains(&"--verbose".to_string());
-    let json_output = args.contains(&"--json".to_string());
-    let sample_size: Option<usize> = args
-        .iter()
-        .position(|a| a == "--sample")
-        .and_then(|i| args.get(i + 1))
-        .and_then(|s| s.parse().ok());
-
-    // Collect all .csl files
+fn collect_styles(styles_dir: &str, sample_size: Option<usize>) -> Vec<PathBuf> {
     let mut styles: Vec<_> = WalkDir::new(styles_dir)
         .into_iter()
         .filter_map(std::result::Result::ok)
@@ -51,12 +45,9 @@ fn main() {
         .map(|e| e.path().to_path_buf())
         .collect();
 
-    // Sample if requested
     if let Some(n) = sample_size {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
-
-        // Deterministic shuffle based on filename hash
         styles.sort_by(|a, b| {
             let mut ha = DefaultHasher::new();
             let mut hb = DefaultHasher::new();
@@ -67,6 +58,11 @@ fn main() {
         styles.truncate(n);
     }
 
+    styles
+}
+
+fn run_batch(cli: CliArgs) {
+    let styles = collect_styles(&cli.styles_dir, cli.sample_size);
     let total = styles.len();
     let mut results = BatchResults::default();
 
@@ -79,7 +75,7 @@ fn main() {
         match &result {
             TestResult::Success => {
                 results.migration_success += 1;
-                if verbose {
+                if cli.verbose {
                     eprintln!("[{}/{}] ✅ {}", i + 1, total, name);
                 }
             }
@@ -89,7 +85,7 @@ fn main() {
                     .migration_errors
                     .entry(categorize_error(err))
                     .or_insert(0) += 1;
-                if verbose {
+                if cli.verbose {
                     eprintln!(
                         "[{}/{}] ❌ {} - Migration: {}",
                         i + 1,
@@ -105,7 +101,7 @@ fn main() {
                     .processor_errors
                     .entry(categorize_error(err))
                     .or_insert(0) += 1;
-                if verbose {
+                if cli.verbose {
                     eprintln!(
                         "[{}/{}] ⚠️  {} - Processor: {}",
                         i + 1,
@@ -121,7 +117,7 @@ fn main() {
                     .yaml_errors
                     .entry(categorize_error(err))
                     .or_insert(0) += 1;
-                if verbose {
+                if cli.verbose {
                     eprintln!(
                         "[{}/{}] ❌ {} - Invalid YAML: {}",
                         i + 1,
@@ -133,19 +129,32 @@ fn main() {
             }
         }
 
-        // Progress indicator every 100 styles
-        if !verbose && (i + 1) % 100 == 0 {
+        if !cli.verbose && (i + 1) % 100 == 0 {
             eprintln!("  Processed {}/{}", i + 1, total);
         }
     }
 
     results.total = total;
 
-    if json_output {
+    if cli.json_output {
         println!("{}", serde_json::to_string_pretty(&results).unwrap());
     } else {
         print_results(&results);
     }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: citum_batch_test <styles_dir> [--verbose] [--sample N]");
+        eprintln!();
+        eprintln!("Options:");
+        eprintln!("  --verbose    Show individual style results");
+        eprintln!("  --sample N   Only test N random styles");
+        eprintln!("  --json       Output as JSON");
+        std::process::exit(1);
+    }
+    run_batch(parse_cli(&args));
 }
 
 #[derive(Default, serde::Serialize)]

--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -13,6 +13,7 @@ mod analyzer;
 mod profile_discovery;
 mod ranker;
 mod savings;
+mod util;
 
 use std::env;
 
@@ -25,10 +26,10 @@ fn main() {
     }
 
     let styles_dir = &args[1];
-    let json_output = args.contains(&"--json".to_string());
-    let rank_parents = args.contains(&"--rank-parents".to_string());
-    let quantify_savings = args.contains(&"--quantify-savings".to_string());
-    let identify_profiles = args.contains(&"--identify-profiles".to_string());
+    let json_output = args.iter().any(|arg| arg == "--json");
+    let rank_parents = args.iter().any(|arg| arg == "--rank-parents");
+    let quantify_savings = args.iter().any(|arg| arg == "--quantify-savings");
+    let identify_profiles = args.iter().any(|arg| arg == "--identify-profiles");
 
     // Check for format filter (--format author-date, --format numeric, etc.)
     let format_filter = args

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -9,6 +9,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::util::short_name_from_identifier;
+
 use citum_migrate::{OptionsExtractor, compilation, fixups, provenance::ProvenanceTracker};
 use citum_schema::StyleBase;
 use citum_schema::locale::GeneralTerm;
@@ -573,6 +575,7 @@ fn jaccard_similarity(left: &HashSet<SemanticItem>, right: &HashSet<SemanticItem
     }
 }
 
+/// Maps a template component to semantic items; structural wrappers (Conditional, Substitute, etc.) are intentionally skipped.
 fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem>) {
     match component {
         TemplateComponent::Variable(v) => items.push(SemanticItem::Variable(v.variable.clone())),
@@ -600,18 +603,12 @@ fn template_to_set(template: &[TemplateComponent]) -> HashSet<SemanticItem> {
     items.into_iter().collect()
 }
 
-fn short_name_from_identifier(identifier: &str) -> std::borrow::Cow<'_, str> {
-    identifier.rsplit('/').next().map_or_else(
-        || std::borrow::Cow::Borrowed(identifier),
-        std::borrow::Cow::Borrowed,
-    )
-}
-
 fn sanitize_url(url: &str) -> String {
-    url.strip_prefix('h')
-        .filter(|_| url.starts_with("hhttps://"))
-        .unwrap_or(url)
-        .to_string()
+    if url.starts_with("hhttps://") {
+        url[1..].to_string()
+    } else {
+        url.to_string()
+    }
 }
 
 fn non_empty(value: &str) -> Option<String> {

--- a/crates/citum-analyze/src/ranker.rs
+++ b/crates/citum-analyze/src/ranker.rs
@@ -8,6 +8,8 @@ use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
 
+use crate::util::truncate;
+
 /// Statistics for parent style ranking.
 #[derive(Default, serde::Serialize)]
 pub struct ParentRankerStats {
@@ -357,13 +359,5 @@ fn print_parent_rankings(stats: &ParentRankerStats) {
         if stats.parse_errors.len() > 5 {
             println!("  ... and {} more", stats.parse_errors.len() - 5);
         }
-    }
-}
-
-fn truncate(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max_len - 3])
     }
 }

--- a/crates/citum-analyze/src/savings.rs
+++ b/crates/citum-analyze/src/savings.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 
 use walkdir::WalkDir;
 
+use crate::util::{short_name_from_identifier, truncate};
+
 /// Runs the corpus-savings report for preset and locale-override opportunities.
 pub fn run_savings_report(styles_dir: &str, json_output: bool) {
     match analyze_savings(Path::new(styles_dir)) {
@@ -315,13 +317,6 @@ fn citation_formats_compatible(left: Option<&str>, right: Option<&str>) -> bool 
     left.is_none() || right.is_none() || left == right
 }
 
-fn short_name_from_identifier(identifier: &str) -> std::borrow::Cow<'_, str> {
-    identifier.rsplit('/').next().map_or_else(
-        || std::borrow::Cow::Borrowed(identifier),
-        std::borrow::Cow::Borrowed,
-    )
-}
-
 fn locale_base_slug(slug: &str, locale: &str) -> Option<String> {
     let locale_suffix = locale_suffix_from_locale(locale)?;
     let explicit_suffix = format!("-{locale_suffix}");
@@ -405,14 +400,6 @@ fn print_savings_report(report: &SavingsReport) {
             family.preset_wrapper_count,
             family.combined_opportunity_count
         );
-    }
-}
-
-fn truncate(value: &str, max_len: usize) -> String {
-    if value.len() <= max_len {
-        value.to_string()
-    } else {
-        format!("{}...", &value[..max_len - 3])
     }
 }
 

--- a/crates/citum-analyze/src/util.rs
+++ b/crates/citum-analyze/src/util.rs
@@ -1,0 +1,18 @@
+use std::borrow::Cow;
+
+/// Extracts the last path segment from a `/`-separated identifier.
+pub(crate) fn short_name_from_identifier(identifier: &str) -> Cow<'_, str> {
+    identifier
+        .rsplit('/')
+        .next()
+        .map_or_else(|| Cow::Borrowed(identifier), Cow::Borrowed)
+}
+
+/// Truncates `s` to `max_len` chars, appending `...` if clipped.
+pub(crate) fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len - 3])
+    }
+}

--- a/docs/guides/CODING_STANDARDS.md
+++ b/docs/guides/CODING_STANDARDS.md
@@ -34,6 +34,59 @@ fn given_a_multilingual_author_when_rendering_a_citation_then_family_name_is_use
 ) { … }
 ```
 
+## Test Independence
+
+Tests must prove the behavior from an independent source, not mirror the current
+implementation output.
+
+- For behavior fixes, the test should fail against the old behavior unless the
+  PR documents why the old behavior cannot be reproduced locally.
+- Prefer expected values from literals, fixtures, oracle output, specs, or
+  registered divergence decisions. Do not derive `expected` from `actual`,
+  `result`, `rendered`, or other values produced by the code under test.
+- Avoid weakening exact output checks to substring checks just to make a test
+  pass. Use `contains` assertions only when the behavior is intentionally
+  partial, order-insensitive, or format-agnostic, and make that scope clear in
+  the test name or setup.
+- Fixture changes must explain the missing shape they add. When fixture data
+  changes expected behavior, pair it with the smallest Rust or oracle check that
+  exercises the new shape.
+- Ignored tests need a reason and a tracking path. Do not leave `#[ignore]`
+  as an unreviewed way to keep the suite green.
+
+Use the advisory review-smell audit before opening PRs that touch Rust tests:
+
+```bash
+python3 scripts/audit-rust-review-smells.py --changed
+```
+
+## String Ownership
+
+Owned strings are normal at data model, serialization, FFI, and output
+boundaries. They are suspicious when allocated only for lookup, comparison, or
+short-lived formatting inside production paths.
+
+- Prefer borrowed `&str` values for lookups, comparisons, and parser decisions.
+  For example, avoid allocating a short `String` only to call `contains`.
+- Allocate when constructing owned schema/data values, crossing FFI or serde
+  boundaries, returning owned rendered output, or storing values beyond the
+  borrowed input lifetime.
+- Treat raw `.to_string()` counts as a triage signal only. Review categorized
+  findings by path kind, especially `hot-path` production findings.
+- Do not enable broad noisy Clippy restriction lints as hard failures without a
+  baseline pass. Use them to inform targeted review.
+- Hot-path allocation reductions are performance work: run before/after
+  benchmarks and report the deltas when changing citation rendering,
+  bibliography processing, style parsing, name formatting, date formatting, or
+  substitution logic.
+
+Use the advisory audit to find suspicious patterns:
+
+```bash
+python3 scripts/audit-rust-review-smells.py --all
+python3 scripts/audit-rust-review-smells.py --all --json
+```
+
 ## Serde Attributes Checklist
 
 - Use `#[serde(rename_all = "kebab-case")]` for YAML/JSON compatibility

--- a/scripts/audit-rust-review-smells.py
+++ b/scripts/audit-rust-review-smells.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Advisory audit for Rust test independence and string ownership review smells."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUST_ROOTS = ("crates", "tests")
+
+HOT_PATH_PARTS = (
+    "processor",
+    "render",
+    "rendering",
+    "bibliography",
+    "citation",
+    "values",
+    "locale",
+    "sorting",
+    "disambiguation",
+    "template_compiler",
+)
+
+SHORT_LITERAL = r'"(?:[^"\\]|\\.){0,24}"'
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single advisory review finding."""
+
+    severity: str
+    category: str
+    path_kind: str
+    path: str
+    line: int
+    rule: str
+    message: str
+    snippet: str
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A line-oriented advisory rule."""
+
+    name: str
+    category: str
+    severity: str
+    pattern: re.Pattern[str]
+    message: str
+    include_kinds: tuple[str, ...] = ("prod", "hot-path", "test", "bench", "fixture")
+
+
+RULES = (
+    Rule(
+        name="string-contains-literal-allocation",
+        category="string-allocation",
+        severity="high",
+        pattern=re.compile(r"\.contains\(&" + SHORT_LITERAL + r"\.to_string\(\)\)"),
+        message=(
+            "Borrow the literal for membership checks instead of allocating a short "
+            "String solely for comparison."
+        ),
+        include_kinds=("prod", "hot-path", "test"),
+    ),
+    Rule(
+        name="push-str-format",
+        category="string-allocation",
+        severity="medium",
+        pattern=re.compile(r"\.push_str\(&format!\("),
+        message=(
+            "Review whether write! on the existing String would avoid a temporary "
+            "allocation; keep format! only when readability is worth it."
+        ),
+        include_kinds=("prod", "hot-path"),
+    ),
+    Rule(
+        name="short-literal-fallback-allocation",
+        category="string-allocation",
+        severity="medium",
+        pattern=re.compile(
+            r"\.(?:ok_or(?:_else)?|unwrap_or(?:_else)?)\([^)]*"
+            + SHORT_LITERAL
+            + r"\.to_string\(\)"
+        ),
+        message=(
+            "Short literal fallback allocates an owned String; confirm this is an "
+            "ownership boundary or use a borrowed/static error shape."
+        ),
+        include_kinds=("prod", "hot-path"),
+    ),
+    Rule(
+        name="ignored-test",
+        category="test-independence",
+        severity="high",
+        pattern=re.compile(r"#\s*\[\s*ignore(?:\s*[=\]])"),
+        message=(
+            "Ignored tests need an explicit reason and tracking path; otherwise they "
+            "can hide regressions."
+        ),
+        include_kinds=("test",),
+    ),
+    Rule(
+        name="render-output-contains-assertion",
+        category="test-independence",
+        severity="medium",
+        pattern=re.compile(
+            r"assert!\([^;]*(?:rendered|result|output|actual|entry|content)"
+            r"\.contains\("
+        ),
+        message=(
+            "Substring assertions on rendered output are weak. Prefer exact output, "
+            "component-level assertions, or document why the test is intentionally partial."
+        ),
+        include_kinds=("test",),
+    ),
+    Rule(
+        name="expected-derived-from-actual",
+        category="test-independence",
+        severity="high",
+        pattern=re.compile(
+            r"(?:let\s+expected\s*=\s*(?:actual|result|rendered|output)|"
+            r"let\s+actual\s*=\s*expected|"
+            r"assert_eq!\(\s*(\w+)\s*,\s*\1\s*\))"
+        ),
+        message=(
+            "Expected values must come from an independent fixture, oracle, spec, or "
+            "literal behavior contract, not from the actual output under test."
+        ),
+        include_kinds=("test",),
+    ),
+)
+
+
+def run_git(args: list[str]) -> str:
+    """Run a git command in the repository and return stdout."""
+
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return completed.stdout
+
+
+def tracked_rust_files() -> list[Path]:
+    """Return all tracked Rust files under the configured Rust roots."""
+
+    output = run_git(["ls-files", "--", *RUST_ROOTS])
+    return sorted(ROOT / line for line in output.splitlines() if line.endswith(".rs"))
+
+
+def changed_rust_files() -> list[Path]:
+    """Return changed Rust files relative to the merge base with HEAD."""
+
+    base = run_git(["merge-base", "HEAD", "origin/main"]).strip()
+    output = run_git(
+        [
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            f"{base}...HEAD",
+            "--",
+            *RUST_ROOTS,
+        ]
+    )
+    return sorted(ROOT / line for line in output.splitlines() if line.endswith(".rs"))
+
+
+def classify(path: Path) -> str:
+    """Classify a Rust path by review surface."""
+
+    rel = path.relative_to(ROOT)
+    parts = rel.parts
+    rel_text = rel.as_posix()
+
+    if "/benches/" in f"/{rel_text}/":
+        return "bench"
+    if "/fixtures/" in f"/{rel_text}/":
+        return "fixture"
+    if (
+        "/tests/" in f"/{rel_text}/"
+        or path.name == "tests.rs"
+        or path.name.endswith("_tests.rs")
+        or path.stem.endswith("_test")
+    ):
+        return "test"
+    if any(part in HOT_PATH_PARTS for part in parts):
+        return "hot-path"
+    return "prod"
+
+
+def dense_literal_to_string_findings(path: Path, lines: list[str], path_kind: str) -> list[Finding]:
+    """Flag dense clusters of short literal to_string calls outside test surfaces."""
+
+    if path_kind not in {"prod", "hot-path"}:
+        return []
+
+    literal_pattern = re.compile(SHORT_LITERAL + r"\.to_string\(\)")
+    test_like_pattern = re.compile(r"\b(?:assert|panic)!\(|#\s*\[\s*(?:test|rstest|case|cfg\(test\))")
+    findings: list[Finding] = []
+    window_size = 25
+    threshold = 6 if path_kind == "hot-path" else 10
+
+    for start in range(0, len(lines), window_size):
+        window = lines[start : start + window_size]
+        count = sum(
+            len(literal_pattern.findall(line))
+            for line in window
+            if not test_like_pattern.search(line)
+        )
+        if count < threshold:
+            continue
+        first_snippet = next(
+            (
+                line.strip()
+                for line in window
+                if literal_pattern.search(line) and not test_like_pattern.search(line)
+            ),
+            "",
+        )
+        findings.append(
+            Finding(
+                severity="medium",
+                category="string-allocation",
+                path_kind=path_kind,
+                path=path.relative_to(ROOT).as_posix(),
+                line=start + 1,
+                rule="dense-literal-to-string",
+                message=(
+                    f"{count} short literal `.to_string()` calls in {window_size} lines. "
+                    "Review whether this is data construction, an ownership boundary, "
+                    "or avoidable churn."
+                ),
+                snippet=first_snippet,
+            )
+        )
+    return findings
+
+
+def scan_file(path: Path) -> list[Finding]:
+    """Scan one Rust file for advisory findings."""
+
+    path_kind = classify(path)
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        lines = path.read_text(errors="replace").splitlines()
+
+    findings: list[Finding] = []
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        for rule in RULES:
+            if path_kind not in rule.include_kinds:
+                continue
+            if not rule.pattern.search(line):
+                continue
+            findings.append(
+                Finding(
+                    severity=rule.severity,
+                    category=rule.category,
+                    path_kind=path_kind,
+                    path=path.relative_to(ROOT).as_posix(),
+                    line=line_number,
+                    rule=rule.name,
+                    message=rule.message,
+                    snippet=stripped,
+                )
+            )
+
+    findings.extend(dense_literal_to_string_findings(path, lines, path_kind))
+    return findings
+
+
+def changed_test_without_behavior_evidence(paths: Iterable[Path]) -> list[Finding]:
+    """Flag changed Rust test files when the PR has no obvious behavior evidence changes."""
+
+    changed = list(paths)
+    test_files = [path for path in changed if classify(path) == "test"]
+    if not test_files:
+        return []
+
+    evidence_paths = (
+        "crates/",
+        "tests/fixtures/",
+        "styles/",
+        "styles-legacy/",
+        "scripts/",
+        "docs/specs/",
+        "docs/architecture/",
+        "docs/policies/",
+    )
+    changed_names = [
+        line
+        for line in run_git(["diff", "--name-only", "origin/main...HEAD"]).splitlines()
+        if line
+    ]
+    has_behavior_evidence = any(
+        name.startswith(evidence_paths) and not name.endswith(".rs") for name in changed_names
+    ) or any(classify(ROOT / name) in {"prod", "hot-path"} for name in changed_names if name.endswith(".rs"))
+
+    if has_behavior_evidence:
+        return []
+
+    return [
+        Finding(
+            severity="medium",
+            category="test-independence",
+            path_kind="test",
+            path=path.relative_to(ROOT).as_posix(),
+            line=1,
+            rule="changed-test-without-behavior-evidence",
+            message=(
+                "This PR changes a Rust test without an obvious production, fixture, "
+                "oracle, or spec/doc evidence change. Confirm the test is not merely "
+                "adapting expectations to current behavior."
+            ),
+            snippet="",
+        )
+        for path in test_files
+    ]
+
+
+def severity_rank(finding: Finding) -> tuple[int, str, int, str]:
+    """Sort findings by severity and location."""
+
+    ranks = {"high": 0, "medium": 1, "low": 2}
+    return (ranks.get(finding.severity, 9), finding.path, finding.line, finding.rule)
+
+
+def print_text(findings: list[Finding]) -> None:
+    """Print findings grouped by severity and category."""
+
+    if not findings:
+        print("No advisory Rust review smells found.")
+        return
+
+    print(f"Advisory Rust review smells: {len(findings)} finding(s)")
+    print("This script is informational; it does not define a merge gate.\n")
+
+    for severity in ("high", "medium", "low"):
+        severity_findings = [f for f in findings if f.severity == severity]
+        if not severity_findings:
+            continue
+        print(f"{severity.upper()}")
+        for finding in severity_findings:
+            print(
+                f"  {finding.path}:{finding.line} "
+                f"[{finding.path_kind}/{finding.category}/{finding.rule}]"
+            )
+            print(f"    {finding.message}")
+            if finding.snippet:
+                print(f"    {finding.snippet}")
+        print()
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Advisory Rust review-smell audit for test independence and string ownership."
+        )
+    )
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--all", action="store_true", help="scan all tracked Rust files")
+    scope.add_argument(
+        "--changed",
+        action="store_true",
+        help="scan changed Rust files relative to origin/main",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the advisory audit."""
+
+    args = parse_args()
+    files = tracked_rust_files() if args.all else changed_rust_files()
+    findings = [finding for path in files for finding in scan_file(path)]
+    if args.changed:
+        findings.extend(changed_test_without_behavior_evidence(files))
+
+    findings.sort(key=severity_rank)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "advisory": True,
+                    "scope": "all" if args.all else "changed",
+                    "finding_count": len(findings),
+                    "findings": [asdict(finding) for finding in findings],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print_text(findings)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds an advisory Rust review-smell audit for test independence and string ownership patterns.
- Documents test independence and string ownership review rules in coding standards.
- Updates repo-local agent and skill guidance so Rust/test work reviews these issues consistently.

## Test plan
- `python3 -m py_compile scripts/audit-rust-review-smells.py`
- `python3 scripts/audit-rust-review-smells.py --changed`
- `python3 scripts/audit-rust-review-smells.py --all`
- `python3 scripts/audit-rust-review-smells.py --all --json > /tmp/citum-rust-review-smells.json`
- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict`
- `git diff --check`
