### PR TITLE
feat(locale): support gender-aware MF2 labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "typst",
  "typst-kit",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "axum",
  "citum-engine",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -899,7 +899,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.26.1"
+version = "0.26.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -1629,30 +1629,83 @@ fn lint_mf2_pattern(pattern: &str) -> Result<(), String> {
 
 /// Validate an MF2 `.match` block.
 fn lint_mf2_match(message: &str) -> Result<(), String> {
-    let after_match = message[".match".len()..].trim_start();
-    let open = after_match
-        .find('{')
-        .ok_or("missing selector after .match")?;
-    let close = find_matching_brace(after_match, open).ok_or("unmatched '{' in .match selector")?;
-    let selector = after_match
-        .get(open + 1..close)
-        .ok_or("invalid selector range")?
-        .trim();
-    if !selector.starts_with('$') {
-        return Err(format!(
-            "selector '{selector}' must start with $ (e.g. {{$count :plural}})"
-        ));
+    let (selector_count, variants) = lint_mf2_selectors(message)?;
+    lint_mf2_variants(variants, selector_count)?;
+    Ok(())
+}
+
+fn lint_mf2_selectors(message: &str) -> Result<(usize, &str), String> {
+    let mut rest = message[".match".len()..].trim_start();
+    let mut selector_count = 0usize;
+
+    while rest.starts_with('{') {
+        let close = find_matching_brace(rest, 0).ok_or("unmatched '{' in .match selector")?;
+        let selector = rest.get(1..close).ok_or("invalid selector range")?.trim();
+        if !selector.starts_with('$') {
+            return Err(format!(
+                "selector '{selector}' must start with $ (e.g. {{$count :plural}})"
+            ));
+        }
+        selector_count += 1;
+        rest = rest
+            .get(close + 1..)
+            .ok_or("missing when blocks after .match selector")?
+            .trim_start();
     }
-    let variants = after_match
-        .get(close + 1..)
-        .ok_or("missing when blocks after .match selector")?
-        .trim();
-    if !variants.contains("when") {
+
+    if selector_count == 0 {
+        return Err("missing selector after .match".to_string());
+    }
+
+    Ok((selector_count, rest))
+}
+
+fn lint_mf2_variants(variants: &str, selector_count: usize) -> Result<(), String> {
+    let mut rest = variants.trim();
+    let mut saw_when = false;
+    let mut saw_wildcard = false;
+
+    while !rest.is_empty() {
+        if !rest.starts_with("when") {
+            return Err(format!("expected 'when' block, found '{rest}'"));
+        }
+
+        saw_when = true;
+        let after_when = rest["when".len()..].trim_start();
+        let brace_pos = after_when
+            .find('{')
+            .ok_or("missing pattern body in when block")?;
+        let key_text = after_when[..brace_pos].trim();
+        let keys: Vec<&str> = key_text.split_whitespace().collect();
+        if keys.len() != selector_count {
+            return Err(format!(
+                "when block has {} selector keys but .match has {selector_count} selectors",
+                keys.len()
+            ));
+        }
+        if keys.iter().all(|key| *key == "*") {
+            saw_wildcard = true;
+        }
+
+        let open_brace_index = rest.len() - after_when.len() + brace_pos;
+        let close_brace_index = find_matching_brace(rest, open_brace_index)
+            .ok_or("unmatched '{' in when block pattern")?;
+        rest = rest
+            .get(close_brace_index + 1..)
+            .ok_or("invalid when block range")?
+            .trim_start();
+    }
+
+    if !saw_when {
         return Err("no 'when' blocks found in .match".to_string());
     }
-    if !variants.contains("when *") {
-        return Err("missing wildcard 'when *' fallback in .match".to_string());
+    if !saw_wildcard {
+        let wildcard = vec!["*"; selector_count].join(" ");
+        return Err(format!(
+            "missing wildcard 'when {wildcard}' fallback in .match"
+        ));
     }
+
     Ok(())
 }
 
@@ -3784,6 +3837,71 @@ grammar-options:
         assert!(report.findings.iter().any(|finding| {
             finding.path == "messages.term.page-label"
                 && finding.message.contains("invalid MF2 message")
+        }));
+    }
+
+    #[test]
+    fn test_lint_raw_locale_accepts_multi_selector_mf2() {
+        let raw = RawLocale {
+            locale: "es-ES".into(),
+            evaluation: Some(EvaluationConfig {
+                message_syntax: MessageSyntax::Mf2,
+            }),
+            messages: HashMap::from([(
+                "role.editor.label-long".into(),
+                ".match {$gender :select} {$count :plural}\nwhen feminine one {editora}\nwhen feminine * {editoras}\nwhen * * {equipo editorial}".into(),
+            )]),
+            ..Default::default()
+        };
+
+        let report = lint_raw_locale(&raw);
+
+        assert!(!report.has_errors());
+    }
+
+    #[test]
+    fn test_lint_raw_locale_rejects_multi_selector_arity_mismatch() {
+        let raw = RawLocale {
+            locale: "es-ES".into(),
+            evaluation: Some(EvaluationConfig {
+                message_syntax: MessageSyntax::Mf2,
+            }),
+            messages: HashMap::from([(
+                "role.editor.label-long".into(),
+                ".match {$gender :select} {$count :plural}\nwhen feminine {editora}\nwhen * * {equipo editorial}".into(),
+            )]),
+            ..Default::default()
+        };
+
+        let report = lint_raw_locale(&raw);
+
+        assert!(report.has_errors());
+        assert!(report.findings.iter().any(|finding| {
+            finding.path == "messages.role.editor.label-long"
+                && finding.message.contains("selector keys")
+        }));
+    }
+
+    #[test]
+    fn test_lint_raw_locale_rejects_missing_multi_selector_wildcard() {
+        let raw = RawLocale {
+            locale: "es-ES".into(),
+            evaluation: Some(EvaluationConfig {
+                message_syntax: MessageSyntax::Mf2,
+            }),
+            messages: HashMap::from([(
+                "role.editor.label-long".into(),
+                ".match {$gender :select} {$count :plural}\nwhen feminine one {editora}\nwhen feminine * {editoras}".into(),
+            )]),
+            ..Default::default()
+        };
+
+        let report = lint_raw_locale(&raw);
+
+        assert!(report.has_errors());
+        assert!(report.findings.iter().any(|finding| {
+            finding.path == "messages.role.editor.label-long"
+                && finding.message.contains("when * *")
         }));
     }
 

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -1590,7 +1590,9 @@ fn number_variable_to_locator(
 ///
 /// Checks that:
 /// - `{…}` placeholders use `$variable` syntax (not bare MF1 identifiers)
-/// - `.match` blocks have a `$`-prefixed selector and at least one `when *` fallback
+/// - `.match` blocks have one or more `$`-prefixed selectors and a full-arity
+///   wildcard fallback arm whose key count equals the number of selectors
+///   (e.g. `when *` for a single selector, `when * *` for two selectors)
 ///
 /// Returns `Err(description)` on the first structural violation.
 fn lint_mf2_message(message: &str) -> Result<(), String> {

--- a/crates/citum-schema-style/src/locale/message.rs
+++ b/crates/citum-schema-style/src/locale/message.rs
@@ -129,25 +129,40 @@ fn resolve_var<'a>(var_name: &str, args: &'a MessageArgs<'a>) -> Option<&'a str>
     }
 }
 
-/// Evaluate a `.match` statement with selector and variants.
+/// Evaluate a `.match` statement with selectors and variants.
 fn evaluate_mf2_matcher(message: &str, args: &MessageArgs<'_>) -> Option<String> {
     let trimmed = message.trim();
     if !trimmed.starts_with(".match") {
         return None;
     }
 
-    let after_match = trimmed[".match".len()..].trim_start();
-    let open_brace = after_match.find('{')?;
-    let close_brace = find_matching_brace(after_match, open_brace)?;
-    let selector_text = after_match.get(open_brace + 1..close_brace)?.trim();
-
-    let variants_start = after_match.get(close_brace + 1..)?.trim_start();
-
-    let (var_name, function) = parse_mf2_selector(selector_text)?;
-    let match_key = determine_match_key(var_name, function, args)?;
-    let matched_pattern = find_mf2_variant(variants_start, &match_key)?;
+    let (selectors, variants_start) = parse_mf2_selectors(trimmed)?;
+    let match_keys = selectors
+        .iter()
+        .map(|(var_name, function)| determine_match_key(var_name, *function, args))
+        .collect::<Option<Vec<_>>>()?;
+    let matched_pattern = find_mf2_variant(variants_start, &match_keys)?;
 
     substitute_mf2_vars(&matched_pattern, args)
+}
+
+/// Parse selector expressions after `.match`.
+fn parse_mf2_selectors(message: &str) -> Option<(Vec<(&str, Option<&str>)>, &str)> {
+    let mut rest = message[".match".len()..].trim_start();
+    let mut selectors = Vec::new();
+
+    while rest.starts_with('{') {
+        let close_brace = find_matching_brace(rest, 0)?;
+        let selector_text = rest.get(1..close_brace)?.trim();
+        selectors.push(parse_mf2_selector(selector_text)?);
+        rest = rest.get(close_brace + 1..)?.trim_start();
+    }
+
+    if selectors.is_empty() {
+        return None;
+    }
+
+    Some((selectors, rest))
 }
 
 /// Parse an MF2 selector like `$count :plural` or `$gender :select`.
@@ -208,10 +223,10 @@ fn determine_match_key(
 
 /// Find the matched variant in MF2 when-blocks and return its pattern.
 ///
-/// Scans for `when <key> { pattern }` lines. Returns the first exact match,
-/// or falls back to `when * { pattern }`.
-fn find_mf2_variant(variants_text: &str, match_key: &str) -> Option<String> {
-    let mut wildcard_pattern: Option<String> = None;
+/// Scans for `when <keys...> { pattern }` lines. Returns the most specific
+/// wildcard-compatible variant.
+fn find_mf2_variant(variants_text: &str, match_keys: &[String]) -> Option<String> {
+    let mut best_match: Option<(usize, String)> = None;
     let mut rest = variants_text;
 
     loop {
@@ -227,6 +242,7 @@ fn find_mf2_variant(variants_text: &str, match_key: &str) -> Option<String> {
         let after_when = trimmed["when".len()..].trim_start();
         let brace_pos = after_when.find('{')?;
         let key_str = after_when[..brace_pos].trim();
+        let variant_keys: Vec<&str> = key_str.split_whitespace().collect();
 
         let open_brace_index = rest.len() - after_when.len() + brace_pos;
         let close_brace_index = find_matching_brace(rest, open_brace_index)?;
@@ -234,16 +250,39 @@ fn find_mf2_variant(variants_text: &str, match_key: &str) -> Option<String> {
             .get(open_brace_index + 1..close_brace_index)?
             .to_string();
 
-        if key_str == match_key {
-            return Some(pattern);
-        } else if key_str == "*" && wildcard_pattern.is_none() {
-            wildcard_pattern = Some(pattern);
+        if let Some(score) = variant_match_score(&variant_keys, match_keys)
+            && match best_match.as_ref() {
+                Some((best_score, _)) => score > *best_score,
+                None => true,
+            }
+        {
+            best_match = Some((score, pattern));
         }
 
         rest = rest.get(close_brace_index + 1..)?;
     }
 
-    wildcard_pattern
+    best_match.map(|(_, pattern)| pattern)
+}
+
+/// Score a variant key tuple against the resolved selector keys.
+fn variant_match_score(variant_keys: &[&str], match_keys: &[String]) -> Option<usize> {
+    if variant_keys.len() != match_keys.len() {
+        return None;
+    }
+
+    let mut score = 0usize;
+    for (variant_key, match_key) in variant_keys.iter().zip(match_keys) {
+        if *variant_key == "*" {
+            continue;
+        }
+        if *variant_key != match_key {
+            return None;
+        }
+        score += 1;
+    }
+
+    Some(score)
 }
 
 /// Find the matching closing brace for an opening brace at a given index.
@@ -369,5 +408,65 @@ mod tests {
         let result = evaluator.evaluate(message, &args);
         // Should return None when count is missing
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_multi_selector_exact_match() {
+        let evaluator = Mf2MessageEvaluator;
+        let args = MessageArgs {
+            count: Some(1),
+            gender: Some("feminine"),
+            ..Default::default()
+        };
+        let message = ".match {$gender :select} {$count :plural}\nwhen feminine one {editora}\nwhen feminine * {editoras}\nwhen * * {equipo editorial}";
+
+        assert_eq!(
+            evaluator.evaluate(message, &args),
+            Some("editora".to_string())
+        );
+    }
+
+    #[test]
+    fn test_multi_selector_partial_wildcard_match() {
+        let evaluator = Mf2MessageEvaluator;
+        let args = MessageArgs {
+            count: Some(3),
+            gender: Some("feminine"),
+            ..Default::default()
+        };
+        let message = ".match {$gender :select} {$count :plural}\nwhen feminine one {editora}\nwhen feminine * {editoras}\nwhen * * {equipo editorial}";
+
+        assert_eq!(
+            evaluator.evaluate(message, &args),
+            Some("editoras".to_string())
+        );
+    }
+
+    #[test]
+    fn test_multi_selector_full_wildcard_match() {
+        let evaluator = Mf2MessageEvaluator;
+        let args = MessageArgs {
+            count: Some(2),
+            gender: Some("common"),
+            ..Default::default()
+        };
+        let message = ".match {$gender :select} {$count :plural}\nwhen feminine one {editora}\nwhen feminine * {editoras}\nwhen * * {equipo editorial}";
+
+        assert_eq!(
+            evaluator.evaluate(message, &args),
+            Some("equipo editorial".to_string())
+        );
+    }
+
+    #[test]
+    fn test_multi_selector_missing_gender() {
+        let evaluator = Mf2MessageEvaluator;
+        let args = MessageArgs {
+            count: Some(1),
+            ..Default::default()
+        };
+        let message = ".match {$gender :select} {$count :plural}\nwhen feminine one {editora}\nwhen * * {equipo editorial}";
+
+        assert_eq!(evaluator.evaluate(message, &args), None);
     }
 }

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -654,7 +654,7 @@ impl Locale {
         }
     }
 
-    /// Resolve a contributor role term, evaluating MF1 messages when configured.
+    /// Resolve a contributor role term, evaluating MF2 messages when configured.
     pub fn resolved_role_term(
         &self,
         role: &ContributorRole,
@@ -664,7 +664,7 @@ impl Locale {
     ) -> Option<String> {
         if let Some(message_id) = Self::role_message_id(role, form)
             && let Some(resolved) =
-                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), &[])
+                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), requested_gender)
         {
             return Some(resolved);
         }
@@ -681,8 +681,11 @@ impl Locale {
         form: TermForm,
     ) -> Option<String> {
         if let Some(message_id) = Self::role_message_id(role, form)
-            && let Some(resolved) =
-                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), &[])
+            && let Some(resolved) = self.resolve_message_text(
+                message_id,
+                Some(u64::from(plural) + 1),
+                Some(GrammaticalGender::Common),
+            )
         {
             return Some(resolved);
         }
@@ -715,7 +718,7 @@ impl Locale {
         }
     }
 
-    /// Resolve a locator term, evaluating MF1 messages when configured.
+    /// Resolve a locator term, evaluating MF2 messages when configured.
     pub fn resolved_locator_term(
         &self,
         locator: &LocatorType,
@@ -725,7 +728,7 @@ impl Locale {
     ) -> Option<String> {
         if let Some(message_id) = Self::locator_message_id(locator, form)
             && let Some(resolved) =
-                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), &[])
+                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), requested_gender)
         {
             return Some(resolved);
         }
@@ -866,7 +869,7 @@ impl Locale {
         }
     }
 
-    /// Resolve a general term, evaluating MF1 messages when configured.
+    /// Resolve a general term, evaluating MF2 messages when configured.
     pub fn resolved_general_term(
         &self,
         term: &GeneralTerm,
@@ -874,7 +877,7 @@ impl Locale {
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<String> {
         if let Some(message_id) = Self::general_message_id(term, form)
-            && let Some(resolved) = self.resolve_message_text(message_id, None, &[])
+            && let Some(resolved) = self.resolve_message_text(message_id, None, requested_gender)
         {
             return Some(resolved);
         }
@@ -1035,17 +1038,27 @@ impl Locale {
         }
     }
 
+    fn gender_selector_key(gender: GrammaticalGender) -> &'static str {
+        match gender {
+            GrammaticalGender::Masculine => "masculine",
+            GrammaticalGender::Feminine => "feminine",
+            GrammaticalGender::Neuter => "neuter",
+            GrammaticalGender::Common => "common",
+        }
+    }
+
     fn resolve_message_text(
         &self,
         message_id: &str,
         count: Option<u64>,
-        _variables: &[(&str, &str)],
+        gender: Option<GrammaticalGender>,
     ) -> Option<String> {
         let message = self.messages.get(message_id)?;
 
         // Build MessageArgs for the evaluator
         let args = MessageArgs {
             count,
+            gender: gender.map(Self::gender_selector_key),
             ..MessageArgs::default()
         };
 
@@ -2102,6 +2115,69 @@ terms:
                 Some(GrammaticalGender::Feminine),
             ),
             Some("editora".to_string())
+        );
+    }
+
+    #[test]
+    fn test_es_es_role_term_resolves_gendered_mf2_message() {
+        let bytes = crate::embedded::get_locale_bytes("es-ES").expect("es-ES should be embedded");
+        let yaml = std::str::from_utf8(bytes).expect("embedded locale should be utf-8");
+        let locale = Locale::from_yaml_str(yaml).expect("embedded es-ES should parse");
+
+        assert_eq!(
+            locale.resolved_role_term(
+                &ContributorRole::Editor,
+                true,
+                TermForm::Long,
+                Some(GrammaticalGender::Masculine),
+            ),
+            Some("editores".to_string())
+        );
+        assert_eq!(
+            locale.resolved_role_term(
+                &ContributorRole::Translator,
+                true,
+                TermForm::Long,
+                Some(GrammaticalGender::Feminine),
+            ),
+            Some("traductoras".to_string())
+        );
+        assert_eq!(
+            locale.resolved_role_term_neutral(&ContributorRole::Editor, true, TermForm::Long),
+            Some("equipo editorial".to_string())
+        );
+    }
+
+    #[test]
+    fn test_role_term_falls_back_when_mf2_message_cannot_evaluate() {
+        let locale = Locale::from_yaml_str(
+            r#"
+locale: es-ES
+evaluation:
+  message-syntax: mf2
+messages:
+  role.editor.label-long: |
+    .match {$gender :unknown} {$count :plural}
+    when feminine one {editora}
+roles:
+  editor:
+    long:
+      singular:
+        feminine: editora heredada
+      plural:
+        feminine: editoras heredadas
+"#,
+        )
+        .expect("locale should parse");
+
+        assert_eq!(
+            locale.resolved_role_term(
+                &ContributorRole::Editor,
+                false,
+                TermForm::Long,
+                Some(GrammaticalGender::Feminine),
+            ),
+            Some("editora heredada".to_string())
         );
     }
 

--- a/docs/guides/AUTHORING_LOCALES.md
+++ b/docs/guides/AUTHORING_LOCALES.md
@@ -12,7 +12,7 @@ Citum locale file in `locales/`. It is the practical companion to
   and consult the `messages:` map first, falling back to the legacy `terms:` /
   `roles:` / `locators:` maps.
 - Gendered term values: live through `MaybeGendered<T>` in the legacy locale
-  maps. This is separate from MF2 selector support.
+  maps and through the scoped `$gender` x `$count` MF2 role-label pattern.
 - Coverage as of writing: `en-US`, `de-DE`, `fr-FR`, `tr-TR`, `es-ES` carry
   v2 `messages:` blocks. Adding new locales should follow the same shape.
 
@@ -33,7 +33,7 @@ Author a v2 `messages:` entry whenever the rendered text depends on a
 | Compositional pattern | `{$start}–{$end}` for page ranges | **Yes** |
 | URL-bearing message | "retrieved from {$url}" | **Yes** |
 | Static label | `term.and: "and"` | Optional — works either way |
-| Gender-dependent label | Spanish `editor / editora`, French `éditeur / éditrice` | **Not yet** — see "Gender" below |
+| Gender-dependent label | Spanish `editor / editora`, French `éditeur / éditrice` | **Yes**, after test coverage — see "Gender" below |
 
 The rule of thumb: if the message body would contain `{` (variable
 substitution or `.match` block), MF2 is the correct home. If it's a bare
@@ -83,8 +83,8 @@ limitation applies to other gendered locales, including French and Arabic.
 | `term.note-label`, `term.note-label-long` | `$count` | |
 | `term.and`, `term.and-symbol`, `term.et-al`, `term.and-others` | none | Conjunctions |
 | `term.accessed`, `term.retrieved`, `term.no-date`, `term.no-date-long`, `term.forthcoming`, `term.circa`, `term.circa-long` | none | Date and access labels |
-| `role.editor.label`, `role.editor.label-long`, `role.editor.verb` | `$count` (label only today) | Avoid for gender-aware locales until multi-selector MF2 lands |
-| `role.translator.label`, `role.translator.label-long`, `role.translator.verb` | `$count` (label only today) | Avoid for gender-aware locales until multi-selector MF2 lands |
+| `role.editor.label`, `role.editor.label-long`, `role.editor.verb` | `$count`, optional `$gender` for labels | Use the two-selector pattern for gender-aware label nouns |
+| `role.translator.label`, `role.translator.label-long`, `role.translator.verb` | `$count`, optional `$gender` for labels | Use the two-selector pattern for gender-aware label nouns |
 | `role.guest.label`, `role.guest.label-long`, `role.guest.verb` | `$count` | |
 | `pattern.page-range` | `$start`, `$end` | Spec'd; not yet consumed by the engine |
 | `pattern.retrieved-from`, `pattern.available-at` | `$url` | Spec'd; not yet consumed by the engine |
@@ -100,7 +100,7 @@ The `legacy-term-aliases:` map bridges single-word legacy keys (e.g. `page`,
 `et_al`, `editor`) to message IDs so styles authored against the v1 vocabulary
 keep rendering. Mirror the en-US shape.
 
-## Gender — interim limitation
+## Gender
 
 `MaybeGendered<T>` is already live for locale term maps. The `roles:`,
 `locators:`, and `terms:` fallback paths can store and resolve gendered values
@@ -108,26 +108,20 @@ for locales that need them, such as Spanish role nouns, French role nouns, and
 Arabic gendered ordinals, using the requested gender from contributor data or
 an explicit template override.
 
-The MF2 path is not equivalent yet. `resolved_role_term` and
-`resolved_locator_term` currently pass `$count` into MF2 evaluation, but they do
-not pass `$gender`. The custom evaluator also supports only one selector per
-`.match`, so a full `$gender` x `$count` role-label matrix cannot be authored
-reliably today.
+The MF2 path supports the scoped gender-aware role-label pattern:
+`.match {$gender :select} {$count :plural}`. Use stable selector keys
+`masculine`, `feminine`, `neuter`, and `common`, and include a full wildcard
+fallback such as `when * *`.
 
-For this branch:
+For new or migrated locales:
 
-- Locale files for languages with role-label gender variants keep those labels
-  in `roles:`. Do not add `role.editor.label`,
-  `role.editor.label-long`, `role.translator.label`, or
-  `role.translator.label-long` MF2 entries for those locales yet.
-- This is an implementation gap, not the desired final architecture. MF2 should
-  become the home for gender x plural role labels after multi-selector support
-  lands.
+- `messages:` is the preferred home for tested gender x plural role labels.
+- Keep equivalent `roles:` values as fallback until deprecating that fallback is
+  intentional and covered by tests.
+- `resolved_role_term_neutral` passes `common` so mixed-gender contributor lists
+  can resolve common MF2 variants.
 - Gender-invariant role messages are safe in `messages:`.
 - Gender-invariant locator and general terms are safe in `messages:`.
-
-The follow-up is to pass gender into `MessageArgs`, support multi-selector
-`.match`, and then migrate gendered role labels from `roles:` to MF2 with tests.
 
 ## Runtime locale selection
 
@@ -153,18 +147,31 @@ term.page-label: |
   when one {p.}
   when * {pp.}
 
-# Select dispatch (arbitrary keys, one selector only today)
+# Select dispatch (arbitrary keys)
 some.gendered: |
   .match {$gender :select}
   when masculine {él}
   when feminine {ella}
   when * {elle}
+
+# Gender-aware role labels
+role.editor.label-long: |
+  .match {$gender :select} {$count :plural}
+  when masculine one {editor}
+  when masculine * {editores}
+  when feminine one {editora}
+  when feminine * {editoras}
+  when common one {persona editora}
+  when common * {equipo editorial}
+  when * * {equipo editorial}
 ```
 
 The current evaluator supports only `one` and `*` plural categories. Full
-CLDR categories (`zero`, `two`, `few`, `many`) and multi-selector `.match`
-blocks require follow-up evaluator work. ICU4X MF2 support is tracked, but not
-treated as available in this branch.
+CLDR categories (`zero`, `two`, `few`, `many`) still require follow-up evaluator
+work. The scoped multi-selector form for gender-aware role labels is active:
+each `when` block must provide one key per selector, and two-selector messages
+must include a full wildcard fallback such as `when * *`. ICU4X MF2 support is
+tracked, but not treated as available in this branch.
 
 ## Verification
 
@@ -186,12 +193,12 @@ cargo run --bin citum -- render refs \
   -s styles/apa-7th.yaml --locale <your-locale>
 ```
 
-A future `citum locale lint <file>` (spec §8) will short-circuit the first
-two — not yet shipped.
+`citum locale lint <file>` validates MF2 message structure before the render
+path needs to evaluate a locale.
 
 ## Related
 
 - Spec: [docs/specs/LOCALE_MESSAGES.md](../specs/LOCALE_MESSAGES.md)
 - Gender model: [docs/specs/GENDERED_LOCALE_TERMS.md](../specs/GENDERED_LOCALE_TERMS.md)
 - ICU4X migration: bean `csl26-qrpo`
-- Gender-aware MF2 role labels: follow-up bean for multi-selector `.match`
+- Gender-aware MF2 role labels: bean `csl26-vm2g`

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -67,13 +67,15 @@ Rationale for MF2 over Fluent or MF1:
 | Plain text | `"retrieved"` | No variables. |
 | Variable substitution | `{$names}` | Named string substitution. |
 | Plural | `.match {$count :plural}`<br>`when one {p.} when * {pp.}` | Two-value dispatch: `one` and `*` (wildcard). Full CLDR categories deferred to ICU4X. |
-| Select | `.match {$gender :select}`<br>`when masc {él} when * {elle}` | Arbitrary string-keyed dispatch with wildcard fallback. |
+| Select | `.match {$gender :select}`<br>`when masculine {él} when * {elle}` | Arbitrary string-keyed dispatch with wildcard fallback. |
+| Multi-selector role labels | `.match {$gender :select} {$count :plural}`<br>`when feminine one {editora} when * * {equipo editorial}` | Active scoped support for gender-aware role labels. Variant key count must match selector count. |
 
 **Out of scope in current evaluator:**
 - Full CLDR plural categories (`zero`, `two`, `few`, `many`) — only `one`/`*` supported.
 - MF2 custom function annotations (`:citum-date`, `:citum-names`) — see §1.5.
 - MF2 markup elements (`{#b}…{/b}`).
-- Multi-selector `.match` (matching on two variables simultaneously).
+- General-purpose multi-selector `.match` beyond Citum's gender-aware role-label
+  subset.
 
 **Date formatting is not done inside MF2 messages.** The engine formats dates
 using the `dateFormats` map and passes the result as a plain `{$date}` variable.
@@ -158,9 +160,12 @@ implementation at locale-load time:
 message. No structural change to `MessageArgs` is needed when swapping to the
 ICU4X evaluator.
 
-MF2 multi-selector patterns (matching on two variables simultaneously) are
-accommodated by `MessageArgs` having multiple fields — the added expressiveness
-is in the message syntax, not in the Rust argument type.
+MF2 multi-selector patterns for gender-aware role labels are accommodated by
+`MessageArgs` having both `$gender` and `$count` fields — the added
+expressiveness is in the message syntax, not in the Rust argument type. The
+custom evaluator supports the scoped pattern used by locales:
+`.match {$gender :select} {$count :plural}` with variants such as
+`when feminine one {...}`, `when feminine * {...}`, and `when * * {...}`.
 
 #### Custom formatters (deferred)
 

--- a/locales/es-ES.yaml
+++ b/locales/es-ES.yaml
@@ -266,16 +266,25 @@ messages:
   term.forthcoming: "en prensa"
   term.circa: "ca."
   term.circa-long: "hacia"
-  # Role labels: omitted intentionally for Spanish in this branch.
-  #
-  # MaybeGendered<T> is live in the `roles:` map above, but the current MF2
-  # dispatch path passes `$count` only and the custom evaluator supports one
-  # selector per `.match`. Adding `role.editor.label` / `role.translator.label`
-  # here would bypass the gender-aware `roles:` fallback before MF2 can express
-  # the full gender x plural matrix.
-  #
-  # Revisit when the gender-aware MF2 follow-up adds `$gender` plumbing and
-  # multi-selector `.match` support.
+  # Role labels
+  role.editor.label-long: |
+    .match {$gender :select} {$count :plural}
+    when masculine one {editor}
+    when masculine * {editores}
+    when feminine one {editora}
+    when feminine * {editoras}
+    when common one {persona editora}
+    when common * {equipo editorial}
+    when * * {equipo editorial}
+  role.translator.label-long: |
+    .match {$gender :select} {$count :plural}
+    when masculine one {traductor}
+    when masculine * {traductores}
+    when feminine one {traductora}
+    when feminine * {traductoras}
+    when common one {persona traductora}
+    when common * {equipo de traducción}
+    when * * {equipo de traducción}
   # Compositional patterns
   pattern.page-range: "{$start}–{$end}"
   pattern.retrieved-from: "recuperado de {$url}"


### PR DESCRIPTION
## Summary
- add scoped multi-selector MF2 evaluation for gender-aware role labels
- pass gender into locale message resolution and keep legacy term fallback
- migrate Spanish editor/translator long labels to MF2
- update locale docs and CLI MF2 linting

## Verification
- cargo fmt --check
- ./scripts/validate-frontmatter.sh --repo-only --copilot-strict
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- cargo nextest run -p citum-engine -E 'test(locale) + test(spanish) + test(es_es) + test(german) + test(french)'
- pre-push hook reran fmt, clippy, and cargo nextest run

Refs: csl26-vm2g