### PR TITLE
feat(cli): distributed architecture phase 1

### DIFF
--- a/.beans/csl26-r8d2--distributed-resolver-architecture.md
+++ b/.beans/csl26-r8d2--distributed-resolver-architecture.md
@@ -25,12 +25,26 @@ Currently, Citum relies on a centralized builtin registry and a local user store
 To support over 1M+ users while enabling institutional autonomy, Citum needs a federated, GitOps-friendly resolution model inspired by modern package managers (Cargo, npm) and decentralized protocols (AT Protocol).
 
 # Proposal
-Evolve `citum-core`'s resolution logic to support a truly distributed ecosystem:
+Evolve `citum-core`'s resolution logic to support a truly distributed ecosystem via a phased approach:
 
-1. **Universal Resource Identifiers (URIs):** Transition `extends` references to a URI-based system (e.g., `@hub/apa`, `did:web:university.edu/styles/thesis`).
-2. **Pluggable Resolvers:** Implement a resolver trait that allows the engine to fetch style parents from multiple backends (local file system, Hub API, Git).
-3. **Immutability and Content Addressing:** Integrate content-addressable hashes (CIDs) or strict semantic versioning to prevent "left-pad" style breakages.
-4. **Caching Layer:** Design a robust local caching mechanism for remote styles to ensure resilient, offline-first rendering.
+## Phase 1: Trait Boundary & URI Foundation (Current Focus)
+Establish a flexible, trait-based resolution boundary and generalize the `extends` mechanism to support URIs, without adding network dependencies yet.
+- **StyleReference Enum:** Update `extends` to support both `StyleBase` enums and URI strings (e.g., `file://...`, `@hub/...`, `https://...`).
+- **StyleResolver Trait:** Introduce a trait in `citum_store` for resolving styles and locales.
+- **Resolver Chain:** Implement concrete resolvers (`FileResolver`, `StoreResolver`, `EmbeddedResolver`) and a `ChainResolver` for sequential fallback.
+- **CLI Refactor:** Transition `citum-cli` to use the `ChainResolver` for all style loading.
+
+## Phase 2: Remote Fetching & Caching
+Add networking capabilities and a local caching layer to ensure offline-first resilience.
+- **Remote Resolvers:** Implement `HttpResolver` and `GitResolver` to fetch styles from standard endpoints.
+- **Caching Middleware:** Wrap remote resolvers in a local cache that stores fetched styles in the user data directory.
+- **Institutional Autonomy:** Enable organizations to host their own style registries via static HTTP or Git.
+
+## Phase 3: Content Addressing & Hub Federation
+Scale the architecture for massive distribution and trust.
+- **CIDs:** Integrate content-addressable hashes (CIDs) for immutable style references.
+- **Verification:** Implement hashing middleware to verify remote style integrity against URIs.
+- **Hub Protocol:** Design and implement decentralized registry protocols for Citum Hub federation.
 
 # Key Considerations
 - **Trust & Security:** Evaluating the implications of fetching and executing remote style/locale definitions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "citum"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "citum-analyze"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "citum-migrate",
  "citum-schema",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "citum-bindings"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "citum-engine",
  "citum-schema",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "serde",
  "winnow 0.7.15",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "biblatex 0.11.0",
  "ciborium",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "citum-migrate"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "citum-schema",
  "csl-legacy",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "citum-pdf"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "typst",
  "typst-kit",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "ciborium",
  "citum-schema-data",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "ciborium",
  "citum-edtf",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "citum-server"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "axum",
  "citum-engine",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "citum_store"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "ciborium",
  "citum-schema",
@@ -900,7 +900,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "csl-legacy"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.34.0"
+version = "0.35.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -125,7 +125,7 @@ fn parse_references(refs_json: &str) -> Result<IndexMap<String, Reference>, Stri
 pub fn ensure_style_has_templates(style: &mut Style) {
     if style.citation.is_none() {
         style.citation = Some(CitationSpec {
-            extends: Some(TemplatePreset::Apa),
+            extends: Some(TemplatePreset::Apa.into()),
             ..Default::default()
         });
     }
@@ -154,7 +154,7 @@ pub fn ensure_style_has_templates(style: &mut Style) {
 
     if style.bibliography.is_none() {
         style.bibliography = Some(citum_schema::BibliographySpec {
-            extends: Some(TemplatePreset::Apa),
+            extends: Some(TemplatePreset::Apa.into()),
             ..Default::default()
         });
     }

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -90,51 +90,55 @@ pub(crate) fn create_processor(
 /// Load a style from a file path, user store, or fallback to builtin name/alias.
 pub(crate) fn load_any_style(
     style_input: &str,
-    no_semantics: bool,
+    _no_semantics: bool,
 ) -> Result<Style, Box<dyn Error>> {
-    let path = Path::new(style_input);
-    if path.exists() && path.is_file() {
-        return load_style(path, no_semantics);
-    }
+    use citum_store::resolver::{ChainResolver, EmbeddedResolver, FileResolver, StyleResolver};
 
-    // Try user store first
+    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
+
+    // Try user store if it exists
     if let Some(data_dir) = platform_data_dir()
         && data_dir.exists()
     {
         let config = StoreConfig::load().unwrap_or_default();
-        let resolver = StoreResolver::new(data_dir, config.store_format());
-        if let Ok(style) = resolver.resolve_style(style_input) {
-            return Ok(style);
-        }
+        resolvers.push(Box::new(StoreResolver::new(
+            data_dir,
+            config.store_format(),
+        )));
     }
 
-    if let Some(res) = citum_schema::embedded::get_embedded_style(style_input) {
-        return res.map_err(std::convert::Into::into);
-    }
+    resolvers.push(Box::new(EmbeddedResolver));
 
-    // Fuzzy matching suggestion
-    let suggestions: Vec<_> = citum_schema::embedded::EMBEDDED_STYLE_NAMES
-        .iter()
-        .chain(
-            citum_schema::embedded::EMBEDDED_STYLE_ALIASES
+    let chain = ChainResolver::new(resolvers);
+
+    match chain.resolve_style(style_input) {
+        Ok(style) => Ok(style),
+        Err(citum_store::resolver::ResolverError::StyleNotFound(_)) => {
+            // Fuzzy matching suggestion for builtin styles
+            let suggestions: Vec<_> = citum_schema::embedded::EMBEDDED_STYLE_NAMES
                 .iter()
-                .map(|(a, _)| a),
-        )
-        .filter(|&&name| strsim::jaro_winkler(style_input, name) > 0.8)
-        .collect();
+                .chain(
+                    citum_schema::embedded::EMBEDDED_STYLE_ALIASES
+                        .iter()
+                        .map(|(a, _)| a),
+                )
+                .filter(|&&name| strsim::jaro_winkler(style_input, name) > 0.8)
+                .collect();
 
-    let mut msg = format!("style not found: '{style_input}'");
-    if suggestions.is_empty() {
-        msg.push_str("\n\nUse `citum styles list` to see all available builtin styles.");
-    } else {
-        msg.push_str("\n\nDid you mean one of these?");
-        for s in suggestions {
-            msg.push_str("\n  - ");
-            msg.push_str(s);
+            let mut msg = format!("style not found: '{style_input}'");
+            if suggestions.is_empty() {
+                msg.push_str("\n\nUse `citum styles list` to see all available builtin styles.");
+            } else {
+                msg.push_str("\n\nDid you mean one of these?");
+                for s in suggestions {
+                    msg.push_str("\n  - ");
+                    msg.push_str(s);
+                }
+            }
+            Err(msg.into())
         }
+        Err(err) => Err(err.into()),
     }
-
-    Err(msg.into())
 }
 
 /// Heuristically locate the `locales/` directory relative to a style file.
@@ -166,23 +170,6 @@ pub(crate) fn load_locale_override_for_file_style(
 ) -> Result<Option<LocaleOverride>, Box<dyn Error>> {
     let overrides_dir = find_locales_dir(style_path).join("overrides");
     load_locale_override_from_dir(override_id, &overrides_dir)
-}
-
-/// Load a Citum style from a file path.
-///
-/// Selects the deserialiser based on the file extension (`cbor`, `json`, or YAML
-/// for anything else).
-pub(crate) fn load_style(path: &Path, _no_semantics: bool) -> Result<Style, Box<dyn Error>> {
-    let bytes = fs::read(path)?;
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
-
-    let style_obj: Style = match ext {
-        "cbor" => ciborium::de::from_reader(std::io::Cursor::new(&bytes))?,
-        "json" => serde_json::from_slice(&bytes)?,
-        _ => Style::from_yaml_bytes(&bytes)?,
-    };
-
-    Ok(style_obj)
 }
 
 /// Load a locale from embedded bytes, falling back to en-US.

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -1166,7 +1166,7 @@ fn chicago_german_override_localizes_editor_verb() {
             default_locale: Some("de-DE".to_string()),
             ..Default::default()
         },
-        extends: Some(StyleBase::ChicagoAuthorDate18th),
+        extends: Some(StyleBase::ChicagoAuthorDate18th.into()),
         options: Some(Config {
             locale_override: Some("de-DE-chicago".to_string()),
             contributors: Some(ContributorConfig {

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -95,7 +95,7 @@ pub use template::{
 pub type Template = Vec<TemplateComponent>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
-pub const STYLE_SCHEMA_VERSION: &str = "0.40.0";
+pub const STYLE_SCHEMA_VERSION: &str = "0.41.0";
 
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]
@@ -189,12 +189,12 @@ pub struct Style {
     pub custom: Option<HashMap<String, serde_json::Value>>,
     /// Extends a base style, with optional local overrides.
     ///
-    /// When present, the base [`StyleBase`] is resolved and the local
+    /// When present, the base [`StyleReference`](style_base::StyleReference) is resolved and the local
     /// overrides are merged before any further processing. Explicit `options`,
     /// `citation`, and `bibliography` keys at the same document level take
     /// precedence over the resolved base.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extends: Option<style_base::StyleBase>,
+    pub extends: Option<style_base::StyleReference>,
     /// Raw YAML captured when the style was loaded via [`Style::from_yaml_str`]
     /// or [`Style::from_yaml_bytes`]. Used by [`merge_style_overlay`] for
     /// null-aware overlay merging (e.g., `ibid: ~` correctly clears an
@@ -252,7 +252,7 @@ impl Style {
         clippy::panic,
         reason = "Convenience API for infallible resolution contexts"
     )]
-    pub fn into_resolved_recursive(self, visited: &mut HashSet<StyleBase>) -> Self {
+    pub fn into_resolved_recursive(self, visited: &mut HashSet<String>) -> Self {
         self.try_into_resolved_recursive(visited)
             .unwrap_or_else(|err| panic!("style resolution failed: {err}"))
     }
@@ -265,24 +265,32 @@ impl Style {
     /// contract, when profile capability validation fails, or when
     /// inheritance loops are detected.
     pub fn try_into_resolved_recursive(
-        self,
-        visited: &mut HashSet<StyleBase>,
+        mut self,
+        visited: &mut HashSet<String>,
     ) -> Result<Self, ResolutionError> {
-        let Some(base) = self.extends.clone() else {
+        let Some(base_ref) = self.extends.clone() else {
             let mut style = self;
             options::scoped::apply_scoped_style_options(&mut style);
             return Ok(style);
         };
 
-        if visited.contains(&base) {
-            return Err(ResolutionError::InheritanceLoop {
-                base: base.key().to_string(),
-            });
+        let key = base_ref.key().to_string();
+        if visited.contains(&key) {
+            return Err(ResolutionError::InheritanceLoop { base: key });
         }
-        visited.insert(base.clone());
+        visited.insert(key);
 
         let is_profile = self.resolves_as_profile();
-        let mut effective = base.try_resolve_with_visited(visited)?;
+        let mut effective = match base_ref {
+            style_base::StyleReference::Base(base) => base.try_resolve_with_visited(visited)?,
+            style_base::StyleReference::Uri(_) => {
+                // Phase 2: Resolve URI via StyleResolver trait.
+                // For now, apply scoped options and return self to avoid
+                // breaking non-URI flows.
+                options::scoped::apply_scoped_style_options(&mut self);
+                return Ok(self);
+            }
+        };
         if is_profile {
             self.validate_profile_shape()?;
         }
@@ -570,6 +578,24 @@ pub enum TemplatePreset {
     NumericCitation,
 }
 
+/// A reference to a template, which can be either a named builtin preset
+/// or a URI (e.g., `file://...`, `@hub/...`, `https://...`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum TemplateReference {
+    /// A named builtin template preset.
+    Preset(TemplatePreset),
+    /// A URI reference to a remote or local template.
+    Uri(String),
+}
+
+impl From<TemplatePreset> for TemplateReference {
+    fn from(preset: TemplatePreset) -> Self {
+        TemplateReference::Preset(preset)
+    }
+}
+
 impl TemplatePreset {
     /// Resolve this preset to a citation template.
     pub fn citation_template(&self) -> Template {
@@ -650,7 +676,7 @@ pub struct CitationSpec {
     /// Reference to an embedded template preset.
     /// If both `extends` and `template` are present, `template` takes precedence.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extends: Option<TemplatePreset>,
+    pub extends: Option<TemplateReference>,
     /// Default template when no localized override is selected.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub template: Option<Template>,
@@ -725,9 +751,15 @@ impl CitationSpec {
     /// Returns the explicit `template` if present, otherwise resolves `extends`.
     /// Returns `None` if neither is specified.
     pub fn resolve_template(&self) -> Option<Template> {
-        self.template
-            .clone()
-            .or_else(|| self.extends.as_ref().map(|p| p.citation_template()))
+        self.template.clone().or_else(|| {
+            self.extends.as_ref().and_then(|r| match r {
+                TemplateReference::Preset(p) => Some(p.citation_template()),
+                TemplateReference::Uri(_) => {
+                    // TODO (Phase 2): Emit validation warning for unresolved URIs
+                    None
+                }
+            })
+        })
     }
 
     /// Resolve the template for a language by checking localized overrides,
@@ -937,7 +969,7 @@ pub struct BibliographySpec {
     /// Reference to an embedded template preset.
     /// If both `extends` and `template` are present, `template` takes precedence.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extends: Option<TemplatePreset>,
+    pub extends: Option<TemplateReference>,
     /// The default template for bibliography entries.
     /// Default template for entries when no localized override is selected.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -976,9 +1008,15 @@ impl BibliographySpec {
     /// Returns the explicit `template` if present, otherwise resolves `extends`.
     /// Returns `None` if neither is specified.
     pub fn resolve_template(&self) -> Option<Template> {
-        self.template
-            .clone()
-            .or_else(|| self.extends.as_ref().map(|p| p.bibliography_template()))
+        self.template.clone().or_else(|| {
+            self.extends.as_ref().and_then(|r| match r {
+                TemplateReference::Preset(p) => Some(p.bibliography_template()),
+                TemplateReference::Uri(_) => {
+                    // TODO (Phase 2): Emit validation warning for unresolved URIs
+                    None
+                }
+            })
+        })
     }
 
     /// Resolve the template for a language by checking localized overrides,

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -132,8 +132,37 @@ impl StyleBase {
             StyleBase::ModernLanguageAssociation => "modern-language-association",
         }
     }
+}
 
-    /// Return the base [`Style`] for this base.
+/// A reference to a base style, which can be either a named builtin base
+/// or a URI (e.g., `file://...`, `@hub/...`, `https://...`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum StyleReference {
+    /// A named builtin style base.
+    Base(StyleBase),
+    /// A URI reference to a remote or local style.
+    Uri(String),
+}
+
+impl StyleReference {
+    /// Returns a string key identifying this reference.
+    pub fn key(&self) -> &str {
+        match self {
+            StyleReference::Base(base) => base.key(),
+            StyleReference::Uri(uri) => uri,
+        }
+    }
+}
+
+impl From<StyleBase> for StyleReference {
+    fn from(base: StyleBase) -> Self {
+        StyleReference::Base(base)
+    }
+}
+
+impl StyleBase {
     ///
     /// # Panics
     ///
@@ -233,7 +262,7 @@ impl StyleBase {
     /// Internal resolver with loop protection that preserves profile errors.
     pub(crate) fn try_resolve_with_visited(
         &self,
-        visited: &mut HashSet<StyleBase>,
+        visited: &mut HashSet<String>,
     ) -> Result<Style, crate::ResolutionError> {
         let mut style = self.base();
         if style.extends.is_some() {
@@ -378,7 +407,7 @@ citation:
                 id: Some("tf-test".into()),
                 ..Default::default()
             },
-            extends: Some(StyleBase::ChicagoAuthorDate18th),
+            extends: Some(StyleBase::ChicagoAuthorDate18th.into()),
             options: Some(Config {
                 page_range_format: Some(PageRangeFormat::Expanded),
                 ..Default::default()
@@ -404,7 +433,7 @@ citation:
     #[test]
     fn style_base_circular_dependency_is_handled() {
         let mut base = StyleBase::ChicagoNotes18th.base();
-        base.extends = Some(StyleBase::ChicagoNotes18th);
+        base.extends = Some(StyleBase::ChicagoNotes18th.into());
 
         let resolved = base.into_resolved();
         assert!(resolved.extends.is_some());

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -34,10 +34,132 @@ pub enum ResolverError {
     CborError(String),
 }
 
+/// A trait for resolving Citum styles and locales from various sources.
+pub trait StyleResolver {
+    /// Resolve a style by URI or ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResolverError::StyleNotFound`] if the style cannot be located.
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError>;
+
+    /// Resolve a locale by ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResolverError::LocaleNotFound`] if the locale cannot be located.
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError>;
+}
+
 /// Resolves user-installed styles and locales from platform-specific data directories.
 pub struct StoreResolver {
     data_dir: PathBuf,
     format: StoreFormat,
+}
+
+impl StyleResolver for StoreResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        StoreResolver::resolve_style(self, uri)
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+        StoreResolver::resolve_locale(self, id)
+    }
+}
+
+/// A resolver that checks for embedded styles and locales.
+pub struct EmbeddedResolver;
+
+impl StyleResolver for EmbeddedResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        citum_schema::embedded::get_embedded_style(uri)
+            .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?
+            .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)))
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+        if let Some(bytes) = citum_schema::embedded::get_locale_bytes(id) {
+            let content = String::from_utf8_lossy(bytes);
+            Locale::from_yaml_str(&content)
+                .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)))
+        } else {
+            Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+        }
+    }
+}
+
+/// A resolver that handles local file paths.
+pub struct FileResolver;
+
+impl StyleResolver for FileResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        // Normalize file:// URIs to plain filesystem paths.
+        let raw_path = uri.strip_prefix("file://").unwrap_or(uri);
+        let path = Path::new(raw_path);
+        if path.exists() && path.is_file() {
+            let bytes = fs::read(path).map_err(ResolverError::Io)?;
+            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
+
+            let style: Style = match ext {
+                "cbor" => ciborium::de::from_reader(Cursor::new(&bytes))
+                    .map_err(|e| ResolverError::CborError(e.to_string()))?,
+                "json" => serde_json::from_slice(&bytes)?,
+                _ => Style::from_yaml_bytes(&bytes)
+                    .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)))?,
+            };
+            Ok(style)
+        } else {
+            Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))
+        }
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+        let locales_dir = Path::new("locales");
+        for ext in ["yaml", "yml", "json", "cbor"] {
+            let path = locales_dir.join(format!("{id}.{ext}"));
+            if path.exists() {
+                return Locale::from_file(&path)
+                    .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)));
+            }
+        }
+        Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+    }
+}
+
+/// A composite resolver that attempts resolution through a chain of resolvers.
+pub struct ChainResolver {
+    resolvers: Vec<Box<dyn StyleResolver>>,
+}
+
+impl ChainResolver {
+    /// Create a new chain resolver with the given list of resolvers.
+    pub fn new(resolvers: Vec<Box<dyn StyleResolver>>) -> Self {
+        ChainResolver { resolvers }
+    }
+}
+
+impl StyleResolver for ChainResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        for resolver in &self.resolvers {
+            match resolver.resolve_style(uri) {
+                Ok(style) => return Ok(style),
+                Err(ResolverError::StyleNotFound(_)) => {}
+                Err(err) => return Err(err),
+            }
+        }
+        Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+        for resolver in &self.resolvers {
+            match resolver.resolve_locale(id) {
+                Ok(locale) => return Ok(locale),
+                Err(ResolverError::LocaleNotFound(_)) => {}
+                Err(err) => return Err(err),
+            }
+        }
+        Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+    }
 }
 
 impl StoreResolver {
@@ -152,7 +274,7 @@ impl StoreResolver {
 
         match format {
             StoreFormat::Yaml => serde_yaml::from_slice(&content)
-                .map_err(|e| ResolverError::YamlError(e.to_string())),
+                .map_err(|e| ResolverError::YamlError(ToString::to_string(&e))),
             StoreFormat::Json => serde_json::from_slice(&content).map_err(ResolverError::JsonError),
             StoreFormat::Cbor => ciborium::de::from_reader(Cursor::new(&content))
                 .map_err(|e| ResolverError::CborError(e.to_string())),

--- a/crates/citum_store/tests/resolver_arch.rs
+++ b/crates/citum_store/tests/resolver_arch.rs
@@ -1,0 +1,93 @@
+//! Tests for the resolver architecture.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::unreachable,
+    clippy::get_unwrap,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+
+use citum_store::resolver::{
+    ChainResolver, EmbeddedResolver, FileResolver, ResolverError, StyleResolver,
+};
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_file_resolver_uri_handling() {
+    let temp = TempDir::new().unwrap();
+    let style_path = temp.path().join("test.yaml");
+    fs::write(&style_path, "info:\n  title: Test Style\n").unwrap();
+
+    let resolver = FileResolver;
+
+    // Test with absolute file path
+    let uri = style_path.to_str().unwrap();
+    let style = resolver.resolve_style(uri).unwrap();
+    assert_eq!(style.info.title.as_deref(), Some("Test Style"));
+}
+
+#[test]
+fn test_file_resolver_locale_resolution() {
+    // FileResolver checks locales/{id}.{ext} relative to CWD.
+    // We only verify the NotFound path here to avoid polluting the workspace.
+    let resolver = FileResolver;
+    match resolver.resolve_locale("nonexistent-test-locale-1234") {
+        Err(ResolverError::LocaleNotFound(_)) => (),
+        _ => panic!("Expected LocaleNotFound"),
+    }
+}
+
+#[test]
+fn test_chain_resolver_fallback() {
+    let temp = TempDir::new().unwrap();
+    let style_path = temp.path().join("test.yaml");
+    fs::write(&style_path, "info:\n  title: Test Style\n").unwrap();
+
+    let file_resolver = Box::new(FileResolver);
+    let embedded_resolver = Box::new(EmbeddedResolver);
+
+    let chain = ChainResolver::new(vec![file_resolver, embedded_resolver]);
+
+    // Should find test.yaml
+    let style_uri = style_path.to_str().unwrap();
+    let style = chain.resolve_style(style_uri).unwrap();
+    assert_eq!(style.info.title.as_deref(), Some("Test Style"));
+
+    // Should find embedded style
+    let style = chain.resolve_style("apa").unwrap();
+    assert_eq!(
+        style.info.title.as_deref(),
+        Some("American Psychological Association 7th edition")
+    );
+
+    // Should return NotFound for missing style
+    match chain.resolve_style("nonexistent") {
+        Err(ResolverError::StyleNotFound(_)) => (),
+        _ => panic!("Expected StyleNotFound error"),
+    }
+}
+
+#[test]
+fn test_chain_resolver_error_propagation() {
+    let temp = TempDir::new().unwrap();
+    let style_path = temp.path().join("invalid.yaml");
+    fs::write(&style_path, "invalid yaml content: [").unwrap();
+
+    let file_resolver = Box::new(FileResolver);
+    let embedded_resolver = Box::new(EmbeddedResolver);
+
+    let chain = ChainResolver::new(vec![file_resolver, embedded_resolver]);
+
+    // Should propagate YamlError rather than falling back to next resolver
+    let style_uri = style_path.to_str().unwrap();
+    match chain.resolve_style(style_uri) {
+        Err(ResolverError::YamlError(_)) => (),
+        err => panic!("Expected YamlError, got {:?}", err),
+    }
+}

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -210,6 +210,11 @@ Track schema changes separately from code changes.
 Historical note: entries below may predate the automation baseline and are the
 authoritative record when matching tags were not created at the time.
 
+#### schema-v0.41.0 (2026-05-03)
+- Schema version bumped from 0.40.0 to 0.41.0
+- Generalized `extends` to support URIs via `StyleReference` and `TemplateReference`
+- Phase 1 of Distributed Resolver Architecture implementation
+
 #### schema-v0.40.0 (2026-05-03)
 - Schema version bumped from 0.39.1 to 0.40.0
 - Renamed citation and bibliography template reuse from `use-preset` to `extends`

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7,7 +7,7 @@
     "version": {
       "description": "Style schema version.",
       "type": "string",
-      "default": "0.40.0"
+      "default": "0.41.0"
     },
     "info": {
       "description": "Style metadata.",
@@ -69,10 +69,10 @@
       "additionalProperties": true
     },
     "extends": {
-      "description": "Extends a base style, with optional local overrides.\n\nWhen present, the base [`StyleBase`] is resolved and the local\noverrides are merged before any further processing. Explicit `options`,\n`citation`, and `bibliography` keys at the same document level take\nprecedence over the resolved base.",
+      "description": "Extends a base style, with optional local overrides.\n\nWhen present, the base [`StyleReference`](style_base::StyleReference) is resolved and the local\noverrides are merged before any further processing. Explicit `options`,\n`citation`, and `bibliography` keys at the same document level take\nprecedence over the resolved base.",
       "anyOf": [
         {
-          "$ref": "#/$defs/StyleBase"
+          "$ref": "#/$defs/StyleReference"
         },
         {
           "type": "null"
@@ -4319,7 +4319,7 @@
           "description": "Reference to an embedded template preset.\nIf both `extends` and `template` are present, `template` takes precedence.",
           "anyOf": [
             {
-              "$ref": "#/$defs/TemplatePreset"
+              "$ref": "#/$defs/TemplateReference"
             },
             {
               "type": "null"
@@ -4722,6 +4722,19 @@
         }
       ]
     },
+    "TemplateReference": {
+      "description": "A reference to a template, which can be either a named builtin preset\nor a URI (e.g., `file://...`, `@hub/...`, `https://...`).",
+      "anyOf": [
+        {
+          "description": "A named builtin template preset.",
+          "$ref": "#/$defs/TemplatePreset"
+        },
+        {
+          "description": "A URI reference to a remote or local template.",
+          "type": "string"
+        }
+      ]
+    },
     "TemplatePreset": {
       "description": "Available embedded template presets.\n\nThese reference battle-tested templates for common citation styles.\nSee `citum_schema::embedded` for the actual template implementations.",
       "oneOf": [
@@ -4956,7 +4969,7 @@
           "description": "Reference to an embedded template preset.\nIf both `extends` and `template` are present, `template` takes precedence.",
           "anyOf": [
             {
-              "$ref": "#/$defs/TemplatePreset"
+              "$ref": "#/$defs/TemplateReference"
             },
             {
               "type": "null"
@@ -5864,6 +5877,19 @@
           "description": "Disambiguate only within the current group.",
           "type": "string",
           "const": "locally"
+        }
+      ]
+    },
+    "StyleReference": {
+      "description": "A reference to a base style, which can be either a named builtin base\nor a URI (e.g., `file://...`, `@hub/...`, `https://...`).",
+      "anyOf": [
+        {
+          "description": "A named builtin style base.",
+          "$ref": "#/$defs/StyleBase"
+        },
+        {
+          "description": "A URI reference to a remote or local style.",
+          "type": "string"
         }
       ]
     },


### PR DESCRIPTION
## Objective
Establish a flexible, trait-based resolution boundary and generalize the extends mechanism to support URIs, without adding network dependencies yet. This fulfills Phase 1 of the Distributed Resolver Architecture (bean csl26-r8d2).

## Changes
- StyleResolver Trait: Introduced in citum_store for resolving styles and locales.
- Resolver Chain: Implemented FileResolver, StoreResolver, EmbeddedResolver, and ChainResolver for sequential fallback.
- URI Support: Updated Style and Spec types to use StyleReference and TemplateReference, enabling support for URIs (e.g., file://..., @hub/..., https://...).
- CLI Refactor: Transitioned citum-cli to use the ChainResolver for all style loading.
- Version Bumps: Workspace version bumped to 0.35.0; Schema version bumped to 0.41.0.

## Bean
Closes (Phase 1) csl26-r8d2