### PR TITLE
feat(styles): add HTTP core catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "boxed_error"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +427,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chinese-number"
@@ -655,9 +670,11 @@ dependencies = [
  "ciborium",
  "citum-schema",
  "dirs",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "toml",
@@ -800,6 +817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +923,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csl-legacy"
@@ -1088,6 +1124,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1480,14 +1526,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1498,7 +1570,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1675,6 +1747,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1683,13 +1772,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2125,6 +2222,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,8 +2415,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "636860251af8963cc40f6b4baadee105f02e21b28131d76eba8e40ce84ab8064"
 dependencies = [
- "rand",
- "rand_chacha",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -2341,6 +2454,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -2436,7 +2555,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2613,7 +2732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2857,6 +2976,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +3038,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2883,7 +3063,17 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2893,7 +3083,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2901,6 +3101,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -3008,6 +3217,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "resb"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3290,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3134,6 +3397,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3349,6 +3647,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3625,6 +3934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svg2pdf"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,6 +3996,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3978,6 +4296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4065,6 +4393,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,6 +4443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ttf-parser"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,6 +4473,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typst"
@@ -4528,6 +4886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,6 +4999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,6 +5042,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4812,6 +5195,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4873,6 +5275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5286,6 +5697,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -24,7 +24,7 @@ citum_schema = { package = "citum-schema", path = "../citum-schema", features = 
 citum_engine = { package = "citum-engine", path = "../citum-engine" }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 biblatex = "0.11"
-citum_store = { package = "citum_store", path = "../citum_store" }
+citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }
 citum-pdf = { path = "../citum-pdf", optional = true }
 citum-bindings = { path = "../citum-bindings", optional = true }
 url = { version = "2.5", features = ["serde"] }

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -410,8 +410,14 @@ pub(crate) enum StyleCommands {
         #[arg(long, value_enum, default_value_t = StyleCatalogSource::All)]
         source: StyleCatalogSource,
         /// Output format
-        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Table)]
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
         format: StyleCatalogFormat,
+        /// Maximum number of rows to print
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Number of matching rows to skip
+        #[arg(long, default_value_t = 0)]
+        offset: usize,
     },
     /// Search styles in the unified catalog
     Search {
@@ -421,15 +427,21 @@ pub(crate) enum StyleCommands {
         #[arg(long, value_enum, default_value_t = StyleCatalogSource::All)]
         source: StyleCatalogSource,
         /// Output format
-        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Table)]
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
         format: StyleCatalogFormat,
+        /// Maximum number of rows to print
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Number of matching rows to skip
+        #[arg(long, default_value_t = 0)]
+        offset: usize,
     },
     /// Show details for a style in the unified catalog
     Info {
         /// Style ID or alias
         name: String,
         /// Output format
-        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Table)]
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
         format: StyleCatalogFormat,
     },
     /// Validate that a style's locale-driven features resolve against a locale file
@@ -456,14 +468,14 @@ impl std::fmt::Display for StyleCatalogSource {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
 pub(crate) enum StyleCatalogFormat {
-    Table,
+    Text,
     Json,
 }
 
 impl std::fmt::Display for StyleCatalogFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StyleCatalogFormat::Table => write!(f, "table"),
+            StyleCatalogFormat::Text => write!(f, "text"),
             StyleCatalogFormat::Json => write!(f, "json"),
         }
     }

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -404,8 +404,69 @@ pub(crate) enum StoreCommands {
 
 #[derive(Subcommand)]
 pub(crate) enum StyleCommands {
+    /// List styles in the unified catalog
+    List {
+        /// Catalog source to include
+        #[arg(long, value_enum, default_value_t = StyleCatalogSource::All)]
+        source: StyleCatalogSource,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Table)]
+        format: StyleCatalogFormat,
+    },
+    /// Search styles in the unified catalog
+    Search {
+        /// Search query matched against IDs, aliases, titles, descriptions, and fields
+        query: String,
+        /// Catalog source to include
+        #[arg(long, value_enum, default_value_t = StyleCatalogSource::All)]
+        source: StyleCatalogSource,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Table)]
+        format: StyleCatalogFormat,
+    },
+    /// Show details for a style in the unified catalog
+    Info {
+        /// Style ID or alias
+        name: String,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Table)]
+        format: StyleCatalogFormat,
+    },
     /// Validate that a style's locale-driven features resolve against a locale file
     Lint(LintStyleArgs),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub(crate) enum StyleCatalogSource {
+    All,
+    Embedded,
+    #[value(name = "core-http")]
+    CoreHttp,
+}
+
+impl std::fmt::Display for StyleCatalogSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StyleCatalogSource::All => write!(f, "all"),
+            StyleCatalogSource::Embedded => write!(f, "embedded"),
+            StyleCatalogSource::CoreHttp => write!(f, "core-http"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub(crate) enum StyleCatalogFormat {
+    Table,
+    Json,
+}
+
+impl std::fmt::Display for StyleCatalogFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StyleCatalogFormat::Table => write!(f, "table"),
+            StyleCatalogFormat::Json => write!(f, "json"),
+        }
+    }
 }
 
 #[derive(Subcommand)]

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -85,12 +85,19 @@ pub(crate) fn run() -> Result<(), Box<dyn Error>> {
             StoreCommands::Remove { name } => run_store_remove(&name),
         },
         Commands::Style { command } => match command {
-            StyleCommands::List { source, format } => run_style_list(source, format),
+            StyleCommands::List {
+                source,
+                format,
+                limit,
+                offset,
+            } => run_style_list(source, format, limit, offset),
             StyleCommands::Search {
                 query,
                 source,
                 format,
-            } => run_style_search(&query, source, format),
+                limit,
+                offset,
+            } => run_style_search(&query, source, format, limit, offset),
             StyleCommands::Info { name, format } => run_style_info(&name, format),
             StyleCommands::Lint(args) => run_lint_style(args),
         },
@@ -315,19 +322,50 @@ fn style_entry_matches_source(entry: &RegistryEntry, source: StyleCatalogSource)
 }
 
 fn style_catalog_row(entry: &RegistryEntry) -> StyleCatalogRow {
+    let title = entry.title.clone().or_else(|| {
+        entry.builtin.as_ref().and_then(|builtin| {
+            citum_schema::embedded::get_embedded_style(builtin)
+                .and_then(Result::ok)
+                .and_then(|style| style.info.title)
+        })
+    });
+
     StyleCatalogRow {
         source: style_entry_source(entry).to_string(),
         id: entry.id.clone(),
         aliases: entry.aliases.clone(),
-        title: entry.title.clone(),
+        title,
         description: entry.description.clone(),
         fields: entry.fields.clone(),
         url: entry.url.clone(),
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct StyleCatalogPage {
+    limit: Option<usize>,
+    offset: usize,
+}
+
+fn paginate_style_catalog_rows(
+    mut rows: Vec<StyleCatalogRow>,
+    page: StyleCatalogPage,
+) -> (usize, Vec<StyleCatalogRow>) {
+    let total = rows.len();
+    if page.offset >= total {
+        return (total, Vec::new());
+    }
+    rows.drain(..page.offset);
+    if let Some(limit) = page.limit {
+        rows.truncate(limit);
+    }
+    (total, rows)
+}
+
 fn print_style_catalog_rows(
     rows: &[StyleCatalogRow],
+    total: usize,
+    source: StyleCatalogSource,
     format: StyleCatalogFormat,
 ) -> Result<(), Box<dyn Error>> {
     if format == StyleCatalogFormat::Json {
@@ -335,44 +373,32 @@ fn print_style_catalog_rows(
         return Ok(());
     }
 
-    let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec![
-            Cell::new("Source").fg(Color::Cyan),
-            Cell::new("ID").fg(Color::Cyan),
-            Cell::new("Aliases").fg(Color::Cyan),
-            Cell::new("Title").fg(Color::Cyan),
-            Cell::new("Description").fg(Color::Cyan),
-            Cell::new("Fields").fg(Color::Cyan),
-            Cell::new("URL").fg(Color::Cyan),
-        ]);
+    print!("{}", format_style_catalog_text(rows, total, source));
+    Ok(())
+}
+
+fn format_style_catalog_text(
+    rows: &[StyleCatalogRow],
+    total: usize,
+    source: StyleCatalogSource,
+) -> String {
+    let mut output = String::new();
+    let _ = writeln!(output, "{total} {source} styles");
+    if rows.len() != total {
+        let _ = writeln!(output, "showing {}", rows.len());
+    }
+    output.push('\n');
 
     for row in rows {
-        let aliases = if row.aliases.is_empty() {
-            "-".to_string()
-        } else {
-            row.aliases.join(", ")
-        };
-        let fields = if row.fields.is_empty() {
-            "-".to_string()
-        } else {
-            row.fields.join(", ")
-        };
-        table.add_row(vec![
-            Cell::new(&row.source),
-            Cell::new(&row.id),
-            Cell::new(aliases),
-            Cell::new(row.title.as_deref().unwrap_or("-")),
-            Cell::new(row.description.as_deref().unwrap_or("-")),
-            Cell::new(fields),
-            Cell::new(row.url.as_deref().unwrap_or("-")),
-        ]);
+        let _ = writeln!(
+            output,
+            "{:<10}  {:<42}  {}",
+            row.source,
+            row.id,
+            row.title.as_deref().unwrap_or("-")
+        );
     }
-
-    println!("{table}");
-    Ok(())
+    output
 }
 
 fn style_catalog_entries(source: StyleCatalogSource) -> Vec<StyleCatalogRow> {
@@ -387,27 +413,30 @@ fn style_catalog_entries(source: StyleCatalogSource) -> Vec<StyleCatalogRow> {
 fn run_style_list(
     source: StyleCatalogSource,
     format: StyleCatalogFormat,
+    limit: Option<usize>,
+    offset: usize,
 ) -> Result<(), Box<dyn Error>> {
     let rows = style_catalog_entries(source);
-    print_style_catalog_rows(&rows, format)
+    let (total, rows) = paginate_style_catalog_rows(rows, StyleCatalogPage { limit, offset });
+    print_style_catalog_rows(&rows, total, source, format)
 }
 
-fn style_entry_matches_query(entry: &RegistryEntry, query: &str) -> bool {
+fn style_row_matches_query(row: &StyleCatalogRow, query: &str) -> bool {
     let query = query.to_lowercase();
-    entry.id.to_lowercase().contains(&query)
-        || entry
+    row.id.to_lowercase().contains(&query)
+        || row
             .aliases
             .iter()
             .any(|alias| alias.to_lowercase().contains(&query))
-        || entry
+        || row
             .title
             .as_ref()
             .is_some_and(|title| title.to_lowercase().contains(&query))
-        || entry
+        || row
             .description
             .as_ref()
             .is_some_and(|description| description.to_lowercase().contains(&query))
-        || entry
+        || row
             .fields
             .iter()
             .any(|field| field.to_lowercase().contains(&query))
@@ -417,16 +446,19 @@ fn run_style_search(
     query: &str,
     source: StyleCatalogSource,
     format: StyleCatalogFormat,
+    limit: Option<usize>,
+    offset: usize,
 ) -> Result<(), Box<dyn Error>> {
     let registry = citum_schema::embedded::default_registry();
     let rows: Vec<_> = registry
         .styles
         .iter()
         .filter(|entry| style_entry_matches_source(entry, source))
-        .filter(|entry| style_entry_matches_query(entry, query))
         .map(style_catalog_row)
+        .filter(|row| style_row_matches_query(row, query))
         .collect();
-    print_style_catalog_rows(&rows, format)
+    let (total, rows) = paginate_style_catalog_rows(rows, StyleCatalogPage { limit, offset });
+    print_style_catalog_rows(&rows, total, source, format)
 }
 
 fn run_style_info(name: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn Error>> {
@@ -435,7 +467,7 @@ fn run_style_info(name: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn 
         .resolve(name)
         .ok_or_else(|| format!("style not found: {name}"))?;
     let row = style_catalog_row(entry);
-    print_style_catalog_rows(&[row], format)
+    print_style_catalog_rows(&[row], 1, StyleCatalogSource::All, format)
 }
 
 /// List all installed user styles and locales.
@@ -1425,6 +1457,68 @@ mod tests {
         assert_eq!(OutputFormat::Djot.to_string(), "djot");
         assert_eq!(OutputFormat::Latex.to_string(), "latex");
         assert_eq!(OutputFormat::Typst.to_string(), "typst");
+    }
+
+    #[test]
+    fn test_style_catalog_embedded_title_falls_back_to_style_metadata() {
+        let registry = citum_schema::embedded::default_registry();
+        let entry = registry.resolve("apa").expect("APA alias should resolve");
+
+        let row = style_catalog_row(entry);
+
+        assert_eq!(
+            row.title.as_deref(),
+            Some("American Psychological Association 7th edition")
+        );
+    }
+
+    #[test]
+    fn test_style_catalog_source_filter_and_pagination() {
+        let rows = style_catalog_entries(StyleCatalogSource::CoreHttp);
+        let (total, page) = paginate_style_catalog_rows(
+            rows,
+            StyleCatalogPage {
+                limit: Some(2),
+                offset: 1,
+            },
+        );
+
+        assert!(total > 2);
+        assert_eq!(page.len(), 2);
+        assert!(page.iter().all(|row| row.source == "core-http"));
+    }
+
+    #[test]
+    fn test_style_catalog_search_matches_embedded_title() {
+        let registry = citum_schema::embedded::default_registry();
+        let rows: Vec<_> = registry
+            .styles
+            .iter()
+            .map(style_catalog_row)
+            .filter(|row| style_row_matches_query(row, "Psychological Association"))
+            .collect();
+
+        assert!(rows.iter().any(|row| row.id == "apa-7th"));
+    }
+
+    #[test]
+    fn test_style_catalog_text_output_is_not_table() {
+        let rows = vec![StyleCatalogRow {
+            source: "core-http".to_string(),
+            id: "alpha".to_string(),
+            aliases: Vec::new(),
+            title: Some("Alpha (biblatex-alpha)".to_string()),
+            description: None,
+            fields: Vec::new(),
+            url: None,
+        }];
+
+        let output = format_style_catalog_text(&rows, 3, StyleCatalogSource::CoreHttp);
+
+        assert_eq!(
+            output,
+            "3 core-http styles\nshowing 1\n\ncore-http   alpha                                       Alpha (biblatex-alpha)\n"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -4,7 +4,7 @@ use crate::args::{
     CheckArgs, CheckItem, Cli, Commands, ConvertCommands, ConvertRefsArgs, ConvertTypedArgs,
     DataType, InputFormat, LintLocaleArgs, LintStyleArgs, LocaleCommands, OutputFormat, RefsFormat,
     RegistryCommands, RenderCommands, RenderDocArgs, RenderMode, RenderRefsArgs, StoreCommands,
-    StyleCommands, StylesCommands,
+    StyleCatalogFormat, StyleCatalogSource, StyleCommands, StylesCommands,
 };
 #[cfg(feature = "schema")]
 use crate::args::{SchemaArgs, SchemaType};
@@ -25,10 +25,10 @@ use citum_engine::{
 };
 #[cfg(feature = "schema")]
 use citum_schema::InputBibliography;
-use citum_schema::Style;
 use citum_schema::lint::{lint_raw_locale, lint_style_against_locale};
 use citum_schema::locale::RawLocale;
 use citum_schema::options::Processing;
+use citum_schema::{RegistryEntry, Style};
 use citum_store::{StoreConfig, StoreResolver, platform_data_dir};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
@@ -85,6 +85,13 @@ pub(crate) fn run() -> Result<(), Box<dyn Error>> {
             StoreCommands::Remove { name } => run_store_remove(&name),
         },
         Commands::Style { command } => match command {
+            StyleCommands::List { source, format } => run_style_list(source, format),
+            StyleCommands::Search {
+                query,
+                source,
+                format,
+            } => run_style_search(&query, source, format),
+            StyleCommands::Info { name, format } => run_style_info(&name, format),
             StyleCommands::Lint(args) => run_lint_style(args),
         },
         Commands::Locale { command } => match command {
@@ -261,6 +268,8 @@ fn run_registry_resolve(name: &str) -> Result<(), Box<dyn Error>> {
     if let Some(entry) = registry.resolve(name) {
         let source = if entry.builtin.is_some() {
             "builtin"
+        } else if entry.url.is_some() {
+            "url"
         } else if entry.path.is_some() {
             "path"
         } else {
@@ -272,6 +281,161 @@ fn run_registry_resolve(name: &str) -> Result<(), Box<dyn Error>> {
         eprintln!("Error: style not found: {name}");
         std::process::exit(1);
     }
+}
+
+#[derive(Serialize)]
+struct StyleCatalogRow {
+    source: String,
+    id: String,
+    aliases: Vec<String>,
+    title: Option<String>,
+    description: Option<String>,
+    fields: Vec<String>,
+    url: Option<String>,
+}
+
+fn style_entry_source(entry: &RegistryEntry) -> &'static str {
+    if entry.builtin.is_some() {
+        "embedded"
+    } else if entry.url.is_some() {
+        "core-http"
+    } else if entry.path.is_some() {
+        "path"
+    } else {
+        "unknown"
+    }
+}
+
+fn style_entry_matches_source(entry: &RegistryEntry, source: StyleCatalogSource) -> bool {
+    match source {
+        StyleCatalogSource::All => true,
+        StyleCatalogSource::Embedded => entry.builtin.is_some(),
+        StyleCatalogSource::CoreHttp => entry.url.is_some(),
+    }
+}
+
+fn style_catalog_row(entry: &RegistryEntry) -> StyleCatalogRow {
+    StyleCatalogRow {
+        source: style_entry_source(entry).to_string(),
+        id: entry.id.clone(),
+        aliases: entry.aliases.clone(),
+        title: entry.title.clone(),
+        description: entry.description.clone(),
+        fields: entry.fields.clone(),
+        url: entry.url.clone(),
+    }
+}
+
+fn print_style_catalog_rows(
+    rows: &[StyleCatalogRow],
+    format: StyleCatalogFormat,
+) -> Result<(), Box<dyn Error>> {
+    if format == StyleCatalogFormat::Json {
+        println!("{}", serde_json::to_string_pretty(rows)?);
+        return Ok(());
+    }
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec![
+            Cell::new("Source").fg(Color::Cyan),
+            Cell::new("ID").fg(Color::Cyan),
+            Cell::new("Aliases").fg(Color::Cyan),
+            Cell::new("Title").fg(Color::Cyan),
+            Cell::new("Description").fg(Color::Cyan),
+            Cell::new("Fields").fg(Color::Cyan),
+            Cell::new("URL").fg(Color::Cyan),
+        ]);
+
+    for row in rows {
+        let aliases = if row.aliases.is_empty() {
+            "-".to_string()
+        } else {
+            row.aliases.join(", ")
+        };
+        let fields = if row.fields.is_empty() {
+            "-".to_string()
+        } else {
+            row.fields.join(", ")
+        };
+        table.add_row(vec![
+            Cell::new(&row.source),
+            Cell::new(&row.id),
+            Cell::new(aliases),
+            Cell::new(row.title.as_deref().unwrap_or("-")),
+            Cell::new(row.description.as_deref().unwrap_or("-")),
+            Cell::new(fields),
+            Cell::new(row.url.as_deref().unwrap_or("-")),
+        ]);
+    }
+
+    println!("{table}");
+    Ok(())
+}
+
+fn style_catalog_entries(source: StyleCatalogSource) -> Vec<StyleCatalogRow> {
+    citum_schema::embedded::default_registry()
+        .styles
+        .iter()
+        .filter(|entry| style_entry_matches_source(entry, source))
+        .map(style_catalog_row)
+        .collect()
+}
+
+fn run_style_list(
+    source: StyleCatalogSource,
+    format: StyleCatalogFormat,
+) -> Result<(), Box<dyn Error>> {
+    let rows = style_catalog_entries(source);
+    print_style_catalog_rows(&rows, format)
+}
+
+fn style_entry_matches_query(entry: &RegistryEntry, query: &str) -> bool {
+    let query = query.to_lowercase();
+    entry.id.to_lowercase().contains(&query)
+        || entry
+            .aliases
+            .iter()
+            .any(|alias| alias.to_lowercase().contains(&query))
+        || entry
+            .title
+            .as_ref()
+            .is_some_and(|title| title.to_lowercase().contains(&query))
+        || entry
+            .description
+            .as_ref()
+            .is_some_and(|description| description.to_lowercase().contains(&query))
+        || entry
+            .fields
+            .iter()
+            .any(|field| field.to_lowercase().contains(&query))
+}
+
+fn run_style_search(
+    query: &str,
+    source: StyleCatalogSource,
+    format: StyleCatalogFormat,
+) -> Result<(), Box<dyn Error>> {
+    let registry = citum_schema::embedded::default_registry();
+    let rows: Vec<_> = registry
+        .styles
+        .iter()
+        .filter(|entry| style_entry_matches_source(entry, source))
+        .filter(|entry| style_entry_matches_query(entry, query))
+        .map(style_catalog_row)
+        .collect();
+    print_style_catalog_rows(&rows, format)
+}
+
+fn run_style_info(name: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn Error>> {
+    let registry = citum_schema::embedded::default_registry();
+    let entry = registry
+        .resolve(name)
+        .ok_or_else(|| format!("style not found: {name}"))?;
+    let row = style_catalog_row(entry);
+    print_style_catalog_rows(&[row], format)
 }
 
 /// List all installed user styles and locales.

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -92,7 +92,10 @@ pub(crate) fn load_any_style(
     style_input: &str,
     _no_semantics: bool,
 ) -> Result<Style, Box<dyn Error>> {
-    use citum_store::resolver::{ChainResolver, EmbeddedResolver, FileResolver, StyleResolver};
+    use citum_store::resolver::{
+        ChainResolver, EmbeddedResolver, FileResolver, HttpResolver, RegistryResolver,
+        StyleResolver,
+    };
 
     let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
 
@@ -107,6 +110,19 @@ pub(crate) fn load_any_style(
         )));
     }
 
+    if let Some(http) = HttpResolver::from_platform_cache_dir() {
+        resolvers.push(Box::new(http));
+    }
+
+    let registry_resolver = RegistryResolver::new(citum_schema::embedded::default_registry())
+        .with_base_dir(std::env::current_dir()?);
+    let registry_resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
+        registry_resolver.with_http(http)
+    } else {
+        registry_resolver
+    };
+    resolvers.push(Box::new(registry_resolver));
+
     resolvers.push(Box::new(EmbeddedResolver));
 
     let chain = ChainResolver::new(resolvers);
@@ -114,20 +130,23 @@ pub(crate) fn load_any_style(
     match chain.resolve_style(style_input) {
         Ok(style) => Ok(style),
         Err(citum_store::resolver::ResolverError::StyleNotFound(_)) => {
-            // Fuzzy matching suggestion for builtin styles
-            let suggestions: Vec<_> = citum_schema::embedded::EMBEDDED_STYLE_NAMES
+            let registry = citum_schema::embedded::default_registry();
+            let candidates: Vec<_> = registry
+                .styles
                 .iter()
-                .chain(
-                    citum_schema::embedded::EMBEDDED_STYLE_ALIASES
-                        .iter()
-                        .map(|(a, _)| a),
-                )
+                .flat_map(|entry| {
+                    std::iter::once(entry.id.as_str())
+                        .chain(entry.aliases.iter().map(String::as_str))
+                })
+                .collect();
+            let suggestions: Vec<_> = candidates
+                .iter()
                 .filter(|&&name| strsim::jaro_winkler(style_input, name) > 0.8)
                 .collect();
 
             let mut msg = format!("style not found: '{style_input}'");
             if suggestions.is_empty() {
-                msg.push_str("\n\nUse `citum styles list` to see all available builtin styles.");
+                msg.push_str("\n\nUse `citum style list` to see all available styles.");
             } else {
                 msg.push_str("\n\nDid you mean one of these?");
                 for s in suggestions {

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -146,7 +146,10 @@ pub(crate) fn load_any_style(
 
             let mut msg = format!("style not found: '{style_input}'");
             if suggestions.is_empty() {
-                msg.push_str("\n\nUse `citum style list` to see all available styles.");
+                msg.push_str(
+                    "\n\nUse `citum style list` to browse catalog styles, \
+                     or pass a local path/direct URL.",
+                );
             } else {
                 msg.push_str("\n\nDid you mean one of these?");
                 for s in suggestions {

--- a/crates/citum-schema-style/src/registry.rs
+++ b/crates/citum-schema-style/src/registry.rs
@@ -43,6 +43,12 @@ pub struct RegistryEntry {
     /// Relative path to a YAML file (used in local registries).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
+    /// HTTP URL to a YAML style file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Human-readable title from the style metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Human-readable description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -122,6 +128,8 @@ impl StyleRegistry {
                 aliases: style_aliases,
                 builtin: Some((*name).to_string()),
                 path: None,
+                url: None,
+                title: None,
                 description: None,
                 fields: Vec::new(),
                 kind: None,
@@ -150,6 +158,9 @@ impl StyleRegistry {
                 let bytes = include_bytes!("../../../registry/default.yaml");
                 let registry: Self = serde_yaml::from_slice(bytes)
                     .expect("embedded registry/default.yaml is valid YAML");
+                registry
+                    .validate_sources()
+                    .expect("embedded registry/default.yaml has valid style sources");
                 for entry in &registry.styles {
                     if entry.kind == Some(StyleKind::Profile)
                         && let Some(name) = &entry.builtin
@@ -170,31 +181,33 @@ impl StyleRegistry {
     ///
     /// # Errors
     /// Returns an error if the file cannot be read or if the YAML cannot be parsed.
-    /// Also returns an error if any entry does not have exactly one of `builtin` or `path`.
+    /// Also returns an error if any entry does not have exactly one of
+    /// `builtin`, `path`, or `url`.
     pub fn load_from_file(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
         let content = std::fs::read(path)?;
         let registry: Self = serde_yaml::from_slice(&content)?;
-        // Validate: each entry must have exactly one of builtin or path.
-        for entry in &registry.styles {
-            match (&entry.builtin, &entry.path) {
-                (None, None) => {
-                    return Err(format!(
-                        "Registry entry '{}' must have either 'builtin' or 'path'",
-                        entry.id
-                    )
-                    .into());
-                }
-                (Some(_), Some(_)) => {
-                    return Err(format!(
-                        "Registry entry '{}' cannot have both 'builtin' and 'path'",
-                        entry.id
-                    )
-                    .into());
-                }
-                _ => {}
+        registry.validate_sources()?;
+        Ok(registry)
+    }
+
+    /// Validate that each entry declares exactly one loadable style source.
+    ///
+    /// # Errors
+    /// Returns an error if any entry has no source or multiple sources.
+    pub fn validate_sources(&self) -> Result<(), Box<dyn std::error::Error>> {
+        for entry in &self.styles {
+            let source_count = usize::from(entry.builtin.is_some())
+                + usize::from(entry.path.is_some())
+                + usize::from(entry.url.is_some());
+            if source_count != 1 {
+                return Err(format!(
+                    "Registry entry '{}' must have exactly one of 'builtin', 'path', or 'url'",
+                    entry.id
+                )
+                .into());
             }
         }
-        Ok(registry)
+        Ok(())
     }
 }
 
@@ -222,6 +235,8 @@ mod tests {
                 aliases: vec!["apa".to_string()],
                 builtin: Some("apa-7th".to_string()),
                 path: None,
+                url: None,
+                title: None,
                 description: Some("APA 7th edition".to_string()),
                 fields: vec!["psychology".to_string()],
                 kind: None,
@@ -241,6 +256,8 @@ mod tests {
                 aliases: vec!["apa".to_string()],
                 builtin: Some("apa-7th".to_string()),
                 path: None,
+                url: None,
+                title: None,
                 description: Some("APA 7th edition".to_string()),
                 fields: vec!["psychology".to_string()],
                 kind: None,
@@ -261,6 +278,8 @@ mod tests {
                     aliases: vec!["apa".to_string()],
                     builtin: Some("apa-7th".to_string()),
                     path: None,
+                    url: None,
+                    title: None,
                     description: None,
                     fields: vec![],
                     kind: None,
@@ -270,6 +289,8 @@ mod tests {
                     aliases: vec![],
                     builtin: Some("mla".to_string()),
                     path: None,
+                    url: None,
+                    title: None,
                     description: None,
                     fields: vec![],
                     kind: None,
@@ -290,6 +311,8 @@ mod tests {
                 aliases: vec!["apa".to_string()],
                 builtin: Some("apa-7th".to_string()),
                 path: None,
+                url: None,
+                title: None,
                 description: Some("APA 7th edition".to_string()),
                 fields: vec!["psychology".to_string()],
                 kind: None,
@@ -304,6 +327,8 @@ mod tests {
                     aliases: vec!["custom".to_string()],
                     path: Some(PathBuf::from("custom.yaml")),
                     builtin: None,
+                    url: None,
+                    title: None,
                     description: Some("Custom style".to_string()),
                     fields: vec![],
                     kind: None,
@@ -313,6 +338,8 @@ mod tests {
                     aliases: vec!["apa".to_string()],
                     builtin: Some("apa-7th".to_string()),
                     path: None,
+                    url: None,
+                    title: None,
                     description: Some("APA 7th edition (modified)".to_string()),
                     fields: vec!["psychology".to_string(), "custom".to_string()],
                     kind: None,
@@ -349,5 +376,18 @@ mod tests {
             .resolve("elsevier-harvard")
             .expect("elsevier-harvard should exist");
         assert_eq!(entry.kind, Some(StyleKind::Profile));
+    }
+
+    #[test]
+    fn test_load_default_contains_embedded_and_core_http_entries() {
+        let registry = StyleRegistry::load_default();
+        let embedded = registry.resolve("apa-7th").expect("apa-7th should exist");
+        assert_eq!(embedded.builtin.as_deref(), Some("apa-7th"));
+
+        let core_http = registry.resolve("alpha").expect("alpha should exist");
+        assert_eq!(
+            core_http.url.as_deref(),
+            Some("https://raw.githubusercontent.com/citum/citum-core/main/styles/alpha.yaml")
+        );
     }
 }

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -13,9 +13,12 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 thiserror = "1.0"
 toml = "0.8"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
+sha2 = { version = "0.10", optional = true }
 
 [features]
 hub = []
+http = ["dep:reqwest", "dep:sha2"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -25,7 +25,9 @@ mod resolver_tests;
 
 pub use config::StoreConfig;
 pub use format::StoreFormat;
-pub use resolver::StoreResolver;
+#[cfg(feature = "http")]
+pub use resolver::HttpResolver;
+pub use resolver::{RegistryResolver, StoreResolver};
 
 use std::path::PathBuf;
 

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -13,6 +13,8 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+#[cfg(feature = "http")]
+use std::time::{Duration, SystemTime};
 use thiserror::Error;
 
 #[cfg(feature = "http")]
@@ -222,14 +224,21 @@ pub struct HttpResolver {
 }
 
 #[cfg(feature = "http")]
+const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[cfg(feature = "http")]
+const HTTP_CACHE_MAX_AGE: Duration = Duration::from_hours(24);
+
+#[cfg(feature = "http")]
 impl HttpResolver {
     /// Create a resolver using the provided cache directory.
     #[must_use]
     pub fn new(cache_dir: PathBuf) -> Self {
-        Self {
-            cache_dir,
-            client: reqwest::blocking::Client::new(),
-        }
+        let client = reqwest::blocking::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::blocking::Client::new());
+        Self { cache_dir, client }
     }
 
     /// Create a resolver using the platform cache directory.
@@ -258,6 +267,27 @@ impl HttpResolver {
             ResolverError::YamlError(format!("failed to parse style fetched from {uri}: {err}"))
         })
     }
+
+    fn cache_is_fresh(path: &Path) -> bool {
+        path.metadata()
+            .and_then(|metadata| metadata.modified())
+            .and_then(|modified| {
+                SystemTime::now()
+                    .duration_since(modified)
+                    .map_err(std::io::Error::other)
+            })
+            .is_ok_and(|age| age < HTTP_CACHE_MAX_AGE)
+    }
+
+    fn write_cache(path: &Path, bytes: &[u8]) -> Result<(), ResolverError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let temp_path = path.with_extension(format!("yaml.tmp.{}", std::process::id()));
+        fs::write(&temp_path, bytes)?;
+        fs::rename(&temp_path, path)?;
+        Ok(())
+    }
 }
 
 #[cfg(feature = "http")]
@@ -277,7 +307,7 @@ impl StyleResolver for HttpResolver {
         }
 
         let cache_path = self.cache_path(uri);
-        if cache_path.is_file() {
+        if cache_path.is_file() && Self::cache_is_fresh(&cache_path) {
             let bytes = fs::read(&cache_path)?;
             return Self::parse_style(uri, &bytes);
         }
@@ -302,11 +332,9 @@ impl StyleResolver for HttpResolver {
         let bytes = response
             .bytes()
             .map_err(|err| ResolverError::HttpError(format!("failed to read {uri}: {err}")))?;
-        if let Some(parent) = cache_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&cache_path, &bytes)?;
-        Self::parse_style(uri, &bytes)
+        let style = Self::parse_style(uri, &bytes)?;
+        Self::write_cache(&cache_path, &bytes)?;
+        Ok(style)
     }
 
     fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -6,7 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Store resolver for locating and managing user styles and locales.
 
 use crate::format::StoreFormat;
-use citum_schema::{Locale, Style};
+use citum_schema::{Locale, Style, StyleRegistry};
 use serde::de::DeserializeOwned;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
@@ -14,6 +14,9 @@ use std::fs;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+#[cfg(feature = "http")]
+use sha2::{Digest, Sha256};
 
 /// Error type for store resolution operations.
 #[derive(Error, Debug)]
@@ -32,6 +35,9 @@ pub enum ResolverError {
     JsonError(#[from] serde_json::Error),
     #[error("cbor error: {0}")]
     CborError(String),
+    #[cfg(feature = "http")]
+    #[error("http error: {0}")]
+    HttpError(String),
 }
 
 /// A trait for resolving Citum styles and locales from various sources.
@@ -88,6 +94,88 @@ impl StyleResolver for EmbeddedResolver {
     }
 }
 
+/// A resolver that looks up styles in a registry and delegates to the matching source.
+pub struct RegistryResolver {
+    registry: StyleRegistry,
+    base_dir: Option<PathBuf>,
+    #[cfg(feature = "http")]
+    http: Option<HttpResolver>,
+}
+
+impl RegistryResolver {
+    /// Create a registry resolver for the given registry.
+    #[must_use]
+    pub fn new(registry: StyleRegistry) -> Self {
+        Self {
+            registry,
+            base_dir: None,
+            #[cfg(feature = "http")]
+            http: None,
+        }
+    }
+
+    /// Set the base directory used for relative path-backed registry entries.
+    #[must_use]
+    pub fn with_base_dir(mut self, base_dir: PathBuf) -> Self {
+        self.base_dir = Some(base_dir);
+        self
+    }
+
+    /// Set the HTTP resolver used for URL-backed registry entries.
+    #[cfg(feature = "http")]
+    #[must_use]
+    pub fn with_http(mut self, http: HttpResolver) -> Self {
+        self.http = Some(http);
+        self
+    }
+}
+
+impl StyleResolver for RegistryResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        let entry = self
+            .registry
+            .resolve(uri)
+            .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?;
+
+        if let Some(builtin) = &entry.builtin {
+            return EmbeddedResolver.resolve_style(builtin);
+        }
+
+        if let Some(path) = &entry.path {
+            let path = self
+                .base_dir
+                .as_ref()
+                .map_or_else(|| path.clone(), |base| base.join(path));
+            let path = path
+                .to_str()
+                .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?;
+            return FileResolver.resolve_style(path);
+        }
+
+        if let Some(url) = &entry.url {
+            #[cfg(feature = "http")]
+            {
+                let http = self
+                    .http
+                    .as_ref()
+                    .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?;
+                return http.resolve_style(url);
+            }
+
+            #[cfg(not(feature = "http"))]
+            {
+                return Err(ResolverError::StyleNotFound(Cow::Owned(url.clone())));
+            }
+        }
+
+        Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+        Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+    }
+}
+
 /// A resolver that handles local file paths.
 pub struct FileResolver;
 
@@ -122,6 +210,106 @@ impl StyleResolver for FileResolver {
                     .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)));
             }
         }
+        Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+    }
+}
+
+/// A resolver that fetches HTTP(S) style URLs and caches them on disk.
+#[cfg(feature = "http")]
+pub struct HttpResolver {
+    cache_dir: PathBuf,
+    client: reqwest::blocking::Client,
+}
+
+#[cfg(feature = "http")]
+impl HttpResolver {
+    /// Create a resolver using the provided cache directory.
+    #[must_use]
+    pub fn new(cache_dir: PathBuf) -> Self {
+        Self {
+            cache_dir,
+            client: reqwest::blocking::Client::new(),
+        }
+    }
+
+    /// Create a resolver using the platform cache directory.
+    #[must_use]
+    pub fn from_platform_cache_dir() -> Option<Self> {
+        dirs::cache_dir().map(|dir| Self::new(dir.join("citum")))
+    }
+
+    fn cache_path(&self, uri: &str) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(uri.as_bytes());
+        let hash = hasher.finalize();
+        let mut hex = String::with_capacity(hash.len() * 2);
+        for byte in hash {
+            hex.push(hex_digit(byte >> 4));
+            hex.push(hex_digit(byte & 0x0f));
+        }
+        self.cache_dir
+            .join("styles")
+            .join("http")
+            .join(format!("{hex}.yaml"))
+    }
+
+    fn parse_style(uri: &str, bytes: &[u8]) -> Result<Style, ResolverError> {
+        Style::from_yaml_bytes(bytes).map_err(|err| {
+            ResolverError::YamlError(format!("failed to parse style fetched from {uri}: {err}"))
+        })
+    }
+}
+
+#[cfg(feature = "http")]
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'a' + (nibble - 10)),
+        _ => '?',
+    }
+}
+
+#[cfg(feature = "http")]
+impl StyleResolver for HttpResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        if !uri.starts_with("http://") && !uri.starts_with("https://") {
+            return Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())));
+        }
+
+        let cache_path = self.cache_path(uri);
+        if cache_path.is_file() {
+            let bytes = fs::read(&cache_path)?;
+            return Self::parse_style(uri, &bytes);
+        }
+
+        let response = self
+            .client
+            .get(uri)
+            .send()
+            .map_err(|err| ResolverError::HttpError(format!("failed to fetch {uri}: {err}")))?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())));
+        }
+
+        if !response.status().is_success() {
+            return Err(ResolverError::HttpError(format!(
+                "failed to fetch {uri}: HTTP {}",
+                response.status()
+            )));
+        }
+
+        let bytes = response
+            .bytes()
+            .map_err(|err| ResolverError::HttpError(format!("failed to read {uri}: {err}")))?;
+        if let Some(parent) = cache_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&cache_path, &bytes)?;
+        Self::parse_style(uri, &bytes)
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
         Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
     }
 }

--- a/crates/citum_store/tests/resolver_arch.rs
+++ b/crates/citum_store/tests/resolver_arch.rs
@@ -12,10 +12,16 @@
     reason = "Panicking is acceptable and often desired in tests."
 )]
 
+use citum_schema::{RegistryEntry, StyleRegistry};
 use citum_store::resolver::{
-    ChainResolver, EmbeddedResolver, FileResolver, ResolverError, StyleResolver,
+    ChainResolver, EmbeddedResolver, FileResolver, RegistryResolver, ResolverError, StyleResolver,
 };
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
 use tempfile::TempDir;
 
 #[test]
@@ -90,4 +96,132 @@ fn test_chain_resolver_error_propagation() {
         Err(ResolverError::YamlError(_)) => (),
         err => panic!("Expected YamlError, got {:?}", err),
     }
+}
+
+#[test]
+fn test_registry_resolver_loads_builtin_entry() {
+    let registry = StyleRegistry {
+        version: "1".to_string(),
+        styles: vec![RegistryEntry {
+            id: "apa-test".to_string(),
+            aliases: vec!["apa-alias".to_string()],
+            builtin: Some("apa-7th".to_string()),
+            path: None,
+            url: None,
+            title: None,
+            description: None,
+            fields: vec![],
+            kind: None,
+        }],
+    };
+    let resolver = RegistryResolver::new(registry);
+    let style = resolver.resolve_style("apa-alias").unwrap();
+    assert_eq!(
+        style.info.title.as_deref(),
+        Some("American Psychological Association 7th edition")
+    );
+}
+
+#[cfg(feature = "http")]
+fn spawn_style_server(
+    body: &'static str,
+    status: &'static str,
+) -> (String, Arc<AtomicUsize>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let requests = Arc::new(AtomicUsize::new(0));
+    let request_counter = Arc::clone(&requests);
+    let handle = thread::spawn(move || {
+        for stream in listener.incoming().take(2) {
+            let mut stream = stream.unwrap();
+            let mut buffer = [0; 1024];
+            let _ = stream.read(&mut buffer);
+            request_counter.fetch_add(1, Ordering::SeqCst);
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        }
+    });
+    (format!("http://{address}/style.yaml"), requests, handle)
+}
+
+#[cfg(feature = "http")]
+#[test]
+fn test_http_resolver_fetches_and_reuses_cache() {
+    use citum_store::resolver::HttpResolver;
+
+    let (url, requests, handle) = spawn_style_server("info:\n  title: HTTP Style\n", "200 OK");
+    let temp = TempDir::new().unwrap();
+    let resolver = HttpResolver::new(temp.path().to_path_buf());
+
+    let style = resolver.resolve_style(&url).unwrap();
+    assert_eq!(style.info.title.as_deref(), Some("HTTP Style"));
+
+    let cached = resolver.resolve_style(&url).unwrap();
+    assert_eq!(cached.info.title.as_deref(), Some("HTTP Style"));
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+    drop(handle);
+}
+
+#[cfg(feature = "http")]
+#[test]
+fn test_http_resolver_reports_not_found() {
+    use citum_store::resolver::HttpResolver;
+
+    let (url, _requests, handle) = spawn_style_server("missing", "404 Not Found");
+    let temp = TempDir::new().unwrap();
+    let resolver = HttpResolver::new(temp.path().to_path_buf());
+
+    match resolver.resolve_style(&url) {
+        Err(ResolverError::StyleNotFound(_)) => {}
+        err => panic!("expected StyleNotFound, got {err:?}"),
+    }
+    drop(handle);
+}
+
+#[cfg(feature = "http")]
+#[test]
+fn test_http_resolver_reports_malformed_yaml() {
+    use citum_store::resolver::HttpResolver;
+
+    let (url, _requests, handle) = spawn_style_server("info: [", "200 OK");
+    let temp = TempDir::new().unwrap();
+    let resolver = HttpResolver::new(temp.path().to_path_buf());
+
+    match resolver.resolve_style(&url) {
+        Err(ResolverError::YamlError(_)) => {}
+        err => panic!("expected YamlError, got {err:?}"),
+    }
+    drop(handle);
+}
+
+#[cfg(feature = "http")]
+#[test]
+fn test_registry_resolver_loads_url_entry() {
+    use citum_store::resolver::HttpResolver;
+
+    let (url, _requests, handle) =
+        spawn_style_server("info:\n  title: Registry HTTP Style\n", "200 OK");
+    let registry = StyleRegistry {
+        version: "1".to_string(),
+        styles: vec![RegistryEntry {
+            id: "http-style".to_string(),
+            aliases: vec![],
+            builtin: None,
+            path: None,
+            url: Some(url),
+            title: None,
+            description: None,
+            fields: vec![],
+            kind: None,
+        }],
+    };
+    let temp = TempDir::new().unwrap();
+    let resolver = RegistryResolver::new(registry).with_http(HttpResolver::new(temp.path().into()));
+
+    let style = resolver.resolve_style("http-style").unwrap();
+    assert_eq!(style.info.title.as_deref(), Some("Registry HTTP Style"));
+    drop(handle);
 }

--- a/crates/citum_store/tests/resolver_arch.rs
+++ b/crates/citum_store/tests/resolver_arch.rs
@@ -194,6 +194,11 @@ fn test_http_resolver_reports_malformed_yaml() {
         Err(ResolverError::YamlError(_)) => {}
         err => panic!("expected YamlError, got {err:?}"),
     }
+    let cache_dir = temp.path().join("styles").join("http");
+    let cache_entries = fs::read_dir(cache_dir)
+        .map(|entries| entries.count())
+        .unwrap_or_default();
+    assert_eq!(cache_entries, 0);
     drop(handle);
 }
 

--- a/docs/schemas/registry.json
+++ b/docs/schemas/registry.json
@@ -51,6 +51,20 @@
             "null"
           ]
         },
+        "url": {
+          "description": "HTTP URL to a YAML style file.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Human-readable title from the style metadata.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "description": {
           "description": "Human-readable description.",
           "type": [

--- a/registry/default.yaml
+++ b/registry/default.yaml
@@ -220,7 +220,7 @@ styles:
 - id: american-mathematical-society-label
   url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-mathematical-society-label.yaml
   kind: journal
-  title: Amercian Mathematical Society (label)
+  title: American Mathematical Society (label)
   fields:
   - math
 - id: american-medical-association-alphabetical

--- a/registry/default.yaml
+++ b/registry/default.yaml
@@ -1,93 +1,1298 @@
-version: "1"
+version: '1'
 styles:
-  - id: apa-7th
-    aliases: [apa, taylor-and-francis-style-p]
-    builtin: apa-7th
-    kind: base
-    description: "APA 7th edition"
-    fields: [psychology, social-science]
-  - id: elsevier-harvard
-    aliases: [harvard, applied-clay-science, environmental-chemistry, international-biodeterioration-and-biodegradation, accident-analysis-and-prevention, entecho, handbook-of-clinical-neurology, journal-of-economic-impact]
-    builtin: elsevier-harvard
-    kind: profile
-    description: "Elsevier Harvard"
-    fields: [science]
-  - id: elsevier-with-titles
-    aliases: [firephyschem, journal-of-applied-engineering-sciences-technology, biochimica-et-biophysica-acta, cancer-biomarkers, engineered-regeneration, gait-and-posture, ios-press-books, necmettin-erbakan-universitesi-fen-ve-muhendislik-bilimleri-dergisi]
-    builtin: elsevier-with-titles
-    kind: profile
-    description: "Elsevier with Titles"
-    fields: [science]
-  - id: elsevier-vancouver
-    aliases: [vancouver]
-    builtin: elsevier-vancouver
-    kind: profile
-    description: "Elsevier Vancouver"
-    fields: [medicine]
-  - id: springer-basic-author-date
-    builtin: springer-basic-author-date
-    kind: profile
-    description: "Springer Basic Author-Date"
-    fields: [science]
-  - id: springer-vancouver-brackets
-    builtin: springer-vancouver-brackets
-    kind: profile
-    description: "Springer Vancouver Brackets"
-    fields: [science]
-  - id: springer-basic-brackets
-    builtin: springer-basic-brackets
-    kind: profile
-    description: "Springer Basic Brackets"
-    fields: [science]
-  - id: american-medical-association
-    aliases: [ama, acta-medica-portuguesa, ophthalmic-plastic-and-reconstructive-surgery, retina]
-    builtin: american-medical-association
-    kind: base
-    description: "American Medical Association"
-    fields: [medicine]
-  - id: ieee
-    aliases: [engineering-technology-and-applied-science-research, ieee-transactions-on-medical-imaging]
-    builtin: ieee
-    kind: base
-    description: "Institute of Electrical and Electronics Engineers"
-    fields: [engineering]
-  - id: taylor-and-francis-chicago-author-date
-    aliases: [annals-of-the-association-of-american-geographers]
-    builtin: taylor-and-francis-chicago-author-date
-    kind: profile
-    description: "Taylor & Francis Chicago Author-Date"
-    fields: [humanities]
-  - id: taylor-and-francis-council-of-science-editors-author-date
-    builtin: taylor-and-francis-council-of-science-editors-author-date
-    kind: profile
-    description: "Taylor & Francis Council of Science Editors Author-Date"
-    fields: [science]
-  - id: taylor-and-francis-national-library-of-medicine
-    builtin: taylor-and-francis-national-library-of-medicine
-    kind: profile
-    description: "Taylor & Francis National Library of Medicine"
-    fields: [medicine]
-  - id: chicago-author-date-18th
-    aliases: [chicago-author-date, taylor-and-francis-style-f]
-    builtin: chicago-author-date-18th
-    kind: base
-    description: "Chicago Author-Date (standard)"
-    fields: [humanities]
-  - id: chicago-shortened-notes-bibliography
-    aliases: [chicago]
-    builtin: chicago-shortened-notes-bibliography
-    kind: profile
-    description: "Chicago Shortened Notes"
-    fields: [humanities]
-  - id: chicago-notes-18th
-    aliases: [chicago-notes]
-    builtin: chicago-notes-18th
-    kind: base
-    description: "Chicago Notes (without bibliography)"
-    fields: [humanities]
-  - id: modern-language-association
-    aliases: [mla, taylor-and-francis-style-e, modern-language-association-notes]
-    builtin: modern-language-association
-    kind: base
-    description: "Modern Language Association"
-    fields: [humanities]
+- id: apa-7th
+  aliases:
+  - apa
+  - taylor-and-francis-style-p
+  builtin: apa-7th
+  kind: base
+  description: APA 7th edition
+  fields:
+  - psychology
+  - social-science
+- id: elsevier-harvard
+  aliases:
+  - harvard
+  - applied-clay-science
+  - environmental-chemistry
+  - international-biodeterioration-and-biodegradation
+  - accident-analysis-and-prevention
+  - entecho
+  - handbook-of-clinical-neurology
+  - journal-of-economic-impact
+  builtin: elsevier-harvard
+  kind: profile
+  description: Elsevier Harvard
+  fields:
+  - science
+- id: elsevier-with-titles
+  aliases:
+  - firephyschem
+  - journal-of-applied-engineering-sciences-technology
+  - biochimica-et-biophysica-acta
+  - cancer-biomarkers
+  - engineered-regeneration
+  - gait-and-posture
+  - ios-press-books
+  - necmettin-erbakan-universitesi-fen-ve-muhendislik-bilimleri-dergisi
+  builtin: elsevier-with-titles
+  kind: profile
+  description: Elsevier with Titles
+  fields:
+  - science
+- id: elsevier-vancouver
+  aliases:
+  - vancouver
+  builtin: elsevier-vancouver
+  kind: profile
+  description: Elsevier Vancouver
+  fields:
+  - medicine
+- id: springer-basic-author-date
+  builtin: springer-basic-author-date
+  kind: profile
+  description: Springer Basic Author-Date
+  fields:
+  - science
+- id: springer-vancouver-brackets
+  builtin: springer-vancouver-brackets
+  kind: profile
+  description: Springer Vancouver Brackets
+  fields:
+  - science
+- id: springer-basic-brackets
+  builtin: springer-basic-brackets
+  kind: profile
+  description: Springer Basic Brackets
+  fields:
+  - science
+- id: american-medical-association
+  aliases:
+  - ama
+  - acta-medica-portuguesa
+  - ophthalmic-plastic-and-reconstructive-surgery
+  - retina
+  builtin: american-medical-association
+  kind: base
+  description: American Medical Association
+  fields:
+  - medicine
+- id: ieee
+  aliases:
+  - engineering-technology-and-applied-science-research
+  - ieee-transactions-on-medical-imaging
+  builtin: ieee
+  kind: base
+  description: Institute of Electrical and Electronics Engineers
+  fields:
+  - engineering
+- id: taylor-and-francis-chicago-author-date
+  aliases:
+  - annals-of-the-association-of-american-geographers
+  builtin: taylor-and-francis-chicago-author-date
+  kind: profile
+  description: Taylor & Francis Chicago Author-Date
+  fields:
+  - humanities
+- id: taylor-and-francis-council-of-science-editors-author-date
+  builtin: taylor-and-francis-council-of-science-editors-author-date
+  kind: profile
+  description: Taylor & Francis Council of Science Editors Author-Date
+  fields:
+  - science
+- id: taylor-and-francis-national-library-of-medicine
+  builtin: taylor-and-francis-national-library-of-medicine
+  kind: profile
+  description: Taylor & Francis National Library of Medicine
+  fields:
+  - medicine
+- id: chicago-author-date-18th
+  aliases:
+  - chicago-author-date
+  - taylor-and-francis-style-f
+  builtin: chicago-author-date-18th
+  kind: base
+  description: Chicago Author-Date (standard)
+  fields:
+  - humanities
+- id: chicago-shortened-notes-bibliography
+  aliases:
+  - chicago
+  builtin: chicago-shortened-notes-bibliography
+  kind: profile
+  description: Chicago Shortened Notes
+  fields:
+  - humanities
+- id: chicago-notes-18th
+  aliases:
+  - chicago-notes
+  builtin: chicago-notes-18th
+  kind: base
+  description: Chicago Notes (without bibliography)
+  fields:
+  - humanities
+- id: modern-language-association
+  aliases:
+  - mla
+  - taylor-and-francis-style-e
+  - modern-language-association-notes
+  builtin: modern-language-association
+  kind: base
+  description: Modern Language Association
+  fields:
+  - humanities
+- id: acm-sig-proceedings
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/acm-sig-proceedings.yaml
+  kind: independent
+  title: ACM SIG Proceedings ("et al." for 3+ authors)
+  description: Used by ACM SIG conferences. Numeric style with et al. for 3 or more authors.
+  fields:
+  - science
+  - engineering
+- id: african-online-scientific-information-systems-harvard
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/african-online-scientific-information-systems-harvard.yaml
+  kind: independent
+  title: African Online Scientific Information Systems (author-date/Harvard)
+  description: Style for AOSIS Publishing's Harvard style as per 13 April 2017.
+- id: african-online-scientific-information-systems-vancouver
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/african-online-scientific-information-systems-vancouver.yaml
+  kind: independent
+  title: African Online Scientific Information Systems - NLM/Vancouver
+  description: Vancouver-like style for AOSIS Publishing as per 13 April 2017.
+- id: aims-press
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/aims-press.yaml
+  kind: independent
+  title: AIMS Press
+  fields:
+  - science
+- id: alpha
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/alpha.yaml
+  kind: independent
+  title: Alpha (biblatex-alpha)
+- id: american-association-for-cancer-research
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-association-for-cancer-research.yaml
+  kind: independent
+  title: American Association for Cancer Research
+  description: Parent style for AACR's journals
+  fields:
+  - medicine
+- id: american-chemical-society
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-chemical-society.yaml
+  kind: independent
+  title: ACS Guide 2022 revision
+  description: The American Chemical Society style
+  fields:
+  - chemistry
+- id: american-fisheries-society
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-fisheries-society.yaml
+  kind: independent
+  title: American Fisheries Society
+  fields:
+  - biology
+- id: american-geophysical-union
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-geophysical-union.yaml
+  kind: independent
+  title: American Geophysical Union
+  description: The American Geophysical Union generic style
+  fields:
+  - geology
+- id: american-institute-of-aeronautics-and-astronautics
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-institute-of-aeronautics-and-astronautics.yaml
+  kind: journal
+  title: American Institute of Aeronautics and Astronautics
+  description: A style for AIAA
+  fields:
+  - engineering
+- id: american-institute-of-physics
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-institute-of-physics.yaml
+  kind: independent
+  title: AIP Style Manual 4th edition
+  description: Common style used by AIP publications.
+  fields:
+  - physics
+- id: american-marketing-association
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-marketing-association.yaml
+  kind: independent
+  title: American Marketing Association
+  description: AMA Reference List Style published by the American Marketing Association
+  fields:
+  - communications
+- id: american-mathematical-society-label
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-mathematical-society-label.yaml
+  kind: journal
+  title: Amercian Mathematical Society (label)
+  fields:
+  - math
+- id: american-medical-association-alphabetical
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-medical-association-alphabetical.yaml
+  kind: journal
+  title: AMA Manual of Style 11th edition (sorted alphabetically)
+  description: 'AMA Manual of Style: A Guide for Authors and Editors (11th ed.), with alphabetically sorted bibliography.'
+  fields:
+  - medicine
+- id: american-medical-association-no-et-al
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-medical-association-no-et-al.yaml
+  kind: journal
+  title: AMA Manual of Style 11th edition (no "et al.")
+  description: 'AMA Manual of Style: A Guide for Authors and Editors (11th ed.), without et al.'
+  fields:
+  - medicine
+- id: american-medical-association-no-url
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-medical-association-no-url.yaml
+  kind: journal
+  title: AMA Manual of Style 11th edition (without URLs)
+  description: 'AMA Manual of Style: A Guide for Authors and Editors (11th ed.), without URLs.'
+  fields:
+  - medicine
+- id: american-meteorological-society
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-meteorological-society.yaml
+  kind: independent
+  title: American Meteorological Society
+  description: A style for all journals by the American Meteorological Society
+  fields:
+  - geography
+- id: american-physics-society
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-physics-society.yaml
+  kind: independent
+  title: American Physical Society
+  description: Common style use by APS publications.
+  fields:
+  - physics
+- id: american-physiological-society
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-physiological-society.yaml
+  kind: independent
+  title: American Physiological Society
+  description: A style for many APS journals
+  fields:
+  - medicine
+- id: american-society-for-microbiology
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-society-for-microbiology.yaml
+  kind: independent
+  title: American Society for Microbiology
+  description: Style for all American Society for Microbiology journals.
+  fields:
+  - biology
+- id: american-society-of-civil-engineers
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-society-of-civil-engineers.yaml
+  kind: independent
+  title: American Society of Civil Engineers
+  description: A style for American Society of Civil Engineers publications
+  fields:
+  - engineering
+- id: american-society-of-mechanical-engineers
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-society-of-mechanical-engineers.yaml
+  kind: journal
+  title: American Society of Mechanical Engineers
+  description: A style for the ASME's 23 journals
+  fields:
+  - engineering
+- id: american-sociological-association
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-sociological-association.yaml
+  kind: independent
+  title: ASA Style Guide 6th/7th edition
+  description: The ASA style following the 6th/7th edition of the Style Guide (reference formatting is the same for both editions).
+  fields:
+  - sociology
+- id: american-statistical-association
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/american-statistical-association.yaml
+  kind: independent
+  title: American Statistical Association
+  description: A style for the American Statistical Association used for all their journals.
+  fields:
+  - math
+- id: angewandte-chemie
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/angewandte-chemie.yaml
+  kind: independent
+  title: Angewandte Chemie International Edition
+- id: annual-reviews-alphabetical
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/annual-reviews-alphabetical.yaml
+  kind: independent
+  title: Annual Reviews (sorted alphabetically)
+- id: annual-reviews-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/annual-reviews-author-date.yaml
+  kind: independent
+  title: Annual Reviews (author-date)
+- id: annual-reviews
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/annual-reviews.yaml
+  kind: independent
+  title: Annual Reviews (sorted by order of appearance)
+- id: association-for-computing-machinery
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/association-for-computing-machinery.yaml
+  kind: independent
+  title: Association for Computing Machinery
+- id: baishideng-publishing-group
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/baishideng-publishing-group.yaml
+  kind: independent
+  title: Baishideng Publishing Group
+- id: begell-house-chicago-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/begell-house-chicago-author-date.yaml
+  kind: independent
+  title: Begell House - Chicago Manual of Style
+  description: The author-date variant of the Begell House Chicago style
+- id: biomed-central
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/biomed-central.yaml
+  kind: independent
+  title: BioMed Central
+  fields:
+  - medicine
+  - biology
+- id: bmj
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/bmj.yaml
+  kind: independent
+  title: BMJ
+  description: Vancouver style adapted for BMJ journals
+  fields:
+  - medicine
+- id: bristol-university-press
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/bristol-university-press.yaml
+  kind: independent
+  title: Bristol University Press
+  fields:
+  - humanities
+- id: canadian-journal-of-fisheries-and-aquatic-sciences
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/canadian-journal-of-fisheries-and-aquatic-sciences.yaml
+  kind: independent
+  title: Canadian Journal of Fisheries and Aquatic Sciences
+  fields:
+  - biology
+- id: cell-numeric
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/cell-numeric.yaml
+  kind: journal
+  title: Cell journals (numeric)
+- id: cell
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/cell.yaml
+  kind: independent
+  title: Cell
+  description: The Cell journal style, switched to numeric superscript as per the Cell editorial office in Sept. 2022
+  fields:
+  - biology
+- id: chem-acs
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chem-acs.yaml
+  kind: independent
+  title: ACS Chemistry (Compound)
+  description: 'American Chemical Society style with compound citation support. Groups related references under a shared citation
+    number with alphabetic sub-labels. Based on the ACS Guide 2022 revision.
+
+    '
+  fields:
+  - chemistry
+- id: chem-biochem
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chem-biochem.yaml
+  kind: independent
+  title: ACS Biochemistry (Compound)
+  description: 'Style for the ACS journal Biochemistry with compound citation support. Distinctive from base ACS: year appears
+    in parentheses immediately after author list, before the title. Superscript citation numbers without brackets.
+
+    '
+  fields:
+  - chemistry
+  - biology
+- id: chem-rsc
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chem-rsc.yaml
+  kind: independent
+  title: Royal Society of Chemistry (Compound)
+  description: 'Royal Society of Chemistry journal style with compound citation support. Groups related references under a
+    shared citation number with alphabetic sub-labels. Based on the standard RSC style.
+
+    '
+  fields:
+  - chemistry
+- id: chicago-author-date-classic
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-author-date-classic.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (author-date, classic variants)
+  description: 'Chicago-style source citations (with Bluebook for legal citations), author-date system, with classic variants:
+    3-em dash for repeated names (CMOS18 13.113), chapter page numbers (CMOS18 14.8), and place of publication (CMOS18 14.30)'
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: chicago-notes-bibliography-17th-edition
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-notes-bibliography-17th-edition.yaml
+  kind: independent
+  title: Chicago Manual of Style 17th edition (notes and bibliography)
+  description: Chicago-style source citations (with Bluebook for legal citations), notes and bibliography system, 17th edition
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: chicago-notes-bibliography-classic-archive-place-first-no-url
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-notes-bibliography-classic-archive-place-first-no-url.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (notes and bibliography, classic variants, archival references with place first,
+    without URLs)
+  description: 'Chicago-style source citations (with Bluebook for legal citations), notes and bibliography system, with classic
+    variants: 3-em dash for repeated names (CMOS18 13.113), chapter page numbers (CMOS18 14.8), and place of publication (CMOS18
+    14.30); archival references with place first (CMOS18 14.205), without URLs (CMOS18 13.6)'
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: chicago-notes-classic-archive-place-first
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-notes-classic-archive-place-first.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (notes without bibliography, classic variants, archival references with place
+    first)
+  description: 'Chicago-style source citations (with Bluebook for legal citations), notes system without bibliography, listing
+    up to six authors in a full citation (CMOS18 13.23), displaying number of volumes (CMOS18 14.20); classic variants: chapter
+    page numbers (CMOS18 14.8), place of publication (CMOS18 14.30); archival references with place first (CMOS18 14.205)'
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: chicago-notes-classic-no-url
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-notes-classic-no-url.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (notes without bibliography, classic variants, without URLs)
+  description: 'Chicago-style source citations (with Bluebook for legal citations), notes system without bibliography, listing
+    up to six authors in a full citation (CMOS18 13.23), displaying number of volumes (CMOS18 14.20), classic variants: chapter
+    page numbers (CMOS18 14.8), place of publication (CMOS18 14.30); without URLs (CMOS18 13.6)'
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: chicago-notes-classic
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-notes-classic.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (notes without bibliography, classic variants)
+  description: 'Chicago-style source citations (with Bluebook for legal citations), notes system without bibliography, listing
+    up to six authors in a full citation (CMOS18 13.23), displaying number of volumes (CMOS18 14.20), classic variants: chapter
+    page numbers (CMOS18 14.8), place of publication (CMOS18 14.30)'
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: chicago-notes-publisher-place-archive-place-first-no-url
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-notes-publisher-place-archive-place-first-no-url.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (notes without bibliography, place of publication substituted for publisher,
+    archival references with place first, without URLs)
+  description: Chicago-style source citations (with Bluebook for legal citations), notes system without bibliography, listing
+    up to six authors in a full citation (CMOS18 13.23), chapter page numbers (CMOS18 14.8), displaying number of volumes
+    (CMOS18 14.20), substituting place of publication for publisher name (CMOS18 14.31), archival references with place first
+    (CMOS18 14.205), without URLs (CMOS18 13.6)
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: chicago-shortened-notes-bibliography-classic-archive-place-first
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/chicago-shortened-notes-bibliography-classic-archive-place-first.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (shortened notes and bibliography, classic variants, archival references with
+    place first)
+  description: 'Chicago-style source citations (with Bluebook for legal citations), shortened author-title notes and bibliography
+    system, with classic variants: 3-em dash for repeated names (CMOS18 13.113), chapter page numbers (CMOS18 14.8), and place
+    of publication (CMOS18 14.30); archival references with place first (CMOS18 14.205)'
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+- id: copernicus-publications
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/copernicus-publications.yaml
+  kind: independent
+  title: Copernicus Publications
+  description: The Copernicus generic style
+  fields:
+  - science
+- id: cse-name-year
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/cse-name-year.yaml
+  kind: independent
+  title: 'CSE Manual: Scientific Style and Format 9th edition (name-year)'
+  description: 'Council of Science Editors style, 9th edition, name-year system: author-date in text, sorted alphabetically.'
+  fields:
+  - biology
+  - botany
+  - chemistry
+  - geology
+  - medicine
+  - science
+  - zoology
+- id: current-opinion
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/current-opinion.yaml
+  kind: independent
+  title: Current Opinion journals
+- id: din-1505-2-alphanumeric
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/din-1505-2-alphanumeric.yaml
+  kind: independent
+  title: DIN 1505-2 (alphanumeric, Deutsch) - standard superseded by ISO-690
+  description: "Style following DIN 1505-2, using the alphanumeric citation keys, for other media types on additional standards\
+    \ \n      Hinweise zur Benutzung: \n      * Zitieren von Gesetzen: \n        - hier m\xFCssen manuell \xA7, Abs und S.\
+    \ zur Seitenangabe beim Zitieren eingetragen werden \n        - im Kurzbeleg wird der Kurztitel verwendet, daf\xFCr keine\
+    \ Autoren eintragen! \n        - als Jahresangabe wird 'Datum des Inkrafttretens' herangezogen, Verwenden nur bei Verweis\
+    \ auf nicht z.Z. g\xFCltige Gesetze, z.B. (idF. v. 12.12.1972) \n       * Zitieren von Normen und Standards - nicht vollst\xE4\
+    ndig nach DIN 1505\n        - Nutzen Sie den Typ 'Bericht' - als Abhilfe, da es keinen Typ 'Standard' gibt.\n        -\
+    \ als Autor die Kurzbezeichnung inkl. Nummer und Jahr eingeben (z.B. VDI 2222-1997), Vorname leer, Jahr leer\n       \
+    \ - als Titel den ausf\xFChrlichen Titel bei Bedarf (z.B. VDI Richtlinie 2222 Blatt 1 - Konstruktionsmethodik - Methodisches\
+    \ Entwickeln von L\xF6sungsprinzipien)"
+- id: disability-and-rehabilitation
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/disability-and-rehabilitation.yaml
+  kind: journal
+  title: Disability and Rehabilitation
+- id: elsevier-vancouver-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/elsevier-vancouver-author-date.yaml
+  kind: journal
+  title: Elsevier - NLM/Vancouver (name-year)
+  description: A style for some Elsevier journals, resembles Vancouver style, but using author-date format
+- id: elsevier-without-titles
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/elsevier-without-titles.yaml
+  kind: independent
+  title: Elsevier (numeric, without titles)
+  description: A style for many of Elsevier's journals that does not include article titles in the reference list
+- id: endocrine-press
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/endocrine-press.yaml
+  kind: journal
+  title: Endocrine Press
+  description: The American Medical Association style  with parentheses, bold authors, and no et-al
+  fields:
+  - medicine
+- id: entomological-society-of-america
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/entomological-society-of-america.yaml
+  kind: journal
+  title: Entomological Society of America
+  fields:
+  - biology
+- id: experimental/bluebook-legal
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/experimental/bluebook-legal.yaml
+  kind: independent
+  title: Bluebook Legal Citation (Simplified)
+  description: 'Demonstrates bibliography grouping with legal type hierarchy following Bluebook conventions. Primary sources
+    (cases, statutes, treaties) are grouped separately with type-based ordering.
+
+    '
+- id: experimental/chicago-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/experimental/chicago-author-date.yaml
+  kind: independent
+  title: Chicago Manual of Style 18th edition (author-date)
+- id: experimental/jm-chicago-legal
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/experimental/jm-chicago-legal.yaml
+  kind: independent
+  title: Juris-M Chicago Legal (Experimental)
+  description: 'Demonstrates legal sectional bibliography groups aligned to Juris-M and Bluebook-oriented workflows.
+
+    '
+- id: experimental/jm-turabian-multilingual
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/experimental/jm-turabian-multilingual.yaml
+  kind: independent
+  title: Turabian Notes (Multilingual)
+  description: 'Experimental multilingual variant of Chicago/Turabian notes style. Supports CJK and other complex scripts
+    with original name ordering and transliterations.
+
+    '
+- id: experimental/locale-specific-bibliography-layouts
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/experimental/locale-specific-bibliography-layouts.yaml
+  kind: independent
+  title: Locale-Specific Bibliography Layouts
+  description: 'Demonstrates bibliography.locales[] selecting a different full-entry layout for CJK items than for the default
+    Latin-script branch.
+
+    '
+- id: experimental/multilingual-academic
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/experimental/multilingual-academic.yaml
+  kind: independent
+  title: Multilingual Academic Citation (Juris-M Style)
+  description: 'Demonstrates per-group sorting for multilingual bibliographies. Vietnamese references use given-family ordering,
+    Western references use family-given ordering.
+
+    '
+- id: experimental/multilingual-partitioned
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/experimental/multilingual-partitioned.yaml
+  kind: journal
+  title: Multilingual Script Partitioning Demo
+- id: frontiers-medical-journals
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/frontiers-medical-journals.yaml
+  kind: independent
+  title: Frontiers medical journals
+  description: Style for the Open Access Frontiers in ... Journals
+  fields:
+  - medicine
+- id: frontiers
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/frontiers.yaml
+  kind: independent
+  title: Frontiers journals
+  description: Style for the Open Access Frontiers in ... Journals
+- id: future-medicine
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/future-medicine.yaml
+  kind: independent
+  title: Future Medicine journals
+  fields:
+  - medicine
+  - biology
+- id: future-science-group
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/future-science-group.yaml
+  kind: independent
+  title: Future Science Group
+  description: Style used by the journals of the Future Science Group, as per Oct-2018 guidelines.
+  fields:
+  - medicine
+- id: gost-r-7-0-5-2008-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/gost-r-7-0-5-2008-author-date.yaml
+  kind: independent
+  title: GOST R 7.0.5-2008 (Author-Date)
+  description: 'Russian bibliography standard GOST R 7.0.5-2008 demonstrating bibliography grouping by reference type with
+    localized Russian headings.
+
+    '
+- id: gost-r-7-0-5-2008-numeric
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/gost-r-7-0-5-2008-numeric.yaml
+  kind: independent
+  title: Russian GOST R 7.0.5-2008 (numeric)
+  description: "This style is independent from style \"GOST-R-7.0.5-2008\", and the main difference is that this is numeric,\
+    \ contrary to author-date. The structure of these two styles is also very different. !!! IMPORTANT !!! Citations are numeric,\
+    \ order of bibliography is in order of citations, default locale is \"ru-RU\".\n\n    \u0421\u0442\u0438\u043B\u044C \u043E\
+    \u0441\u043D\u043E\u0432\u0430\u043D \u043D\u0430 \u0413\u041E\u0421\u0422 \u0420 7.0.5-2008 \u0438 \u0413\u041E\u0421\
+    \u0422 7.1.2003. \u041E\u0441\u043D\u043E\u0432\u043D\u0430\u044F \u043F\u0440\u043E\u0431\u043B\u0435\u043C\u0430 \u0441\
+    \u0435\u0439\u0447\u0430\u0441 \u2014 \u044D\u0442\u043E \u043B\u043E\u043A\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u044F\
+    \ \u0442\u0435\u0440\u043C\u0438\u043D\u043E\u0432 (\u0421., \u0422., \u043F\u043E\u0434 \u0440\u0435\u0434., \u0438 \u0434\
+    \u0440. ... \u0438\u043B\u0438 \u0441\u043E\u043E\u0442\u0432\u0435\u0442\u0441\u0442\u0432\u0435\u043D\u043D\u043E P.,\
+    \ Vol., ed., et al.). \u0412 \u043F\u0440\u0438\u043D\u0446\u0438\u043F\u0435 \u044D\u0442\u043E \u0440\u0430\u0431\u043E\
+    \u0442\u0430\u0435\u0442 \u0438 \u043A\u043E\u043D\u0442\u0440\u043E\u043B\u0438\u0440\u0443\u0435\u0442\u0441\u044F \u043F\
+    \u043E\u043B\u0435\u043C  default-locale (\u0432\u044B\u0448\u0435, \u0432\u043E \u0432\u0442\u043E\u0440\u043E\u0439\
+    \ \u0441\u0442\u0440\u043E\u0447\u043A\u0435). \u0414\u043B\u044F \u0440\u0443\u0441\u0441\u043A\u043E\u0433\u043E \u043D\
+    \u0430\u0434\u043E \u0437\u0430\u043C\u0435\u043D\u0438\u0442\u044C \u043D\u0430 \"ru-RU\". \u042D\u0442\u043E \u043E\u043F\
+    \u0440\u0435\u0434\u0435\u043B\u044F\u0435\u0442 \u043E\u0434\u043D\u0438 \u043D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\
+    \u0438 \u0434\u043B\u044F \u0432\u0441\u0435\u0439 \u0431\u0438\u0431\u043B\u0438\u043E\u0433\u0440\u0430\u0444\u0438\u0438\
+    . \u041E\u0434\u043D\u0430\u043A\u043E, \u0438\u0434\u0435\u0430\u043B\u044C\u043D\u043E\u0435 \u0440\u0435\u0448\u0435\
+    \u043D\u0438\u0435 \u2014 \u044D\u0442\u043E \u0432\u044B\u0431\u0438\u0440\u0430\u0442\u044C \u044F\u0437\u044B\u043A\
+    \ \u043B\u043E\u043A\u0430\u043B\u0438\u0437\u0430\u0446\u0438\u0438 \u0442\u0435\u0440\u043C\u0438\u043D\u043E\u0432\
+    \ \u0432 \u0437\u0430\u0432\u0438\u0441\u0438\u043C\u043E\u0441\u0442\u0438 \u043E\u0442 \u044F\u0437\u044B\u043A\u0430\
+    \ \u0437\u0430\u043F\u0438\u0441\u0438 (\u043A\u0430\u043A \u0438 \u043F\u0440\u0435\u0434\u043F\u0438\u0441\u044B\u0432\
+    \u0430\u0435\u0442 \u0413\u041E\u0421\u0422). \u042D\u0442\u043E \u043D\u0435\u0432\u043E\u0437\u043C\u043E\u0436\u043D\
+    \u043E \u0441\u0434\u0435\u043B\u0430\u0442\u044C \u0432 \u0440\u0430\u043C\u043A\u0430\u0445 Zotero 4.0 \u0438 CSL 1.0,\
+    \ \u043D\u043E \u0443\u0436\u0435 \u0441\u0435\u0439\u0447\u0430\u0441 \u0447\u0442\u043E-\u0442\u043E \u043C\u043E\u0436\
+    \u043D\u043E \u0441\u0434\u0435\u043B\u0430\u0442\u044C \u0432 \u0440\u0430\u043C\u043A\u0430\u0445 MultiLingual Zotero\
+    \ \u2014 \u0441\u043C. \u043D\u0430\u043F\u0440\u0438\u043C\u0435\u0440 http://forums.zotero.org/discussion/18482/multilingual-zotero-fields-and-csl-variables.\
+    \ Typst \u043F\u043E\u0437\u0432\u043E\u043B\u044F\u0435\u0442 \u0438\u0437\u043C\u0435\u043D\u044F\u0442\u044C \u043B\
+    \u043E\u043A\u0430\u043B\u044C \u0431\u0438\u0431\u043B\u0438\u043E\u0433\u0440\u0430\u0444\u0438\u0438 \u0438 \u0446\u0438\
+    \u0442\u0430\u0442, \u0438\u0441\u043F\u043E\u043B\u044C\u0437\u0443\u044F \u043F\u043E\u043B\u0435 lang \u044D\u043B\u0435\
+    \u043C\u0435\u043D\u0442\u0430 text.\n\n    \u0418 \u043F\u043E\u0441\u043B\u0435\u0434\u043D\u0435\u0435, \u043F\u0430\
+    \u0442\u0435\u043D\u0442\u044B \u043F\u043E \u0443\u043C\u043E\u043B\u0447\u0430\u043D\u0438\u044E \u043F\u0440\u0435\u0434\
+    \u0441\u0442\u0430\u0432\u043B\u0435\u043D\u044B \u043A\u0430\u043A USA, \u043F\u043E\u0441\u043A\u043E\u043B\u044C\u043A\
+    \u0443 \u0432 CSL 1.0 \u043D\u0435\u0442 \u043F\u0435\u0440\u0435\u043C\u0435\u043D\u043D\u043E\u0439, \u0441\u043E\u043E\
+    \u0442\u0432\u0435\u0442\u0441\u0442\u0432\u0443\u044E\u0449\u0435\u0439 \u043F\u043E\u043B\u044E country \u0432 \u0431\
+    \u0430\u0437\u0435 Zotero 4.0+. \u041D\u0430\u0434\u0435\u044E\u0441\u044C, \u044D\u0442\u043E \u0431\u0443\u0434\u0435\
+    \u0442 \u0438\u0441\u043F\u0440\u0430\u0432\u043B\u0435\u043D\u043E \u0432 \u0431\u0443\u0434\u0443\u0449\u0438\u0445\
+    \ \u0432\u0435\u0440\u0441\u0438\u044F\u0445."
+- id: hainan-medical-university-journal-publisher
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/hainan-medical-university-journal-publisher.yaml
+  kind: independent
+  title: Hainan Medical University Journal Publisher
+  fields:
+  - medicine
+  - biology
+- id: harvard-cite-them-right
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/harvard-cite-them-right.yaml
+  kind: independent
+  title: Cite Them Right 12th edition (author-date/Harvard)
+  description: Harvard according to Cite Them Right, 11th edition.
+- id: hawaii-international-conference-on-system-sciences-proceedings
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/hawaii-international-conference-on-system-sciences-proceedings.yaml
+  kind: journal
+  title: Hawaii International Conference on System Sciences Proceedings
+- id: institute-for-operations-research-and-the-management-sciences
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/institute-for-operations-research-and-the-management-sciences.yaml
+  kind: independent
+  title: Institute for Operations Research and the Management Sciences
+  fields:
+  - engineering
+- id: institute-of-mathematics-and-its-applications
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/institute-of-mathematics-and-its-applications.yaml
+  kind: independent
+  title: Institute of Mathematics and its Applications
+  fields:
+  - math
+- id: institute-of-physics-numeric
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/institute-of-physics-numeric.yaml
+  kind: independent
+  title: Institute of Physics (numeric)
+- id: integrated-science-publishing-journals
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/integrated-science-publishing-journals.yaml
+  kind: independent
+  title: Integrated Science Publishing journals
+  fields:
+  - science
+- id: inter-research-science-center
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/inter-research-science-center.yaml
+  kind: journal
+  title: Inter-Research Science Center
+  fields:
+  - biology
+- id: international-journal-of-wildland-fire
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/international-journal-of-wildland-fire.yaml
+  kind: journal
+  title: International Journal of Wildland Fire
+  description: "This style produces the CSIRO style used in the International Journal of Wildland Fire,\n      the Australian\
+    \ Journal of Botany and several other Australian journals.  It has been\n      validated for the journal, book, book chapter,\
+    \ report, and conference paper citation\n      styles.  This style is in the public domain."
+  fields:
+  - science
+- id: international-union-of-crystallography
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/international-union-of-crystallography.yaml
+  kind: independent
+  title: International Union of Crystallography journals
+  fields:
+  - chemistry
+- id: iso690-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/iso690-author-date.yaml
+  kind: independent
+  title: ISO 690 (author-date)
+  description: 'ISO 690 author-date style for international bibliography standards. Locale-agnostic with support for multilingual
+    citations.
+
+    '
+- id: iso690-numeric
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/iso690-numeric.yaml
+  kind: independent
+  title: ISO 690 (numeric)
+  description: 'ISO 690 numeric citation-sequence style for international bibliography standards. Locale-agnostic with support
+    for multilingual citations.
+
+    '
+- id: karger-journals-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/karger-journals-author-date.yaml
+  kind: independent
+  title: Karger journals (author-date)
+- id: karger-journals
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/karger-journals.yaml
+  kind: independent
+  title: Karger journals
+- id: landes-bioscience-journals
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/landes-bioscience-journals.yaml
+  kind: independent
+  title: Landes Bioscience Journals
+  description: Vancouver style adapted for Landes Bioscience Journals (et al for 10+ authors, only year, space after semicolon
+  fields:
+  - medicine
+- id: mary-ann-liebert-harvard
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/mary-ann-liebert-harvard.yaml
+  kind: independent
+  title: Mary Ann Liebert (author-date/Harvard)
+- id: mary-ann-liebert-vancouver
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/mary-ann-liebert-vancouver.yaml
+  kind: independent
+  title: Mary Ann Liebert - NLM/Vancouver
+- id: medicina-clinica
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/medicina-clinica.yaml
+  kind: independent
+  title: "Medicina Cl\xEDnica (Espa\xF1ol)"
+  description: Style for Medicina Clinica (and most Spanish Elsevier journals that follow an adapted Vancouver style)
+  fields:
+  - medicine
+- id: medicine-publishing
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/medicine-publishing.yaml
+  kind: independent
+  title: Medicine Publishing
+  description: Vancouver style for all journals of The Medicine Publishing Collection.
+  fields:
+  - medicine
+- id: memorias-do-instituto-oswaldo-cruz
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/memorias-do-instituto-oswaldo-cruz.yaml
+  kind: independent
+  title: "Mem\xF3rias do Instituto Oswaldo Cruz"
+- id: mhra-author-date-publisher-place
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/mhra-author-date-publisher-place.yaml
+  kind: independent
+  title: MHRA Style Guide 4th edition (author-date, place of publication)
+  description: MHRA source citations, author-date system, with place of publication (MHRA 7.3)
+  fields:
+  - history
+  - humanities
+  - linguistics
+  - literature
+  - philosophy
+  - theology
+- id: mhra-notes-publisher-place-no-url
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/mhra-notes-publisher-place-no-url.yaml
+  kind: independent
+  title: MHRA Style Guide 4th edition (notes, place of publication, without URLs)
+  description: MHRA source citations, notes system, with place of publication (MHRA 7.3), without URLs
+  fields:
+  - history
+  - humanities
+  - linguistics
+  - literature
+  - philosophy
+  - theology
+- id: mhra-notes-publisher-place
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/mhra-notes-publisher-place.yaml
+  kind: independent
+  title: MHRA Style Guide 4th edition (notes, place of publication)
+  description: MHRA source citations, notes system, with place of publication (MHRA 7.3)
+  fields:
+  - history
+  - humanities
+  - linguistics
+  - literature
+  - philosophy
+  - theology
+- id: mhra-notes
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/mhra-notes.yaml
+  kind: independent
+  title: MHRA Style Guide 4th edition (notes)
+- id: mhra-shortened-notes-publisher-place
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/mhra-shortened-notes-publisher-place.yaml
+  kind: independent
+  title: MHRA Style Guide 4th edition (shortened notes, place of publication)
+- id: microbiology-society
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/microbiology-society.yaml
+  kind: independent
+  title: Microbiology Society
+  fields:
+  - biology
+- id: multidisciplinary-digital-publishing-institute
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/multidisciplinary-digital-publishing-institute.yaml
+  kind: independent
+  title: Multidisciplinary Digital Publishing Institute
+- id: museum-national-dhistoire-naturelle
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/museum-national-dhistoire-naturelle.yaml
+  kind: independent
+  title: "Mus\xE9um national d'Histoire naturelle"
+  fields:
+  - biology
+  - botany
+  - anthropology
+  - geology
+  - zoology
+- id: nature-publishing-group-vancouver
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nature-publishing-group-vancouver.yaml
+  kind: independent
+  title: Nature Publishing Group - NLM/Vancouver
+  description: Superscript Vancouver style for some NPG journals, with et-al-min="7" and et-al-use-first="6"
+  fields:
+  - science
+- id: nature
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nature.yaml
+  kind: independent
+  title: Nature
+  fields:
+  - science
+- id: new-harts-rules-author-date-space-publisher
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/new-harts-rules-author-date-space-publisher.yaml
+  kind: independent
+  title: 'New Hart''s Rules: The Oxford Style Guide 2nd edition (author-date, bracketed date with space, publisher)'
+- id: new-harts-rules-notes-label-page-no-url
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/new-harts-rules-notes-label-page-no-url.yaml
+  kind: independent
+  title: 'New Hart''s Rules: The Oxford Style Guide 2nd edition (notes, page abbreviations, without URLs)'
+  description: Oxford source citations, notes system, page abbreviations with locator (NHR 17.2.5), without URLs
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - linguistics
+  - literature
+  - philosophy
+  - psychology
+  - science
+  - sociology
+  - theology
+- id: new-harts-rules-notes-label-page
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/new-harts-rules-notes-label-page.yaml
+  kind: independent
+  title: 'New Hart''s Rules: The Oxford Style Guide 2nd edition (notes, page abbreviations)'
+  description: Oxford source citations, notes system, page abbreviations with locator (NHR 17.2.5)
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - linguistics
+  - literature
+  - philosophy
+  - psychology
+  - science
+  - sociology
+  - theology
+- id: new-harts-rules-notes
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/new-harts-rules-notes.yaml
+  kind: independent
+  title: 'New Hart''s Rules: The Oxford Style Guide 2nd edition (notes)'
+  description: Oxford source citations, notes system
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - linguistics
+  - literature
+  - philosophy
+  - psychology
+  - science
+  - sociology
+  - theology
+- id: nlm-citation-sequence-brackets-no-et-al
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-citation-sequence-brackets-no-et-al.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence, brackets, no "et al.")'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); citation-sequence system, with in-text indicators in brackets, no "et al."'
+  fields:
+  - medicine
+- id: nlm-citation-sequence-brackets-year-only-no-issue
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-citation-sequence-brackets-year-only-no-issue.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence, brackets, year-only dates, no issue
+    numbers)'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); citation-sequence system, with in-text indicators in brackets, year-only dates, and no issue numbers.'
+  fields:
+  - medicine
+- id: nlm-citation-sequence-brackets
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-citation-sequence-brackets.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence, brackets)'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); citation-sequence system, with in-text indicators in brackets.'
+  fields:
+  - medicine
+- id: nlm-citation-sequence-superscript-brackets-year-only
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-citation-sequence-superscript-brackets-year-only.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence, superscript, brackets, year-only dates)'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); citation-sequence system, with superscripted in-text indicators, brackets, and year-only dates.'
+  fields:
+  - medicine
+- id: nlm-citation-sequence-superscript-year-only-no-issue
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-citation-sequence-superscript-year-only-no-issue.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence, superscript, year-only dates, no issue
+    numbers)'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); citation-sequence system, with superscripted in-text indicators, year-only dates, and no issue numbers.'
+  fields:
+  - medicine
+- id: nlm-citation-sequence-superscript
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-citation-sequence-superscript.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence, superscript)'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); citation-sequence system, with superscripted in-text indicators.'
+  fields:
+  - medicine
+- id: nlm-citation-sequence
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-citation-sequence.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (citation-sequence)'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); citation-sequence system.'
+  fields:
+  - medicine
+- id: nlm-name-year
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/nlm-name-year.yaml
+  kind: independent
+  title: 'NLM Style Guide (Vancouver): Citing Medicine 2nd edition (name-year)'
+  description: 'Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers, 2nd edition (2015), based on ANSI/NISO
+    Z39.29-2005 (R2010); name-year system.'
+  fields:
+  - medicine
+- id: numeric-comp
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/numeric-comp.yaml
+  kind: independent
+  title: Numeric Compound
+  description: 'A generic numeric style with compound citation support. Groups related references under a shared citation
+    number with alphabetic sub-labels (a, b, c). Analog of the biblatex numeric-comp style.
+
+    '
+- id: oscola-no-ibid
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/oscola-no-ibid.yaml
+  kind: independent
+  title: OSCOLA 4th edition (no ibid.)
+  description: 'Oxford University Standard for Citation of Legal Authorities, notes system, no ibid. For a Zotero group showing
+    data entry: https://zotero.org/groups/2205533/collections/AC7ETLN4'
+  fields:
+  - law
+- id: oscola
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/oscola.yaml
+  kind: independent
+  title: Oxford University Standard for Citation of Legal Authorities 4th edition
+  description: 'Oxford University Standard for Citation of Legal Authorities, notes system. For a Zotero group showing data
+    entry: https://zotero.org/groups/2205533/collections/AC7ETLN4'
+  fields:
+  - law
+- id: oxford-journals-scimed-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/oxford-journals-scimed-author-date.yaml
+  kind: independent
+  title: Oxford Journals Sciences and Medicine (author-date)
+  fields:
+  - medicine
+  - science
+- id: oxford-journals-scimed-numeric
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/oxford-journals-scimed-numeric.yaml
+  kind: independent
+  title: Oxford Journals Sciences and Medicine (numeric)
+  fields:
+  - medicine
+  - science
+- id: pensoft-journals
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/pensoft-journals.yaml
+  kind: independent
+  title: Pensoft Journals
+  description: The Pensoft Journals style
+- id: pharmacoepidemiology-and-drug-safety
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/pharmacoepidemiology-and-drug-safety.yaml
+  kind: journal
+  title: Pharmacoepidemiology and Drug Safety
+- id: plos
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/plos.yaml
+  kind: independent
+  title: Public Library of Science
+  description: Vancouver for PLoS Journals as of January 2015
+  fields:
+  - science
+- id: proceedings-of-the-royal-society-b
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/proceedings-of-the-royal-society-b.yaml
+  kind: independent
+  title: Proceedings of the Royal Society B
+  fields:
+  - biology
+- id: royal-society-of-chemistry
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/royal-society-of-chemistry.yaml
+  kind: independent
+  title: Royal Society of Chemistry
+  description: The Royal Society of Chemistry journal style.
+  fields:
+  - chemistry
+- id: sage-harvard
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/sage-harvard.yaml
+  kind: independent
+  title: SAGE (author-date/Harvard)
+  description: The SAGE Harvard author-date style
+- id: sage-vancouver
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/sage-vancouver.yaml
+  kind: independent
+  title: SAGE - NLM/Vancouver
+  description: Vancouver superscript style modified to italicize journal names strip periods for use in SAGE journals
+  fields:
+  - medicine
+- id: spandidos-publications
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/spandidos-publications.yaml
+  kind: independent
+  title: Spandidos Publications
+  fields:
+  - medicine
+- id: spie-journals
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/spie-journals.yaml
+  kind: independent
+  title: SPIE journals
+  description: "Designed for SPIE journals, based on information at http://spie.org/x85036.xml and sample .docx manuscript\
+    \ given there (http://spie.org/Documents/Publications/Journals/journal%20Word%20template.doc). The latter probably originated\
+    \ from the style for e-journals (which was previously available at http://spie.org/x3658.xml), and thus slightly contradicts\
+    \ former requirements. The differences are:\n    1) style on the web page requires using et al., when there are more than\
+    \ three authors - we follow this rule.\n    2) style in the sample manuscript asks to add DOI if available, while the\
+    \ style on the web page says nothing about it - we do include DOI (this should not harm in all cases).\n    Also previous\
+    \ versions of this style were based on more detailed instructions for SPIE e-journals (including larger number of document\
+    \ types). Those details are present in the current version as well, but no more supported by a documented style."
+  fields:
+  - physics
+  - engineering
+- id: springer-basic-author-date-no-et-al
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-basic-author-date-no-et-al.yaml
+  kind: independent
+  title: Springer - Basic (author-date, no "et al.")
+  description: Springer Author Date Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences,
+    Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology
+    Editors.
+- id: springer-basic-brackets-no-et-al-alphabetical
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-basic-brackets-no-et-al-alphabetical.yaml
+  kind: independent
+  title: Springer - Basic (numeric, brackets, no "et al.", alphabetical)
+- id: springer-basic-brackets-no-et-al
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-basic-brackets-no-et-al.yaml
+  kind: independent
+  title: Springer - Basic (numeric, brackets, no "et al.")
+  description: Springer Numbered Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer
+    Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.
+- id: springer-fachzeitschriften-medizin-psychologie
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-fachzeitschriften-medizin-psychologie.yaml
+  kind: independent
+  title: Springer - Fachzeitschriften Medizin Psychologie (Deutsch)
+  description: Springer Basic style (German, numeric, brackets, alphabetical) for Springer journals in medicine and psychology.
+  fields:
+  - medicine
+  - psychology
+- id: springer-humanities-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-humanities-author-date.yaml
+  kind: independent
+  title: Springer - Humanities (author-date)
+  description: Style for Springer's humanities journals - the journals do look slightly different from each other, but this
+    should work quite closely
+  fields:
+  - humanities
+- id: springer-humanities-brackets
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-humanities-brackets.yaml
+  kind: independent
+  title: Springer - Humanities (numeric, brackets)
+  description: Style for Springer's humanities journals - the journals do look slightly different from each other, but this
+    should work quite closely
+  fields:
+  - humanities
+- id: springer-mathphys-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-mathphys-author-date.yaml
+  kind: independent
+  title: Springer - MathPhys (author-date)
+  description: This style is used by a number of Springer publications.
+  fields:
+  - science
+- id: springer-mathphys-brackets
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-mathphys-brackets.yaml
+  kind: independent
+  title: Springer - MathPhys (numeric, brackets)
+  description: This style is used by a number of Springer publications.
+  fields:
+  - science
+- id: springer-physics-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-physics-author-date.yaml
+  kind: independent
+  title: Springer - Physics (author-date)
+  description: This style is similar to American Physical Society (APS) and is used by a number of Springer publications.
+  fields:
+  - physics
+- id: springer-physics-brackets
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-physics-brackets.yaml
+  kind: independent
+  title: Springer - Physics (numeric, brackets)
+  description: This style is similar to American Physical Society (APS) and is used by a number of Springer publications.
+  fields:
+  - physics
+- id: springer-socpsych-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-socpsych-author-date.yaml
+  kind: independent
+  title: Springer - SocPsych (author-date)
+  description: This style corresponds to 'Springer SocPsych' in the pdf document 'Key Style Points' at this url
+  fields:
+  - psychology
+- id: springer-socpsych-brackets
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-socpsych-brackets.yaml
+  kind: independent
+  title: Springer - SocPsych (numeric, brackets)
+  fields:
+  - psychology
+- id: springer-vancouver-author-date
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/springer-vancouver-author-date.yaml
+  kind: independent
+  title: Springer - NLM/Vancouver (name-year)
+  description: This style based on the NLM guidelines Citing Medicine is very similar to Vancouver and is used by a number
+    of Springer publications.
+- id: the-company-of-biologists
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/the-company-of-biologists.yaml
+  kind: independent
+  title: The Company of Biologists
+  description: Style used by the journals published by The Company of Biologists.
+  fields:
+  - biology
+- id: the-geological-society-of-london
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/the-geological-society-of-london.yaml
+  kind: independent
+  title: The Geological Society of London
+  description: Parent style for the Journals and Books published by The Geological Society (London); details provided by publisher
+  fields:
+  - geology
+- id: the-institution-of-engineering-and-technology
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/the-institution-of-engineering-and-technology.yaml
+  kind: independent
+  title: The Institution of Engineering and Technology
+  description: Style for all IET Journals
+  fields:
+  - engineering
+- id: the-optical-society
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/the-optical-society.yaml
+  kind: journal
+  title: The Optical Society
+  description: Common style use by OSA publications.
+  fields:
+  - physics
+- id: thieme-german
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/thieme-german.yaml
+  kind: independent
+  title: Thieme-German (Deutsch)
+- id: thomson-reuters-legal-tax-and-accounting-australia
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/thomson-reuters-legal-tax-and-accounting-australia.yaml
+  kind: independent
+  title: Thomson Reuters - Legal, Tax & Accounting Australia
+  description: Style for a series of Thomson Reuters law publications for Australia
+  fields:
+  - law
+- id: trends-journals
+  url: https://raw.githubusercontent.com/citum/citum-core/main/styles/trends-journals.yaml
+  kind: independent
+  title: Trends journals
+  description: Style for the "Trends" journals by Cell Press
+  fields:
+  - biology
+  - medicine

--- a/styles/american-mathematical-society-label.yaml
+++ b/styles/american-mathematical-society-label.yaml
@@ -1,6 +1,6 @@
 extends: elsevier-with-titles
 info:
-  title: Amercian Mathematical Society (label)
+  title: American Mathematical Society (label)
   fields:
   - math
   source:


### PR DESCRIPTION
## Summary
- add optional HTTP style resolution in citum_store with URL-hash caching
- extend registry entries with URL-backed catalog metadata
- expose embedded and non-embedded repo styles through citum style list/search/info
- wire render/check style loading through file, store, HTTP, registry, and embedded resolvers

## Verification
- cargo run --bin citum --features schema -- schema --out-dir docs/schemas
- cargo check --all-targets --all-features
- cargo run --bin citum -- style list --source core-http --format json
- cargo run --bin citum -- style info alpha --format json
- cargo run --bin citum -- style search apa --format json
- cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s alpha --json
- cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s apa --json
- cargo test -p citum_store --features http
- cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run

Refs: csl26-r8d2