### PR TITLE
chore(beans): tag schema-impacting open beans

### DIFF
--- a/.beans/archive/csl26-hk27--align-core-hookspath-with-repo-githooks.md
+++ b/.beans/archive/csl26-hk27--align-core-hookspath-with-repo-githooks.md
@@ -4,8 +4,10 @@ title: Align core hooksPath with repo githooks
 status: todo
 type: task
 priority: normal
+tags:
+    - infra
 created_at: 2026-03-13T22:58:00Z
-updated_at: 2026-03-13T22:58:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 This checkout has the real commit hook in `.githooks/commit-msg`, but Git is

--- a/.beans/archive/csl26-x1y2--hook-up-generalized-relational-fixtures-to-fidelit.md
+++ b/.beans/archive/csl26-x1y2--hook-up-generalized-relational-fixtures-to-fidelit.md
@@ -4,8 +4,10 @@ title: Hook up generalized relational fixtures to fidelity reporting
 status: todo
 type: task
 priority: normal
+tags:
+    - testing
 created_at: 2026-04-01T15:00:00Z
-updated_at: 2026-04-02T00:23:32Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 Following the implementation of the generalized relational container model (PR #485 / v0.20.0) and the numbering cleanup, the fidelity pipeline now needs richer benchmark inputs that exercise the new relational model instead of relying only on the older flat fixtures.

--- a/.beans/csl26-4mzf--rename-style-files-to-short-name-edition-conventio.md
+++ b/.beans/csl26-4mzf--rename-style-files-to-short-name-edition-conventio.md
@@ -4,8 +4,11 @@ title: Rename style files to short-name + edition convention
 status: todo
 type: task
 priority: normal
+tags:
+    - style
+    - infra
 created_at: 2026-03-17T11:11:49Z
-updated_at: 2026-03-17T11:12:12Z
+updated_at: 2026-04-25T20:20:07Z
 blocked_by:
     - csl26-fsjy
 ---

--- a/.beans/csl26-7edf--add-dedicated-partsupplementprinting-number-fields.md
+++ b/.beans/csl26-7edf--add-dedicated-partsupplementprinting-number-fields.md
@@ -4,8 +4,11 @@ title: Add dedicated part/supplement/printing number fields
 status: todo
 type: feature
 priority: deferred
+tags:
+    - schema
+    - engine
 created_at: 2026-03-05T15:22:41Z
-updated_at: 2026-04-24T12:14:10Z
+updated_at: 2026-04-25T20:20:06Z
 parent: csl26-li63
 ---
 

--- a/.beans/csl26-7grx--expand-citations-fixture-for-alias-discovery-blind.md
+++ b/.beans/csl26-7grx--expand-citations-fixture-for-alias-discovery-blind.md
@@ -3,8 +3,11 @@
 title: Expand citations fixture for alias-discovery blind spots
 status: todo
 type: task
+priority: normal
+tags:
+    - testing
 created_at: 2026-04-19T13:11:00Z
-updated_at: 2026-04-19T13:11:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 Add 4 missing scenario types to tests/fixtures/citations-expanded.json so find-alias-candidates.js can distinguish same-family variants: (1) subsequent/repeated cite, (2) note-context citation, (3) bracket/delimiter shape variation, (4) archive reference with both archive and archive-place. Unblocks promoting 8 withheld 1.000-score candidates (AMA brackets/parens, chicago-shortened-* variants, MLA notes) to registry aliases. See docs/guides/ALIAS_DISCOVERY.md#known-fixture-blind-spots.

--- a/.beans/csl26-8kod--components-column-coverage-for-biblatex-authority.md
+++ b/.beans/csl26-8kod--components-column-coverage-for-biblatex-authority.md
@@ -3,8 +3,12 @@
 title: Components column coverage for biblatex-authority styles
 status: todo
 type: task
+priority: normal
+tags:
+    - testing
+    - migrate
 created_at: 2026-03-07T19:25:01Z
-updated_at: 2026-03-07T19:25:01Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 The five compound-numeric styles (numeric-comp, chem-acs, angewandte-chemie, chem-rsc, chem-biochem) use biblatex as their benchmark authority. The biblatex oracle in report-core.js builds entries as { expected, actual, match } with no component-level breakdown, so computeComponentMatchRate() always returns null and the Components column in compat.html is empty for these styles.

--- a/.beans/csl26-9pui--add-behavioral-bdd-tests-for-bibliography-loading.md
+++ b/.beans/csl26-9pui--add-behavioral-bdd-tests-for-bibliography-loading.md
@@ -3,8 +3,11 @@
 title: Add behavioral BDD tests for bibliography loading
 status: todo
 type: task
+priority: normal
+tags:
+    - testing
 created_at: 2026-03-14T15:51:53Z
-updated_at: 2026-03-14T15:51:53Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 The io.rs parse branch tests added in PR #365 are unit tests against private helpers. Add behavioral coverage for bibliography loading through the public API (load_bibliography_with_sets or CLI), using the project's BDD naming convention (describe_X::it_Y). Cover: CSL-JSON array, Citum YAML, wrapped legacy format, IndexMap format. Should appear in the behavior coverage report.

--- a/.beans/csl26-egzd--style-structure-lint-hard-fail-rollout.md
+++ b/.beans/csl26-egzd--style-structure-lint-hard-fail-rollout.md
@@ -4,8 +4,10 @@ title: Style-structure lint hard-fail rollout
 status: todo
 type: task
 priority: normal
+tags:
+    - infra
 created_at: 2026-03-27T13:16:35Z
-updated_at: 2026-03-27T13:29:52Z
+updated_at: 2026-04-25T20:20:07Z
 parent: csl26-li63
 ---
 

--- a/.beans/csl26-erwz--user-style-locale-store-citum-store.md
+++ b/.beans/csl26-erwz--user-style-locale-store-citum-store.md
@@ -4,8 +4,10 @@ title: User style & locale store (citum_store)
 status: todo
 type: epic
 priority: normal
+tags:
+    - cli
 created_at: 2026-03-04T18:11:14Z
-updated_at: 2026-03-04T18:20:34Z
+updated_at: 2026-04-25T20:20:07Z
 parent: csl26-li63
 ---
 

--- a/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
+++ b/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
@@ -4,8 +4,11 @@ title: write versioning policy docs before first public release
 status: todo
 type: task
 priority: deferred
+tags:
+    - policy
+    - dx
 created_at: 2026-02-24T17:28:17Z
-updated_at: 2026-04-24T12:14:43Z
+updated_at: 2026-04-25T20:20:08Z
 parent: csl26-li63
 blocked_by:
     - csl26-yipx

--- a/.beans/csl26-h7xz--document-template-inferrer-in-rendering-workflowmd.md
+++ b/.beans/csl26-h7xz--document-template-inferrer-in-rendering-workflowmd.md
@@ -4,8 +4,10 @@ title: Document template inferrer in RENDERING_WORKFLOW.md
 status: todo
 type: task
 priority: low
+tags:
+    - dx
 created_at: 2026-02-08T06:29:15Z
-updated_at: 2026-02-08T06:29:15Z
+updated_at: 2026-04-25T20:20:08Z
 ---
 
 Add usage docs for scripts/infer-template.js and scripts/lib/template-inferrer.js to docs/guides/RENDERING_WORKFLOW.md. Cover CLI flags (--section, --json, --verbose), example commands, and how it fits into the hybrid migration strategy.

--- a/.beans/csl26-iphj--archivepublisher-place-unification.md
+++ b/.beans/csl26-iphj--archivepublisher-place-unification.md
@@ -4,8 +4,10 @@ title: Archive/publisher place unification
 status: todo
 type: task
 priority: low
+tags:
+    - schema
 created_at: 2026-03-29T10:54:28Z
-updated_at: 2026-03-29T10:54:28Z
+updated_at: 2026-04-25T20:17:09Z
 ---
 
 Future: extract a shared Place type (or unify semantics) for archive.place and SimpleName.location — both are Option<String> with geographic-place semantics. Noted in ARCHIVAL_UNPUBLISHED_SUPPORT.md Design Rationale section. Premature to do now (no structural gain), but worth tracking.

--- a/.beans/csl26-j80k--add-gen-block-iterator-refactoring-once-stable.md
+++ b/.beans/csl26-j80k--add-gen-block-iterator-refactoring-once-stable.md
@@ -4,8 +4,10 @@ title: Add gen block iterator refactoring once stable
 status: todo
 type: feature
 priority: low
+tags:
+    - engine
 created_at: 2026-02-21T01:11:20Z
-updated_at: 2026-02-21T01:11:20Z
+updated_at: 2026-04-25T20:20:06Z
 ---
 
 Rust `gen {}` blocks (lazy zero-allocation iterators) are experimental as of Rust 1.85

--- a/.beans/csl26-jk10--evaluate-cbor-embedding-for-builtin-styles.md
+++ b/.beans/csl26-jk10--evaluate-cbor-embedding-for-builtin-styles.md
@@ -8,8 +8,10 @@ tags:
     - styles
     - performance
     - build
+    - infra
+    - research
 created_at: 2026-04-21T17:10:10Z
-updated_at: 2026-04-21T17:10:10Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 Assess converting embedded builtin style assets from YAML source files to build-generated CBOR blobs for runtime embedding.

--- a/.beans/csl26-k7nf--typst-citation-interactivity-follow-up.md
+++ b/.beans/csl26-k7nf--typst-citation-interactivity-follow-up.md
@@ -4,8 +4,10 @@ title: Typst Citation Interactivity Follow-up
 status: todo
 type: research
 priority: normal
+tags:
+    - research
 created_at: 2026-03-01T15:12:10Z
-updated_at: 2026-03-01T15:12:10Z
+updated_at: 2026-04-25T20:20:07Z
 blocking:
     - csl26-93yh
 ---

--- a/.beans/csl26-kjzk--consider-boltffi-for-bindings.md
+++ b/.beans/csl26-kjzk--consider-boltffi-for-bindings.md
@@ -4,8 +4,11 @@ title: Consider boltffi for bindings
 status: todo
 type: task
 priority: normal
+tags:
+    - bindings
+    - research
 created_at: 2026-02-17T22:02:32Z
-updated_at: 2026-02-18T15:00:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 BoltFFI looks promising as a unifying path for multi-language bindings, especially for TypeScript/WASM plus native targets (Swift/Kotlin). This bean defines a forward-looking plan that keeps current velocity while reducing long-term binding complexity.

--- a/.beans/csl26-ldgf--genre-formalization-for-localization.md
+++ b/.beans/csl26-ldgf--genre-formalization-for-localization.md
@@ -4,8 +4,10 @@ title: Genre formalization for localization
 status: draft
 type: feature
 priority: normal
+tags:
+    - policy
 created_at: 2026-03-29T10:41:12Z
-updated_at: 2026-03-29T17:32:00Z
+updated_at: 2026-04-25T20:20:08Z
 ---
 
 The genre field is currently Option<String>, which cannot be localized. Formalize genre as an enum with locale-keyed labels so styles can render material-type descriptors (letter, photograph, etc.) in the target locale. Cross-cutting: affects all reference types. Triggered by archival spec review (csl26-jgt4).

--- a/.beans/csl26-li63--production-readiness.md
+++ b/.beans/csl26-li63--production-readiness.md
@@ -5,43 +5,39 @@ status: todo
 type: milestone
 priority: normal
 created_at: 2026-02-07T07:40:14Z
-updated_at: 2026-04-25T10:57:30Z
+updated_at: 2026-04-25T20:24:48Z
 ---
 
-Tooling, testing infrastructure, documentation, and performance
-optimization for the first public release.
+Tracks remaining blockers for citum-core 1.0. Excludes web-platform
+work (citum-hub) and bindings (citum-labs).
 
-## Acceptance criteria
+## Acceptance Criteria
 
-The release goes out when each line below is checked. This list is the
-working definition of "production ready" for citum-core; it intentionally
-excludes web-platform work (citum-hub) and bindings (citum-labs).
+### Schema (land in sequence — freeze after all checked)
+
+- [ ] `RichText` type for `note`/`abstract` (csl26-suz3, in-progress) — step 1
+- [ ] Gender-aware MF2 role labels + multi-selector `.match` (csl26-vm2g) — step 2, with mlc2
+- [ ] Locale-backed archive hierarchy labels (csl26-mlc2) — step 2, blocked by csl26-y3kj
+- [ ] Dedicated part/supplement/printing-number fields (csl26-7edf) — step 3
+- [ ] `Style.version` wired to schema validation (csl26-yipx) — step 4, co-land with csl26-fuw7
+- [ ] `Place` type unification: archive vs publisher (csl26-iphj) — deferred, candidate for 1.1
+
+### Other blockers
+
+- [ ] Versioning policy doc (csl26-fuw7) — co-land with csl26-yipx
+- [ ] MaybeGendered snapshot tests (csl26-y3kj) — core model live; tests only
+- [ ] User style + locale store format config (csl26-erwz)
+- [ ] Style-structure lint hard-fail rollout (csl26-egzd)
+
+### Done
 
 - [x] JSON schema generation for references, citations, locales (csl26-n79w)
 - [x] Core vs. Community Style Split (csl26-tb4i)
 - [x] Server mode evaluation (csl26-kpv4)
-- [ ] Versioning policy doc committed before first public release (csl26-fuw7)
-- [ ] Style.version wired to schema validation in `citum check` (csl26-yipx)
-- [ ] Style-structure lint hard-fail rollout (csl26-egzd)
-- [ ] Dedicated part / supplement / printing number fields (csl26-7edf)
-- [ ] User style + locale store (citum_store) — csl26-erwz
-- [ ] Djot as default markup for annotations / reference fields (csl26-suz3, in-progress)
-- [ ] MaybeGendered<T> on locale terms (csl26-y3kj) — core model is live;
-      gender-aware MF2 role-label migration remains follow-up work
-- [ ] Gender-aware MF2 role labels with multi-selector `.match` support
-      (csl26-vm2g)
-- [ ] Locale-backed archive hierarchy labels (csl26-mlc2)
 
-## Strategic pointers
+## Strategic Pointers
 
 - Roadmap and phase sequencing: [docs/architecture/ROADMAP.md](../docs/architecture/ROADMAP.md)
 - Live style fidelity: [docs/TIER_STATUS.md](../docs/TIER_STATUS.md)
 - Portfolio gate: `scripts/report-data/core-quality-baseline.json`
 - Locale authoring (MF2): [docs/guides/AUTHORING_LOCALES.md](../docs/guides/AUTHORING_LOCALES.md)
-
-## Notes
-
-- The bean body was refreshed 2026-04-25 from a one-liner to the structured
-  status above. Children list is authoritative — this body summarises but
-  doesn't add new scope. Update the checkboxes when child beans land,
-  not the prose.

--- a/.beans/csl26-mlc2--design-locale-backed-archive-hierarchy-labels.md
+++ b/.beans/csl26-mlc2--design-locale-backed-archive-hierarchy-labels.md
@@ -4,8 +4,11 @@ title: Design locale-backed archive hierarchy labels
 status: todo
 type: feature
 priority: normal
+tags:
+    - schema
+    - locale
 created_at: 2026-04-23T15:08:48Z
-updated_at: 2026-04-24T12:14:13Z
+updated_at: 2026-04-25T20:20:06Z
 parent: csl26-li63
 blocked_by:
     - csl26-y3kj

--- a/.beans/csl26-mwnt--apa-year-suffix-disambiguation-cleanup.md
+++ b/.beans/csl26-mwnt--apa-year-suffix-disambiguation-cleanup.md
@@ -4,8 +4,10 @@ title: apa year-suffix disambiguation cleanup
 status: todo
 type: task
 priority: normal
+tags:
+    - engine
 created_at: 2026-04-09T15:40:00Z
-updated_at: 2026-04-10T19:10:00Z
+updated_at: 2026-04-25T20:20:06Z
 ---
 
 Own any residual APA year-letter or anonymous-ordering mismatches that remain

--- a/.beans/csl26-o0s8--deprecate-csl-json-input-support-post-10.md
+++ b/.beans/csl26-o0s8--deprecate-csl-json-input-support-post-10.md
@@ -4,8 +4,11 @@ title: Deprecate CSL-JSON input support (post-1.0)
 status: todo
 type: task
 priority: deferred
+tags:
+    - migrate
+    - cli
 created_at: 2026-03-28T14:40:08Z
-updated_at: 2026-03-28T14:40:08Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 Post-1.0 cleanup: remove CSL-JSON as a first-class input format.

--- a/.beans/csl26-ocdt--evaluate-preset-base-and-public-wrapper-duplicatio.md
+++ b/.beans/csl26-ocdt--evaluate-preset-base-and-public-wrapper-duplicatio.md
@@ -4,8 +4,11 @@ title: evaluate preset-base and public-wrapper duplication across embedded style
 status: todo
 type: task
 priority: normal
+tags:
+    - style
+    - research
 created_at: 2026-04-10T17:36:49Z
-updated_at: 2026-04-10T17:37:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 Evaluate whether Citum's current split between:

--- a/.beans/csl26-piea--implement-type-addition-policy-infrastructure.md
+++ b/.beans/csl26-piea--implement-type-addition-policy-infrastructure.md
@@ -4,8 +4,10 @@ title: Implement type addition policy infrastructure
 status: todo
 type: task
 priority: normal
+tags:
+    - policy
 created_at: 2026-02-15T00:17:53Z
-updated_at: 2026-02-15T00:17:53Z
+updated_at: 2026-04-25T20:20:08Z
 ---
 
 Complete infrastructure for type addition policy enforcement.

--- a/.beans/csl26-qrpo--swap-mf2-parser-for-icu4x-icu-message-format-when.md
+++ b/.beans/csl26-qrpo--swap-mf2-parser-for-icu4x-icu-message-format-when.md
@@ -4,8 +4,10 @@ title: Swap mf2_parser for ICU4X icu_message_format when stable
 status: todo
 type: task
 priority: deferred
+tags:
+    - locale
 created_at: 2026-03-22T12:45:31Z
-updated_at: 2026-04-25T00:00:00Z
+updated_at: 2026-04-25T20:20:06Z
 ---
 
 The current Mf2MessageEvaluator in crates/citum-schema-style/src/locale/message.rs is a

--- a/.beans/csl26-r4dm--author-standards-backed-cse-and-nlm-family-bases-fo.md
+++ b/.beans/csl26-r4dm--author-standards-backed-cse-and-nlm-family-bases-fo.md
@@ -5,11 +5,12 @@ status: todo
 type: task
 priority: normal
 tags:
+    - standards
+    - style
     - styles
     - taxonomy
-    - standards
 created_at: 2026-04-21T13:31:00Z
-updated_at: 2026-04-21T13:31:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 `csl26-nrkn` confirmed that the Taylor & Francis and Springer CSE/NLM variants

--- a/.beans/csl26-registry-distributed-reconsideration.md
+++ b/.beans/csl26-registry-distributed-reconsideration.md
@@ -7,8 +7,10 @@ priority: low
 tags:
     - registry
     - architecture
+    - style
+    - research
 created_at: 2026-04-23T00:00:00Z
-updated_at: 2026-04-24T12:14:01Z
+updated_at: 2026-04-25T20:20:08Z
 ---
 
 # Objective

--- a/.beans/csl26-suz3--djot-as-default-markup-for-annotations-and-referen.md
+++ b/.beans/csl26-suz3--djot-as-default-markup-for-annotations-and-referen.md
@@ -4,8 +4,11 @@ title: Djot as default markup for annotations and reference fields
 status: in-progress
 type: feature
 priority: normal
+tags:
+    - schema
+    - engine
 created_at: 2026-03-02T20:10:22Z
-updated_at: 2026-04-24T12:14:10Z
+updated_at: 2026-04-25T20:20:06Z
 parent: csl26-li63
 ---
 

--- a/.beans/csl26-tr2m--route-csl-bill-type-to-class-hearing.md
+++ b/.beans/csl26-tr2m--route-csl-bill-type-to-class-hearing.md
@@ -4,8 +4,10 @@ title: 'Route CSL bill type to class: hearing'
 status: todo
 type: feature
 priority: normal
+tags:
+    - migrate
 created_at: 2026-04-04T14:00:22Z
-updated_at: 2026-04-10T19:04:55Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 Congressional hearing items in Zotero export as CSL type `bill` but should

--- a/.beans/csl26-u1tq--author-dedicated-elsevier-family-bases-for-harvard-an.md
+++ b/.beans/csl26-u1tq--author-dedicated-elsevier-family-bases-for-harvard-an.md
@@ -5,11 +5,12 @@ status: todo
 type: task
 priority: normal
 tags:
+    - bases
+    - style
     - styles
     - taxonomy
-    - bases
 created_at: 2026-04-21T13:30:00Z
-updated_at: 2026-04-21T13:30:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 `csl26-nrkn` confirmed that `elsevier-harvard` and `elsevier-vancouver` are

--- a/.beans/csl26-ulf6--evaluate-deno-runtime-for-wasmtesting.md
+++ b/.beans/csl26-ulf6--evaluate-deno-runtime-for-wasmtesting.md
@@ -4,8 +4,10 @@ title: Evaluate Deno runtime for WASM/testing
 status: todo
 type: task
 priority: deferred
+tags:
+    - research
 created_at: 2026-02-16T07:42:39Z
-updated_at: 2026-02-16T07:42:39Z
+updated_at: 2026-04-25T20:20:08Z
 ---
 
 Consider Deno (TypeScript-first, Rust-based) post-1.0 or when implementing WASM browser bindings (tier 2). Benefits: zero-config TS, built-in permissions, single binary. Use case: Modern runtime for WASM testing/benchmarking vs Node.js overhead.

--- a/.beans/csl26-vm2g--support-gender-aware-mf2-role-labels.md
+++ b/.beans/csl26-vm2g--support-gender-aware-mf2-role-labels.md
@@ -4,8 +4,11 @@ title: Support gender-aware MF2 role labels
 status: todo
 type: feature
 priority: normal
+tags:
+    - schema
+    - locale
 created_at: 2026-04-25T00:00:00Z
-updated_at: 2026-04-25T00:00:00Z
+updated_at: 2026-04-25T20:20:06Z
 parent: csl26-li63
 ---
 

--- a/.beans/csl26-wp6y--define-fidelity-benchmark-for-preset-backed-styles.md
+++ b/.beans/csl26-wp6y--define-fidelity-benchmark-for-preset-backed-styles.md
@@ -4,8 +4,11 @@ title: Define policy and guardrails for preset-backed styles with local override
 status: todo
 type: task
 priority: normal
+tags:
+    - policy
+    - style
 created_at: 2026-03-18T19:57:26Z
-updated_at: 2026-03-18T23:05:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 We need a follow-up policy decision for how preset-backed styles should be authored, interpreted, and benchmarked once a style file references a style preset and then overrides some fields locally.

--- a/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
+++ b/.beans/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
@@ -8,8 +8,9 @@ tags:
     - styles
     - taxonomy
     - springer
+    - style
 created_at: 2026-04-21T13:32:00Z
-updated_at: 2026-04-21T15:35:00Z
+updated_at: 2026-04-25T20:20:07Z
 ---
 
 `csl26-nrkn` confirmed that `springer-basic-brackets` has real parentage to

--- a/.beans/csl26-y3kj--support-gender-on-locale-term-singlemultiple-forms.md
+++ b/.beans/csl26-y3kj--support-gender-on-locale-term-singlemultiple-forms.md
@@ -4,8 +4,11 @@ title: Add MaybeGendered<T> to locale term model
 status: in-progress
 type: feature
 priority: low
+tags:
+    - locale
+    - testing
 created_at: 2026-03-09T22:28:26Z
-updated_at: 2026-04-25T00:00:00Z
+updated_at: 2026-04-25T20:20:06Z
 parent: csl26-li63
 ---
 

--- a/.beans/csl26-yipx--wire-styleversion-to-schema-validation-in-csln-che.md
+++ b/.beans/csl26-yipx--wire-styleversion-to-schema-validation-in-csln-che.md
@@ -4,8 +4,11 @@ title: wire Style.version to schema validation in citum check
 status: todo
 type: feature
 priority: normal
+tags:
+    - schema
+    - cli
 created_at: 2026-02-24T17:28:12Z
-updated_at: 2026-04-24T12:14:43Z
+updated_at: 2026-04-25T20:20:06Z
 parent: csl26-li63
 ---
 

--- a/.beans/csl26-zlvp--external-style-authoring-agent-skill-hub-ui-wizard.md
+++ b/.beans/csl26-zlvp--external-style-authoring-agent-skill-hub-ui-wizard.md
@@ -4,8 +4,11 @@ title: 'External style authoring: agent skill + hub UI wizard'
 status: todo
 type: feature
 priority: deferred
+tags:
+    - style
+    - dx
 created_at: 2026-03-16T20:11:54Z
-updated_at: 2026-03-16T20:13:01Z
+updated_at: 2026-04-25T20:20:07Z
 blocked_by:
     - csl26-fuw7
 ---


### PR DESCRIPTION
## Summary

Tags all 35 open beans with a consistent domain taxonomy so work can be
filtered by area and schema-blocking items are visible before the 1.0 freeze.

**Tag vocabulary**

| Tag | Meaning |
|-----|---------|
| `schema` | citum_schema type changes (blocks 1.0 stability) |
| `engine` | citum_engine rendering/processing |
| `migrate` | citum_migrate converter logic |
| `locale` | locale model, MF2, term resolution |
| `style` | style YAML files and registry |
| `cli` | CLI commands, citum_store |
| `testing` | fixtures, coverage, fidelity reporting |
| `infra` | CI, hooks, build tooling |
| `bindings` | FFI, language bindings |
| `research` | evaluation with no immediate code output |
| `policy` | governance docs, versioning contract |
| `dx` | developer-facing docs and ergonomics |

**All open beans with tags**

| Bean | Title | Tags |
|------|-------|------|
| csl26-suz3 | Djot markup for note/abstract (phase 2) | schema, engine |
| csl26-y3kj | MaybeGendered<T> snapshot tests | locale, testing |
| csl26-erwz | User style & locale store (citum_store) | cli |
| csl26-mlc2 | Locale-backed archive hierarchy labels | schema, locale |
| csl26-tr2m | Route CSL bill type to class: hearing | migrate |
| csl26-vm2g | Gender-aware MF2 role labels | schema, locale |
| csl26-yipx | Wire Style.version to schema validation | schema, cli |
| csl26-9pui | BDD tests for bibliography loading | testing |
| csl26-hk27 | Align core hooksPath with repo githooks | infra |
| csl26-mwnt | APA year-suffix disambiguation cleanup | engine |
| csl26-u1tq | Elsevier Harvard/Vancouver family bases | style |
| csl26-r4dm | CSE and NLM family bases | style |
| csl26-8kod | biblatex-authority components coverage | testing, migrate |
| csl26-kjzk | Consider boltffi for bindings | bindings, research |
| csl26-wp6y | Policy for preset-backed styles | policy, style |
| csl26-jk10 | Evaluate CBOR embedding for builtins | infra, research |
| csl26-ocdt | Preset-base/wrapper duplication audit | style, research |
| csl26-7grx | Expand citations fixture | testing |
| csl26-x1y2 | Hook relational fixtures to reporting | testing |
| csl26-piea | Type addition policy infrastructure | policy |
| csl26-4mzf | Rename style files to short-name convention | style, infra |
| csl26-xt7k | Split Springer Basic family-root | style |
| csl26-egzd | Style-structure lint hard-fail rollout | infra |
| csl26-k7nf | Typst citation interactivity | research |
| csl26-j80k | gen block iterator refactoring (post-stable) | engine |
| csl26-iphj | Archive/publisher place unification | schema |
| csl26-h7xz | Document template inferrer | dx |
| csl26-7edf | part/supplement/printing number fields | schema, engine |
| csl26-zlvp | External style authoring wizard | style, dx |
| csl26-o0s8 | Deprecate CSL-JSON input (post-1.0) | migrate, cli |
| csl26-ulf6 | Evaluate Deno runtime for WASM/testing | research |
| csl26-qrpo | Swap mf2_parser for ICU4X | locale |
| csl26-fuw7 | Versioning policy docs | policy, dx |
| csl26-ldgf | Genre formalization (decision recorded) | policy |
| csl26 | Reconsider distributed registry | style, research |

---

## Schema-blocking items (6 beans — must land before 1.0 schema freeze)

| Bean | What changes | Priority |
|------|-------------|----------|
| csl26-suz3 | `RichText` type; changes `note`/`abstract` field types | in-progress |
| csl26-7edf | `part-number`, `supplement-number`, `printing-number` fields | deferred |
| csl26-mlc2 | New locale term families (`archive-box`, `archive-folder`, `archive-item`) | normal |
| csl26-vm2g | Locale message schema: multi-selector `.match` + `$gender` in MF2 | normal |
| csl26-yipx | `SchemaVersion` struct in citum_schema; wires version validation | normal |
| csl26-iphj | `Place` type unification across archive/publisher (deferred, low) | low |

**Likely sequence to schema stability**

1. **csl26-suz3** (in-progress) — `RichText` for note/abstract is the only phase 2 gap; unblock first since it changes a frequently-used field type.
2. **csl26-vm2g** + **csl26-mlc2** (locale cluster) — both extend the locale schema and share an MF2 dependency (`csl26-y3kj` is a prerequisite for mlc2). Natural to batch these.
3. **csl26-7edf** — isolated field additions; can land independently but marked deferred, so may slip to a 1.0-patch unless promoted.
4. **csl26-yipx** — adds `SchemaVersion`; low risk, can land anytime but `csl26-fuw7` (versioning docs) should be co-committed.
5. **csl26-iphj** — explicitly deferred/low; the `Place` type unification is a nice-to-have cleanup. Reasonable to defer past 1.0 and revisit in 1.1.

---

## Test plan

- [x] `beans list --json | jq '[.[] | select((.tags // []) | contains(["schema"]))]'` returns exactly 6 beans
- [x] Every open bean has at least one tag
