### PR TITLE
docs(beans): add vouch reference to production-readiness

### DIFF
--- a/.beans/csl26-li63--production-readiness.md
+++ b/.beans/csl26-li63--production-readiness.md
@@ -41,3 +41,4 @@ work (citum-hub) and bindings (citum-labs).
 - Live style fidelity: [docs/TIER_STATUS.md](../docs/TIER_STATUS.md)
 - Portfolio gate: `scripts/report-data/core-quality-baseline.json`
 - Locale authoring (MF2): [docs/guides/AUTHORING_LOCALES.md](../docs/guides/AUTHORING_LOCALES.md)
+- PR trust scaling (future): [mitchellh/vouch](https://github.com/mitchellh/vouch)


### PR DESCRIPTION
Adds a reference to [mitchellh/vouch](https://github.com/mitchellh/vouch) in the Production Readiness bean as a possible future consideration for managing PR trust at scale.

Refs: csl26-li63