### PR TITLE
fix(migrate): standalone springer-basic-brackets-no-et-al

### DIFF
--- a/.beans/archive/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
+++ b/.beans/archive/csl26-xt7k--split-springer-basic-family-root-behavior-from-publi.md
@@ -1,7 +1,7 @@
 ---
 # csl26-xt7k
 title: Split Springer Basic family-root behavior from public wrappers
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - springer
     - style
 created_at: 2026-04-21T13:32:00Z
-updated_at: 2026-04-25T20:20:07Z
+updated_at: 2026-04-30T21:03:19Z
 ---
 
 `csl26-nrkn` confirmed that `springer-basic-brackets` has real parentage to
@@ -31,17 +31,17 @@ explicitly scope the inheritance-model follow-up needed to make that possible.
 
 ## Tasks
 
-- [ ] Decide whether the project needs a dedicated hidden Springer Basic family
+- [x] Decide whether the project needs a dedicated hidden Springer Basic family
       root instead of reusing the public `springer-basic-author-date` handle.
-- [ ] Define the minimum bibliography/type-variant delta required by
+- [x] Define the minimum bibliography/type-variant delta required by
       `springer-basic-brackets`.
-- [ ] Decide whether the project should add finer-grained inheritance/override
+- [x] Decide whether the project should add finer-grained inheritance/override
       mechanics for bibliography/type-variant structures, or keep the current
       merge semantics and accept larger wrapper YAML for this family.
-- [ ] If the current merge model remains in place, scope the smallest
+- [x] If the current merge model remains in place, scope the smallest
       infrastructure follow-up bean that would change the merge/override model
       enough to make the wrapper materially smaller.
-- [ ] Land the wrapper conversion only when the reduced YAML is materially
+- [x] Land the wrapper conversion only when the reduced YAML is materially
       smaller and preserves current accepted output.
 
 ## Acceptance
@@ -56,3 +56,26 @@ explicitly scope the inheritance-model follow-up needed to make that possible.
 - csl26-nrkn
 - csl26-ocdt
 - csl26-wp6y
+
+## Summary of Changes
+
+**Decision 1 — No hidden family root.** The two cores differ in processing
+mode, citation template, and bibliography coverage. A shared root would only
+save scalar options — not worth the indirection.
+
+**Decision 2 — Minimum delta already achieved.** The embedded layer already
+has the thinnest possible wrappers (2 option fields each). The no-et-al
+variants cannot meaningfully thin-wrap the full cores.
+
+**Decision 3 — Accept current merge semantics.** Arrays replace wholesale;
+objects deep-merge. No change to merge mechanics in this PR.
+
+**Decision 4 — Follow-up bean created** for finer-grained array/map override
+mechanics (low priority, not blocking).
+
+**Decision 5 — Fix landed.** Removed `extends: springer-basic-author-date`
+from `styles/springer-basic-brackets-no-et-al.yaml` (wrong base: numeric
+style must not extend an author-date root). Made standalone by adding
+`strip-periods`, `punctuation-in-quote`, `hanging-indent`, `entry-suffix`,
+plus explicit `webpage` and `legal-case` type-variants previously inherited.
+Oracle: 18/18 citations, 34/34 bibliography.

--- a/docs/guides/JJ_AI_CHANGE_STACK.md
+++ b/docs/guides/JJ_AI_CHANGE_STACK.md
@@ -92,6 +92,27 @@ git status --short --branch
 If jj is unavailable, use the existing Git workflow. Do not block Citum work just
 because jj is missing.
 
+## Hook Gap
+
+jj does not run git hooks. `commit-msg`, `pre-commit`, and `pre-push` are all
+silently skipped. Run the equivalent checks manually before every push:
+
+```bash
+# 1. Validate commit message (subject format, 50-char limit, body presence)
+jj log -r @ --no-graph --template 'description' > /tmp/jj-msg.txt \
+  && bash .githooks/commit-msg /tmp/jj-msg.txt
+
+# 2. For Rust changes — pre-commit gate
+cargo fmt --check \
+  && cargo clippy --all-targets --all-features -- -D warnings \
+  && cargo nextest run
+
+# 3. For any push — pre-push gate (schema regen, quality baseline)
+bash .githooks/pre-push
+```
+
+Skipping step 1 is the most common CI failure when using jj. Always run it.
+
 ## Citum Adapter
 
 The jj workflow is subordinate to Citum's repo rules:
@@ -129,6 +150,7 @@ Before push or PR creation:
   published diff.
 - Confirm `.ai-intents/` paths are absent from the final jj change and from
   `git status --short --branch`.
+- Run the manual hook checks from the **Hook Gap** section above.
 - Run the verification gate for the touched change type.
 - Push the Git branch and check CI for PR branches.
 

--- a/styles/springer-basic-brackets-no-et-al.yaml
+++ b/styles/springer-basic-brackets-no-et-al.yaml
@@ -1,4 +1,3 @@
-extends: springer-basic-author-date
 info:
   title: Springer - Basic (numeric, brackets, no "et al.")
   description: Springer Numbered Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.
@@ -27,6 +26,8 @@ options:
     - editor
     - translator
   processing: numeric
+  strip-periods: true
+  punctuation-in-quote: true
   contributors:
     display-as-sort: all
     name-form: initials
@@ -55,6 +56,8 @@ bibliography:
       delimiter: ', '
       delimiter-precedes-last: always
       sort-separator: ' '
+    hanging-indent: true
+    entry-suffix: ""
     separator: '. '
   type-variants:
     article-journal:
@@ -135,6 +138,32 @@ bibliography:
     - variable: doi
     - variable: publisher-place
       prefix: ', '
+    webpage:
+    - contributor: author
+      form: long
+      name-order: family-first
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: ' '
+    - title: primary
+      prefix: ' '
+    - variable: url
+      prefix: '. '
+    - date: accessed
+      form: month-day
+      prefix: '. Accessed '
+    - date: accessed
+      form: year
+      prefix: ' '
+    legal-case:
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+    - title: primary
+      prefix: ' '
   template:
   - contributor: author
     form: long


### PR DESCRIPTION
## Summary

- Remove `extends: springer-basic-author-date` from
  `styles/springer-basic-brackets-no-et-al.yaml` — a numeric style must not
  extend an author-date root.
- Make the style standalone by adding previously-inherited fields:
  `strip-periods`, `punctuation-in-quote`, `hanging-indent`, `entry-suffix`,
  plus explicit `webpage` and `legal-case` type-variants.
- Complete bean csl26-xt7k with all five architecture decisions documented.
- Create follow-up bean csl26-adaj (draft, low priority) for finer-grained
  array/map override mechanics.

## Fidelity

| Surface | Before | After |
|---------|--------|-------|
| Citations | 18/18 | 18/18 |
| Bibliography | 34/34 | 34/34 |

## Architecture decisions (csl26-xt7k)

1. **No hidden family root** — author-date-core and brackets-core differ enough
   in processing mode, citation template, and bibliography coverage to justify
   staying as independent files.
2. **Minimum delta already achieved** in the embedded layer (2-field wrappers).
3. **Accept current merge semantics** — array-replace-wholesale is fine for
   this family; no mechanics change in this PR.
4. **Follow-up scoped** (csl26-adaj) for patch-style override mechanics.
5. **Wrong-base fix landed** — see above.

## Test plan

- [x] `node scripts/oracle.js styles-legacy/springer-basic-brackets-no-et-al.csl` → 18/18 / 34/34
- [x] `./scripts/check-docs-beans-hygiene.sh` passes
