### PR TITLE
feat(engine): native bibliography partitioning and grouping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "typst",
  "typst-kit",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "axum",
  "citum-engine",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -900,7 +900,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.32.0"
+version = "0.32.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -987,76 +987,39 @@ fn render_bibliography_section<F>(ctx: &RenderContext<'_>, show_keys: bool, outp
 where
     F: citum_engine::render::format::OutputFormat<Output = String>,
 {
-    // Check if the style has bibliography groups defined
-    if ctx
-        .processor
-        .style
-        .bibliography
-        .as_ref()
-        .and_then(|b| b.groups.as_ref())
-        .is_some()
-    {
-        let _ = writeln!(output, "BIBLIOGRAPHY:");
-        if show_keys {
-            // When show_keys is requested, render each entry with its ID prefix so the
-            // oracle parser can match entries by key. Group headings are omitted in this
-            // mode because the oracle only looks for `[id] text` patterns.
-            let filter: HashSet<&str> = ctx
-                .item_ids
-                .iter()
-                .map(std::string::String::as_str)
-                .collect();
-            let processed = ctx.processor.process_references();
-            for entry in processed.bibliography {
-                if filter.contains(entry.id.as_str()) {
-                    let text = citum_engine::render::refs_to_string_with_format::<F>(
-                        vec![entry.clone()],
-                        ctx.annotations,
-                        Some(ctx.annotation_style),
-                    );
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() {
-                        let _ = writeln!(output, "  [{}] {}", entry.id, trimmed);
-                    }
+    let _ = writeln!(output, "BIBLIOGRAPHY:");
+    if show_keys {
+        // When show_keys is requested, render each entry with its ID prefix so the
+        // oracle parser can match entries by key. Group headings are omitted in this
+        // mode because the oracle only looks for `[id] text` patterns.
+        let filter: HashSet<&str> = ctx
+            .item_ids
+            .iter()
+            .map(std::string::String::as_str)
+            .collect();
+        let processed = ctx.processor.process_references();
+        for entry in processed.bibliography {
+            if filter.contains(entry.id.as_str()) {
+                let text = citum_engine::render::refs_to_string_with_format::<F>(
+                    vec![entry.clone()],
+                    ctx.annotations,
+                    Some(ctx.annotation_style),
+                );
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    let _ = writeln!(output, "  [{}] {}", entry.id, trimmed);
                 }
             }
-        } else {
-            // Use grouped renderer for human-readable output (preserves group headings)
-            let grouped = ctx.processor.render_grouped_bibliography_with_format::<F>();
-            output.push_str(&grouped);
         }
     } else {
-        let _ = writeln!(output, "BIBLIOGRAPHY:");
-        if show_keys {
-            // Oracle/show_keys path: render each entry individually so entries
-            // can be matched by reference ID. Compound merging is skipped here
-            // because the oracle addresses each ref independently.
-            let filter: HashSet<&str> = ctx
-                .item_ids
-                .iter()
-                .map(std::string::String::as_str)
-                .collect();
-            let processed = ctx.processor.process_references();
-            for entry in processed.bibliography {
-                if filter.contains(entry.id.as_str()) {
-                    let text = citum_engine::render::refs_to_string_with_format::<F>(
-                        vec![entry.clone()],
-                        ctx.annotations,
-                        Some(ctx.annotation_style),
-                    );
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() {
-                        let _ = writeln!(output, "  [{}] {}", entry.id, trimmed);
-                    }
-                }
-            }
-        } else {
-            // Human-readable path: use the engine bibliography renderer so
-            // compound numeric groups are merged while still honoring keys.
-            let bib = ctx
-                .processor
-                .render_selected_bibliography_with_format::<F, _>(ctx.item_ids.to_vec());
-            let _ = writeln!(output, "{bib}");
+        // Use engine's built-in bibliography renderer which handles grouping/partitioning.
+        // We use render_selected_bibliography_with_format to respect the CLI's item_ids filter.
+        let rendered = ctx
+            .processor
+            .render_selected_bibliography_with_format::<F, _>(ctx.item_ids.to_vec());
+        output.push_str(&rendered);
+        if !rendered.is_empty() && !rendered.ends_with('\n') {
+            output.push('\n');
         }
     }
 }

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -288,7 +288,7 @@ impl Processor {
         ));
     }
 
-    fn render_with_partition_sections<F>(
+    pub(super) fn render_with_partition_sections<F>(
         &self,
         sorted_refs: Vec<&Reference>,
         partitioning: &BibliographySortPartitioning,
@@ -317,39 +317,23 @@ impl Processor {
         fmt.finish(result)
     }
 
-    fn append_unassigned_entries<F>(
-        &self,
-        result: &mut String,
-        bibliography: &[ProcEntry],
-        assigned: &HashSet<String>,
-    ) where
-        F: OutputFormat<Output = String>,
-    {
-        let unassigned = self.merge_compound_entries::<F>(
-            bibliography
-                .iter()
-                .filter(|entry| !assigned.contains(&entry.id))
-                .cloned()
-                .collect(),
-        );
-
-        if unassigned.is_empty() {
-            return;
-        }
-
-        if !result.is_empty() {
-            result.push_str("\n\n");
-        }
-
-        result.push_str(&crate::render::refs_to_string_with_format::<F>(
-            unassigned, None, None,
-        ));
-    }
-
     pub(super) fn render_with_custom_groups<F>(
         &self,
-        bibliography: &[ProcEntry],
+        all_entries: &[ProcEntry],
         groups: &[BibliographyGroup],
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let selected: HashSet<String> = all_entries.iter().map(|e| e.id.clone()).collect();
+        self.render_with_custom_groups_filtered::<F>(all_entries, groups, &selected)
+    }
+
+    pub(super) fn render_with_custom_groups_filtered<F>(
+        &self,
+        all_entries: &[ProcEntry],
+        groups: &[BibliographyGroup],
+        selected: &HashSet<String>,
     ) -> String
     where
         F: OutputFormat<Output = String>,
@@ -364,7 +348,13 @@ impl Processor {
 
         for group in groups {
             let matching_refs =
-                self.collect_matching_group_refs(bibliography, &assigned, &evaluator, group);
+                self.collect_matching_group_refs(all_entries, &assigned, &evaluator, group);
+
+            let matching_refs: Vec<&Reference> = matching_refs
+                .into_iter()
+                .filter(|r| r.id().as_deref().is_some_and(|id| selected.contains(id)))
+                .collect();
+
             if matching_refs.is_empty() {
                 continue;
             }
@@ -378,7 +368,7 @@ impl Processor {
             };
             let local_hints = self.build_group_local_hints(&sorted_refs, group);
             let entries = self.merge_compound_entries::<F>(self.render_group_entries::<F>(
-                bibliography,
+                all_entries,
                 sorted_refs,
                 group,
                 local_hints.as_ref(),
@@ -387,8 +377,45 @@ impl Processor {
             self.append_rendered_group::<F>(&mut result, group, entries);
         }
 
-        self.append_unassigned_entries::<F>(&mut result, bibliography, &assigned);
+        self.append_unassigned_entries_filtered::<F>(&mut result, all_entries, &assigned, selected);
         fmt.finish(result)
+    }
+
+    fn append_unassigned_entries_filtered<F>(
+        &self,
+        result: &mut String,
+        bibliography: &[ProcEntry],
+        assigned: &HashSet<String>,
+        selected: &HashSet<String>,
+    ) where
+        F: OutputFormat<Output = String>,
+    {
+        let unassigned_refs: Vec<&Reference> = bibliography
+            .iter()
+            .filter(|entry| !assigned.contains(&entry.id) && selected.contains(&entry.id))
+            .filter_map(|entry| self.bibliography.get(&entry.id))
+            .collect();
+
+        if unassigned_refs.is_empty() {
+            return;
+        }
+
+        // Re-process references to ensure correct author substitution and disambiguation
+        // within the unassigned subset.
+        let unassigned = self.merge_compound_entries::<F>(self.process_sorted_refs::<_, F>(
+            unassigned_refs.into_iter(),
+            |reference, entry_number| {
+                self.process_bibliography_entry_with_format::<F>(reference, entry_number)
+            },
+        ));
+
+        if !result.is_empty() {
+            result.push_str("\n\n");
+        }
+
+        result.push_str(&crate::render::refs_to_string_with_format::<F>(
+            unassigned, None, None,
+        ));
     }
 
     fn render_with_legacy_grouping<F>(&self, bibliography: &[ProcEntry]) -> String
@@ -463,14 +490,16 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
+        let processed = self.process_references();
+        let all_entries = processed.bibliography;
+
         if let Some(groups) = self
             .style
             .bibliography
             .as_ref()
             .and_then(|bibliography| bibliography.groups.as_ref())
         {
-            let processed = self.process_references();
-            return self.render_with_custom_groups::<F>(&processed.bibliography, groups);
+            return self.render_with_custom_groups::<F>(&all_entries, groups);
         }
 
         let bibliography_options = self.get_bibliography_options();
@@ -482,10 +511,7 @@ impl Processor {
             return self.render_with_partition_sections::<F>(sorted_refs, partitioning);
         }
 
-        let processed = self.process_references();
-        self.render_with_legacy_grouping::<F>(
-            &self.merge_compound_entries::<F>(processed.bibliography),
-        )
+        self.render_with_legacy_grouping::<F>(&self.merge_compound_entries::<F>(all_entries))
     }
 
     /// Render frontmatter-defined bibliography groups for document output.
@@ -499,7 +525,8 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        self.render_with_custom_groups::<F>(&self.process_references().bibliography, groups)
+        let all_entries = self.process_references().bibliography;
+        self.render_with_custom_groups::<F>(&all_entries, groups)
     }
 
     /// Render one bibliography block for document output.

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -184,8 +184,35 @@ impl Processor {
         F: OutputFormat<Output = String>,
         I: IntoIterator<Item = String>,
     {
-        self.initialize_numeric_bibliography_numbers();
         let selected: HashSet<String> = item_ids.into_iter().collect();
+
+        // 1. Check for custom bibliography groups
+        if let Some(groups) = self
+            .style
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.groups.as_ref())
+        {
+            let all_entries = self.process_references().bibliography;
+            return self.render_with_custom_groups_filtered::<F>(&all_entries, groups, &selected);
+        }
+
+        // 2. Check for automatic sort partitioning with sections
+        let bibliography_options = self.get_bibliography_options();
+        if let Some(partitioning) = bibliography_options.sort_partitioning.as_ref()
+            && crate::sort_partitioning::should_render_sections(partitioning)
+        {
+            self.initialize_numeric_bibliography_numbers();
+            let all_sorted = self.sort_references(self.bibliography.values().collect());
+            let selected_sorted: Vec<&Reference> = all_sorted
+                .into_iter()
+                .filter(|r| r.id().as_deref().is_some_and(|id| selected.contains(id)))
+                .collect();
+            return self.render_with_partition_sections::<F>(selected_sorted, partitioning);
+        }
+
+        // 3. Fallback to flat rendering
+        self.initialize_numeric_bibliography_numbers();
         let sorted_refs = self.sort_references(self.bibliography.values().collect());
 
         let bibliography = self.process_sorted_refs::<_, F>(

--- a/crates/citum-engine/src/sort_partitioning.rs
+++ b/crates/citum-engine/src/sort_partitioning.rs
@@ -159,7 +159,11 @@ fn script_code_for_char(ch: char) -> Option<String> {
         return None;
     }
 
-    Some(script.short_name().to_string())
+    let code = script.short_name();
+    match code {
+        "Hant" | "Hans" | "Jpan" | "Kore" => Some("Hani".to_string()),
+        _ => Some(code.to_string()),
+    }
 }
 
 fn non_empty_key(key: String) -> Option<String> {
@@ -210,6 +214,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "Comprehensive script detection test cases."
+    )]
     fn detects_common_script_partition_keys() {
         let locale = Locale::en_us();
         let script = partitioning(BibliographyPartitionKind::Script);
@@ -271,6 +279,44 @@ mod tests {
         assert_eq!(
             partition_key(
                 &reference("hang", Some("김"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Hang")
+        );
+
+        // Normalized CJK scripts should all map to "Hani"
+        assert_eq!(
+            partition_key(
+                &reference("hans", Some("张"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Hani")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("hant", Some("張"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Hani")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("jpan", Some("佐藤"), "Title", None),
+                &locale,
+                &script
+            )
+            .as_deref(),
+            Some("Hani")
+        );
+        assert_eq!(
+            partition_key(
+                &reference("kore", Some("김"), "Title", None),
                 &locale,
                 &script
             )

--- a/crates/citum-engine/src/sort_partitioning.rs
+++ b/crates/citum-engine/src/sort_partitioning.rs
@@ -161,7 +161,7 @@ fn script_code_for_char(ch: char) -> Option<String> {
 
     let code = script.short_name();
     match code {
-        "Hant" | "Hans" | "Jpan" | "Kore" => Some("Hani".to_string()),
+        "Hant" | "Hans" | "Jpan" | "Kore" | "Hira" | "Kana" => Some("Hani".to_string()),
         _ => Some(code.to_string()),
     }
 }
@@ -265,7 +265,7 @@ mod tests {
                 &script
             )
             .as_deref(),
-            Some("Hira")
+            Some("Hani")
         );
         assert_eq!(
             partition_key(
@@ -274,7 +274,7 @@ mod tests {
                 &script
             )
             .as_deref(),
-            Some("Kana")
+            Some("Hani")
         );
         assert_eq!(
             partition_key(

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -927,6 +927,56 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
             <div class="border-b border-slate-200">
                 <div class="px-8 py-4 bg-slate-100">
                     <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+                        Automatic Script &amp; Language Partitioning
+                    </h3>
+                </div>
+                <div class="p-8 bg-slate-50">
+                    <p class="text-sm text-slate-600 mb-6">
+                        Bibliographies can be automatically partitioned by script or language. This ensures that
+                        references in different scripts (e.g., Latin and Arabic) are grouped together, and that
+                        subsequent-author substitutions correctly reset for each new partition section.
+                    </p>
+                    <div class="grid lg:grid-cols-2 gap-8">
+                        <!-- Config -->
+                        <div class="space-y-4">
+                            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Style Configuration</div>
+                            <div class="bg-slate-900 rounded p-4 overflow-x-auto">
+                                <pre class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">sort-partitioning</span>:
+      <span class="text-primary">by</span>: <span class="text-emerald-400">script</span>
+      <span class="text-primary">mode</span>: <span class="text-emerald-400">sort-and-sections</span>
+      <span class="text-primary">headings</span>:
+        <span class="text-primary">Latn</span>:
+          <span class="text-primary">literal</span>: <span class="text-emerald-400">"Western Sources"</span>
+        <span class="text-primary">Arab</span>:
+          <span class="text-primary">literal</span>: <span class="text-emerald-400">"Arabic Sources"</span></pre>
+                            </div>
+                        </div>
+                        <!-- Mock Output -->
+                        <div class="space-y-4">
+                            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Partitioned Output</div>
+                            <div class="bg-white border border-slate-200 rounded p-4 text-xs font-mono text-slate-700 shadow-inner overflow-x-auto h-[220px]">
+                                <div class="font-bold text-slate-400 mb-2"># Western Sources</div>
+                                <div class="mb-2">Smith, John. 2024. _First Book_.</div>
+                                <div class="mb-4">———. 2025. _Second Book_.</div>
+
+                                <div class="font-bold text-slate-400 mb-2"># Arabic Sources</div>
+                                <div class="mb-2">محمود, علي. 2023. _الكتاب الأول_.</div>
+                                <div class="mb-2">———. 2024. _الكتاب الثاني_.</div>
+                            </div>
+                            <p class="text-[11px] text-slate-500 italic">
+                                Subsequent author dashes (———) are automatically reset when entering a new script partition.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Reference Data -->
+            <div class="border-b border-slate-200">
+                <div class="px-8 py-4 bg-slate-100">
+                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
                         Reference Data (YAML)
                     </h3>
                 </div>
@@ -1034,6 +1084,20 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                     <p class="text-xs text-slate-500 mt-2">
                         For style-authoring work, compare this data with a style that sets different
                         <code class="text-xs bg-slate-200 px-1 rounded">options.multilingual</code> values.
+                    </p>
+                </div>
+                <div class="border border-indigo-500/30 rounded-lg p-4 mb-3">
+                    <p class="text-xs text-slate-600 mb-2">
+                        Render the script-partitioned bibliography example:
+                    </p>
+                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
+                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+  -b examples/multilingual-refs.yaml \
+  -s styles/experimental/multilingual-partitioned.yaml</pre>
+                    </div>
+                    <p class="text-xs text-slate-500 mt-2">
+                        This style demonstrates <code class="text-xs bg-slate-200 px-1 rounded">sort-partitioning</code>
+                        by script, which separates Latin and Non-Latin records into distinct sections with reset subsequent-author substitutions.
                     </p>
                 </div>
                 <div class="border border-primary/30 rounded-lg p-4">

--- a/styles/experimental/multilingual-partitioned.yaml
+++ b/styles/experimental/multilingual-partitioned.yaml
@@ -22,6 +22,6 @@ bibliography:
         Arab:
           literal: "Arabic Sources"
         Hani:
-          literal: "CJK Sources"
+          literal: "Chinese & Japanese Sources"
         Hang:
           literal: "Korean Sources"

--- a/styles/experimental/multilingual-partitioned.yaml
+++ b/styles/experimental/multilingual-partitioned.yaml
@@ -1,0 +1,27 @@
+# Minimal style to demonstrate automatic script partitioning
+version: "0.10.0"
+info:
+  title: Multilingual Script Partitioning Demo
+  id: multilingual-partitioned-demo
+extends: modern-language-association
+
+options:
+  multilingual:
+    title-mode: combined
+    name-mode: primary
+
+bibliography:
+  options:
+    sort-partitioning:
+      by: script
+      mode: sort-and-sections
+      order: [Latn, Arab, Hani, Hang]
+      headings:
+        Latn:
+          literal: "Western Sources"
+        Arab:
+          literal: "Arabic Sources"
+        Hani:
+          literal: "CJK Sources"
+        Hang:
+          literal: "Korean Sources"


### PR DESCRIPTION
This PR refactors bibliography partitioning and grouping to be handled natively by the engine and fixes a CJK script detection bug.

### Key Changes
- **Engine-Native Rendering**: `render_selected_bibliography_with_format` in `citum-engine` now automatically detects grouping/partitioning configuration in the style and renders accordingly.
- **CLI Simplification**: The CLI logic is simplified to a single call to the engine's bibliography renderer, removing the need for manual style inspection.
- **CJK Script Fix**: Maps granular script codes (`Jpan`, `Hant`, `Hans`, `Kore`) to the canonical `Hani` key to ensure proper heading matching in styles.
- **Experimental Style**: Includes `multilingual-partitioned.yaml` for testing and demonstration.
- **Version Bump**: Workspace version bumped to `0.32.1`.