### PR TITLE
chore(scripts): make RPC benchmark configurable

### DIFF
--- a/.beans/csl26-stat--consider-stateful-mode-for-citum-server.md
+++ b/.beans/csl26-stat--consider-stateful-mode-for-citum-server.md
@@ -1,0 +1,44 @@
+---
+# csl26-stat
+title: Consider optional stateful mode for citum-server
+status: draft
+type: research
+priority: low
+created_at: 2026-05-03T15:00:00Z
+updated_at: 2026-05-03T15:00:00Z
+---
+
+# Background
+
+`citum-server` currently uses a stateless JSON-RPC architecture. For methods like `render_citation` and `render_bibliography`, the client must send the entire `refs` library and `style_path` on every request.
+
+Recent benchmarking (PR #612) verified performance with `interval=1` (simulating true real-time, per-keystroke updates):
+- With 500 references, bibliography refreshes average ~21ms.
+- With 5000 references, bibliography refreshes average ~210ms.
+
+While ~210ms is highly performant given the serialization/parsing overhead, it is approaching the threshold of perceptible UI lag for real-time word processor plugins.
+
+# Proposal
+
+To support massive bibliographies with near-zero latency, consider adding an *optional* stateful mode to the server while preserving the stateless mode as the default.
+
+## Architectural Requirements
+
+1. **Persistent Application State:**
+   Introduce a session manager, e.g., `Arc<RwLock<HashMap<String, Processor>>>`, to keep instantiated processors hot in memory.
+
+2. **Session Management Methods:**
+   - `init_document(doc_id, style_path, initial_refs)`: Creates the processor.
+   - `close_document(doc_id)`: Frees the memory when the user closes the document.
+   - `update_refs(doc_id, added_refs, removed_ref_ids)`: Delta-updates to push new references without resending the entire library.
+
+3. **Stateful Rendering:**
+   `render_citation` and `render_bibliography` could accept an optional `doc_id`. If provided, the server bypasses JSON deserialization and style parsing entirely.
+
+4. **Handling Mutability:**
+   `Processor` maintains disambiguation and numbering state. A stateful server requires the plugin to manage operations linearly or requires a mechanism to reset/recalculate state when earlier citations are edited.
+
+## Trade-offs
+
+- **Pros:** Zero serialization overhead; sub-millisecond response times even for massive libraries; true real-time sync.
+- **Cons:** High client complexity (word processors are notoriously bad at lifecycle management, risking memory leaks if `close_document` is missed); risk of state drift between client and server.

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -1,0 +1,919 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Style Author Guide | Citum</title>
+
+        <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
+        <link
+            href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
+            rel="stylesheet"
+        />
+        <link
+            href="https://fonts.googleapis.com/icon?family=Material+Icons"
+            rel="stylesheet"
+        />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
+            rel="stylesheet"
+        />
+
+        <script>
+            tailwind.config = {
+                darkMode: "class",
+                theme: {
+                    extend: {
+                        colors: {
+                            primary: "#2a94d6",
+                            "background-light": "#fdfbf7",
+                            "accent-cream": "#f5f2eb",
+                        },
+                        fontFamily: {
+                            display: ["Libre Franklin", "sans-serif"],
+                            mono: ["JetBrains Mono", "monospace"],
+                        },
+                        borderRadius: {
+                            DEFAULT: "0.25rem",
+                            lg: "0.5rem",
+                            xl: "0.75rem",
+                            full: "9999px",
+                        },
+                    },
+                },
+            };
+        </script>
+        <style type="text/tailwindcss">
+            body {
+                font-family: "Libre Franklin", sans-serif;
+                color: #374151;
+            }
+            .font-mono {
+                font-family: "JetBrains Mono", monospace;
+            }
+            .glass-nav {
+                background: rgba(253, 251, 247, 0.85);
+                backdrop-filter: blur(12px);
+                border-bottom: 1px solid rgba(42, 148, 214, 0.1);
+            }
+            .sidebar-link {
+                @apply flex items-center gap-2 px-3 py-2 rounded text-sm text-slate-600 hover:text-primary hover:bg-primary/5 transition-all;
+            }
+            .sidebar-link.active {
+                @apply text-primary bg-primary/10 font-medium;
+            }
+            .toc-section {
+                @apply mb-6;
+            }
+            .toc-section-title {
+                @apply text-xs font-semibold uppercase tracking-widest text-slate-500 mb-2;
+            }
+        </style>
+        <link rel="stylesheet" href="../assets/citum-theme.css">
+</head>
+
+    <body class="bg-background-light text-slate-700 selection:bg-primary/20">
+        <!-- Navigation -->
+        <!-- LAYOUT_NAV_START -->
+        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
+            <div class="flex items-center gap-2 shrink-0">
+                <a href="../index.html" class="flex items-center gap-2 group">
+                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
+                        <span class="text-white font-mono font-bold">C</span>
+                    </div>
+                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+                </a>
+            </div>
+            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
+                <a class="nav-link" href="https://citum.org">Home</a>
+                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
+                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
+                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
+                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
+                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
+                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
+                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    Source
+                </a>
+            </div>
+            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="material-icons text-[20px]">menu</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
+            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
+                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
+                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
+                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
+                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
+                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
+                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
+                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
+                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
+            </div>
+        </div>        <!-- LAYOUT_NAV_END -->
+
+        <!-- Header -->
+        <header class="pt-32 pb-16 px-6 border-b border-slate-200">
+            <div class="max-w-7xl mx-auto">
+                <h1
+                    class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6"
+                >
+                    Style Author Guide
+                </h1>
+                <p
+                    class="text-xl text-slate-500 max-w-3xl leading-relaxed"
+                >
+                    Learn how to write Citum styles from scratch. This guide covers the YAML syntax, component types, template structure, and best practices for creating citation and bibliography styles.
+                </p>
+            </div>
+        </header>
+
+        <!-- Two-Column Layout -->
+        <div class="flex flex-col lg:flex-row max-w-7xl mx-auto px-6 py-12 gap-12">
+            <!-- Left Sidebar: Table of Contents -->
+            <aside class="w-full lg:w-64 flex-shrink-0">
+                <div class="sticky top-24 space-y-8">
+                    <nav class="space-y-1">
+                        <div class="toc-section">
+                            <div class="toc-section-title">Getting Started</div>
+                            <a href="#how-citum-differs" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                How Citum Differs from CSL 1.0
+                            </a>
+                            <a href="#style-anatomy" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Style File Anatomy
+                            </a>
+                        </div>
+
+                        <div class="toc-section">
+                            <div class="toc-section-title">Core Concepts</div>
+                            <a href="#global-options" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Global Options
+                            </a>
+                            <a href="#template-components" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Template Components
+                            </a>
+                            <a href="#rendering-options" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Rendering Options
+                            </a>
+                        </div>
+ 
+                        <div class="toc-section">
+                            <div class="toc-section-title">Configuration</div>
+                            <a href="#style-presets" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Style-Level Presets
+                            </a>
+                        </div>
+ 
+                        <div class="toc-section">
+                            <div class="toc-section-title">Advanced Patterns</div>
+                            <a href="#type-variants" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Type Variants
+                            </a>
+                            <a href="#citation-modes" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Citation Modes
+                            </a>
+                            <a href="#options-inheritance" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Options Inheritance
+                            </a>
+                            <a href="#bib-sort-groups" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Bibliography Sort &amp; Groups
+                            </a>
+                        </div>
+
+                        <div class="toc-section">
+                            <div class="toc-section-title">Reference</div>
+                            <a href="#reference-types" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Reference Types
+                            </a>
+                            <a href="#complete-examples" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Complete Examples
+                            </a>
+                            <a href="#workflow-tips" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Workflow & Tips
+                            </a>
+                        </div>
+                    </nav>
+                </div>
+            </aside>
+
+            <!-- Main Content -->
+            <main class="flex-1 min-w-0 space-y-16 pb-24 prose prose-slate prose-blue max-w-none prose-headings:m-0 prose-p:leading-relaxed prose-pre:p-0 prose-pre:bg-transparent">
+<h1 id="style-author-guide" class="font-bold text-slate-900 mt-8 mb-4">Style Author Guide</h1><p>This guide is for people who write and maintain Citum styles.</p>
+
+            <section id="how-citum-differs" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">compare_arrows</span>
+                    How Citum Differs
+                </h2>
+        <p>Citum introduces a modern, declarative approach to citation styling compared to CSL 1.0&#39;s procedural XML language. Understanding these differences is essential for writing Citum styles effectively.</p>
+
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900">Aspect</th><th class="px-4 py-3 text-left font-semibold text-slate-900">CSL 1.0 (XML)</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Citum (YAML)</th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Format</td><td class="px-4 py-3 text-slate-600">Procedural XML markup</td><td class="px-4 py-3 text-slate-600">Declarative YAML</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Logic</td><td class="px-4 py-3 text-slate-600"><code>choose</code>/<code>if</code>/<code>else</code> conditionals</td><td class="px-4 py-3 text-slate-600">Type variants + inheritance</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Name Formatting</td><td class="px-4 py-3 text-slate-600">Inline XML attributes</td><td class="px-4 py-3 text-slate-600">Global presets + options</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Dates</td><td class="px-4 py-3 text-slate-600">Object with year/month/day</td><td class="px-4 py-3 text-slate-600">EDTF string format</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Inheritance</td><td class="px-4 py-3 text-slate-600">Parent style aliasing</td><td class="px-4 py-3 text-slate-600">Extends + scoped options</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Readability</td><td class="px-4 py-3 text-slate-600">Verbose and nested</td><td class="px-4 py-3 text-slate-600">Concise and explicit</td></tr>
+                </tbody>
+            </table>
+        </div>
+    
+            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
+                <div class="flex items-start gap-3">
+                    <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
+                    <div class="flex-1 text-blue-800 text-sm">
+                        <strong>Explicit Over Magic</strong>
+Citum styles are explicitly declarative. Special behavior is expressed in the style itself, not hidden in processor logic. If you need a different layout for journals vs books, you declare it with type variants. This makes styles portable, testable, and understandable without reading source code.
+                    </div>
+                </div>
+            </div>
+        </section>
+
+            <section id="style-anatomy" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">folder_special</span>
+                    Style Anatomy
+                </h2>
+        <p>Every Citum style file contains four top-level sections: metadata, options, citation template, and bibliography template.</p>
+<h3 id="minimal-style-skeleton" class="font-bold text-slate-900 mt-8 mb-4">Minimal Style Skeleton</h3>
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-500"># yaml-language-server: $schema=https://citum.github.io/citum-core/schemas/style.json</span>
+
+<span class="text-primary">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">"My Style Name"</span>
+  <span class="text-primary">id</span>: <span class="text-emerald-400">"my-style"</span>
+  <span class="text-primary">description</span>: <span class="text-emerald-400">"Optional short description"</span>
+  <span class="text-primary">default-locale</span>: <span class="text-emerald-400">"en-US"</span>
+
+<span class="text-primary">options</span>:
+  <span class="text-primary">processing</span>: <span class="text-emerald-400">author-date</span>
+
+<span class="text-primary">citation</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+
+<span class="text-primary">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span></code></pre>
+        </div>
+    
+            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
+                <div class="flex items-start gap-3">
+                    <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
+                    <div class="flex-1 text-blue-800 text-sm">
+                        <strong>Editor autocomplete and validation</strong>
+The <code>yaml-language-server</code> comment in the skeleton above enables full autocomplete and inline validation in editors that support the <a href="https://github.com/redhat-developer/yaml-language-server">YAML Language Server protocol</a>.
+                    </div>
+                </div>
+            </div>
+        <h3 id="info-fields" class="font-bold text-slate-900 mt-8 mb-4">Info Fields</h3><ul>
+<li><code>title</code>: Human-readable name (e.g., &quot;American Psychological Association 7th Edition&quot;).</li>
+<li><code>id</code>: Unique identifier in kebab-case (e.g., &quot;apa-7th&quot;).</li>
+<li><code>default-locale</code>: BCP 47 language tag (e.g., &quot;en-US&quot;, &quot;de-DE&quot;).</li>
+<li><code>fields</code>: Discipline categories (e.g., anthropology, biology, history).</li>
+</ul>
+</section>
+
+            <section id="global-options" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">tune</span>
+                    Global Options
+                </h2>
+        <p>Global options control the processing mode and apply defaults to all components in both citation and bibliography templates.</p>
+<h3 id="processing-modes" class="font-bold text-slate-900 mt-8 mb-4">Processing Modes</h3>
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900">Mode</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Description</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Example</th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>author-date</code></td><td class="px-4 py-3 text-slate-600">Author+year/page citations</td><td class="px-4 py-3 text-slate-600">(Smith, 2020)</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>numeric</code></td><td class="px-4 py-3 text-slate-600">Numbered citations</td><td class="px-4 py-3 text-slate-600">[1]</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>note</code></td><td class="px-4 py-3 text-slate-600">Footnote-based citations</td><td class="px-4 py-3 text-slate-600">Smith, &quot;Title,&quot; 2020</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>label</code></td><td class="px-4 py-3 text-slate-600">Alphabetic or numeric keys</td><td class="px-4 py-3 text-slate-600">[Kuh62]</td></tr>
+                </tbody>
+            </table>
+        </div>
+    <h3 id="contributor-presets" class="font-bold text-slate-900 mt-8 mb-4">Contributor Presets</h3><p>Named presets control name formatting without spelling out every field:</p>
+<ul>
+<li><code>apa</code>: Family-first, &quot;&amp;&quot; symbol, initials with period-space.</li>
+<li><code>chicago</code>: Family-first, &quot;and&quot; text, full names.</li>
+<li><code>vancouver</code>: All family-first, no conjunction, compact initials.</li>
+<li><code>ieee</code>: Given-first, &quot;and&quot; text, initials with period-space.</li>
+<li><code>harvard</code>: All family-first, &quot;and&quot; text, compact initials.</li>
+<li><code>springer</code>: All family-first, no conjunction, compact initials.</li>
+</ul>
+<h3 id="date-presets" class="font-bold text-slate-900 mt-8 mb-4">Date Presets</h3>
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900">Preset</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Format</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Example</th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>long</code></td><td class="px-4 py-3 text-slate-600">Full month names, EDTF markers</td><td class="px-4 py-3 text-slate-600">January 15, 2024</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>short</code></td><td class="px-4 py-3 text-slate-600">Abbreviated month names</td><td class="px-4 py-3 text-slate-600">Jan 15, 2024</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>numeric</code></td><td class="px-4 py-3 text-slate-600">Numeric months</td><td class="px-4 py-3 text-slate-600">1/15/2024</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>iso</code></td><td class="px-4 py-3 text-slate-600">ISO 8601, no EDTF markers</td><td class="px-4 py-3 text-slate-600">2024-01-15</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+            <section id="template-components" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">layers</span>
+                    Template Components
+                </h2>
+        <h3 id="contributor" class="font-bold text-slate-900 mt-8 mb-4">Contributor</h3><p>Renders author, editor, translator, and other contributors.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>          <span class="text-slate-500"># long | short | verb | verb-short</span>
+  <span class="text-primary">name-order</span>: <span class="text-emerald-400">family-first</span>  <span class="text-slate-500"># family-first | given-first</span></code></pre>
+        </div>
+    <h3 id="date" class="font-bold text-slate-900 mt-8 mb-4">Date</h3><p>Renders date fields using EDTF format.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>  <span class="text-slate-500"># year | year-month | full | month-day | year-month-day</span></code></pre>
+        </div>
+    <h3 id="title" class="font-bold text-slate-900 mt-8 mb-4">Title</h3><p>Renders the title of the item.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>  <span class="text-slate-500"># long | short</span></code></pre>
+        </div>
+    <h3 id="number" class="font-bold text-slate-900 mt-8 mb-4">Number</h3><p>Renders numeric data: volume, issue, pages, edition, etc.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">number</span>: <span class="text-emerald-400">pages</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">numeric</span>  <span class="text-slate-500"># numeric | ordinal | roman</span></code></pre>
+        </div>
+    </section>
+
+            <section id="gender-aware-locale-terms" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">translate</span>
+                    Gender-Aware Locale Terms
+                </h2>
+        <p>Citum locale terms can now vary by grammatical gender when the language requires it.</p>
+<h3 id="reference-data" class="font-bold text-slate-900 mt-8 mb-4">Reference Data</h3><p>Contributor-driven role labels use an explicit <code>gender</code> field on contributor entries:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">contributors</span>:
+  <span class="text-slate-400">- </span><span class="text-primary">role</span>: <span class="text-emerald-400">editor</span>
+    <span class="text-primary">contributor</span>:
+      <span class="text-primary">family</span>: <span class="text-emerald-400">"Martinez"</span>
+      <span class="text-primary">given</span>: <span class="text-emerald-400">"Ana"</span>
+    <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span></code></pre>
+        </div>
+    <p>Mixed-gender contributor groups prefer a locale&#39;s neutral/common form when one exists. If a locale only provides gendered masculine/feminine variants and no neutral/common form, Citum does not silently fall back to a masculine-specific label for the mixed group.</p>
+<h3 id="template-overrides" class="font-bold text-slate-900 mt-8 mb-4">Template Overrides</h3><p>Use a template-level <code>gender</code> override when a term or number label must request a specific agreement form directly:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">editor</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>
+  <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span>
+
+<span class="text-slate-400">- </span><span class="text-primary">term</span>: <span class="text-emerald-400">volume</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+  <span class="text-primary">gender</span>: <span class="text-emerald-400">masculine</span>
+
+<span class="text-slate-400">- </span><span class="text-primary">number</span>: <span class="text-emerald-400">volume</span>
+  <span class="text-primary">label-form</span>: <span class="text-emerald-400">short</span>
+  <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span></code></pre>
+        </div>
+    <h3 id="locale-yaml" class="font-bold text-slate-900 mt-8 mb-4">Locale YAML</h3><p>Locale terms still accept plain strings, but they can now also use gendered maps:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">roles</span>:
+  <span class="text-primary">editor</span>:
+    <span class="text-primary">long</span>:
+      <span class="text-primary">singular</span>:
+        <span class="text-primary">masculine</span>: <span class="text-emerald-400">editor</span>
+        <span class="text-primary">feminine</span>: <span class="text-emerald-400">editora</span>
+        <span class="text-primary">common</span>: <span class="text-emerald-400">persona</span> editora
+      <span class="text-primary">plural</span>:
+        <span class="text-primary">masculine</span>: <span class="text-emerald-400">editores</span>
+        <span class="text-primary">feminine</span>: <span class="text-emerald-400">editoras</span>
+        <span class="text-primary">common</span>: <span class="text-emerald-400">equipo</span> editorial</code></pre>
+        </div>
+    <p>Locator terms can also declare lexical gender metadata for noun agreement:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">locators</span>:
+  <span class="text-primary">page</span>:
+    <span class="text-primary">long</span>:
+      <span class="text-primary">singular</span>: página
+      <span class="text-primary">plural</span>: páginas
+    <span class="text-primary">short</span>:
+      <span class="text-primary">singular</span>: <span class="text-emerald-400">p.</span>
+      <span class="text-primary">plural</span>: <span class="text-emerald-400">pp.</span>
+    <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span></code></pre>
+        </div>
+    
+            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
+                <div class="flex items-start gap-3">
+                    <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
+                    <div class="flex-1 text-blue-800 text-sm">
+                        <strong>Current scope</strong>
+Gender-aware rendering currently applies to locale term selection and contributor role labels. Verb-form role terms such as <code>edited by</code> remain ungendered in this release, even though they share the same underlying Rust type.
+                    </div>
+                </div>
+            </div>
+        </section>
+
+            <section id="rendering-options" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">formatting</span>
+                    Rendering Options
+                </h2>
+        <p>Every component can be modified with rendering options that control punctuation, formatting, and text wrapping.</p>
+
+            <div class="border border-amber-500/30 bg-amber-50 p-4 rounded-lg mb-6 not-prose">
+                <div class="flex gap-3">
+                    <span class="material-icons text-amber-600 flex-shrink-0">warning</span>
+                    <div class="text-amber-800 text-sm">
+                        <strong>Avoid locale-specific strings</strong>
+Do not hardcode text content like <code>&quot;In: &quot;</code>, <code>&quot;Editor&quot;</code>, or <code>&quot;pp. &quot;</code> in <code>prefix</code> or <code>suffix</code>. Always use the <code>term</code> component for localized text. Reserve prefix and suffix for punctuation and spacing.
+                    </div>
+                </div>
+            </div>
+        
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900">Option</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Values</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Purpose</th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>prefix</code></td><td class="px-4 py-3 text-slate-600"><code>&quot; &quot;</code>, <code>&quot;, &quot;</code>, <code>&quot;. &quot;</code></td><td class="px-4 py-3 text-slate-600">Text before the component</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>suffix</code></td><td class="px-4 py-3 text-slate-600"><code>&quot;.&quot;, &quot;,&quot;, &quot;: &quot;</code></td><td class="px-4 py-3 text-slate-600">Text after the component</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>wrap</code></td><td class="px-4 py-3 text-slate-600"><code>parentheses</code>, <code>brackets</code>, <code>quotes</code></td><td class="px-4 py-3 text-slate-600">Automatically wrap value</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>emph</code></td><td class="px-4 py-3 text-slate-600"><code>true</code>, <code>false</code></td><td class="px-4 py-3 text-slate-600">Render in italics</td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>strong</code></td><td class="px-4 py-3 text-slate-600"><code>true</code>, <code>false</code></td><td class="px-4 py-3 text-slate-600">Render in bold</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+            <section id="style-inheritance" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">auto_awesome</span>
+                    Style Inheritance
+                </h2>
+        <p>Inherit from a named base style using <code>extends:</code>. The base style supplies all
+templates; the inheriting style can only set metadata and normal typed options
+(see below).</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span></code></pre>
+        </div>
+    </section>
+
+            <section id="scoped-options" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">tune</span>
+                    Scoped Options
+                </h2>
+        <p>When a style uses <code>extends:</code>, it tunes behaviour through the same scoped option
+blocks used by standalone styles.</p>
+<p>Use the option block that matches the scope of the behavior:</p>
+<ul>
+<li><code>options.*</code> for style-wide configuration such as contributor presets</li>
+<li><code>citation.options.*</code> for citation-only behavior</li>
+<li><code>bibliography.options.*</code> for bibliography-only behavior</li>
+</ul>
+<p><strong>Allowed values for the common scoped fields</strong></p>
+
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900">Field</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Allowed values</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Use when</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Example value</th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>bibliography.options.date-position</code></td><td class="px-4 py-3 text-slate-600"><code>after-author</code>, <code>after-title</code>, <code>terminal</code></td><td class="px-4 py-3 text-slate-600">the style should move the year within bibliography entries</td><td class="px-4 py-3 text-slate-600"><code>after-author</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>options.contributors</code></td><td class="px-4 py-3 text-slate-600">contributor presets such as <code>apa</code>, <code>chicago</code>, <code>springer</code>, <code>vancouver</code></td><td class="px-4 py-3 text-slate-600">the style should switch contributor formatting</td><td class="px-4 py-3 text-slate-600"><code>springer</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>citation.options.label-wrap</code></td><td class="px-4 py-3 text-slate-600"><code>none</code>, <code>parentheses</code>, <code>brackets</code>, <code>superscript</code></td><td class="px-4 py-3 text-slate-600">the style should change citation label punctuation</td><td class="px-4 py-3 text-slate-600"><code>brackets</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>bibliography.options.label-mode</code></td><td class="px-4 py-3 text-slate-600"><code>none</code>, <code>numeric</code>, <code>author-date</code></td><td class="px-4 py-3 text-slate-600">the style should change bibliography label display</td><td class="px-4 py-3 text-slate-600"><code>numeric</code></td></tr>
+                </tbody>
+            </table>
+        </div>
+    
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-500"># Standalone style: <span class="text-emerald-400">configure</span> the style directly</span>
+<span class="text-indigo-400">options</span>:
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">springer</span>
+  <span class="text-primary">dates</span>: <span class="text-emerald-400">short</span></code></pre>
+        </div>
+    <p>When a style uses <code>extends:</code>, treat the file as an override layer. Any option you
+do not restate continues to come from the base style, so the wrapper usually
+shows only the behavior it wants to change.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-500"># Wrapper style: <span class="text-emerald-400">configure</span> the inherited base through normal scoped options</span>
+<span class="text-slate-500"># Omitted options still come from `springer-basic-author-date-core`</span>
+<span class="text-indigo-400">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span>
+<span class="text-indigo-400">options</span>:
+  <span class="text-slate-500"># Override only contributor formatting; other top-level options are inherited</span>
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">springer</span>
+<span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-slate-500"># Override only bibliography date placement; labels/templates still come from the base</span>
+    <span class="text-primary">date-position</span>: <span class="text-emerald-400">after-author</span></code></pre>
+        </div>
+    
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-slate-500"># Omitted citation/bibliography options still come from `elsevier-vancouver-core`</span>
+<span class="text-indigo-400">extends</span>: <span class="text-emerald-400">elsevier-vancouver-core</span>
+<span class="text-indigo-400">citation</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-slate-500"># Override citation label punctuation only</span>
+    <span class="text-primary">label-wrap</span>: <span class="text-emerald-400">brackets</span>
+<span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-slate-500"># Override bibliography label mode only</span>
+    <span class="text-primary">label-mode</span>: <span class="text-emerald-400">numeric</span></code></pre>
+        </div>
+    
+            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
+                <div class="flex items-start gap-3">
+                    <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
+                    <div class="flex-1 text-blue-800 text-sm">
+                        <strong>Beginner rule</strong>
+
+Ask this first:
+
+- does this file use <code>extends:</code>?
+  - yes: use the same <code>options.*</code>, <code>citation.options.*</code>, and <code>bibliography.options.*</code> blocks you would use anywhere else
+  - no: use those same blocks directly
+
+If you need to change templates or <code>type-variants</code>, you are no longer making
+a profile. You need a new base style or an independent style.
+                    </div>
+                </div>
+            </div>
+        </section>
+
+            <section id="type-variants" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">category</span>
+                    Type Variants
+                </h2>
+        <p>When reference types need a different layout, use <code>type-variants</code>.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+  <span class="text-primary">type-variants</span>:
+    <span class="text-primary">article-journal</span>:
+      <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+      <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span></code></pre>
+        </div>
+    
+            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
+                <div class="flex items-start gap-3">
+                    <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
+                    <div class="flex-1 text-blue-800 text-sm">
+                        <strong>Type Variants Replace the Default Template</strong>
+If a reference type matches a <code>type-variants</code> entry, that template is used in full instead of the default template. Types not listed fall through to the default.
+                    </div>
+                </div>
+            </div>
+        </section>
+
+            <section id="citation-modes" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">article</span>
+                    Citation Modes
+                </h2>
+        <p>Use different citation templates for narrative vs. parenthetical citations, shortened forms, and special cases like ibid.</p>
+<h3 id="integral-vs-non-integral-citations" class="font-bold text-slate-900 mt-8 mb-4">Integral vs Non-Integral Citations</h3><p>Use <code>integral:</code> and <code>non-integral:</code> blocks for narrative (&quot;Smith (2020) argued...&quot;) vs parenthetical (&quot;...was argued (Smith, 2020)&quot;) styles:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">citation</span>:
+  <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span>       <span class="text-slate-500"># default wrapping</span>
+  <span class="text-primary">template</span>:               <span class="text-slate-500"># used as fallback if no mode-specific block</span>
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+  <span class="text-primary">non-integral</span>:           <span class="text-slate-500"># (Smith, 2020)</span>
+    <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span>
+    <span class="text-primary">template</span>:
+      <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+      <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>
+  <span class="text-primary">integral</span>:               <span class="text-slate-500"># Smith (2020)</span>
+    <span class="text-primary">delimiter</span>: <span class="text-emerald-400">" "</span>
+    <span class="text-primary">template</span>:
+      <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+      <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>
+        <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span></code></pre>
+        </div>
+    <h3 id="note-style-subsequent-and-ibid" class="font-bold text-slate-900 mt-8 mb-4">Note-style: Subsequent and Ibid</h3><p>Use <code>subsequent:</code> for shortened second-and-later citations, and <code>ibid:</code> for same-source repetitions:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">citation</span>:
+  <span class="text-primary">template</span>:               <span class="text-slate-500"># Full first citation</span>
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+      <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">", "</span>
+    <span class="text-slate-400">- </span><span class="text-primary">variable</span>: <span class="text-emerald-400">locator</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">", "</span>
+  <span class="text-primary">subsequent</span>:             <span class="text-slate-500"># Short form for later citations</span>
+    <span class="text-primary">options</span>:
+      <span class="text-primary">contributors</span>:
+        <span class="text-primary">name-form</span>: <span class="text-emerald-400">family-only</span>
+    <span class="text-primary">template</span>:
+      <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+      <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+      <span class="text-slate-400">- </span><span class="text-primary">variable</span>: <span class="text-emerald-400">locator</span>
+        <span class="text-primary">prefix</span>: <span class="text-emerald-400">", "</span>
+  <span class="text-primary">ibid</span>:                    <span class="text-slate-500"># Same source, possibly different locator</span>
+    <span class="text-primary">suffix</span>: <span class="text-emerald-400">"Ibid."</span>
+    <span class="text-primary">template</span>:
+      <span class="text-slate-400">- </span><span class="text-primary">variable</span>: <span class="text-emerald-400">locator</span>
+        <span class="text-primary">prefix</span>: <span class="text-emerald-400">", "</span></code></pre>
+        </div>
+    <h3 id="multi-cite-and-collapse" class="font-bold text-slate-900 mt-8 mb-4">Multi-cite and Collapse</h3><p>For numeric styles, use <code>multi-cite-delimiter</code> (default &quot;; &quot;) to separate multiple citations, and <code>collapse: citation-number</code> to render ranges like [1–3]:</p>
+<ul>
+<li><code>multi-cite-delimiter</code>: String to separate multiple citations.</li>
+<li><code>collapse: citation-number</code>: Consecutive numbers are collapsed into ranges.</li>
+</ul>
+</section>
+
+            <section id="options-inheritance" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">share</span>
+                    Options Inheritance
+                </h2>
+        <p>Global options apply to all components, but can be overridden at the citation and bibliography level.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">options</span>:
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">apa</span>       <span class="text-slate-500"># Global: family-first, initials, up to 20 names</span>
+
+<span class="text-primary">citation</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">contributors</span>:
+      <span class="text-primary">shorten</span>: { min: 3, use-first: <span class="text-emerald-400">1</span> }   <span class="text-slate-500"># Citation-level override</span>
+
+<span class="text-primary">bibliography</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">contributors</span>:
+      <span class="text-primary">shorten</span>: { min: 20, use-first: <span class="text-emerald-400">19</span> }  <span class="text-slate-500"># Bibliography-level override</span></code></pre>
+        </div>
+    <h3 id="inheritance-chain" class="font-bold text-slate-900 mt-8 mb-4">Inheritance Chain</h3><ol>
+<li>Component-level options (highest priority)</li>
+<li>Citation/Bibliography-level options</li>
+<li>Global options (lowest priority)</li>
+</ol>
+</section>
+
+            <section id="bib-sort-groups" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">sort</span>
+                    Bib Sort & Groups
+                </h2>
+        <p>Control bibliography ordering and split it into labeled sections based on reference properties.</p>
+<h3 id="sort" class="font-bold text-slate-900 mt-8 mb-4">Sort</h3><p>The <code>bibliography.sort</code> field controls ordering. Use a preset string or a custom sort template:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">sort</span>: <span class="text-emerald-400">author-date-title</span>   <span class="text-slate-500"># preset: <span class="text-emerald-400">sort</span> by author, then date, then title</span></code></pre>
+        </div>
+    <p><strong>Preset sort values:</strong> <code>author-date-title</code>, <code>author-title-date</code>.</p>
+<h3 id="groups" class="font-bold text-slate-900 mt-8 mb-4">Groups</h3><p>The <code>bibliography.groups</code> field splits the bibliography into labeled sections:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">groups</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">id</span>: <span class="text-emerald-400">primary</span>
+      <span class="text-primary">heading</span>:
+        <span class="text-primary">localized</span>:
+          en-US: <span class="text-emerald-400">"Primary Sources"</span>
+      <span class="text-primary">selector</span>:
+        <span class="text-primary">type</span>: <span class="text-emerald-400">legal-case</span>
+    <span class="text-slate-400">- </span><span class="text-primary">id</span>: <span class="text-emerald-400">other</span>
+      <span class="text-primary">heading</span>:
+        <span class="text-primary">localized</span>:
+          en-US: <span class="text-emerald-400">"Secondary Sources"</span>
+      <span class="text-primary">selector</span>:
+        <span class="text-primary">not</span>:
+          <span class="text-primary">type</span>: <span class="text-emerald-400">legal-case</span></code></pre>
+        </div>
+    </section>
+
+            <section id="reference-types" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">list</span>
+                    Reference Types
+                </h2>
+        <p>References use a <code>class</code> (top-level discriminator) and <code>type</code> (subtype). In styles, use the <code>type</code> value as keys under <code>type-variants</code>.</p>
+
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900">Class</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Types</th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Monograph</td><td class="px-4 py-3 text-slate-600"><code>book</code>, <code>manual</code>, <code>report</code>, <code>thesis</code>, <code>webpage</code>, <code>post</code>, <code>interview</code>, <code>manuscript</code>, <code>document</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Collection</td><td class="px-4 py-3 text-slate-600"><code>anthology</code>, <code>proceedings</code>, <code>edited-book</code>, <code>edited-volume</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Component</td><td class="px-4 py-3 text-slate-600"><code>chapter</code>, <code>article-journal</code>, <code>article-magazine</code>, <code>article-newspaper</code>, <code>broadcast</code>, <code>post</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600">Standalone</td><td class="px-4 py-3 text-slate-600"><code>legal-case</code>, <code>statute</code>, <code>treaty</code>, <code>hearing</code>, <code>regulation</code>, <code>brief</code>, <code>patent</code>, <code>dataset</code>, <code>standard</code>, <code>software</code></td></tr>
+                </tbody>
+            </table>
+        </div>
+    
+            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
+                <div class="flex items-start gap-3">
+                    <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
+                    <div class="flex-1 text-blue-800 text-sm">
+                        <strong>Using Type Values in type-variants</strong>
+- Use the <code>type</code> value (e.g., <code>article-journal</code>, <code>book</code>) in <code>type-variants:</code>.
+- Special keywords <code>default</code> and <code>all</code> also work.
+- For components, parents are embedded under the <code>parent:</code> key.
+                    </div>
+                </div>
+            </div>
+        </section>
+
+            <section id="complete-examples" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">code</span>
+                    Complete Examples
+                </h2>
+        <h3 id="example-1-minimal-author-date-style" class="font-bold text-slate-900 mt-8 mb-4">Example 1: Minimal Author-Date Style</h3>
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">"Simple Author-Date"</span>
+  <span class="text-primary">id</span>: <span class="text-emerald-400">"simple-author-date"</span>
+
+<span class="text-primary">options</span>:
+  <span class="text-primary">processing</span>: <span class="text-emerald-400">author-date</span>
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">apa</span>
+
+<span class="text-primary">citation</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">" "</span>
+      <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span>
+
+<span class="text-primary">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">" "</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">" "</span>
+      <span class="text-primary">suffix</span>: <span class="text-emerald-400">"."</span></code></pre>
+        </div>
+    <h3 id="example-2-minimal-numeric-style" class="font-bold text-slate-900 mt-8 mb-4">Example 2: Minimal Numeric Style</h3>
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">"Simple Numeric"</span>
+  <span class="text-primary">id</span>: <span class="text-emerald-400">"simple-numeric"</span>
+
+<span class="text-primary">options</span>:
+  <span class="text-primary">processing</span>: <span class="text-emerald-400">numeric</span>
+
+<span class="text-primary">citation</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">number</span>: <span class="text-emerald-400">citation-number</span>
+      <span class="text-primary">wrap</span>: <span class="text-emerald-400">brackets</span>
+
+<span class="text-primary">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">number</span>: <span class="text-emerald-400">citation-number</span>
+      <span class="text-primary">suffix</span>: <span class="text-emerald-400">". "</span>
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">" "</span></code></pre>
+        </div>
+    <h3 id="example-3-style-inheritance-with-scoped-options" class="font-bold text-slate-900 mt-8 mb-4">Example 3: Style Inheritance with Scoped Options</h3><p>Inherit from a shared base and tune it via normal scoped options. No templates
+needed — the base supplies them.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">Springer</span> - Basic (author-date)
+  <span class="text-primary">description</span>: &gt;-
+    Springer Author Date Style for Medicine, Life Sciences,
+    Chemistry, Geosciences, Computer Science, and Engineering.
+
+<span class="text-primary">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span>
+<span class="text-indigo-400">options</span>:
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">springer</span>
+<span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">date-position</span>: <span class="text-emerald-400">after-author</span></code></pre>
+        </div>
+    
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">Elsevier</span> - NLM/Vancouver (citation-sequence)
+  <span class="text-primary">description</span>: <span class="text-emerald-400">A</span> style for some Elsevier journals, resembles Vancouver style.
+
+<span class="text-primary">extends</span>: <span class="text-emerald-400">elsevier-vancouver-core</span>
+<span class="text-indigo-400">citation</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">label-wrap</span>: <span class="text-emerald-400">brackets</span>
+<span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">label-mode</span>: <span class="text-emerald-400">numeric</span></code></pre>
+        </div>
+    </section>
+
+            <section id="workflow-tips" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">lightbulb</span>
+                    Workflow & Tips
+                </h2>
+        <h3 id="recommended-workflow" class="font-bold text-slate-900 mt-8 mb-4">Recommended Workflow</h3><ol>
+<li><strong>Start with a reference style</strong>: Use an existing style as a template.</li>
+<li><strong>Write metadata</strong>: Set title, id, and default locale in <code>info</code>.</li>
+<li><strong>Define global options</strong>: Set mode and contributor/date presets.</li>
+<li><strong>Write citation template</strong>: Start with author, date, and title.</li>
+<li><strong>Test with oracle</strong>: Compare output against reference implementation.</li>
+<li><strong>Add type-variants</strong>: Only for types needing a structurally different template.</li>
+</ol>
+<h3 id="common-mistakes-to-avoid" class="font-bold text-slate-900 mt-8 mb-4">Common Mistakes to Avoid</h3>
+            <div class="border border-amber-500/30 bg-amber-50 p-4 rounded-lg mb-6 not-prose">
+                <div class="flex gap-3">
+                    <span class="material-icons text-amber-600 flex-shrink-0">warning</span>
+                    <div class="text-amber-800 text-sm">
+                        <strong>Over-using type-variants</strong>
+Only add <code>type-variants</code> for types that need a genuinely different component set. Use presets and a well-designed generic template for the common case.
+                    </div>
+                </div>
+            </div>
+        
+            <div class="border border-amber-500/30 bg-amber-50 p-4 rounded-lg mb-6 not-prose">
+                <div class="flex gap-3">
+                    <span class="material-icons text-amber-600 flex-shrink-0">warning</span>
+                    <div class="text-amber-800 text-sm">
+                        <strong>Over-complicated options inheritance</strong>
+Keep global options simple. Override only at citation/bibliography level when truly needed.
+                    </div>
+                </div>
+            </div>
+        
+            <div class="border border-amber-500/30 bg-amber-50 p-4 rounded-lg mb-6 not-prose">
+                <div class="flex gap-3">
+                    <span class="material-icons text-amber-600 flex-shrink-0">warning</span>
+                    <div class="text-amber-800 text-sm">
+                        <strong>Mismatching prefix/suffix pairs</strong>
+Always pair opening prefix with closing suffix. For structural wrapping (e.g. parentheses), use the <code>wrap</code> option instead.
+                    </div>
+                </div>
+            </div>
+        </section>
+</main>
+        </div>
+
+        <!-- Footer -->
+        <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
+                <div class="flex items-center gap-2">
+                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
+                        <span class="text-white font-mono text-xs font-bold">C</span>
+                    </div>
+                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+                </div>
+                <div class="flex gap-8 text-sm font-medium text-slate-500">
+                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
+                    <a class="hover:text-primary transition-colors" href="../examples.html">Examples</a>
+                    <a class="hover:text-primary transition-colors" href="../reports.html">Reports</a>
+                </div>
+                <div class="text-sm text-slate-400">
+                    © 2026 Citum Project.
+                </div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+
+        <script>
+            const navToggle = document.querySelector("[data-nav-toggle]");
+            const mobileMenu = document.querySelector("[data-mobile-menu]");
+
+            if (navToggle && mobileMenu) {
+                navToggle.addEventListener("click", () => {
+                    const expanded = navToggle.getAttribute("aria-expanded") === "true";
+                    navToggle.setAttribute("aria-expanded", String(!expanded));
+                    mobileMenu.classList.toggle("hidden", expanded);
+                });
+            }
+        </script>
+    </body>
+</html>

--- a/scripts/benchmark-rpc-workflow.js
+++ b/scripts/benchmark-rpc-workflow.js
@@ -16,11 +16,17 @@ const { performance } = require('node:perf_hooks');
 const path = require('node:path');
 const fs = require('node:fs');
 
-// --- Configuration ---
-const REFS_COUNT = 500;
-const CITATIONS_COUNT = 100;
-const REFRESH_INTERVAL = 20;
-const STYLE_PATH = 'styles/embedded/apa-7th.yaml';
+// --- Configuration (with CLI overrides) ---
+const args = process.argv.slice(2);
+const getArg = (name, defaultValue) => {
+  const index = args.findIndex(arg => arg === name);
+  return (index !== -1 && args[index + 1]) ? args[index + 1] : defaultValue;
+};
+
+const REFS_COUNT = parseInt(getArg('--refs', '500'), 10);
+const CITATIONS_COUNT = parseInt(getArg('--cites', '100'), 10);
+const REFRESH_INTERVAL = parseInt(getArg('--interval', '20'), 10);
+const STYLE_PATH = getArg('--style', 'styles/embedded/apa-7th.yaml');
 const SERVER_BIN = path.resolve(__dirname, '../target/release/citum-server');
 
 // --- State ---


### PR DESCRIPTION
This PR makes the RPC benchmark script configurable via CLI flags, allowing for testing of real-time synchronization performance and scalability.

Changes:
- Add `--interval` flag to control bibliography refresh frequency (set to 1 for true real-time testing).
- Add `--refs` flag to test with different bibliography sizes.
- Add `--cites` flag to control simulation length.
- Add `--style` flag to specify the CSL style.

Test results with `--interval 1` and 5000 references showed an average bibliography refresh time of ~210ms, confirming that the stateless architecture remains performant even under heavy load.