### PR TITLE
feat(engine): partition multilingual bibliographies

### DIFF
--- a/.beans/archive/csl26-al0f--per-script-bibliography-partitioning.md
+++ b/.beans/archive/csl26-al0f--per-script-bibliography-partitioning.md
@@ -1,11 +1,11 @@
 ---
 # csl26-al0f
 title: Per-script bibliography partitioning
-status: in-progress
+status: completed
 type: feature
 priority: high
 created_at: 2026-05-01T11:32:07Z
-updated_at: 2026-05-01T12:55:13Z
+updated_at: 2026-05-01T14:04:49Z
 ---
 
 Allow multilingual bibliographies to be grouped or sorted per script/language (e.g. Latin names in one section, Arabic in another) rather than interleaved by a single global collator. Currently explicitly out of scope in the Unicode sorting spec — deferred by design. Implement once the single-collator pass is proven stable. Related: UNICODE_BIBLIOGRAPHY_SORTING.md Scope section.
@@ -15,3 +15,11 @@ A single global collator produces consistent order, but many users expect separa
 The mixed-script bibliography integration test added in csl26-dnz7 (sort_oracle::test_mixed_script_bibliography_sort_stability) validates the single-collator foundation this builds on. This feature likely requires a new schema option (see csl26-xz2t) to let styles request partitioned output.
 
 Spec: docs/specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md
+
+## Summary of Changes
+
+- Cached partition keys and configured ranks during partition sorting.
+- Rendered automatic partition sections from sorted references so subsequent-author substitution matches the final visible order and resets per section.
+- Added regression coverage for section substitution reset and partition ordering, and documented the schema option in the changelog.
+
+\nFollow-up: reconcile PR version metadata to the pre-1.0 expected workspace version before force-push and CI confirmation.

--- a/.beans/csl26-al0f--per-script-bibliography-partitioning.md
+++ b/.beans/csl26-al0f--per-script-bibliography-partitioning.md
@@ -1,11 +1,11 @@
 ---
 # csl26-al0f
 title: Per-script bibliography partitioning
-status: todo
+status: in-progress
 type: feature
 priority: high
 created_at: 2026-05-01T11:32:07Z
-updated_at: 2026-05-01T12:02:48Z
+updated_at: 2026-05-01T12:55:13Z
 ---
 
 Allow multilingual bibliographies to be grouped or sorted per script/language (e.g. Latin names in one section, Arabic in another) rather than interleaved by a single global collator. Currently explicitly out of scope in the Unicode sorting spec — deferred by design. Implement once the single-collator pass is proven stable. Related: UNICODE_BIBLIOGRAPHY_SORTING.md Scope section.
@@ -13,3 +13,5 @@ Allow multilingual bibliographies to be grouped or sorted per script/language (e
 A single global collator produces consistent order, but many users expect separate sections or language/script-first grouping in multilingual lists. This is a common product-level response to the fact that no universal multilingual order feels natural to every reader — it is not a collation bug, but users will report it as one. There is documented user demand for this in citation software. Example: https://forums.zotero.org/discussion/comment/280559/#Comment_280559 — a user with a mixed Latin/CJK bibliography explains the expected grouping behaviour.
 
 The mixed-script bibliography integration test added in csl26-dnz7 (sort_oracle::test_mixed_script_bibliography_sort_stability) validates the single-collator foundation this builds on. This feature likely requires a new schema option (see csl26-xz2t) to let styles request partitioned output.
+
+Spec: docs/specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md

--- a/.beans/csl26-tap8--support-broader-per-document-configuration-overrid.md
+++ b/.beans/csl26-tap8--support-broader-per-document-configuration-overrid.md
@@ -1,0 +1,33 @@
+---
+# csl26-tap8
+title: Support broader per-document configuration overrides
+status: todo
+type: task
+priority: normal
+tags:
+    - engine
+    - schema
+created_at: 2026-05-01T14:26:15Z
+updated_at: 2026-05-01T14:26:15Z
+---
+
+Extend the document frontmatter parsing to support broader configuration
+overrides beyond just `bibliography` groups and `integral-names`.
+
+## Context
+
+Currently, `sort-partitioning` and other behavioral settings only live on
+the `Style`'s `BibliographyOptions` or `Config`. A user cannot override
+these on a per-document basis without modifying the style.
+
+## Required Changes
+
+- Extend `DocumentFrontmatter` in `crates/citum-engine/src/processor/document/djot/parsing.rs`
+  to allow an `options` block (analogous to `BibliographyOptions` or
+  `CitationOptions`).
+- Update `ParsedDocument` in `crates/citum-engine/src/processor/document/types.rs`
+  to hold these new configuration overrides.
+- Update `Processor` (likely in `setup.rs`) to merge document-level
+  configuration overrides into the style's default configuration.
+
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -560,13 +560,14 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "thiserror 2.0.18",
+ "unicode-script",
  "url",
  "winnow 0.7.15",
 ]
 
 [[package]]
 name = "citum-migrate"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -580,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "typst",
  "typst-kit",
@@ -589,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -601,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -616,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -634,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -649,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -899,7 +900,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.31.2"
+version = "0.32.0"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.31.2"
+version = "0.32.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -28,6 +28,7 @@ jotdown = "0.5"
 orgize = "0.9"
 icu_collator = { version = "2.2.0", features = ["compiled_data"] }
 icu_locale = "2.2.0"
+unicode-script = "0.5.8"
 
 [features]
 ffi = []

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -99,6 +99,7 @@ pub mod processor;
 pub mod reference;
 /// Output-format renderers and string conversion helpers.
 pub mod render;
+mod sort_partitioning;
 mod sort_support;
 /// Template value resolution and formatting helpers.
 pub mod values;

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -15,6 +15,7 @@ use crate::render::ProcEntry;
 use crate::render::format::{OutputFormat, ProcEntryMetadata};
 use crate::values::{ProcHints, RenderContext, RenderOptions, format_contributors_short};
 use citum_schema::grouping::{BibliographyGroup, DisambiguationScope, GroupHeading};
+use citum_schema::options::{BibliographyPartitionHeading, BibliographySortPartitioning};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
@@ -65,6 +66,20 @@ impl Processor {
             .iter()
             .min_by(|left, right| left.0.cmp(right.0))
             .map(|(_locale, value)| value.clone())
+    }
+
+    fn resolve_partition_heading(&self, heading: &BibliographyPartitionHeading) -> Option<String> {
+        match heading {
+            BibliographyPartitionHeading::Literal { literal } => Some(literal.clone()),
+            BibliographyPartitionHeading::Term { term, form } => self.locale.resolved_general_term(
+                term,
+                form.unwrap_or(citum_schema::locale::TermForm::Long),
+                None,
+            ),
+            BibliographyPartitionHeading::Localized { localized } => {
+                self.resolve_localized_heading(localized)
+            }
+        }
     }
 
     fn collect_matching_group_refs<'a>(
@@ -250,6 +265,58 @@ impl Processor {
         ));
     }
 
+    fn append_rendered_partition<F>(
+        &self,
+        result: &mut String,
+        heading: Option<&BibliographyPartitionHeading>,
+        entries: Vec<ProcEntry>,
+    ) where
+        F: OutputFormat<Output = String>,
+    {
+        if !result.is_empty() {
+            result.push_str("\n\n");
+        }
+
+        if let Some(heading) =
+            heading.and_then(|group_heading| self.resolve_partition_heading(group_heading))
+        {
+            result.push_str(&self.render_group_heading::<F>(&heading));
+        }
+
+        result.push_str(&crate::render::refs_to_string_with_format::<F>(
+            entries, None, None,
+        ));
+    }
+
+    fn render_with_partition_sections<F>(
+        &self,
+        sorted_refs: Vec<&Reference>,
+        partitioning: &BibliographySortPartitioning,
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let fmt = F::default();
+        let mut result = String::new();
+
+        for (partition_key, references) in
+            crate::sort_partitioning::partition_references(sorted_refs, &self.locale, partitioning)
+        {
+            let heading = partition_key
+                .as_ref()
+                .and_then(|key| partitioning.headings.get(key));
+            let entries = self.merge_compound_entries::<F>(self.process_sorted_refs::<_, F>(
+                references.into_iter(),
+                |reference, entry_number| {
+                    self.process_bibliography_entry_with_format::<F>(reference, entry_number)
+                },
+            ));
+            self.append_rendered_partition::<F>(&mut result, heading, entries);
+        }
+
+        fmt.finish(result)
+    }
+
     fn append_unassigned_entries<F>(
         &self,
         result: &mut String,
@@ -396,17 +463,26 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        let processed = self.process_references();
-
         if let Some(groups) = self
             .style
             .bibliography
             .as_ref()
             .and_then(|bibliography| bibliography.groups.as_ref())
         {
+            let processed = self.process_references();
             return self.render_with_custom_groups::<F>(&processed.bibliography, groups);
         }
 
+        let bibliography_options = self.get_bibliography_options();
+        if let Some(partitioning) = bibliography_options.sort_partitioning.as_ref()
+            && crate::sort_partitioning::should_render_sections(partitioning)
+        {
+            self.initialize_numeric_bibliography_numbers();
+            let sorted_refs = self.sort_references(self.bibliography.values().collect());
+            return self.render_with_partition_sections::<F>(sorted_refs, partitioning);
+        }
+
+        let processed = self.process_references();
         self.render_with_legacy_grouping::<F>(
             &self.merge_compound_entries::<F>(processed.bibliography),
         )

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -205,24 +205,7 @@ impl Processor {
     }
 
     fn sort_citation_number_order(&self) -> Vec<String> {
-        if let Some(sort_spec) = self
-            .style
-            .bibliography
-            .as_ref()
-            .and_then(|bibliography| bibliography.sort.as_ref())
-        {
-            let sorter = crate::grouping::GroupSorter::new(&self.locale);
-            return sorter
-                .sort_references(self.bibliography.values().collect(), &sort_spec.resolve())
-                .into_iter()
-                .filter_map(citum_schema::reference::InputReference::id)
-                .map(String::from)
-                .collect();
-        }
-
-        let bibliography_config = self.get_bibliography_config();
-        Sorter::new(&bibliography_config, &self.locale)
-            .sort_references(self.bibliography.values().collect())
+        self.sort_references(self.bibliography.values().collect())
             .into_iter()
             .filter_map(citum_schema::reference::InputReference::id)
             .map(String::from)
@@ -457,14 +440,27 @@ impl Processor {
     ///
     /// Uses style-specified sort keys (author, title, issued, etc.) and sort order.
     pub fn sort_references<'a>(&self, references: Vec<&'a Reference>) -> Vec<&'a Reference> {
-        if let Some(sort_spec) = self.resolved_bibliography_sort() {
+        let mut sorted_refs = if let Some(sort_spec) = self.resolved_bibliography_sort() {
             let sorter = crate::grouping::GroupSorter::new(&self.locale);
-            return sorter.sort_references(references, &sort_spec);
+            sorter.sort_references(references, &sort_spec)
+        } else {
+            let bibliography_config = self.get_bibliography_config();
+            let sorter = Sorter::new(&bibliography_config, &self.locale);
+            sorter.sort_references(references)
+        };
+
+        let bibliography_options = self.get_bibliography_options();
+        if let Some(partitioning) = bibliography_options.sort_partitioning.as_ref()
+            && crate::sort_partitioning::should_sort_flat(partitioning)
+        {
+            crate::sort_partitioning::sort_by_partition(
+                sorted_refs.as_mut_slice(),
+                &self.locale,
+                partitioning,
+            );
         }
 
-        let bibliography_config = self.get_bibliography_config();
-        let sorter = Sorter::new(&bibliography_config, &self.locale);
-        sorter.sort_references(references)
+        sorted_refs
     }
 
     /// Sort citation items according to the style's citation sort specification.

--- a/crates/citum-engine/src/sort_partitioning.rs
+++ b/crates/citum-engine/src/sort_partitioning.rs
@@ -1,0 +1,359 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Multilingual bibliography partitioning helpers.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use citum_schema::grouping::NameSortOrder;
+use citum_schema::locale::Locale;
+use citum_schema::options::{
+    BibliographyPartitionKind, BibliographyPartitionMode, BibliographySortPartitioning,
+};
+use unicode_script::{Script, UnicodeScript};
+
+use crate::reference::Reference;
+use crate::sort_support::author_sort_key_opt;
+
+/// Whether partitioning should affect flat bibliography sort order.
+pub(crate) fn should_sort_flat(partitioning: &BibliographySortPartitioning) -> bool {
+    matches!(
+        partitioning.mode,
+        BibliographyPartitionMode::SortOnly | BibliographyPartitionMode::SortAndSections
+    )
+}
+
+/// Whether partitioning should render visible grouped bibliography sections.
+pub(crate) fn should_render_sections(partitioning: &BibliographySortPartitioning) -> bool {
+    matches!(
+        partitioning.mode,
+        BibliographyPartitionMode::Sections | BibliographyPartitionMode::SortAndSections
+    )
+}
+
+/// Derive the bibliography partition key for one reference.
+pub(crate) fn partition_key(
+    reference: &Reference,
+    locale: &Locale,
+    partitioning: &BibliographySortPartitioning,
+) -> Option<String> {
+    match partitioning.by {
+        BibliographyPartitionKind::Script => script_partition_key(reference, locale),
+        BibliographyPartitionKind::Language => language_partition_key(reference),
+    }
+}
+
+/// Sort references by partition while preserving existing order inside partitions.
+pub(crate) fn sort_by_partition(
+    references: &mut [&Reference],
+    locale: &Locale,
+    partitioning: &BibliographySortPartitioning,
+) {
+    let ordering = PartitionOrdering::new(partitioning);
+    let mut cached = cache_partitioned_references(references.iter().copied(), locale, partitioning);
+    cached.sort_by(|left, right| ordering.compare_keys(left.key.as_deref(), right.key.as_deref()));
+
+    for (slot, entry) in references.iter_mut().zip(cached) {
+        *slot = entry.reference;
+    }
+}
+
+/// Partition references into section buckets ordered by configured partition rank.
+pub(crate) fn partition_references<'a>(
+    references: Vec<&'a Reference>,
+    locale: &Locale,
+    partitioning: &BibliographySortPartitioning,
+) -> Vec<(Option<String>, Vec<&'a Reference>)> {
+    let ordering = PartitionOrdering::new(partitioning);
+    let mut grouped: HashMap<Option<String>, Vec<&'a Reference>> = HashMap::new();
+
+    for entry in cache_partitioned_references(references, locale, partitioning) {
+        grouped
+            .entry(entry.key.clone())
+            .or_default()
+            .push(entry.reference);
+    }
+
+    let mut keys = grouped.keys().cloned().collect::<Vec<_>>();
+    keys.sort_by(|left, right| ordering.compare_keys(left.as_deref(), right.as_deref()));
+
+    keys.into_iter()
+        .filter_map(|key| grouped.remove(&key).map(|entries| (key, entries)))
+        .collect()
+}
+
+struct PartitionOrdering {
+    configured_ranks: HashMap<String, usize>,
+}
+
+impl PartitionOrdering {
+    fn new(partitioning: &BibliographySortPartitioning) -> Self {
+        Self {
+            configured_ranks: partitioning
+                .order
+                .iter()
+                .cloned()
+                .enumerate()
+                .map(|(rank, key)| (key, rank))
+                .collect(),
+        }
+    }
+
+    fn compare_keys(&self, left: Option<&str>, right: Option<&str>) -> Ordering {
+        self.partition_rank(left)
+            .cmp(&self.partition_rank(right))
+            .then_with(|| match (left, right) {
+                (Some(left_key), Some(right_key)) => left_key.cmp(right_key),
+                (Some(_), None) => Ordering::Less,
+                (None, Some(_)) => Ordering::Greater,
+                (None, None) => Ordering::Equal,
+            })
+    }
+
+    fn partition_rank(&self, partition_key: Option<&str>) -> usize {
+        let Some(partition_key) = partition_key else {
+            return usize::MAX;
+        };
+
+        self.configured_ranks
+            .get(partition_key)
+            .copied()
+            .unwrap_or(usize::MAX - 1)
+    }
+}
+
+struct PartitionedReference<'a> {
+    reference: &'a Reference,
+    key: Option<String>,
+}
+
+fn cache_partitioned_references<'a>(
+    references: impl IntoIterator<Item = &'a Reference>,
+    locale: &Locale,
+    partitioning: &BibliographySortPartitioning,
+) -> Vec<PartitionedReference<'a>> {
+    references
+        .into_iter()
+        .map(|reference| PartitionedReference {
+            key: partition_key(reference, locale, partitioning),
+            reference,
+        })
+        .collect()
+}
+
+fn language_partition_key(reference: &Reference) -> Option<String> {
+    crate::values::effective_item_language(reference).and_then(non_empty_key)
+}
+
+fn script_partition_key(reference: &Reference, locale: &Locale) -> Option<String> {
+    let sort_key = author_sort_key_opt(reference, NameSortOrder::FamilyGiven, locale, true)?;
+    sort_key.chars().find_map(script_code_for_char)
+}
+
+fn script_code_for_char(ch: char) -> Option<String> {
+    let script = ch.script();
+    if matches!(script, Script::Common | Script::Inherited | Script::Unknown) {
+        return None;
+    }
+
+    Some(script.short_name().to_string())
+}
+
+fn non_empty_key(key: String) -> Option<String> {
+    let trimmed = key.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::unreachable,
+    clippy::get_unwrap,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn partitioning(by: BibliographyPartitionKind) -> BibliographySortPartitioning {
+        BibliographySortPartitioning {
+            by,
+            mode: BibliographyPartitionMode::SortOnly,
+            order: Vec::new(),
+            headings: std::collections::HashMap::new(),
+        }
+    }
+
+    fn reference(id: &str, family: Option<&str>, title: &str, language: Option<&str>) -> Reference {
+        let mut value = json!({
+            "id": id,
+            "type": "book",
+            "title": title
+        });
+        if let Some(family) = family {
+            value["author"] = json!([{"family": family, "given": "Test"}]);
+        }
+        if let Some(language) = language {
+            value["language"] = json!(language);
+        }
+
+        let legacy: csl_legacy::csl_json::Reference = serde_json::from_value(value).unwrap();
+        legacy.into()
+    }
+
+    #[test]
+    fn detects_common_script_partition_keys() {
+        let locale = Locale::en_us();
+        let script = partitioning(BibliographyPartitionKind::Script);
+
+        assert_eq!(
+            partition_key(
+                &reference("latn", Some("Smith"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Latn")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("cyrl", Some("Пушкин"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Cyrl")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("arab", Some("الغزالي"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Arab")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("hani", Some("乌云"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Hani")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("hira", Some("あおい"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Hira")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("kana", Some("アオイ"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Kana")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("hang", Some("김"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Hang")
+        );
+    }
+
+    #[test]
+    fn skips_punctuation_before_script_detection() {
+        let locale = Locale::en_us();
+        let script = partitioning(BibliographyPartitionKind::Script);
+        let reference = reference("punct", Some("...Пушкин"), "Title", None);
+
+        assert_eq!(
+            partition_key(&reference, &locale, &script).as_deref(),
+            Some("Cyrl")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_title_for_script_detection() {
+        let locale = Locale::en_us();
+        let script = partitioning(BibliographyPartitionKind::Script);
+        let reference = reference("title", None, "東京", None);
+
+        assert_eq!(
+            partition_key(&reference, &locale, &script).as_deref(),
+            Some("Hani")
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unknown_script_key() {
+        let locale = Locale::en_us();
+        let script = partitioning(BibliographyPartitionKind::Script);
+        let reference = reference("unknown", None, "1234", None);
+
+        assert_eq!(partition_key(&reference, &locale, &script), None);
+    }
+
+    #[test]
+    fn language_partitioning_uses_effective_item_language() {
+        let locale = Locale::en_us();
+        let language = partitioning(BibliographyPartitionKind::Language);
+        let reference = reference("ru", Some("Пушкин"), "Title", Some("ru"));
+
+        assert_eq!(
+            partition_key(&reference, &locale, &language).as_deref(),
+            Some("ru")
+        );
+    }
+
+    #[test]
+    fn partitions_references_in_configured_order() {
+        let locale = Locale::en_us();
+        let partitioning = BibliographySortPartitioning {
+            by: BibliographyPartitionKind::Language,
+            mode: BibliographyPartitionMode::Sections,
+            order: vec!["ru".to_string(), "en".to_string()],
+            headings: std::collections::HashMap::new(),
+        };
+        let ru = reference("ru", Some("Пушкин"), "Title", Some("ru"));
+        let en = reference("en", Some("Smith"), "Title", Some("en"));
+        let unknown = reference("unknown", Some("Doe"), "Title", None);
+
+        let partitioned = partition_references(vec![&en, &unknown, &ru], &locale, &partitioning);
+
+        assert_eq!(
+            partitioned
+                .iter()
+                .map(|(key, refs)| (
+                    key.as_deref(),
+                    refs.iter()
+                        .map(|reference| reference.id().expect("test fixture ids").to_string())
+                        .collect::<Vec<_>>()
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (Some("ru"), vec!["ru".to_string()]),
+                (Some("en"), vec!["en".to_string()]),
+                (None, vec!["unknown".to_string()]),
+            ]
+        );
+    }
+}

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -24,10 +24,11 @@ use citum_schema::{
     BibliographySpec, CitationSpec, Style, StyleInfo,
     options::{
         AndOptions, ArticleJournalBibliographyConfig, ArticleJournalNoPageFallback,
-        BibliographyOptions, Config, ContributorConfig, DelimiterPrecedesLast,
-        DemoteNonDroppingParticle, DisplayAsSort, LinkAnchor, LinkTarget, LinksConfig,
-        MultilingualConfig, MultilingualMode, Processing, ProcessingCustom, Sort, SortKey,
-        SortSpec,
+        BibliographyOptions, BibliographyPartitionHeading, BibliographyPartitionKind,
+        BibliographyPartitionMode, BibliographySortPartitioning, Config, ContributorConfig,
+        DelimiterPrecedesLast, DemoteNonDroppingParticle, DisplayAsSort, LinkAnchor, LinkTarget,
+        LinksConfig, MultilingualConfig, MultilingualMode, Processing, ProcessingCustom, Sort,
+        SortKey, SortSpec,
     },
     reference::{
         Contributor, EdtfString, InputReference, Monograph, MonographType, Numbering,
@@ -138,6 +139,297 @@ fn build_title_year_sorted_style(sort: Vec<SortSpec>) -> Style {
         }),
         ..Default::default()
     }
+}
+
+fn build_partition_style(partition_yaml: &str, groups_yaml: &str) -> Style {
+    fn indent_block(block: &str) -> String {
+        block
+            .trim_matches('\n')
+            .lines()
+            .map(|line| {
+                if line.is_empty() {
+                    String::new()
+                } else {
+                    format!("  {line}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    let partition_yaml = indent_block(partition_yaml);
+    let groups_yaml = indent_block(groups_yaml);
+    let yaml = format!(
+        r#"
+info:
+  id: partition-test
+  title: Partition Test
+  default-locale: en-US
+bibliography:
+{partition_yaml}
+{groups_yaml}
+  sort:
+    template:
+      - key: title
+  template:
+    - title: primary
+"#
+    );
+
+    serde_yaml::from_str(&yaml).expect("partition style should parse")
+}
+
+fn partition_reference(id: &str, title: &str, language: Option<&str>) -> InputReference {
+    let mut fixture = serde_json::json!({
+        "id": id,
+        "type": "book",
+        "title": title
+    });
+    if let Some(language) = language {
+        fixture["language"] = serde_json::json!(language);
+    }
+
+    let legacy: csl_legacy::csl_json::Reference =
+        serde_json::from_value(fixture).expect("partition fixture should parse");
+    legacy.into()
+}
+
+fn script_partition_bibliography() -> IndexMap<String, InputReference> {
+    IndexMap::from([
+        (
+            "latin".to_string(),
+            partition_reference("latin", "Alpha", Some("en")),
+        ),
+        (
+            "cyrl".to_string(),
+            partition_reference("cyrl", "Бета", Some("ru")),
+        ),
+        (
+            "hani".to_string(),
+            partition_reference("hani", "東京", Some("ja")),
+        ),
+    ])
+}
+
+fn language_partition_bibliography() -> IndexMap<String, InputReference> {
+    IndexMap::from([
+        (
+            "en".to_string(),
+            partition_reference("en", "Alpha", Some("en")),
+        ),
+        (
+            "ru".to_string(),
+            partition_reference("ru", "Beta", Some("ru")),
+        ),
+        (
+            "ja".to_string(),
+            partition_reference("ja", "Gamma", Some("ja")),
+        ),
+    ])
+}
+
+fn language_partition_reference(
+    id: &str,
+    family: &str,
+    given: &str,
+    title: &str,
+    language: &str,
+) -> InputReference {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_value(serde_json::json!({
+        "id": id,
+        "type": "book",
+        "title": title,
+        "language": language,
+        "author": [{
+            "family": family,
+            "given": given
+        }]
+    }))
+    .expect("language partition fixture should parse");
+    legacy.into()
+}
+
+fn language_partition_substitute_style() -> Style {
+    let mut style = make_style_with_substitute(Some("———".to_string()));
+    style.info.title = Some("Partition Substitute Test".to_string());
+    style.info.id = Some("partition-substitute-test".into());
+    style
+        .bibliography
+        .as_mut()
+        .expect("partition substitute style should have bibliography")
+        .options
+        .get_or_insert_with(BibliographyOptions::default)
+        .sort_partitioning = Some(BibliographySortPartitioning {
+        by: BibliographyPartitionKind::Language,
+        mode: BibliographyPartitionMode::Sections,
+        order: vec!["ru".to_string(), "en".to_string()],
+        headings: HashMap::from([
+            (
+                "ru".to_string(),
+                BibliographyPartitionHeading::Literal {
+                    literal: "Russian".to_string(),
+                },
+            ),
+            (
+                "en".to_string(),
+                BibliographyPartitionHeading::Literal {
+                    literal: "English".to_string(),
+                },
+            ),
+        ]),
+    });
+    style
+        .bibliography
+        .as_mut()
+        .expect("partition substitute style should have bibliography")
+        .template = Some(vec![
+        citum_schema::tc_contributor!(Author, Long),
+        citum_schema::tc_title!(Primary, prefix = ". "),
+    ]);
+    style
+}
+
+#[test]
+fn given_no_partitioning_when_rendering_mixed_script_bibliography_then_single_collator_order_is_preserved()
+ {
+    announce_behavior(
+        "Mixed-script bibliographies preserve the existing single-collator order unless partitioning is enabled.",
+    );
+    let style = build_partition_style("", "");
+    let processor = Processor::new(style, script_partition_bibliography());
+
+    assert_eq!(processor.render_bibliography(), "Alpha\n\nБета\n\n東京");
+}
+
+#[test]
+fn given_script_sort_only_partitioning_when_rendering_flat_bibliography_then_partition_order_precedes_title_sort()
+ {
+    announce_behavior(
+        "Script partitioning in sort-only mode renders one flat bibliography ordered by configured script blocks.",
+    );
+    let style = build_partition_style(
+        r#"
+options:
+  sort-partitioning:
+    by: script
+    mode: sort-only
+    order: [Cyrl, Latn, Hani]
+"#,
+        "",
+    );
+    let processor = Processor::new(style, script_partition_bibliography());
+
+    assert_eq!(processor.render_bibliography(), "Бета\n\nAlpha\n\n東京");
+}
+
+#[test]
+fn given_language_sort_only_partitioning_when_rendering_flat_bibliography_then_effective_language_order_is_used()
+ {
+    announce_behavior(
+        "Language partitioning uses reference language before the normal bibliography sort chain.",
+    );
+    let style = build_partition_style(
+        r#"
+options:
+  sort-partitioning:
+    by: language
+    mode: sort-only
+    order: [ru, en, ja]
+"#,
+        "",
+    );
+    let processor = Processor::new(style, language_partition_bibliography());
+
+    assert_eq!(processor.render_bibliography(), "Beta\n\nAlpha\n\nGamma");
+}
+
+#[test]
+fn given_script_section_partitioning_when_rendering_grouped_bibliography_then_configured_headings_are_used()
+ {
+    announce_behavior(
+        "Script partitioning in sections mode renders automatic grouped bibliography sections with configured headings.",
+    );
+    let style = build_partition_style(
+        r#"
+options:
+  sort-partitioning:
+    by: script
+    mode: sections
+    order: [Cyrl, Latn, Hani]
+    headings:
+      Cyrl: { literal: "Cyrillic" }
+      Latn: { literal: "Latin" }
+      Hani: { literal: "Han" }
+"#,
+        "",
+    );
+    let processor = Processor::new(style, script_partition_bibliography());
+
+    assert_eq!(
+        processor.render_grouped_bibliography_with_format::<PlainText>(),
+        "# Cyrillic\n\nБета\n\n# Latin\n\nAlpha\n\n# Han\n\n東京"
+    );
+}
+
+#[test]
+fn given_explicit_groups_when_partition_sections_are_enabled_then_manual_groups_remain_authoritative()
+ {
+    announce_behavior(
+        "Explicit bibliography groups disable automatic partition sections while retaining partition-aware order inside unsorted groups.",
+    );
+    let style = build_partition_style(
+        r#"
+options:
+  sort-partitioning:
+    by: script
+    mode: sort-and-sections
+    order: [Cyrl, Latn, Hani]
+    headings:
+      Cyrl: { literal: "Cyrillic" }
+      Latn: { literal: "Latin" }
+      Hani: { literal: "Han" }
+"#,
+        r#"
+groups:
+  - id: manual
+    heading: { literal: "Manual Group" }
+    selector: {}
+"#,
+    );
+    let processor = Processor::new(style, script_partition_bibliography());
+
+    assert_eq!(
+        processor.render_grouped_bibliography_with_format::<PlainText>(),
+        "# Manual Group\n\nБета\n\nAlpha\n\n東京"
+    );
+}
+
+#[test]
+fn language_partition_sections_reset_subsequent_author_substitution_per_section() {
+    announce_behavior(
+        "Partition sections render subsequent-author substitution within a section only, resetting the chain at each new partition.",
+    );
+    let style = language_partition_substitute_style();
+    let bibliography = IndexMap::from([
+        (
+            "ru-first".to_string(),
+            language_partition_reference("ru-first", "Smith", "John", "Alpha", "ru"),
+        ),
+        (
+            "ru-second".to_string(),
+            language_partition_reference("ru-second", "Smith", "John", "Beta", "ru"),
+        ),
+        (
+            "en-only".to_string(),
+            language_partition_reference("en-only", "Smith", "John", "Gamma", "en"),
+        ),
+    ]);
+    let processor = Processor::new(style, bibliography);
+
+    assert_eq!(
+        processor.render_grouped_bibliography_with_format::<PlainText>(),
+        "# Russian\n\nSmith, John. Alpha.\n\n———. Beta.\n\n# English\n\nSmith, John. Gamma."
+    );
 }
 
 fn build_container_title_short_style(title_type: TitleType) -> Style {

--- a/crates/citum-schema-style/src/grouping.rs
+++ b/crates/citum-schema-style/src/grouping.rs
@@ -64,7 +64,7 @@ pub struct BibliographyGroup {
 }
 
 /// Localizable heading source for bibliography groups.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum GroupHeading {

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -95,7 +95,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.39.0";
+pub const STYLE_SCHEMA_VERSION: &str = "0.39.1";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/citum-schema-style/src/options/bibliography.rs
+++ b/crates/citum-schema-style/src/options/bibliography.rs
@@ -8,6 +8,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::locale::{GeneralTerm, TermForm};
+
 /// Bibliography-specific configuration.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -50,6 +52,9 @@ pub struct BibliographyConfig {
     /// When present, enables grouping of references by input bibliography `sets`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compound_numeric: Option<CompoundNumericConfig>,
+    /// Partitioning policy for multilingual bibliography sorting and sections.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_partitioning: Option<BibliographySortPartitioning>,
 }
 
 /// Article-journal-specific bibliography configuration.
@@ -69,6 +74,74 @@ pub struct ArticleJournalBibliographyConfig {
 pub enum ArticleJournalNoPageFallback {
     /// Replace the standard article detail block with the DOI component.
     Doi,
+}
+
+/// Bibliography partitioning policy for multilingual sort order and sections.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct BibliographySortPartitioning {
+    /// Source used to derive each reference's partition key.
+    pub by: BibliographyPartitionKind,
+    /// Whether partitioning affects flat sorting, visible sections, or both.
+    #[serde(default)]
+    pub mode: BibliographyPartitionMode,
+    /// Preferred partition order. Unlisted partitions sort after listed ones.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub order: Vec<String>,
+    /// Optional headings for visible partition sections.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headings: HashMap<String, BibliographyPartitionHeading>,
+}
+
+/// Localizable heading source for automatic bibliography partition sections.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", untagged)]
+pub enum BibliographyPartitionHeading {
+    /// Fixed literal heading text.
+    Literal {
+        /// Literal heading value.
+        literal: String,
+    },
+    /// Locale general term key resolved at render time.
+    Term {
+        /// Locale general term key.
+        term: GeneralTerm,
+        /// Optional term form (defaults to long).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        form: Option<TermForm>,
+    },
+    /// Locale-indexed heading map.
+    Localized {
+        /// Map keyed by BCP 47 locale identifiers or language tags.
+        localized: HashMap<String, String>,
+    },
+}
+
+/// Partition key source for bibliography partitioning.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum BibliographyPartitionKind {
+    /// Partition by Unicode script detected from author/editor/title sort text.
+    Script,
+    /// Partition by the reference's effective item language.
+    Language,
+}
+
+/// Rendering mode for bibliography partitioning.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum BibliographyPartitionMode {
+    /// Sort a flat bibliography by partition before normal sort keys.
+    #[default]
+    SortOnly,
+    /// Render visible sections for grouped bibliography output only.
+    Sections,
+    /// Sort flat output by partition and render visible sections for grouped output.
+    SortAndSections,
 }
 
 /// Rules for subsequent author substitution.
@@ -171,6 +244,7 @@ impl Default for BibliographyConfig {
             suppress_period_after_url: false,
             custom: None,
             compound_numeric: None,
+            sort_partitioning: None,
         }
     }
 }
@@ -259,5 +333,87 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: BibliographyConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_sort_partitioning_deserializes_script_sort_only() {
+        let json = r#"{
+            "sort-partitioning": {
+                "by": "script",
+                "mode": "sort-only",
+                "order": ["Cyrl", "Latn"],
+                "headings": {
+                    "Cyrl": {"literal": "Cyrillic"}
+                }
+            }
+        }"#;
+        let config: BibliographyConfig = serde_json::from_str(json).unwrap();
+        let partitioning = config
+            .sort_partitioning
+            .expect("partitioning should deserialize");
+
+        assert_eq!(partitioning.by, BibliographyPartitionKind::Script);
+        assert_eq!(partitioning.mode, BibliographyPartitionMode::SortOnly);
+        assert_eq!(
+            partitioning.order,
+            vec!["Cyrl".to_string(), "Latn".to_string()]
+        );
+        assert_eq!(
+            partitioning.headings.get("Cyrl"),
+            Some(&BibliographyPartitionHeading::Literal {
+                literal: "Cyrillic".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_sort_partitioning_defaults_to_sort_only() {
+        let json = r#"{"sort-partitioning": {"by": "language"}}"#;
+        let config: BibliographyConfig = serde_json::from_str(json).unwrap();
+        let partitioning = config
+            .sort_partitioning
+            .expect("partitioning should deserialize");
+
+        assert_eq!(partitioning.by, BibliographyPartitionKind::Language);
+        assert_eq!(partitioning.mode, BibliographyPartitionMode::SortOnly);
+        assert!(partitioning.order.is_empty());
+        assert!(partitioning.headings.is_empty());
+    }
+
+    #[test]
+    fn test_sort_partitioning_roundtrip() {
+        let mut headings = HashMap::new();
+        headings.insert(
+            "Latn".to_string(),
+            BibliographyPartitionHeading::Literal {
+                literal: "Latin".to_string(),
+            },
+        );
+        let config = BibliographyConfig {
+            sort_partitioning: Some(BibliographySortPartitioning {
+                by: BibliographyPartitionKind::Script,
+                mode: BibliographyPartitionMode::SortAndSections,
+                order: vec!["Latn".to_string()],
+                headings,
+            }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: BibliographyConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_sort_partitioning_rejects_unknown_fields() {
+        let json = r#"{"sort-partitioning": {"by": "script", "unknown": true}}"#;
+        let error = serde_json::from_str::<BibliographyConfig>(json)
+            .expect_err("unknown partitioning fields should be rejected");
+
+        assert!(
+            error.to_string().contains("unknown field"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -18,7 +18,8 @@ pub mod substitute;
 
 pub use bibliography::{
     ArticleJournalBibliographyConfig, ArticleJournalNoPageFallback, BibliographyConfig,
-    SubsequentAuthorSubstituteRule,
+    BibliographyPartitionHeading, BibliographyPartitionKind, BibliographyPartitionMode,
+    BibliographySortPartitioning, SubsequentAuthorSubstituteRule,
 };
 pub use contributors::{
     AndOptions, AndOtherOptions, ContributorConfig, ContributorConfigEntry, DelimiterPrecedesLast,
@@ -291,6 +292,9 @@ pub struct BibliographyOptions {
     /// Configuration for compound numeric bibliography entries.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compound_numeric: Option<bibliography::CompoundNumericConfig>,
+    /// Partitioning policy for multilingual bibliography sorting and sections.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_partitioning: Option<bibliography::BibliographySortPartitioning>,
     /// Hyperlink configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<LinksConfig>,
@@ -552,6 +556,7 @@ impl BibliographyOptions {
             suppress_period_after_url: self.suppress_period_after_url,
             custom: None,
             compound_numeric: self.compound_numeric.clone(),
+            sort_partitioning: self.sort_partitioning.clone(),
         }
     }
 

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,10 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.39.1 (2026-05-01)
+- Schema version bumped from 0.39.0 to 0.39.1
+- Added `bibliography.options.sort-partitioning` and related schema definitions
+
 #### schema-v0.39.0 (2026-04-30)
 - Schema version bumped from 0.38.0 to 0.39.0
 - Added `MonthAbbrDayYear` date form (abbreviated month + day + year in US order)

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7,7 +7,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.39.0"
+      "default": "0.39.1"
     },
     "info": {
       "description": "Style metadata.",
@@ -5185,6 +5185,17 @@
             }
           ]
         },
+        "sort-partitioning": {
+          "description": "Partitioning policy for multilingual bibliography sorting and sections.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BibliographySortPartitioning"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "links": {
           "description": "Hyperlink configuration.",
           "anyOf": [
@@ -5381,6 +5392,132 @@
           "description": "Numeric sub-labels: 1, 2, 3, ...",
           "type": "string",
           "const": "numeric"
+        }
+      ]
+    },
+    "BibliographySortPartitioning": {
+      "description": "Bibliography partitioning policy for multilingual sort order and sections.",
+      "type": "object",
+      "properties": {
+        "by": {
+          "description": "Source used to derive each reference's partition key.",
+          "$ref": "#/$defs/BibliographyPartitionKind"
+        },
+        "mode": {
+          "description": "Whether partitioning affects flat sorting, visible sections, or both.",
+          "$ref": "#/$defs/BibliographyPartitionMode",
+          "default": "sort-only"
+        },
+        "order": {
+          "description": "Preferred partition order. Unlisted partitions sort after listed ones.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "headings": {
+          "description": "Optional headings for visible partition sections.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/BibliographyPartitionHeading"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "by"
+      ]
+    },
+    "BibliographyPartitionKind": {
+      "description": "Partition key source for bibliography partitioning.",
+      "oneOf": [
+        {
+          "description": "Partition by Unicode script detected from author/editor/title sort text.",
+          "type": "string",
+          "const": "script"
+        },
+        {
+          "description": "Partition by the reference's effective item language.",
+          "type": "string",
+          "const": "language"
+        }
+      ]
+    },
+    "BibliographyPartitionMode": {
+      "description": "Rendering mode for bibliography partitioning.",
+      "oneOf": [
+        {
+          "description": "Sort a flat bibliography by partition before normal sort keys.",
+          "type": "string",
+          "const": "sort-only"
+        },
+        {
+          "description": "Render visible sections for grouped bibliography output only.",
+          "type": "string",
+          "const": "sections"
+        },
+        {
+          "description": "Sort flat output by partition and render visible sections for grouped output.",
+          "type": "string",
+          "const": "sort-and-sections"
+        }
+      ]
+    },
+    "BibliographyPartitionHeading": {
+      "description": "Localizable heading source for automatic bibliography partition sections.",
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "type": "object",
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ]
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "type": "object",
+          "properties": {
+            "term": {
+              "description": "Locale general term key.",
+              "$ref": "#/$defs/GeneralTerm"
+            },
+            "form": {
+              "description": "Optional term form (defaults to long).",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "term"
+          ]
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "type": "object",
+          "properties": {
+            "localized": {
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "localized"
+          ]
         }
       ]
     },

--- a/docs/specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md
+++ b/docs/specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md
@@ -1,6 +1,6 @@
 # Multilingual Bibliography Partitioning Specification
 
-**Status:** Draft
+**Status:** Active
 **Date:** 2026-05-01
 **Related:** `csl26-al0f`, `csl26-xz2t`, [`UNICODE_BIBLIOGRAPHY_SORTING.md`](./UNICODE_BIBLIOGRAPHY_SORTING.md)
 
@@ -61,3 +61,4 @@ Script detection should use Unicode Script properties through a direct engine de
 ## Changelog
 
 - 2026-05-01: Initial draft.
+- 2026-05-01: Marked Active for initial implementation.

--- a/docs/specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md
+++ b/docs/specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md
@@ -1,0 +1,63 @@
+# Multilingual Bibliography Partitioning Specification
+
+**Status:** Draft
+**Date:** 2026-05-01
+**Related:** `csl26-al0f`, `csl26-xz2t`, [`UNICODE_BIBLIOGRAPHY_SORTING.md`](./UNICODE_BIBLIOGRAPHY_SORTING.md)
+
+## Purpose
+
+Define style-controlled bibliography partitioning for multilingual bibliographies so entries can be ordered by script or language before normal author/date/title sorting, with optional visible sections for styles that need headings.
+
+## Scope
+
+In scope: flat partition-aware bibliography sorting, optional automatic bibliography sections, script partition detection from rendered sort text, language partitioning from effective item language, schema options, and regression tests. Out of scope: transliteration-aware sort keys, language-specific display names invented by the engine, and replacing explicit `bibliography.groups`.
+
+## Design
+
+Styles opt in with `bibliography.options.sort-partitioning`:
+
+```yaml
+bibliography:
+  options:
+    sort-partitioning:
+      by: script
+      mode: sort-only
+      order: [Cyrl, Latn, Hani, Hira, Kana]
+      headings:
+        Cyrl: { literal: "Cyrillic" }
+        Latn: { literal: "Latin" }
+```
+
+`by` selects the partition key source:
+
+- `script`: derive an ISO 15924-style script code from the first significant character in the author sort key, then editor, then title.
+- `language`: use the existing effective item language for the reference.
+
+`mode` controls presentation:
+
+- `sort-only`: render one flat bibliography, ordered by partition rank before the normal sort chain.
+- `sections`: render automatic sections only for grouped bibliography output when no explicit `bibliography.groups` are present.
+- `sort-and-sections`: apply both partition-aware sort order and automatic sections.
+
+The `order` list is the only source of user-visible partition order. Values missing from `order` sort after configured partitions by their partition key. References with no detectable key sort last inside the partition tier. `headings` is optional and only used for section modes; the engine must not invent localized section labels.
+
+Explicit `bibliography.groups` remains authoritative. When groups are present, automatic partition sections are disabled to avoid nested groups, but partition-aware sorting still applies inside each group unless the group declares its own sort.
+
+## Implementation Notes
+
+The motivating Zotero thread asks for Cyrillic entries first, then Latin, then Chinese/Japanese as a single continuous bibliography, not necessarily as formally headed sections: <https://forums.zotero.org/discussion/comment/280559/#Comment_280559>. That makes `sort-only` the default mode for parity with the primary user story.
+
+Script detection should use Unicode Script properties through a direct engine dependency. Common scripts supported by the first implementation include `Latn`, `Cyrl`, `Arab`, `Hani`, `Hira`, `Kana`, and `Hang`; unsupported or inherited/common characters are skipped until a significant script character is found.
+
+## Acceptance Criteria
+
+- [ ] Existing styles preserve current single-collator sorting unless they opt in.
+- [ ] `sort-only` partitions flat bibliographies before existing author/date/title sorting.
+- [ ] `language` partitioning uses effective item language and configured order.
+- [ ] `sections` renders partition headings only when grouped bibliography output is requested and no explicit groups exist.
+- [ ] Explicit `bibliography.groups` disables automatic partition sections and preserves group-first semantics.
+- [ ] Schema generation includes the new option and all public Rust items are documented.
+
+## Changelog
+
+- 2026-05-01: Initial draft.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -53,7 +53,6 @@ to make sure the document should be a spec rather than architecture or policy.
 
 | File | Feature |
 |------|---------|
-| [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | Sort and section multilingual bibliographies by script or language |
 | [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Verification model for profile styles using external authority |
 
 ### Active
@@ -81,6 +80,7 @@ to make sure the document should be a spec rather than architecture or policy.
 | [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md) | ICU MF2 parameterized message system replacing flat YAML terms |
 | [`LOCATOR_RENDERING.md`](./LOCATOR_RENDERING.md) | Style-level LocatorConfig replacing per-template locator fields |
 | [`MIGRATION_TAXONOMY_AWARE_WRAPPERS.md`](./MIGRATION_TAXONOMY_AWARE_WRAPPERS.md) | Taxonomy-aware wrapper derivation during style migration |
+| [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | Sort and section multilingual bibliographies by script or language |
 | [`MIGRATE_RESEARCH_RICH_INPUTS.md`](./MIGRATE_RESEARCH_RICH_INPUTS.md) | Bounded rich-input workflow for migrate-research passes |
 | [`MIXED_CONDITION_NOTE_POSITION_TREES.md`](./MIXED_CONDITION_NOTE_POSITION_TREES.md) | Migration of legacy choose trees with mixed position predicates |
 | [`NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md`](./NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md) | Representation of domain-specific numbering and locator labels |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -53,6 +53,7 @@ to make sure the document should be a spec rather than architecture or policy.
 
 | File | Feature |
 |------|---------|
+| [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | Sort and section multilingual bibliographies by script or language |
 | [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Verification model for profile styles using external authority |
 
 ### Active


### PR DESCRIPTION
## Summary
- Adds `bibliography.options.sort-partitioning` for script or language partition keys.
- Supports `sort-only`, `sections`, and `sort-and-sections` modes.
- Uses Unicode Script buckets for script partitioning and effective item language for language partitioning.
- Keeps explicit `bibliography.groups` authoritative while allowing partition-aware sorting inside those groups.
- Activates `docs/specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`, archives bean `csl26-al0f`, and regenerates schemas.

## Testing Plan
- Schema serde coverage for YAML/JSON parsing, enum names, round-trip behavior, defaults, and unknown-field rejection.
- Engine unit coverage for script-key extraction across Latin, Cyrillic, Arabic, Han, Hiragana, Katakana, Hangul, punctuation-first names, title fallback, and unknown script.
- Integration coverage with full expected bibliography strings for no-option baseline behavior, script sort-only partition ordering, language sort-only ordering, visible section rendering with headings, and explicit groups remaining authoritative.
- Schema/version release validation through generated `docs/schemas/style.json` and `Schema-Bump: patch`.

## Verification
- `./scripts/validate-frontmatter.sh --copilot-strict`
- `cargo test -p citum-schema-style options::bibliography::tests::test_sort_partitioning -- --nocapture`
- `cargo test -p citum-engine sort_partitioning::tests -- --nocapture`
- `cargo test -p citum-engine --test bibliography partition -- --nocapture`
- `cargo run --bin citum --features schema -- schema --out-dir docs/schemas`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `python3 scripts/audit-rust-review-smells.py --changed`
- `./scripts/check-docs-beans-hygiene.sh`
- Pre-push hooks reran schema release validation, workspace version validation, bean hygiene, `cargo fmt --check`, clippy, and `cargo nextest run` successfully.

Refs: csl26-al0f
