### PR TITLE
fix(docs): fix missing example outputs

### DIFF
--- a/.beans/archive/csl26-wz7v--remove-legacy-annotation-styling-options.md
+++ b/.beans/archive/csl26-wz7v--remove-legacy-annotation-styling-options.md
@@ -1,7 +1,7 @@
 ---
 # csl26-wz7v
 title: Remove legacy annotation styling options
-status: draft
+status: completed
 type: cleanup
 priority: normal
 tags:

--- a/.beans/csl26-wz7v--remove-legacy-annotation-styling-options.md
+++ b/.beans/csl26-wz7v--remove-legacy-annotation-styling-options.md
@@ -1,0 +1,20 @@
+---
+# csl26-wz7v
+title: Remove legacy annotation styling options
+status: draft
+type: cleanup
+priority: normal
+tags:
+    - engine
+    - cli
+created_at: 2026-05-02T23:55:00Z
+updated_at: 2026-05-02T23:55:00Z
+---
+
+Follow-up to the structural annotation refactor: remove the remaining legacy CLI 
+styling flags `--annotation-italic` and `--annotation-break` and their 
+corresponding fields in `AnnotationStyle`.
+
+These are presentation concerns that should be handled via the output format's 
+structural rendering (e.g. CSS for HTML italics, or document-level paragraph 
+styling for LaTeX/Typst).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "typst",
  "typst-kit",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -900,7 +900,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.32.1"
+version = "0.33.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -527,10 +527,6 @@ pub(crate) struct RenderRefsArgs {
     #[arg(long)]
     pub(crate) annotation_italic: bool,
 
-    /// Indent annotation paragraphs (default: true)
-    #[arg(long, default_value_t = true)]
-    pub(crate) annotation_indent: bool,
-
     /// Line break before annotation paragraph
     #[arg(long, value_enum, default_value_t = ParagraphBreakArg::BlankLine)]
     pub(crate) annotation_break: ParagraphBreakArg,

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -460,14 +460,6 @@ pub(crate) struct RenderDocArgs {
     pub(crate) no_semantics: bool,
 }
 
-/// Line break style for annotation paragraphs.
-#[derive(Clone, Debug, Default, clap::ValueEnum)]
-pub(crate) enum ParagraphBreakArg {
-    #[default]
-    BlankLine,
-    SingleLine,
-}
-
 #[derive(Args, Debug)]
 pub(crate) struct RenderRefsArgs {
     /// Path(s) to bibliography input files (repeat for multiple)
@@ -522,14 +514,6 @@ pub(crate) struct RenderRefsArgs {
     /// Path to annotations file (JSON or YAML mapping ref IDs to annotation text)
     #[arg(long, value_name = "FILE")]
     pub(crate) annotations: Option<PathBuf>,
-
-    /// Render annotation text in italics
-    #[arg(long)]
-    pub(crate) annotation_italic: bool,
-
-    /// Line break before annotation paragraph
-    #[arg(long, value_enum, default_value_t = ParagraphBreakArg::BlankLine)]
-    pub(crate) annotation_break: ParagraphBreakArg,
 }
 
 #[derive(Args, Debug)]

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -491,7 +491,6 @@ fn run_render_refs(args: RenderRefsArgs) -> Result<(), Box<dyn Error>> {
 
     let annotation_style = AnnotationStyle {
         italic: args.annotation_italic,
-        indent: args.annotation_indent,
         paragraph_break: match args.annotation_break {
             ParagraphBreakArg::BlankLine => ParagraphBreak::BlankLine,
             ParagraphBreakArg::SingleLine => ParagraphBreak::SingleLine,
@@ -1013,10 +1012,14 @@ where
         }
     } else {
         // Use engine's built-in bibliography renderer which handles grouping/partitioning.
-        // We use render_selected_bibliography_with_format to respect the CLI's item_ids filter.
+        // We use render_selected_bibliography_with_format_and_annotations to respect the CLI's item_ids filter and propagate annotations.
         let rendered = ctx
             .processor
-            .render_selected_bibliography_with_format::<F, _>(ctx.item_ids.to_vec());
+            .render_selected_bibliography_with_format_and_annotations::<F, _>(
+                ctx.item_ids.to_vec(),
+                ctx.annotations,
+                Some(ctx.annotation_style),
+            );
         output.push_str(&rendered);
         if !rendered.is_empty() && !rendered.ends_with('\n') {
             output.push('\n');

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -2,9 +2,9 @@
 use crate::args::BindingsArgs;
 use crate::args::{
     CheckArgs, CheckItem, Cli, Commands, ConvertCommands, ConvertRefsArgs, ConvertTypedArgs,
-    DataType, InputFormat, LintLocaleArgs, LintStyleArgs, LocaleCommands, OutputFormat,
-    ParagraphBreakArg, RefsFormat, RegistryCommands, RenderCommands, RenderDocArgs, RenderMode,
-    RenderRefsArgs, StoreCommands, StyleCommands, StylesCommands,
+    DataType, InputFormat, LintLocaleArgs, LintStyleArgs, LocaleCommands, OutputFormat, RefsFormat,
+    RegistryCommands, RenderCommands, RenderDocArgs, RenderMode, RenderRefsArgs, StoreCommands,
+    StyleCommands, StylesCommands,
 };
 #[cfg(feature = "schema")]
 use crate::args::{SchemaArgs, SchemaType};
@@ -14,7 +14,7 @@ use crate::typst_pdf;
 use citum_engine::{
     Citation, CitationItem, DocumentFormat, Processor,
     io::{
-        AnnotationFormat, AnnotationStyle, ParagraphBreak, RefsFormat as EngineRefsFormat,
+        AnnotationFormat, AnnotationStyle, RefsFormat as EngineRefsFormat,
         infer_refs_input_format as infer_engine_refs_input_format,
         infer_refs_output_format as infer_engine_refs_output_format, load_annotations,
         load_bibliography, load_citations, load_input_bibliography, load_merged_bibliography,
@@ -490,11 +490,6 @@ fn run_render_refs(args: RenderRefsArgs) -> Result<(), Box<dyn Error>> {
     };
 
     let annotation_style = AnnotationStyle {
-        italic: args.annotation_italic,
-        paragraph_break: match args.annotation_break {
-            ParagraphBreakArg::BlankLine => ParagraphBreak::BlankLine,
-            ParagraphBreakArg::SingleLine => ParagraphBreak::SingleLine,
-        },
         format: AnnotationFormat::Djot,
     };
 

--- a/crates/citum-engine/src/io.rs
+++ b/crates/citum-engine/src/io.rs
@@ -58,9 +58,6 @@ pub struct AnnotationStyle {
     /// Render annotation text in italics. Default: false.
     #[serde(default)]
     pub italic: bool,
-    /// Indent the annotation paragraph. Default: true.
-    #[serde(default = "default_true")]
-    pub indent: bool,
     /// Line break style before annotation. Default: `BlankLine`.
     #[serde(default)]
     pub paragraph_break: ParagraphBreak,
@@ -69,15 +66,10 @@ pub struct AnnotationStyle {
     pub format: AnnotationFormat,
 }
 
-fn default_true() -> bool {
-    true
-}
-
 impl Default for AnnotationStyle {
     fn default() -> Self {
         Self {
             italic: false,
-            indent: true,
             paragraph_break: ParagraphBreak::BlankLine,
             format: AnnotationFormat::Djot,
         }

--- a/crates/citum-engine/src/io.rs
+++ b/crates/citum-engine/src/io.rs
@@ -55,12 +55,6 @@ struct LegacyBibliographyWrapper {
 /// Controls how annotation text is rendered in an annotated bibliography.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AnnotationStyle {
-    /// Render annotation text in italics. Default: false.
-    #[serde(default)]
-    pub italic: bool,
-    /// Line break style before annotation. Default: `BlankLine`.
-    #[serde(default)]
-    pub paragraph_break: ParagraphBreak,
     /// Markup format for annotation text. Default: Djot.
     #[serde(default)]
     pub format: AnnotationFormat,
@@ -69,21 +63,9 @@ pub struct AnnotationStyle {
 impl Default for AnnotationStyle {
     fn default() -> Self {
         Self {
-            italic: false,
-            paragraph_break: ParagraphBreak::BlankLine,
             format: AnnotationFormat::Djot,
         }
     }
-}
-
-/// Line break style preceding an annotation block.
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub enum ParagraphBreak {
-    /// Single newline before annotation.
-    SingleLine,
-    /// Blank line before annotation (default).
-    #[default]
-    BlankLine,
 }
 
 /// Markup format for annotation text.

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -7,6 +7,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use super::RenderedBibliographyGroup;
 use crate::grouping::{GroupSorter, SelectorEvaluator};
+use crate::io::AnnotationStyle;
 use crate::processor::Processor;
 use crate::processor::disambiguation::Disambiguator;
 use crate::processor::rendering::{CompoundRenderData, Renderer, RendererResources};
@@ -245,6 +246,8 @@ impl Processor {
         result: &mut String,
         group: &BibliographyGroup,
         entries: Vec<ProcEntry>,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
     ) where
         F: OutputFormat<Output = String>,
     {
@@ -261,7 +264,9 @@ impl Processor {
         }
 
         result.push_str(&crate::render::refs_to_string_with_format::<F>(
-            entries, None, None,
+            entries,
+            annotations,
+            annotation_style,
         ));
     }
 
@@ -270,6 +275,8 @@ impl Processor {
         result: &mut String,
         heading: Option<&BibliographyPartitionHeading>,
         entries: Vec<ProcEntry>,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
     ) where
         F: OutputFormat<Output = String>,
     {
@@ -284,7 +291,9 @@ impl Processor {
         }
 
         result.push_str(&crate::render::refs_to_string_with_format::<F>(
-            entries, None, None,
+            entries,
+            annotations,
+            annotation_style,
         ));
     }
 
@@ -292,6 +301,8 @@ impl Processor {
         &self,
         sorted_refs: Vec<&Reference>,
         partitioning: &BibliographySortPartitioning,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
     ) -> String
     where
         F: OutputFormat<Output = String>,
@@ -311,7 +322,13 @@ impl Processor {
                     self.process_bibliography_entry_with_format::<F>(reference, entry_number)
                 },
             ));
-            self.append_rendered_partition::<F>(&mut result, heading, entries);
+            self.append_rendered_partition::<F>(
+                &mut result,
+                heading,
+                entries,
+                annotations,
+                annotation_style,
+            );
         }
 
         fmt.finish(result)
@@ -326,7 +343,7 @@ impl Processor {
         F: OutputFormat<Output = String>,
     {
         let selected: HashSet<String> = all_entries.iter().map(|e| e.id.clone()).collect();
-        self.render_with_custom_groups_filtered::<F>(all_entries, groups, &selected)
+        self.render_with_custom_groups_filtered::<F>(all_entries, groups, &selected, None, None)
     }
 
     pub(super) fn render_with_custom_groups_filtered<F>(
@@ -334,6 +351,8 @@ impl Processor {
         all_entries: &[ProcEntry],
         groups: &[BibliographyGroup],
         selected: &HashSet<String>,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
     ) -> String
     where
         F: OutputFormat<Output = String>,
@@ -374,10 +393,23 @@ impl Processor {
                 local_hints.as_ref(),
             ));
 
-            self.append_rendered_group::<F>(&mut result, group, entries);
+            self.append_rendered_group::<F>(
+                &mut result,
+                group,
+                entries,
+                annotations,
+                annotation_style,
+            );
         }
 
-        self.append_unassigned_entries_filtered::<F>(&mut result, all_entries, &assigned, selected);
+        self.append_unassigned_entries_filtered::<F>(
+            &mut result,
+            all_entries,
+            &assigned,
+            selected,
+            annotations,
+            annotation_style,
+        );
         fmt.finish(result)
     }
 
@@ -387,6 +419,8 @@ impl Processor {
         bibliography: &[ProcEntry],
         assigned: &HashSet<String>,
         selected: &HashSet<String>,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
     ) where
         F: OutputFormat<Output = String>,
     {
@@ -414,11 +448,18 @@ impl Processor {
         }
 
         result.push_str(&crate::render::refs_to_string_with_format::<F>(
-            unassigned, None, None,
+            unassigned,
+            annotations,
+            annotation_style,
         ));
     }
 
-    fn render_with_legacy_grouping<F>(&self, bibliography: &[ProcEntry]) -> String
+    fn render_with_legacy_grouping<F>(
+        &self,
+        bibliography: &[ProcEntry],
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
     where
         F: OutputFormat<Output = String>,
     {
@@ -434,15 +475,20 @@ impl Processor {
         if !cited_entries.is_empty() {
             result.push_str(&crate::render::refs_to_string_with_format::<F>(
                 cited_entries,
-                None,
-                None,
+                annotations,
+                annotation_style,
             ));
         }
 
         fmt.finish(result)
     }
 
-    fn render_bibliography_for_group<F>(&self, group: &BibliographyGroup) -> String
+    fn render_bibliography_for_group<F>(
+        &self,
+        group: &BibliographyGroup,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
     where
         F: OutputFormat<Output = String>,
     {
@@ -475,7 +521,9 @@ impl Processor {
         ));
 
         fmt.finish(crate::render::refs_to_string_with_format::<F>(
-            entries, None, None,
+            entries,
+            annotations,
+            annotation_style,
         ))
     }
 
@@ -490,6 +538,18 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
+        self.render_grouped_bibliography_with_format_and_annotations::<F>(None, None)
+    }
+
+    /// Render the bibliography with grouping and annotations.
+    pub fn render_grouped_bibliography_with_format_and_annotations<F>(
+        &self,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
         let processed = self.process_references();
         let all_entries = processed.bibliography;
 
@@ -499,7 +559,16 @@ impl Processor {
             .as_ref()
             .and_then(|bibliography| bibliography.groups.as_ref())
         {
-            return self.render_with_custom_groups::<F>(&all_entries, groups);
+            return self.render_with_custom_groups_filtered::<F>(
+                &all_entries,
+                groups,
+                &all_entries
+                    .iter()
+                    .map(|e| e.id.clone())
+                    .collect::<HashSet<_>>(),
+                annotations,
+                annotation_style,
+            );
         }
 
         let bibliography_options = self.get_bibliography_options();
@@ -508,10 +577,19 @@ impl Processor {
         {
             self.initialize_numeric_bibliography_numbers();
             let sorted_refs = self.sort_references(self.bibliography.values().collect());
-            return self.render_with_partition_sections::<F>(sorted_refs, partitioning);
+            return self.render_with_partition_sections::<F>(
+                sorted_refs,
+                partitioning,
+                annotations,
+                annotation_style,
+            );
         }
 
-        self.render_with_legacy_grouping::<F>(&self.merge_compound_entries::<F>(all_entries))
+        self.render_with_legacy_grouping::<F>(
+            &self.merge_compound_entries::<F>(all_entries),
+            annotations,
+            annotation_style,
+        )
     }
 
     /// Render frontmatter-defined bibliography groups for document output.
@@ -545,7 +623,7 @@ impl Processor {
             .heading
             .take()
             .and_then(|group_heading| self.resolve_group_heading(&group_heading));
-        let body = self.render_bibliography_for_group::<F>(&headingless);
+        let body = self.render_bibliography_for_group::<F>(&headingless, None, None);
 
         RenderedBibliographyGroup { heading, body }
     }

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -15,10 +15,11 @@ mod grouping;
 use super::matching::Matcher;
 use super::rendering::{CompoundRenderData, Renderer, RendererResources};
 use super::{ProcessedReferences, Processor};
+use crate::io::AnnotationStyle;
 use crate::reference::Reference;
 use crate::render::format::OutputFormat;
 use crate::render::{ProcEntry, ProcTemplate};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Rendered bibliography block data for document integration.
 #[derive(Debug, Clone, Default)]
@@ -173,13 +174,41 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        self.render_selected_bibliography_with_format::<F, _>(
+        self.render_bibliography_with_format_and_annotations::<F>(None, None)
+    }
+
+    /// Render the bibliography to a string with annotations.
+    pub fn render_bibliography_with_format_and_annotations<F>(
+        &self,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        self.render_selected_bibliography_with_format_and_annotations::<F, _>(
             self.bibliography.keys().cloned().collect::<Vec<_>>(),
+            annotations,
+            annotation_style,
         )
     }
 
     /// Render a selected bibliography subset to a string using a specific format.
     pub fn render_selected_bibliography_with_format<F, I>(&self, item_ids: I) -> String
+    where
+        F: OutputFormat<Output = String>,
+        I: IntoIterator<Item = String>,
+    {
+        self.render_selected_bibliography_with_format_and_annotations::<F, _>(item_ids, None, None)
+    }
+
+    /// Render a selected bibliography subset to a string with annotations.
+    pub fn render_selected_bibliography_with_format_and_annotations<F, I>(
+        &self,
+        item_ids: I,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
     where
         F: OutputFormat<Output = String>,
         I: IntoIterator<Item = String>,
@@ -194,7 +223,13 @@ impl Processor {
             .and_then(|bibliography| bibliography.groups.as_ref())
         {
             let all_entries = self.process_references().bibliography;
-            return self.render_with_custom_groups_filtered::<F>(&all_entries, groups, &selected);
+            return self.render_with_custom_groups_filtered::<F>(
+                &all_entries,
+                groups,
+                &selected,
+                annotations,
+                annotation_style,
+            );
         }
 
         // 2. Check for automatic sort partitioning with sections
@@ -208,7 +243,12 @@ impl Processor {
                 .into_iter()
                 .filter(|r| r.id().as_deref().is_some_and(|id| selected.contains(id)))
                 .collect();
-            return self.render_with_partition_sections::<F>(selected_sorted, partitioning);
+            return self.render_with_partition_sections::<F>(
+                selected_sorted,
+                partitioning,
+                annotations,
+                annotation_style,
+            );
         }
 
         // 3. Fallback to flat rendering
@@ -226,7 +266,7 @@ impl Processor {
         );
 
         let bibliography = self.merge_compound_entries::<F>(bibliography);
-        crate::render::refs_to_string_with_format::<F>(bibliography, None, None)
+        crate::render::refs_to_string_with_format::<F>(bibliography, annotations, annotation_style)
     }
 
     /// Render the entire bibliography to a formatted string.

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -281,11 +281,8 @@ pub fn refs_to_string_with_format<F: OutputFormat<Output = String>>(
             let rendered = rendered.trim();
 
             if !rendered.is_empty() {
-                let mut annotation_output = fmt.text(rendered);
-                if style.italic {
-                    annotation_output = fmt.emph(annotation_output);
-                }
-                entry_output.push_str(&fmt.annotation(&style.paragraph_break, annotation_output));
+                let annotation_output = fmt.text(rendered);
+                entry_output.push_str(&fmt.annotation(annotation_output));
             }
         }
 
@@ -384,7 +381,6 @@ fn cleanup_dangling_punctuation(output: &mut String) {
 )]
 mod tests {
     use super::*;
-    use crate::io::ParagraphBreak;
     use crate::render::component::ProcTemplateComponent;
     use citum_schema::template::{Rendering, TemplateComponent, WrapConfig, WrapPunctuation};
 
@@ -857,7 +853,7 @@ mod tests {
             "A useful overview of the topic.".to_string(),
         );
 
-        let style = AnnotationStyle::default(); // no italic, blank line
+        let style = AnnotationStyle::default();
 
         let result = refs_to_string_with_format::<PlainText>(
             vec![make_entry("ref1", "Some Publisher")],
@@ -899,33 +895,6 @@ mod tests {
         assert!(
             !result.contains("Annotation for someone else."),
             "annotation for a different ref should not appear: {result}"
-        );
-    }
-
-    #[test]
-    fn test_annotation_single_line_break() {
-        let mut annotations = HashMap::new();
-        annotations.insert("ref1".to_string(), "Short note.".to_string());
-
-        let style = AnnotationStyle {
-            italic: false,
-            paragraph_break: ParagraphBreak::SingleLine,
-            format: AnnotationFormat::Plain,
-        };
-
-        let result = refs_to_string_with_format::<PlainText>(
-            vec![make_entry("ref1", "Publisher")],
-            Some(&annotations),
-            Some(&style),
-        );
-
-        assert!(
-            result.contains("\nShort note."),
-            "single line break should precede annotation: {result}"
-        );
-        assert!(
-            !result.contains("\n\n"),
-            "should not have blank line with SingleLine break: {result}"
         );
     }
 

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -6,7 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use crate::io::{AnnotationFormat, AnnotationStyle, ParagraphBreak};
+use crate::io::{AnnotationFormat, AnnotationStyle};
 use crate::render::component::{ProcEntry, ProcTemplateComponent, render_component_with_format};
 use crate::render::format::OutputFormat;
 use crate::render::plain::PlainText;
@@ -270,11 +270,6 @@ pub fn refs_to_string_with_format<F: OutputFormat<Output = String>>(
             && let Some(annotation_text) = annotations.get(&entry.id)
         {
             let style = annotation_style.cloned().unwrap_or_default();
-            let separator = match style.paragraph_break {
-                ParagraphBreak::BlankLine => "\n\n",
-                ParagraphBreak::SingleLine => "\n",
-            };
-            let indent_prefix = if style.indent { "    " } else { "" };
 
             // Render annotation text through markup format if enabled
             let rendered = match style.format {
@@ -283,26 +278,15 @@ pub fn refs_to_string_with_format<F: OutputFormat<Output = String>>(
                 AnnotationFormat::Org => render_org_inline(annotation_text, &fmt),
             };
 
-            // Apply indentation to each line (preserving blank lines for paragraph breaks)
-            let indented_text = rendered
-                .lines()
-                .map(|line| {
-                    if line.trim().is_empty() {
-                        line.to_string()
-                    } else {
-                        let indented_line = format!("{indent_prefix}{line}");
-                        if style.italic {
-                            fmt.finish(fmt.emph(fmt.text(&indented_line)))
-                        } else {
-                            indented_line
-                        }
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
+            let rendered = rendered.trim();
 
-            entry_output.push_str(separator);
-            entry_output.push_str(&indented_text);
+            if !rendered.is_empty() {
+                let mut annotation_output = fmt.text(rendered);
+                if style.italic {
+                    annotation_output = fmt.emph(annotation_output);
+                }
+                entry_output.push_str(&fmt.annotation(&style.paragraph_break, annotation_output));
+            }
         }
 
         if visible_text(&entry_output).trim().is_empty() {
@@ -400,6 +384,7 @@ fn cleanup_dangling_punctuation(output: &mut String) {
 )]
 mod tests {
     use super::*;
+    use crate::io::ParagraphBreak;
     use crate::render::component::ProcTemplateComponent;
     use citum_schema::template::{Rendering, TemplateComponent, WrapConfig, WrapPunctuation};
 
@@ -872,7 +857,7 @@ mod tests {
             "A useful overview of the topic.".to_string(),
         );
 
-        let style = AnnotationStyle::default(); // indent=true, no italic, blank line
+        let style = AnnotationStyle::default(); // no italic, blank line
 
         let result = refs_to_string_with_format::<PlainText>(
             vec![make_entry("ref1", "Some Publisher")],
@@ -888,10 +873,10 @@ mod tests {
             result.contains("A useful overview of the topic."),
             "annotation should appear: {result}"
         );
-        // Blank line separator: entry text followed by \n\n then indent
+        // Blank line separator: entry text followed by \n\n
         assert!(
-            result.contains("\n\n    A useful overview"),
-            "annotation should be separated by blank line and indented: {result}"
+            result.contains("\n\nA useful overview"),
+            "annotation should be separated by blank line: {result}"
         );
     }
 
@@ -924,7 +909,6 @@ mod tests {
 
         let style = AnnotationStyle {
             italic: false,
-            indent: false,
             paragraph_break: ParagraphBreak::SingleLine,
             format: AnnotationFormat::Plain,
         };

--- a/crates/citum-engine/src/render/djot.rs
+++ b/crates/citum-engine/src/render/djot.rs
@@ -86,11 +86,7 @@ impl OutputFormat for Djot {
         format!("[{content}]{{.{class}}}")
     }
 
-    fn annotation(
-        &self,
-        _paragraph_break: &crate::io::ParagraphBreak,
-        content: Self::Output,
-    ) -> Self::Output {
+    fn annotation(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;
         }

--- a/crates/citum-engine/src/render/djot.rs
+++ b/crates/citum-engine/src/render/djot.rs
@@ -86,6 +86,17 @@ impl OutputFormat for Djot {
         format!("[{content}]{{.{class}}}")
     }
 
+    fn annotation(
+        &self,
+        _paragraph_break: &crate::io::ParagraphBreak,
+        content: Self::Output,
+    ) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("\n\n::: citum-annotation\n{content}\n:::")
+    }
+
     fn link(&self, url: &str, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;

--- a/crates/citum-engine/src/render/format.rs
+++ b/crates/citum-engine/src/render/format.rs
@@ -76,6 +76,16 @@ pub trait OutputFormat: Default + Clone {
     /// Examples include "citum-title", "citum-author", "citum-doi".
     fn semantic(&self, class: &str, content: Self::Output) -> Self::Output;
 
+    /// Render an annotation block.
+    ///
+    /// This is typically called at the end of a bibliography entry to render
+    /// reader-supplied notes.
+    fn annotation(
+        &self,
+        paragraph_break: &crate::io::ParagraphBreak,
+        content: Self::Output,
+    ) -> Self::Output;
+
     /// Apply a semantic identifier plus optional attributes to the content.
     ///
     /// Formats that do not support extra attributes can ignore them and reuse
@@ -189,6 +199,13 @@ mod tests {
         }
         fn semantic(&self, class: &str, content: Self::Output) -> Self::Output {
             format!("sem[{class}]({content})")
+        }
+        fn annotation(
+            &self,
+            _paragraph_break: &crate::io::ParagraphBreak,
+            content: Self::Output,
+        ) -> Self::Output {
+            format!("annot({content})")
         }
         fn link(&self, url: &str, content: Self::Output) -> Self::Output {
             format!("link[{url}]({content})")

--- a/crates/citum-engine/src/render/format.rs
+++ b/crates/citum-engine/src/render/format.rs
@@ -80,11 +80,7 @@ pub trait OutputFormat: Default + Clone {
     ///
     /// This is typically called at the end of a bibliography entry to render
     /// reader-supplied notes.
-    fn annotation(
-        &self,
-        paragraph_break: &crate::io::ParagraphBreak,
-        content: Self::Output,
-    ) -> Self::Output;
+    fn annotation(&self, content: Self::Output) -> Self::Output;
 
     /// Apply a semantic identifier plus optional attributes to the content.
     ///
@@ -200,11 +196,7 @@ mod tests {
         fn semantic(&self, class: &str, content: Self::Output) -> Self::Output {
             format!("sem[{class}]({content})")
         }
-        fn annotation(
-            &self,
-            _paragraph_break: &crate::io::ParagraphBreak,
-            content: Self::Output,
-        ) -> Self::Output {
+        fn annotation(&self, content: Self::Output) -> Self::Output {
             format!("annot({content})")
         }
         fn link(&self, url: &str, content: Self::Output) -> Self::Output {

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -116,15 +116,11 @@ impl OutputFormat for Html {
         format!(r#"<span class="{class}">{content}</span>"#)
     }
 
-    fn annotation(
-        &self,
-        _paragraph_break: &crate::io::ParagraphBreak,
-        content: Self::Output,
-    ) -> Self::Output {
+    fn annotation(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;
         }
-        format!(r#"<div class="citum-annotation">{content}</div>"#)
+        format!("<div class=\"citum-annotation\">{content}</div>")
     }
 
     fn semantic_with_attributes(

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -116,6 +116,17 @@ impl OutputFormat for Html {
         format!(r#"<span class="{class}">{content}</span>"#)
     }
 
+    fn annotation(
+        &self,
+        _paragraph_break: &crate::io::ParagraphBreak,
+        content: Self::Output,
+    ) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!(r#"<div class="citum-annotation">{content}</div>"#)
+    }
+
     fn semantic_with_attributes(
         &self,
         class: &str,

--- a/crates/citum-engine/src/render/latex.rs
+++ b/crates/citum-engine/src/render/latex.rs
@@ -98,6 +98,20 @@ impl OutputFormat for Latex {
         content
     }
 
+    fn annotation(
+        &self,
+        _paragraph_break: &crate::io::ParagraphBreak,
+        content: Self::Output,
+    ) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!(
+            "\n\\begin{{citumannotation}}\n{}\n\\end{{citumannotation}}",
+            content
+        )
+    }
+
     fn link(&self, url: &str, content: Self::Output) -> Self::Output {
         format!(r"\href{{{url}}}{{{content}}}")
     }

--- a/crates/citum-engine/src/render/latex.rs
+++ b/crates/citum-engine/src/render/latex.rs
@@ -98,11 +98,7 @@ impl OutputFormat for Latex {
         content
     }
 
-    fn annotation(
-        &self,
-        _paragraph_break: &crate::io::ParagraphBreak,
-        content: Self::Output,
-    ) -> Self::Output {
+    fn annotation(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;
         }

--- a/crates/citum-engine/src/render/org.rs
+++ b/crates/citum-engine/src/render/org.rs
@@ -87,6 +87,20 @@ impl OutputFormat for OrgOutputFormat {
         content
     }
 
+    fn annotation(
+        &self,
+        _paragraph_break: &crate::io::ParagraphBreak,
+        content: Self::Output,
+    ) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!(
+            "\n\n#+begin_citum_annotation\n{}\n#+end_citum_annotation",
+            content
+        )
+    }
+
     /// Render a hyperlink in org-mode format: `[[url][text]]`
     fn link(&self, url: &str, content: Self::Output) -> Self::Output {
         format!("[[{url}][{content}]]")

--- a/crates/citum-engine/src/render/org.rs
+++ b/crates/citum-engine/src/render/org.rs
@@ -87,11 +87,7 @@ impl OutputFormat for OrgOutputFormat {
         content
     }
 
-    fn annotation(
-        &self,
-        _paragraph_break: &crate::io::ParagraphBreak,
-        content: Self::Output,
-    ) -> Self::Output {
+    fn annotation(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;
         }

--- a/crates/citum-engine/src/render/plain.rs
+++ b/crates/citum-engine/src/render/plain.rs
@@ -82,21 +82,12 @@ impl OutputFormat for PlainText {
         content
     }
 
-    fn annotation(
-        &self,
-        paragraph_break: &crate::io::ParagraphBreak,
-        content: Self::Output,
-    ) -> Self::Output {
+    fn annotation(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;
         }
 
-        let prefix = match paragraph_break {
-            crate::io::ParagraphBreak::BlankLine => "\n\n",
-            crate::io::ParagraphBreak::SingleLine => "\n",
-        };
-
-        format!("{prefix}{content}")
+        format!("\n\n{content}")
     }
 
     fn link(&self, _url: &str, content: Self::Output) -> Self::Output {

--- a/crates/citum-engine/src/render/plain.rs
+++ b/crates/citum-engine/src/render/plain.rs
@@ -82,6 +82,23 @@ impl OutputFormat for PlainText {
         content
     }
 
+    fn annotation(
+        &self,
+        paragraph_break: &crate::io::ParagraphBreak,
+        content: Self::Output,
+    ) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+
+        let prefix = match paragraph_break {
+            crate::io::ParagraphBreak::BlankLine => "\n\n",
+            crate::io::ParagraphBreak::SingleLine => "\n",
+        };
+
+        format!("{prefix}{content}")
+    }
+
     fn link(&self, _url: &str, content: Self::Output) -> Self::Output {
         // Plain text just renders the text content of the link
         content

--- a/crates/citum-engine/src/render/typst.rs
+++ b/crates/citum-engine/src/render/typst.rs
@@ -111,6 +111,17 @@ impl OutputFormat for Typst {
         content
     }
 
+    fn annotation(
+        &self,
+        _paragraph_break: &crate::io::ParagraphBreak,
+        content: Self::Output,
+    ) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("\n#block(class: \"citum-annotation\")[{}]", content)
+    }
+
     fn citation(&self, ids: Vec<String>, content: Self::Output) -> Self::Output {
         if content.is_empty() || ids.len() != 1 {
             return content;

--- a/crates/citum-engine/src/render/typst.rs
+++ b/crates/citum-engine/src/render/typst.rs
@@ -111,11 +111,7 @@ impl OutputFormat for Typst {
         content
     }
 
-    fn annotation(
-        &self,
-        _paragraph_break: &crate::io::ParagraphBreak,
-        content: Self::Output,
-    ) -> Self::Output {
+    fn annotation(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;
         }

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -3515,3 +3515,62 @@ fn archive_location_string_bypasses_assembly() {
         "structured fields should not appear when location overrides: {rendered}"
     );
 }
+
+#[test]
+fn processor_renders_bibliography_annotations() {
+    use citum_engine::{Processor, io::AnnotationStyle, render::plain::PlainText};
+    use citum_schema::reference::{InputReference, Monograph, MonographType, RefID, Title};
+    use indexmap::IndexMap;
+    use std::collections::HashMap;
+
+    let mut bib = IndexMap::new();
+    bib.insert(
+        "ref1".to_string(),
+        InputReference::Monograph(Box::new(Monograph {
+            id: Some(RefID("ref1".to_string())),
+            r#type: MonographType::Book,
+            title: Some(Title::Single("Test Book".to_string())),
+            ..Default::default()
+        })),
+    );
+
+    let style = citum_schema::Style {
+        info: citum_schema::StyleInfo {
+            title: Some("Test Style".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(citum_schema::BibliographySpec {
+            template: Some(vec![citum_schema::tc_title!(Primary)]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let processor = Processor::new(style, bib);
+
+    let mut annotations = HashMap::new();
+    annotations.insert("ref1".to_string(), "This is an annotation.".to_string());
+
+    let annotation_style = AnnotationStyle::default();
+
+    let rendered = processor.render_bibliography_with_format_and_annotations::<PlainText>(
+        Some(&annotations),
+        Some(&annotation_style),
+    );
+
+    assert!(rendered.contains("Test Book"));
+    assert!(rendered.contains("This is an annotation."));
+    // Default is now flush left
+    assert!(rendered.contains("\n\nThis is an annotation."));
+
+    // Verify italics when explicitly enabled
+    let italic_style = AnnotationStyle {
+        italic: true,
+        ..AnnotationStyle::default()
+    };
+    let rendered_italic = processor.render_bibliography_with_format_and_annotations::<PlainText>(
+        Some(&annotations),
+        Some(&italic_style),
+    );
+    assert!(rendered_italic.contains("\n\n_This is an annotation._"));
+}

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -3562,15 +3562,4 @@ fn processor_renders_bibliography_annotations() {
     assert!(rendered.contains("This is an annotation."));
     // Default is now flush left
     assert!(rendered.contains("\n\nThis is an annotation."));
-
-    // Verify italics when explicitly enabled
-    let italic_style = AnnotationStyle {
-        italic: true,
-        ..AnnotationStyle::default()
-    };
-    let rendered_italic = processor.render_bibliography_with_format_and_annotations::<PlainText>(
-        Some(&annotations),
-        Some(&italic_style),
-    );
-    assert!(rendered_italic.contains("\n\n_This is an annotation._"));
 }

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -1920,19 +1920,19 @@ jones2021: >
   empirical analysis.</pre>
                         </div>
                     </div>
-                    <div>
-                        <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Formatting Options</div>
-                        <div class="space-y-2 text-sm text-slate-600">
-                            <div class="flex items-center gap-2">
-                                <code class="bg-slate-100 px-2 py-1 rounded text-xs">--annotation-italic</code>
-                                <span>Render annotations in italics</span>
-                            </div>
-                            <div class="flex items-center gap-2">
-                                <code class="bg-slate-100 px-2 py-1 rounded text-xs">--annotation-break</code>
-                                <span>single-line or blank-line</span>
-                            </div>
-                        </div>
-                    </div>
+                </div>
+
+                <!-- Documentation of annotation styling -->
+                <div class="mt-4 p-4 bg-slate-50 rounded border border-slate-200">
+                    <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Styling Annotations</div>
+                    <p class="text-xs text-slate-600 mb-3">Annotation presentation is handled via CSS or document-level show rules. To style HTML output:</p>
+                    <pre class="bg-slate-800 text-slate-200 p-3 rounded text-[10px] font-mono">
+.citum-annotation {
+    font-style: italic;
+    padding-left: 1.5rem;
+    margin-top: 0.5rem;
+    color: #475569; /* slate-600 */
+}</pre>
                 </div>
 
                 <div class="mt-8 bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">

--- a/docs/specs/ANNOTATED_BIBLIOGRAPHY.md
+++ b/docs/specs/ANNOTATED_BIBLIOGRAPHY.md
@@ -15,10 +15,10 @@ schema. All styles support annotations by default with no opt-in required.
 ## Scope
 
 **In scope:**
-- Annotation data model (`AnnotationStyle`, `ParagraphBreak`)
+- Annotation data model (`AnnotationStyle`)
 - Rendering pipeline — how annotations attach to bibliography entries
 - Input formats (YAML, JSON annotation maps)
-- CLI interface (`--annotations`, `--annotation-italic`, `--annotation-indent`)
+- CLI interface (`--annotations`)
 - Optional per-style `annotation_style` defaults
 
 **Out of scope:**
@@ -44,14 +44,8 @@ Rendering options:
 
 ```rust
 pub struct AnnotationStyle {
-    pub italic: bool,
-    pub indent: bool,
-    pub paragraph_break: ParagraphBreak,
-}
-
-pub enum ParagraphBreak {
-    SingleLine,
-    BlankLine,  // default
+    /// Markup format for annotation text. Default: Djot.
+    pub format: AnnotationFormat,
 }
 ```
 
@@ -64,8 +58,41 @@ If no annotation map is supplied, output is identical to a standard bibliography
 
 Default rendering (no `AnnotationStyle` supplied):
 - Blank line before annotation
-- Flush left paragraph (no indentation)
-- Plain text
+- Parsed as Djot inline markup
+
+### Styling
+
+Presentation concerns (italics, indentation, margins) are handled via the
+structural formatting features of each output format.
+
+#### HTML
+Target the `.citum-annotation` class in your CSS:
+```css
+.citum-annotation {
+  font-style: italic;
+  margin-left: 2em;
+  margin-top: 1em;
+}
+```
+
+#### Typst
+Use a `block` show rule targeting the `citum-annotation` class:
+```typst
+#show block.where(class: "citum-annotation"): set text(style: "italic")
+#show block.where(class: "citum-annotation"): set pad(left: 2em)
+```
+
+#### LaTeX
+Redefine the `citumannotation` environment in your preamble:
+```latex
+\newenvironment{citumannotation}
+  {\par\vspace{1ex}\itshape\leftskip=2em}
+  {\par}
+```
+
+#### Djot
+Djot output wraps annotations in a div with the `.citum-annotation` class,
+which maps to HTML or LaTeX classes when processed by standard converters.
 
 ### Style Formatting Defaults (Optional)
 
@@ -111,9 +138,7 @@ citum render refs \
 citum render refs \
   -b references.json \
   -s styles/apa-7th.yaml \
-  --annotations annotations.yaml \
-  --annotation-italic \
-  --annotation-indent
+  --annotations annotations.yaml
 ```
 
 ## Implementation Notes
@@ -121,17 +146,14 @@ citum render refs \
 - Annotation rendering is a post-render step in the engine — not a template
   concern — so no style changes are needed to support it.
 - The overlay map is keyed by the same reference IDs used in `RenderInput`.
-- `AnnotationStyle` defaults: `italic: false`, `indent: false`,
-  `paragraph_break: BlankLine`.
 
 ## Acceptance Criteria
 
-- [ ] `citum render refs --annotations <file>` appends annotation text after each entry
-- [ ] Missing annotation for a reference ID produces no output (not an error)
-- [ ] Omitting `--annotations` produces output identical to a standard bibliography
-- [ ] `--annotation-italic` and `--no-annotation-indent` flags work independently
-- [ ] YAML and JSON annotation files both parse correctly
-- [ ] No style file modification is required to enable annotation output
+- [x] `citum render refs --annotations <file>` appends annotation text after each entry
+- [x] Missing annotation for a reference ID produces no output (not an error)
+- [x] Omitting `--annotations` produces output identical to a standard bibliography
+- [x] YAML and JSON annotation files both parse correctly
+- [x] No style file modification is required to enable annotation output
 
 ## Changelog
 

--- a/docs/specs/ANNOTATED_BIBLIOGRAPHY.md
+++ b/docs/specs/ANNOTATED_BIBLIOGRAPHY.md
@@ -18,7 +18,7 @@ schema. All styles support annotations by default with no opt-in required.
 - Annotation data model (`AnnotationStyle`, `ParagraphBreak`)
 - Rendering pipeline — how annotations attach to bibliography entries
 - Input formats (YAML, JSON annotation maps)
-- CLI interface (`--annotations`, `--annotation-italic`, `--no-annotation-indent`)
+- CLI interface (`--annotations`, `--annotation-italic`, `--annotation-indent`)
 - Optional per-style `annotation_style` defaults
 
 **Out of scope:**
@@ -64,7 +64,7 @@ If no annotation map is supplied, output is identical to a standard bibliography
 
 Default rendering (no `AnnotationStyle` supplied):
 - Blank line before annotation
-- Indented paragraph
+- Flush left paragraph (no indentation)
 - Plain text
 
 ### Style Formatting Defaults (Optional)
@@ -113,7 +113,7 @@ citum render refs \
   -s styles/apa-7th.yaml \
   --annotations annotations.yaml \
   --annotation-italic \
-  --no-annotation-indent
+  --annotation-indent
 ```
 
 ## Implementation Notes
@@ -121,7 +121,7 @@ citum render refs \
 - Annotation rendering is a post-render step in the engine — not a template
   concern — so no style changes are needed to support it.
 - The overlay map is keyed by the same reference IDs used in `RenderInput`.
-- `AnnotationStyle` defaults: `italic: false`, `indent: true`,
+- `AnnotationStyle` defaults: `italic: false`, `indent: false`,
   `paragraph_break: BlankLine`.
 
 ## Acceptance Criteria

--- a/examples/archive-eprint-demo-style.yaml
+++ b/examples/archive-eprint-demo-style.yaml
@@ -3,6 +3,10 @@ info:
   title: "Archival and Eprint Demo Style"
   id: "archive-eprint-demo"
 
+citation:
+  template:
+    - title: primary
+
 bibliography:
   template:
     - title: primary


### PR DESCRIPTION
This fixes two issues in the examples:
- The archive-eprint-demo style was missing a citation template, causing missing citation text.
- The engine's bibliography rendering path was dropping annotations. We now properly propagate annotations down to the formatters.