### PR TITLE
docs: refresh docs visual system

### DIFF
--- a/docs/assets/citum-interactive.css
+++ b/docs/assets/citum-interactive.css
@@ -5,12 +5,12 @@
 
 :root {
   /* Colors */
-  --citum-citation-color: #0066cc;
-  --citum-citation-hover-bg: rgba(0, 102, 204, 0.1);
-  --citum-highlight-bg: #fff9c4;
-  --citum-highlight-border: #fbc02d;
-  --citum-tooltip-bg: #333;
-  --citum-tooltip-color: #fff;
+  --citum-citation-color: var(--citum-blue-dark, oklch(0.47 0.12 238));
+  --citum-citation-hover-bg: var(--citum-blue-soft, oklch(0.94 0.025 238));
+  --citum-highlight-bg: oklch(0.94 0.07 86);
+  --citum-highlight-border: var(--citum-warning, oklch(0.66 0.13 74));
+  --citum-tooltip-bg: var(--citum-ink-strong, oklch(0.19 0.025 255));
+  --citum-tooltip-color: oklch(0.985 0.008 238);
   
   /* Sidebar */
   --citum-sidebar-width: 300px;
@@ -42,7 +42,7 @@
 .citum-citation.is-highlighted {
   background-color: var(--citum-highlight-bg);
   box-shadow: 0 0 0 2px var(--citum-highlight-bg);
-  color: #000;
+  color: var(--citum-ink-strong, oklch(0.19 0.025 255));
 }
 
 /* Bibliography */
@@ -56,19 +56,19 @@
 .citum-entry {
   margin-bottom: var(--citum-entry-spacing);
   padding: 0.5rem 1rem;
-  border-left: 4px solid transparent;
-  border-radius: 0 6px 6px 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
   transition: all var(--citum-transition-speed) cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .citum-entry:hover {
-  background-color: #fcfcfc;
+  background-color: var(--citum-surface, oklch(0.995 0.006 86));
 }
 
 .citum-entry:target,
 .citum-entry.is-highlighted {
   background-color: var(--citum-highlight-bg);
-  border-left-color: var(--citum-highlight-border);
+  border-color: var(--citum-highlight-border);
   transform: translateX(4px);
 }
 
@@ -90,7 +90,8 @@
     max-height: calc(100vh - 4rem);
     overflow-y: auto;
     padding-right: 1.5rem;
-    border-left: 1px solid #f0f0f0;
+    border: 1px solid var(--citum-border, oklch(0.88 0.024 238));
+    border-radius: 12px;
     border-top: none;
     padding-top: 0;
     padding-left: 2rem;
@@ -141,8 +142,8 @@
 /* High Contrast / Print */
 @media (prefers-contrast: more) {
   :root {
-    --citum-citation-color: #0000ff;
-    --citum-highlight-bg: #ffff00;
+    --citum-citation-color: oklch(0.43 0.24 264);
+    --citum-highlight-bg: oklch(0.96 0.16 103);
   }
 }
 

--- a/docs/assets/citum-theme.css
+++ b/docs/assets/citum-theme.css
@@ -1,0 +1,339 @@
+:root {
+  --citum-blue: oklch(0.64 0.13 238);
+  --citum-blue-dark: oklch(0.47 0.12 238);
+  --citum-blue-soft: oklch(0.94 0.025 238);
+  --citum-paper: oklch(0.985 0.012 86);
+  --citum-paper-deep: oklch(0.955 0.018 86);
+  --citum-surface: oklch(0.995 0.006 86);
+  --citum-surface-cool: oklch(0.965 0.013 247);
+  --citum-ink: oklch(0.29 0.025 255);
+  --citum-ink-strong: oklch(0.19 0.025 255);
+  --citum-muted: oklch(0.47 0.025 255);
+  --citum-faint: oklch(0.64 0.018 255);
+  --citum-border: oklch(0.88 0.024 238);
+  --citum-border-strong: oklch(0.79 0.05 238);
+  --citum-success: oklch(0.55 0.12 158);
+  --citum-warning: oklch(0.66 0.13 74);
+  --citum-danger: oklch(0.54 0.15 28);
+  --citum-shadow: 0 2px 12px oklch(0.21 0.025 255 / 0.06);
+  --citum-shadow-lift: 0 16px 36px oklch(0.21 0.025 255 / 0.08);
+  --citum-radius-sm: 8px;
+  --citum-radius-md: 12px;
+  --citum-radius-lg: 18px;
+  --citum-font-serif: "Newsreader", serif;
+  --citum-font-sans: "Libre Franklin", sans-serif;
+  --citum-font-mono: "JetBrains Mono", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--citum-paper);
+}
+
+body {
+  font-family: var(--citum-font-sans);
+  background:
+    radial-gradient(circle at 14% -10%, oklch(0.93 0.04 238 / 0.72), transparent 30rem),
+    linear-gradient(180deg, var(--citum-paper) 0%, oklch(0.975 0.011 86) 52%, var(--citum-paper-deep) 100%);
+  color: var(--citum-ink);
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  color: var(--citum-ink-strong);
+  font-family: var(--citum-font-serif);
+  letter-spacing: -0.012em;
+}
+
+code,
+pre,
+.font-mono {
+  font-family: var(--citum-font-mono);
+}
+
+a {
+  color: inherit;
+}
+
+.glass-nav,
+.citum-nav {
+  background: oklch(0.985 0.012 86 / 0.88);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--citum-border);
+}
+
+.citum-brand-mark,
+.bg-primary {
+  background: var(--citum-blue);
+}
+
+.text-primary {
+  color: var(--citum-blue-dark);
+}
+
+.border-primary {
+  border-color: var(--citum-blue);
+}
+
+.bg-background-light {
+  background-color: var(--citum-paper);
+}
+
+.bg-accent-cream {
+  background-color: var(--citum-paper-deep);
+}
+
+.bg-white {
+  background-color: var(--citum-surface);
+}
+
+.text-white {
+  color: oklch(0.985 0.008 238);
+}
+
+.text-slate-900,
+.text-gray-900 {
+  color: var(--citum-ink-strong);
+}
+
+.text-slate-700,
+.text-gray-700 {
+  color: var(--citum-ink);
+}
+
+.text-slate-600,
+.text-gray-600,
+.text-slate-500,
+.text-gray-500 {
+  color: var(--citum-muted);
+}
+
+.text-slate-400,
+.text-gray-400 {
+  color: var(--citum-faint);
+}
+
+.border-slate-100,
+.border-slate-200,
+.border-gray-100 {
+  border-color: var(--citum-border);
+}
+
+.nav-link,
+.citum-doc-link {
+  color: var(--citum-muted);
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 999px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link[aria-current="page"],
+.citum-doc-link:hover,
+.citum-doc-link[aria-current="page"] {
+  background: var(--citum-blue-soft);
+  color: var(--citum-ink-strong);
+}
+
+.btn-primary,
+.citum-button-primary {
+  align-items: center;
+  background: var(--citum-blue);
+  border-radius: var(--citum-radius-sm);
+  box-shadow: 0 4px 14px oklch(0.64 0.13 238 / 0.26);
+  color: oklch(0.985 0.008 238);
+  display: inline-flex;
+  font-size: 0.94rem;
+  font-weight: 700;
+  gap: 0.45rem;
+  padding: 10px 20px;
+  text-decoration: none;
+  transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.2s ease;
+}
+
+.btn-primary:hover,
+.citum-button-primary:hover {
+  box-shadow: 0 8px 22px oklch(0.64 0.13 238 / 0.32);
+  transform: translateY(-1px);
+}
+
+.btn-secondary,
+.citum-button-secondary {
+  align-items: center;
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border-strong);
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-ink);
+  display: inline-flex;
+  font-size: 0.94rem;
+  font-weight: 700;
+  gap: 0.45rem;
+  padding: 10px 20px;
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn-secondary:hover,
+.citum-button-secondary:hover {
+  background: var(--citum-blue-soft);
+  border-color: var(--citum-blue);
+}
+
+.kicker,
+.citum-kicker {
+  background: var(--citum-blue-soft);
+  border: 1px solid var(--citum-border-strong);
+  border-radius: 999px;
+  color: var(--citum-blue-dark);
+  display: inline-block;
+  font-size: 0.78rem;
+  font-variant-caps: small-caps;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 4px 12px;
+}
+
+.asymmetric-grid,
+.citum-asymmetric {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  grid-template-columns: minmax(0, 1.18fr) minmax(280px, 0.82fr);
+}
+
+.citum-section {
+  padding-block: clamp(3rem, 8vw, 6rem);
+}
+
+.citum-panel,
+.panel,
+.card,
+.report-card,
+.example-card {
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  box-shadow: var(--citum-shadow);
+}
+
+.report-card,
+.example-card {
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.report-card:hover,
+.example-card:hover {
+  border-color: var(--citum-border-strong);
+  box-shadow: var(--citum-shadow-lift);
+  transform: translateY(-1px);
+}
+
+.workshop-block,
+.citum-workshop,
+.code-block {
+  background: var(--citum-surface-cool);
+  border: 1px solid oklch(0.86 0.018 247);
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-ink);
+  font-family: var(--citum-font-mono);
+  overflow-x: auto;
+}
+
+.workshop-label,
+.citum-label {
+  color: var(--citum-muted);
+  font-family: var(--citum-font-sans);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.citum-table-shell {
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  box-shadow: var(--citum-shadow);
+  overflow-x: auto;
+}
+
+.citum-callout {
+  background: var(--citum-blue-soft);
+  border: 1px solid var(--citum-border-strong);
+  border-radius: var(--citum-radius-md);
+  padding: 1.25rem 1.5rem;
+}
+
+.citum-status-row {
+  align-items: start;
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: auto 1fr;
+  padding: 1rem;
+}
+
+.citum-leading-number {
+  background: var(--citum-blue);
+  border-radius: 999px;
+  color: oklch(0.985 0.008 238);
+  display: grid;
+  font-family: var(--citum-font-mono);
+  font-size: 0.78rem;
+  font-weight: 800;
+  height: 2rem;
+  place-items: center;
+  width: 2rem;
+}
+
+.citum-no-side-stripe {
+  border-left-width: 1px;
+}
+
+@keyframes citum-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-in,
+.citum-animate-in {
+  animation: citum-fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  opacity: 0;
+}
+
+.delay-1 {
+  animation-delay: 0.1s;
+}
+
+.delay-2 {
+  animation-delay: 0.2s;
+}
+
+@media (max-width: 768px) {
+  .asymmetric-grid,
+  .citum-asymmetric {
+    grid-template-columns: 1fr;
+  }
+
+  .citum-doc-link,
+  .nav-link {
+    padding-inline: 10px;
+  }
+}

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -8,7 +8,7 @@
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
     <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+        href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
         rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link
@@ -26,7 +26,7 @@
                         "accent-cream": "#f5f2eb",
                     },
                     fontFamily: {
-                        display: ["Inter", "sans-serif"],
+                        display: ["Libre Franklin", "sans-serif"],
                         mono: ["JetBrains Mono", "monospace"],
                     },
                     borderRadius: {
@@ -41,7 +41,7 @@
     </script>
     <style type="text/tailwindcss">
         body {
-                font-family: "Inter", sans-serif;
+                font-family: "Libre Franklin", sans-serif;
                 color: #374151;
             }
             .font-mono {
@@ -53,7 +53,7 @@
                 border-bottom: 1px solid rgba(42, 148, 214, 0.1);
             }
             .example-card {
-                background: #ffffff;
+                background: var(--citum-surface);
                 border: 1px solid #e2e8f0;
                 transition: all 0.3s ease;
             }
@@ -64,6 +64,7 @@
                     0 2px 4px -1px rgba(0, 0, 0, 0.06);
             }
         </style>
+    <link rel="stylesheet" href="assets/citum-theme.css">
 </head>
 
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
@@ -104,7 +105,7 @@
                 </a>
             </div>
             <button type="button"
-                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-slate-700"
+                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700"
                 data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
@@ -125,7 +126,7 @@
     <!-- Header -->
     <header class="pt-32 pb-16 px-6">
         <div class="max-w-4xl mx-auto text-center">
-            <h1 class="text-4xl md:text-5xl font-mono font-bold tracking-tight text-slate-900 mb-6">
+            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6">
                 Feature Examples
             </h1>
             <p class="text-xl text-slate-500 max-w-2xl mx-auto leading-relaxed">
@@ -241,10 +242,10 @@
                 </p>
             </div>
 
-            <div class="p-6 bg-white">
+            <div class="p-6 bg-[var(--citum-surface)]">
                 <div class="grid gap-6">
                     <!-- Djot Input -->
-                    <div class="border-l-4 border-slate-300 pl-4">
+                    <div class="border border-slate-300/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Djot Input (paper.djot)
                         </div>
@@ -258,7 +259,7 @@ Suppress author with locator: [-@kuhn1962, p. 10].</pre>
                     </div>
 
                     <!-- Rendered Output -->
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Rendered Output (Plain Text)
                         </div>
@@ -369,29 +370,29 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                         Rendered Examples (Current Djot Input)
                     </h3>
                 </div>
-                <div class="p-6 bg-white">
+                <div class="p-6 bg-[var(--citum-surface)]">
                     <div class="grid gap-4">
-                        <div class="border-l-4 border-primary pl-4">
+                        <div class="border border-primary/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Multi-Cite with Locator</div>
                             <div class="font-mono text-xs text-slate-400 mb-1">Source: [@kuhn1962; @watson1953, ch. 2]</div>
                             <div class="font-mono text-sm text-slate-900">(Kuhn; Watson and Crick, ch. 2)</div>
                         </div>
-                        <div class="border-l-4 border-emerald-500 pl-4">
+                        <div class="border border-emerald-500/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Structured Locator</div>
                             <div class="font-mono text-xs text-slate-400 mb-1">Source: [@kuhn1962, section: 5]</div>
                             <div class="font-mono text-sm text-slate-900">(Kuhn, sec. 5)</div>
                         </div>
-                        <div class="border-l-4 border-amber-500 pl-4">
+                        <div class="border border-amber-500/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Narrative Name Memory</div>
                             <div class="font-mono text-xs text-slate-400 mb-1">Source: [+@smith2010, p. 10] ... later [+@smith2010, p. 12] ... then in Chapter 2 [+@smith2010, p. 14]</div>
                             <div class="font-mono text-sm text-slate-900">John Smith (10) ... later Smith (12) ... then John Smith (14) again</div>
                         </div>
-                        <div class="border-l-4 border-indigo-500 pl-4">
+                        <div class="border border-indigo-500/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Integral Citation</div>
                             <div class="font-mono text-xs text-slate-400 mb-1">Source: [+@kuhn1962, p. 10]</div>
                             <div class="font-mono text-sm text-slate-900">Thomas S. Kuhn (10)</div>
                         </div>
-                        <div class="border-l-4 border-rose-500 pl-4">
+                        <div class="border border-rose-500/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Visibility Modifier</div>
                             <div class="font-mono text-xs text-slate-400 mb-1">Source: [-@kuhn1962, p. 10]</div>
                             <div class="font-mono text-sm text-slate-900">(10)</div>
@@ -418,10 +419,10 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                 </p>
             </div>
 
-            <div class="p-6 bg-white">
+            <div class="p-6 bg-[var(--citum-surface)]">
                 <div class="grid gap-6">
                     <!-- Legal Hierarchy Example -->
-                    <div class="border-l-4 border-indigo-500 pl-4">
+                    <div class="border border-indigo-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">
                             Legal Hierarchy (Type-Based Grouping)
                         </div>
@@ -445,7 +446,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                     </div>
 
                     <!-- Multilingual Example -->
-                    <div class="border-l-4 border-purple-500 pl-4">
+                    <div class="border border-purple-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">
                             Multilingual (Per-Group Name Ordering)
                         </div>
@@ -490,7 +491,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                     </div>
 
                     <!-- Localized Disambiguation Example -->
-                    <div class="border-l-4 border-amber-500 pl-4">
+                    <div class="border border-amber-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">
                             Localized Disambiguation (Per-Group Year Suffixes)
                         </div>
@@ -533,7 +534,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                 </div>
             </div>
 
-            <div class="border-t border-slate-200 bg-white p-6">
+            <div class="border-t border-slate-200 bg-[var(--citum-surface)] p-6">
                 <div class="flex items-center gap-2 mb-4">
                     <span class="material-icons text-sm text-primary">record_voice_over</span>
                     <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
@@ -541,7 +542,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                     </h3>
                 </div>
                 <div class="grid gap-4">
-                    <div class="border-l-4 border-primary pl-4">
+                    <div class="border border-primary/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Checked-In Locale
                         </div>
@@ -551,7 +552,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                             <code class="text-xs bg-slate-100 px-1 rounded">editor / editora / persona editora</code>.
                         </div>
                     </div>
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Contributor-Driven Role Label
                         </div>
@@ -562,7 +563,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                             A feminine contributor entry selects the feminine role label from the Spanish locale.
                         </div>
                     </div>
-                    <div class="border-l-4 border-indigo-500 pl-4">
+                    <div class="border border-indigo-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Mixed-Gender Group
                         </div>
@@ -573,7 +574,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                             Mixed contributor genders prefer the locale's neutral/common form instead of falling back to a masculine-specific label.
                         </div>
                     </div>
-                    <div class="border-l-4 border-amber-500 pl-4">
+                    <div class="border border-amber-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Template Override
                         </div>
@@ -591,7 +592,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
             </div>
 
             <!-- Try It Yourself -->
-            <div class="bg-white p-6 border-t border-slate-200">
+            <div class="bg-[var(--citum-surface)] p-6 border-t border-slate-200">
                 <div class="flex items-center gap-2 mb-4">
                     <span class="material-icons text-sm text-emerald-600">terminal</span>
                     <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
@@ -600,7 +601,7 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
                 </div>
 
                 <!-- English Grouping Example -->
-                <div class="border-l-4 border-emerald-500 pl-4 mb-6">
+                <div class="border border-emerald-500/30 rounded-lg p-4 mb-6">
                     <p class="text-xs text-slate-600 mb-2">
                         Render a grouped bibliography with primary, archival, and secondary sources in English:
                     </p>
@@ -634,7 +635,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </div>
 
                 <!-- German Grouping Example -->
-                <div class="border-l-4 border-emerald-500 pl-4">
+                <div class="border border-emerald-500/30 rounded-lg p-4">
                     <p class="text-xs text-slate-600 mb-2">
                         Render the multilingual grouping example shipped in the repo:
                     </p>
@@ -724,9 +725,9 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </div>
             </div>
 
-            <div class="p-6 bg-white border-b border-slate-200">
+            <div class="p-6 bg-[var(--citum-surface)] border-b border-slate-200">
                 <div class="grid gap-4">
-                    <div class="border-l-4 border-primary pl-4">
+                    <div class="border border-primary/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Historical Manuscript Demo Output
                         </div>
@@ -741,7 +742,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                             renders as <code class="text-xs bg-slate-100 px-1 rounded">100 BC</code>.
                         </div>
                     </div>
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Archive + Eprint Demo Output
                         </div>
@@ -759,14 +760,14 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </div>
             </div>
 
-            <div class="bg-white p-6">
+            <div class="bg-[var(--citum-surface)] p-6">
                 <div class="flex items-center gap-2 mb-4">
                     <span class="material-icons text-sm text-emerald-600">terminal</span>
                     <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
                         Try It Yourself
                     </h3>
                 </div>
-                <div class="border-l-4 border-emerald-500 pl-4 mb-6">
+                <div class="border border-emerald-500/30 rounded-lg p-4 mb-6">
                     <p class="text-xs text-slate-600 mb-2">
                         Render the archival manuscript with the current Chicago notes style:
                     </p>
@@ -777,7 +778,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
   -k dead-sea-scrolls</pre>
                     </div>
                 </div>
-                <div class="border-l-4 border-indigo-500 pl-4">
+                <div class="border border-indigo-500/30 rounded-lg p-4">
                     <p class="text-xs text-slate-600 mb-2">
                         Render the structured <code class="text-xs bg-slate-100 px-1 rounded">archive-info</code> +
                         <code class="text-xs bg-slate-100 px-1 rounded">eprint</code> example with the demo style:
@@ -854,17 +855,17 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </div>
             </div>
 
-            <div class="p-6 bg-white">
+            <div class="p-6 bg-[var(--citum-surface)]">
                 <div class="grid gap-4">
-                    <div class="border-l-4 border-indigo-500 pl-4">
+                    <div class="border border-indigo-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Citation Behavior</div>
                         <div class="font-mono text-sm text-slate-900">subentry=true: [2a]/[2b], subentry=false: [2]</div>
                     </div>
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Loader Validation</div>
                         <div class="text-sm text-slate-700">Unknown IDs and duplicate membership across sets are rejected.</div>
                     </div>
-                    <div class="border-l-4 border-amber-500 pl-4">
+                    <div class="border border-amber-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Design Note</div>
                         <div class="text-sm text-slate-700">No per-reference <code class="text-xs bg-slate-100 px-1 rounded">group-key</code> is required or supported.</div>
                     </div>
@@ -961,9 +962,9 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                         Rendered with MLA
                     </h3>
                 </div>
-                <div class="p-6 bg-white">
+                <div class="p-6 bg-[var(--citum-surface)]">
                     <div class="grid gap-4">
-                        <div class="border-l-4 border-primary pl-4">
+                        <div class="border border-primary/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                                 Non-Integral Citation
                             </div>
@@ -974,7 +975,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                                 Current MLA rendering for the checked-in multilingual record
                             </div>
                         </div>
-                        <div class="border-l-4 border-emerald-500 pl-4">
+                        <div class="border border-emerald-500/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                                 Integral Citation
                             </div>
@@ -985,7 +986,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                                 Integral rendering uses the same checked-in data
                             </div>
                         </div>
-                        <div class="border-l-4 border-indigo-500 pl-4">
+                        <div class="border border-indigo-500/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                                 Bibliography Entry
                             </div>
@@ -996,7 +997,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                                 Verified with <code class="text-xs bg-slate-100 px-1 rounded">citum render refs -b examples/multilingual-refs.yaml -s mla -k genji_tale</code>
                             </div>
                         </div>
-                        <div class="border-l-4 border-amber-500 pl-4">
+                        <div class="border border-amber-500/30 rounded-lg p-4">
                             <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                                 Mixed Corpus
                             </div>
@@ -1012,14 +1013,14 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
             </div>
 
             <!-- Try It Yourself -->
-            <div class="bg-white p-6 border-t border-slate-200">
+            <div class="bg-[var(--citum-surface)] p-6 border-t border-slate-200">
                 <div class="flex items-center gap-2 mb-4">
                     <span class="material-icons text-sm text-emerald-600">terminal</span>
                     <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
                         Try It Yourself
                     </h3>
                 </div>
-                <div class="border-l-4 border-emerald-500 pl-4 mb-3">
+                <div class="border border-emerald-500/30 rounded-lg p-4 mb-3">
                     <p class="text-xs text-slate-600 mb-2">
                         Render the checked-in multilingual bibliography with a builtin style:
                     </p>
@@ -1033,7 +1034,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                         <code class="text-xs bg-slate-200 px-1 rounded">options.multilingual</code> values.
                     </p>
                 </div>
-                <div class="border-l-4 border-primary pl-4">
+                <div class="border border-primary/30 rounded-lg p-4">
                     <p class="text-xs text-slate-600 mb-2">
                         Render the shipped German Chicago locale-override example:
                     </p>
@@ -1073,10 +1074,10 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </p>
             </div>
 
-            <div class="p-6 bg-white">
+            <div class="p-6 bg-[var(--citum-surface)]">
                 <div class="grid gap-8">
                     <!-- Date Ranges -->
-                    <div class="border-l-4 border-primary pl-4">
+                    <div class="border border-primary/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Date Intervals (Level 0)</div>
                         <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
                             <pre
@@ -1087,7 +1088,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                     </div>
 
                     <!-- Uncertain & Approximate -->
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Uncertain & Approximate (Level
                             1)</div>
                         <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
@@ -1100,7 +1101,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                     </div>
 
                     <!-- Seasons -->
-                    <div class="border-l-4 border-indigo-500 pl-4">
+                    <div class="border border-indigo-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Seasons (Level 1)</div>
                         <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
                             <pre
@@ -1112,7 +1113,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                     </div>
 
                     <!-- Unspecified Digits -->
-                    <div class="border-l-4 border-rose-500 pl-4">
+                    <div class="border border-rose-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Unspecified Digits (Level 1)
                         </div>
                         <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
@@ -1225,9 +1226,9 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
 <span class="text-slate-500"># Supported fields here include: contributors | label-wrap | label-mode | date-position</span></pre>
                 </div>
             </div>
-            <div class="bg-white p-6 border-t border-slate-200">
+            <div class="bg-[var(--citum-surface)] p-6 border-t border-slate-200">
                 <div class="grid gap-4">
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Author-Date Inheritance
                         </div>
@@ -1236,7 +1237,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                             inherits Springer's author-date base and sets name and date axes.
                         </div>
                     </div>
-                    <div class="border-l-4 border-primary pl-4">
+                    <div class="border border-primary/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Numeric Inheritance
                         </div>
@@ -1368,10 +1369,10 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </p>
             </div>
 
-            <div class="p-6 bg-white">
+            <div class="p-6 bg-[var(--citum-surface)]">
                 <div class="grid gap-6">
                     <!-- Plain Text -->
-                    <div class="border-l-4 border-slate-300 pl-4">
+                    <div class="border border-slate-300/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Plain Text (-f plain)
                         </div>
@@ -1382,7 +1383,7 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                     </div>
 
                     <!-- LaTeX -->
-                    <div class="border-l-4 border-indigo-500 pl-4">
+                    <div class="border border-indigo-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Native LaTeX (-f latex)
                         </div>
@@ -1393,7 +1394,7 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                     </div>
 
                     <!-- HTML -->
-                    <div class="border-l-4 border-primary pl-4">
+                    <div class="border border-primary/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Semantic HTML (-f html)
                         </div>
@@ -1407,7 +1408,7 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                     </div>
 
                     <!-- Djot -->
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Djot (-f djot)
                         </div>
@@ -1418,7 +1419,7 @@ Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                     </div>
 
                     <!-- Typst -->
-                    <div class="border-l-4 border-sky-500 pl-4">
+                    <div class="border border-sky-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
                             Typst Markup (-f typst)
                         </div>
@@ -1496,7 +1497,7 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                         What This Gives You
                     </h3>
                 </div>
-                <div class="p-8 bg-white">
+                <div class="p-8 bg-[var(--citum-surface)]">
                     <div class="grid md:grid-cols-2 gap-6 text-sm text-slate-600 leading-relaxed">
                         <div class="rounded-lg border border-slate-200 bg-slate-50 p-5">
                             <h4 class="font-bold text-slate-900 mb-2">Citum remains the citation formatter</h4>
@@ -1633,7 +1634,7 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                     Binary Object Representation) for near-instant loading.
                 </p>
             </div>
-            <div class="p-8 bg-white">
+            <div class="p-8 bg-[var(--citum-surface)]">
                 <div class="grid md:grid-cols-2 gap-8">
                     <div>
                         <h4 class="font-bold text-slate-900 mb-3 text-sm uppercase tracking-wider">
@@ -1680,7 +1681,7 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                     rich IDE support, validation, and auto-completion in editors like VS Code.
                 </p>
             </div>
-            <div class="p-8 bg-white">
+            <div class="p-8 bg-[var(--citum-surface)]">
                 <div class="p-4 bg-slate-50 border border-slate-200 rounded-lg">
                     <h4 class="font-bold text-slate-900 mb-2 text-sm uppercase tracking-wider">
                         Generation Command (Optional Feature)
@@ -1719,24 +1720,24 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                     <span class="material-icons text-sm">auto_fix_high</span>
                 </a>
             </div>
-            <div class="p-6 bg-white">
+            <div class="p-6 bg-[var(--citum-surface)]">
                 <div class="grid md:grid-cols-2 gap-6">
-                    <div class="border-l-4 border-indigo-500 pl-4">
+                    <div class="border border-indigo-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Bidirectional Navigation</div>
                         <p class="text-sm text-slate-600">Click a citation to scroll to its bibliography entry. Hover an
                             entry to highlight all its citations in the document.</p>
                     </div>
-                    <div class="border-l-4 border-emerald-500 pl-4">
+                    <div class="border border-emerald-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Hover Tooltips</div>
                         <p class="text-sm text-slate-600">Instant reference previews on citation hover, utilizing
                             metadata attributes stored directly in the entry container.</p>
                     </div>
-                    <div class="border-l-4 border-amber-500 pl-4">
+                    <div class="border border-amber-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Sidebar Layouts</div>
                         <p class="text-sm text-slate-600">Optimized for note-style documents. Bibliographies can be
                             pulled into a sticky sidebar on large screens.</p>
                     </div>
-                    <div class="border-l-4 border-rose-500 pl-4">
+                    <div class="border border-rose-500/30 rounded-lg p-4">
                         <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Theming</div>
                         <p class="text-sm text-slate-600">Fully customizable via CSS variables. Includes high-contrast
                             support and clean print styles.</p>
@@ -1770,7 +1771,7 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                 </div>
 
                 <div class="mt-8 grid md:grid-cols-2 gap-6">
-                    <div class="bg-white p-4 rounded-lg border border-slate-200">
+                    <div class="bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
                         <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
                             <span class="material-icons text-primary text-base">auto_fix_high</span>
                             Requirements
@@ -1779,7 +1780,7 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                             (including v0.6.0+), which includes the semantic classes and data attributes used by the
                             interactive layer.</p>
                     </div>
-                    <div class="bg-white p-4 rounded-lg border border-slate-200">
+                    <div class="bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
                         <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
                             <span class="material-icons text-primary text-base">view_sidebar</span>
                             Sidebar Layout
@@ -1809,7 +1810,7 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                     respecting formatting options for italic, indentation, and paragraph spacing.
                 </p>
             </div>
-            <div class="p-6 bg-white">
+            <div class="p-6 bg-[var(--citum-surface)]">
                 <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">Render with Annotations</div>
                 <div class="bg-slate-900 rounded p-3 overflow-x-auto mb-6">
                     <pre class="font-mono text-xs text-emerald-400">citum render refs \
@@ -1868,7 +1869,7 @@ jones2021: >
                     </div>
                 </div>
 
-                <div class="mt-8 bg-white p-4 rounded-lg border border-slate-200">
+                <div class="mt-8 bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
                     <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
                         <span class="material-icons text-primary text-base">format_bold</span>
                         Djot Inline Markup
@@ -1884,7 +1885,7 @@ jones2021: >
                     <p class="text-xs text-slate-400 mt-2">To opt out, set <code class="bg-slate-100 px-1 rounded">format: plain</code> in the annotation style options.</p>
                 </div>
 
-                <div class="mt-4 bg-white p-4 rounded-lg border border-slate-200">
+                <div class="mt-4 bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
                     <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
                         <span class="material-icons text-primary text-base">description</span>
                         Why Separate from References?
@@ -1900,7 +1901,7 @@ jones2021: >
 </div>
 
     <!-- Footer -->
-    <footer class="py-12 px-6 border-t border-slate-200 bg-white">
+    <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row justify-between items-center gap-8">
                 <div class="flex items-center gap-2">

--- a/docs/guides/style-author-guide.template.html
+++ b/docs/guides/style-author-guide.template.html
@@ -7,7 +7,7 @@
 
         <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
         <link
-            href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+            href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
             rel="stylesheet"
         />
         <link
@@ -30,7 +30,7 @@
                             "accent-cream": "#f5f2eb",
                         },
                         fontFamily: {
-                            display: ["Inter", "sans-serif"],
+                            display: ["Libre Franklin", "sans-serif"],
                             mono: ["JetBrains Mono", "monospace"],
                         },
                         borderRadius: {
@@ -45,7 +45,7 @@
         </script>
         <style type="text/tailwindcss">
             body {
-                font-family: "Inter", sans-serif;
+                font-family: "Libre Franklin", sans-serif;
                 color: #374151;
             }
             .font-mono {
@@ -69,7 +69,8 @@
                 @apply text-xs font-semibold uppercase tracking-widest text-slate-500 mb-2;
             }
         </style>
-    </head>
+        <link rel="stylesheet" href="../assets/citum-theme.css">
+</head>
 
     <body class="bg-background-light text-slate-700 selection:bg-primary/20">
         <!-- Navigation -->
@@ -146,7 +147,7 @@
                 </div>
                 <button
                     type="button"
-                    class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-slate-700"
+                    class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700"
                     data-nav-toggle
                     aria-expanded="false"
                     aria-controls="mobile-nav"
@@ -175,7 +176,7 @@
         <header class="pt-32 pb-16 px-6 border-b border-slate-200">
             <div class="max-w-7xl mx-auto">
                 <h1
-                    class="text-4xl md:text-5xl font-mono font-bold tracking-tight text-slate-900 mb-6"
+                    class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6"
                 >
                     Style Author Guide
                 </h1>
@@ -275,7 +276,7 @@
         </div>
 
         <!-- Footer -->
-        <footer class="py-12 px-6 border-t border-slate-200 bg-white">
+        <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
             <div class="max-w-7xl mx-auto">
                 <div
                     class="flex flex-col md:flex-row justify-between items-center gap-8"

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
     <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+        href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
         rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link
@@ -28,7 +28,7 @@
                         "accent-cream": "#f5f2eb",
                     },
                     fontFamily: {
-                        "display": ["Inter", "sans-serif"],
+                        "display": ["Libre Franklin", "sans-serif"],
                         "mono": ["JetBrains Mono", "monospace"]
                     },
                     borderRadius: {
@@ -43,7 +43,7 @@
     </script>
     <style type="text/tailwindcss">
         body {
-            font-family: 'Inter', sans-serif;
+            font-family: 'Libre Franklin', sans-serif;
             color: #374151;
         }
         .font-mono {
@@ -57,11 +57,11 @@
         .code-gradient {
             background: linear-gradient(135deg, rgba(42, 148, 214, 0.05) 0%, rgba(253, 251, 247, 0) 100%);
         }
-        .feature-card {
-            background: #ffffff;
+        .citum-panel {
+            background: var(--citum-surface);
             transition: all 0.3s ease;
         }
-        .feature-card:hover {
+        .citum-panel:hover {
             border-color: #2a94d6;
             transform: translateY(-2px);
             box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
@@ -76,6 +76,7 @@
             opacity: 1;
         }
     </style>
+    <link rel="stylesheet" href="assets/citum-theme.css">
 </head>
 
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
@@ -117,7 +118,7 @@
                 </a>
             </div>
             <button type="button"
-                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-slate-700"
+                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700"
                 data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
@@ -142,27 +143,28 @@
                 class="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[800px] bg-primary/10 rounded-full blur-[120px]">
             </div>
         </div>
-        <div class="max-w-4xl mx-auto text-center relative z-10">
-            <div class="mb-8 flex flex-wrap items-center justify-center gap-2 text-sm">
-                <span class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">On this page</span>
-                <a class="rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-slate-700 hover:border-primary/40 hover:text-primary transition-colors"
+        <div class="max-w-7xl mx-auto relative z-10 grid lg:grid-cols-[1.1fr_0.9fr] gap-12 items-center">
+            <div>
+            <div class="mb-8 flex flex-wrap items-center gap-2 text-sm">
+                <span class="citum-kicker">Docs workshop</span>
+                <a class="rounded-full border border-slate-200 bg-[var(--citum-surface)]/80 px-4 py-2 text-slate-700 hover:border-primary/40 hover:text-primary transition-colors"
                     href="#features">Features</a>
-                <a class="rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-slate-700 hover:border-primary/40 hover:text-primary transition-colors"
+                <a class="rounded-full border border-slate-200 bg-[var(--citum-surface)]/80 px-4 py-2 text-slate-700 hover:border-primary/40 hover:text-primary transition-colors"
                     href="#roadmap">Current Status</a>
             </div>
-            <h1 class="text-6xl md:text-8xl font-mono font-bold tracking-tight text-slate-900 mb-6">
-                Citum
+            <h1 class="text-6xl md:text-8xl font-bold tracking-tight text-slate-900 mb-6 max-w-[9ch]">
+                Citum docs
             </h1>
-            <p class="text-xl md:text-2xl text-slate-500 mb-10 max-w-2xl mx-auto font-display leading-relaxed">
+            <p class="text-xl md:text-2xl text-slate-500 mb-10 max-w-2xl leading-relaxed">
                 A Rust citation engine and YAML style system for
                 rendering documents, styling references, and validating
                 bibliographic data.
             </p>
 
             <!-- Getting Started Command -->
-            <div class="max-w-md mx-auto mb-10">
+            <div class="max-w-xl mb-10">
                 <div
-                    class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group cursor-text border border-slate-700 shadow-lg text-left">
+                    class="workshop-block bg-slate-900 rounded-lg p-4 flex items-center justify-between group cursor-text border border-slate-700 shadow-lg text-left">
                     <code
                         class="font-mono text-emerald-400 text-sm">$ cargo install --git https://github.com/citum/citum-core --bin citum</code>
                     <button class="text-slate-500 hover:text-white transition-colors"
@@ -174,17 +176,31 @@
                 <p class="text-slate-400 text-xs mt-2 font-mono">Requires Rust toolchain</p>
             </div>
 
-            <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-                <a class="w-full sm:w-auto px-8 py-4 bg-primary text-white font-semibold rounded-lg hover:brightness-105 transition-all flex items-center justify-center gap-2"
+            <div class="flex flex-col sm:flex-row items-start gap-4">
+                <a class="w-full sm:w-auto citum-button-primary"
                     href="#features">
                     Explore Features
                     <span class="material-icons text-sm">arrow_downward</span>
                 </a>
-                <a class="w-full sm:w-auto px-8 py-4 bg-slate-200/50 text-slate-700 font-semibold rounded-lg hover:bg-slate-200 transition-all flex items-center justify-center gap-2"
+                <a class="w-full sm:w-auto citum-button-secondary"
                     href="https://github.com/citum/citum-core/tree/main/docs">
                     View Documentation
                 </a>
             </div>
+            </div>
+            <aside class="workshop-block p-6 rotate-1">
+                <div class="workshop-label">Rendering trace</div>
+                <pre class="text-sm leading-relaxed"><span class="text-slate-400"># Input</span>
+[@kuhn1962, pp. 10-12]
+
+<span class="text-slate-400"># Resolver</span>
+style: chicago-author-date
+position: first
+locale: en-US
+
+<span class="text-slate-400"># Output</span>
+<span class="text-primary">(Kuhn 1962, 10-12)</span></pre>
+            </aside>
         </div>
     </header>
 
@@ -229,7 +245,7 @@
 
                 <!-- Document Processing -->
                 <a href="examples.html#document-processing"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">description</span>
@@ -242,7 +258,7 @@
 
                 <!-- Advanced Citations -->
                 <a href="examples.html#advanced-citations"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">auto_awesome</span>
@@ -255,7 +271,7 @@
 
                 <!-- Bibliography Grouping -->
                 <a href="examples.html#bibliography-grouping"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">library_books</span>
@@ -269,7 +285,7 @@
 
                 <!-- Compound Numeric Sets -->
                 <a href="examples.html#compound-numeric-sets"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">view_agenda</span>
@@ -283,7 +299,7 @@
 
                 <!-- Multilingual Support -->
                 <a href="examples.html#multilingual-support"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">translate</span>
@@ -299,7 +315,7 @@
 
                 <!-- Advanced Dates -->
                 <a href="examples.html#advanced-dates"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">event</span>
@@ -313,7 +329,7 @@
 
                 <!-- Smart Presets -->
                 <a href="examples.html#options-presets"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">tune</span>
@@ -329,7 +345,7 @@
 
                 <!-- Title Formatting -->
                 <a href="examples.html#titles-links"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">title</span>
@@ -343,7 +359,7 @@
 
                 <!-- Type-Specific Overrides -->
                 <a href="examples.html#overrides"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">sync_alt</span>
@@ -357,7 +373,7 @@
 
                 <!-- Pluggable Output Formats -->
                 <a href="examples.html#output-formats"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">html</span>
@@ -370,7 +386,7 @@
 
                 <!-- Universal C-FFI -->
                 <a href="examples.html#lualatex-integration"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">settings_input_component</span>
@@ -383,7 +399,7 @@
 
                 <!-- Performance -->
                 <a href="examples.html#binary-performance"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">speed</span>
@@ -396,7 +412,7 @@
 
                 <!-- JSON Server Mode -->
                 <a href="https://github.com/citum/citum-core/tree/main/crates/citum-server"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block"
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block"
                     target="_blank">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
@@ -410,7 +426,7 @@
 
                 <!-- Web Interactivity -->
                 <a href="examples.html#web-interactivity"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">mouse</span>
@@ -424,7 +440,7 @@
 
                 <!-- Annotated Bibliographies -->
                 <a href="examples.html#annotated-bibliography"
-                    class="feature-card p-8 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">comment</span>
@@ -594,7 +610,7 @@
                         class="aspect-square md:aspect-video lg:aspect-square bg-slate-800 rounded-xl overflow-hidden shadow-2xl relative flex items-center justify-center p-8">
                         <div class="text-slate-400 font-mono text-sm">
                             <div class="mb-4 text-emerald-400"># Output Preview</div>
-                            <div class="pl-4 border-l-2 border-slate-700">
+                            <div class="pl-4 border border-slate-700/30 rounded-lg">
                                 <p class="mb-2">Smith, J. A. (2023). <span class="italic">The Future of
                                         Citations</span>. Academic Press.</p>
                                 <p class="mb-2">Doe, A., & Lee, B. (2024). Rust in Publishing. <span
@@ -620,7 +636,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
 
                 <!-- Compatibility Report -->
-                <a href="https://docs.citum.org/compat.html" class="p-6 rounded-xl border border-slate-100 bg-white block hover:border-primary/40 transition-colors">
+                <a href="https://docs.citum.org/compat.html" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
                     <div class="flex items-center gap-3 mb-4">
                         <span
                             class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
@@ -635,7 +651,7 @@
                 </a>
 
                 <!-- Behavior Coverage -->
-                <a href="https://docs.citum.org/behavior-report.html" class="p-6 rounded-xl border border-slate-100 bg-white block hover:border-primary/40 transition-colors">
+                <a href="https://docs.citum.org/behavior-report.html" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
                     <div class="flex items-center gap-3 mb-4">
                         <span
                             class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
@@ -650,7 +666,7 @@
                 </a>
 
                 <!-- Migration Behavior Coverage -->
-                <a href="https://docs.citum.org/migration-behavior-report.html" class="p-6 rounded-xl border border-slate-100 bg-white block hover:border-primary/40 transition-colors">
+                <a href="https://docs.citum.org/migration-behavior-report.html" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
                     <div class="flex items-center gap-3 mb-4">
                         <span
                             class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
@@ -665,7 +681,7 @@
                 </a>
 
                 <!-- Tier Tracking -->
-                <a href="TIER_STATUS.md" class="p-6 rounded-xl border border-slate-100 bg-white block hover:border-primary/40 transition-colors">
+                <a href="TIER_STATUS.md" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
                     <div class="flex items-center gap-3 mb-4">
                         <span
                             class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
@@ -681,7 +697,7 @@
 
                 <!-- Quality Gates -->
                 <a href="https://github.com/citum/citum-core/blob/main/docs/architecture/SQI_REFINEMENT_PLAN.md"
-                    class="p-6 rounded-xl border border-slate-100 bg-white block hover:border-primary/40 transition-colors">
+                    class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
                     <div class="flex items-center gap-3 mb-4">
                         <span
                             class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
@@ -706,8 +722,8 @@
                     </div>
                     <p class="text-sm text-slate-500 mb-4">
                         Install and manage your own styles and locales locally in YAML, JSON, or CBOR formats.
-                        <code class="text-xs bg-white px-1 rounded border border-slate-200">citum store install</code>
-                        <code class="text-xs bg-white px-1 rounded border border-slate-200">citum store list</code>
+                        <code class="text-xs bg-[var(--citum-surface)] px-1 rounded border border-slate-200">citum store install</code>
+                        <code class="text-xs bg-[var(--citum-surface)] px-1 rounded border border-slate-200">citum store list</code>
                     </p>
                     <p class="text-[10px] font-mono text-slate-400">Works across CLI, desktop, web, and mobile</p>
                 </div>
@@ -734,7 +750,7 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
                 <!-- Style Schema -->
                 <a href="schemas/style.json"
-                    class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons text-sm">architecture</span>
@@ -744,7 +760,7 @@
                 </a>
                 <!-- Bib Schema -->
                 <a href="schemas/bib.json"
-                    class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons text-sm">inventory_2</span>
@@ -754,7 +770,7 @@
                 </a>
                 <!-- Locale Schema -->
                 <a href="schemas/locale.json"
-                    class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons text-sm">language</span>
@@ -764,7 +780,7 @@
                 </a>
                 <!-- Citations Schema -->
                     <a href="schemas/citation.json"
-                        class="feature-card p-6 rounded-xl border border-slate-200 transition-all group block">
+                        class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons text-sm">format_quote</span>
@@ -828,7 +844,7 @@
     </section>
 
     <!-- Footer -->
-    <footer class="py-12 px-6 border-t border-slate-200 bg-white">
+    <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row justify-between items-center gap-8">
                 <div class="flex items-center gap-2">

--- a/docs/interactive-demo.html
+++ b/docs/interactive-demo.html
@@ -4,11 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Citum | Interactive HTML Demo</title>
-  <link rel="stylesheet" href="assets/citum-interactive.css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
   <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+      href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
       rel="stylesheet" />
   <script>
       tailwind.config = {
@@ -21,7 +20,7 @@
                       "accent-cream": "#f5f2eb",
                   },
                   fontFamily: {
-                      "display": ["Inter", "sans-serif"],
+                      "display": ["Libre Franklin", "sans-serif"],
                       "mono": ["JetBrains Mono", "monospace"]
                   },
                   borderRadius: {
@@ -41,10 +40,10 @@
         border-bottom: 1px solid rgba(42, 148, 214, 0.1);
     }
     body {
-      font-family: 'Inter', sans-serif;
+      font-family: 'Libre Franklin', sans-serif;
       line-height: 1.6;
-      color: #333;
-      background: #fdfbf7;
+      color: var(--citum-ink);
+      background: var(--citum-paper);
     }
     .font-mono {
         font-family: 'JetBrains Mono', monospace;
@@ -55,7 +54,7 @@
       padding: 2rem;
     }
     header {
-      border-bottom: 2px solid #eee;
+      border-bottom: 1px solid var(--citum-border);
       margin-bottom: 3rem;
       padding-bottom: 1rem;
     }
@@ -63,20 +62,20 @@
       display: inline-flex;
       align-items: center;
       gap: 0.5rem;
-      color: #666;
+      color: var(--citum-muted);
       text-decoration: none;
       font-size: 0.9rem;
       padding: 0.4rem 0.8rem;
       border-radius: 4px;
-      background: #eee;
+      background: var(--citum-blue-soft);
       transition: all 0.2s;
     }
     .config-link:hover {
-      background: #e2e2e2;
-      color: #333;
+      background: var(--citum-paper-deep);
+      color: var(--citum-ink-strong);
     }
     .controls {
-      background: #f5f2eb;
+      background: var(--citum-paper-deep);
       padding: 1rem;
       border-radius: 8px;
       margin-bottom: 2rem;
@@ -93,17 +92,19 @@
     /* Layout toggles */
     .btn {
       padding: 0.5rem 1rem;
-      border: 1px solid #ddd;
-      background: white;
+      border: 1px solid var(--citum-border);
+      background: var(--citum-surface);
       border-radius: 4px;
       cursor: pointer;
     }
     .btn.active {
-      background: #0066cc;
-      color: white;
-      border-color: #0066cc;
+      background: var(--citum-blue);
+      color: oklch(0.985 0.008 238);
+      border-color: var(--citum-blue);
     }
   </style>
+    <link rel="stylesheet" href="assets/citum-theme.css">
+  <link rel="stylesheet" href="assets/citum-interactive.css">
 </head>
 <body class="bg-background-light text-slate-700">
 
@@ -135,7 +136,7 @@
                   href="https://github.com/citum/citum-core">GitHub</a>
           </div>
           <button type="button"
-              class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-slate-700"
+              class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700"
               data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
               <span class="material-icons text-[20px]">menu</span>
           </button>

--- a/docs/reports.html
+++ b/docs/reports.html
@@ -8,7 +8,7 @@
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
     <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+        href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
         rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 
@@ -23,7 +23,7 @@
                         "accent-cream": "#f5f2eb",
                     },
                     fontFamily: {
-                        display: ["Inter", "sans-serif"],
+                        display: ["Libre Franklin", "sans-serif"],
                         mono: ["JetBrains Mono", "monospace"],
                     },
                     borderRadius: {
@@ -38,7 +38,7 @@
     </script>
     <style type="text/tailwindcss">
         body {
-            font-family: "Inter", sans-serif;
+            font-family: "Libre Franklin", sans-serif;
             color: #374151;
         }
         .font-mono {
@@ -50,7 +50,7 @@
             border-bottom: 1px solid rgba(42, 148, 214, 0.1);
         }
         .report-card {
-            background: #ffffff;
+            background: var(--citum-surface);
             transition: all 0.25s ease;
         }
         .report-card:hover {
@@ -59,6 +59,7 @@
             box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
         }
     </style>
+    <link rel="stylesheet" href="assets/citum-theme.css">
 </head>
 
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
@@ -82,7 +83,7 @@
                 <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600" href="https://github.com/citum/citum-core">GitHub</a>
             </div>
             <button type="button"
-                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-slate-700"
+                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700"
                 data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
@@ -102,7 +103,7 @@
 
     <header class="pt-32 pb-16 px-6 border-b border-slate-200">
         <div class="max-w-5xl mx-auto">
-            <h1 class="text-4xl md:text-5xl font-mono font-bold tracking-tight text-slate-900 mb-6">Reports</h1>
+            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6">Reports</h1>
             <p class="text-xl text-slate-500 max-w-3xl leading-relaxed">
                 Current generated reports for compatibility, engine behavior coverage, migration behavior coverage, and release-facing verification snapshots.
             </p>
@@ -152,7 +153,7 @@
         </div>
     </main>
 
-    <footer class="py-12 px-6 border-t border-slate-200 bg-white">
+    <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row justify-between items-center gap-8">
                 <div class="flex items-center gap-2">

--- a/scripts/build-author-guide.js
+++ b/scripts/build-author-guide.js
@@ -91,7 +91,7 @@ renderer.blockquote = function(arg1) {
 
     if (text.includes('[!TIP]')) {
         return `
-            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose">
+            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
                 <div class="flex items-start gap-3">
                     <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
                     <div class="flex-1 text-blue-800 text-sm">
@@ -103,7 +103,7 @@ renderer.blockquote = function(arg1) {
     }
     if (text.includes('[!WARNING]')) {
         return `
-            <div class="border-l-4 border-amber-500 bg-amber-50 p-4 rounded mb-6 not-prose">
+            <div class="border border-amber-500/30 bg-amber-50 p-4 rounded-lg mb-6 not-prose">
                 <div class="flex gap-3">
                     <span class="material-icons text-amber-600 flex-shrink-0">warning</span>
                     <div class="text-amber-800 text-sm">
@@ -131,7 +131,7 @@ renderer.code = function(arg1, arg2) {
         : code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
     return `
-        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose">
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
             <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-${lang}">${highlighted}</code></pre>
         </div>
     `;
@@ -155,7 +155,7 @@ renderer.table = function(token) {
     }
 
     return `
-        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose">
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
             <table class="w-full text-sm">
                 <thead class="bg-slate-50">
                     <tr>${header}</tr>

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -528,23 +528,24 @@ def build_html_report(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{html.escape(report_title)}</title>
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet">
   <style>
     :root {{
-      --bg: #f8fafc;
-      --card: #ffffff;
-      --text: #0f172a;
-      --muted: #475569;
-      --border: #dbe3ef;
-      --accent: #0f766e;
-      --accent-soft: #ccfbf1;
-      --fail: #b91c1c;
-      --skip: #92400e;
+      --bg: oklch(0.985 0.012 86);
+      --card: oklch(0.995 0.006 86);
+      --text: oklch(0.19 0.025 255);
+      --muted: oklch(0.47 0.025 255);
+      --border: oklch(0.88 0.024 238);
+      --accent: oklch(0.47 0.12 238);
+      --accent-soft: oklch(0.94 0.025 238);
+      --fail: oklch(0.54 0.15 28);
+      --skip: oklch(0.66 0.13 74);
     }}
     * {{ box-sizing: border-box; }}
     body {{
       margin: 0;
-      font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background: linear-gradient(180deg, #f8fafc 0%, #eef6f7 100%);
+      font-family: "Libre Franklin", sans-serif;
+      background: linear-gradient(180deg, var(--bg) 0%, oklch(0.955 0.018 86) 100%);
       color: var(--text);
       line-height: 1.6;
     }}
@@ -558,11 +559,13 @@ def build_html_report(
     }}
     h1 {{
       font-size: 2.4rem;
+      font-family: "Newsreader", serif;
       line-height: 1.1;
       margin: 0 0 12px;
     }}
     h2 {{
       font-size: 1.35rem;
+      font-family: "Newsreader", serif;
       margin: 0 0 12px;
     }}
     p, li {{
@@ -574,7 +577,8 @@ def build_html_report(
     }}
     .timestamp {{
       font-size: 0.9rem;
-      color: #64748b;
+      color: var(--muted);
+      font-family: "JetBrains Mono", monospace;
     }}
     .overview, .domain-section, .failure-section {{
       background: var(--card);
@@ -582,7 +586,7 @@ def build_html_report(
       border-radius: 18px;
       padding: 24px;
       margin-bottom: 20px;
-      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.05);
+      box-shadow: 0 2px 12px oklch(0.21 0.025 255 / 0.06);
     }}
     .overview ul, .scenario-list {{
       margin: 0;
@@ -607,10 +611,10 @@ def build_html_report(
     }}
     .section-summary, .section-note {{
       margin: 0 0 14px;
-      color: #64748b;
+      color: var(--muted);
     }}
     .meta {{
-      color: #64748b;
+      color: var(--muted);
       font-size: 0.92rem;
     }}
     .status {{

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -2590,7 +2590,7 @@ function generateHtmlHeader(report) {
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
     <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap"
+        href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
         rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 
@@ -2605,7 +2605,7 @@ function generateHtmlHeader(report) {
                         "accent-cream": "#f5f2eb",
                     },
                     fontFamily: {
-                        "display": ["Inter", "sans-serif"],
+                        "display": ["Libre Franklin", "sans-serif"],
                         "mono": ["JetBrains Mono", "monospace"]
                     },
                     borderRadius: {
@@ -2620,7 +2620,7 @@ function generateHtmlHeader(report) {
     </script>
     <style type="text/tailwindcss">
         body {
-            font-family: 'Inter', sans-serif;
+            font-family: 'Libre Franklin', sans-serif;
             color: #374151;
         }
         .font-mono {
@@ -2658,6 +2658,7 @@ function generateHtmlHeader(report) {
             color: #475569;
         }
     </style>
+    <link rel="stylesheet" href="assets/citum-theme.css">
 </head>
 
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
@@ -2690,7 +2691,7 @@ function generateHtmlHeader(report) {
                     href="https://github.com/citum/citum-core">GitHub</a>
             </div>
             <button type="button"
-                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-slate-700"
+                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700"
                 data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
@@ -2713,7 +2714,7 @@ function generateHtmlHeader(report) {
         <div class="max-w-7xl mx-auto">
             <div class="flex items-center justify-between mb-6">
                 <div>
-                    <h1 class="text-4xl md:text-5xl font-mono font-bold tracking-tight text-slate-900 mb-2">
+                    <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-2">
                         Style Compatibility Report
                     </h1>
                     <p class="text-slate-500">Compatibility metrics for styles in <code>styles/</code></p>
@@ -2753,28 +2754,28 @@ function generateHtmlStats(report) {
         <div class="max-w-7xl mx-auto">
             <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
                 <!-- Core Styles -->
-                <div class="bg-white rounded-xl border border-slate-200 p-6">
+                <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Core Styles</div>
                     <div class="text-3xl font-bold text-slate-900">${report.totalStyles}</div>
                     <div class="text-xs text-slate-400 mt-2">${report.totalImpact}% known CSL dependent coverage</div>
                 </div>
 
                 <!-- Citations Overall -->
-                <div class="bg-white rounded-xl border border-slate-200 p-6">
+                <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Citations</div>
                     <div class="text-3xl font-bold text-slate-900">${report.citationsOverall.passed}/${report.citationsOverall.total}</div>
                     <div class="text-xs text-slate-400 mt-2">${citationsPct}% pass rate</div>
                 </div>
 
                 <!-- Bibliography Overall -->
-                <div class="bg-white rounded-xl border border-slate-200 p-6">
+                <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Bibliography</div>
                     <div class="text-3xl font-bold text-slate-900">${report.bibliographyOverall.passed}/${report.bibliographyOverall.total}</div>
                     <div class="text-xs text-slate-400 mt-2">${biblioPct}% pass rate</div>
                 </div>
 
                 <!-- Quality Overall -->
-                <div class="bg-white rounded-xl border border-slate-200 p-6">
+                <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Quality (SQI)</div>
                     <div class="text-3xl font-bold text-slate-900">${qualityPct}%</div>
                     <div class="text-xs text-slate-400 mt-2">Type coverage, fallback, concision, presets</div>
@@ -2790,7 +2791,7 @@ function generateHtmlSqiExplainer() {
     <!-- SQI Explainer -->
     <section class="py-8 px-6">
         <div class="max-w-7xl mx-auto">
-            <div class="bg-white rounded-xl border border-slate-200 p-6">
+            <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                 <h2 class="text-lg font-semibold text-slate-900 mb-2">How To Read This Report</h2>
                 <p class="text-sm text-slate-600 mb-3">
                     <strong>Fidelity</strong> is the hard gate: rendered output should match citeproc-js.
@@ -3040,7 +3041,7 @@ function generateDetailContent(style) {
   const cslReachText = style.cslReach != null ? String(style.cslReach) : '—';
 
   html += `
-                            <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
+                            <div class="mb-4 p-3 rounded border border-slate-200 bg-[var(--citum-surface)]">
                                 <div class="text-xs font-semibold text-slate-900 mb-2">Verification Context</div>
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs">
                                     <div><span class="font-semibold text-slate-700">Lineage:</span> <span class="font-mono text-slate-600">${escapeHtml(style.originLabel || '—')}</span></div>
@@ -3073,7 +3074,7 @@ function generateDetailContent(style) {
     const presets = qb.subscores?.presetUsage?.score ?? 0;
     const concisionDetail = qb.subscores?.concision || {};
     html += `
-                            <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
+                            <div class="mb-4 p-3 rounded border border-slate-200 bg-[var(--citum-surface)]">
                                 <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): ${overall}%</div>
                                 <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
                                     <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type ${typeCoverage.toFixed(1)}%</div>
@@ -3121,7 +3122,7 @@ function generateDetailContent(style) {
       ? `<div class="text-xs text-slate-500">Unresolved: ${escapeHtml(conformance.unresolved.join(', '))}</div>`
       : '<span class="text-xs text-slate-500">No unresolved conformance dimensions recorded.</span>';
     html += `
-                            <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
+                            <div class="mb-4 p-3 rounded border border-slate-200 bg-[var(--citum-surface)]">
                                 <div class="text-xs font-semibold text-slate-900 mb-3">Repeated-Note Audit</div>
                                 <div class="mb-3">
                                     <div class="flex items-center justify-between gap-3 mb-2">
@@ -3158,7 +3159,7 @@ function generateDetailContent(style) {
 
   if (Array.isArray(style.benchmarkRunResults) && style.benchmarkRunResults.length > 0) {
     html += `
-                            <div class="mb-4 p-3 rounded border border-slate-200 bg-white">
+                            <div class="mb-4 p-3 rounded border border-slate-200 bg-[var(--citum-surface)]">
                                 <div class="text-xs font-semibold text-slate-900 mb-1">Official Supplemental Rich Benchmark Evidence</div>
                                 <div class="text-xs text-slate-500 mb-3">Baseline fidelity remains the gate. Rich benchmark runs extend the official evidence for configured styles.</div>
                                 <div class="space-y-3">
@@ -3389,7 +3390,7 @@ function generateHtmlFooter() {
   return `
 
     <!-- Footer -->
-    <footer class="py-12 px-6 border-t border-slate-200 bg-white">
+    <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
         <div class="max-w-7xl mx-auto">
             <div class="flex flex-col md:flex-row justify-between items-center gap-8">
                 <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add a shared OKLCH-based docs theme matching the citum.org scholarly workshop direction
- apply Newsreader, Libre Franklin, and JetBrains Mono across static docs pages and report generators
- retokenize interactive citation styles and replace side-stripe/card patterns with evidence panels

## Test plan
- `node scripts/build-author-guide.js`
- `node scripts/report-core.js --write-html > /tmp/citum-report-core.json`
- `scripts/test-report.sh`
- `rg -n "border-l-4|#fff|#ffffff|#000|feature-card|background-clip|Inter:wght|font-family: .*Inter|\\[\\\"Inter" docs/*.html docs/guides/*.html docs/assets/*.css scripts/report-core.js scripts/build-author-guide.js scripts/generate-test-report.py`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- browser sanity check on `docs/index.html`, `docs/examples.html`, `docs/reports.html`, and `docs/compat.html` via local server

## Notes
- Generated `docs/compat.html` and `docs/guides/style-author-guide.html` were regenerated locally but remain ignored build artifacts in this repo.
