### PR TITLE
feat(schema): route CSL bill+authority to hearing

### DIFF
--- a/.beans/archive/csl26-tr2m--route-csl-bill-type-to-class-hearing.md
+++ b/.beans/archive/csl26-tr2m--route-csl-bill-type-to-class-hearing.md
@@ -1,13 +1,13 @@
 ---
 # csl26-tr2m
 title: 'Route CSL bill type to class: hearing'
-status: todo
+status: completed
 type: feature
 priority: normal
 tags:
     - migrate
 created_at: 2026-04-04T14:00:22Z
-updated_at: 2026-04-25T20:20:07Z
+updated_at: 2026-04-30T19:18:49Z
 ---
 
 Congressional hearing items in Zotero export as CSL type `bill` but should

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "typst",
  "typst-kit",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "axum",
  "citum-engine",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -899,7 +899,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.30.2"
+version = "0.30.4"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.30.2"
+version = "0.30.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -3,10 +3,10 @@ use crate::reference::contributor::{
 };
 use crate::reference::date::EdtfString;
 use crate::reference::types::{
-    ArchiveInfo, Collection, CollectionComponent, CollectionType, Dataset, LegalCase, Monograph,
-    MonographComponentType, MonographType, NumOrStr, Patent, Publisher, Regulation, RichText,
-    Serial, SerialComponent, SerialComponentType, SerialType, Software, Standard, Statute,
-    StructuredTitle, Subtitle, Title, Treaty,
+    ArchiveInfo, Collection, CollectionComponent, CollectionType, Dataset, Hearing, LegalCase,
+    Monograph, MonographComponentType, MonographType, NumOrStr, Patent, Publisher, Regulation,
+    RichText, Serial, SerialComponent, SerialComponentType, SerialType, Software, Standard,
+    Statute, StructuredTitle, Subtitle, Title, Treaty,
 };
 use crate::reference::{
     AudioVisualType, AudioVisualWork, Event, InputReference, LangID, Numbering, NumberingType,
@@ -1282,6 +1282,11 @@ fn from_dataset_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) ->
 }
 
 fn from_bill_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    // CSL bills with both title and authority are congressional hearings (Zotero export pattern)
+    if legacy.title.is_some() && legacy.authority.is_some() {
+        return from_hearing_ref(legacy, ctx);
+    }
+
     let titleless_proceeding =
         legacy.title.is_none() && (legacy.authority.is_some() || legacy.chapter_number.is_some());
     let titleless_record = legacy.title.is_none()
@@ -1425,6 +1430,26 @@ fn from_document_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -
         keywords: None,
         original,
         ..Default::default()
+    }))
+}
+
+fn from_hearing_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> InputReference {
+    let original = legacy_original_relation(&legacy);
+    InputReference::Hearing(Box::new(Hearing {
+        id: ctx.id,
+        title: build_title(ctx.title, ctx.short_title),
+        original,
+        authority: legacy.authority,
+        // CSL chapter-number doubles as session/congress identifier for legislative sources
+        session_number: legacy.chapter_number,
+        created: ctx.created,
+        issued: ctx.issued,
+        url: ctx.url,
+        accessed: ctx.accessed,
+        language: ctx.language,
+        field_languages: HashMap::new(),
+        note: ctx.note.map(RichText::Plain),
+        keywords: None,
     }))
 }
 

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -521,6 +521,35 @@ fn test_parse_csl_bill_proceeding_uses_number_as_surrogate_title() {
 }
 
 #[test]
+fn test_parse_csl_bill_with_title_and_authority_routes_to_hearing() {
+    let json = r#"{
+        "id": "hearing-1",
+        "type": "bill",
+        "title": "Homeland Security Act of 2002: Hearings on H.R. 5005",
+        "authority": "U.S. Senate Committee on the Judiciary",
+        "chapter-number": "107th Cong., 2d Sess.",
+        "issued": {"date-parts": [[2002]]}
+    }"#;
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
+    let reference: InputReference = legacy.into();
+
+    match reference {
+        InputReference::Hearing(hearing) => {
+            assert_eq!(
+                hearing.authority.as_deref(),
+                Some("U.S. Senate Committee on the Judiciary")
+            );
+            assert_eq!(
+                hearing.session_number.as_deref(),
+                Some("107th Cong., 2d Sess.")
+            );
+        }
+        other => panic!("expected hearing, got {:?}", other),
+    }
+}
+
+#[test]
 fn conversion_applies_note_type_override() {
     let json = r#"{
         "id": "note-type-override",


### PR DESCRIPTION
## Summary

- Routes CSL `bill` references with both a `title` and `authority` to `InputReference::Hearing` instead of the generic document path
- Congressional hearings from Zotero export as CSL `bill` with these two fields set
- Maps `chapter-number` → `Hearing.session_number` (CSL reuses this field for session/congress identifiers in legislative sources)
- Adds integration test covering the new routing path
- Patch-bumps workspace version to 0.30.3 (publishable crate change)

## Test plan

- [x] `cargo nextest run` — 1129/1129 tests pass
- [x] New test `test_parse_csl_bill_with_title_and_authority_routes_to_hearing` covers the hearing route
- [x] Existing bill-record and bill-proceeding tests unaffected
