### PR TITLE
refactor(engine): rename csln- prefix to citum-

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.29.0"
+version = "0.29.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -441,7 +441,7 @@ fn test_note_style_html_output_contains_footnotes() {
 
     assert_eq!(
         result,
-        "<p>Text.<a id=\"fnref1\" href=\"#fn1\" role=\"doc-noteref\"><sup>1</sup></a></p>\n<section id=\"Bibliography\">\n<h1>Bibliography</h1>\n<div class=\"csln-bibliography\">\n<div class=\"csln-entry\" id=\"ref-item1\" data-author=\"Doe\" data-year=\"2020\" data-title=\"Book One\"><span class=\"csln-author\">John Doe</span><span class=\"csln-title\">. Book One</span></div>\n</div>\n</section>\n<section role=\"doc-endnotes\">\n<hr>\n<ol>\n<li id=\"fn1\">\n<p><span class=\"csln-citation\" data-ref=\"item1\">Book One, <span class=\"csln-title\">Book One</span></span>.<a href=\"#fnref1\" role=\"doc-backlink\">↩\u{fe0e}</a></p>\n</li>\n</ol>\n</section>\n"
+        "<p>Text.<a id=\"fnref1\" href=\"#fn1\" role=\"doc-noteref\"><sup>1</sup></a></p>\n<section id=\"Bibliography\">\n<h1>Bibliography</h1>\n<div class=\"citum-bibliography\">\n<div class=\"citum-entry\" id=\"ref-item1\" data-author=\"Doe\" data-year=\"2020\" data-title=\"Book One\"><span class=\"citum-author\">John Doe</span><span class=\"citum-title\">. Book One</span></div>\n</div>\n</section>\n<section role=\"doc-endnotes\">\n<hr>\n<ol>\n<li id=\"fn1\">\n<p><span class=\"citum-citation\" data-ref=\"item1\">Book One, <span class=\"citum-title\">Book One</span></span>.<a href=\"#fnref1\" role=\"doc-backlink\">↩\u{fe0e}</a></p>\n</li>\n</ol>\n</section>\n"
     );
 }
 

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -1777,7 +1777,7 @@ fn test_whole_entry_linking_html() {
 
     assert_eq!(
         result,
-        "<div class=\"csln-bibliography\">\n<div class=\"csln-entry\" id=\"ref-link1\" data-year=\"2023\" data-title=\"Linked Page\"><a href=\"https://example.com/\"><span class=\"csln-author\"><a href=\"https://example.com/\">Linked Page</a></span> <span class=\"csln-issued\">(<a href=\"https://example.com/\">2023</a>)</span></a></div>\n</div>"
+        "<div class=\"citum-bibliography\">\n<div class=\"citum-entry\" id=\"ref-link1\" data-year=\"2023\" data-title=\"Linked Page\"><a href=\"https://example.com/\"><span class=\"citum-author\"><a href=\"https://example.com/\">Linked Page</a></span> <span class=\"citum-issued\">(<a href=\"https://example.com/\">2023</a>)</span></a></div>\n</div>"
     );
 }
 
@@ -1811,10 +1811,10 @@ fn test_global_title_linking_html() {
     let result = processor.render_bibliography_with_format::<Html>();
 
     // The title should be automatically hyperlinked because of global config.
-    // Note: In this test, title substitutes for author, so it gets csln-author class.
+    // Note: In this test, title substitutes for author, so it gets citum-author class.
     assert_eq!(
         result,
-        "<div class=\"csln-bibliography\">\n<div class=\"csln-entry\" id=\"ref-doi1\" data-year=\"2023\" data-title=\"Linked Title\"><span class=\"csln-author\"><a href=\"https://doi.org/10.1001/test\">Linked Title</a></span> <span class=\"csln-issued\">(2023)</span></div>\n</div>"
+        "<div class=\"citum-bibliography\">\n<div class=\"citum-entry\" id=\"ref-doi1\" data-year=\"2023\" data-title=\"Linked Title\"><span class=\"citum-author\"><a href=\"https://doi.org/10.1001/test\">Linked Title</a></span> <span class=\"citum-issued\">(2023)</span></div>\n</div>"
     );
 }
 
@@ -1861,7 +1861,7 @@ fn test_inline_title_link_takes_precedence_over_global_title_link_html() {
 
     assert_eq!(
         result,
-        "<div class=\"csln-bibliography\">\n<div class=\"csln-entry\" id=\"ref-doi-inline\" data-year=\"2023\" data-title=\"[Linked title](https://example.com)\"><span class=\"csln-title\"><a href=\"https://example.com\">Linked title</a></span></div>\n</div>"
+        "<div class=\"citum-bibliography\">\n<div class=\"citum-entry\" id=\"ref-doi-inline\" data-year=\"2023\" data-title=\"[Linked title](https://example.com)\"><span class=\"citum-title\"><a href=\"https://example.com\">Linked title</a></span></div>\n</div>"
     );
 }
 
@@ -1903,7 +1903,7 @@ fn test_chicago_title_preset_preserves_djot_markup_html() {
 
     assert!(
         result.contains(
-            r#"<span class="csln-title">“<i>Homo sapiens</i> and <b>modern</b> world”</span>"#
+            r#"<span class="citum-title">“<i>Homo sapiens</i> and <b>modern</b> world”</span>"#
         ),
         "Result: {result}"
     );
@@ -3987,12 +3987,12 @@ bibliography:
     let result = processor.render_bibliography_with_format::<Html>();
 
     assert_eq!(
-        result.matches("csln-bibliography").count(),
+        result.matches("citum-bibliography").count(),
         1,
         "merged HTML should have exactly one bibliography wrapper: {result}"
     );
     assert_eq!(
-        result.matches("csln-entry").count(),
+        result.matches("citum-entry").count(),
         1,
         "merged HTML should have exactly one entry wrapper: {result}"
     );

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -574,8 +574,8 @@ mod tests {
         let result = refs_to_string_with_format::<Html>(entries, None, None);
         assert_eq!(
             result,
-            r#"<div class="csln-bibliography">
-<div class="csln-entry" id="ref-ref-1">Reference Content</div>
+            r#"<div class="citum-bibliography">
+<div class="citum-entry" id="ref-ref-1">Reference Content</div>
 </div>"#
         );
     }
@@ -809,19 +809,19 @@ mod tests {
         );
 
         assert!(
-            !result.contains("322(10)</i></span>. <span class=\"csln-pages\">, 891–921."),
+            !result.contains("322(10)</i></span>. <span class=\"citum-pages\">, 891–921."),
             "separator should not inject a period before pages: {result}"
         );
         assert!(
-            !result.contains("891–921.</span>. <span class=\"csln-doi\">"),
+            !result.contains("891–921.</span>. <span class=\"citum-doi\">"),
             "separator should not inject a period before DOI: {result}"
         );
         assert!(
-            result
-                .contains("<span class=\"csln-pages\">, 891–921.</span><span class=\"csln-doi\">")
-                || result.contains(
-                    "<span class=\"csln-pages\">, 891–921.</span> <span class=\"csln-doi\">"
-                ),
+            result.contains(
+                "<span class=\"citum-pages\">, 891–921.</span><span class=\"citum-doi\">"
+            ) || result.contains(
+                "<span class=\"citum-pages\">, 891–921.</span> <span class=\"citum-doi\">"
+            ),
             "HTML output should preserve pages punctuation without duplicate separators: {result}"
         );
     }

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -57,15 +57,15 @@ fn resolve_semantic_class(component: &ProcTemplateComponent) -> Option<String> {
     use citum_schema::template::{DateVariable, SimpleVariable};
     match &component.template_component {
         TemplateComponent::Title(t) => match t.title {
-            TitleType::Primary => Some("csln-title".to_string()),
+            TitleType::Primary => Some("citum-title".to_string()),
             TitleType::ParentMonograph | TitleType::ParentSerial => {
-                Some("csln-container-title".to_string())
+                Some("citum-container-title".to_string())
             }
-            _ => Some("csln-title".to_string()),
+            _ => Some("citum-title".to_string()),
         },
-        TemplateComponent::Contributor(c) => Some(format!("csln-{}", c.contributor.as_str())),
+        TemplateComponent::Contributor(c) => Some(format!("citum-{}", c.contributor.as_str())),
         TemplateComponent::Date(d) => Some(format!(
-            "csln-{}",
+            "citum-{}",
             match d.date {
                 DateVariable::Issued => "issued",
                 DateVariable::Accessed => "accessed",
@@ -74,9 +74,9 @@ fn resolve_semantic_class(component: &ProcTemplateComponent) -> Option<String> {
                 DateVariable::EventDate => "event-date",
             }
         )),
-        TemplateComponent::Number(n) => Some(format!("csln-{}", n.number.as_key())),
+        TemplateComponent::Number(n) => Some(format!("citum-{}", n.number.as_key())),
         TemplateComponent::Variable(v) => Some(format!(
-            "csln-{}",
+            "citum-{}",
             match v.variable {
                 SimpleVariable::Doi => "doi",
                 SimpleVariable::Url => "url",

--- a/crates/citum-engine/src/render/format.rs
+++ b/crates/citum-engine/src/render/format.rs
@@ -73,7 +73,7 @@ pub trait OutputFormat: Default + Clone {
     /// Apply a semantic identifier (class) to the content.
     ///
     /// This is used for machine readability or fine-grained CSS styling.
-    /// Examples include "csln-title", "csln-author", "csln-doi".
+    /// Examples include "citum-title", "citum-author", "citum-doi".
     fn semantic(&self, class: &str, content: Self::Output) -> Self::Output;
 
     /// Apply a semantic identifier plus optional attributes to the content.

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -144,7 +144,7 @@ impl OutputFormat for Html {
             return content;
         }
         let ids_str = ids.join(" ");
-        format!(r#"<span class="csln-citation" data-ref="{ids_str}">{content}</span>"#)
+        format!(r#"<span class="citum-citation" data-ref="{ids_str}">{content}</span>"#)
     }
 
     fn link(&self, url: &str, content: Self::Output) -> Self::Output {
@@ -160,7 +160,7 @@ impl OutputFormat for Html {
 
     fn bibliography(&self, entries: Vec<Self::Output>) -> Self::Output {
         format!(
-            r#"<div class="csln-bibliography">
+            r#"<div class="citum-bibliography">
 {}
 </div>"#,
             self.join(entries, "\n")
@@ -200,6 +200,6 @@ impl OutputFormat for Html {
             attrs.push('"');
         }
 
-        format!(r#"<div class="csln-entry" {attrs}>{content}</div>"#)
+        format!(r#"<div class="citum-entry" {attrs}>{content}</div>"#)
     }
 }

--- a/crates/citum-engine/src/render/test_formats.rs
+++ b/crates/citum-engine/src/render/test_formats.rs
@@ -20,7 +20,10 @@ mod tests {
         };
 
         let result = render_component_with_format::<Html>(&component);
-        assert_eq!(result, r#"<span class="csln-title"><i>My Title</i></span>"#);
+        assert_eq!(
+            result,
+            r#"<span class="citum-title"><i>My Title</i></span>"#
+        );
     }
 
     #[test]
@@ -34,7 +37,7 @@ mod tests {
         let result = render_component_with_format::<Html>(&component);
         assert_eq!(
             result,
-            r#"<span class="csln-author"><span style="font-variant:small-caps">Smith</span></span>"#
+            r#"<span class="citum-author"><span style="font-variant:small-caps">Smith</span></span>"#
         );
     }
 
@@ -50,7 +53,7 @@ mod tests {
         let result = render_component_with_format::<Html>(&component);
         assert_eq!(
             result,
-            r#"<span class="csln-title" data-index="2"><i>My Title</i></span>"#
+            r#"<span class="citum-title" data-index="2"><i>My Title</i></span>"#
         );
     }
 
@@ -63,7 +66,7 @@ mod tests {
         };
 
         let result = render_component_with_format::<Djot>(&component);
-        assert_eq!(result, "[_My Title_]{.csln-title}");
+        assert_eq!(result, "[_My Title_]{.citum-title}");
     }
 
     #[test]
@@ -75,7 +78,7 @@ mod tests {
         };
 
         let result = render_component_with_format::<Djot>(&component);
-        assert_eq!(result, "[[Smith]{.small-caps}]{.csln-author}");
+        assert_eq!(result, "[[Smith]{.small-caps}]{.citum-author}");
     }
 
     #[test]
@@ -90,7 +93,7 @@ mod tests {
         let result = render_component_with_format::<Html>(&component);
         assert_eq!(
             result,
-            r#"<span class="csln-url"><a href="https://example.com">https://example.com</a></span>"#
+            r#"<span class="citum-url"><a href="https://example.com">https://example.com</a></span>"#
         );
     }
 
@@ -106,7 +109,7 @@ mod tests {
         let result = render_component_with_format::<Html>(&component);
         assert_eq!(
             result,
-            r#"<span class="csln-url"><a href="%22%20onmouseover=%22alert(1)">label</a></span>"#
+            r#"<span class="citum-url"><a href="%22%20onmouseover=%22alert(1)">label</a></span>"#
         );
     }
 
@@ -134,7 +137,7 @@ mod tests {
         let result = render_component_with_format::<Html>(&component);
         assert_eq!(
             result,
-            r#"<span class="csln-title"><a href="https://doi.org/10.1001/test">My Title</a></span>"#
+            r#"<span class="citum-title"><a href="https://doi.org/10.1001/test">My Title</a></span>"#
         );
     }
 

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -772,11 +772,11 @@ bibliography:
     let rendered = processor.render_bibliography_with_format::<Html>();
 
     assert!(
-        rendered.contains(r#"class="csln-author" data-index="0""#),
+        rendered.contains(r#"class="citum-author" data-index="0""#),
         "author wrapper should carry the first type-template index: {rendered}"
     );
     assert!(
-        rendered.contains(r#"class="csln-title" data-index="2""#),
+        rendered.contains(r#"class="citum-title" data-index="2""#),
         "title wrapper should carry the sparse third type-template index: {rendered}"
     );
     assert!(
@@ -873,11 +873,11 @@ fn assert_list_preview_inherits_parent_index(use_type_template: bool) {
     let rendered = processor.render_bibliography_with_format::<Html>();
 
     assert!(
-        rendered.contains(r#"class="csln-author" data-index="0""#),
+        rendered.contains(r#"class="citum-author" data-index="0""#),
         "list-rendered author should inherit the parent top-level index: {rendered}"
     );
     assert!(
-        rendered.contains(r#"class="csln-title" data-index="0""#),
+        rendered.contains(r#"class="citum-title" data-index="0""#),
         "list-rendered title should inherit the parent top-level index: {rendered}"
     );
 }

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -1416,11 +1416,11 @@ citation:
         .expect("citation should render");
 
     assert!(
-        rendered.contains(r#"class="csln-title" data-index="0""#),
+        rendered.contains(r#"class="citum-title" data-index="0""#),
         "title wrapper should carry the first template index: {rendered}"
     );
     assert!(
-        rendered.contains(r#"class="csln-url" data-index="2""#),
+        rendered.contains(r#"class="citum-url" data-index="2""#),
         "url wrapper should carry the sparse third template index: {rendered}"
     );
     assert!(

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -166,11 +166,11 @@ fn given_example_mla_document_when_rendered_as_html_then_citation_markup_is_not_
     );
 
     assert!(
-        html_output.contains(r#"<span class="csln-citation" data-ref="smith2010">"#),
+        html_output.contains(r#"<span class="citum-citation" data-ref="smith2010">"#),
         "citation markup should be real HTML: {html_output}"
     );
     assert!(
-        html_output.contains(r#"<div class="csln-bibliography">"#),
+        html_output.contains(r#"<div class="citum-bibliography">"#),
         "bibliography markup should be real HTML: {html_output}"
     );
     assert!(

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -134,7 +134,7 @@ mod tests {
             .as_str()
             .expect("content should be a string");
         assert!(
-            content.contains("csln-bibliography"),
+            content.contains("citum-bibliography"),
             "html bibliography should include wrapper markup"
         );
     }

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -122,7 +122,7 @@ fn render_bibliography_html_returns_wrapped_markup() {
         .as_str()
         .expect("content should be a string");
     assert!(
-        content.contains("csln-bibliography"),
+        content.contains("citum-bibliography"),
         "html bibliography should include wrapper markup"
     );
 }
@@ -193,7 +193,7 @@ fn render_citation_html_returns_markup() {
     assert_eq!(result["id"], 9);
     let citation = result["result"].as_str().expect("result should be string");
     assert!(
-        citation.contains("csln-citation"),
+        citation.contains("citum-citation"),
         "html citation should contain citation wrapper: {citation}"
     );
 }
@@ -217,7 +217,7 @@ fn render_citation_html_injects_template_indices_when_requested() {
     let result = dispatch(req).expect("dispatch should succeed");
     let citation = result["result"].as_str().expect("result should be string");
     assert!(
-        citation.contains(r#"class="csln-issued" data-index="0""#),
+        citation.contains(r#"class="citum-issued" data-index="0""#),
         "html citation should annotate the rendered citation component when requested: {citation}"
     );
 }


### PR DESCRIPTION
## Summary

- Replace all `csln-` CSS class prefixes with `citum-` across the HTML output
  renderer (`html.rs`, `component.rs`) and all test assertions (13 files total)
- Bumps workspace version to 0.29.1 — HTML class names are public API

## Test plan

- [x] 1128 tests pass (`cargo nextest run`)
- [x] `cargo fmt --check` and `cargo clippy` clean
- [x] Verify rendered HTML output in browser uses `citum-` classes

Closes: csl26-d1ho
