### PR TITLE
fix(release): remove invalid [workspace] section from release.toml

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,3 @@
-[workspace]
 shared-version = true
 consolidate-commits = true
 dependent-version = "upgrade"


### PR DESCRIPTION
## Summary

- Removes the `[workspace]` TOML section header from `release.toml`
- `cargo-release` expects flat top-level keys; the section header caused `Failed to parse release.toml` on every release workflow run since the automation overhaul landed in `6147eb12`

## Test plan

- [x] `cargo release config` locally parses without errors (verified)
- [x] Release workflow passes on merge to main
