### PR TITLE
feat(styles): fidelity wave — locator/patent/date-form

### DIFF
--- a/.beans/archive/csl26-mwnt--apa-year-suffix-disambiguation-cleanup.md
+++ b/.beans/archive/csl26-mwnt--apa-year-suffix-disambiguation-cleanup.md
@@ -1,13 +1,13 @@
 ---
 # csl26-mwnt
 title: apa year-suffix disambiguation cleanup
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
     - engine
 created_at: 2026-04-09T15:40:00Z
-updated_at: 2026-04-25T20:20:06Z
+updated_at: 2026-04-30T22:35:43Z
 ---
 
 Own any residual APA year-letter or anonymous-ordering mismatches that remain
@@ -30,11 +30,11 @@ Expected owning subsystem:
 ## Tasks
 - [x] Wait until the web-native, container-packaging, and authored /
   containerized clusters have been re-run.
-- [ ] Extract any rows where the only remaining difference is year suffix,
+- [x] Extract any rows where the only remaining difference is year suffix,
   anonymous ordering, or disambiguation ordering.
-- [ ] Fix the residual disambiguation or anonymous-ordering behavior in one
+- [x] Fix the residual disambiguation or anonymous-ordering behavior in one
   bounded processor pass.
-- [ ] Re-run the reduced fixture and the full APA benchmark and record before /
+- [x] Re-run the reduced fixture and the full APA benchmark and record before /
   after counts in this bean.
 
 ## Acceptance
@@ -47,3 +47,14 @@ Expected owning subsystem:
 - Stop after 2 distinct processor attempts with no net gain and reclassify as
   intentional divergence only if the oracle behavior is non-portable or
   inconsistent.
+
+## Summary of Changes
+
+No code changes required. All three remaining tasks resolved as N/A:
+the structural fixes from csl26-5ap9 eliminated every year-suffix and
+disambiguation mismatch. Final oracle state:
+
+- Standard fixture: citations 18/18, bibliography 33/33
+- Rich-input fixture: citations 44/44, bibliography 72/72, 0 failures
+
+Baseline gate (40/40) still holds. Bean closed without any processor edits.

--- a/.beans/archive/csl26-ugzi--style-fidelity-wave-locator-patent-fixes-agu-ima-i.md
+++ b/.beans/archive/csl26-ugzi--style-fidelity-wave-locator-patent-fixes-agu-ima-i.md
@@ -1,0 +1,27 @@
+---
+# csl26-ugzi
+title: 'Style fidelity wave: locator + patent fixes (AGU, IMA, INFORMS)'
+status: completed
+type: task
+priority: normal
+created_at: 2026-04-30T22:59:26Z
+updated_at: 2026-04-30T23:20:25Z
+---
+
+Fix systematic fidelity gaps in 3 styles:
+1. american-geophysical-union (0.981→1.0): patent type-variant uses 'number: number' which doesn't resolve for patent type; fix to 'number: patent-number'
+2. institute-of-mathematics-and-its-applications (0.885→~1.0): IMA CSL suppresses locators in citations entirely; Citum style incorrectly includes 'variable: locator'; also fix bibliography et-al shorten inheritance
+3. institute-for-operations-research-and-the-management-sciences (0.885→~0.96+): missing 'prefix: ", "' on locator variable causes '1962p. 23' instead of '1962, p. 23'; add type-variants for legal/webpage
+
+- [x] Fix AGU patent type-variant number variable
+- [x] Fix IMA citation template (remove locator) + bibliography shorten
+- [x] Fix INFORMS locator prefix + add legal/webpage type-variants
+- [x] Run oracle and verify improvements
+- [x] Pre-commit gate pass
+
+## Summary of Changes
+
+- **american-geophysical-union** (0.981 → 1.0): fixed patent type-variant using `number: number` (wrong) → `number: patent-number`
+- **institute-of-mathematics-and-its-applications** (0.885 → 1.0): removed `variable: locator` from citation template (IMA CSL suppresses locators); added explicit `shorten: {min: 99}` to bibliography contributors to prevent global et-al settings cascading
+- **institute-for-operations-research-and-the-management-sciences** (0.885 → 1.0): added `prefix: ", "` to citation locator; added `webpage` type-variant using `term: retrieved` locale term + new `month-abbr-day-year` date form; added `legal_case` type-variant stripping reporter/volume/pages (title serves as identifier)
+- **Engine co-evolution**: added `MonthAbbrDayYear` date form ("Jan 15, 2024" format) to `DateForm` enum and both rendering functions in `date.rs`

--- a/.beans/csl26-dxr4--reconsider-distributed-registry-architecture.md
+++ b/.beans/csl26-dxr4--reconsider-distributed-registry-architecture.md
@@ -1,5 +1,5 @@
 ---
-# csl26
+# csl26-dxr4
 title: Reconsider distributed registry architecture
 status: draft
 type: task

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "typst",
  "typst-kit",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -899,7 +899,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.30.3"
+version = "0.31.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -384,6 +384,16 @@ fn format_range_start(
                 (false, Some(d)) => format!("{d} {month} {year}"),
             }
         }
+        DateForm::MonthAbbrDayYear => {
+            let year = extract_year(date);
+            let month = extract_month(date, &locale.dates.months.short);
+            let day = date.day();
+            match (month.is_empty(), day) {
+                (true, _) => year,
+                (false, None) => format!("{month} {year}"),
+                (false, Some(d)) => format!("{month} {d}, {year}"),
+            }
+        }
     }
 }
 
@@ -491,7 +501,10 @@ fn inline_disamb_suffix(formatted: &str, form: &DateForm, year: &str, suffix: &s
 
     let year_index = match form {
         DateForm::Year | DateForm::YearMonthDay => formatted.find(year),
-        DateForm::YearMonth | DateForm::Full | DateForm::DayMonthAbbrYear => formatted.rfind(year),
+        DateForm::YearMonth
+        | DateForm::Full
+        | DateForm::DayMonthAbbrYear
+        | DateForm::MonthAbbrDayYear => formatted.rfind(year),
         DateForm::MonthDay => None,
     };
 
@@ -644,6 +657,19 @@ fn format_single_date(
                 (true, _) => Some(year),
                 (false, None) => Some(format!("{month} {year}")),
                 (false, Some(d)) => Some(format!("{d} {month} {year}")),
+            }
+        }
+        DateForm::MonthAbbrDayYear => {
+            let year = extract_year(date);
+            if year.is_empty() {
+                return None;
+            }
+            let month = extract_month(date, &locale.dates.months.short);
+            let day = date.day();
+            match (month.is_empty(), day) {
+                (true, _) => Some(year),
+                (false, None) => Some(format!("{month} {year}")),
+                (false, Some(d)) => Some(format!("{month} {d}, {year}")),
             }
         }
     }

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -95,7 +95,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.38.0";
+pub const STYLE_SCHEMA_VERSION: &str = "0.39.0";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -635,6 +635,8 @@ pub enum DateForm {
     MonthDay,
     YearMonthDay,
     DayMonthAbbrYear,
+    /// Abbreviated month + day + year in US order: "Jan 15, 2024".
+    MonthAbbrDayYear,
 }
 
 /// A title component.

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,10 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.39.0 (2026-04-30)
+- Schema version bumped from 0.38.0 to 0.39.0
+- Added `MonthAbbrDayYear` date form (abbreviated month + day + year in US order)
+
 #### schema-v0.38.0 (2026-04-29)
 - Schema version bumped from 0.37.1 to 0.38.0
 - Breaking: geographic place fields now use the transparent `Place` newtype while preserving string wire compatibility

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7,7 +7,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.38.0"
+      "default": "0.39.0"
     },
     "info": {
       "description": "Style metadata.",
@@ -1261,14 +1261,23 @@
     },
     "DateForm": {
       "description": "Date rendering forms.",
-      "type": "string",
-      "enum": [
-        "year",
-        "year-month",
-        "full",
-        "month-day",
-        "year-month-day",
-        "day-month-abbr-year"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "year",
+            "year-month",
+            "full",
+            "month-day",
+            "year-month-day",
+            "day-month-abbr-year"
+          ]
+        },
+        {
+          "description": "Abbreviated month + day + year in US order: \"Jan 15, 2024\".",
+          "type": "string",
+          "const": "month-abbr-day-year"
+        }
       ]
     },
     "TemplateTitle": {

--- a/styles/american-geophysical-union.yaml
+++ b/styles/american-geophysical-union.yaml
@@ -342,7 +342,7 @@ bibliography:
         wrap:
           punctuation: parentheses
         prefix: ' '
-      - number: number
+      - number: patent-number
         prefix: '. '
     personal_communication:
       - contributor: author

--- a/styles/institute-for-operations-research-and-the-management-sciences.yaml
+++ b/styles/institute-for-operations-research-and-the-management-sciences.yaml
@@ -61,6 +61,7 @@ citation:
     form: year
     prefix: " "
   - variable: locator
+    prefix: ", "
   wrap:
     punctuation: parentheses
   delimiter: ". "
@@ -82,6 +83,40 @@ bibliography:
     entry-suffix: .
     separator: ". "
   type-variants:
+    webpage:
+    - contributor: author
+      form: long
+      name-order: family-first
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      prefix: " "
+    - group:
+      - term: retrieved
+        form: long
+        text-case: capitalize-first
+      - date: accessed
+        form: month-abbr-day-year
+        wrap:
+          punctuation: parentheses
+        prefix: " "
+      suffix: ", "
+      prefix: ". "
+    - variable: url
+    legal_case:
+    - contributor: author
+      form: long
+      name-order: family-first
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      prefix: " "
     chapter:
     - contributor: author
       form: long

--- a/styles/institute-of-mathematics-and-its-applications.yaml
+++ b/styles/institute-of-mathematics-and-its-applications.yaml
@@ -61,7 +61,6 @@ citation:
   - date: issued
     form: year
     prefix: ", "
-  - variable: locator
   wrap:
     punctuation: parentheses
   delimiter: ". "
@@ -72,6 +71,10 @@ bibliography:
       display-as-sort: all
       name-form: initials
       initialize-with: .
+      shorten:
+        min: 99
+        use-first: 99
+        and-others: et-al
     hanging-indent: true
     entry-suffix: .
     separator: ", "


### PR DESCRIPTION
## Summary

Brings three styles from ~0.885–0.981 to 1.0 fidelity via targeted style fixes and one engine co-evolution.

**Engine change:** Added `MonthAbbrDayYear` date form (`"Jan 15, 2024"` format) to `DateForm` enum and both date rendering paths in `citum-engine`. This is a schema-major addition (new enum variant).

**Style fixes:**
- `american-geophysical-union`: patent type-variant used `number: number` instead of `number: patent-number`
- `institute-of-mathematics-and-its-applications`: removed spurious `variable: locator` from citation template (IMA CSL suppresses locators); added explicit `shorten` cap on bibliography contributors to block global cascade
- `institute-for-operations-research-and-the-management-sciences`: added `prefix: ", "` to locator in citation; added `webpage` type-variant using `term: retrieved` (not hardcoded English) + new `MonthAbbrDayYear` form; added `legal_case` type-variant (title substitutes for author — no anonymous fallback)

## Test plan

- [x] `cargo nextest run` — all 1129 tests pass
- [x] `node scripts/report-core.js` quality gate passes
- [x] AGU, IMA, INFORMS each reach 1.0 fidelity in oracle output
- [x] CI green
