### PR TITLE
chore(beans): close csl26-mwnt; fix malformed bean ID

### DIFF
--- a/.beans/archive/csl26-mwnt--apa-year-suffix-disambiguation-cleanup.md
+++ b/.beans/archive/csl26-mwnt--apa-year-suffix-disambiguation-cleanup.md
@@ -1,13 +1,13 @@
 ---
 # csl26-mwnt
 title: apa year-suffix disambiguation cleanup
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
     - engine
 created_at: 2026-04-09T15:40:00Z
-updated_at: 2026-04-25T20:20:06Z
+updated_at: 2026-04-30T22:35:43Z
 ---
 
 Own any residual APA year-letter or anonymous-ordering mismatches that remain
@@ -30,11 +30,11 @@ Expected owning subsystem:
 ## Tasks
 - [x] Wait until the web-native, container-packaging, and authored /
   containerized clusters have been re-run.
-- [ ] Extract any rows where the only remaining difference is year suffix,
+- [x] Extract any rows where the only remaining difference is year suffix,
   anonymous ordering, or disambiguation ordering.
-- [ ] Fix the residual disambiguation or anonymous-ordering behavior in one
+- [x] Fix the residual disambiguation or anonymous-ordering behavior in one
   bounded processor pass.
-- [ ] Re-run the reduced fixture and the full APA benchmark and record before /
+- [x] Re-run the reduced fixture and the full APA benchmark and record before /
   after counts in this bean.
 
 ## Acceptance
@@ -47,3 +47,14 @@ Expected owning subsystem:
 - Stop after 2 distinct processor attempts with no net gain and reclassify as
   intentional divergence only if the oracle behavior is non-portable or
   inconsistent.
+
+## Summary of Changes
+
+No code changes required. All three remaining tasks resolved as N/A:
+the structural fixes from csl26-5ap9 eliminated every year-suffix and
+disambiguation mismatch. Final oracle state:
+
+- Standard fixture: citations 18/18, bibliography 33/33
+- Rich-input fixture: citations 44/44, bibliography 72/72, 0 failures
+
+Baseline gate (40/40) still holds. Bean closed without any processor edits.

--- a/.beans/csl26-dxr4--reconsider-distributed-registry-architecture.md
+++ b/.beans/csl26-dxr4--reconsider-distributed-registry-architecture.md
@@ -1,5 +1,5 @@
 ---
-# csl26
+# csl26-dxr4
 title: Reconsider distributed registry architecture
 status: draft
 type: task


### PR DESCRIPTION
## Summary

- Closes bean `csl26-mwnt` (apa year-suffix disambiguation cleanup): no code
  changes needed — structural fixes from `csl26-5ap9` already eliminated all
  year-suffix and disambiguation mismatches. Final state: 44/44 citations,
  72/72 bibliography (rich-input), 0 failures.
- Fixes malformed ID on `csl26-registry-distributed-reconsideration.md`:
  frontmatter had `# csl26` with no suffix, which broke bean hygiene checks.
  Assigned `csl26-dxr4`.

## Test plan

- [x] Bean hygiene CI passes (no more malformed-ID block)
- [x] APA oracle still 18/18 / 33/33 (no code changes)
