### PR TITLE
feat(schema): resolve template v3 variants

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  issues: write
 
 jobs:
   # ── Step 1: Detect what changed and infer bump level ──────────────
@@ -162,6 +163,11 @@ jobs:
           if [ -n "$EXISTING" ]; then
             gh pr edit "$EXISTING" --title "chore: release v${NEW_VERSION}" --body "$BODY"
           else
+            if ! gh label list --json name --jq '.[].name' | grep -qx "release"; then
+              gh label create "release" \
+                --color "0E8A16" \
+                --description "Automated release pull requests"
+            fi
             gh pr create --head "release/next" --base main \
               --title "chore: release v${NEW_VERSION}" --body "$BODY" \
               --label "release"

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -128,7 +128,11 @@ pub(crate) fn load_any_style(
     let chain = ChainResolver::new(resolvers);
 
     match chain.resolve_style(style_input) {
-        Ok(style) => Ok(style),
+        Ok(style) => {
+            let mut resolved = style.try_into_resolved_with(Some(&chain))?;
+            resolved.extends = None;
+            Ok(resolved)
+        }
         Err(citum_store::resolver::ResolverError::StyleNotFound(_)) => {
             let registry = citum_schema::embedded::default_registry();
             let candidates: Vec<_> = registry

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -493,7 +493,8 @@ fn build_type_variant_bench_style() -> Style {
                         },
                         ..Default::default()
                     }),
-                ],
+                ]
+                .into(),
             )])),
             ..Default::default()
         }),

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -58,16 +58,20 @@ struct GroupItemRenderRequest<'a> {
 /// or `None` if there are no variants or none match.
 fn resolve_type_variant<'a>(
     type_variants: Option<
-        &'a indexmap::IndexMap<citum_schema::template::TypeSelector, citum_schema::Template>,
+        &'a indexmap::IndexMap<citum_schema::template::TypeSelector, citum_schema::TemplateVariant>,
     >,
     ref_type: &str,
 ) -> Option<&'a [TemplateComponent]> {
     let selector_candidates = aliased_type_selector_candidates(ref_type);
-    type_variants?.iter().find_map(|(selector, template)| {
-        selector_candidates
+    type_variants?.iter().find_map(|(selector, variant)| {
+        if selector_candidates
             .iter()
             .any(|candidate| selector.matches(candidate))
-            .then_some(template.as_slice())
+        {
+            variant.as_template()
+        } else {
+            None
+        }
     })
 }
 

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -542,7 +542,7 @@ impl<'a> Renderer<'a> {
                     let mut matched_template = None;
                     for (selector, template) in type_variants {
                         if selector.matches(&ref_type) {
-                            matched_template = Some(template.clone());
+                            matched_template = template.clone().into_template();
                             break;
                         }
                     }

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -627,7 +627,8 @@ fn test_type_specific_rendering() {
                 },
                 ..Default::default()
             }),
-        ],
+        ]
+        .into(),
     );
     // Book variant: Author (Short), Title (Primary), Year
     type_variants.insert(
@@ -658,7 +659,8 @@ fn test_type_specific_rendering() {
                 },
                 ..Default::default()
             }),
-        ],
+        ]
+        .into(),
     );
 
     let style = Style {
@@ -781,7 +783,8 @@ fn test_bibliography_type_specific_rendering() {
                 },
                 ..Default::default()
             }),
-        ],
+        ]
+        .into(),
     );
 
     let style = Style {

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -297,7 +297,12 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
             options: bibliography_scope_options,
             extends: None,
             template: Some(c.new_bib),
-            type_variants: c.type_templates,
+            type_variants: c.type_templates.map(|type_templates| {
+                type_templates
+                    .into_iter()
+                    .map(|(selector, template)| (selector, template.into()))
+                    .collect()
+            }),
             sort: bibliography_sort,
             ..Default::default()
         }),

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -87,12 +87,27 @@ pub use presets::{ContributorPreset, DatePreset, SortPreset, SubstitutePreset, T
 pub use registry::{RegistryEntry, StyleRegistry};
 pub use style_base::StyleBase;
 pub use template::{
-    Rendering, TemplateComponent, TemplateContributor, TemplateDate, TemplateGroup, TemplateNumber,
-    TemplateTerm, TemplateTitle, TemplateVariable, TypeSelector, WrapConfig, WrapPunctuation,
+    Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
+    TemplateContributor, TemplateDate, TemplateGroup, TemplateModifyOperation, TemplateNumber,
+    TemplateRemoveOperation, TemplateTerm, TemplateTitle, TemplateVariable, TemplateVariant,
+    TemplateVariantDiff, TypeSelector, WrapConfig, WrapPunctuation,
 };
 
 /// A named template (reusable sequence of components).
 pub type Template = Vec<TemplateComponent>;
+
+/// Type-specific template variants keyed by reference-type selector.
+pub type TemplateVariants = IndexMap<TypeSelector, TemplateVariant>;
+
+/// Resolver interface used by schema-layer style inheritance.
+pub trait StyleResolver {
+    /// Resolve a style by URI, registry ID, or implementation-specific key.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ResolutionError`] when the style cannot be loaded or parsed.
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolutionError>;
+}
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
 pub const STYLE_SCHEMA_VERSION: &str = "0.41.0";
@@ -134,6 +149,35 @@ pub enum ResolutionError {
         /// Reason for failure.
         reason: String,
     },
+    /// A Template V3 variant references a missing parent variant.
+    MissingTemplateVariantParent {
+        /// Human-readable location hint.
+        location: String,
+        /// Parent selector that could not be found.
+        selector: String,
+    },
+    /// A Template V3 variant parent chain contains a cycle.
+    TemplateVariantCycle {
+        /// Human-readable location hint.
+        location: String,
+        /// Selector that closed the cycle.
+        selector: String,
+    },
+    /// A Template V3 operation matched no components.
+    TemplateVariantAnchorNotFound {
+        /// Human-readable location hint.
+        location: String,
+    },
+    /// A Template V3 operation matched more than one component.
+    TemplateVariantAmbiguousAnchor {
+        /// Human-readable location hint.
+        location: String,
+    },
+    /// A Template V3 add operation does not define exactly one anchor.
+    InvalidTemplateVariantAdd {
+        /// Human-readable location hint.
+        location: String,
+    },
 }
 
 impl std::fmt::Display for ResolutionError {
@@ -151,9 +195,41 @@ impl std::fmt::Display for ResolutionError {
             ResolutionError::UriResolutionFailed { uri, reason } => {
                 write!(f, "failed to resolve URI `{uri}`: {reason}")
             }
+            ResolutionError::MissingTemplateVariantParent { location, selector } => {
+                write!(
+                    f,
+                    "template variant `{location}` extends missing variant `{selector}`"
+                )
+            }
+            ResolutionError::TemplateVariantCycle { location, selector } => {
+                write!(
+                    f,
+                    "template variant inheritance loop at `{location}` through `{selector}`"
+                )
+            }
+            ResolutionError::TemplateVariantAnchorNotFound { location } => {
+                write!(
+                    f,
+                    "template variant operation in `{location}` matched no component"
+                )
+            }
+            ResolutionError::TemplateVariantAmbiguousAnchor { location } => {
+                write!(
+                    f,
+                    "template variant operation in `{location}` matched multiple components"
+                )
+            }
+            ResolutionError::InvalidTemplateVariantAdd { location } => {
+                write!(
+                    f,
+                    "template variant add operation in `{location}` must specify exactly one of before/after"
+                )
+            }
         }
     }
 }
+
+impl std::error::Error for ResolutionError {}
 
 impl std::fmt::Display for SchemaWarning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -222,7 +298,8 @@ impl Style {
     /// and any explicit `options`, `citation`, or `bibliography` keys in the current
     /// style document are merged on top (taking ultimate precedence).
     ///
-    /// Returns the original style unchanged if no base is specified.
+    /// Styles without a base still resolve Template V3 variants and scoped
+    /// options, but do not merge any inherited style data.
     ///
     /// # Panics
     ///
@@ -249,7 +326,23 @@ impl Style {
     /// structure, when profile capability validation fails, or when inheritance
     /// loops are detected.
     pub fn try_into_resolved(self) -> Result<Self, ResolutionError> {
-        self.try_into_resolved_recursive(&mut HashSet::new())
+        self.try_into_resolved_with(None)
+    }
+
+    /// Resolve this style into its final effective form using an optional style resolver.
+    ///
+    /// The resolver is used for URI, registry, and remote `extends` references
+    /// that cannot be satisfied by embedded bases alone.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when style inheritance or Template V3 variant
+    /// resolution fails.
+    pub fn try_into_resolved_with(
+        self,
+        resolver: Option<&dyn StyleResolver>,
+    ) -> Result<Self, ResolutionError> {
+        self.try_into_resolved_recursive_with(resolver, &mut HashSet::new())
     }
 
     /// Internal recursive resolver with loop protection.
@@ -279,8 +372,23 @@ impl Style {
         self,
         visited: &mut HashSet<String>,
     ) -> Result<Self, ResolutionError> {
+        self.try_into_resolved_recursive_with(None, visited)
+    }
+
+    /// Internal recursive resolver with loop protection and optional external resolver.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when style inheritance or Template V3 variant
+    /// resolution fails.
+    pub fn try_into_resolved_recursive_with(
+        self,
+        resolver: Option<&dyn StyleResolver>,
+        visited: &mut HashSet<String>,
+    ) -> Result<Self, ResolutionError> {
         let Some(base_ref) = self.extends.clone() else {
             let mut style = self;
+            resolve_style_template_variants(&mut style, None)?;
             options::scoped::apply_scoped_style_options(&mut style);
             return Ok(style);
         };
@@ -293,53 +401,24 @@ impl Style {
 
         let is_profile = self.resolves_as_profile();
         let mut effective = match base_ref {
-            style_base::StyleReference::Base(base) => base.try_resolve_with_visited(visited)?,
+            style_base::StyleReference::Base(base) => {
+                base.try_resolve_with_visited(resolver, visited)?
+            }
             style_base::StyleReference::Uri(ref uri) => {
-                let Some(raw_path) = uri.strip_prefix("file://") else {
-                    return Err(ResolutionError::UriResolutionFailed {
-                        uri: uri.clone(),
-                        reason: "unsupported scheme; only file:// URIs are supported".to_string(),
-                    });
-                };
-                let path = std::path::Path::new(raw_path);
-                let bytes =
-                    std::fs::read(path).map_err(|e| ResolutionError::UriResolutionFailed {
-                        uri: uri.clone(),
-                        reason: e.to_string(),
-                    })?;
-                let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
-                let base_style: Style =
-                    match ext {
-                        "cbor" => ciborium::de::from_reader(std::io::Cursor::new(&bytes)).map_err(
-                            |e| ResolutionError::UriResolutionFailed {
-                                uri: uri.clone(),
-                                reason: e.to_string(),
-                            },
-                        )?,
-                        "json" => serde_json::from_slice(&bytes).map_err(|e| {
-                            ResolutionError::UriResolutionFailed {
-                                uri: uri.clone(),
-                                reason: e.to_string(),
-                            }
-                        })?,
-                        _ => Style::from_yaml_bytes(&bytes).map_err(|e| {
-                            ResolutionError::UriResolutionFailed {
-                                uri: uri.clone(),
-                                reason: e.to_string(),
-                            }
-                        })?,
-                    };
-                base_style.try_into_resolved_recursive(visited)?
+                let base_style = resolve_style_reference_uri(uri, resolver)?;
+                base_style.try_into_resolved_recursive_with(resolver, visited)?
             }
         };
         if is_profile {
             self.validate_profile_shape()?;
         }
 
+        let inherited_variants = inherited_variant_context(&effective);
         merge_style_overlay(&mut effective, &self);
         effective.version = self.version;
         effective.extends = self.extends;
         effective.raw_yaml = self.raw_yaml;
+        resolve_style_template_variants(&mut effective, inherited_variants.as_ref())?;
         options::scoped::apply_scoped_style_options(&mut effective);
         if is_profile {
             effective.extends = None;
@@ -493,6 +572,379 @@ fn yaml_path_present(value: Option<&serde_yaml::Value>, path: &[&str]) -> bool {
         current = next;
     }
     true
+}
+
+fn resolve_style_reference_uri(
+    uri: &str,
+    resolver: Option<&dyn StyleResolver>,
+) -> Result<Style, ResolutionError> {
+    if let Some(resolver) = resolver {
+        return resolver.resolve_style(uri);
+    }
+
+    let Some(raw_path) = uri.strip_prefix("file://") else {
+        return Err(ResolutionError::UriResolutionFailed {
+            uri: uri.to_string(),
+            reason: "unsupported scheme; an external style resolver is required".to_string(),
+        });
+    };
+    let path = std::path::Path::new(raw_path);
+    let bytes = std::fs::read(path).map_err(|e| ResolutionError::UriResolutionFailed {
+        uri: uri.to_string(),
+        reason: e.to_string(),
+    })?;
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
+    match ext {
+        "cbor" => ciborium::de::from_reader(std::io::Cursor::new(&bytes)).map_err(|e| {
+            ResolutionError::UriResolutionFailed {
+                uri: uri.to_string(),
+                reason: e.to_string(),
+            }
+        }),
+        "json" => {
+            serde_json::from_slice(&bytes).map_err(|e| ResolutionError::UriResolutionFailed {
+                uri: uri.to_string(),
+                reason: e.to_string(),
+            })
+        }
+        _ => Style::from_yaml_bytes(&bytes).map_err(|e| ResolutionError::UriResolutionFailed {
+            uri: uri.to_string(),
+            reason: e.to_string(),
+        }),
+    }
+}
+
+#[derive(Clone, Default)]
+struct StyleVariantContext {
+    citation: Option<CitationVariantContext>,
+    bibliography: Option<TemplateVariants>,
+}
+
+#[derive(Clone, Default)]
+struct CitationVariantContext {
+    type_variants: Option<TemplateVariants>,
+    integral: Option<Box<CitationVariantContext>>,
+    non_integral: Option<Box<CitationVariantContext>>,
+    subsequent: Option<Box<CitationVariantContext>>,
+    ibid: Option<Box<CitationVariantContext>>,
+}
+
+fn inherited_variant_context(style: &Style) -> Option<StyleVariantContext> {
+    let context = StyleVariantContext {
+        citation: style.citation.as_ref().map(citation_variant_context),
+        bibliography: style
+            .bibliography
+            .as_ref()
+            .and_then(|bib| bib.type_variants.clone()),
+    };
+    (context.citation.is_some() || context.bibliography.is_some()).then_some(context)
+}
+
+fn citation_variant_context(spec: &CitationSpec) -> CitationVariantContext {
+    CitationVariantContext {
+        type_variants: spec.type_variants.clone(),
+        integral: spec
+            .integral
+            .as_deref()
+            .map(citation_variant_context)
+            .map(Box::new),
+        non_integral: spec
+            .non_integral
+            .as_deref()
+            .map(citation_variant_context)
+            .map(Box::new),
+        subsequent: spec
+            .subsequent
+            .as_deref()
+            .map(citation_variant_context)
+            .map(Box::new),
+        ibid: spec
+            .ibid
+            .as_deref()
+            .map(citation_variant_context)
+            .map(Box::new),
+    }
+}
+
+fn resolve_style_template_variants(
+    style: &mut Style,
+    inherited: Option<&StyleVariantContext>,
+) -> Result<(), ResolutionError> {
+    if let Some(citation) = style.citation.as_mut() {
+        resolve_citation_template_variants(
+            citation,
+            inherited.and_then(|context| context.citation.as_ref()),
+            "citation",
+            None,
+        )?;
+    }
+    if let Some(bibliography) = style.bibliography.as_mut() {
+        let section_template = bibliography.resolve_template();
+        resolve_template_variant_map(
+            bibliography.type_variants.as_mut(),
+            section_template.as_deref(),
+            inherited.and_then(|context| context.bibliography.as_ref()),
+            "bibliography.type-variants",
+        )?;
+    }
+    Ok(())
+}
+
+fn resolve_citation_template_variants(
+    spec: &mut CitationSpec,
+    inherited: Option<&CitationVariantContext>,
+    location: &str,
+    fallback_template: Option<&[TemplateComponent]>,
+) -> Result<(), ResolutionError> {
+    let section_template = spec.resolve_template();
+    let effective_section_template = section_template.as_deref().or(fallback_template);
+    resolve_template_variant_map(
+        spec.type_variants.as_mut(),
+        effective_section_template,
+        inherited.and_then(|context| context.type_variants.as_ref()),
+        &format!("{location}.type-variants"),
+    )?;
+
+    for (name, child, inherited_child) in [
+        (
+            "integral",
+            spec.integral.as_deref_mut(),
+            inherited.and_then(|context| context.integral.as_deref()),
+        ),
+        (
+            "non-integral",
+            spec.non_integral.as_deref_mut(),
+            inherited.and_then(|context| context.non_integral.as_deref()),
+        ),
+        (
+            "subsequent",
+            spec.subsequent.as_deref_mut(),
+            inherited.and_then(|context| context.subsequent.as_deref()),
+        ),
+        (
+            "ibid",
+            spec.ibid.as_deref_mut(),
+            inherited.and_then(|context| context.ibid.as_deref()),
+        ),
+    ] {
+        if let Some(child) = child {
+            resolve_citation_template_variants(
+                child,
+                inherited_child,
+                &format!("{location}.{name}"),
+                effective_section_template,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn resolve_template_variant_map(
+    variants: Option<&mut TemplateVariants>,
+    section_template: Option<&[TemplateComponent]>,
+    inherited: Option<&TemplateVariants>,
+    location: &str,
+) -> Result<(), ResolutionError> {
+    let Some(variants) = variants else {
+        return Ok(());
+    };
+    let original = variants.clone();
+    let mut resolved = TemplateVariants::new();
+    let mut visiting = HashSet::new();
+
+    for selector in original.keys() {
+        let template = resolve_template_variant(
+            selector,
+            &original,
+            &mut resolved,
+            inherited,
+            section_template,
+            location,
+            &mut visiting,
+        )?;
+        resolved.insert(selector.clone(), TemplateVariant::Full(template));
+    }
+
+    *variants = resolved;
+    Ok(())
+}
+
+fn resolve_template_variant(
+    selector: &TypeSelector,
+    original: &TemplateVariants,
+    resolved: &mut TemplateVariants,
+    inherited: Option<&TemplateVariants>,
+    section_template: Option<&[TemplateComponent]>,
+    location: &str,
+    visiting: &mut HashSet<TypeSelector>,
+) -> Result<Template, ResolutionError> {
+    let variant_location = format!("{location}[{selector}]");
+    if let Some(template) = resolved
+        .get(selector)
+        .and_then(TemplateVariant::as_template)
+        .map(<[TemplateComponent]>::to_vec)
+    {
+        return Ok(template);
+    }
+
+    if !visiting.insert(selector.clone()) {
+        return Err(ResolutionError::TemplateVariantCycle {
+            location: variant_location,
+            selector: selector.to_string(),
+        });
+    }
+
+    let variant =
+        original
+            .get(selector)
+            .ok_or_else(|| ResolutionError::MissingTemplateVariantParent {
+                location: variant_location.clone(),
+                selector: selector.to_string(),
+            })?;
+
+    let template = match variant {
+        TemplateVariant::Full(template) => template.clone(),
+        TemplateVariant::Diff(diff) => {
+            let mut parent = resolve_variant_parent_template(
+                selector,
+                diff,
+                original,
+                resolved,
+                inherited,
+                section_template,
+                &variant_location,
+                visiting,
+            )?;
+            apply_template_variant_diff(&mut parent, diff, &variant_location)?;
+            parent
+        }
+    };
+
+    visiting.remove(selector);
+    Ok(template)
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Template variant resolution needs explicit inherited and local context."
+)]
+fn resolve_variant_parent_template(
+    selector: &TypeSelector,
+    diff: &TemplateVariantDiff,
+    original: &TemplateVariants,
+    resolved: &mut TemplateVariants,
+    inherited: Option<&TemplateVariants>,
+    section_template: Option<&[TemplateComponent]>,
+    location: &str,
+    visiting: &mut HashSet<TypeSelector>,
+) -> Result<Template, ResolutionError> {
+    if let Some(parent_selector) = &diff.extends {
+        if original.contains_key(parent_selector) {
+            return resolve_template_variant(
+                parent_selector,
+                original,
+                resolved,
+                inherited,
+                section_template,
+                location,
+                visiting,
+            );
+        }
+        return inherited
+            .and_then(|variants| variants.get(parent_selector))
+            .and_then(TemplateVariant::as_template)
+            .map(<[TemplateComponent]>::to_vec)
+            .ok_or_else(|| ResolutionError::MissingTemplateVariantParent {
+                location: location.to_string(),
+                selector: parent_selector.to_string(),
+            });
+    }
+
+    inherited
+        .and_then(|variants| variants.get(selector))
+        .and_then(TemplateVariant::as_template)
+        .map(<[TemplateComponent]>::to_vec)
+        .or_else(|| section_template.map(<[TemplateComponent]>::to_vec))
+        .ok_or_else(|| ResolutionError::MissingTemplateVariantParent {
+            location: location.to_string(),
+            selector: selector.to_string(),
+        })
+}
+
+fn apply_template_variant_diff(
+    template: &mut Template,
+    diff: &TemplateVariantDiff,
+    location: &str,
+) -> Result<(), ResolutionError> {
+    for op in &diff.modify {
+        let index = find_required_anchor(template, &op.match_selector, location)?;
+        if let Some(component) = template.get_mut(index) {
+            component.rendering_mut().merge(&op.rendering);
+        }
+    }
+    for op in &diff.remove {
+        let index = find_required_anchor(template, &op.match_selector, location)?;
+        template.remove(index);
+    }
+    for op in &diff.add {
+        let anchor = match (&op.before, &op.after) {
+            (Some(selector), None) => Some((selector, false)),
+            (None, Some(selector)) => Some((selector, true)),
+            _ => {
+                return Err(ResolutionError::InvalidTemplateVariantAdd {
+                    location: location.to_string(),
+                });
+            }
+        };
+        let Some((selector, insert_after)) = anchor else {
+            return Err(ResolutionError::InvalidTemplateVariantAdd {
+                location: location.to_string(),
+            });
+        };
+        let anchor_index = find_required_anchor(template, selector, location)?;
+        let insert_at = if insert_after {
+            anchor_index.saturating_add(1)
+        } else {
+            anchor_index
+        };
+        template.insert(insert_at, op.component.clone());
+    }
+    Ok(())
+}
+
+fn find_required_anchor(
+    template: &[TemplateComponent],
+    selector: &TemplateComponentSelector,
+    location: &str,
+) -> Result<usize, ResolutionError> {
+    find_optional_anchor(template, selector, location)?.ok_or_else(|| {
+        ResolutionError::TemplateVariantAnchorNotFound {
+            location: location.to_string(),
+        }
+    })
+}
+
+fn find_optional_anchor(
+    template: &[TemplateComponent],
+    selector: &TemplateComponentSelector,
+    location: &str,
+) -> Result<Option<usize>, ResolutionError> {
+    if selector.is_empty() {
+        return Err(ResolutionError::TemplateVariantAmbiguousAnchor {
+            location: location.to_string(),
+        });
+    }
+    let mut matches = template
+        .iter()
+        .enumerate()
+        .filter_map(|(index, component)| selector.matches(component).then_some(index));
+    let first = matches.next();
+    if matches.next().is_some() {
+        return Err(ResolutionError::TemplateVariantAmbiguousAnchor {
+            location: location.to_string(),
+        });
+    }
+    Ok(first)
 }
 
 #[allow(
@@ -730,7 +1182,7 @@ pub struct CitationSpec {
     /// If both the main spec and the active mode sub-spec have a `type-variants`
     /// entry for the same type, the mode-specific one wins.
     #[serde(skip_serializing_if = "Option::is_none", rename = "type-variants")]
-    pub type_variants: Option<IndexMap<template::TypeSelector, Template>>,
+    pub type_variants: Option<TemplateVariants>,
     /// Wrap the entire citation in punctuation. Preferred over prefix/suffix.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wrap: Option<template::WrapConfig>,
@@ -839,9 +1291,9 @@ impl CitationSpec {
         language: Option<&str>,
     ) -> Option<Template> {
         if let Some(type_variants) = &self.type_variants {
-            for (selector, template) in type_variants {
+            for (selector, variant) in type_variants {
                 if selector.matches(ref_type) {
-                    return Some(template.clone());
+                    return variant.clone().into_template();
                 }
             }
         }
@@ -1022,7 +1474,7 @@ pub struct BibliographySpec {
     /// template for entries of the specified types. Keys are reference type
     /// names (e.g., "chapter", "article-journal").
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub type_variants: Option<IndexMap<template::TypeSelector, Template>>,
+    pub type_variants: Option<TemplateVariants>,
     /// Optional global bibliography sorting specification.
     ///
     /// When present, used for sorting the flat bibliography or as default
@@ -1735,7 +2187,7 @@ bibliography:
         let mut type_variants = IndexMap::new();
         type_variants.insert(
             template::TypeSelector::Single("typo-type".to_string()),
-            vec![],
+            TemplateVariant::Full(vec![]),
         );
 
         let style = Style {
@@ -1761,7 +2213,7 @@ bibliography:
         let mut type_variants = IndexMap::new();
         type_variants.insert(
             template::TypeSelector::Single("legal-case".to_string()),
-            vec![],
+            TemplateVariant::Full(vec![]),
         );
 
         let style = Style {
@@ -1794,6 +2246,200 @@ citation:
             "type_variants should be None after null override, got: {:?}",
             citation.type_variants.as_ref().map(|tv| tv.keys().count())
         );
+    }
+
+    #[test]
+    fn template_v3_diff_resolves_to_full_type_variant() {
+        let yaml = r#"
+bibliography:
+  template:
+  - contributor: author
+    form: long
+  - title: primary
+  - variable: publisher
+  - variable: url
+  type-variants:
+    article-journal:
+      modify:
+      - match: { variable: publisher }
+        suppress: true
+      remove:
+      - match: { variable: url }
+      add:
+      - after: { title: primary }
+        component: { title: parent-serial, emph: true }
+"#;
+        let resolved = Style::from_yaml_str(yaml)
+            .expect("style should parse")
+            .try_into_resolved()
+            .expect("diff should resolve");
+        let variants = resolved
+            .bibliography
+            .expect("bibliography should exist")
+            .type_variants
+            .expect("variants should exist");
+        let template = variants
+            .get(&TypeSelector::Single("article-journal".to_string()))
+            .and_then(TemplateVariant::as_template)
+            .expect("variant should resolve to a full template");
+
+        assert_eq!(template.len(), 4);
+        assert!(matches!(
+            &template[2],
+            TemplateComponent::Title(title)
+                if title.title == template::TitleType::ParentSerial
+                    && title.rendering.emph == Some(true)
+        ));
+        assert!(template.iter().any(|component| matches!(
+            component,
+            TemplateComponent::Variable(variable)
+                if variable.variable == template::SimpleVariable::Publisher
+                    && variable.rendering.suppress == Some(true)
+        )));
+    }
+
+    #[test]
+    fn template_v3_add_with_missing_anchor_returns_resolution_error() {
+        let yaml = r#"
+bibliography:
+  template:
+  - title: primary
+  type-variants:
+    book:
+      add:
+      - after: { variable: publisher }
+        component: { date: issued, form: year }
+"#;
+        let err = Style::from_yaml_str(yaml)
+            .expect("style should parse")
+            .try_into_resolved()
+            .expect_err("missing add anchor should reject the diff");
+
+        assert!(matches!(
+            err,
+            ResolutionError::TemplateVariantAnchorNotFound { location }
+                if location == "bibliography.type-variants[book]"
+        ));
+    }
+
+    #[test]
+    fn template_v3_nested_citation_diff_can_use_outer_template() {
+        let style = Style {
+            citation: Some(CitationSpec {
+                template: Some(vec![
+                    TemplateComponent::Contributor(template::TemplateContributor {
+                        contributor: template::ContributorRole::Author,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(template::TemplateTitle {
+                        title: template::TitleType::Primary,
+                        ..Default::default()
+                    }),
+                ]),
+                integral: Some(Box::new(CitationSpec {
+                    type_variants: Some(indexmap::IndexMap::from([(
+                        TypeSelector::Single("personal_communication".to_string()),
+                        TemplateVariant::Diff(TemplateVariantDiff {
+                            remove: vec![TemplateRemoveOperation {
+                                match_selector: TemplateComponentSelector {
+                                    fields: std::collections::BTreeMap::from([(
+                                        "title".to_string(),
+                                        serde_json::json!("primary"),
+                                    )]),
+                                },
+                            }],
+                            ..Default::default()
+                        }),
+                    )])),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let resolved = style
+            .try_into_resolved()
+            .expect("nested diff should resolve against outer citation template");
+        let variants = resolved
+            .citation
+            .expect("citation should exist")
+            .integral
+            .expect("integral citation should exist")
+            .type_variants
+            .expect("variants should exist");
+        let template = variants
+            .get(&TypeSelector::Single("personal_communication".to_string()))
+            .and_then(TemplateVariant::as_template)
+            .expect("variant should resolve");
+
+        assert_eq!(template.len(), 1);
+        assert!(matches!(template[0], TemplateComponent::Contributor(_)));
+    }
+
+    #[test]
+    fn template_v3_overlay_variant_defaults_to_inherited_variant() {
+        #[derive(Clone)]
+        struct FakeResolver {
+            style: Style,
+        }
+
+        impl StyleResolver for FakeResolver {
+            fn resolve_style(&self, uri: &str) -> Result<Style, ResolutionError> {
+                if uri == "parent-style" {
+                    Ok(self.style.clone())
+                } else {
+                    Err(ResolutionError::UriResolutionFailed {
+                        uri: uri.to_string(),
+                        reason: "missing test style".to_string(),
+                    })
+                }
+            }
+        }
+
+        let parent = Style::from_yaml_str(
+            r#"
+bibliography:
+  template:
+  - title: primary
+  type-variants:
+    book:
+    - title: primary
+      emph: true
+"#,
+        )
+        .expect("parent should parse");
+        let child = Style::from_yaml_str(
+            r#"
+extends: parent-style
+bibliography:
+  type-variants:
+    book:
+      modify:
+      - match: { title: primary }
+        quote: true
+"#,
+        )
+        .expect("child should parse");
+
+        let resolved = child
+            .try_into_resolved_with(Some(&FakeResolver { style: parent }))
+            .expect("child diff should resolve");
+        let template = resolved
+            .bibliography
+            .expect("bibliography should exist")
+            .type_variants
+            .expect("variants should exist")
+            .get(&TypeSelector::Single("book".to_string()))
+            .and_then(TemplateVariant::as_template)
+            .expect("book variant should resolve")
+            .to_vec();
+
+        assert!(matches!(
+            &template[0],
+            TemplateComponent::Title(title)
+                if title.rendering.emph == Some(true)
+                    && title.rendering.quote == Some(true)
+        ));
     }
 
     #[test]

--- a/crates/citum-schema-style/src/lint.rs
+++ b/crates/citum-schema-style/src/lint.rs
@@ -7,7 +7,7 @@ use crate::template::{
     ContributorForm, ContributorRole, LabelForm as TemplateLabelForm, NumberVariable,
     RoleLabelForm, TemplateComponent, TemplateContributor,
 };
-use crate::{CitationSpec, Style, Template};
+use crate::{CitationSpec, Style, TemplateVariant};
 
 /// A single lint finding produced by locale or style validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -326,13 +326,28 @@ fn collect_bibliography_spec_requirements(
         }
     }
     if let Some(type_variants) = &spec.type_variants {
-        for (selector, template) in type_variants {
-            collect_template_requirements(
-                template,
-                &format!("{path}.type-variants[{selector:?}]"),
-                &effective_config,
-                requirements,
-            );
+        for (selector, variant) in type_variants {
+            let variant_path = format!("{path}.type-variants[{selector:?}]");
+            match variant {
+                TemplateVariant::Full(template) => {
+                    collect_template_requirements(
+                        template,
+                        &variant_path,
+                        &effective_config,
+                        requirements,
+                    );
+                }
+                TemplateVariant::Diff(diff) => {
+                    for (index, operation) in diff.add.iter().enumerate() {
+                        collect_template_requirements(
+                            std::slice::from_ref(&operation.component),
+                            &format!("{variant_path}.add[{index}].component"),
+                            &effective_config,
+                            requirements,
+                        );
+                    }
+                }
+            }
         }
     }
     if let Some(groups) = &spec.groups {
@@ -361,7 +376,7 @@ fn collect_bibliography_spec_requirements(
 }
 
 fn collect_template_requirements(
-    template: &Template,
+    template: &[TemplateComponent],
     path: &str,
     config: &Config,
     requirements: &mut Vec<LocaleRequirement>,

--- a/crates/citum-schema-style/src/options/scoped.rs
+++ b/crates/citum-schema-style/src/options/scoped.rs
@@ -234,8 +234,8 @@ fn set_citation_wrap(citation: &mut CitationSpec, wrap: LabelWrap) {
 fn apply_bibliography_label_mode(bibliography: &mut BibliographySpec, mode: BibliographyLabelMode) {
     update_label_mode(bibliography.template.as_mut(), mode);
     if let Some(variants) = bibliography.type_variants.as_mut() {
-        for template in variants.values_mut() {
-            update_label_mode(Some(template), mode);
+        for variant in variants.values_mut() {
+            update_label_mode(variant.as_template_mut(), mode);
         }
     }
 }
@@ -243,8 +243,8 @@ fn apply_bibliography_label_mode(bibliography: &mut BibliographySpec, mode: Bibl
 fn apply_bibliography_label_wrap(bibliography: &mut BibliographySpec, wrap: BibliographyLabelWrap) {
     update_label_wrap(bibliography.template.as_mut(), wrap);
     if let Some(variants) = bibliography.type_variants.as_mut() {
-        for template in variants.values_mut() {
-            update_label_wrap(Some(template), wrap);
+        for variant in variants.values_mut() {
+            update_label_wrap(variant.as_template_mut(), wrap);
         }
     }
 }
@@ -252,8 +252,8 @@ fn apply_bibliography_label_wrap(bibliography: &mut BibliographySpec, wrap: Bibl
 fn apply_date_position(bibliography: &mut BibliographySpec, position: DatePosition) {
     reposition_date(bibliography.template.as_mut(), position);
     if let Some(variants) = bibliography.type_variants.as_mut() {
-        for template in variants.values_mut() {
-            reposition_date(Some(template), position);
+        for variant in variants.values_mut() {
+            reposition_date(variant.as_template_mut(), position);
         }
     }
 }
@@ -261,8 +261,8 @@ fn apply_date_position(bibliography: &mut BibliographySpec, position: DatePositi
 fn apply_title_terminator(bibliography: &mut BibliographySpec, terminator: TitleTerminator) {
     update_title_terminator(bibliography.template.as_mut(), terminator);
     if let Some(variants) = bibliography.type_variants.as_mut() {
-        for template in variants.values_mut() {
-            update_title_terminator(Some(template), terminator);
+        for variant in variants.values_mut() {
+            update_title_terminator(variant.as_template_mut(), terminator);
         }
     }
 }
@@ -391,15 +391,15 @@ fn apply_citation_wrap_recursive(citation: &mut CitationSpec, wrap: LabelWrap) {
     if wrap == LabelWrap::Superscript {
         apply_citation_superscript(citation.template.as_mut());
         if let Some(variants) = citation.type_variants.as_mut() {
-            for template in variants.values_mut() {
-                apply_citation_superscript(Some(template));
+            for variant in variants.values_mut() {
+                apply_citation_superscript(variant.as_template_mut());
             }
         }
     } else {
         update_label_wrap(citation.template.as_mut(), wrap);
         if let Some(variants) = citation.type_variants.as_mut() {
-            for template in variants.values_mut() {
-                update_label_wrap(Some(template), wrap);
+            for variant in variants.values_mut() {
+                update_label_wrap(variant.as_template_mut(), wrap);
             }
         }
     }

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -262,13 +262,11 @@ impl StyleBase {
     /// Internal resolver with loop protection that preserves profile errors.
     pub(crate) fn try_resolve_with_visited(
         &self,
+        resolver: Option<&dyn crate::StyleResolver>,
         visited: &mut HashSet<String>,
     ) -> Result<Style, crate::ResolutionError> {
-        let mut style = self.base();
-        if style.extends.is_some() {
-            style = style.try_into_resolved_recursive(visited)?;
-        }
-        Ok(style)
+        self.base()
+            .try_into_resolved_recursive_with(resolver, visited)
     }
 }
 
@@ -287,7 +285,7 @@ impl StyleBase {
 mod tests {
     use super::*;
     use crate::options::{Config, PageRangeFormat};
-    use crate::{Style, StyleInfo};
+    use crate::{Style, StyleInfo, TemplateVariant};
 
     #[test]
     fn style_base_chicago_notes_base_is_valid() {
@@ -431,12 +429,30 @@ citation:
     }
 
     #[test]
+    fn style_base_resolution_materializes_template_v3_variants() {
+        let mut visited = HashSet::new();
+        let resolved = StyleBase::Ieee
+            .try_resolve_with_visited(None, &mut visited)
+            .expect("ieee base resolves");
+        let variants = resolved
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.type_variants.as_ref())
+            .expect("ieee bibliography variants resolve");
+
+        assert!(
+            variants
+                .values()
+                .all(|variant| matches!(variant, TemplateVariant::Full(_)))
+        );
+    }
+
+    #[test]
     fn style_base_circular_dependency_is_handled() {
         let mut base = StyleBase::ChicagoNotes18th.base();
         base.extends = Some(StyleBase::ChicagoNotes18th.into());
 
-        let resolved = base.into_resolved();
-        assert!(resolved.extends.is_some());
+        let _ = base.try_into_resolved();
     }
 
     #[test]

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -38,7 +38,7 @@ use crate::locale::{GeneralTerm, GrammaticalGender, TermForm};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::hash::{Hash, Hasher};
 
 /// Rendering instructions applied to template components.
@@ -450,6 +450,161 @@ impl TemplateComponent {
     pub fn rendering_mut(&mut self) -> &mut Rendering {
         crate::dispatch_component!(self, |inner| &mut inner.rendering)
     }
+}
+
+/// Type-specific template override, either as a complete legacy template or a V3 diff.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum TemplateVariant {
+    /// Complete replacement template used by Template V1/V2 styles.
+    Full(Vec<TemplateComponent>),
+    /// Structural diff applied to a parent template during style resolution.
+    Diff(TemplateVariantDiff),
+}
+
+impl TemplateVariant {
+    /// Return this variant as a concrete template if it has already been resolved.
+    #[must_use]
+    pub fn as_template(&self) -> Option<&[TemplateComponent]> {
+        match self {
+            Self::Full(template) => Some(template.as_slice()),
+            Self::Diff(_) => None,
+        }
+    }
+
+    /// Return this variant as a mutable concrete template if it has already been resolved.
+    pub fn as_template_mut(&mut self) -> Option<&mut Vec<TemplateComponent>> {
+        match self {
+            Self::Full(template) => Some(template),
+            Self::Diff(_) => None,
+        }
+    }
+
+    /// Convert this variant into its concrete template if it has already been resolved.
+    #[must_use]
+    pub fn into_template(self) -> Option<Vec<TemplateComponent>> {
+        match self {
+            Self::Full(template) => Some(template),
+            Self::Diff(_) => None,
+        }
+    }
+}
+
+impl From<Vec<TemplateComponent>> for TemplateVariant {
+    fn from(template: Vec<TemplateComponent>) -> Self {
+        Self::Full(template)
+    }
+}
+
+/// Structural diff that derives a type-specific template from a parent template.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct TemplateVariantDiff {
+    /// Optional parent type variant selector within the same section.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extends: Option<TypeSelector>,
+    /// Rendering-only modifications applied in authored order.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub modify: Vec<TemplateModifyOperation>,
+    /// Component removals applied in authored order.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub remove: Vec<TemplateRemoveOperation>,
+    /// Component additions applied in authored order.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub add: Vec<TemplateAddOperation>,
+}
+
+/// Partial component selector used to locate anchors in a template.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(transparent)]
+pub struct TemplateComponentSelector {
+    /// Component fields that must be present with equal values on the target component.
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl TemplateComponentSelector {
+    /// Returns `true` when this selector has no fields.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Returns `true` when every selector field is present with the same value.
+    #[must_use]
+    pub fn matches(&self, component: &TemplateComponent) -> bool {
+        let Ok(serde_json::Value::Object(component_fields)) = serde_json::to_value(component)
+        else {
+            return false;
+        };
+
+        self.fields.iter().all(|(key, expected)| {
+            component_fields
+                .get(key)
+                .is_some_and(|actual| selector_value_matches(expected, actual))
+        })
+    }
+}
+
+fn selector_value_matches(expected: &serde_json::Value, actual: &serde_json::Value) -> bool {
+    match (expected, actual) {
+        (serde_json::Value::Object(expected_fields), serde_json::Value::Object(actual_fields)) => {
+            expected_fields.iter().all(|(key, expected_value)| {
+                actual_fields.get(key).is_some_and(|actual_value| {
+                    selector_value_matches(expected_value, actual_value)
+                })
+            })
+        }
+        (serde_json::Value::Array(expected_items), serde_json::Value::Array(actual_items)) => {
+            expected_items.len() == actual_items.len()
+                && expected_items.iter().zip(actual_items.iter()).all(
+                    |(expected_item, actual_item)| {
+                        selector_value_matches(expected_item, actual_item)
+                    },
+                )
+        }
+        _ => expected == actual,
+    }
+}
+
+/// Rendering-only modification for the component matched by `match`.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct TemplateModifyOperation {
+    /// Selector identifying exactly one component to modify.
+    #[serde(rename = "match")]
+    pub match_selector: TemplateComponentSelector,
+    /// Rendering fields to merge onto the matched component.
+    #[serde(flatten, default)]
+    pub rendering: Rendering,
+}
+
+/// Removal operation for the component matched by `match`.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct TemplateRemoveOperation {
+    /// Selector identifying exactly one component to remove.
+    #[serde(rename = "match")]
+    pub match_selector: TemplateComponentSelector,
+}
+
+/// Addition operation that inserts a component before or after an anchor.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct TemplateAddOperation {
+    /// Anchor selector before which the component should be inserted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<TemplateComponentSelector>,
+    /// Anchor selector after which the component should be inserted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<TemplateComponentSelector>,
+    /// Component to insert.
+    pub component: TemplateComponent,
 }
 
 /// Configuration for role labels (e.g., "eds.", "trans.").
@@ -1262,6 +1417,33 @@ wrap: parentheses
         assert!(mixed.matches("default"));
         assert!(mixed.matches("chapter"));
         assert!(!mixed.matches("book"));
+    }
+
+    #[test]
+    fn test_template_component_selector_matches_nested_partial_group() {
+        let component: TemplateComponent = serde_yaml::from_str(
+            r#"
+delimiter: ""
+group:
+- number: citation-number
+  wrap:
+    punctuation: brackets
+- contributor: author
+  form: long
+"#,
+        )
+        .unwrap();
+        let selector = TemplateComponentSelector {
+            fields: BTreeMap::from([(
+                "group".to_string(),
+                serde_json::json!([
+                    { "number": "citation-number" },
+                    { "contributor": "author" }
+                ]),
+            )]),
+        };
+
+        assert!(selector.matches(&component));
     }
 
     #[test]

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -75,6 +75,13 @@ impl StyleResolver for StoreResolver {
     }
 }
 
+impl citum_schema::StyleResolver for StoreResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
+    }
+}
+
 /// A resolver that checks for embedded styles and locales.
 pub struct EmbeddedResolver;
 
@@ -93,6 +100,13 @@ impl StyleResolver for EmbeddedResolver {
         } else {
             Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
         }
+    }
+}
+
+impl citum_schema::StyleResolver for EmbeddedResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
     }
 }
 
@@ -178,6 +192,13 @@ impl StyleResolver for RegistryResolver {
     }
 }
 
+impl citum_schema::StyleResolver for RegistryResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
+    }
+}
+
 /// A resolver that handles local file paths.
 pub struct FileResolver;
 
@@ -213,6 +234,13 @@ impl StyleResolver for FileResolver {
             }
         }
         Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+    }
+}
+
+impl citum_schema::StyleResolver for FileResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
     }
 }
 
@@ -342,6 +370,14 @@ impl StyleResolver for HttpResolver {
     }
 }
 
+#[cfg(feature = "http")]
+impl citum_schema::StyleResolver for HttpResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
+    }
+}
+
 /// A composite resolver that attempts resolution through a chain of resolvers.
 pub struct ChainResolver {
     resolvers: Vec<Box<dyn StyleResolver>>,
@@ -375,6 +411,23 @@ impl StyleResolver for ChainResolver {
             }
         }
         Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+    }
+}
+
+impl citum_schema::StyleResolver for ChainResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
+    }
+}
+
+fn resolution_error_from_store_error(
+    uri: &str,
+    err: ResolverError,
+) -> citum_schema::ResolutionError {
+    citum_schema::ResolutionError::UriResolutionFailed {
+        uri: uri.to_string(),
+        reason: err.to_string(),
     }
 }
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -4353,10 +4353,7 @@
             "null"
           ],
           "additionalProperties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/$defs/TemplateComponent"
-            }
+            "$ref": "#/$defs/TemplateVariant"
           }
         },
         "wrap": {
@@ -4804,6 +4801,269 @@
         "template"
       ]
     },
+    "TemplateVariant": {
+      "description": "Type-specific template override, either as a complete legacy template or a V3 diff.",
+      "anyOf": [
+        {
+          "description": "Complete replacement template used by Template V1/V2 styles.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        {
+          "description": "Structural diff applied to a parent template during style resolution.",
+          "$ref": "#/$defs/TemplateVariantDiff"
+        }
+      ]
+    },
+    "TemplateVariantDiff": {
+      "description": "Structural diff that derives a type-specific template from a parent template.",
+      "type": "object",
+      "properties": {
+        "extends": {
+          "description": "Optional parent type variant selector within the same section.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modify": {
+          "description": "Rendering-only modifications applied in authored order.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateModifyOperation"
+          }
+        },
+        "remove": {
+          "description": "Component removals applied in authored order.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateRemoveOperation"
+          }
+        },
+        "add": {
+          "description": "Component additions applied in authored order.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateAddOperation"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "TypeSelector": {
+      "description": "Selector for reference types in overrides.\nCan be a single type string or a list of types.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "Single": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Single"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Multiple": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "Multiple"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "TemplateModifyOperation": {
+      "description": "Rendering-only modification for the component matched by `match`.",
+      "type": "object",
+      "properties": {
+        "match": {
+          "description": "Selector identifying exactly one component to modify.",
+          "$ref": "#/$defs/TemplateComponentSelector"
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "match"
+      ]
+    },
+    "TemplateComponentSelector": {
+      "description": "Partial component selector used to locate anchors in a template.",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "TemplateRemoveOperation": {
+      "description": "Removal operation for the component matched by `match`.",
+      "type": "object",
+      "properties": {
+        "match": {
+          "description": "Selector identifying exactly one component to remove.",
+          "$ref": "#/$defs/TemplateComponentSelector"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "match"
+      ]
+    },
+    "TemplateAddOperation": {
+      "description": "Addition operation that inserts a component before or after an anchor.",
+      "type": "object",
+      "properties": {
+        "before": {
+          "description": "Anchor selector before which the component should be inserted.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateComponentSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "after": {
+          "description": "Anchor selector after which the component should be inserted.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateComponentSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "component": {
+          "description": "Component to insert.",
+          "$ref": "#/$defs/TemplateComponent"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "component"
+      ]
+    },
     "CitationCollapse": {
       "description": "Citation collapse behavior for multi-item citations.",
       "oneOf": [
@@ -5003,10 +5263,7 @@
             "null"
           ],
           "additionalProperties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/$defs/TemplateComponent"
-            }
+            "$ref": "#/$defs/TemplateVariant"
           }
         },
         "sort": {
@@ -5801,38 +6058,6 @@
           ]
         }
       }
-    },
-    "TypeSelector": {
-      "description": "Selector for reference types in overrides.\nCan be a single type string or a list of types.",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "Single": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "Single"
-          ],
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "Multiple": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "Multiple"
-          ],
-          "additionalProperties": false
-        }
-      ]
     },
     "CitedStatus": {
       "description": "Citation status filter.",


### PR DESCRIPTION
## Summary
- Adds Template V3 public schema for diff-based `type-variants` while preserving legacy array-valued variants.
- Resolves Template V3 diffs during style resolution, including inherited and explicit variant parents, nested citation specs, selector diagnostics, scoped options, and render paths.
- Adds schema-level resolver integration for store/file/registry/http resolver chains.
- Adds the unrelated release workflow fix required before merge: the release PR job now creates the `release` label on demand before `gh pr create --label release`.

## Stack
- Base: `main`
- Follow-up: #624 / `codex/csl26-t3v1-template-v3-ecosystem`

## Verification
- PR 1 standalone: `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run` - pass.
- Stacked full gate: `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run` - pass, 1190 tests.
- Schema regeneration: `cargo run --bin citum --features schema -- schema --out-dir docs/schemas` - pass.
- Frontmatter: `./scripts/validate-frontmatter.sh --repo-only --copilot-strict` - pass.
- Local commit-message hook checked for all stack commits after the CI hygiene finding - pass.

## Review / Feedback
- Copilot review comments addressed: CLI resolver double-resolution, nested citation diff fallback, raw lint coverage for diff `add` components, selector-specific resolution errors, and resolver docs.
- Local review findings addressed, including invalid add-anchor handling and exact diff resolution tests.
- Review subagents were requested, but both failed before returning findings due account usage limits; no actionable subagent findings were returned.

## CI
- GitHub checks on #623 are all passing: CI changes, Hygiene Checks, Rust CI, API Semver Check, and Fidelity Checks.
- Residual risks: none currently identified beyond normal maintainer review and testing.
