### PR TITLE
docs: add declarative schema design section to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,105 @@ These checks are **mandatory** for all `.rs` files, `Cargo.toml`, and `Cargo.loc
 
 **Do not commit if any check fails — fix the issues first.**
 
+## Schema & Style Design Philosophy
+
+Citum uses a **declarative schema**: styles are data, not programs. This is the
+sharpest divergence from CSL 1.0 and the most important design constraint for
+contributors working on the schema (`citum_schema`) or the engine
+(`citum_engine`).
+
+### What "declarative" means here
+
+A style YAML file describes *what* a citation should look like — which fields
+appear, in what order, wrapped in what punctuation — without encoding *how* the
+processor should compute it. The processor stays dumb; the style stays explicit.
+
+The primary mechanism for reusable formatting variation is **`options`**, not
+template branching. Contributor formatting, date presentation, processing mode,
+and label behavior are all declared in `options.*` blocks. Templates handle
+structure, field order, and local rendering details such as `prefix`, `suffix`,
+and `wrap`. This is why CSL 1.0 conditionals and macro chains have no equivalent
+in Citum styles — those decisions are either lifted into named `options` presets,
+expressed as explicit structural `type-variants`, or made unnecessary by the
+type system.
+
+**Do not add procedural logic to styles.** A style is valid Citum if every
+rendering decision can be read off the YAML without knowing Rust. If you need to
+read engine source to understand why a style produces a given output, that logic
+belongs in the style, not the engine.
+
+### What this replaces in CSL 1.0
+
+| CSL 1.0 pattern | Citum equivalent |
+|-----------------|-----------------|
+| `<choose><if type="article-journal">…</if></choose>` | Prefer scoped `options.*` for reusable formatting policy; use `type-variants:` only when the template structure differs by type |
+| `<if variable="DOI">…</if>` (optional-field branching) | Template items are skipped automatically when the variable is absent |
+| `<text macro="author"/>` (macro call chain) | Named presets (`options.contributors`, `options.dates`) |
+| Hardcoded separator by type in the processor | `suffix:` / `prefix:` on the relevant template item in the style |
+| `<choose><if position="first-in-cluster">` | Engine-managed; styles configure via `citation.options.group-delimiter` / `options.processing.group` |
+
+The goal is that a style author — not a Rust programmer — can express any
+supported formatting difference without touching the engine.
+
+### Rules for schema contributors
+
+**Prefer flat, typed fields over open maps.**
+New schema fields go on the appropriate typed struct, not into a
+`HashMap<String, serde_json::Value>`. Open maps
+(`custom: Option<HashMap<String, serde_json::Value>>`) exist only as an explicit
+escape hatch for user-defined extensions.
+
+**New fields must deserialize when absent and default to a neutral/off value.**
+Use `Option<T>` or `#[serde(default)]` / `#[serde(default = "...")]` on concrete
+types as appropriate so older styles remain valid against newer engine versions.
+
+**No `unwrap()`, no `unsafe`, no silent fallbacks.**
+Missing data surfaces as `None` and is handled by the template skip mechanism.
+Do not paper over missing fields with magic defaults in the processor.
+
+**`type-variants` are a last resort.**
+Before reaching for `type-variants`, ask whether the base template can handle
+the case naturally. Reserve `type-variants` for genuine structural differences
+(e.g., a journal article omits `publisher`; a dataset adds `version`). Do not
+use `type-variants` for punctuation-only variation.
+
+**Processor logic requires a style escape hatch.**
+If the engine must behave differently for two reference types, there must be a
+style-level knob that controls it. Hardcoded type-conditional logic in Rust is a
+design smell — open a discussion before adding it.
+
+### Quick reference
+
+```yaml
+# Good: style declares the structural difference explicitly
+bibliography:
+  template:
+    - contributor: author
+    - date: issued
+      form: year
+      wrap: parentheses
+    - title: primary
+    - variable: publisher       # skipped automatically for types without a publisher
+  type-variants:
+    article-journal:
+      - contributor: author
+      - date: issued
+        form: year
+        wrap: parentheses
+      - title: primary
+      - title: parent-serial  # replaces publisher for journal articles
+```
+
+```rust
+// Bad: processor encodes type knowledge that belongs in the style
+if ref_type == RefType::ArticleJournal {
+    output.push(render_journal_title(ctx));  // ← this logic belongs in style YAML
+}
+```
+
+For the full rationale, see
+[docs/architecture/DESIGN_PRINCIPLES.md](./docs/architecture/DESIGN_PRINCIPLES.md).
+
 ## Commit Conventions
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/) format:


### PR DESCRIPTION
## Summary

- Adds a new `## Schema & Style Design Philosophy` section to `CONTRIBUTING.md`
- Targets developers and coding LLMs who need to understand Citum's declarative model before writing schema or engine code
- Bridges `DESIGN_PRINCIPLES.md` (maintainer rationale) and the style author guide (YAML authoring) with a concise, pattern-matchable developer primer

## Content

- **What "declarative" means** — styles describe *what*, the processor computes *how*; no procedural logic in style YAML
- **CSL 1.0 comparison table** — five common procedural patterns mapped to their Citum equivalents (`choose/if`, optional-field branching, macro chains, type-conditional separators, position guards)
- **Four schema contributor rules** — typed structs over open maps; `Option<T>` with `#[serde(default)]`; no `unwrap()`/silent fallbacks; `type-variants` as last resort; processor logic requires a style escape hatch
- **YAML/Rust quick reference** — concrete good/bad code blocks a coding LLM can pattern-match against

## Amended after review

- Replaced stale per-component template `overrides` guidance with current scoped `options.*` and spec-level `type-variants` guidance
- Corrected the YAML example so each `type-variants` value is the replacement template array directly, matching the current schema
- Clarified that `options` carry reusable formatting policy while templates still own structure, field order, and local rendering details such as `prefix`, `suffix`, and `wrap`

## Test plan

- [x] Re-read CONTRIBUTING.md around the new section and verified the examples match the current `type-variants` schema shape
- [x] `git diff --check`
- [x] No Rust changes — CI build/test checks not required

