### PR TITLE
docs: add jj AI change stack guide

### DIFF
--- a/.claude/skills/pr-workflow-fast/SKILL.md
+++ b/.claude/skills/pr-workflow-fast/SKILL.md
@@ -20,6 +20,8 @@ description: >
 - Branch prefix: `codex/`.
 - Name pattern: `codex/<scope>-<short-goal>`.
 - Keep PR scope narrow and mergeable.
+- When `.jj` is present, `docs/guides/JJ_AI_CHANGE_STACK.md` may be used for
+  local change-stack curation before pushing the Git branch.
 
 ## Change-Type Gates
 1. Docs/styles only (`.md`, `styles/*.yaml`):

--- a/.claude/skills/style-evolve/SKILL.md
+++ b/.claude/skills/style-evolve/SKILL.md
@@ -23,6 +23,8 @@ Do not ask users to call internal skills directly.
 Before doing anything else, read:
 - `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` — failure classification and stop conditions
 - `docs/guides/STYLE_WORKFLOW_EXECUTION.md` — decision flow, evidence ladder, shared gates
+- `docs/guides/JJ_AI_CHANGE_STACK.md` when `.jj` is present and local change-stack
+  curation would help isolate a style pass
 
 ## Autonomous Operation
 

--- a/.codex/skills/migrate-research/SKILL.md
+++ b/.codex/skills/migrate-research/SKILL.md
@@ -13,6 +13,8 @@ Read first:
 - `docs/guides/STYLE_WORKFLOW_EXECUTION.md`
 - `docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md`
 - `docs/guides/CODEX_SKILLS.md`
+- `docs/guides/JJ_AI_CHANGE_STACK.md` when `.jj` is present and the research
+  pass needs an isolated local change
 
 ## Use When
 

--- a/.codex/skills/rust-simplify/SKILL.md
+++ b/.codex/skills/rust-simplify/SKILL.md
@@ -8,6 +8,9 @@ description: One-file-at-a-time Rust quality pass for Citum, using jcodemunch to
 Use this skill for bounded Rust cleanup work in the Citum workspace when the task is to
 improve code quality rather than fix a specific bug.
 
+When `.jj` is present, use `docs/guides/JJ_AI_CHANGE_STACK.md` for optional
+local change isolation and intent capture before publishing through Git/GitHub.
+
 Read first:
 - `docs/guides/CODING_STANDARDS.md`
 - `docs/guides/CODEX_SKILLS.md`

--- a/.codex/skills/style-evolve/SKILL.md
+++ b/.codex/skills/style-evolve/SKILL.md
@@ -12,6 +12,8 @@ Read first:
 - `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`
 - `docs/guides/STYLE_WORKFLOW_EXECUTION.md`
 - `docs/guides/CODEX_SKILLS.md`
+- `docs/guides/JJ_AI_CHANGE_STACK.md` when `.jj` is present and local stack
+  curation would help isolate the work
 
 ## Public Modes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,15 @@ gh run view <run-id> --log-failed
 ```
 Do not consider the task done until CI passes.
 
+### Optional jj AI Change Stack
+
+This repo may use jj as a local, optional change-stack layer for AI-assisted
+work when `.jj` is present. Git and GitHub remain the public collaboration
+interface. Follow [docs/guides/JJ_AI_CHANGE_STACK.md](./docs/guides/JJ_AI_CHANGE_STACK.md)
+for intent capture, agent coordination, and stack curation. Intent files may
+live inside an evolving jj change, but must be deleted before the final
+Git-visible commit is published unless explicitly requested.
+
 ### Confirmations Required
 
 - `Cargo.toml` / `Cargo.lock` changes
@@ -233,6 +242,8 @@ python3 scripts/audit-rust-review-smells.py --changed    # Run before committing
 Direct commits to `main` allowed (rapid development mode). Pre-commit checks required for Rust; docs/styles skip.
 
 **When the user says "PR"**: Create a branch, implement, then `gh pr create`. Never push directly to main for that task.
+For PR work, jj may be used locally to curate the change stack, but the final
+published work must be on a Git branch and submitted through GitHub.
 **Never create a branch unless the user asked for a PR or explicitly asked for a branch.**
 **Never make content decisions unilaterally** (e.g. what text to put in a title field) — confirm with the user first.
 

--- a/docs/guides/CODEX_SKILLS.md
+++ b/docs/guides/CODEX_SKILLS.md
@@ -42,5 +42,8 @@ The script is idempotent and fails if a target path is already a non-symlink.
 
 - Keep workflow logic in `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` and
   `docs/guides/STYLE_WORKFLOW_EXECUTION.md`.
+- When `.jj` is present, Codex skills may use
+  `docs/guides/JJ_AI_CHANGE_STACK.md` for local change isolation, intent
+  capture, and stack curation. Keep Git/GitHub as the published interface.
 - Keep Codex skills thin and host-focused.
 - Keep `./scripts/codex <role> <target...>` as a fallback for direct role execution.

--- a/docs/guides/JJ_AI_CHANGE_STACK.md
+++ b/docs/guides/JJ_AI_CHANGE_STACK.md
@@ -1,0 +1,136 @@
+# jj AI Change Stack
+
+## Purpose
+
+Use jj as an optional local change-stack layer for AI-assisted work while keeping
+Git and GitHub as the public collaboration interface.
+
+This workflow is for Claude, Codex, and other LLM-assisted sessions. It captures
+short-lived intent during development, makes exploratory changes easier to split
+or abandon, and preserves Citum's existing commit, PR, and verification gates.
+
+## Default Model
+
+- Use GitHub branches and PRs for published collaboration.
+- Use jj locally when `.jj` is present and the user has not requested a Git-only
+  workflow.
+- Keep one jj change per coherent plan step, bean/spec phase, style pass, or
+  Rust fix.
+- Let the parent session own jj stack curation. Subagents may implement or
+  review bounded changes, but they must not independently split, squash, rebase,
+  abandon, publish, or otherwise rewrite the shared stack.
+- Treat raw prompt capture as temporary local provenance. In jj, intent files
+  may be part of the evolving mutable change while work is in progress. They
+  must be deleted from that change before export or publication, so the final
+  Git-visible commit does not contain them unless the user explicitly asks for
+  durable prompt provenance.
+
+## Intent Capture
+
+During local work, agents may create temporary intent files under:
+
+```text
+.ai-intents/INTENT-YYYY-MM-DD-HHMM-<slug>.md
+```
+
+Each file should contain only the information needed to curate the local stack:
+
+- task, bean, issue, or PR identifier, if any
+- model or tool used
+- prompt summary or short quoted prompt excerpt
+- plan step or change purpose
+- files or subsystem touched
+- verification command and result
+
+These files are temporary. In a colocated jj/Git repository, they may be tracked
+inside the current mutable jj change during drafting. jj snapshots workspace
+edits into that change automatically, so there is no separate Git-style staging
+step for the intent file. Before export or publication, delete the file and let
+jj amend the current change so the final Git-visible snapshot has no
+`.ai-intents/` paths. Do not publish intent files unless the user explicitly
+chooses durable prompt provenance for a specific commit.
+
+## Command Protocol
+
+Before starting a local AI-assisted stack:
+
+```bash
+jj status
+jj log
+git status --short --branch
+```
+
+For each coherent step:
+
+```bash
+jj new
+# create a temporary .ai-intents/ file if intent capture is useful
+# implement one bounded step
+jj status
+jj diff
+jj describe
+```
+
+During curation:
+
+```bash
+jj split
+jj squash
+jj rebase
+jj describe
+```
+
+Before publishing through Git/GitHub:
+
+```bash
+jj status
+# delete .ai-intents/ from the current change, if present
+jj git export
+git status --short --branch
+```
+
+If jj is unavailable, use the existing Git workflow. Do not block Citum work just
+because jj is missing.
+
+## Citum Adapter
+
+The jj workflow is subordinate to Citum's repo rules:
+
+- When the user asks for a PR, create a `codex/<scope>-<goal>` branch and open a
+  PR instead of pushing to `main`.
+- Keep commit messages conventional and follow the 50/72 rule.
+- For Rust changes, run the required Rust gate before committing:
+  `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`.
+- If `cargo nextest` is unavailable, use `cargo test`.
+- If schema crate or CLI schema behavior changes, regenerate schemas and include
+  the required schema/version footer.
+- For style work, route through `/style-evolve` and preserve fidelity gates.
+- For task-tracked work, keep bean state changes in the same final Git commit as
+  the related work.
+
+## Agent Coordination
+
+Use jj to isolate and curate changes, not to distribute history ownership across
+agents.
+
+- The parent session decides when to create a new jj change and how to curate the
+  stack.
+- Implementation subagents receive one bounded task and report changed paths,
+  verification, and risks.
+- Review subagents inspect diffs and findings without rewriting history.
+- If two LLMs produce competing designs, put each design on a separate jj change
+  or branch, compare the diffs, then keep or squash only the selected approach.
+
+## Publishing
+
+Before push or PR creation:
+
+- Ensure `jj status` and `git status --short --branch` agree on the intended
+  published diff.
+- Confirm `.ai-intents/` paths are absent from the final jj change and from
+  `git status --short --branch`.
+- Run the verification gate for the touched change type.
+- Push the Git branch and check CI for PR branches.
+
+Global Claude or Codex `ai-change-stack` skills may point at this guide, but
+repo-local changes do not install or modify global skill files.


### PR DESCRIPTION
## Summary

- add a Citum adapter guide for optional jj-based AI change stacks
- link the guide from Claude/Codex workflow surfaces
- clarify that intent files may live in mutable jj changes during drafting, but must be deleted before the final Git-visible commit is published

## Validation

- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict`
- `./scripts/check-docs-beans-hygiene.sh`
- `jj --version`
- confirmed no `.ai-intents/` directory is present before commit/push

Note: bean hygiene reports an unrelated soft-stale advisory for `csl26`, but the hygiene script exits successfully.