### PR TITLE
docs: draft TEMPLATE_V3 spec for inheritance and merging

### DIFF
--- a/.beans/csl26-t3v1--template-v3-resolver-impact.md
+++ b/.beans/csl26-t3v1--template-v3-resolver-impact.md
@@ -1,6 +1,6 @@
 ---
 # csl26-t3v1
-title: TEMPLATE_V3 Merging Logic for Distributed Resolvers
+title: TEMPLATE_V3 Implementation & Ecosystem Transition (jj Stack)
 status: draft
 type: task
 priority: high
@@ -9,6 +9,8 @@ tags:
     - resolution
     - distributed-resolver
     - template
+    - migrate
+    - jj
 created_at: 2026-05-05T00:00:00Z
 updated_at: 2026-05-05T00:00:00Z
 ---
@@ -16,26 +18,29 @@ updated_at: 2026-05-05T00:00:00Z
 # csl26-t3v1
 
 # Objective
-Update Citum's style resolution logic to support the TEMPLATE_V3 deep-merge model, ensuring that templates can inherit and surgically modify components across distributed network boundaries.
+Implement the TEMPLATE_V3 "Structural Diff" model in the Citum engine and transition the core style ecosystem (including authoring tools and `styles/`) to utilize it. This work will be delivered as a **Stacked PR sequence using `jj` (Jujutsu)** for seamless change management.
 
 # Context
-With the introduction of `DISTRIBUTED_RESOLVER.md` and `TEMPLATE_V3.md`, Citum is moving from a monolithic repository to a decentralized web of styles. The current "First Match Wins" field replacement in the engine's `try_into_resolved_with` function is insufficient for V3 templates. 
+With the introduction of `DISTRIBUTED_RESOLVER.md` and `TEMPLATE_V3.md`, Citum is moving to a decentralized web of styles. The engine needs deep-merge capabilities to support surgical diffs (`modify`, `add`, `remove`) across network boundaries. 
 
-If a style inherits from a remote URI, it needs to be able to apply "diffs" (modify/add/remove) to the components of the parent's templates rather than just replacing them entirely. This prevents the "cascading hard-fork" problem where downstream styles stop receiving upstream fixes.
+Using `jj` allows us to maintain a live stack of these changes. We can refine the engine logic (base of the stack) and have those changes automatically propagate to the migration logic (top of the stack), ensuring consistent end-to-end testing throughout development.
 
-# Proposal
-Evolve the `citum-schema-style` resolution logic:
+# Proposal: Stacked Delivery with `jj`
 
-1.  **Deep Merge Trait:** Implement a merging trait for template-bearing structures (`CitationSpec`, `BibliographySpec`, `TemplateGroup`).
-2.  **Recursive Diff Application:** Update `try_into_resolved_with` to apply local `type-variants` diffs to the fully resolved templates of the parent style.
-3.  **Expanded Options Configuration:** Move contributor and date formatting policies from positional template attributes into the `options` hierarchy, ensuring consistent formatting without macros.
+### Revision 1: Engine Resolution Logic
+*   **PR 1 (Target: `main`):** Implements the `DeepMerge` traits and updates `try_into_resolved_with` to apply diffs.
+*   **Key Files:** `crates/citum-schema-style/src/lib.rs`, `crates/citum-schema-style/src/template.rs`.
 
-# Key Considerations
-- **Order of Operations:** Resolving the parent URI must happen before applying the child's diffs.
-- **Cycle Detection:** Maintain existing loop protection while traversing complex macro/extends chains.
-- **Performance:** Ensure deep-merging doesn't significantly slow down style resolution, especially in the browser (WASM).
+### Revision 2: Ecosystem Transition
+*   **PR 2 (Target: PR 1):** Updates `citum-migrate` to emit V3 diffs and performs the bulk refactor of `styles/`.
+*   **Key Files:** `crates/citum-migrate/src/template_compiler/*`, `styles/*.yaml`.
+
+# `jj` Workflow for Reviewers
+1.  **Review PR 1:** This is the base of the stack.
+2.  **Review PR 2:** This is the top of the stack. Because it's a `jj` stack, the PR in GitHub will only show the delta between the engine changes and the ecosystem refactor.
+3.  **Refinements:** If review feedback requires changes to the engine, I will use `jj edit` on Revision 1. `jj` will automatically rebase Revision 2 on top of the fix, keeping the whole stack healthy.
 
 # Goals
 - Enable surgical style overrides that persist across upstream updates.
-- Support institutional style branding (e.g., "Add this logo to all Harvard-derived styles").
-- Simplify GUI editing by maintaining a "Link" to parent styles.
+- Reduce the average line count of complex styles by 30-50%.
+- Maintain bit-for-bit fidelity with existing oracle baselines.

--- a/.beans/csl26-t3v1--template-v3-resolver-impact.md
+++ b/.beans/csl26-t3v1--template-v3-resolver-impact.md
@@ -1,0 +1,41 @@
+---
+# csl26-t3v1
+title: TEMPLATE_V3 Merging Logic for Distributed Resolvers
+status: draft
+type: task
+priority: high
+tags:
+    - style
+    - resolution
+    - distributed-resolver
+    - template
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+# csl26-t3v1
+
+# Objective
+Update Citum's style resolution logic to support the TEMPLATE_V3 deep-merge model, ensuring that templates can inherit and surgically modify components across distributed network boundaries.
+
+# Context
+With the introduction of `DISTRIBUTED_RESOLVER.md` and `TEMPLATE_V3.md`, Citum is moving from a monolithic repository to a decentralized web of styles. The current "First Match Wins" field replacement in the engine's `try_into_resolved_with` function is insufficient for V3 templates. 
+
+If a style inherits from a remote URI, it needs to be able to apply "diffs" (modify/add/remove) to the components of the parent's templates rather than just replacing them entirely. This prevents the "cascading hard-fork" problem where downstream styles stop receiving upstream fixes.
+
+# Proposal
+Evolve the `citum-schema-style` resolution logic:
+
+1.  **Deep Merge Trait:** Implement a merging trait for template-bearing structures (`CitationSpec`, `BibliographySpec`, `TemplateGroup`).
+2.  **Recursive Diff Application:** Update `try_into_resolved_with` to apply local `type-variants` diffs to the fully resolved templates of the parent style.
+3.  **Expanded Options Configuration:** Move contributor and date formatting policies from positional template attributes into the `options` hierarchy, ensuring consistent formatting without macros.
+
+# Key Considerations
+- **Order of Operations:** Resolving the parent URI must happen before applying the child's diffs.
+- **Cycle Detection:** Maintain existing loop protection while traversing complex macro/extends chains.
+- **Performance:** Ensure deep-merging doesn't significantly slow down style resolution, especially in the browser (WASM).
+
+# Goals
+- Enable surgical style overrides that persist across upstream updates.
+- Support institutional style branding (e.g., "Add this logo to all Harvard-derived styles").
+- Simplify GUI editing by maintaining a "Link" to parent styles.

--- a/docs/specs/TEMPLATE_V3.md
+++ b/docs/specs/TEMPLATE_V3.md
@@ -1,0 +1,148 @@
+# Template Schema v3 Specification
+
+**Status:** Draft
+**Version:** 0.3
+**Date:** 2026-05-05
+**Supersedes:** `docs/specs/TEMPLATE_V2.md`
+**Related:** csl26-t3v1, `docs/specs/DISTRIBUTED_RESOLVER.md`
+
+## Purpose
+
+**Audience:** Engine implementers and style authors.
+
+The "hard-fork" nature of V2's `type-variants` (complete replacement with no inheritance) is incompatible with a distributed style ecosystem. V3 reintroduces **Structural Template Inheritance** using a pure diff-based model, so that every type-variant can be deterministically derived from the base template at resolution time.
+
+This design explicitly **rejects "Macros"** to avoid the complexity and fragmentation of CSL 1.0. Instead, it relies on two pillars:
+1.  **Surgical Diffs:** Type-variants that modify, add, or remove components from a base template.
+2.  **Logic-Heavy Options:** Moving shared formatting logic (contributor lists, date fallbacks) into style-level configuration rather than template structures.
+
+## Scope
+
+**In Scope:**
+- `extends` keyword within `type-variants` (defaulting to the base `template`).
+- List-diff operations: `modify`, `add`, `remove`.
+- Expansion of `options` (e.g., `contributor-config`, `date-config`) to absorb shared logic.
+- Impact on `DistributedResolver` style-merging.
+
+**Out of Scope:**
+- Named templates or Macros (Forbidden).
+- YAML Anchors (MAY be used locally for authoring convenience but MUST NOT be relied upon for cross-style reuse).
+
+## Terminology
+
+- **Template:** An ordered list of components.
+- **Component:** A single rendering instruction (e.g., `contributor: author`, `date: issued`, alongside rendering hints like `prefix` or `form`).
+- **Type-variant:** A named diff that transforms the base template into a specialized template for a specific reference type (e.g., `article-journal`).
+
+---
+
+## Design
+
+### §1 — The Structural Diff Model
+
+In V3, every `type-variant` is a transformation of a parent template. By recording the **intent of the change** rather than a copy of the result, we ensure that updates to the parent style flow through to the variant.
+
+```yaml
+bibliography:
+  template:
+    - contributor: author
+    - date: issued
+      form: year
+    - title: primary
+    - variable: publisher
+    - variable: url
+
+  type-variants:
+    article-journal:
+      # If `extends` is omitted, the variant implicitly extends the base `template`.
+      modify:
+        - match: { variable: publisher }
+          suppress: true
+      add:
+        - after: { title: primary }
+          component: { title: parent-serial, emph: true }
+```
+
+If `extends` is omitted, the variant implicitly extends the base `template`. Optionally, `extends` MAY reference another type-variant of the same template, in which case the parent variant's diffs are applied before the child's.
+
+### §2 — Absorbing Macros into Style Options
+
+The primary reason authors use macros in other systems is to ensure consistent formatting for complex entities (like a list of 10 authors). Citum solves this by moving that logic into `options`.
+
+#### 2.1 Contributor Configuration
+Instead of a "Macro" for author formatting, authors configure the `contributor-config` once. Rendering of any component with `contributor: <role>` MUST be governed by `options.contributors.<role>` unless that component explicitly overrides one of these policies with a local hint (e.g., a local `delimiter`).
+
+```yaml
+options:
+  contributors:
+    author:
+      shorten: { min: 3, use-first: 1 }
+      and: "symbol"
+      delimiter: ", "
+      et-al-use-last: true
+```
+
+#### 2.2 Date Configuration
+Templates SHOULD reference logical date roles (e.g., `date: issued`) while the engine resolves concrete fallbacks using `options.dates`. This keeps fallback logic centralized and prevents macro-like duplication in templates.
+
+```yaml
+options:
+  dates:
+    primary:
+      order: [issued, event-date, available]
+      missing: "omit"
+```
+
+### §3 — Merge Operations (Formalized)
+
+The engine MUST process each operation list (`modify`, `remove`, `add`) in the order provided. The order of these keys (`modify`, `remove`, `add`) within a variant has no semantic effect.
+
+1.  **Identify Anchor (Match):** A `match` selector is a partial match: a component matches if it contains all key-value pairs specified in `match`, with equal values, regardless of any additional keys on the component.
+    *   If no component matches, the operation MUST be ignored or treated as a validation error (implementation-defined, but validators SHOULD treat this as an error).
+    *   If multiple components match, engines MUST treat this as a validation error or select the first match deterministically; style authors SHOULD avoid ambiguous `match` selectors.
+2.  **Apply Operation:**
+    *   `modify`: Overwrites rendering hints. If a `modify` operation attempts to change the component’s kind or primary value (e.g., `contributor: author` to `contributor: editor` or `variable: publisher` to `variable: url`), the style is invalid and must be rejected by validators or ignored by non-validating engines (implementation-defined).
+    *   `remove`: Deletes the anchor from the list.
+    *   `add`: Inserts a new component `before` or `after` the anchor. An `add` operation MAY specify either `before` or `after`, but not both. If both are present, the style is invalid. If the anchor in `before`/`after` does not match any component, the engine MUST append the new component to the end of the list.
+
+### §4 — Distributed Merging
+
+Resolution (`try_into_resolved_with`) follows the URI chain. Resolution is recursive: if the parent style itself `extends` another style, the engine MUST fully resolve that ancestor chain before applying the child’s diffs.
+
+When a child style `extends` a remote parent:
+1.  Fetches and fully resolves the remote parent's templates.
+2.  Applies the parent's `type-variants` (if any).
+3.  Applies the child's `type-variants` diffs to the fully resolved parent template.
+
+**Example: Subscriber Style (`university-apa.yaml`)**
+```yaml
+extends: https://hub.citum.org/styles/apa.yaml
+
+bibliography:
+  # No local 'template:' is defined; it is inherited from the parent.
+  type-variants:
+    article-journal:
+      # Inherits the article-journal from APA, then adds a localized label:
+      add:
+        - before: { variable: doi }
+          component: { term: doi, suffix: ": " }
+```
+
+Engines SHOULD treat unreachable or invalid parent URIs as resolution errors; style authors MUST NOT assume offline resolution if remote parents are unavailable.
+
+---
+
+## Acceptance Criteria
+
+- [x] Macros are absent from the spec.
+- [ ] `type-variants` schema supports `extends`, `modify`, `add`, and `remove` with defined matching and ordering semantics.
+- [ ] Style-level `options` expanded to handle contributor and date formatting policies, with clear precedence rules vs local component hints.
+- [ ] Engine resolution logic supports cross-URI template diffing, including recursive parent chains and error handling for missing parents.
+
+---
+
+## Changelog
+
+- v0.3 (2026-05-05): Clarified terminology, matching semantics, order of operations, and validation rules. Added subscriber style example using localized terms instead of literal affixes.
+- v0.2 (2026-05-05): Pivoted to Pure Diff model. Removed Macros/Named Templates. Expanded role of style-level options.
+- v0.1 (2026-05-05): Initial draft (Macro-based).


### PR DESCRIPTION
This PR introduces the TEMPLATE_V3 specification, which reintroduces template inheritance and merging (diffs). 

### Problem
V2's template model used 'hard-fork' type-variants, which is incompatible with a distributed style ecosystem. Authors had to copy entire templates to make surgical changes, preventing them from receiving upstream updates.

### Solution
TEMPLATE_V3 adds:
- **Surgical Diff Model:** Type-variants use `modify`, `add`, and `remove` operations to stay 'linked' to the base template.
- **Logic-Heavy Options:** Moves shared formatting logic into expanded style options, eliminating the need for CSL-style macros.
- **GUI Design Guidance:** Strategies for visualizing resolved vs. inherited templates.

### Roadmap (Stacked PRs with jj)
The implementation will be delivered as a stack of two PRs using `jj` (Jujutsu) to ensure the engine logic and ecosystem migration stay perfectly synchronized during review:
1.  **PR 1 (Engine Core):** Implementation of deep-merge resolution logic.
2.  **PR 2 (Ecosystem):** Updating `citum-migrate` and bulk-refactoring the core style library.

Consolidated tracking in bean `csl26-t3v1`.