### PR TITLE
feat(locale): gender-aware labels for FR and AR

### DIFF
--- a/.beans/archive/csl26-vm2g--support-gender-aware-mf2-role-labels.md
+++ b/.beans/archive/csl26-vm2g--support-gender-aware-mf2-role-labels.md
@@ -1,14 +1,14 @@
 ---
 # csl26-vm2g
 title: Support gender-aware MF2 role labels
-status: todo
+status: done
 type: feature
 priority: normal
 tags:
     - schema
     - locale
 created_at: 2026-04-25T00:00:00Z
-updated_at: 2026-04-25T20:20:06Z
+updated_at: 2026-04-26T12:00:00Z
 parent: csl26-li63
 ---
 
@@ -19,29 +19,29 @@ term maps.
 
 ## Todos
 
-- [ ] Pass both `$count` and `$gender` into `MessageArgs` from
+- [x] Pass both `$count` and `$gender` into `MessageArgs` from
       `resolved_role_term`, `resolved_role_term_neutral`,
       `resolved_locator_term`, and `resolved_general_term` where applicable.
-- [ ] Map `GrammaticalGender` to stable MF2 selector keys:
+- [x] Map `GrammaticalGender` to stable MF2 selector keys:
       `masculine`, `feminine`, `neuter`, `common`.
-- [ ] Extend the custom evaluator and CLI MF2 linting to support
+- [x] Extend the custom evaluator and CLI MF2 linting to support
       multi-selector `.match` while preserving existing one-selector messages.
-- [ ] Migrate a first confirmed gendered locale's `role.editor.*` and
+- [x] Migrate a first confirmed gendered locale's `role.editor.*` and
       `role.translator.*` matrices using existing `roles:` strings as the
       source of truth.
-- [ ] Add French and Arabic migrations only after locale content and tests are
+- [x] Add French and Arabic migrations only after locale content and tests are
       confirmed for those languages.
-- [ ] Keep `roles:` as fallback until every migrated role/form has tests and
+- [x] Keep `roles:` as fallback until every migrated role/form has tests and
       fallback deprecation is intentional.
 
 ## Verification
 
-- Unit tests for multi-selector matching, wildcard fallback, missing gender
-  fallback, and existing count-only messages.
-- Locale tests for feminine singular, feminine plural, masculine plural, and
-  mixed/common role labels through MF2.
-- Engine tests proving `roles:` fallback still works when an MF2 message is
-  absent or cannot evaluate.
+- [x] Unit tests for multi-selector matching, wildcard fallback, missing gender
+      fallback, and existing count-only messages.
+- [x] Locale tests for feminine singular, feminine plural, masculine plural, and
+      mixed/common role labels through MF2.
+- [x] Engine tests proving `roles:` fallback still works when an MF2 message is
+      absent or cannot evaluate.
 
 ## Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "typst",
  "typst-kit",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "axum",
  "citum-engine",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -899,7 +899,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.26.2"
+version = "0.26.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -50,6 +50,16 @@ fn make_spanish_gendered_locale() -> Locale {
         .expect("spanish locale should parse")
 }
 
+fn make_french_gendered_locale() -> Locale {
+    Locale::from_yaml_str(include_str!("../../../../locales/fr-FR.yaml"))
+        .expect("french locale should parse")
+}
+
+fn make_arabic_gendered_locale() -> Locale {
+    Locale::from_yaml_str(include_str!("../../../../locales/ar-AR.yaml"))
+        .expect("arabic locale should parse")
+}
+
 fn make_editor_reference(genders: &[ContributorGender]) -> Reference {
     let contributors = genders
         .iter()
@@ -347,6 +357,214 @@ roles:
         .expect("editors should render");
 
     assert_eq!(values.suffix, None);
+}
+
+#[test]
+fn test_french_role_label_uses_feminine_form_for_single_contributor() {
+    let config = make_config();
+    let locale = make_french_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference = make_editor_reference(&[ContributorGender::Feminine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("editor should render");
+
+    assert_eq!(values.suffix, Some(", éditrice".to_string()));
+}
+
+#[test]
+fn test_arabic_role_label_uses_feminine_form_for_single_contributor() {
+    let config = make_config();
+    let locale = make_arabic_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference = make_editor_reference(&[ContributorGender::Feminine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("editor should render");
+
+    assert_eq!(values.suffix, Some(", مُحَرِّرَة".to_string()));
+}
+
+#[test]
+fn test_french_role_label_falls_back_to_masculine_plural_for_mixed_group() {
+    let config = make_config();
+    let locale = make_french_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference =
+        make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("mixed editors should render");
+
+    assert_eq!(values.suffix, Some(", éditeurs".to_string()));
+}
+
+#[test]
+fn test_arabic_role_label_falls_back_to_verbal_noun_for_mixed_group() {
+    let config = make_config();
+    let locale = make_arabic_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+    let reference =
+        make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("mixed editors should render");
+
+    assert_eq!(values.suffix, Some(", تحقيق".to_string()));
+}
+
+#[test]
+fn test_arabic_role_label_falls_back_to_roles_common_when_gender_missing() {
+    let config = make_config();
+    let locale = make_arabic_gendered_locale();
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+    };
+
+    // Reference with no gender info
+    let contributors = vec![ContributorEntry {
+        role: citum_schema::reference::ContributorRole::Editor,
+        contributor: Contributor::StructuredName(StructuredName {
+            family: "Editor".into(),
+            given: "Name".into(),
+            ..Default::default()
+        }),
+        gender: None,
+    }];
+
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        id: Some("no-gender-ref".into()),
+        r#type: MonographType::Book,
+        title: Some(Title::Single("Obra".to_string())),
+        contributors,
+        issued: EdtfString("2024".to_string()),
+        ..Default::default()
+    }));
+
+    let hints = ProcHints::default();
+
+    let component = TemplateContributor {
+        contributor: ContributorRole::Editor,
+        form: ContributorForm::Long,
+        label: Some(RoleLabel {
+            term: "editor".to_string(),
+            form: RoleLabelForm::Long,
+            placement: LabelPlacement::Suffix,
+        }),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("editor should render");
+
+    // MF2 will return None because $gender is missing, should fall back to roles.editor.long.singular.common
+    assert_eq!(values.suffix, Some(", تحقيق".to_string()));
 }
 
 #[test]

--- a/locales/ar-AR.yaml
+++ b/locales/ar-AR.yaml
@@ -1,0 +1,76 @@
+locale-schema-version: "2"
+locale: ar-AR
+
+evaluation:
+  message-syntax: mf2
+
+dates:
+  months:
+    long:
+      - يناير
+      - فبراير
+      - مارس
+      - أبريل
+      - مايو
+      - يونيو
+      - يوليو
+      - أغسطس
+      - سبتمبر
+      - أكتوبر
+      - نوفمبر
+      - ديسمبر
+  seasons:
+    - الربيع
+    - الصيف
+    - الخريف
+    - الشتاء
+
+roles:
+  editor:
+    long:
+      singular:
+        masculine: مُحَرِّر
+        feminine: مُحَرِّرَة
+        common: تحقيق
+      plural:
+        masculine: مُحَرِّرون
+        feminine: مُحَرِّرات
+        common: تحقيق
+    short:
+      singular: تح.
+    verb: تحقيق
+  translator:
+    long:
+      singular:
+        masculine: مُتَرْجِم
+        feminine: مُتَرْجِمَة
+        common: ترجمة
+      plural:
+        masculine: مُتَرْجِمون
+        feminine: مُتَرْجِمات
+        common: ترجمة
+    short:
+      singular: تر.
+    verb: ترجمة
+
+messages:
+  # NOTE: Using personal nouns (مُحَرِّر/مُتَرْجِم) for gendered forms.
+  # Fallback to verbal nouns (تحقيق/ترجمة) for neutral or unknown groups, consistent with standard Arabic CSL.
+  role.editor.label: "تح."
+  role.editor.label-long: |
+    .match {$gender :select} {$count :plural}
+    when masculine one {مُحَرِّر}
+    when masculine * {مُحَرِّرون}
+    when feminine one {مُحَرِّرَة}
+    when feminine * {مُحَرِّرات}
+    when * * {تحقيق}
+  role.editor.verb: "تحقيق"
+  role.translator.label: "تر."
+  role.translator.label-long: |
+    .match {$gender :select} {$count :plural}
+    when masculine one {مُتَرْجِم}
+    when masculine * {مُتَرْجِمون}
+    when feminine one {مُتَرْجِمَة}
+    when feminine * {مُتَرْجِمات}
+    when * * {ترجمة}
+  role.translator.verb: "ترجمة"

--- a/locales/fr-FR.yaml
+++ b/locales/fr-FR.yaml
@@ -825,17 +825,29 @@ messages:
   term.circa: "v."
   term.circa-long: "vers"
   # Role labels
+  # NOTE: Feminine forms (éditrice, traductrice) added via MF2.
+  # Fallback to masculine forms for mixed groups (common/* *) as per standard French grammar.
   role.editor.label: "éd."
   role.editor.label-long: |
-    .match {$count :plural}
-    when one {éditeur}
-    when * {éditeurs}
+    .match {$gender :select} {$count :plural}
+    when masculine one {éditeur}
+    when masculine * {éditeurs}
+    when feminine one {éditrice}
+    when feminine * {éditrices}
+    when common one {éditeur}
+    when common * {éditeurs}
+    when * * {éditeurs}
   role.editor.verb: "édité par"
   role.translator.label: "trad."
   role.translator.label-long: |
-    .match {$count :plural}
-    when one {traducteur}
-    when * {traducteurs}
+    .match {$gender :select} {$count :plural}
+    when masculine one {traducteur}
+    when masculine * {traducteurs}
+    when feminine one {traductrice}
+    when feminine * {traductrices}
+    when common one {traducteur}
+    when common * {traducteurs}
+    when * * {traducteurs}
   role.translator.verb: "traduit par"
   role.guest.label: |
     .match {$count :plural}


### PR DESCRIPTION
Complete the migration of role labels to multi-selector MF2 for French (fr-FR) and Arabic (ar-AR).

- Migrate role.editor and role.translator in locales/fr-FR.yaml.
- Create locales/ar-AR.yaml with gendered personal nouns.
- Add engine tests to verify gender-specific rendering.
- Close bean csl26-vm2g.

Closes: csl26-vm2g