### PR TITLE
feat(schema): unify geographic place type

### DIFF
--- a/.beans/archive/csl26-iphj--archivepublisher-place-unification.md
+++ b/.beans/archive/csl26-iphj--archivepublisher-place-unification.md
@@ -1,13 +1,13 @@
 ---
 # csl26-iphj
 title: Archive/publisher place unification
-status: todo
+status: completed
 type: task
 priority: low
 tags:
     - schema
 created_at: 2026-03-29T10:54:28Z
-updated_at: 2026-04-25T20:17:09Z
+updated_at: 2026-04-29T15:10:33Z
 ---
 
 Future: extract a shared Place type (or unify semantics) for archive.place and SimpleName.location — both are Option<String> with geographic-place semantics. Noted in ARCHIVAL_UNPUBLISHED_SUPPORT.md Design Rationale section. Premature to do now (no structural gain), but worth tracking.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "typst",
  "typst-kit",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -899,7 +899,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.29.1"
+version = "0.30.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-engine/src/biblatex.rs
+++ b/crates/citum-engine/src/biblatex.rs
@@ -168,7 +168,7 @@ pub(crate) fn input_reference_from_biblatex(entry: &biblatex_crate::Entry) -> In
     let issued = field_str("date").map_or(EdtfString(String::new()), EdtfString);
     let publisher = field_str("publisher").map(|p| Publisher {
         name: p.into(),
-        place: field_str("location"),
+        place: field_str("location").map(Into::into),
     });
 
     let author = entry

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -634,7 +634,7 @@ fn make_archive_eprint_reference() -> InputReference {
         archive_location: None,
         archive_info: Some(ArchiveInfo {
             name: Some(MultilingualString::Simple("Houghton Library".to_string())),
-            place: Some("Cambridge, MA".to_string()),
+            place: Some("Cambridge, MA".into()),
             collection: Some("Ada Lovelace Papers".to_string()),
             collection_id: Some("MS Am 1280".to_string()),
             series: Some("Correspondence".to_string()),
@@ -729,7 +729,7 @@ fn make_historical_archive_reference() -> InputReference {
                 "Israel Antiquities Authority".to_string(),
             )),
             location: Some("Shrine of the Book".to_string()),
-            place: Some("Jerusalem".to_string()),
+            place: Some("Jerusalem".into()),
             ..Default::default()
         }),
         eprint: None,
@@ -2636,7 +2636,7 @@ fn given_archive_location_override_when_rendering_bibliography_then_legacy_fallb
     monograph.id = Some("archive-eprint-location-ref".into());
     monograph.archive_info = Some(ArchiveInfo {
         name: Some(MultilingualString::Simple("Houghton Library".to_string())),
-        place: Some("Cambridge, MA".to_string()),
+        place: Some("Cambridge, MA".into()),
         collection: Some("Ada Lovelace Papers".to_string()),
         location: Some("MS Am 1280, Box 12, Folder 4".to_string()),
         url: Some(Url::parse("https://example.com/archive").expect("url should parse")),

--- a/crates/citum-schema-data/src/reference/contributor.rs
+++ b/crates/citum-schema-data/src/reference/contributor.rs
@@ -1,4 +1,4 @@
-use crate::reference::types::MultilingualString;
+use crate::reference::types::{MultilingualString, Place};
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -58,9 +58,11 @@ pub struct MultilingualName {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 pub struct SimpleName {
+    /// Institutional or organization name.
     pub name: MultilingualString,
+    /// Geographic place associated with the name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub location: Option<String>,
+    pub location: Option<Place>,
 }
 
 /// A structured name is a name broken down into its constituent parts.
@@ -124,7 +126,7 @@ impl Contributor {
 
     pub fn location(&self) -> Option<String> {
         match self {
-            Contributor::SimpleName(n) => n.location.clone(),
+            Contributor::SimpleName(n) => n.location.clone().map(Into::into),
             _ => None,
         }
     }

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -109,11 +109,11 @@ fn relation_monograph(
     let publisher = match (publisher, publisher_place) {
         (Some(name), place) => Some(Publisher {
             name: name.into(),
-            place,
+            place: place.map(Into::into),
         }),
         (None, Some(place)) => Some(Publisher {
             name: String::new().into(),
-            place: Some(place),
+            place: Some(place.into()),
         }),
         (None, None) => None,
     };
@@ -229,7 +229,7 @@ fn archive_info_from_legacy_flat(legacy: &csl_legacy::csl_json::Reference) -> Op
     Some(ArchiveInfo {
         name: legacy.archive.clone().map(Into::into),
         location: legacy.archive_location.clone(),
-        place,
+        place: place.map(Into::into),
         collection,
         ..Default::default()
     })
@@ -276,7 +276,7 @@ fn from_software_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
         issued: ctx.issued,
         publisher: legacy.publisher.map(|n| Publisher {
             name: n.into(),
-            place: legacy.publisher_place,
+            place: legacy.publisher_place.map(Into::into),
         }),
         version: None,
         repository: None,
@@ -507,7 +507,7 @@ fn from_monograph_ref(
         issued: ctx.issued,
         publisher: legacy.publisher.map(|n| Publisher {
             name: n.into(),
-            place: legacy.publisher_place,
+            place: legacy.publisher_place.map(Into::into),
         }),
         url: ctx.url,
         accessed: ctx.accessed,
@@ -616,7 +616,7 @@ fn from_collection_component_ref(
                 contributors: container_contributors,
                 publisher: legacy.publisher.map(|n| Publisher {
                     name: n.into(),
-                    place: legacy.publisher_place,
+                    place: legacy.publisher_place.map(Into::into),
                 }),
                 edition: parent_edition.clone(),
                 numbering: legacy
@@ -662,7 +662,7 @@ fn from_collection_component_ref(
                 issued: EdtfString(String::new()),
                 publisher: legacy.publisher.map(|n| Publisher {
                     name: n.into(),
-                    place: legacy.publisher_place,
+                    place: legacy.publisher_place.map(Into::into),
                 }),
                 edition: parent_edition,
                 numbering: parent_volume
@@ -810,7 +810,7 @@ pub fn input_reference_from_legacy_edited_book(
             .unwrap_or(EdtfString(String::new())),
         publisher: publisher.map(|name| Publisher {
             name: name.into(),
-            place: publisher_place.clone(),
+            place: publisher_place.clone().map(Into::into),
         }),
         numbering,
         url: url.as_deref().and_then(|value| Url::parse(value).ok()),
@@ -944,7 +944,7 @@ fn from_serial_component_ref(
                 contributors: serial_contributors,
                 publisher: legacy.publisher.clone().map(|n| Publisher {
                     name: n.into(),
-                    place: legacy.publisher_place.clone(),
+                    place: legacy.publisher_place.clone().map(Into::into),
                 }),
                 url: None,
                 accessed: None,
@@ -1085,7 +1085,7 @@ fn from_audio_visual_ref(
         numbering,
         publisher: legacy.publisher.map(|name| Publisher {
             name: name.into(),
-            place: legacy.publisher_place,
+            place: legacy.publisher_place.map(Into::into),
         }),
         medium: legacy.medium,
         platform: None,
@@ -1197,7 +1197,7 @@ fn from_standard_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
         status: None,
         publisher: legacy.publisher.map(|n| Publisher {
             name: n.into(),
-            place: legacy.publisher_place,
+            place: legacy.publisher_place.map(Into::into),
         }),
         url: ctx.url,
         accessed: ctx.accessed,
@@ -1257,7 +1257,7 @@ fn from_dataset_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) ->
         issued: ctx.issued,
         publisher: legacy.publisher.map(|n| Publisher {
             name: n.into(),
-            place: legacy.publisher_place,
+            place: legacy.publisher_place.map(Into::into),
         }),
         version,
         format: legacy.medium,
@@ -1396,7 +1396,7 @@ fn from_document_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
         issued: ctx.issued,
         publisher: legacy.publisher.map(|n| Publisher {
             name: n.into(),
-            place: legacy.publisher_place,
+            place: legacy.publisher_place.map(Into::into),
         }),
         url: ctx.url,
         accessed: ctx.accessed,
@@ -1472,7 +1472,7 @@ fn from_preprint_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
         issued: ctx.issued,
         publisher: legacy.publisher.map(|name| Publisher {
             name: name.into(),
-            place: legacy.publisher_place,
+            place: legacy.publisher_place.map(Into::into),
         }),
         url: ctx.url,
         accessed: ctx.accessed,

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -22,8 +22,8 @@ pub use self::contributor::{
 pub use self::date::EdtfString;
 use self::types::common::HasNumbering;
 pub use self::types::common::{
-    FieldLanguageMap, LangID, MultilingualString, NumOrStr, Numbering, NumberingType, Publisher,
-    RefID, RichText, Title,
+    FieldLanguageMap, LangID, MultilingualString, NumOrStr, Numbering, NumberingType, Place,
+    Publisher, RefID, RichText, Title,
 };
 pub use self::types::legal::{Brief, Hearing, LegalCase, Regulation, Statute, Treaty};
 pub use self::types::specialized::{
@@ -533,7 +533,7 @@ impl InputReference {
             InputReference::Monograph(r) => r
                 .publisher
                 .as_ref()
-                .and_then(|p| p.place.clone())
+                .and_then(|p| p.place.clone().map(Into::into))
                 .or_else(|| {
                     r.container.as_ref().and_then(|c| match c {
                         WorkRelation::Embedded(p) => p.publisher_place(),
@@ -551,7 +551,7 @@ impl InputReference {
             InputReference::Collection(r) => r
                 .publisher
                 .as_ref()
-                .and_then(|p| p.place.clone())
+                .and_then(|p| p.place.clone().map(Into::into))
                 .or_else(|| {
                     r.container.as_ref().and_then(|c| match c {
                         WorkRelation::Embedded(p) => p.publisher_place(),
@@ -559,12 +559,27 @@ impl InputReference {
                     })
                 }),
             InputReference::Serial(_) => None,
-            InputReference::Classic(r) => r.publisher.as_ref().and_then(|p| p.place.clone()),
-            InputReference::Dataset(r) => r.publisher.as_ref().and_then(|p| p.place.clone()),
-            InputReference::Standard(r) => r.publisher.as_ref().and_then(|p| p.place.clone()),
-            InputReference::Software(r) => r.publisher.as_ref().and_then(|p| p.place.clone()),
+            InputReference::Classic(r) => r
+                .publisher
+                .as_ref()
+                .and_then(|p| p.place.clone().map(Into::into)),
+            InputReference::Dataset(r) => r
+                .publisher
+                .as_ref()
+                .and_then(|p| p.place.clone().map(Into::into)),
+            InputReference::Standard(r) => r
+                .publisher
+                .as_ref()
+                .and_then(|p| p.place.clone().map(Into::into)),
+            InputReference::Software(r) => r
+                .publisher
+                .as_ref()
+                .and_then(|p| p.place.clone().map(Into::into)),
             InputReference::Event(r) => r.location.clone(),
-            InputReference::AudioVisual(r) => r.publisher.as_ref().and_then(|p| p.place.clone()),
+            InputReference::AudioVisual(r) => r
+                .publisher
+                .as_ref()
+                .and_then(|p| p.place.clone().map(Into::into)),
             _ => None,
         }
     }
@@ -688,13 +703,18 @@ impl InputReference {
     /// Return the archive geographic place from structured ArchiveInfo.
     pub fn archive_place(&self) -> Option<String> {
         match self {
-            InputReference::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.place.clone()),
-            InputReference::CollectionComponent(r) => {
-                r.archive_info.as_ref().and_then(|i| i.place.clone())
-            }
-            InputReference::SerialComponent(r) => {
-                r.archive_info.as_ref().and_then(|i| i.place.clone())
-            }
+            InputReference::Monograph(r) => r
+                .archive_info
+                .as_ref()
+                .and_then(|i| i.place.clone().map(Into::into)),
+            InputReference::CollectionComponent(r) => r
+                .archive_info
+                .as_ref()
+                .and_then(|i| i.place.clone().map(Into::into)),
+            InputReference::SerialComponent(r) => r
+                .archive_info
+                .as_ref()
+                .and_then(|i| i.place.clone().map(Into::into)),
             _ => None,
         }
     }

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -1229,7 +1229,7 @@ fn conversion_maps_original_publisher_metadata_into_original_relation() {
             .publisher
             .as_ref()
             .and_then(|publisher| publisher.place.clone()),
-        Some("Boston".to_string())
+        Some(Place::from("Boston"))
     );
 }
 
@@ -1269,7 +1269,7 @@ fn conversion_preserves_place_only_original_publication_metadata() {
             .publisher
             .as_ref()
             .and_then(|publisher| publisher.place.clone()),
-        Some("Boston".to_string())
+        Some(Place::from("Boston"))
     );
 }
 
@@ -1462,6 +1462,6 @@ fn conversion_maps_original_relation_for_legal_case_references() {
             .publisher
             .as_ref()
             .and_then(|publisher| publisher.place.clone()),
-        Some("Boston".to_string())
+        Some(Place::from("Boston"))
     );
 }

--- a/crates/citum-schema-data/src/reference/types/common.rs
+++ b/crates/citum-schema-data/src/reference/types/common.rs
@@ -116,6 +116,106 @@ impl PartialEq<RefID> for String {
     }
 }
 
+/// Geographic place name used for publication and archive locations.
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "bindings", derive(Type))]
+#[serde(transparent)]
+pub struct Place(
+    /// The rendered place string, such as a city or city-country label.
+    pub String,
+);
+
+impl Place {
+    /// Borrow the place name as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Place {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for Place {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for Place {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for Place {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl From<String> for Place {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for Place {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<Place> for String {
+    fn from(value: Place) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for Place {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(value))
+    }
+}
+
+impl PartialEq<&str> for Place {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<str> for Place {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<String> for Place {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<Place> for &str {
+    fn eq(&self, other: &Place) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<Place> for String {
+    fn eq(&self, other: &Place) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
 /// Inline markup for freeform text fields (note, abstract).
 ///
 /// Serializes from a plain string or a `{ djot: "..." }` object.
@@ -599,7 +699,7 @@ pub struct ArchiveInfo {
     ///
     /// Parallel to `SimpleName.location`; both carry geographic-place semantics.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub place: Option<String>,
+    pub place: Option<Place>,
     /// Name of the collection within the archive.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub collection: Option<String>,
@@ -667,7 +767,7 @@ pub struct Publisher {
     pub name: MultilingualString,
     /// Geographic place of publication (city, country).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub place: Option<String>,
+    pub place: Option<Place>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -677,7 +777,7 @@ pub struct Publisher {
 enum PublisherCompat {
     PublisherObject {
         name: MultilingualString,
-        place: Option<String>,
+        place: Option<Place>,
     },
     Contributor(Box<Contributor>),
     Name(MultilingualString),
@@ -828,8 +928,10 @@ mod tests {
     fn newtypes_stay_string_shaped_in_json_schema() {
         let ref_schema = schema_for!(RefID);
         let lang_schema = schema_for!(LangID);
+        let place_schema = schema_for!(super::Place);
 
         assert_eq!(ref_schema.to_value()["type"], "string");
         assert_eq!(lang_schema.to_value()["type"], "string");
+        assert_eq!(place_schema.to_value()["type"], "string");
     }
 }

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -84,7 +84,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.37.1";
+pub const STYLE_SCHEMA_VERSION: &str = "0.38.0";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/docs/reference/BIBLATEX_MAPPING.md
+++ b/docs/reference/BIBLATEX_MAPPING.md
@@ -215,7 +215,7 @@ pub struct Collection {
 
 2. **Name Parsing**: The `biblatex` crate parses names into `Person` structs with family/given/prefix/suffix parts.
 
-3. **Location Field**: BibLaTeX's `location` (publisher location) is distinct from `SimpleName.location` (organization location). Consider renaming one.
+3. **Location Field**: BibLaTeX's `location` is a publisher place and maps to the shared `Place` newtype. `SimpleName.location` uses the same type for organization places, while event locations and archive shelfmarks remain plain strings.
 
 4. **Crossref Resolution**: BibLaTeX `crossref` and `xref` fields reference parent entries. The converter should resolve these to inline parent structures.
 

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,10 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.38.0 (2026-04-29)
+- Schema version bumped from 0.37.1 to 0.38.0
+- Breaking: geographic place fields now use the transparent `Place` newtype while preserving string wire compatibility
+
 #### schema-v0.37.1 (2026-04-28)
 - Schema version bumped from 0.37.0 to 0.37.1
 - Added `part_number`, `supplement_number`, `printing_number` shorthand fields to Monograph, Collection, CollectionComponent, SerialComponent, and Classic

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -572,12 +572,18 @@
       "type": "object",
       "properties": {
         "name": {
+          "description": "Institutional or organization name.",
           "$ref": "#/$defs/MultilingualString"
         },
         "location": {
-          "type": [
-            "string",
-            "null"
+          "description": "Geographic place associated with the name.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Place"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },
@@ -597,6 +603,10 @@
           "$ref": "#/$defs/MultilingualComplex"
         }
       ]
+    },
+    "Place": {
+      "description": "Geographic place name used for publication and archive locations.",
+      "type": "string"
     },
     "StructuredName": {
       "description": "A structured name is a name broken down into its constituent parts.",
@@ -774,9 +784,13 @@
               "$ref": "#/$defs/MultilingualString"
             },
             "place": {
-              "type": [
-                "string",
-                "null"
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Place"
+                },
+                {
+                  "type": "null"
+                }
               ]
             }
           },
@@ -856,9 +870,13 @@
         },
         "place": {
           "description": "Geographic location (city/country) of the archive.\n\nParallel to `SimpleName.location`; both carry geographic-place semantics.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Place"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "collection": {

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7,7 +7,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.37.1"
+      "default": "0.38.0"
     },
     "info": {
       "description": "Style metadata.",

--- a/docs/specs/ARCHIVAL_UNPUBLISHED_SUPPORT.md
+++ b/docs/specs/ARCHIVAL_UNPUBLISHED_SUPPORT.md
@@ -275,10 +275,10 @@ because:
 - Nesting a `Contributor` inside `ArchiveInfo` for just name + place would add
   YAML depth without benefit.
 
-The geographic-place concept (`place` on `ArchiveInfo`, `location` on
-`SimpleName`) could be unified into a shared type in a future cross-cutting
-refactor, but extracting a newtype for what is currently `Option<String>` in
-both cases is premature.
+The geographic-place concept is now unified through the shared `Place` newtype
+on `ArchiveInfo.place`, `SimpleName.location`, and publisher places. The wire
+format remains a string, while Rust code can distinguish geographic places from
+shelfmarks, call numbers, and event locations.
 
 ### EprintInfo Struct
 


### PR DESCRIPTION
## Summary
- add a transparent Place newtype for geographic place fields
- use Place for archive, publisher, and SimpleName geographic locations while preserving string wire format
- bump schema to 0.38.0, workspace to 0.30.0, regenerate schemas, and archive csl26-iphj

## Verification
- cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run
- cargo run --bin citum --features schema -- schema --out-dir docs/schemas
- ./scripts/validate-frontmatter.sh --copilot-strict
- python3 scripts/audit-rust-review-smells.py --changed
- pre-push hook: schema/version validation, fmt, clippy, nextest