### PR TITLE
feat(migrate): emit template v3 diffs

### DIFF
--- a/.beans/archive/csl26-t3v1--template-v3-resolver-impact.md
+++ b/.beans/archive/csl26-t3v1--template-v3-resolver-impact.md
@@ -1,7 +1,7 @@
 ---
 # csl26-t3v1
 title: TEMPLATE_V3 Implementation & Ecosystem Transition (jj Stack)
-status: draft
+status: completed
 type: task
 priority: high
 tags:
@@ -12,7 +12,7 @@ tags:
     - migrate
     - jj
 created_at: 2026-05-05T00:00:00Z
-updated_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T22:56:33Z
 ---
 
 # csl26-t3v1
@@ -44,3 +44,12 @@ Using `jj` allows us to maintain a live stack of these changes. We can refine th
 - Enable surgical style overrides that persist across upstream updates.
 - Reduce the average line count of complex styles by 30-50%.
 - Maintain bit-for-bit fidelity with existing oracle baselines.
+
+## Summary of Changes
+
+Delivered as a two-PR jj stack:
+
+- **PR #623** (engine): Added schema-level Template V3 variant resolution — `TemplateVariant::Diff` support in `try_into_resolved`, LCS-based diff application, and `extends` chain resolution in `citum-schema-style`.
+- **PR #624** (ecosystem): Updated `citum-migrate` to emit diff-form type variants, added `scripts/convert-template-v3.js` for post-hoc surgical conversion of existing styles, and converted the `styles/` portfolio.
+
+Post-review fix (session 2026-05-05): replaced full-file `yaml.dump` round-trip with surgical line-range replacement and added a size guard (diff only accepted when shorter than the full template YAML). Final LOC result in `styles/`: **+3,639 / -13,056 = net -9,417 lines** — genuine semantic compression with no formatting noise.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"ae9cf0e8-7ec7-4bb8-962a-94252d034404","pid":4432,"procStart":"Mon Apr 27 11:28:05 2026","acquiredAt":1777294478833}
+{"sessionId":"9d1180e6-f307-4d9f-8927-4e346cdc983d","pid":75515,"procStart":"Tue May  5 22:19:45 2026","acquiredAt":1778022340249}

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -21,15 +21,311 @@ use citum_migrate::{
 };
 use citum_schema::{
     BibliographySpec, CitationCollapse, CitationSpec, Style, StyleInfo,
-    template::{TemplateComponent, TypeSelector, WrapPunctuation},
+    template::{
+        Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
+        TemplateModifyOperation, TemplateRemoveOperation, TemplateVariant, TemplateVariantDiff,
+        TypeSelector, WrapPunctuation,
+    },
 };
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Shorthand for the per-type template map used throughout the migration pipeline.
 type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
+
+type TypeVariantMap = indexmap::IndexMap<TypeSelector, TemplateVariant>;
+
+fn build_type_variants(
+    default_template: &[TemplateComponent],
+    type_templates: TypeTemplateMap,
+) -> TypeVariantMap {
+    let mut variants = TypeVariantMap::new();
+    let mut candidate_parents: Vec<(TypeSelector, Vec<TemplateComponent>)> = Vec::new();
+
+    for (selector, template) in type_templates {
+        let variant = template_variant_from_full_template(
+            default_template,
+            &candidate_parents,
+            &selector,
+            template.clone(),
+        );
+        variants.insert(selector.clone(), variant);
+        candidate_parents.push((selector, template));
+    }
+
+    variants
+}
+
+fn template_variant_from_full_template(
+    default_template: &[TemplateComponent],
+    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
+    selector: &TypeSelector,
+    target_template: Vec<TemplateComponent>,
+) -> TemplateVariant {
+    let Some(diff) =
+        derive_best_template_variant_diff(default_template, candidate_parents, &target_template)
+    else {
+        return TemplateVariant::Full(target_template);
+    };
+
+    if diff_resolves_to_template(
+        default_template,
+        candidate_parents,
+        selector,
+        &diff,
+        &target_template,
+    ) {
+        TemplateVariant::Diff(diff)
+    } else {
+        TemplateVariant::Full(target_template)
+    }
+}
+
+fn derive_best_template_variant_diff(
+    default_template: &[TemplateComponent],
+    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
+    target_template: &[TemplateComponent],
+) -> Option<TemplateVariantDiff> {
+    let mut best_diff = derive_template_variant_diff(default_template, target_template);
+    let mut best_weight = best_diff
+        .as_ref()
+        .map(diff_operation_weight)
+        .unwrap_or(usize::MAX);
+
+    for (parent_selector, parent_template) in candidate_parents {
+        let Some(mut parent_diff) = derive_template_variant_diff(parent_template, target_template)
+        else {
+            continue;
+        };
+        let weight = diff_operation_weight(&parent_diff);
+        if weight >= best_weight {
+            continue;
+        }
+        parent_diff.extends = Some(parent_selector.clone());
+        best_diff = Some(parent_diff);
+        best_weight = weight;
+    }
+
+    best_diff
+}
+
+fn diff_operation_weight(diff: &TemplateVariantDiff) -> usize {
+    diff.modify.len() + diff.remove.len() + diff.add.len()
+}
+
+fn diff_resolves_to_template(
+    default_template: &[TemplateComponent],
+    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
+    selector: &TypeSelector,
+    diff: &TemplateVariantDiff,
+    expected_template: &[TemplateComponent],
+) -> bool {
+    let mut variants = TypeVariantMap::new();
+    for (parent_selector, parent_template) in candidate_parents {
+        variants.insert(
+            parent_selector.clone(),
+            TemplateVariant::Full(parent_template.clone()),
+        );
+    }
+    variants.insert(selector.clone(), TemplateVariant::Diff(diff.clone()));
+    let style = Style {
+        bibliography: Some(BibliographySpec {
+            template: Some(default_template.to_vec()),
+            type_variants: Some(variants),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    style
+        .try_into_resolved()
+        .ok()
+        .and_then(|style| style.bibliography)
+        .and_then(|bibliography| bibliography.type_variants)
+        .and_then(|variants| variants.get(selector).cloned())
+        .and_then(TemplateVariant::into_template)
+        .is_some_and(|resolved| resolved == expected_template)
+}
+
+fn derive_template_variant_diff(
+    default_template: &[TemplateComponent],
+    target_template: &[TemplateComponent],
+) -> Option<TemplateVariantDiff> {
+    if default_template.is_empty() {
+        return None;
+    }
+
+    let default_keys = component_keys(default_template)?;
+    let target_keys = component_keys(target_template)?;
+    let common_pairs = lcs_pairs(&default_keys, &target_keys);
+    let mut diff = TemplateVariantDiff::default();
+
+    for (index, component) in default_template.iter().enumerate() {
+        if !common_pairs
+            .iter()
+            .any(|(base_index, _)| *base_index == index)
+        {
+            diff.remove.push(TemplateRemoveOperation {
+                match_selector: component_selector(component)?,
+            });
+        }
+    }
+
+    for (base_index, target_index) in &common_pairs {
+        let base_component = default_template.get(*base_index)?;
+        let target_component = target_template.get(*target_index)?;
+        if base_component != target_component {
+            if !is_rendering_only_change(base_component, target_component) {
+                return None;
+            }
+            diff.modify.push(TemplateModifyOperation {
+                match_selector: component_selector(base_component)?,
+                rendering: target_component.rendering().clone(),
+            });
+        }
+    }
+
+    let mut last_anchor: Option<TemplateComponentSelector> = None;
+    for (target_index, component) in target_template.iter().enumerate() {
+        if let Some((base_index, _)) = common_pairs
+            .iter()
+            .find(|(_, common_target_index)| *common_target_index == target_index)
+        {
+            last_anchor = default_template
+                .get(*base_index)
+                .and_then(component_selector);
+            continue;
+        }
+
+        let next_anchor = common_pairs
+            .iter()
+            .find(|(_, common_target_index)| *common_target_index > target_index)
+            .and_then(|(base_index, _)| default_template.get(*base_index))
+            .and_then(component_selector);
+
+        let component_selector = component_selector(component)?;
+        let add = if let Some(before) = next_anchor {
+            TemplateAddOperation {
+                before: Some(before),
+                after: None,
+                component: component.clone(),
+            }
+        } else if let Some(after) = last_anchor.clone() {
+            TemplateAddOperation {
+                before: None,
+                after: Some(after),
+                component: component.clone(),
+            }
+        } else {
+            return None;
+        };
+        diff.add.push(add);
+        last_anchor = Some(component_selector);
+    }
+
+    Some(diff)
+}
+
+fn component_keys(template: &[TemplateComponent]) -> Option<Vec<String>> {
+    template
+        .iter()
+        .map(|component| serde_json::to_string(&component_selector(component)?.fields).ok())
+        .collect()
+}
+
+fn component_selector(component: &TemplateComponent) -> Option<TemplateComponentSelector> {
+    let serde_json::Value::Object(fields) = serde_json::to_value(component).ok()? else {
+        return None;
+    };
+    for key in [
+        "contributor",
+        "date",
+        "title",
+        "number",
+        "variable",
+        "term",
+        "group",
+    ] {
+        if let Some(value) = fields.get(key) {
+            let mut selector = BTreeMap::new();
+            selector.insert(key.to_string(), value.clone());
+            return Some(TemplateComponentSelector { fields: selector });
+        }
+    }
+    None
+}
+
+fn is_rendering_only_change(base: &TemplateComponent, target: &TemplateComponent) -> bool {
+    let mut normalized_base = base.clone();
+    let mut normalized_target = target.clone();
+    *normalized_base.rendering_mut() = Rendering::default();
+    *normalized_target.rendering_mut() = Rendering::default();
+    normalized_base == normalized_target
+}
+
+fn lcs_pairs(left: &[String], right: &[String]) -> Vec<(usize, usize)> {
+    let mut lengths = vec![vec![0usize; right.len() + 1]; left.len() + 1];
+
+    for i in (0..left.len()).rev() {
+        for j in (0..right.len()).rev() {
+            let diagonal = lengths
+                .get(i + 1)
+                .and_then(|row| row.get(j + 1))
+                .copied()
+                .unwrap_or(0);
+            let down = lengths
+                .get(i + 1)
+                .and_then(|row| row.get(j))
+                .copied()
+                .unwrap_or(0);
+            let right_value = lengths
+                .get(i)
+                .and_then(|row| row.get(j + 1))
+                .copied()
+                .unwrap_or(0);
+            let value = if left.get(i) == right.get(j) {
+                diagonal + 1
+            } else {
+                down.max(right_value)
+            };
+            if let Some(cell) = lengths.get_mut(i).and_then(|row| row.get_mut(j)) {
+                *cell = value;
+            }
+        }
+    }
+
+    let mut pairs = Vec::new();
+    let mut i = 0;
+    let mut j = 0;
+    while i < left.len() && j < right.len() {
+        if left.get(i) == right.get(j) {
+            pairs.push((i, j));
+            i += 1;
+            j += 1;
+            continue;
+        }
+
+        let down = lengths
+            .get(i + 1)
+            .and_then(|row| row.get(j))
+            .copied()
+            .unwrap_or(0);
+        let right_value = lengths
+            .get(i)
+            .and_then(|row| row.get(j + 1))
+            .copied()
+            .unwrap_or(0);
+        if down >= right_value {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    pairs
+}
 
 struct CliArgs {
     path: String,
@@ -248,6 +544,10 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
     if let Some(type_templates) = c.type_templates.as_mut() {
         type_templates.retain(|_, template| template != &c.new_bib);
     }
+    let type_variants = c
+        .type_templates
+        .take()
+        .map(|type_templates| build_type_variants(&c.new_bib, type_templates));
 
     // [PRUNING] Prune redundant citation modes (e.g. ibid/subsequent if they match base).
     let subsequent = c
@@ -297,12 +597,7 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
             options: bibliography_scope_options,
             extends: None,
             template: Some(c.new_bib),
-            type_variants: c.type_templates.map(|type_templates| {
-                type_templates
-                    .into_iter()
-                    .map(|(selector, template)| (selector, template.into()))
-                    .collect()
-            }),
+            type_variants,
             sort: bibliography_sort,
             ..Default::default()
         }),
@@ -993,6 +1288,178 @@ mod tests {
                 })
                 .collect(),
         }
+    }
+
+    #[test]
+    fn template_v3_diff_generator_emits_rendering_modify() {
+        let default_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            }),
+        ];
+        let target_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                rendering: Rendering {
+                    suffix: Some(".".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        ];
+
+        let variant = template_variant_from_full_template(
+            &default_template,
+            &[],
+            &TypeSelector::Single("book".to_string()),
+            target_template,
+        );
+
+        let TemplateVariant::Diff(diff) = variant else {
+            panic!("rendering-only template changes should emit Template V3 diffs");
+        };
+        assert_eq!(diff.modify.len(), 1);
+        assert!(diff.remove.is_empty());
+        assert!(diff.add.is_empty());
+    }
+
+    #[test]
+    fn template_v3_diff_generator_emits_structural_remove_and_add() {
+        let default_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            }),
+            TemplateComponent::Variable(TemplateVariable {
+                variable: SimpleVariable::Publisher,
+                ..Default::default()
+            }),
+        ];
+        let target_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            TemplateComponent::Date(TemplateDate {
+                date: DateVariable::Issued,
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            }),
+        ];
+
+        let variant = template_variant_from_full_template(
+            &default_template,
+            &[],
+            &TypeSelector::Single("book".to_string()),
+            target_template,
+        );
+
+        let TemplateVariant::Diff(diff) = variant else {
+            panic!("safe structural template changes should emit Template V3 diffs");
+        };
+        assert!(diff.modify.is_empty());
+        assert_eq!(diff.remove.len(), 1);
+        assert_eq!(diff.add.len(), 1);
+    }
+
+    #[test]
+    fn template_v3_diff_generator_falls_back_for_non_rendering_changes() {
+        let default_template = vec![TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            ..Default::default()
+        })];
+        let target_template = vec![TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            form: Some(citum_schema::template::TitleForm::Short),
+            ..Default::default()
+        })];
+
+        let variant = template_variant_from_full_template(
+            &default_template,
+            &[],
+            &TypeSelector::Single("book".to_string()),
+            target_template,
+        );
+
+        assert!(matches!(variant, TemplateVariant::Full(_)));
+    }
+
+    #[test]
+    fn template_v3_diff_generator_can_extend_prior_variant() {
+        let default_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            }),
+            TemplateComponent::Variable(TemplateVariable {
+                variable: SimpleVariable::Publisher,
+                ..Default::default()
+            }),
+        ];
+        let book_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                rendering: Rendering {
+                    suffix: Some(".".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        ];
+        let chapter_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                rendering: Rendering {
+                    suffix: Some("!".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        ];
+        let parent_selector = TypeSelector::Single("book".to_string());
+        let parents = vec![(parent_selector.clone(), book_template)];
+
+        let variant = template_variant_from_full_template(
+            &default_template,
+            &parents,
+            &TypeSelector::Single("chapter".to_string()),
+            chapter_template,
+        );
+
+        let TemplateVariant::Diff(diff) = variant else {
+            panic!("variant should extend prior variant when it is more concise");
+        };
+        assert_eq!(diff.extends, Some(parent_selector));
+        assert_eq!(diff.modify.len(), 1);
+        assert!(diff.remove.is_empty());
     }
 
     #[test]

--- a/scripts/convert-template-v3.js
+++ b/scripts/convert-template-v3.js
@@ -1,0 +1,538 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_STYLES_DIR = path.join(PROJECT_ROOT, 'styles');
+const RENDERING_KEYS = new Set([
+  'text-case',
+  'emph',
+  'quote',
+  'strong',
+  'small-caps',
+  'vertical-align',
+  'prefix',
+  'suffix',
+  'wrap',
+  'suppress',
+  'initialize-with',
+  'name-form',
+  'strip-periods',
+]);
+const SELECTOR_KEYS = ['contributor', 'date', 'title', 'number', 'variable', 'term', 'group'];
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = {
+    paths: [],
+    write: false,
+    json: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--write') {
+      args.write = true;
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '-h' || arg === '--help') {
+      printUsage();
+      process.exit(0);
+    } else {
+      args.paths.push(arg);
+    }
+  }
+
+  return args;
+}
+
+function printUsage() {
+  console.log('Usage: node scripts/convert-template-v3.js [--write] [--json] [styles/file.yaml ...]');
+}
+
+function listStyleFiles(inputPaths) {
+  if (inputPaths.length === 0) {
+    return walkYaml(DEFAULT_STYLES_DIR);
+  }
+
+  return inputPaths
+    .map((inputPath) => path.resolve(inputPath))
+    .flatMap((inputPath) => {
+      if (fs.statSync(inputPath).isDirectory()) {
+        return walkYaml(inputPath);
+      }
+      return inputPath.endsWith('.yaml') ? [inputPath] : [];
+    })
+    .sort();
+}
+
+function walkYaml(dirPath) {
+  return fs.readdirSync(dirPath, { withFileTypes: true })
+    .flatMap((entry) => {
+      const filePath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        return walkYaml(filePath);
+      }
+      return entry.isFile() && entry.name.endsWith('.yaml') ? [filePath] : [];
+    })
+    .sort();
+}
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function componentSelector(component) {
+  if (!component || typeof component !== 'object' || Array.isArray(component)) {
+    return null;
+  }
+
+  for (const key of SELECTOR_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(component, key)) {
+      return { [key]: component[key] };
+    }
+  }
+  return null;
+}
+
+function componentKey(component) {
+  const selector = componentSelector(component);
+  return selector ? JSON.stringify(selector) : null;
+}
+
+function lcsPairs(left, right) {
+  const lengths = Array.from({ length: left.length + 1 }, () => Array(right.length + 1).fill(0));
+
+  for (let i = left.length - 1; i >= 0; i -= 1) {
+    for (let j = right.length - 1; j >= 0; j -= 1) {
+      lengths[i][j] = left[i] === right[j]
+        ? lengths[i + 1][j + 1] + 1
+        : Math.max(lengths[i + 1][j], lengths[i][j + 1]);
+    }
+  }
+
+  const pairs = [];
+  let i = 0;
+  let j = 0;
+  while (i < left.length && j < right.length) {
+    if (left[i] === right[j]) {
+      pairs.push([i, j]);
+      i += 1;
+      j += 1;
+    } else if (lengths[i + 1][j] >= lengths[i][j + 1]) {
+      i += 1;
+    } else {
+      j += 1;
+    }
+  }
+  return pairs;
+}
+
+function stripRendering(component) {
+  const stripped = { ...component };
+  for (const key of RENDERING_KEYS) {
+    delete stripped[key];
+  }
+  return stripped;
+}
+
+function isRenderingOnlyChange(base, target) {
+  return JSON.stringify(stripRendering(base)) === JSON.stringify(stripRendering(target));
+}
+
+function selectorValueMatches(expected, actual) {
+  if (Array.isArray(expected)) {
+    return Array.isArray(actual)
+      && expected.length === actual.length
+      && expected.every((item, index) => selectorValueMatches(item, actual[index]));
+  }
+  if (expected && typeof expected === 'object') {
+    return actual && typeof actual === 'object' && !Array.isArray(actual)
+      && Object.entries(expected).every(([key, value]) => selectorValueMatches(value, actual[key]));
+  }
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function componentMatchesSelector(component, selector) {
+  return Object.entries(selector).every(([key, expected]) => (
+    selectorValueMatches(expected, component?.[key])
+  ));
+}
+
+function findTemplateIndex(template, selector) {
+  const matches = [];
+  template.forEach((component, index) => {
+    if (componentMatchesSelector(component, selector)) {
+      matches.push(index);
+    }
+  });
+  return matches.length === 1 ? matches[0] : -1;
+}
+
+function applyDiff(baseTemplate, diff) {
+  const template = cloneJson(baseTemplate);
+
+  for (const operation of diff.modify || []) {
+    const index = findTemplateIndex(template, operation.match);
+    if (index < 0) return null;
+    const rendering = { ...operation };
+    delete rendering.match;
+    template[index] = { ...template[index], ...rendering };
+  }
+
+  for (const operation of diff.remove || []) {
+    const index = findTemplateIndex(template, operation.match);
+    if (index < 0) return null;
+    template.splice(index, 1);
+  }
+
+  for (const operation of diff.add || []) {
+    const anchor = operation.before || operation.after;
+    const index = findTemplateIndex(template, anchor);
+    if (index < 0) return null;
+    template.splice(operation.before ? index : index + 1, 0, cloneJson(operation.component));
+  }
+
+  return template;
+}
+
+function deriveTemplateVariantDiff(baseTemplate, targetTemplate) {
+  if (!Array.isArray(baseTemplate) || !Array.isArray(targetTemplate) || baseTemplate.length === 0) {
+    return null;
+  }
+
+  const baseKeys = baseTemplate.map(componentKey);
+  const targetKeys = targetTemplate.map(componentKey);
+  if (baseKeys.some((key) => !key) || targetKeys.some((key) => !key)) {
+    return null;
+  }
+
+  const pairs = lcsPairs(baseKeys, targetKeys);
+  const diff = {};
+  const modify = [];
+  const remove = [];
+  const add = [];
+
+  for (let baseIndex = 0; baseIndex < baseTemplate.length; baseIndex += 1) {
+    if (!pairs.some(([pairedBase]) => pairedBase === baseIndex)) {
+      remove.push({ match: componentSelector(baseTemplate[baseIndex]) });
+    }
+  }
+
+  for (const [baseIndex, targetIndex] of pairs) {
+    const baseComponent = baseTemplate[baseIndex];
+    const targetComponent = targetTemplate[targetIndex];
+    if (JSON.stringify(baseComponent) === JSON.stringify(targetComponent)) continue;
+    if (!isRenderingOnlyChange(baseComponent, targetComponent)) return null;
+
+    const operation = { match: componentSelector(baseComponent) };
+    for (const key of RENDERING_KEYS) {
+      if (Object.prototype.hasOwnProperty.call(targetComponent, key)) {
+        operation[key] = targetComponent[key];
+      }
+    }
+    modify.push(operation);
+  }
+
+  let lastAnchor = null;
+  for (let targetIndex = 0; targetIndex < targetTemplate.length; targetIndex += 1) {
+    const pair = pairs.find(([, pairedTarget]) => pairedTarget === targetIndex);
+    if (pair) {
+      lastAnchor = componentSelector(baseTemplate[pair[0]]);
+      continue;
+    }
+
+    const nextPair = pairs.find(([, pairedTarget]) => pairedTarget > targetIndex);
+    const operation = { component: targetTemplate[targetIndex] };
+    if (nextPair) {
+      operation.before = componentSelector(baseTemplate[nextPair[0]]);
+    } else if (lastAnchor) {
+      operation.after = lastAnchor;
+    } else {
+      return null;
+    }
+    add.push(operation);
+    lastAnchor = componentSelector(targetTemplate[targetIndex]);
+  }
+
+  if (modify.length > 0) diff.modify = modify;
+  if (remove.length > 0) diff.remove = remove;
+  if (add.length > 0) diff.add = add;
+  if (Object.keys(diff).length === 0) return null;
+
+  const resolved = applyDiff(baseTemplate, diff);
+  return JSON.stringify(resolved) === JSON.stringify(targetTemplate) ? diff : null;
+}
+
+function diffOperationWeight(diff) {
+  return (diff.modify || []).length
+    + (diff.remove || []).length
+    + (diff.add || []).length;
+}
+
+function deriveBestTemplateVariantDiff(baseTemplate, candidateParents, targetTemplate) {
+  let bestDiff = deriveTemplateVariantDiff(baseTemplate, targetTemplate);
+  let bestWeight = bestDiff ? diffOperationWeight(bestDiff) : Infinity;
+
+  for (const [parentName, parentTemplate] of candidateParents) {
+    const parentDiff = deriveTemplateVariantDiff(parentTemplate, targetTemplate);
+    if (!parentDiff) continue;
+    const weight = diffOperationWeight(parentDiff);
+    if (weight >= bestWeight) continue;
+    bestDiff = {
+      extends: parentName,
+      ...parentDiff,
+    };
+    bestWeight = weight;
+  }
+
+  return bestDiff;
+}
+
+function convertSection(section, sectionPath = [], log = []) {
+  if (!section || typeof section !== 'object') {
+    return { converted: 0, total: 0 };
+  }
+
+  let converted = 0;
+  let total = 0;
+  const baseTemplate = section.template;
+  const variants = section['type-variants'];
+  if (Array.isArray(baseTemplate) && variants && typeof variants === 'object' && !Array.isArray(variants)) {
+    const candidateParents = [];
+    for (const [variantName, variantTemplate] of Object.entries(variants)) {
+      if (!Array.isArray(variantTemplate)) continue;
+      total += 1;
+      const diff = deriveBestTemplateVariantDiff(baseTemplate, candidateParents, variantTemplate);
+      if (diff) {
+        const diffYaml = yaml.dump(diff, { noRefs: true, lineWidth: -1 });
+        const fullYaml = yaml.dump(variantTemplate, { noRefs: true, lineWidth: -1 });
+        if (diffYaml.length < fullYaml.length) {
+          variants[variantName] = diff;
+          converted += 1;
+          log.push({ sectionPath, variantName, diff: cloneJson(diff) });
+        }
+      }
+      candidateParents.push([variantName, variantTemplate]);
+    }
+  }
+
+  for (const childKey of ['integral', 'non-integral', 'subsequent', 'ibid']) {
+    const child = convertSection(section[childKey], [...sectionPath, childKey], log);
+    converted += child.converted;
+    total += child.total;
+  }
+
+  return { converted, total };
+}
+
+function convertStyle(data) {
+  if (data.extends != null) {
+    return { converted: 0, total: 0, log: [] };
+  }
+
+  const log = [];
+  const citation = convertSection(data.citation, ['citation'], log);
+  const bibliography = convertSection(data.bibliography, ['bibliography'], log);
+  return {
+    converted: citation.converted + bibliography.converted,
+    total: citation.total + bibliography.total,
+    log,
+  };
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function findTypeVariantsLine(lines, sectionPath) {
+  let searchFrom = 0;
+  let lastSegIndent = -2; // tracks indent of last matched segment
+
+  for (const segment of sectionPath) {
+    const segRegex = new RegExp(`^(\\s*)${escapeRegex(segment)}:\\s*$`);
+    let found = -1;
+    let segIndent = -1;
+    for (let i = searchFrom; i < lines.length; i += 1) {
+      const m = lines[i].match(segRegex);
+      if (m) {
+        found = i;
+        segIndent = m[1].length;
+        break;
+      }
+    }
+    if (found < 0) return -1;
+    searchFrom = found + 1;
+    lastSegIndent = segIndent;
+  }
+
+  // type-variants: must be a direct child of the last segment,
+  // so its indent must be exactly lastSegIndent + 2.
+  const expectedIndent = lastSegIndent + 2;
+  const tvRegex = new RegExp(`^(\\s{${expectedIndent}})type-variants:\\s*$`);
+
+  for (let i = searchFrom; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (tvRegex.test(line)) return i;
+    // Stop if we exit the parent block (non-blank line at or below parent indent)
+    const lineIndent = line.search(/\S/);
+    if (lineIndent >= 0 && lineIndent <= lastSegIndent && i > searchFrom) break;
+  }
+  return -1;
+}
+
+function findVariantBlock(lines, typeVariantsLine, variantName) {
+  const tvIndent = lines[typeVariantsLine].search(/\S/);
+  const keyIndent = tvIndent + 2;
+  const keyRegex = new RegExp(`^(\\s{${keyIndent}})${escapeRegex(variantName)}:`);
+
+  let keyLine = -1;
+  for (let i = typeVariantsLine + 1; i < lines.length; i += 1) {
+    if (keyRegex.test(lines[i])) {
+      keyLine = i;
+      break;
+    }
+    // Stop if we've left the type-variants block
+    const lineIndent = lines[i].search(/\S/);
+    if (lineIndent >= 0 && lineIndent <= tvIndent) break;
+  }
+  if (keyLine < 0) return null;
+
+  // Find the end of this variant's block (content lines, not including the key line)
+  // The block ends when we encounter a non-blank line at keyIndent that looks like a sibling key
+  // (i.e., a mapping key at the same level, including inline-value forms like `key: []`)
+  let endLine = keyLine + 1;
+  while (endLine < lines.length) {
+    const l = lines[endLine];
+    if (l.trim() === '') {
+      endLine += 1;
+      continue;
+    }
+    const indent = l.search(/\S/);
+    // Stop if we find a sibling key (indent == keyIndent and line starts with a mapping key).
+    // Use `[\w-]+:` without trailing `$` so inline-value forms like `key: []` also terminate.
+    if (indent === keyIndent && /^\s*[\w-]+:/.test(l)) break;
+    // Also stop if indent < keyIndent (left the section)
+    if (indent < keyIndent) break;
+    endLine += 1;
+  }
+
+  // startLine is the first content line (keyLine + 1), endLine is where the content ends
+  return { keyLine, startLine: keyLine + 1, endLine, keyIndent };
+}
+
+function locateAndBuildReplacement(lines, entry) {
+  const replacement = findTypeVariantsLine(lines, entry.sectionPath);
+  if (replacement < 0) return null;
+
+  const block = findVariantBlock(lines, replacement, entry.variantName);
+  if (!block) return null;
+
+  const { startLine, endLine, keyIndent } = block;
+
+  // Render only the diff object as YAML
+  const valueYaml = yaml.dump(entry.diff, { noRefs: true, lineWidth: -1, indent: 2 });
+
+  // The YAML dump has absolute indentation from 0. We need to shift all lines
+  // to be indented by keyIndent + 2 spaces
+  const targetBaseIndent = keyIndent + 2;
+  const newLines = valueYaml
+    .trimEnd()
+    .split('\n')
+    .map((l) => {
+      if (l.trim() === '') return '';
+      // Get the indentation from the dump
+      const dumpIndent = l.search(/\S/);
+      // Get the content (everything from first non-space)
+      const content = l.substring(dumpIndent);
+      // Preserve relative indentation: if dump had 6 spaces, that's 6 more than base 0
+      // We want to keep that relative indentation but shift to targetBaseIndent
+      const relativeIndent = dumpIndent;
+      return ' '.repeat(targetBaseIndent + relativeIndent) + content;
+    });
+
+  // newLines will replace the old content (from startLine to endLine)
+  // The key line itself is preserved above (keyLine), we only replace content lines
+
+  return { startLine, endLine, newLines };
+}
+
+function surgicalWrite(filePath, rawText, log) {
+  const lines = rawText.split('\n');
+
+  // Process replacements bottom-to-top so earlier line numbers stay valid
+  const replacements = [];
+
+  for (const entry of log) {
+    const replacement = locateAndBuildReplacement(lines, entry);
+    if (!replacement) {
+      // Fallback: if we can't locate the block surgically, skip (keeps original)
+      continue;
+    }
+    replacements.push(replacement);
+  }
+
+  // Sort by startLine descending
+  replacements.sort((a, b) => b.startLine - a.startLine);
+
+  for (const { startLine, endLine, newLines } of replacements) {
+    lines.splice(startLine, endLine - startLine, ...newLines);
+  }
+
+  fs.writeFileSync(filePath, lines.join('\n'));
+}
+
+function main() {
+  const args = parseArgs();
+  const summaries = [];
+
+  for (const filePath of listStyleFiles(args.paths)) {
+    const rawText = fs.readFileSync(filePath, 'utf8');
+    const data = yaml.load(rawText) || {};
+    const summary = convertStyle(data);
+    if (summary.total > 0) {
+      summaries.push({
+        file: path.relative(PROJECT_ROOT, filePath),
+        converted: summary.converted,
+        total: summary.total,
+      });
+    }
+    if (summary.converted > 0 && args.write && summary.log.length > 0) {
+      try {
+        surgicalWrite(filePath, rawText, summary.log);
+        // Verify the result can be parsed
+        yaml.load(fs.readFileSync(filePath, 'utf8'));
+      } catch (err) {
+        // Fallback: write the full dump if surgical write failed
+        fs.writeFileSync(filePath, yaml.dump(data, { noRefs: true, lineWidth: -1 }));
+      }
+    }
+  }
+
+  const totals = summaries.reduce(
+    (acc, summary) => ({
+      files: acc.files + 1,
+      converted: acc.converted + summary.converted,
+      total: acc.total + summary.total,
+    }),
+    { files: 0, converted: 0, total: 0 }
+  );
+
+  if (args.json) {
+    console.log(JSON.stringify({ totals, summaries }, null, 2));
+  } else {
+    console.log(`Template V3 conversion: ${totals.converted}/${totals.total} variants in ${totals.files} files`);
+    for (const summary of summaries) {
+      console.log(`${summary.file}: ${summary.converted}/${summary.total}`);
+    }
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  convertStyle,
+  deriveTemplateVariantDiff,
+};

--- a/scripts/convert-template-v3.test.js
+++ b/scripts/convert-template-v3.test.js
@@ -1,0 +1,299 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  convertStyle,
+  deriveTemplateVariantDiff,
+} = require('./convert-template-v3');
+
+test('deriveTemplateVariantDiff emits rendering modify plus structural operations', () => {
+  const base = [
+    { contributor: 'author' },
+    { title: 'primary' },
+    { variable: 'publisher' },
+  ];
+  const target = [
+    { contributor: 'author' },
+    { date: 'issued', form: 'year' },
+    { title: 'primary', suffix: '.' },
+  ];
+
+  const diff = deriveTemplateVariantDiff(base, target);
+
+  assert.deepEqual(diff, {
+    modify: [
+      { match: { title: 'primary' }, suffix: '.' },
+    ],
+    remove: [
+      { match: { variable: 'publisher' } },
+    ],
+    add: [
+      { component: { date: 'issued', form: 'year' }, before: { title: 'primary' } },
+    ],
+  });
+});
+
+test('deriveTemplateVariantDiff returns null for non-rendering mutations', () => {
+  const diff = deriveTemplateVariantDiff(
+    [{ title: 'primary' }],
+    [{ title: 'primary', form: 'short' }]
+  );
+
+  assert.equal(diff, null);
+});
+
+test('deriveTemplateVariantDiff can select grouped components', () => {
+  const base = [
+    {
+      delimiter: '',
+      group: [
+        { number: 'citation-number', wrap: { punctuation: 'brackets' } },
+        { contributor: 'author', form: 'long' },
+      ],
+    },
+    { title: 'primary' },
+  ];
+  const target = [
+    {
+      delimiter: '',
+      group: [
+        { number: 'citation-number', wrap: { punctuation: 'brackets' } },
+        { contributor: 'author', form: 'long' },
+      ],
+      suffix: '.',
+    },
+    { title: 'primary' },
+  ];
+
+  const diff = deriveTemplateVariantDiff(base, target);
+
+  assert.deepEqual(diff, {
+    modify: [
+      { match: { group: base[0].group }, suffix: '.' },
+    ],
+  });
+});
+
+test('convertStyle rewrites only exact diff-compatible variants', () => {
+  const base = [
+    { contributor: 'author' },
+    { title: 'primary' },
+    { variable: 'publisher' },
+    { variable: 'publisher-place' },
+    { date: 'issued' },
+    { number: 'pages' },
+  ];
+  const style = {
+    bibliography: {
+      template: base,
+      'type-variants': {
+        book: [
+          { contributor: 'author' },
+          { title: 'primary', suffix: '.' },
+          { variable: 'publisher' },
+          { variable: 'publisher-place' },
+          { date: 'issued' },
+          { number: 'pages' },
+        ],
+        webpage: [
+          { contributor: 'author' },
+          { title: 'primary', form: 'short' },
+          { variable: 'publisher' },
+          { variable: 'publisher-place' },
+          { date: 'issued' },
+          { number: 'pages' },
+        ],
+      },
+    },
+  };
+
+  const summary = convertStyle(style);
+
+  assert.equal(summary.converted, 1);
+  assert.equal(summary.total, 2);
+  assert.equal(summary.log.length, 1);
+  assert.deepEqual(style.bibliography['type-variants'].book, {
+    modify: [
+      { match: { title: 'primary' }, suffix: '.' },
+    ],
+  });
+  assert.deepEqual(style.bibliography['type-variants'].webpage, [
+    { contributor: 'author' },
+    { title: 'primary', form: 'short' },
+    { variable: 'publisher' },
+    { variable: 'publisher-place' },
+    { date: 'issued' },
+    { number: 'pages' },
+  ]);
+});
+
+test('convertStyle derives variants from earlier same-section parents', () => {
+  const style = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+        { variable: 'publisher' },
+        { variable: 'publisher-place' },
+        { date: 'issued' },
+      ],
+      'type-variants': {
+        book: [
+          { contributor: 'author' },
+          { title: 'primary', suffix: '.' },
+          { variable: 'publisher' },
+          { variable: 'publisher-place' },
+          { date: 'issued' },
+        ],
+        chapter: [
+          { contributor: 'author' },
+          { title: 'primary', suffix: '!' },
+          { variable: 'publisher' },
+          { variable: 'publisher-place' },
+          { date: 'issued' },
+        ],
+      },
+    },
+  };
+
+  const summary = convertStyle(style);
+
+  assert.equal(summary.converted, 2);
+  assert.equal(summary.total, 2);
+  assert.equal(summary.log.length, 2);
+  assert.deepEqual(style.bibliography['type-variants'].book, {
+    modify: [
+      { match: { title: 'primary' }, suffix: '.' },
+    ],
+  });
+  assert.deepEqual(style.bibliography['type-variants'].chapter, {
+    modify: [
+      { match: { title: 'primary' }, suffix: '!' },
+    ],
+  });
+});
+
+test('convertStyle skips extending styles to preserve inherited variant overlays', () => {
+  const style = {
+    extends: 'base-style',
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        book: [
+          { contributor: 'author' },
+          { title: 'primary', suffix: '.' },
+        ],
+      },
+    },
+  };
+
+  const summary = convertStyle(style);
+
+  assert.equal(summary.converted, 0);
+  assert.equal(summary.total, 0);
+  assert.equal(summary.log.length, 0);
+  assert.deepEqual(style.bibliography['type-variants'].book, [
+    { contributor: 'author' },
+    { title: 'primary', suffix: '.' },
+  ]);
+});
+
+test('cli summary includes scanned styles with no safe conversions', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'template-v3-'));
+  const stylePath = path.join(tmpDir, 'fallback.yaml');
+  fs.writeFileSync(stylePath, `
+bibliography:
+  template:
+    - title: primary
+  type-variants:
+    book:
+      - title: primary
+        form: short
+`);
+
+  const output = execFileSync(
+    process.execPath,
+    [path.join(__dirname, 'convert-template-v3.js'), '--json', stylePath],
+    { encoding: 'utf8' }
+  );
+  const summary = JSON.parse(output);
+
+  assert.deepEqual(summary.totals, { files: 1, converted: 0, total: 1 });
+  assert.equal(summary.summaries[0].converted, 0);
+});
+
+test('--write modifies only type-variants block, leaving other lines unchanged', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'citum-test-'));
+  const filePath = path.join(tmpDir, 'test.yaml');
+
+  const input = [
+    'info:',
+    '  title: Test Style',
+    '  categories:',
+    '    - science',
+    'options:',
+    '  initialize-with: ". "',
+    'bibliography:',
+    '  template:',
+    '    - contributor: author',
+    '    - title: primary',
+    '    - variable: publisher',
+    '    - variable: publisher-place',
+    '    - date: issued',
+    '    - number: pages',
+    '  type-variants:',
+    '    book:',
+    '      - contributor: author',
+    '      - title: primary',
+    '        suffix: .',
+    '      - variable: publisher',
+    '      - variable: publisher-place',
+    '      - date: issued',
+    '      - number: pages',
+    '    webpage:',
+    '      - contributor: author',
+    '      - title: primary',
+    '        form: short',
+    '      - variable: publisher',
+    '      - variable: publisher-place',
+    '      - date: issued',
+    '      - number: pages',
+  ].join('\n');
+
+  fs.writeFileSync(filePath, input, 'utf8');
+
+  execFileSync(process.execPath, [
+    path.join(__dirname, 'convert-template-v3.js'),
+    '--write',
+    filePath,
+  ]);
+
+  const output = fs.readFileSync(filePath, 'utf8');
+  const inputLines = input.split('\n');
+  const outputLines = output.split('\n');
+
+  // The info/options/bibliography template sections must be byte-for-byte identical
+  // Lines 0-14 (before type-variants) must be unchanged
+  for (let i = 0; i <= 14; i += 1) {
+    assert.equal(outputLines[i], inputLines[i], `Line ${i} changed unexpectedly`);
+  }
+
+  // The converted variant (book) must be in diff form
+  const bookStart = outputLines.findIndex((l) => /^\s{4}book:/.test(l));
+  assert.ok(bookStart >= 0, 'book: key must exist');
+  const bookBlock = outputLines.slice(bookStart, bookStart + 5).join('\n');
+  assert.ok(bookBlock.includes('modify:'), 'book must have modify: diff');
+
+  // The non-convertible variant (webpage) must be unchanged (still array form)
+  const webpageStart = outputLines.findIndex((l) => /^\s{4}webpage:/.test(l));
+  assert.ok(webpageStart >= 0, 'webpage: key must exist');
+  const webpageLine = outputLines[webpageStart + 1];
+  assert.ok(webpageLine.trim().startsWith('-'), 'webpage must remain as array');
+});

--- a/scripts/lib/verification-policy.js
+++ b/scripts/lib/verification-policy.js
@@ -282,9 +282,14 @@ module.exports = {
 function deepMerge(target, source) {
   if (!source || typeof source !== 'object') return target;
   if (!target || typeof target !== 'object') return source;
+  if (Array.isArray(target) || Array.isArray(source)) return source;
 
   const result = { ...target };
   for (const [key, value] of Object.entries(source)) {
+    if (key === 'type-variants') {
+      result[key] = mergeTypeVariants(result[key], value);
+      continue;
+    }
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       result[key] = deepMerge(result[key], value);
     } else {
@@ -292,6 +297,175 @@ function deepMerge(target, source) {
     }
   }
   return result;
+}
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function isTemplateVariantDiff(value) {
+  return isPlainObject(value)
+    && (
+      Object.prototype.hasOwnProperty.call(value, 'extends')
+      || Object.prototype.hasOwnProperty.call(value, 'modify')
+      || Object.prototype.hasOwnProperty.call(value, 'remove')
+      || Object.prototype.hasOwnProperty.call(value, 'add')
+    );
+}
+
+function mergeTypeVariants(target, source) {
+  if (!isPlainObject(source)) return source;
+  if (!isPlainObject(target)) return source;
+
+  const result = { ...target };
+  for (const [variantName, value] of Object.entries(source)) {
+    if (isTemplateVariantDiff(value) && target[variantName] != null && value.extends == null) {
+      result[variantName] = { ...value };
+      Object.defineProperty(result[variantName], '__baseVariant', {
+        value: cloneJson(target[variantName]),
+        enumerable: true,
+      });
+    } else {
+      result[variantName] = value;
+    }
+  }
+  return result;
+}
+
+function selectorValueMatches(expected, actual) {
+  if (Array.isArray(expected)) {
+    return Array.isArray(actual)
+      && expected.length === actual.length
+      && expected.every((item, index) => selectorValueMatches(item, actual[index]));
+  }
+  if (isPlainObject(expected)) {
+    return isPlainObject(actual)
+      && Object.entries(expected).every(([key, value]) => selectorValueMatches(value, actual[key]));
+  }
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function componentMatchesSelector(component, selector) {
+  if (!isPlainObject(component) || !isPlainObject(selector)) return false;
+  return Object.entries(selector).every(([key, expected]) => (
+    Object.prototype.hasOwnProperty.call(component, key)
+    && selectorValueMatches(expected, component[key])
+  ));
+}
+
+function findTemplateIndex(template, selector, context) {
+  const matches = [];
+  for (let index = 0; index < template.length; index += 1) {
+    if (componentMatchesSelector(template[index], selector)) {
+      matches.push(index);
+    }
+  }
+  if (matches.length !== 1) {
+    throw new Error(`${context} matched ${matches.length} template components`);
+  }
+  return matches[0];
+}
+
+function resolveTemplateVariant(variants, variantName, baseTemplate, stack = [], cache = new Map()) {
+  if (cache.has(variantName)) return cloneJson(cache.get(variantName));
+  const variant = variants[variantName];
+  if (Array.isArray(variant)) {
+    cache.set(variantName, cloneJson(variant));
+    return cloneJson(variant);
+  }
+  if (!isTemplateVariantDiff(variant)) return variant;
+  if (stack.includes(variantName)) {
+    throw new Error(`Template variant cycle: ${stack.concat(variantName).join(' -> ')}`);
+  }
+
+  let template;
+  if (variant.extends != null) {
+    const parentName = String(variant.extends);
+    if (!Object.prototype.hasOwnProperty.call(variants, parentName)) {
+      throw new Error(`Template variant ${variantName} extends missing variant ${parentName}`);
+    }
+    template = resolveTemplateVariant(
+      variants,
+      parentName,
+      baseTemplate,
+      stack.concat(variantName),
+      cache
+    );
+  } else if (variant.__baseVariant != null) {
+    template = resolveTemplateVariant(
+      { __base: variant.__baseVariant },
+      '__base',
+      baseTemplate,
+      stack.concat(variantName),
+      new Map()
+    );
+  } else {
+    template = cloneJson(baseTemplate);
+  }
+
+  for (const operation of variant.modify || []) {
+    const index = findTemplateIndex(template, operation.match, `${variantName}.modify`);
+    const rendering = { ...operation };
+    delete rendering.match;
+    template[index] = { ...template[index], ...rendering };
+  }
+
+  for (const operation of variant.remove || []) {
+    const index = findTemplateIndex(template, operation.match, `${variantName}.remove`);
+    template.splice(index, 1);
+  }
+
+  for (const operation of variant.add || []) {
+    if (!isPlainObject(operation.component)) {
+      throw new Error(`${variantName}.add requires a component`);
+    }
+    const hasBefore = isPlainObject(operation.before);
+    const hasAfter = isPlainObject(operation.after);
+    if (hasBefore === hasAfter) {
+      throw new Error(`${variantName}.add must specify exactly one of before or after`);
+    }
+    const anchor = hasBefore ? operation.before : operation.after;
+    const index = findTemplateIndex(template, anchor, `${variantName}.add`);
+    template.splice(hasBefore ? index : index + 1, 0, cloneJson(operation.component));
+  }
+
+  cache.set(variantName, cloneJson(template));
+  return cloneJson(template);
+}
+
+function resolveSectionTemplateVariants(section) {
+  if (!isPlainObject(section)) return;
+  const variants = section['type-variants'];
+  if (isPlainObject(variants)) {
+    const baseTemplate = Array.isArray(section.template) ? section.template : [];
+    const resolvedVariants = {};
+    const cache = new Map();
+    for (const variantName of Object.keys(variants)) {
+      resolvedVariants[variantName] = resolveTemplateVariant(
+        variants,
+        variantName,
+        baseTemplate,
+        [],
+        cache
+      );
+    }
+    section['type-variants'] = resolvedVariants;
+  }
+
+  for (const childKey of ['integral', 'non-integral', 'subsequent', 'ibid']) {
+    resolveSectionTemplateVariants(section[childKey]);
+  }
+}
+
+function resolveTemplateVariantDiffs(styleData) {
+  if (!isPlainObject(styleData)) return styleData;
+  resolveSectionTemplateVariants(styleData.citation);
+  resolveSectionTemplateVariants(styleData.bibliography);
+  return styleData;
 }
 
 const STYLE_BASES = {
@@ -419,7 +593,7 @@ function localStyleOverlay(styleData) {
  */
 function resolveStyleData(styleData, visited = new Set()) {
   const baseSpec = styleData?.extends;
-  let resolved = styleData;
+  let resolved = cloneJson(styleData);
 
   if (baseSpec) {
     const baseKey = typeof baseSpec === 'string' ? baseSpec : baseSpec.extends;
@@ -447,6 +621,7 @@ function resolveStyleData(styleData, visited = new Set()) {
   if (resolved.bibliography) {
     resolved.bibliography = resolveTemplatePresets(resolved.bibliography, resolved);
   }
+  resolveTemplateVariantDiffs(resolved);
 
   return resolved;
 }

--- a/scripts/oracle-yaml.test.js
+++ b/scripts/oracle-yaml.test.js
@@ -10,7 +10,7 @@ const {
   shouldUseStructuredOracle,
 } = require('./oracle-yaml');
 const { resolveYamlVerificationPlan } = require('./lib/style-verification');
-const { resolveStyleData } = require('./lib/verification-policy');
+const { deepMerge, resolveStyleData } = require('./lib/verification-policy');
 
 function planFor(styleFile, overrides = {}) {
   const isEmbedded = [
@@ -121,6 +121,166 @@ test('resolveStyleData deep-merges preset wrappers with local overrides', () => 
     resolved.bibliography['type-variants']['motion-picture'][4].prefix,
     'Directed by '
   );
+});
+
+test('resolveStyleData resolves Template V3 diff type variants', () => {
+  const resolved = resolveStyleData({
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+        { variable: 'publisher' },
+      ],
+      'type-variants': {
+        book: {
+          modify: [
+            { match: { title: 'primary' }, prefix: 'In ' },
+          ],
+          remove: [
+            { match: { variable: 'publisher' } },
+          ],
+          add: [
+            { after: { title: 'primary' }, component: { date: 'issued', form: 'year' } },
+          ],
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(resolved.bibliography['type-variants'].book, [
+    { contributor: 'author' },
+    { title: 'primary', prefix: 'In ' },
+    { date: 'issued', form: 'year' },
+  ]);
+});
+
+test('resolveStyleData matches Template V3 grouped selectors recursively', () => {
+  const group = [
+    { number: 'citation-number', wrap: { punctuation: 'brackets' } },
+    { contributor: 'author', form: 'long' },
+  ];
+  const resolved = resolveStyleData({
+    bibliography: {
+      template: [
+        { delimiter: '', group },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        book: {
+          modify: [
+            { match: { group }, suffix: '.' },
+          ],
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(resolved.bibliography['type-variants'].book, [
+    { delimiter: '', group, suffix: '.' },
+    { title: 'primary' },
+  ]);
+});
+
+test('resolveStyleData lets child diff variants inherit same-key parent variants', () => {
+  const merged = deepMerge(
+    {
+      bibliography: {
+        template: [
+          { contributor: 'author' },
+          { title: 'primary' },
+        ],
+        'type-variants': {
+          book: [
+            { contributor: 'editor' },
+            { title: 'primary' },
+          ],
+        },
+      },
+    },
+    {
+      bibliography: {
+        'type-variants': {
+          book: {
+            modify: [
+              { match: { title: 'primary' }, suffix: '.' },
+            ],
+          },
+        },
+      },
+    }
+  );
+
+  const resolved = resolveStyleData(merged);
+
+  assert.deepEqual(resolved.bibliography['type-variants'].book, [
+    { contributor: 'editor' },
+    { title: 'primary', suffix: '.' },
+  ]);
+});
+
+test('resolveStyleData lets child diff variants inherit same-key parent diffs', () => {
+  const merged = deepMerge(
+    {
+      bibliography: {
+        template: [
+          { contributor: 'author' },
+          { title: 'primary' },
+          { variable: 'publisher' },
+        ],
+        'type-variants': {
+          book: {
+            remove: [
+              { match: { variable: 'publisher' } },
+            ],
+          },
+        },
+      },
+    },
+    {
+      bibliography: {
+        'type-variants': {
+          book: {
+            modify: [
+              { match: { title: 'primary' }, suffix: '.' },
+            ],
+          },
+        },
+      },
+    }
+  );
+
+  const resolved = resolveStyleData(merged);
+
+  assert.deepEqual(resolved.bibliography['type-variants'].book, [
+    { contributor: 'author' },
+    { title: 'primary', suffix: '.' },
+  ]);
+});
+
+test('resolveStyleData does not mutate authored type variant diffs', () => {
+  const style = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        book: {
+          modify: [
+            { match: { title: 'primary' }, suffix: '.' },
+          ],
+        },
+      },
+    },
+  };
+
+  resolveStyleData(style);
+
+  assert.deepEqual(style.bibliography['type-variants'].book, {
+    modify: [
+      { match: { title: 'primary' }, suffix: '.' },
+    ],
+  });
 });
 
 test('oracle-yaml sums component summary counts across structured family runs', () => {

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -244,6 +244,10 @@ function hashContent(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
 }
 
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
 function hashFile(filePath) {
   return hashContent(fs.readFileSync(filePath));
 }
@@ -506,7 +510,7 @@ function discoverCoreStyles(provenanceConfig = loadReportProvenance()) {
 
     try {
       rawStyleData = yaml.load(fs.readFileSync(stylePath, 'utf8'));
-      styleData = resolveStyleData(rawStyleData);
+      styleData = resolveStyleData(cloneJson(rawStyleData));
     } catch {
       rawStyleData = null;
       styleData = null;
@@ -1577,7 +1581,7 @@ function loadStyleYaml(styleName, stylePathOverride = null) {
     return {
       stylePath,
       rawStyleData,
-      resolvedStyleData: resolveStyleData(rawStyleData),
+      resolvedStyleData: resolveStyleData(cloneJson(rawStyleData)),
       error: null,
     };
   } catch (error) {
@@ -1641,10 +1645,11 @@ function collectTemplateScopes(styleData) {
 
   function addVariantScopes(prefix, variants, kind) {
     for (const [rawKey, template] of Object.entries(variants || {})) {
-      if (!Array.isArray(template)) continue;
+      const components = Array.isArray(template) ? template : templateVariantAuthoredComponents(template);
+      if (!Array.isArray(components)) continue;
       const typeSelectors = parseOverrideKey(rawKey).filter((key) => key !== 'default');
       variantSelectorCount += typeSelectors.length || 1;
-      addScope(`${prefix}.${rawKey}`, template, {
+      addScope(`${prefix}.${rawKey}`, components, {
         kind,
         typeSelectors,
         typeSelectorCount: typeSelectors.length || 1,
@@ -1672,6 +1677,25 @@ function collectTemplateScopes(styleData) {
   }
 
   return { scopes, variantSelectorCount };
+}
+
+function templateVariantAuthoredComponents(variant) {
+  if (!variant || typeof variant !== 'object' || Array.isArray(variant)) return null;
+  const components = [];
+  for (const operation of variant.modify || []) {
+    const component = { ...(operation.match || {}) };
+    for (const [key, value] of Object.entries(operation)) {
+      if (key !== 'match') component[key] = value;
+    }
+    components.push(component);
+  }
+  for (const operation of variant.remove || []) {
+    components.push({ ...(operation.match || {}), suppress: true });
+  }
+  for (const operation of variant.add || []) {
+    if (operation.component) components.push(operation.component);
+  }
+  return components.length > 0 ? components : null;
 }
 
 function parseOverrideKey(rawKey) {
@@ -2102,6 +2126,14 @@ function computePresetUsageScore(styleData, concisionScore) {
   };
 }
 
+function selectQualityAuthorshipData(authoredStyleData, effectiveStyleData) {
+  const authoredScopes = collectTemplateScopes(authoredStyleData).scopes;
+  if (authoredScopes.length === 0 && effectiveStyleData) {
+    return effectiveStyleData;
+  }
+  return authoredStyleData || effectiveStyleData;
+}
+
 function computeQualityMetrics(styleSpec, oracleResult, styleYamlPath = null) {
   const loaded = loadStyleYaml(styleSpec.name, styleYamlPath);
   if (!loaded.resolvedStyleData) {
@@ -2119,10 +2151,11 @@ function computeQualityMetrics(styleSpec, oracleResult, styleYamlPath = null) {
 
   const authoredStyleData = loaded.rawStyleData || loaded.resolvedStyleData;
   const effectiveStyleData = loaded.resolvedStyleData;
+  const qualityAuthorshipData = selectQualityAuthorshipData(authoredStyleData, effectiveStyleData);
   const typeCoverage = computeTypeCoverageScore(oracleResult.citationsByType || {});
   let fallbackRobustness = computeFallbackRobustness(effectiveStyleData);
-  const concision = computeConcisionScore(effectiveStyleData, styleSpec.format);
-  const presetUsage = computePresetUsageScore(authoredStyleData, concision.score);
+  const concision = computeConcisionScore(qualityAuthorshipData, styleSpec.format);
+  const presetUsage = computePresetUsageScore(qualityAuthorshipData, concision.score);
   const weights = {
     typeCoverage: 0.35,
     fallbackRobustness: 0.25,
@@ -3658,6 +3691,7 @@ module.exports = {
   mergeOracleResults,
   toPublishedBenchmarkRunRecord,
   determineBenchmarkStatus,
+  selectQualityAuthorshipData,
   selectPrimaryComparator,
   serializeTimingSummary,
   textSimilarity,

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const {
   validateVerificationPolicy,
   resolveRegisteredDivergence,
+  resolveStyleData,
   loadVerificationPolicy,
   resolveVerificationPolicy,
   resolveScopeAuthority,
@@ -40,6 +41,7 @@ const {
   resolveSelectedStyles,
   runCachedJsonJob,
   selectPrimaryComparator,
+  selectQualityAuthorshipData,
   toPublishedBenchmarkRunRecord,
   determineBenchmarkStatus,
 } = require('./report-core');
@@ -168,6 +170,63 @@ test('collectTemplateScopes includes type-variants and type-templates', () => {
   assert.equal(variantSelectorCount, 4);
 });
 
+test('collectTemplateScopes includes resolved Template V3 diff variants', () => {
+  const { scopes, variantSelectorCount } = collectTemplateScopes(
+    resolveStyleData({
+      bibliography: {
+        template: [
+          { contributor: 'author' },
+          { title: 'primary' },
+        ],
+        'type-variants': {
+          book: {
+            modify: [
+              { match: { title: 'primary' }, suffix: '.' },
+            ],
+          },
+        },
+      },
+    })
+  );
+
+  assert.equal(scopes.some((scope) => scope.name === 'bibliography.type-variants.book'), true);
+  assert.equal(variantSelectorCount, 1);
+});
+
+test('collectTemplateScopes scores authored Template V3 diff components', () => {
+  const { scopes, variantSelectorCount } = collectTemplateScopes({
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        book: {
+          modify: [
+            { match: { title: 'primary' }, suffix: '.' },
+          ],
+          remove: [
+            { match: { contributor: 'author' } },
+          ],
+          add: [
+            { after: { title: 'primary' }, component: { date: 'issued', form: 'year' } },
+          ],
+        },
+      },
+    },
+  });
+
+  const scope = scopes.find((candidate) => candidate.name === 'bibliography.type-variants.book');
+
+  assert.equal(Boolean(scope), true);
+  assert.deepEqual(scope.components, [
+    { title: 'primary', suffix: '.' },
+    { contributor: 'author', suppress: true },
+    { date: 'issued', form: 'year' },
+  ]);
+  assert.equal(variantSelectorCount, 1);
+});
+
 test('computeConcisionScore penalizes duplicate-heavy type-variant structures', () => {
   const duplicatedStyle = {
     citation: {
@@ -225,6 +284,43 @@ test('computeConcisionScore rewards preset-backed compact structures', () => {
   assert.equal(score.variantSelectors, 0);
   assert.equal(score.exactDuplicateScopes, 0);
   assert.ok(score.score >= 90, `expected concision >= 90, got ${score.score}`);
+});
+
+test('selectQualityAuthorshipData falls back for inherited wrapper styles', () => {
+  const authored = {
+    extends: 'apa-7th',
+  };
+  const resolved = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+    },
+  };
+
+  assert.equal(selectQualityAuthorshipData(authored, resolved), resolved);
+});
+
+test('selectQualityAuthorshipData keeps authored Template V3 diff scopes', () => {
+  const authored = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        book: {
+          modify: [
+            { match: { title: 'primary' }, suffix: '.' },
+          ],
+        },
+      },
+    },
+  };
+  const resolved = resolveStyleData(authored);
+
+  assert.equal(selectQualityAuthorshipData(authored, resolved), authored);
 });
 
 test('apa-7th concision regression reflects preset-first success', () => {

--- a/scripts/style-structure-lint.test.js
+++ b/scripts/style-structure-lint.test.js
@@ -150,6 +150,41 @@ bibliography:
   assert.equal(violations.some((violation) => violation.ruleId === 'STYLE004'), true);
 });
 
+test('STYLE004 skips Template V3 diff variants', () => {
+  const content = `version: ""
+bibliography:
+  template:
+    - contributor: author
+    - title: primary
+  type-variants:
+    article-journal:
+      modify:
+        - match:
+            title: primary
+          suffix: "."
+`;
+  const data = {
+    version: '',
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        'article-journal': {
+          modify: [
+            { match: { title: 'primary' }, suffix: '.' },
+          ],
+        },
+      },
+    },
+  };
+
+  const violations = lintParsedStyle('styles/fixture.yaml', content, data);
+
+  assert.equal(violations.some((violation) => violation.ruleId === 'STYLE004'), false);
+});
+
 test('applyFixes removes inert substitute overrides, hoists shorten config, and drops duplicate variants', () => {
   const style = {
     version: '',

--- a/styles/acm-sig-proceedings.yaml
+++ b/styles/acm-sig-proceedings.yaml
@@ -181,24 +181,17 @@ bibliography:
       suffix: ". "
     - variable: publisher
     report:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-      suffix: " "
-    - date: issued
-      form: year
-      suffix: ". "
-    - title: primary
-      emph: true
-      suffix: ". "
-    - variable: number
-      prefix: "Technical Report #"
-      suffix: ". "
-    - variable: publisher
+      extends: thesis
+      remove:
+        - match:
+            variable: archive-location
+      add:
+        - component:
+            variable: number
+            prefix: 'Technical Report #'
+            suffix: '. '
+          before:
+            variable: publisher
     webpage:
     - number: citation-number
       wrap:
@@ -241,18 +234,7 @@ bibliography:
       suffix: ". "
     - number: pages
     book:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-      suffix: " "
-    - date: issued
-      form: year
-      suffix: ". "
-    - title: primary
-      emph: true
-      suffix: ". "
-    - variable: publisher
+      extends: thesis
+      remove:
+        - match:
+            variable: archive-location

--- a/styles/african-online-scientific-information-systems-harvard.yaml
+++ b/styles/african-online-scientific-information-systems-harvard.yaml
@@ -102,26 +102,10 @@ bibliography:
     separator: ", "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/african-online-scientific-information-systems-vancouver.yaml
+++ b/styles/african-online-scientific-information-systems-vancouver.yaml
@@ -60,58 +60,32 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/aims-press.yaml
+++ b/styles/aims-press.yaml
@@ -46,36 +46,31 @@ bibliography:
     separator: ", "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-    - number: pages
-      prefix: ": "
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
   template:
   - contributor: author
     form: long

--- a/styles/alpha.yaml
+++ b/styles/alpha.yaml
@@ -73,39 +73,18 @@ bibliography:
     - number: pages
       prefix: ' '
     chapter:
-    - number: citation-label
-      wrap:
-        punctuation: brackets
-      suffix: ' '
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - variable: publisher-place
-    - number: volume
-    - number: pages
-      prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - number: citation-label
-      wrap:
-        punctuation: brackets
-      suffix: ' '
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-    - number: pages
-      prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - number: citation-label
     wrap:

--- a/styles/american-association-for-cancer-research.yaml
+++ b/styles/american-association-for-cancer-research.yaml
@@ -48,141 +48,43 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/american-chemical-society.yaml
+++ b/styles/american-chemical-society.yaml
@@ -48,136 +48,35 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+      add:
+        - component:
+            prefix: ', '
+            group:
+              - number: volume
+          before:
+            number: pages
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     patent:
     - number: citation-number
       wrap:

--- a/styles/american-fisheries-society.yaml
+++ b/styles/american-fisheries-society.yaml
@@ -98,28 +98,10 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: pages
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      prefix: "in "
-    - variable: publisher
-      prefix: ", editor. "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
+      modify:
+        - match:
+            contributor: editor
+          prefix: 'in '
     legal_case:
     - contributor: author
       form: long
@@ -150,22 +132,18 @@ bibliography:
     - variable: publisher
     - variable: publisher-place
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      sort-separator: ", "
-      and: text
-    - date: issued
-      form: year
-    - term: no-date
-      form: short
-      wrap:
-        punctuation: parentheses
-        inner-prefix: " "
-        inner-suffix: .
-    - title: primary
-    - variable: genre
-    - variable: publisher
-    - variable: publisher-place
+      extends: legal_case
+      remove:
+        - match:
+            variable: authority
+        - match:
+            contributor: editor
+        - match:
+            title: parent-serial
+        - match:
+            number: edition
+        - match:
+            term: edition
   template:
   - contributor: author
     form: long

--- a/styles/american-geophysical-union.yaml
+++ b/styles/american-geophysical-union.yaml
@@ -57,14 +57,10 @@ citation:
       delimiter: ', '
   type-variants:
     personal_communication:
-      - contributor: author
-        form: short
-        prefix: 'pp. '
-      - date: issued
-        form: year
-        prefix: ', '
-      - variable: locator
-        prefix: ', '
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
   template:
     - contributor: author
       form: short
@@ -95,192 +91,54 @@ bibliography:
     separator: '. '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - date: issued
-        form: year
-        prefix: ' '
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: ', '
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-        prefix: https://doi.org/
-      - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: ', '
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: ', '
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
     broadcast:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: ', '
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - date: issued
-        form: year
-        prefix: ' '
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            prefix: 'In '
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: 'pp. '
-        wrap:
-          punctuation: parentheses
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+          wrap:
+            punctuation: parentheses
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            prefix: '. In '
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'In '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     entry-encyclopedia:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - date: issued
-        form: year
-        prefix: ' '
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: 'pp. '
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     interview:
       - contributor: author
         form: long
@@ -299,39 +157,12 @@ bibliography:
       - variable: url
         prefix: '. Retrieved from '
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - date: issued
-        form: year
-        prefix: ' '
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: 'pp. '
-        wrap:
-          punctuation: parentheses
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+          wrap:
+            punctuation: parentheses
     patent:
       - contributor: author
         form: long
@@ -345,34 +176,9 @@ bibliography:
       - number: patent-number
         prefix: '. '
     personal_communication:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 6
-      - title: primary
-      - prefix: '. In '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - number: pages
-        prefix: ', '
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
   template:
     - contributor: author
       form: long

--- a/styles/american-institute-of-physics.yaml
+++ b/styles/american-institute-of-physics.yaml
@@ -43,51 +43,15 @@ bibliography:
     separator: ", "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
     - number: citation-number
     - contributor: author
@@ -98,28 +62,10 @@ bibliography:
     - term: no-date
       form: short
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      prefix: "pp. "
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/american-meteorological-society.yaml
+++ b/styles/american-meteorological-society.yaml
@@ -90,27 +90,10 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-      prefix: ": "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: ". "
-    - number: volume
-    - number: pages
-    - variable: doi
-      prefix: https://doi.org/
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
   template:
   - contributor: author
     form: long

--- a/styles/american-physics-society.yaml
+++ b/styles/american-physics-society.yaml
@@ -42,96 +42,34 @@ bibliography:
     separator: ", "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-      emph: true
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-    - variable: url
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     dataset:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-      emph: true
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-    - variable: url
-    - number: pages
-      prefix: "), "
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-      emph: true
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-    - variable: url
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     interview:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-      emph: true
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-    - variable: url
-    - number: pages
-      prefix: "), "
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-      emph: true
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-    - variable: url
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      prefix: "pp. "
-    - title: primary
-      emph: true
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-    - variable: url
-    - number: pages
-      prefix: "), "
+      extends: dataset
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
     software:
     - number: citation-number
       wrap:

--- a/styles/american-physiological-society.yaml
+++ b/styles/american-physiological-society.yaml
@@ -42,81 +42,19 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/american-society-for-microbiology.yaml
+++ b/styles/american-society-for-microbiology.yaml
@@ -47,45 +47,18 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: pages
-      prefix: "pp. "
-    - contributor: editor
-      form: verb
-      name-order: family-first
-      prefix: "In "
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+        - match:
+            contributor: editor
+          prefix: 'In '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: pages
-      prefix: "pp. "
-    - contributor: editor
-      form: verb
-      name-order: family-first
-      prefix: ". In "
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
     - number: citation-number
       suffix: ". "
@@ -109,32 +82,22 @@ bibliography:
     - variable: publisher
     - variable: publisher-place
     webpage:
-    - number: citation-number
-      suffix: ". "
-    - contributor: author
-      form: long
-      sort-separator: " "
-    - date: issued
-      form: year
-    - title: primary
-    - variable: version
-      wrap:
-        punctuation: parentheses
-    - number: number
-      prefix: ". "
-    - title: parent-serial
-      prefix: ". "
-    - number: edition
-    - term: edition
-      form: short
-    - variable: genre
-    - variable: publisher
-    - variable: publisher-place
-    - variable: url
-    - term: retrieved
-      form: long
-    - date: accessed
-      form: year
+      extends: patent
+      add:
+        - component:
+            variable: url
+          after:
+            variable: publisher-place
+        - component:
+            term: retrieved
+            form: long
+          after:
+            variable: url
+        - component:
+            date: accessed
+            form: year
+          after:
+            term: retrieved
   template:
   - contributor: author
     form: long

--- a/styles/american-society-of-civil-engineers.yaml
+++ b/styles/american-society-of-civil-engineers.yaml
@@ -80,55 +80,22 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
-      prefix: https://doi.org/
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            number: pages
   template:
   - contributor: author
     form: long

--- a/styles/american-sociological-association.yaml
+++ b/styles/american-sociological-association.yaml
@@ -92,80 +92,29 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            number: pages
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/american-statistical-association.yaml
+++ b/styles/american-statistical-association.yaml
@@ -101,111 +101,24 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: doi
-      prefix: https://doi.org/
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: issue
-    - number: pages
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: doi
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: doi
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: issue
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: doi
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: issue
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/angewandte-chemie.yaml
+++ b/styles/angewandte-chemie.yaml
@@ -67,18 +67,14 @@ bibliography:
     - number: pages
       prefix: "pp. "
     paper-conference:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      prefix: " in "
-    - date: issued
-      form: year
-    - number: pages
-      prefix: "pp. "
+      extends: chapter
+      remove:
+        - match:
+            contributor: editor
+        - match:
+            variable: publisher
+        - match:
+            variable: publisher-place
     article-journal:
     - number: citation-number
       wrap:
@@ -95,46 +91,30 @@ bibliography:
     - variable: doi
       prefix: "DOI "
     article-newspaper:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-serial
-    - date: issued
-      form: year
-      prefix: " "
+      extends: article-journal
+      remove:
+        - match:
+            number: volume
+        - match:
+            number: pages
+        - match:
+            variable: doi
     article-magazine:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-serial
-    - date: issued
-      form: year
-      prefix: " "
-    - number: volume
-    - number: pages
+      extends: article-journal
+      remove:
+        - match:
+            variable: doi
     entry-encyclopedia:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      prefix: " in "
-    - number: volume
-      prefix: "Vol. "
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-    - number: pages
-      prefix: "pp. "
+      extends: chapter
+      remove:
+        - match:
+            contributor: editor
+      add:
+        - component:
+            number: volume
+            prefix: 'Vol. '
+          before:
+            variable: publisher
     thesis:
     - number: citation-number
       wrap:
@@ -161,25 +141,25 @@ bibliography:
     - date: issued
       form: year
     personal_communication:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-    - date: issued
-      form: year
+      extends: thesis
+      remove:
+        - match:
+            variable: genre
+      add:
+        - component:
+            title: primary
+          before:
+            date: issued
     personal-communication:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-    - date: issued
-      form: year
+      extends: thesis
+      remove:
+        - match:
+            variable: genre
+      add:
+        - component:
+            title: primary
+          before:
+            date: issued
     webpage:
     - number: citation-number
       wrap:

--- a/styles/annual-reviews-alphabetical.yaml
+++ b/styles/annual-reviews-alphabetical.yaml
@@ -55,136 +55,70 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - number: volume
-    - variable: publisher-place
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            variable: publisher-place
     book:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: pages
-    - variable: publisher
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     film:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - number: pages
-    - variable: publisher
+      remove:
+        - match:
+            title: parent-serial
     legal-case:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+        - match:
+            number: pages
+      add:
+        - component:
+            group:
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+          before:
+            variable: publisher-place
     patent:
     - number: citation-number
       suffix: ". "

--- a/styles/annual-reviews-author-date.yaml
+++ b/styles/annual-reviews-author-date.yaml
@@ -107,119 +107,53 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            number: pages
     book:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/annual-reviews.yaml
+++ b/styles/annual-reviews.yaml
@@ -52,89 +52,48 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            variable: publisher-place
     book:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
     - number: citation-number
       suffix: ". "

--- a/styles/association-for-computing-machinery.yaml
+++ b/styles/association-for-computing-machinery.yaml
@@ -36,53 +36,30 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-      prefix: ", "
-    - number: volume
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     book:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: publisher-place
-      prefix: ", "
-    - number: volume
-    - variable: url
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     patent:
     - contributor: author
       form: long

--- a/styles/baishideng-publishing-group.yaml
+++ b/styles/baishideng-publishing-group.yaml
@@ -57,154 +57,47 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: doi
-      prefix: . [
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: ": "
-    - variable: doi
-      prefix: . [
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
+      extends: article-journal
+      remove:
+        - match:
+            number: issue
     book:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: doi
-      prefix: . [
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: doi
-      prefix: . [
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
+      extends: article-journal
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: doi
-      prefix: . [
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
+      remove:
+        - match:
+            date: issued
     motion_picture:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: doi
-      prefix: . [
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/begell-house-chicago-author-date.yaml
+++ b/styles/begell-house-chicago-author-date.yaml
@@ -89,78 +89,24 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: doi
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - date: issued
-      form: year
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: doi
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - date: issued
-      form: year
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: doi
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - date: issued
-      form: year
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: doi
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - date: issued
-      form: year
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     legal_case:
     - contributor: author
       form: long
@@ -218,32 +164,17 @@ bibliography:
     - term: no-date
       form: short
     personal_communication:
-    - contributor: author
-      form: long
-      sort-separator: ", "
-      shorten:
-        min: 11
-        use-first: 7
-        and-others: et-al
-        delimiter-precedes-last: always
-      and: text
-    - variable: genre
-    - contributor: recipient
-      form: long
-      delimiter: ", "
-      shorten:
-        min: 11
-        use-first: 7
-        and-others: et-al
-        delimiter-precedes-last: contextual
-      and: text
-    - title: primary
-    - title: parent-serial
-      emph: true
-    - date: issued
-      form: full
-    - term: no-date
-      form: short
+      extends: patent
+      remove:
+        - match:
+            number: number
+        - match:
+            term: and
+      add:
+        - component:
+            variable: genre
+          before:
+            contributor: recipient
   template:
   - contributor: author
     form: long

--- a/styles/biomed-central.yaml
+++ b/styles/biomed-central.yaml
@@ -47,129 +47,50 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - number: pages
-      prefix: ":"
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: doi
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - number: pages
-      prefix: ":"
-    - variable: doi
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
     - contributor: author
       form: long

--- a/styles/bmj.yaml
+++ b/styles/bmj.yaml
@@ -83,32 +83,11 @@ bibliography:
       prefix: " (accessed "
       suffix: ")"
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: doi
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
+        - match:
+            number: issue
     chapter:
     - contributor: author
       form: long
@@ -140,34 +119,9 @@ bibliography:
     - variable: publisher
       prefix: ": "
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - number: pages
-      prefix: ":"
-    - variable: doi
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/canadian-journal-of-fisheries-and-aquatic-sciences.yaml
+++ b/styles/canadian-journal-of-fisheries-and-aquatic-sciences.yaml
@@ -96,57 +96,15 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-      prefix: ", "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-      prefix: ", "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/cell.yaml
+++ b/styles/cell.yaml
@@ -55,96 +55,24 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ", "
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: publisher
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     dataset:
     - contributor: author
       form: long

--- a/styles/chem-acs.yaml
+++ b/styles/chem-acs.yaml
@@ -51,269 +51,64 @@ bibliography:
       collapse-subentries: true
   type-variants:
     article-journal:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: true
-      prefix: " In "
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - contributor: editor
-      form: long
-      name-order: family-first
-      suffix: ", Eds."
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: " "
-    - prefix: ", "
-      group:
-      - number: volume
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: url
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+      add:
+        - component:
+            prefix: ', '
+            group:
+              - number: volume
+          before:
+            number: pages
     article-magazine:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: true
-      prefix: " In "
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - contributor: editor
-      form: long
-      name-order: family-first
-      suffix: ", Eds."
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: " "
-    - prefix: ", "
-      group:
-      - number: volume
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: url
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+      add:
+        - component:
+            prefix: ', '
+            group:
+              - number: volume
+          before:
+            number: pages
     book:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: true
-      prefix: " In "
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - contributor: editor
-      form: long
-      name-order: family-first
-      suffix: ", Eds."
-      prefix: "; "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: url
+      modify:
+        - match:
+            contributor: editor
+          prefix: '; '
+          suffix: ', Eds.'
+        - match:
+            date: issued
+          prefix: ', '
     chapter:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: true
-      prefix: " In "
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - contributor: editor
-      form: long
-      name-order: family-first
-      suffix: ", Eds."
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ": "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: url
+      modify:
+        - match:
+            date: issued
+          prefix: ': '
+        - match:
+            number: pages
+          prefix: ', pp '
     paper-conference:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: true
-      prefix: " In "
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - contributor: editor
-      form: long
-      name-order: family-first
-      suffix: ", Eds."
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: url
+      extends: chapter
+      modify:
+        - match:
+            date: issued
+          prefix: ', '
     report:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: true
-      prefix: " In "
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - contributor: editor
-      form: long
-      name-order: family-first
-      suffix: ", Eds."
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: url
+      modify:
+        - match:
+            date: issued
+          prefix: ', '
     thesis:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: true
-      prefix: " In "
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - contributor: editor
-      form: long
-      name-order: family-first
-      suffix: ", Eds."
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: url
+      modify:
+        - match:
+            date: issued
+          prefix: ', '
     patent:
     - number: citation-number
       wrap:

--- a/styles/chem-biochem.yaml
+++ b/styles/chem-biochem.yaml
@@ -48,110 +48,24 @@ bibliography:
       subentry: true
   type-variants:
     article-journal:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-      suffix: "."
-    - title: primary
-      prefix: " "
-      suffix: "."
-    - title: parent-serial
-      emph: true
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-      prefix: ", in "
-    - contributor: editor
-      form: short
-      name-order: given-first
-      prefix: " ("
-      suffix: ")"
-    - number: edition
-      prefix: ", "
-    - number: volume
-      emph: true
-      prefix: " "
-    - number: pages
-      prefix: ", "
+      modify:
+        - match:
+            title: primary
+          prefix: ' '
+          suffix: .
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: publisher-place
     book:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-      suffix: "."
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-      prefix: ", in "
-    - contributor: editor
-      form: short
-      name-order: given-first
-      prefix: " ("
-      suffix: ")"
-    - number: edition
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ", "
-    - number: volume
-      emph: true
-      prefix: " "
-    - number: pages
-      prefix: ", "
+      remove:
+        - match:
+            title: parent-serial
     chapter:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-      suffix: "."
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-      prefix: ", in "
-    - contributor: editor
-      form: short
-      name-order: given-first
-      prefix: " ("
-      suffix: ")"
-    - number: edition
-      prefix: ", "
-    - variable: publisher
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ", "
-    - number: volume
-      emph: true
-      prefix: " "
-    - number: pages
-      prefix: ", "
+      remove:
+        - match:
+            title: parent-serial
     thesis:
     - number: citation-number
       wrap:
@@ -168,22 +82,13 @@ bibliography:
       form: year
       prefix: ", "
     report:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - variable: genre
-      prefix: ", "
-    - variable: publisher-place
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
+      extends: thesis
+      add:
+        - component:
+            variable: publisher-place
+            prefix: ', '
+          before:
+            date: issued
   template:
   - number: citation-number
     wrap:

--- a/styles/chem-rsc.yaml
+++ b/styles/chem-rsc.yaml
@@ -56,193 +56,55 @@ bibliography:
       collapse-subentries: true
   type-variants:
     article-journal:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      prefix: ", "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: doi
+        - match:
+            variable: publisher-place
     article-magazine:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      prefix: ", "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: doi
+        - match:
+            variable: publisher-place
     article-newspaper:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      prefix: ", "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: doi
+        - match:
+            variable: publisher-place
     book:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: primary
-      wrap:
-        punctuation: quotes
-      quote: false
-    - title: parent-monograph
-      prefix: ", "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: publisher
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            title: primary
+          quote: false
+          wrap:
+            punctuation: quotes
     chapter:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: parent-monograph
-      prefix: "in "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: publisher
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            title: parent-monograph
+          prefix: 'in '
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            title: primary
     entry-encyclopedia:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: parent-monograph
-      prefix: "in "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: publisher
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            title: parent-monograph
+          prefix: 'in '
+      remove:
+        - match:
+            title: primary
     legal_case:
     - number: citation-number
       wrap:
@@ -259,108 +121,23 @@ bibliography:
     - date: issued
       form: year
     motion_picture:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: primary
-      wrap:
-        punctuation: quotes
-      quote: false
-    - title: parent-monograph
-      prefix: ", "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: publisher
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            title: primary
+          quote: false
+          wrap:
+            punctuation: quotes
     paper-conference:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: parent-monograph
-      prefix: ", "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: publisher
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: publisher-place
-      prefix: ", "
+      extends: chapter
+      modify:
+        - match:
+            title: parent-monograph
+          prefix: ', '
     report:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-      suffix: " "
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-    - title: primary
-      wrap:
-        punctuation: quotes
-      quote: false
-    - title: parent-monograph
-      prefix: ", "
-    - title: parent-serial
-      prefix: ", "
-    - contributor: editor
-      form: long
-      name-order: given-first
-      and: text
-      prefix: ", ed. "
-    - variable: genre
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: volume
-      prefix: ", "
-    - number: pages
-    - variable: doi
-      prefix: ", DOI: "
-    - variable: publisher-place
-      prefix: ", "
+      extends: book
+      remove:
+        - match:
+            variable: publisher
     thesis:
     - number: citation-number
       wrap:

--- a/styles/chicago-author-date-classic.yaml
+++ b/styles/chicago-author-date-classic.yaml
@@ -64,14 +64,9 @@ citation:
         delimiter-precedes-last: contextual
   type-variants:
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 3
-        use-first: 1
-    - variable: locator
-      prefix: " "
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long
@@ -102,63 +97,23 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - prefix: ") "
-      group:
-      - number: volume
-      - number: issue
-    - number: pages
-      prefix: ": "
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - prefix: ") "
-      group:
-      - number: volume
-    - number: pages
-      prefix: ": "
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+      add:
+        - component:
+            prefix: ') '
+            group:
+              - number: volume
+          before:
+            number: pages
     legal_case:
     - title: primary
     - variable: authority

--- a/styles/chicago-notes-bibliography-17th-edition.yaml
+++ b/styles/chicago-notes-bibliography-17th-edition.yaml
@@ -76,11 +76,9 @@ citation:
         name-form: family-only
     type-variants:
       default:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
+        remove:
+          - match:
+              variable: locator
     template:
     - contributor: author
       form: short
@@ -91,88 +89,14 @@ citation:
       prefix: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - number: pages
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: https://doi.org/
-    - number: number
-      prefix: ", Patent "
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     default:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - number: pages
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
+      remove:
+        - match:
+            number: number
   template:
   - contributor: author
     form: long
@@ -232,30 +156,10 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first-only
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-      prefix: " "
-    - number: pages
-      prefix: ": "
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
   template:
   - contributor: author
     form: long

--- a/styles/chicago-notes-bibliography-classic-archive-place-first-no-url.yaml
+++ b/styles/chicago-notes-bibliography-classic-archive-place-first-no-url.yaml
@@ -73,11 +73,9 @@ citation:
         name-form: family-only
     type-variants:
       default:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
+        remove:
+          - match:
+              variable: locator
     template:
     - contributor: author
       form: short
@@ -88,53 +86,13 @@ citation:
       prefix: ", "
   type-variants:
     default:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 3
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: ": "
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
-    - delimiter: none
-      prefix: ", "
-      group:
-      - date: issued
-        form: month-day
-      - date: issued
-        form: year
-        prefix: ", "
+      remove:
+        - match:
+            number: number
+        - match:
+            variable: medium
+        - match:
+            contributor: interviewer
   template:
   - contributor: author
     form: long

--- a/styles/chicago-notes-classic-archive-place-first.yaml
+++ b/styles/chicago-notes-classic-archive-place-first.yaml
@@ -70,11 +70,9 @@ citation:
         name-form: family-only
     type-variants:
       default:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
+        remove:
+          - match:
+              variable: locator
     template:
     - contributor: author
       form: short
@@ -85,82 +83,14 @@ citation:
       prefix: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - number: pages
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: https://doi.org/
-    - number: number
-      prefix: ", Patent "
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     default:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - number: pages
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
+      remove:
+        - match:
+            number: number
   template:
   - contributor: author
     form: long

--- a/styles/chicago-notes-classic-no-url.yaml
+++ b/styles/chicago-notes-classic-no-url.yaml
@@ -70,11 +70,9 @@ citation:
         name-form: family-only
     type-variants:
       default:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
+        remove:
+          - match:
+              variable: locator
     template:
     - contributor: author
       form: short
@@ -85,50 +83,13 @@ citation:
       prefix: ", "
   type-variants:
     default:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: ": "
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
-    - delimiter: none
-      prefix: ", "
-      group:
-      - date: issued
-        form: month-day
-      - date: issued
-        form: year
-        prefix: ", "
+      remove:
+        - match:
+            number: number
+        - match:
+            variable: medium
+        - match:
+            contributor: interviewer
   template:
   - contributor: author
     form: long

--- a/styles/chicago-notes-classic.yaml
+++ b/styles/chicago-notes-classic.yaml
@@ -69,11 +69,9 @@ citation:
         name-form: family-only
     type-variants:
       default:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
+        remove:
+          - match:
+              variable: locator
     template:
     - contributor: author
       form: short
@@ -84,82 +82,14 @@ citation:
       prefix: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - number: pages
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: https://doi.org/
-    - number: number
-      prefix: ", Patent "
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     default:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - number: pages
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
+      remove:
+        - match:
+            number: number
   template:
   - contributor: author
     form: long

--- a/styles/chicago-notes-publisher-place-archive-place-first-no-url.yaml
+++ b/styles/chicago-notes-publisher-place-archive-place-first-no-url.yaml
@@ -71,11 +71,9 @@ citation:
         name-form: family-only
     type-variants:
       default:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
+        remove:
+          - match:
+              variable: locator
     template:
     - contributor: author
       form: short
@@ -86,48 +84,13 @@ citation:
       prefix: ", "
   type-variants:
     default:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - number: volume
-      prefix: ") 2, no. "
-    - contributor: editor
-      form: verb
-      name-order: given-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: ": "
-    - delimiter: none
-      group:
-      - date: issued
-        form: month-day
-        prefix: ", issued "
-      - date: issued
-        form: year
-        prefix: ", "
-    - delimiter: none
-      prefix: ", "
-      group:
-      - date: issued
-        form: month-day
-      - date: issued
-        form: year
-        prefix: ", "
+      remove:
+        - match:
+            number: number
+        - match:
+            variable: medium
+        - match:
+            contributor: interviewer
   template:
   - contributor: author
     form: long

--- a/styles/chicago-shortened-notes-bibliography-classic-archive-place-first.yaml
+++ b/styles/chicago-shortened-notes-bibliography-classic-archive-place-first.yaml
@@ -96,33 +96,10 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first-only
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-      prefix: " "
-    - number: pages
-      prefix: ": "
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
   template:
   - contributor: author
     form: long

--- a/styles/copernicus-publications.yaml
+++ b/styles/copernicus-publications.yaml
@@ -78,37 +78,14 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-    - variable: publisher
-    - number: pages
-    - date: issued
-      form: year
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: doi
-    - variable: publisher-place
-    - variable: publisher
-    - number: pages
-    - date: issued
-      form: year
+      remove:
+        - match:
+            number: issue
   template:
   - contributor: author
     form: long

--- a/styles/cse-name-year.yaml
+++ b/styles/cse-name-year.yaml
@@ -52,13 +52,13 @@ citation:
       delimiter: ', '
   type-variants:
     article-newspaper:
-      - contributor: author
-        form: long
-        name-order: family-first
+      remove:
+        - match:
+            date: issued
     patent:
-      - contributor: author
-        form: long
-        name-order: family-first
+      remove:
+        - match:
+            date: issued
   template:
     - contributor: author
       form: long
@@ -87,87 +87,32 @@ bibliography:
     separator: '. '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - date: issued
-        form: year
-        prefix: ' '
-      - title: primary
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-      - title: parent-serial
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - variable: publisher
-      - number: pages
-        prefix: '; p '
-      - variable: doi
-        prefix: https://doi.org/
-      - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     chapter:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - date: issued
-        form: year
-        prefix: ' '
-      - title: primary
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            prefix: 'on '
-          - title: parent-monograph
-      - title: parent-serial
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - variable: publisher
-      - number: pages
-        prefix: '; p '
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     webpage:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - date: issued
-        form: year
-        prefix: ' '
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-          - title: parent-monograph
-      - title: parent-serial
-      - group:
-          - number: volume
-          - number: issue
-            wrap:
-              punctuation: parentheses
-      - variable: publisher
-      - number: pages
-        prefix: '; p '
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            title: primary
   template:
     - contributor: author
       form: long

--- a/styles/current-opinion.yaml
+++ b/styles/current-opinion.yaml
@@ -42,24 +42,9 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: volume
-      prefix: ", "
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/din-1505-2-alphanumeric.yaml
+++ b/styles/din-1505-2-alphanumeric.yaml
@@ -73,71 +73,20 @@ bibliography:
     separator: " : "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/elsevier-without-titles.yaml
+++ b/styles/elsevier-without-titles.yaml
@@ -36,36 +36,17 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: " "
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: publisher-place
     book:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: " "
-    - title: primary
-    - variable: publisher
-    - variable: publisher-place
+      add:
+        - component:
+            title: primary
+          before:
+            variable: publisher
     chapter:
     - contributor: author
       form: long
@@ -79,54 +60,20 @@ bibliography:
     - number: pages
       prefix: "pp. "
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: " "
-    - variable: publisher-place
+      remove:
+        - match:
+            variable: publisher
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: "pp. "
-    - title: primary
-    - variable: publisher
-    - variable: publisher-place
+      extends: book
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      prefix: "pp. "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - number: pages
-      prefix: " "
-    - variable: publisher
-    - variable: publisher-place
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
     report:
     - contributor: author
       form: long

--- a/styles/embedded/american-medical-association.yaml
+++ b/styles/embedded/american-medical-association.yaml
@@ -171,24 +171,18 @@ bibliography:
       - number: pages
         prefix: ":"
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-    - term: online
-      prefix: "Published "
-      suffix: " "
-    - date: issued
-      form: year
-      suffix: ". "
-    - date: accessed
-      form: month-day
-      prefix: "Accessed "
-    - date: accessed
-      form: year
-      prefix: ", "
-      suffix: ". "
-    - variable: url
+      extends: webpage
+      modify:
+        - match:
+            date: issued
+          suffix: '. '
+      add:
+        - component:
+            term: online
+            prefix: 'Published '
+            suffix: ' '
+          before:
+            date: issued
     legal-case:
     - title: primary
     - delimiter: " "
@@ -222,23 +216,17 @@ bibliography:
     - variable: patent-number
       prefix: ":"
     motion-picture:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      text-case: title
-    - variable: publisher
-      suffix: "; "
-    - date: issued
-      form: year
-    - date: accessed
-      form: month-day
-      prefix: "Accessed "
-    - date: accessed
-      form: year
-      prefix: ", "
-      suffix: ". "
-    - variable: url
+      extends: webpage
+      modify:
+        - match:
+            title: primary
+          text-case: title
+      add:
+        - component:
+            variable: publisher
+            suffix: '; '
+          before:
+            date: issued
     broadcast:
     - contributor: author
       form: long

--- a/styles/embedded/apa-7th.yaml
+++ b/styles/embedded/apa-7th.yaml
@@ -757,47 +757,34 @@ bibliography:
     - variable: url
       prefix: " "
     webpage:
-    - contributor: author
-      form: long
-      suffix: "."
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      emph: false
-    - delimiter: "; "
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-      group:
-      - contributor: editor
-        form: long
-        name-order: given-first
-        label: {term: editor, form: short, placement: suffix}
-      - contributor: translator
-        form: long
-        name-order: given-first
-        label: {term: translator, form: short, placement: suffix}
-    - group:
-      - variable: genre
-        text-case: capitalize-first
-      - variable: medium
-        text-case: capitalize-first
-      delimiter: "; "
-      wrap:
-        punctuation: brackets
-      prefix: " "
-      suffix: "."
-    - title: parent-monograph
-      emph: false
-      text-case: title
-      prefix: " "
-      suffix: "."
-    - variable: url
-      prefix: " "
+      extends: post
+      add:
+        - component:
+            delimiter: '; '
+            wrap:
+              punctuation: parentheses
+            prefix: ' '
+            group:
+              - contributor: editor
+                form: long
+                name-order: given-first
+                label:
+                  term: editor
+                  form: short
+                  placement: suffix
+              - contributor: translator
+                form: long
+                name-order: given-first
+                label:
+                  term: translator
+                  form: short
+                  placement: suffix
+          before:
+            group:
+              - variable: genre
+                text-case: capitalize-first
+              - variable: medium
+                text-case: capitalize-first
   template:
   - contributor: author
     form: long

--- a/styles/embedded/chicago-author-date-18th.yaml
+++ b/styles/embedded/chicago-author-date-18th.yaml
@@ -164,63 +164,24 @@ bibliography:
           - archival
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        prefix: " ("
-        suffix: ")"
-    - number: pages
-      prefix: ": "
-    - variable: publisher
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-    - number: pages
-      prefix: ": "
-    - variable: publisher
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                prefix: ' ('
+                suffix: )
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            number: pages
     bill-proceeding:
     - title: primary
     - variable: publisher
@@ -334,33 +295,9 @@ bibliography:
         punctuation: quotes
     - variable: url
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        prefix: " ("
-        suffix: ")"
-    - variable: publisher
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            number: pages
     entry-dictionary:
     - title: parent-monograph
       emph: true
@@ -379,34 +316,20 @@ bibliography:
     - variable: doi
       prefix: "https://doi.org/"
     legal-case:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-      emph: true
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        prefix: " ("
-        suffix: ")"
-    - number: pages
-      prefix: ": "
-    - variable: publisher
-    - variable: doi
-    - variable: url
+      extends: book
+      modify:
+        - match:
+            title: primary
+          emph: true
+      remove:
+        - match:
+            contributor: translator
+      add:
+        - component:
+            number: pages
+            prefix: ': '
+          before:
+            variable: publisher
     motion-picture:
     - contributor: author
       form: long
@@ -440,78 +363,15 @@ bibliography:
         form: full
         prefix: ", issued "
     report:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        prefix: " ("
-        suffix: ")"
-    - variable: publisher
-    - variable: doi
-    - variable: url
-    statute, legislation:
-    - group:
-      - title: primary
-        text-case: title
-      - variable: number
-        prefix: "Pub. L. No. "
-      - group:
-        - number: volume
-        - variable: code
-        - variable: section
-          prefix: " § "
-        - variable: page
-          prefix: " "
-        delimiter: " "
-      delimiter: ", "
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: url
+      extends: book
+      remove:
+        - match:
+            contributor: translator
     thesis:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        prefix: " ("
-        suffix: ")"
-    - variable: publisher
-    - variable: doi
-    - variable: url
+      extends: book
+      remove:
+        - match:
+            contributor: translator
     personal-communication: []
   template:
   - contributor: author

--- a/styles/embedded/chicago-notes-18th.yaml
+++ b/styles/embedded/chicago-notes-18th.yaml
@@ -59,29 +59,26 @@ citation:
         name-form: family-only
     type-variants:
       article-journal:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
-      - variable: locator
-        prefix: ", "
+        add:
+          - component:
+              variable: locator
+              prefix: ', '
+            after:
+              title: primary
       book:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
-      - variable: locator
-        prefix: ", "
+        add:
+          - component:
+              variable: locator
+              prefix: ', '
+            after:
+              title: primary
       chapter:
-      - contributor: author
-        form: short
-      - title: primary
-        form: short
-        prefix: ", "
-      - variable: locator
-        prefix: ", "
+        add:
+          - component:
+              variable: locator
+              prefix: ', '
+            after:
+              title: primary
     template:
     - contributor: author
       form: short
@@ -403,55 +400,13 @@ citation:
     - variable: medium
       prefix: ", "
     paper-conference:
-    - contributor: author
-      form: long
-      shorten: *id001
-    - title: primary
-      prefix: ", "
-    - group:
-      - title: parent-serial
-        prefix: ", "
-      - variable: publisher-place
-        wrap:
-          punctuation: parentheses
-        prefix: " "
-      - number: volume
-        prefix: " "
-      - number: issue
-        prefix: ", no. "
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: " "
-      - number: pages
-        prefix: ": "
-      delimiter: ""
-    - group:
-      - title: parent-monograph
-        prefix: ", in "
-      - title: parent-serial
-        prefix: ", in "
-      - number: volume
-        prefix: ", vol. "
-      - contributor: editor
-        form: long
-        prefix: ", ed. "
-      - group: *id002
-        delimiter: ", "
-        wrap:
-          punctuation: parentheses
-        prefix: " "
-      delimiter: ""
-    - group:
-      - title: parent-serial
-      - date: issued
-        form: year
-      - number: pages
-      delimiter: ", "
-      prefix: ", "
-    - variable: doi
-      prefix: ", https://doi.org/"
+      remove:
+        - match:
+            group:
+              - variable: genre
+              - variable: publisher
+              - date: issued
+                form: year
     patent:
     - contributor: author
       form: long
@@ -492,52 +447,24 @@ citation:
       form: year
       prefix: ", "
     report:
-    - contributor: author
-      form: long
-      shorten: *id001
-    - title: primary
-      prefix: ", "
-    - group:
-      - variable: genre
-      - variable: publisher
-      - date: issued
-        form: year
-      delimiter: ", "
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      extends: dataset
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: url
     thesis:
-    - contributor: author
-      form: long
-      shorten: *id001
-    - title: primary
-      prefix: ", "
-    - group:
-      - variable: genre
-      - variable: publisher
-      - date: issued
-        form: year
-      delimiter: ", "
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      extends: dataset
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: url
     webpage:
-    - contributor: author
-      form: long
-      shorten: *id001
-    - title: primary
-      prefix: ", "
-    - group:
-      - variable: genre
-      - variable: publisher
-      - date: issued
-        form: year
-      delimiter: ", "
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: url
-      prefix: ", "
+      extends: dataset
+      remove:
+        - match:
+            variable: publisher
   template:
   - contributor: author
     form: long

--- a/styles/embedded/elsevier-harvard-core.yaml
+++ b/styles/embedded/elsevier-harvard-core.yaml
@@ -194,35 +194,33 @@ bibliography:
     - number: pages
       prefix: " pp. "
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: ", "
-      suffix: "."
-    - title: primary
-    - title: parent-monograph
-      prefix: ", in: "
-      suffix: "."
-    - number: pages
-      prefix: "pp. "
-      suffix: "."
+      add:
+        - component:
+            title: parent-monograph
+            prefix: ', in: '
+            suffix: .
+          after:
+            title: primary
+        - component:
+            number: pages
+            prefix: 'pp. '
+            suffix: .
+          after:
+            title: parent-monograph
     thesis:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: ", "
-      suffix: "."
-    - title: primary
-    - variable: genre
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-      suffix: "."
-    - variable: publisher
+      add:
+        - component:
+            variable: genre
+            wrap:
+              punctuation: parentheses
+            prefix: ' '
+            suffix: .
+          after:
+            title: primary
+        - component:
+            variable: publisher
+          after:
+            variable: genre
     webpage:
     - contributor: author
       form: long
@@ -255,17 +253,16 @@ bibliography:
     - title: parent-serial
       suffix: "."
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: ", "
-      suffix: "."
-    - title: primary
-      suffix: "."
-    - title: parent-monograph
-      suffix: "."
+      modify:
+        - match:
+            title: primary
+          suffix: .
+      add:
+        - component:
+            title: parent-monograph
+            suffix: .
+          after:
+            title: primary
     legal-case:
     - title: primary
     - date: issued
@@ -288,17 +285,13 @@ bibliography:
     - title: primary
       suffix: "."
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: ", "
-      suffix: "."
-    - title: primary
-      suffix: "."
-    - variable: number
-      suffix: "."
+      extends: dataset,motion-picture,interview,personal-communication
+      add:
+        - component:
+            variable: number
+            suffix: .
+          after:
+            title: primary
     report:
     - contributor: author
       form: long

--- a/styles/embedded/elsevier-vancouver-core.yaml
+++ b/styles/embedded/elsevier-vancouver-core.yaml
@@ -79,39 +79,37 @@ bibliography:
         target: doi
         anchor: component
     article-magazine:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - group:
-      - title: parent-serial
-      - date: issued
-        form: year
-        prefix: ' '
-        suffix: ';'
-      - number: volume
-      - number: pages
-        prefix: ':'
-      delimiter: none
+      remove:
+        - match:
+            date: issued
+      add:
+        - component:
+            group:
+              - title: parent-serial
+              - date: issued
+                form: year
+                prefix: ' '
+                suffix: ;
+              - number: volume
+              - number: pages
+                prefix: ':'
+            delimiter: none
+          after:
+            title: primary
     article-newspaper:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - group:
-      - title: parent-serial
-      - date: issued
-        form: year
-        prefix: ' '
-      delimiter: none
+      remove:
+        - match:
+            date: issued
+      add:
+        - component:
+            group:
+              - title: parent-serial
+              - date: issued
+                form: year
+                prefix: ' '
+            delimiter: none
+          after:
+            title: primary
     book:
     - number: citation-number
       wrap:
@@ -133,18 +131,12 @@ bibliography:
     - date: issued
       form: year
     broadcast:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - title: parent-serial
-      suffix: ' '
-    - date: issued
-      form: year
+      add:
+        - component:
+            title: parent-serial
+            suffix: ' '
+          before:
+            date: issued
     chapter:
     - number: citation-number
       wrap:
@@ -167,99 +159,77 @@ bibliography:
     - number: pages
       prefix: ', p. '
     dataset:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: ' '
-    - date: issued
-      form: year
+      modify:
+        - match:
+            title: primary
+          suffix: ' '
     entry-encyclopedia:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - group:
-      - title: parent-serial
-      - date: issued
-        form: year
-        prefix: ' '
-        suffix: ';'
-      - number: volume
-      - number: pages
-        prefix: ':'
-      delimiter: none
+      remove:
+        - match:
+            date: issued
+      add:
+        - component:
+            group:
+              - title: parent-serial
+              - date: issued
+                form: year
+                prefix: ' '
+                suffix: ;
+              - number: volume
+              - number: pages
+                prefix: ':'
+            delimiter: none
+          after:
+            title: primary
     interview:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: ' '
-    - date: issued
-      form: year
+      modify:
+        - match:
+            title: primary
+          suffix: ' '
     paper-conference:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - title: parent-monograph
-      suffix: ', '
-    - date: issued
-      form: year
-      suffix: ', '
-    - number: pages
-      prefix: 'p. '
+      modify:
+        - match:
+            date: issued
+          suffix: ', '
+      add:
+        - component:
+            title: parent-monograph
+            suffix: ', '
+          before:
+            date: issued
+        - component:
+            number: pages
+            prefix: 'p. '
+          after:
+            date: issued
     personal-communication:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: ' '
-    - date: issued
-      form: year
+      modify:
+        - match:
+            title: primary
+          suffix: ' '
     report:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - variable: publisher-place
-      suffix: ': '
-    - variable: publisher
-      suffix: '; '
-    - date: issued
-      form: year
+      add:
+        - component:
+            variable: publisher-place
+            suffix: ': '
+          before:
+            date: issued
+        - component:
+            variable: publisher
+            suffix: '; '
+          before:
+            date: issued
     legal-case:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - title: primary
-      suffix: '. '
-    - number: volume
-      prefix: 'vol. '
-      suffix: '. '
-    - date: issued
-      form: year
+      remove:
+        - match:
+            contributor: author
+      add:
+        - component:
+            number: volume
+            prefix: 'vol. '
+            suffix: '. '
+          before:
+            date: issued
     webpage:
     - number: citation-number
       wrap:
@@ -278,33 +248,24 @@ bibliography:
       prefix: ' (accessed '
       suffix: ')'
     patent:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - variable: number
-      suffix: ', '
-    - date: issued
-      form: year
+      add:
+        - component:
+            variable: number
+            suffix: ', '
+          before:
+            date: issued
     thesis:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      suffix: '. '
-    - title: primary
-      suffix: '. '
-    - variable: genre
-      suffix: '. '
-    - variable: publisher
-      suffix: ', '
-    - date: issued
-      form: year
+      add:
+        - component:
+            variable: genre
+            suffix: '. '
+          before:
+            date: issued
+        - component:
+            variable: publisher
+            suffix: ', '
+          before:
+            date: issued
   template:
   - number: citation-number
     wrap:

--- a/styles/embedded/elsevier-with-titles-core.yaml
+++ b/styles/embedded/elsevier-with-titles-core.yaml
@@ -414,20 +414,19 @@ bibliography:
       - number: pages
         prefix: " pp. "
     patent:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-      suffix: ""
-    - contributor: author
-      form: long
-      suffix: ", "
-    - title: primary
-    - variable: number
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-      suffix: "."
+      extends: legal-case
+      add:
+        - component:
+            contributor: author
+            form: long
+            suffix: ', '
+          before:
+            title: primary
+        - component:
+            variable: number
+            prefix: ', '
+          before:
+            date: issued
     report:
     - number: citation-number
       wrap:
@@ -446,22 +445,16 @@ bibliography:
       prefix: ", "
       suffix: "."
     thesis:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-      suffix: ""
-    - contributor: author
-      form: long
-      suffix: ", "
-    - title: primary
-    - variable: genre
-      prefix: ", "
-    - variable: publisher
-      prefix: ", "
-    - date: issued
-      form: year
-      prefix: ", "
-      suffix: "."
+      extends: report
+      remove:
+        - match:
+            variable: publisher-place
+      add:
+        - component:
+            variable: genre
+            prefix: ', '
+          before:
+            variable: publisher
     webpage:
     - number: citation-number
       wrap:
@@ -556,33 +549,19 @@ bibliography:
       prefix: " "
       suffix: "."
     motion-picture:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-      suffix: ""
-    - contributor: author
-      form: long
-      suffix: ", "
-    - title: primary
-    - date: issued
-      form: year
-      prefix: ", "
-      suffix: "."
+      extends: legal-case
+      add:
+        - component:
+            contributor: author
+            form: long
+            suffix: ', '
+          before:
+            title: primary
     personal-communication:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-      suffix: ""
-    - contributor: author
-      form: long
-      suffix: ", "
-    - title: primary
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: ", "
-      suffix: "."
+      extends: interview
+      remove:
+        - match:
+            variable: url
   template:
   - number: citation-number
     wrap:

--- a/styles/embedded/ieee.yaml
+++ b/styles/embedded/ieee.yaml
@@ -45,75 +45,15 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 8
-          use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-magazine:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 8
-          use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     book:
     - delimiter: ""
       group:
@@ -180,40 +120,10 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     chapter:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 8
-          use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     dataset:
     - delimiter: ""
       group:
@@ -247,38 +157,11 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     entry-encyclopedia:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 8
-          use-first: 1
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      extends: broadcast
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     motion-picture:
     - delimiter: ""
       group:
@@ -312,40 +195,10 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     paper-conference:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 8
-          use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
     - number: citation-number
       wrap:
@@ -432,39 +285,11 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     thesis:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 8
-          use-first: 1
-    - title: primary
-      emph: true
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-      prefix: ". "
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      extends: book
+      modify:
+        - match:
+            title: primary
+          emph: true
   template:
   - delimiter: ""
     group:

--- a/styles/embedded/modern-language-association.yaml
+++ b/styles/embedded/modern-language-association.yaml
@@ -87,180 +87,33 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - contributor: translator
-      form: verb
-      name-order: given-first
-      prefix: ". "
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher
-    - date: issued
-      form: day-month-abbr-year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - contributor: translator
-      form: verb
-      name-order: given-first
-      prefix: ". "
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher
-    - date: issued
-      form: day-month-abbr-year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: ", "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - contributor: translator
-      form: verb
-      name-order: given-first
-      prefix: ". "
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher
-    - date: issued
-      form: day-month-abbr-year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: ", "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - contributor: translator
-      form: verb
-      name-order: given-first
-      prefix: ". "
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher
-    - date: issued
-      form: day-month-abbr-year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: ", "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - contributor: translator
-      form: verb
-      name-order: given-first
-      prefix: ". "
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher
-    - date: issued
-      form: day-month-abbr-year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: ", "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     manuscript:
     - contributor: author
       form: long
@@ -280,21 +133,10 @@ bibliography:
     - variable: archive-location
       prefix: ", "
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - title: primary
-      quote: true
-    - variable: genre
-      prefix: ". "
-    - date: issued
-      form: day-month-abbr-year
-      prefix: ". "
-    - variable: archive-name
-      prefix: ", "
+      extends: manuscript
+      remove:
+        - match:
+            variable: archive-location
     interview:
     - contributor: author
       form: long

--- a/styles/embedded/springer-basic-author-date-core.yaml
+++ b/styles/embedded/springer-basic-author-date-core.yaml
@@ -149,40 +149,23 @@ bibliography:
       - variable: publisher
       - variable: publisher-place
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-        and-others: text
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - delimiter: " "
-      group:
-      - prefix: "In: "
-        contributor: editor
-        form: long
-        name-order: family-first
-      - title: parent-monograph
-    - title: parent-serial
-    - delimiter: ", "
-      group:
-      - variable: publisher
-      - variable: publisher-place
-      - number: pages
-        prefix: "pp "
-    - delimiter: none
-      prefix: " "
-      group:
-      - number: volume
-      - number: issue
-    - variable: doi
+      remove:
+        - match:
+            contributor: editor
+        - match:
+            group:
+              - number: volume
+              - number: issue
+              - number: pages
+      add:
+        - component:
+            delimiter: none
+            prefix: ' '
+            group:
+              - number: volume
+              - number: issue
+          before:
+            variable: doi
     thesis:
     - contributor: author
       form: long
@@ -251,59 +234,37 @@ bibliography:
       - number: pages
         prefix: ""
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-        and-others: text
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
+      extends: thesis
+      remove:
+        - match:
+            group:
+              - variable: genre
+                text-case: capitalize-first
+              - variable: publisher
     report:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-        and-others: text
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - delimiter: ", "
-      prefix: ". "
-      group:
-      - variable: publisher
-      - variable: publisher-place
+      extends: dataset
+      add:
+        - component:
+            delimiter: ', '
+            prefix: '. '
+            group:
+              - variable: publisher
+              - variable: publisher-place
+          after:
+            title: primary
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-        and-others: text
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      prefix: ". In: "
-    - number: pages
-      prefix: ". pp "
+      extends: dataset
+      add:
+        - component:
+            title: parent-monograph
+            prefix: '. In: '
+          after:
+            title: primary
+        - component:
+            number: pages
+            prefix: '. pp '
+          after:
+            title: parent-monograph
     legal-case:
     - date: issued
       form: year

--- a/styles/embedded/springer-basic-brackets-core.yaml
+++ b/styles/embedded/springer-basic-brackets-core.yaml
@@ -52,40 +52,26 @@ bibliography:
     separator: '. '
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-        and-others: et-al
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - delimiter: " "
-      group:
-      - prefix: "In: "
-        contributor: editor
-        form: long
-        name-order: family-first
-      - title: parent-monograph
-    - title: parent-serial
-    - delimiter: ", "
-      group:
-      - variable: publisher
-      - variable: publisher-place
-    - delimiter: ":"
-      prefix: " "
-      group:
-      - number: volume
-      - number: pages
-        prefix: ""
-    - variable: doi
-      prefix: ". https://doi.org/"
+      remove:
+        - match:
+            contributor: editor
+        - match:
+            group:
+              - variable: publisher
+              - variable: publisher-place
+              - number: pages
+                prefix: 'pp '
+      add:
+        - component:
+            delimiter: ', '
+            group:
+              - variable: publisher
+              - variable: publisher-place
+          before:
+            group:
+              - number: volume
+              - number: pages
+                prefix: ''
     book:
     - contributor: author
       form: long
@@ -106,80 +92,13 @@ bibliography:
       - variable: publisher
       - variable: publisher-place
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-        and-others: et-al
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - delimiter: " "
-      group:
-      - prefix: "In: "
-        contributor: editor
-        form: long
-        name-order: family-first
-      - title: parent-monograph
-    - title: parent-serial
-    - delimiter: ", "
-      group:
-      - variable: publisher
-      - variable: publisher-place
-      - number: pages
-        prefix: "pp "
-    - delimiter: ":"
-      prefix: " "
-      group:
-      - number: volume
-      - number: pages
-        prefix: ""
-    - variable: doi
-      prefix: ". https://doi.org/"
+      remove:
+        - match:
+            contributor: editor
     default:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-        and-others: et-al
-    - contributor: editor
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - delimiter: " "
-      group:
-      - prefix: "In: "
-        contributor: editor
-        form: long
-        name-order: family-first
-      - title: parent-monograph
-    - title: parent-serial
-    - delimiter: ", "
-      group:
-      - variable: publisher
-      - variable: publisher-place
-      - number: pages
-        prefix: "pp "
-    - delimiter: ":"
-      prefix: " "
-      group:
-      - number: volume
-      - number: pages
-        prefix: ""
+      remove:
+        - match:
+            variable: doi
     thesis:
     - contributor: author
       form: long
@@ -254,47 +173,36 @@ bibliography:
       - number: pages
         prefix: ""
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
+      extends: thesis
+      remove:
+        - match:
+            group:
+              - variable: genre
+              - variable: publisher
     report:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - delimiter: ", "
-      prefix: ". "
-      group:
-      - variable: publisher
-      - variable: publisher-place
+      extends: dataset
+      add:
+        - component:
+            delimiter: ', '
+            prefix: '. '
+            group:
+              - variable: publisher
+              - variable: publisher-place
+          after:
+            title: primary
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      prefix: ". In: "
-    - number: pages
-      prefix: ". pp "
+      extends: dataset
+      add:
+        - component:
+            title: parent-monograph
+            prefix: '. In: '
+          after:
+            title: primary
+        - component:
+            number: pages
+            prefix: '. pp '
+          after:
+            title: parent-monograph
     legal-case:
     - date: issued
       form: year

--- a/styles/embedded/springer-vancouver-brackets-core.yaml
+++ b/styles/embedded/springer-vancouver-brackets-core.yaml
@@ -201,22 +201,13 @@ bibliography:
       prefix: '. p. '
 
     dataset:
-    - contributor: author
-      form: long
-    - title: primary
-    - variable: publisher
-      suffix: '; '
-    - date: issued
-      form: year
-    - date: accessed
-      form: year-month-day
-      prefix: '[cited '
-      suffix: ']. '
-    - variable: url
-    - date: accessed
-      form: year-month-day
-      prefix: '. Accessed '
-
+      extends: webpage
+      add:
+        - component:
+            variable: publisher
+            suffix: '; '
+          before:
+            date: issued
     legal-case:
     - title: primary
     - variable: reporter

--- a/styles/embedded/taylor-and-francis-council-of-science-editors-author-date-core.yaml
+++ b/styles/embedded/taylor-and-francis-council-of-science-editors-author-date-core.yaml
@@ -86,82 +86,37 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/embedded/taylor-and-francis-national-library-of-medicine-core.yaml
+++ b/styles/embedded/taylor-and-francis-national-library-of-medicine-core.yaml
@@ -49,210 +49,66 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      extends: article-journal
+      add:
+        - component:
+            date: issued
+            form: year
+          before:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/frontiers-medical-journals.yaml
+++ b/styles/frontiers-medical-journals.yaml
@@ -56,91 +56,38 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: volume
-      prefix: " "
-    - number: pages
-      prefix: ":"
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: volume
-      prefix: " "
-    - number: issue
-      prefix: ":"
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: volume
-      prefix: " "
-    - number: issue
-      prefix: ":"
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/frontiers.yaml
+++ b/styles/frontiers.yaml
@@ -81,33 +81,9 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: "), "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            number: issue
   template:
   - contributor: author
     form: long

--- a/styles/future-medicine.yaml
+++ b/styles/future-medicine.yaml
@@ -72,32 +72,19 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - group:
-      - number: volume
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - number: pages
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            contributor: editor
     patent:
     - number: citation-number
     - contributor: author
@@ -114,50 +101,27 @@ bibliography:
       wrap:
         punctuation: parentheses
     thesis:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - number: pages
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      remove:
+        - match:
+            title: primary
     entry-encyclopedia:
-    - number: citation-number
-    - contributor: author
-      form: long
-      sort-separator: " "
-      shorten:
-        min: 7
-        use-first: 3
-        and-others: et-al
-        delimiter-precedes-last: contextual
-    - title: primary
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
+      extends: patent
+      remove:
+        - match:
+            number: number
+      add:
+        - component:
+            title: primary
+          before:
+            date: issued
+        - component:
+            variable: publisher
+          before:
+            date: issued
+        - component:
+            variable: publisher-place
+          before:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/future-science-group.yaml
+++ b/styles/future-science-group.yaml
@@ -44,57 +44,13 @@ bibliography:
     separator: ". "
   type-variants:
     book:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
+      remove:
+        - match:
+            date: issued
     motion_picture:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/gost-r-7-0-5-2008-numeric.yaml
+++ b/styles/gost-r-7-0-5-2008-numeric.yaml
@@ -107,149 +107,35 @@ bibliography:
 
   type-variants:
     article-journal:
-    - number: citation-number
-      prefix: "["
-      suffix: "] "
-    - contributor: author
-      form: long
-      name-order: family-first
-      name-form: initials
-      initialize-with: ". "
-    - title: primary
-      suffix: " //"
-    - title: parent-serial
-    - title: parent-monograph
-    - variable: publisher-place
-      suffix: ":"
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-      prefix: "Vol. "
-    - number: issue
-      prefix: "№ "
-    - number: pages
-      prefix: "P. "
+      modify:
+        - match:
+            title: primary
+          suffix: ' //'
     article-magazine:
-    - number: citation-number
-      prefix: "["
-      suffix: "] "
-    - contributor: author
-      form: long
-      name-order: family-first
-      name-form: initials
-      initialize-with: ". "
-    - title: primary
-      suffix: " //"
-    - title: parent-serial
-    - title: parent-monograph
-    - variable: publisher-place
-      suffix: ":"
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-      prefix: "Vol. "
-    - number: issue
-      prefix: "№ "
-    - number: pages
-      prefix: "P. "
+      modify:
+        - match:
+            title: primary
+          suffix: ' //'
     article-newspaper:
-    - number: citation-number
-      prefix: "["
-      suffix: "] "
-    - contributor: author
-      form: long
-      name-order: family-first
-      name-form: initials
-      initialize-with: ". "
-    - title: primary
-      suffix: " //"
-    - title: parent-serial
-    - title: parent-monograph
-    - variable: publisher-place
-      suffix: ":"
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-      prefix: "Vol. "
-    - number: issue
-      prefix: "№ "
-    - number: pages
-      prefix: "P. "
+      modify:
+        - match:
+            title: primary
+          suffix: ' //'
     chapter:
-    - number: citation-number
-      prefix: "["
-      suffix: "] "
-    - contributor: author
-      form: long
-      name-order: family-first
-      name-form: initials
-      initialize-with: ". "
-    - title: primary
-      suffix: " //"
-    - title: parent-serial
-    - title: parent-monograph
-    - variable: publisher-place
-      suffix: ":"
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-      prefix: "Vol. "
-    - number: issue
-      prefix: "№ "
-    - number: pages
-      prefix: "P. "
+      modify:
+        - match:
+            title: primary
+          suffix: ' //'
     legal-case:
-    - number: citation-number
-      prefix: "["
-      suffix: "] "
-    - contributor: author
-      form: long
-      name-order: family-first
-      name-form: initials
-      initialize-with: ". "
-    - title: primary
-      suffix: " //"
-    - title: parent-serial
-    - title: parent-monograph
-    - variable: publisher-place
-      suffix: ":"
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-      prefix: "Vol. "
-    - number: issue
-      prefix: "№ "
-    - number: pages
-      prefix: "P. "
+      modify:
+        - match:
+            title: primary
+          suffix: ' //'
     reference-entry:
-    - number: citation-number
-      prefix: "["
-      suffix: "] "
-    - contributor: author
-      form: long
-      name-order: family-first
-      name-form: initials
-      initialize-with: ". "
-    - title: primary
-      suffix: " //"
-    - title: parent-serial
-    - title: parent-monograph
-    - variable: publisher-place
-      suffix: ":"
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-      prefix: "Vol. "
-    - number: issue
-      prefix: "№ "
-    - number: pages
-      prefix: "P. "
+      modify:
+        - match:
+            title: primary
+          suffix: ' //'
   template:
   - number: citation-number
     prefix: "["

--- a/styles/hainan-medical-university-journal-publisher.yaml
+++ b/styles/hainan-medical-university-journal-publisher.yaml
@@ -98,90 +98,34 @@ bibliography:
       prefix: " (accessed "
       suffix: ")"
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: ", 2006: "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: ", 2006: "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: url
+      extends: article-magazine
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: ", 2006: "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/harvard-cite-them-right.yaml
+++ b/styles/harvard-cite-them-right.yaml
@@ -103,164 +103,67 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: " "
-    - prefix: ", in "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: " "
-    - prefix: ", in "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            number: pages
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: " "
-    - prefix: ", in "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-        prefix: "in "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            prefix: ', in '
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+                prefix: 'in '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: " "
-    - prefix: ", in "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/institute-for-operations-research-and-the-management-sciences.yaml
+++ b/styles/institute-for-operations-research-and-the-management-sciences.yaml
@@ -118,35 +118,25 @@ bibliography:
     - title: primary
       prefix: " "
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
   template:
   - contributor: author
     form: long

--- a/styles/institute-of-mathematics-and-its-applications.yaml
+++ b/styles/institute-of-mathematics-and-its-applications.yaml
@@ -80,80 +80,35 @@ bibliography:
     separator: ", "
   type-variants:
     book:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: family-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: family-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/integrated-science-publishing-journals.yaml
+++ b/styles/integrated-science-publishing-journals.yaml
@@ -48,131 +48,35 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-    - variable: publisher-place
-      prefix: ", "
-    - number: pages
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+      add:
+        - component:
+            prefix: ', '
+            group:
+              - number: volume
+          before:
+            variable: publisher-place
     chapter:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - variable: publisher-place
-      prefix: ", "
-    - number: pages
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - variable: publisher-place
-      prefix: ", "
-    - number: pages
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - variable: publisher-place
-      prefix: ", "
-    - number: pages
+      remove:
+        - match:
+            date: issued
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 3
-      prefix: "pp. "
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-    - variable: publisher
-      prefix: "; "
-    - date: issued
-      form: year
-      prefix: ", "
-    - prefix: ", "
-      group:
-      - number: volume
-      - number: issue
-    - variable: publisher-place
-      prefix: ", "
-    - number: pages
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
     webpage:
     - number: citation-number
       suffix: ". "
@@ -190,18 +94,18 @@ bibliography:
       prefix: "(accessed "
       suffix: )
     patent:
-    - number: citation-number
-      suffix: ". "
-    - contributor: author
-      form: long
-      shorten:
-        min: 6
-        use-first: 3
-        and-others: et-al
-        delimiter-precedes-last: always
-    - title: primary
-    - date: issued
-      form: full
+      extends: webpage
+      remove:
+        - match:
+            variable: url
+        - match:
+            date: accessed
+      add:
+        - component:
+            date: issued
+            form: full
+          after:
+            title: primary
   template:
   - contributor: author
     form: long

--- a/styles/international-union-of-crystallography.yaml
+++ b/styles/international-union-of-crystallography.yaml
@@ -83,113 +83,33 @@ bibliography:
     separator: " "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: ". "
+      remove:
+        - match:
+            title: primary
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: ". "
+      remove:
+        - match:
+            title: primary
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: ". "
+      remove:
+        - match:
+            title: primary
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-      prefix: ". "
+      extends: article-journal
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-      prefix: ". "
+      extends: article-journal
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher-place
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: ". "
+      remove:
+        - match:
+            title: primary
   template:
   - contributor: author
     form: long

--- a/styles/landes-bioscience-journals.yaml
+++ b/styles/landes-bioscience-journals.yaml
@@ -46,28 +46,23 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: url
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: pages
-      prefix: ". page "
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
   template:
   - contributor: author
     form: long

--- a/styles/mary-ann-liebert-harvard.yaml
+++ b/styles/mary-ann-liebert-harvard.yaml
@@ -81,155 +81,29 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; 2006; "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: doi
-      prefix: "; "
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; 2006; "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: doi
-      prefix: "; "
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: doi
-      prefix: "; "
+      extends: article-journal
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; 2006; "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: doi
-      prefix: "; "
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: doi
-      prefix: "; "
+      extends: article-journal
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/mary-ann-liebert-vancouver.yaml
+++ b/styles/mary-ann-liebert-vancouver.yaml
@@ -51,155 +51,29 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; "
-    - variable: doi
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; "
-    - variable: doi
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
+      extends: article-journal
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; "
-    - variable: doi
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: "; "
-    - variable: publisher-place
-      prefix: ": "
+      extends: article-journal
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     legal-case:
     - title: primary
       prefix: "Anonymous. "

--- a/styles/medicina-clinica.yaml
+++ b/styles/medicina-clinica.yaml
@@ -43,115 +43,44 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
     - number: citation-number
       suffix: .

--- a/styles/medicine-publishing.yaml
+++ b/styles/medicine-publishing.yaml
@@ -44,104 +44,37 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: url
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: url
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - date: issued
-      form: year
-    - number: volume
-    - variable: url
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: url
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/mhra-author-date-publisher-place.yaml
+++ b/styles/mhra-author-date-publisher-place.yaml
@@ -54,11 +54,9 @@ citation:
         use-first: 1
   type-variants:
     personal_communication:
-      - contributor: author
-        form: long
-        name-order: given-first
-      - variable: locator
-        prefix: ' '
+      remove:
+        - match:
+            date: issued
   template:
     - contributor: author
       form: long

--- a/styles/mhra-notes-publisher-place-no-url.yaml
+++ b/styles/mhra-notes-publisher-place-no-url.yaml
@@ -370,207 +370,38 @@ bibliography:
     separator: ': '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-newspaper:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - number: pages
+      remove:
+        - match:
+            date: issued
     chapter:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     dataset:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - number: pages
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     interview:
       - contributor: interviewer
         form: long

--- a/styles/mhra-notes-publisher-place.yaml
+++ b/styles/mhra-notes-publisher-place.yaml
@@ -206,38 +206,16 @@ citation:
       - number: volume
       - variable: doi
     default:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - number: pages
-        show-with-locator: true
-      - variable: url
-      - variable: publisher-place
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - variable: doi
+      extends: dataset
+      add:
+        - component:
+            date: issued
+            form: year
+            wrap:
+              punctuation: parentheses
+            prefix: ' '
+          before:
+            variable: doi
     entry-encyclopedia:
       - contributor: author
         form: long
@@ -402,221 +380,38 @@ bibliography:
     separator: ': '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-newspaper:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - number: pages
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     dataset:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - number: pages
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - variable: publisher-place
-        prefix: ' ('
-      - variable: publisher
-        prefix: ': '
-      - number: volume
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     interview:
       - contributor: interviewer
         form: long

--- a/styles/mhra-notes.yaml
+++ b/styles/mhra-notes.yaml
@@ -79,25 +79,10 @@ citation:
       - variable: doi
         prefix: ", doi:"
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: given-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-serial
-        emph: true
-      - number: volume
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: " "
-      - number: pages
-        prefix: ", pp. "
-        show-with-locator: true
-      - variable: doi
-        prefix: ", doi:"
+      extends: article-journal
+      remove:
+        - match:
+            variable: locator
     chapter:
       - contributor: author
         form: long
@@ -126,26 +111,9 @@ citation:
         prefix: " "
       - variable: doi
     dataset:
-      - contributor: author
-        form: long
-        name-order: given-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - variable: publisher
-        prefix: " ("
-      - number: pages
-        show-with-locator: true
-      - number: volume
-      - variable: url
-      - variable: doi
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
       - contributor: author
         form: long
@@ -264,137 +232,64 @@ bibliography:
         and-others: text
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-serial
-        emph: true
-      - number: volume
-      - date: issued
-        form: year
-        prefix: " "
-      - number: pages
-        prefix: "pp. "
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            title: parent-monograph
+        - match:
+            contributor: editor
+        - match:
+            variable: publisher
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: family-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-serial
-        emph: true
-      - number: volume
-      - date: issued
-        form: year
-        prefix: " "
-      - number: pages
-        prefix: "pp. "
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            title: parent-monograph
+        - match:
+            contributor: editor
+        - match:
+            variable: publisher
     article-newspaper:
-      - contributor: author
-        form: long
-        name-order: family-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-serial
-        emph: true
-      - number: volume
-      - number: pages
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            title: parent-monograph
+        - match:
+            contributor: editor
+        - match:
+            variable: publisher
+        - match:
+            date: issued
     chapter:
-      - contributor: author
-        form: long
-        name-order: family-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - variable: publisher
-        prefix: " ("
-      - number: volume
-      - date: issued
-        form: year
-        prefix: " "
-      - number: pages
-        prefix: "pp. "
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     dataset:
-      - contributor: author
-        form: long
-        name-order: family-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - variable: publisher
-        prefix: " ("
-      - number: volume
-      - number: pages
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-      - contributor: author
-        form: long
-        name-order: family-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - variable: publisher
-        prefix: " ("
-      - number: volume
-      - date: issued
-        form: year
-        prefix: " "
-      - number: pages
-        prefix: "pp. "
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: family-first
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - number: volume
-      - date: issued
-        form: year
-        prefix: " "
-      - number: pages
-        prefix: "pp. "
-      - variable: doi
-      - variable: url
+      extends: article-journal
+      remove:
+        - match:
+            title: parent-serial
+      add:
+        - component:
+            title: parent-monograph
+            emph: true
+          before:
+            number: volume
     patent:
       - contributor: author
         form: long

--- a/styles/mhra-shortened-notes-publisher-place.yaml
+++ b/styles/mhra-shortened-notes-publisher-place.yaml
@@ -54,221 +54,38 @@ bibliography:
     separator: ": "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      prefix: " "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      prefix: " "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      prefix: " "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      prefix: " "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: given-first
-      shorten:
-        min: 4
-        use-first: 1
-    - variable: publisher-place
-      prefix: " ("
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - date: issued
-      form: year
-      prefix: " "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
     - contributor: author
       form: long

--- a/styles/microbiology-society.yaml
+++ b/styles/microbiology-society.yaml
@@ -69,176 +69,52 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     broadcast:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: url
+      extends: article-magazine
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 5
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/museum-national-dhistoire-naturelle.yaml
+++ b/styles/museum-national-dhistoire-naturelle.yaml
@@ -97,106 +97,44 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-      prefix: ". — "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-    - variable: publisher
-    - number: pages
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-      prefix: ". — "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-      prefix: ". — "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-      prefix: ". — "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/nature-publishing-group-vancouver.yaml
+++ b/styles/nature-publishing-group-vancouver.yaml
@@ -93,84 +93,33 @@ bibliography:
       prefix: " (accessed "
       suffix: ")"
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: url
-      prefix: .
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: ", "
-    - variable: url
-      prefix: .
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-      prefix: ": "
-    - variable: url
-      prefix: .
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/nature.yaml
+++ b/styles/nature.yaml
@@ -54,45 +54,11 @@ bibliography:
     separator: ". "
   type-variants:
     report:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: pages
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: ", "
-    article-journal+arxiv:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      prefix: " "
-    - title: parent-serial
-    - variable: doi
-      prefix: " https://doi.org/"
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: ", "
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: publisher-place
   template:
   - contributor: author
     form: long

--- a/styles/new-harts-rules-author-date-space-publisher.yaml
+++ b/styles/new-harts-rules-author-date-space-publisher.yaml
@@ -33,11 +33,9 @@ options:
 citation:
   type-variants:
     personal_communication:
-      - contributor: author
-        form: short
-        name-order: family-first
-      - variable: locator
-        prefix: ': '
+      remove:
+        - match:
+            date: issued
   template:
     - contributor: author
       form: short
@@ -64,84 +62,37 @@ bibliography:
     separator: ', '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - title: primary
-        wrap:
-          punctuation: quotes
-        prefix: ' '
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher
-      - number: pages
-        prefix: '), '
-      - variable: publisher-place
-      - number: volume
-        prefix: '), '
-      - number: issue
-        prefix: /
-      - variable: doi
-        prefix: https://doi.org/
-      - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     chapter:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - title: primary
-        wrap:
-          punctuation: quotes
-        prefix: ' '
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-            prefix: 'in '
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher
-      - number: pages
-        prefix: '), '
-      - variable: publisher-place
-      - number: volume
-        prefix: '), '
-      - number: issue
-        prefix: /
-      - variable: doi
-        prefix: '/2, '
-      - variable: url
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            prefix: ', in '
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+                prefix: 'in '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     patent:
       - contributor: author
         form: long
@@ -162,51 +113,45 @@ bibliography:
           punctuation: quotes
       - number: number
     interview:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-          and-others: et-al
-          delimiter-precedes-last: contextual
-      - date: issued
-        form: year
-        prefix: ' '
-        wrap:
-          punctuation: parentheses
-      - title: primary
-        prefix: ' '
-        wrap:
-          punctuation: quotes
-      - contributor: interviewer
-        form: long
-      - variable: medium
-      - variable: url
+      extends: patent
+      remove:
+        - match:
+            number: number
+      add:
+        - component:
+            contributor: interviewer
+            form: long
+          after:
+            title: primary
+        - component:
+            variable: medium
+          after:
+            contributor: interviewer
+        - component:
+            variable: url
+          after:
+            variable: medium
     personal-communication: []
     motion_picture:
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 5
-          use-first: 1
-          and-others: et-al
-          delimiter-precedes-last: contextual
-      - date: issued
-        form: year
-        prefix: ' '
-        wrap:
-          punctuation: parentheses
-      - title: primary
-        prefix: ' '
-        wrap:
-          punctuation: quotes
-      - variable: genre
-      - variable: medium
-      - contributor: director
-        form: long
-        prefix: 'Directed by '
+      extends: patent
+      remove:
+        - match:
+            number: number
+      add:
+        - component:
+            variable: genre
+          after:
+            title: primary
+        - component:
+            variable: medium
+          after:
+            variable: genre
+        - component:
+            contributor: director
+            form: long
+            prefix: 'Directed by '
+          after:
+            variable: medium
     personal_communication: []
   template:
     - contributor: author

--- a/styles/new-harts-rules-notes-label-page-no-url.yaml
+++ b/styles/new-harts-rules-notes-label-page-no-url.yaml
@@ -67,185 +67,42 @@ citation:
         prefix: ', '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            number: number
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            number: number
     chapter:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-        prefix: 'in '
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      extends: article-journal
+      modify:
+        - match:
+            contributor: editor
+          prefix: 'in '
     default:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - number: pages
+      remove:
+        - match:
+            number: number
     interview:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - number: pages
+      extends: default
+      remove:
+        - match:
+            date: issued
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - title: parent-monograph
-        emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      extends: default
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     legal_case:
       - title: primary
         wrap:
@@ -320,65 +177,15 @@ bibliography:
     separator: ' '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     chapter:
       - contributor: author
         form: long
@@ -411,61 +218,14 @@ bibliography:
       - number: pages
         prefix: 'pp. '
     interview:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - number: pages
+      remove:
+        - match:
+            date: issued
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     legal_case:
       - title: primary
         wrap:

--- a/styles/new-harts-rules-notes-label-page.yaml
+++ b/styles/new-harts-rules-notes-label-page.yaml
@@ -67,175 +67,61 @@ citation:
         prefix: ', '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-        prefix: 'pp. '
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - variable: doi
-        prefix: https://doi.org/
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+        - match:
+            variable: doi
+          prefix: https://doi.org/
+      remove:
+        - match:
+            number: number
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-        prefix: 'pp. '
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            number: number
     chapter:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-            prefix: 'in '
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-        prefix: 'pp. '
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - variable: doi
-      - variable: url
+      extends: article-magazine
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            prefix: ', in '
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+                prefix: 'in '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     default:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            number: number
     interview:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - variable: doi
-      - variable: url
+      extends: default
+      remove:
+        - match:
+            date: issued
     legal_case:
       - title: primary
         wrap:
@@ -269,40 +155,11 @@ citation:
             form: year
             prefix: ", "
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-        prefix: 'pp. '
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - variable: doi
-      - variable: url
+      extends: default
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
     - contributor: author
       form: long
@@ -349,163 +206,54 @@ bibliography:
     separator: ' '
   type-variants:
     article-journal:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - variable: publisher-place
-        prefix: ' ('
-      - number: volume
-        prefix: ), 2/
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-        prefix: https://doi.org/
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - variable: publisher-place
-        prefix: ' ('
-      - number: volume
-        prefix: ), 2/
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     chapter:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - variable: publisher-place
-        prefix: ' ('
-      - number: volume
-        prefix: ), 2/
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-            prefix: 'in '
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      extends: article-magazine
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 1
+                prefix: 'in '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     interview:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - variable: publisher-place
-        prefix: ' ('
-      - number: volume
-        prefix: ), 2/
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-      - variable: doi
-      - variable: url
+      remove:
+        - match:
+            date: issued
     paper-conference:
-      - contributor: author
-        form: long
-        name-order: family-first-only
-        shorten:
-          min: 5
-          use-first: 1
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - variable: publisher-place
-        prefix: ' ('
-      - number: volume
-        prefix: ), 2/
-      - group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - date: issued
-        form: year
-        prefix: ' '
-      - number: pages
-        prefix: 'pp. '
-      - variable: doi
-      - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     legal_case:
       - title: primary
         wrap:

--- a/styles/new-harts-rules-notes.yaml
+++ b/styles/new-harts-rules-notes.yaml
@@ -134,108 +134,17 @@ citation:
       - variable: doi
       - variable: url
     default:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - date: issued
-        form: year
-        wrap:
-          punctuation: parentheses
-        prefix: ' '
-      - variable: doi
-      - variable: url
-      - delimiter: none
-        group:
-          - date: issued
-            form: month-day
-            prefix: ', issued '
-          - date: issued
-            form: year
-            prefix: ', '
-      - delimiter: none
-        prefix: ', '
-        group:
-          - date: issued
-            form: month-day
-          - date: issued
-            form: year
-            prefix: ', '
+      remove:
+        - match:
+            number: number
+        - match:
+            variable: medium
+        - match:
+            contributor: interviewer
     interview:
-      - contributor: author
-        form: long
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 1
-          and-others: et-al
-      - title: primary
-        wrap:
-          punctuation: quotes
-      - prefix: ', in '
-        group:
-          - contributor: editor
-            form: verb
-            name-order: given-first
-            shorten:
-              min: 4
-              use-first: 1
-          - title: parent-monograph
-            emph: true
-      - title: parent-serial
-        emph: true
-      - number: pages
-      - variable: publisher-place
-      - number: volume
-        prefix: ), 2/
-      - variable: doi
-      - variable: url
-      - number: number
-        prefix: ', Patent '
-      - delimiter: none
-        group:
-          - date: issued
-            form: month-day
-            prefix: ', issued '
-          - date: issued
-            form: year
-            prefix: ', '
-      - delimiter: none
-        prefix: ', '
-        group:
-          - date: issued
-            form: month-day
-          - date: issued
-            form: year
-            prefix: ', '
-      - variable: medium
-        prefix: ', '
-      - contributor: interviewer
-        form: verb
-        name-order: given-first
-        prefix: ', '
+      remove:
+        - match:
+            date: issued
   template:
     - contributor: author
       form: long

--- a/styles/nlm-citation-sequence-brackets-no-et-al.yaml
+++ b/styles/nlm-citation-sequence-brackets-no-et-al.yaml
@@ -60,191 +60,57 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/nlm-citation-sequence-brackets-year-only-no-issue.yaml
+++ b/styles/nlm-citation-sequence-brackets-year-only-no-issue.yaml
@@ -72,30 +72,23 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
   template:
   - contributor: author
     form: long

--- a/styles/nlm-citation-sequence-brackets.yaml
+++ b/styles/nlm-citation-sequence-brackets.yaml
@@ -51,215 +51,57 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/nlm-citation-sequence-superscript-brackets-year-only.yaml
+++ b/styles/nlm-citation-sequence-superscript-brackets-year-only.yaml
@@ -51,33 +51,23 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
   template:
   - contributor: author
     form: long

--- a/styles/nlm-citation-sequence-superscript-year-only-no-issue.yaml
+++ b/styles/nlm-citation-sequence-superscript-year-only-no-issue.yaml
@@ -68,188 +68,57 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: url
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/nlm-citation-sequence-superscript.yaml
+++ b/styles/nlm-citation-sequence-superscript.yaml
@@ -49,215 +49,57 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/nlm-citation-sequence.yaml
+++ b/styles/nlm-citation-sequence.yaml
@@ -49,215 +49,57 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/nlm-name-year.yaml
+++ b/styles/nlm-name-year.yaml
@@ -111,223 +111,57 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/oscola-no-ibid.yaml
+++ b/styles/oscola-no-ibid.yaml
@@ -65,21 +65,9 @@ citation:
       delimiter-precedes-last: never
   type-variants:
     patent:
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ", "
-    - number: volume
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long
@@ -142,39 +130,13 @@ bibliography:
     separator: " "
   type-variants:
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ", "
-    - variable: publisher
-      prefix: " ("
-    - number: volume
-    - variable: url
-    - title: parent-monograph
-    - title: parent-serial
+      remove:
+        - match:
+            date: issued
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ", "
-    - variable: publisher
-      prefix: " ("
-    - number: volume
-    - variable: url
-    - title: parent-monograph
-    - title: parent-serial
+      remove:
+        - match:
+            date: issued
     interview:
     - variable: note
     - contributor: author

--- a/styles/oscola.yaml
+++ b/styles/oscola.yaml
@@ -64,21 +64,9 @@ citation:
       delimiter-precedes-last: never
   type-variants:
     patent:
-    - contributor: author
-      form: long
-      name-order: given-first
-      and: text
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ", "
-    - number: volume
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long
@@ -147,39 +135,13 @@ bibliography:
     separator: " "
   type-variants:
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ", "
-    - variable: publisher
-      prefix: " ("
-    - number: volume
-    - variable: url
-    - title: parent-monograph
-    - title: parent-serial
+      remove:
+        - match:
+            date: issued
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ", "
-    - variable: publisher
-      prefix: " ("
-    - number: volume
-    - variable: url
-    - title: parent-monograph
-    - title: parent-serial
+      remove:
+        - match:
+            date: issued
     interview:
     - variable: note
     - contributor: author

--- a/styles/oxford-journals-scimed-author-date.yaml
+++ b/styles/oxford-journals-scimed-author-date.yaml
@@ -95,57 +95,13 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
     chapter:
     - contributor: author
       form: long
@@ -177,31 +133,9 @@ bibliography:
     - number: pages
       prefix: ":"
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: volume
-    - number: pages
-      prefix: ":"
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/oxford-journals-scimed-numeric.yaml
+++ b/styles/oxford-journals-scimed-numeric.yaml
@@ -76,57 +76,13 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
     chapter:
     - contributor: author
       form: long
@@ -157,31 +113,9 @@ bibliography:
     - variable: publisher
       prefix: ": "
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: ":"
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/pensoft-journals.yaml
+++ b/styles/pensoft-journals.yaml
@@ -99,86 +99,32 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: doi
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     legal_case:
     - contributor: author
       form: long

--- a/styles/plos.yaml
+++ b/styles/plos.yaml
@@ -44,133 +44,46 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - number: volume
-    - number: pages
-      prefix: ": "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      extends: article-journal
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: "; "
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/proceedings-of-the-royal-society-b.yaml
+++ b/styles/proceedings-of-the-royal-society-b.yaml
@@ -55,81 +55,19 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " 2019 "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - date: issued
-      form: year
-    - number: pages
-      prefix: ", "
-    - variable: doi
-      prefix: . (
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " 2019 "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", "
-    - date: issued
-      form: year
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: . (
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: " 2019 "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ", "
-    - date: issued
-      form: year
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-      prefix: . (
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/royal-society-of-chemistry.yaml
+++ b/styles/royal-society-of-chemistry.yaml
@@ -70,65 +70,34 @@ bibliography:
     - variable: doi
       prefix: "DOI:"
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-    - variable: publisher-place
+      remove:
+        - match:
+            title: primary
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-    - variable: publisher-place
+      remove:
+        - match:
+            title: primary
     broadcast:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-    - variable: publisher-place
+      remove:
+        - match:
+            title: primary
     chapter:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-      prefix: "pp. "
-    - contributor: editor
-      form: short
-      name-order: given-first
-      prefix: ", editors. "
-    - variable: publisher-place
+      extends: article-magazine
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            variable: publisher
+      add:
+        - component:
+            contributor: editor
+            form: short
+            name-order: given-first
+            prefix: ', editors. '
+          before:
+            variable: publisher-place
     dataset:
     - delimiter: none
       group:
@@ -140,60 +109,23 @@ bibliography:
     - date: issued
       form: year
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-    - variable: publisher-place
+      extends: article-magazine
+      remove:
+        - match:
+            variable: publisher
     interview:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-    - variable: publisher-place
+      remove:
+        - match:
+            title: primary
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
+      extends: chapter
+      remove:
+        - match:
+            contributor: editor
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - date: issued
-      form: year
-    - number: volume
-    - number: pages
-    - variable: publisher-place
+      remove:
+        - match:
+            title: primary
     standard:
     - delimiter: none
       group:

--- a/styles/sage-harvard.yaml
+++ b/styles/sage-harvard.yaml
@@ -112,108 +112,54 @@ bibliography:
     separator: ". "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                wrap:
+                  punctuation: parentheses
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            variable: publisher
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-        prefix: "on "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+                prefix: 'on '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     legal_case:
     - contributor: author
       form: long

--- a/styles/sage-vancouver.yaml
+++ b/styles/sage-vancouver.yaml
@@ -42,86 +42,18 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     broadcast:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
     - contributor: author
       form: long
@@ -153,86 +85,18 @@ bibliography:
     - variable: publisher-place
     - variable: url
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      prefix: ", "
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", "
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/spie-journals.yaml
+++ b/styles/spie-journals.yaml
@@ -58,169 +58,34 @@ bibliography:
     separator: ", "
   type-variants:
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: " ["
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     chapter:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: " ["
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: " ["
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     interview:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 1
-    - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: " ["
+      remove:
+        - match:
+            title: primary
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: " ["
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      shorten:
-        min: 8
-        use-first: 1
-      prefix: "pp. "
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-    - variable: publisher
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: " ["
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
     webpage:
     - number: citation-number
       suffix: .

--- a/styles/springer-basic-author-date-no-et-al.yaml
+++ b/styles/springer-basic-author-date-no-et-al.yaml
@@ -87,83 +87,32 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - variable: publisher
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-    - variable: publisher-place
-      prefix: ", "
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - variable: publisher
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-    - variable: publisher-place
-      prefix: ", "
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
   template:
   - contributor: author
     form: long

--- a/styles/springer-basic-brackets-no-et-al-alphabetical.yaml
+++ b/styles/springer-basic-brackets-no-et-al-alphabetical.yaml
@@ -39,31 +39,23 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - variable: publisher-place
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - variable: publisher
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     patent:
     - contributor: author
       form: long

--- a/styles/springer-basic-brackets-no-et-al.yaml
+++ b/styles/springer-basic-brackets-no-et-al.yaml
@@ -61,83 +61,32 @@ bibliography:
     separator: '. '
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: ' '
-    - title: primary
-      prefix: ' '
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ':'
-    - variable: publisher
-    - number: pages
-      prefix: ', pp '
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-      prefix: ', '
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: ' '
-    - title: primary
-      prefix: ' '
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ', pp '
-    - variable: doi
-    - variable: publisher-place
-      prefix: ', '
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: ' '
-    - title: primary
-      prefix: ' '
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: 'on '
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ':'
-    - variable: publisher
-    - number: pages
-      prefix: ', pp '
-    - variable: doi
-    - variable: publisher-place
-      prefix: ', '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     webpage:
     - contributor: author
       form: long

--- a/styles/springer-fachzeitschriften-medizin-psychologie.yaml
+++ b/styles/springer-fachzeitschriften-medizin-psychologie.yaml
@@ -62,92 +62,32 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - variable: publisher
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-      prefix: ", "
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-    - variable: publisher-place
-      prefix: ", "
+      remove:
+        - match:
+            number: issue
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 5
-        use-first: 3
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: issue
-      prefix: ":"
-    - variable: publisher
-    - number: pages
-      prefix: ", pp "
-    - variable: doi
-    - variable: publisher-place
-      prefix: ", "
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     webpage:
     - number: citation-number
       suffix: ". "

--- a/styles/springer-humanities-author-date.yaml
+++ b/styles/springer-humanities-author-date.yaml
@@ -84,52 +84,14 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
-      prefix: https://doi.org/
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
+      remove:
+        - match:
+            number: issue
   template:
   - contributor: author
     form: long

--- a/styles/springer-humanities-brackets.yaml
+++ b/styles/springer-humanities-brackets.yaml
@@ -69,52 +69,14 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-      prefix: ": "
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
-      prefix: https://doi.org/
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: ": "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - variable: doi
+      remove:
+        - match:
+            number: issue
   template:
   - contributor: author
     form: long

--- a/styles/springer-mathphys-author-date.yaml
+++ b/styles/springer-mathphys-author-date.yaml
@@ -84,62 +84,20 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: pages
-    - variable: publisher-place
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: doi
-    - variable: url
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: doi
-    - variable: url
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/springer-mathphys-brackets.yaml
+++ b/styles/springer-mathphys-brackets.yaml
@@ -50,65 +50,20 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: pages
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
-      prefix: https://doi.org/
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - title: primary
-      prefix: ": "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - variable: doi
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     entry-encyclopedia:
     - number: citation-number
       suffix: ". "

--- a/styles/springer-physics-author-date.yaml
+++ b/styles/springer-physics-author-date.yaml
@@ -101,167 +101,61 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      remove:
+        - match:
+            title: primary
+        - match:
+            variable: publisher
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      remove:
+        - match:
+            title: primary
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      remove:
+        - match:
+            title: primary
     broadcast:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      extends: article-magazine
+      remove:
+        - match:
+            variable: publisher
     chapter:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", pp. "
+      extends: article-magazine
+      modify:
+        - match:
+            number: pages
+          prefix: ', pp. '
     dataset:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      extends: article-magazine
+      remove:
+        - match:
+            variable: publisher
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      extends: article-magazine
+      remove:
+        - match:
+            variable: publisher
     interview:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      extends: article-magazine
+      remove:
+        - match:
+            variable: publisher
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-      prefix: "in "
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", pp. "
+      extends: chapter
+      modify:
+        - match:
+            title: parent-monograph
+          prefix: 'in '
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      prefix: "pp. "
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      extends: article-magazine
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - number: volume
-    - variable: publisher
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-    - number: pages
-      prefix: ", "
+      remove:
+        - match:
+            title: primary
     legal_case:
     - contributor: author
       form: long

--- a/styles/springer-physics-brackets.yaml
+++ b/styles/springer-physics-brackets.yaml
@@ -42,34 +42,18 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: pages
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: publisher-place
     book:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - title: primary
-      emph: true
-    - number: volume
-    - number: pages
-    - variable: publisher
-      prefix: " ("
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
+      add:
+        - component:
+            title: primary
+            emph: true
+          before:
+            number: volume
     chapter:
     - contributor: author
       form: long
@@ -84,38 +68,17 @@ bibliography:
     - number: pages
       prefix: "pp. "
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-monograph
-    - title: parent-serial
-    - title: primary
-      emph: true
-    - number: volume
-    - number: pages
-    - variable: publisher
-      prefix: " ("
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
+      add:
+        - component:
+            title: primary
+            emph: true
+          before:
+            number: volume
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: given-first
-      prefix: "pp. "
-    - title: parent-monograph
-    - title: parent-serial
-    - number: volume
-    - number: pages
-    - variable: publisher
-      prefix: " ("
-    - variable: publisher-place
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
+      modify:
+        - match:
+            contributor: author
+          prefix: 'pp. '
     report:
     - contributor: author
       form: long
@@ -154,23 +117,22 @@ bibliography:
       wrap:
         punctuation: parentheses
     motion-picture:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: primary
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
+      extends: report
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: publisher-place
     broadcast:
-    - contributor: author
-      form: long
-      name-order: given-first
-    - title: parent-serial
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
+      extends: patent
+      remove:
+        - match:
+            number: patent-number
+      add:
+        - component:
+            title: parent-serial
+          before:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/springer-socpsych-author-date.yaml
+++ b/styles/springer-socpsych-author-date.yaml
@@ -74,265 +74,68 @@ bibliography:
     separator: ": "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     broadcast:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "In "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-      wrap:
-        punctuation: parentheses
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+          wrap:
+            punctuation: parentheses
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            prefix: '. In '
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'In '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     interview:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-      wrap:
-        punctuation: parentheses
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+          wrap:
+            punctuation: parentheses
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-    - number: pages
-    - variable: publisher-place
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: doi
-    - variable: url
+      remove:
+        - match:
+            date: issued
     legal-case:
     - title: primary
       suffix: "., "

--- a/styles/springer-socpsych-brackets.yaml
+++ b/styles/springer-socpsych-brackets.yaml
@@ -69,287 +69,68 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     broadcast:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "In "
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-      wrap:
-        punctuation: parentheses
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+          wrap:
+            punctuation: parentheses
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+                emph: true
+      add:
+        - component:
+            prefix: '. In '
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'In '
+              - title: parent-monograph
+                emph: true
+          before:
+            title: parent-serial
     interview:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-      wrap:
-        punctuation: parentheses
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+          wrap:
+            punctuation: parentheses
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
     personal_communication:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 7
-    - title: primary
-    - prefix: ". In "
-      group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ", "
-    - variable: publisher
-      prefix: "). "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/springer-vancouver-author-date.yaml
+++ b/styles/springer-vancouver-author-date.yaml
@@ -93,223 +93,57 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - date: issued
-      form: year
-      prefix: "; "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 6
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - number: pages
-      prefix: ":"
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/taylor-and-francis-council-of-science-editors-author-date.yaml
+++ b/styles/taylor-and-francis-council-of-science-editors-author-date.yaml
@@ -86,82 +86,37 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "; "
-    - variable: doi
-      prefix: https://doi.org/
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
-    - variable: doi
-    - variable: publisher-place
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/taylor-and-francis-national-library-of-medicine.yaml
+++ b/styles/taylor-and-francis-national-library-of-medicine.yaml
@@ -49,239 +49,63 @@ bibliography:
     separator: ". "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-        prefix: "on "
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
+      remove:
+        - match:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+              - title: parent-monograph
+      add:
+        - component:
+            group:
+              - contributor: editor
+                form: verb
+                name-order: given-first
+                shorten:
+                  min: 4
+                  use-first: 3
+                prefix: 'on '
+              - title: parent-monograph
+          before:
+            title: parent-serial
     dataset:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - date: issued
-      form: year
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-      prefix: "pp. "
-    - variable: url
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      prefix: " "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        shorten:
-          min: 4
-          use-first: 3
-      - title: parent-monograph
-    - title: parent-serial
-    - group:
-      - number: volume
-      - number: issue
-        wrap:
-          punctuation: parentheses
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: long

--- a/styles/the-company-of-biologists.yaml
+++ b/styles/the-company-of-biologists.yaml
@@ -108,53 +108,15 @@ bibliography:
     separator: ". "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: family-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: pages
-      prefix: "pp. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
   template:
   - contributor: author
     form: long

--- a/styles/the-geological-society-of-london.yaml
+++ b/styles/the-geological-society-of-london.yaml
@@ -96,53 +96,14 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 2
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-      prefix: ". "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - number: issue
-    - variable: doi
-      prefix: https://doi.org/
-    - number: pages
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 2
-    - date: issued
-      form: year
-      prefix: " "
-    - title: primary
-      prefix: ". "
-    - group:
-      - contributor: editor
-        form: verb
-        name-order: given-first
-      - title: parent-monograph
-        emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
-    - variable: doi
-    - number: pages
+      remove:
+        - match:
+            number: issue
     legal_case:
     - contributor: author
       form: long

--- a/styles/the-institution-of-engineering-and-technology.yaml
+++ b/styles/the-institution-of-engineering-and-technology.yaml
@@ -61,183 +61,38 @@ bibliography:
     separator: ", "
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ": "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: " ("
-    - date: issued
-      form: year
-    - number: volume
-    - number: issue
-      wrap:
-        punctuation: parentheses
-      prefix: ", ("
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ": "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: " ("
-    - date: issued
-      form: year
-    - number: volume
-    - number: issue
-      wrap:
-        punctuation: parentheses
-      prefix: ", ("
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ": "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: " ("
-    - date: issued
-      form: year
-    - number: volume
-    - number: issue
-      wrap:
-        punctuation: parentheses
-      prefix: ", ("
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ": "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: " ("
-    - date: issued
-      form: year
-    - number: volume
-    - number: issue
-      wrap:
-        punctuation: parentheses
-      prefix: ", ("
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ": "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: " ("
-    - date: issued
-      form: year
-    - number: volume
-    - number: issue
-      wrap:
-        punctuation: parentheses
-      prefix: ", ("
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ": "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: " ("
-    - number: volume
-    - number: issue
-      wrap:
-        punctuation: parentheses
-      prefix: ", ("
-    - number: pages
-      prefix: "), "
+      remove:
+        - match:
+            date: issued
     thesis:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - title: primary
-      wrap:
-        punctuation: quotes
-      prefix: ": "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - variable: publisher
-      prefix: " ("
-    - number: volume
-    - number: issue
-      wrap:
-        punctuation: parentheses
-      prefix: ", ("
-    - number: pages
-      prefix: "), "
+      remove:
+        - match:
+            date: issued
     webpage:
     - number: citation-number
     - contributor: author

--- a/styles/thieme-german.yaml
+++ b/styles/thieme-german.yaml
@@ -136,33 +136,25 @@ bibliography:
       suppress: false
     - title: parent-serial
     webpage:
-    - number: citation-number
-      quote: false
-      wrap:
-        punctuation: brackets
-      strip-periods: false
-    - contributor: author
-      form: long
-      sort-separator: ' '
-      shorten:
-        min: 4
-        use-first: 3
-        and-others: et-al
-        delimiter-precedes-last: always
-    - title: primary
-    - title: parent-serial
-      strip-periods: true
-    - date: issued
-      form: year
-      suffix: ;
-    - number: volume
-    - number: pages
-      prefix: ': '
-    - variable: url
-    - term: accessed
-      form: long
-    - date: accessed
-      form: full
+      extends: article-journal
+      remove:
+        - match:
+            variable: doi
+      add:
+        - component:
+            variable: url
+          after:
+            number: pages
+        - component:
+            term: accessed
+            form: long
+          after:
+            variable: url
+        - component:
+            date: accessed
+            form: full
+          after:
+            term: accessed
     patent:
     - contributor: author
       form: long

--- a/styles/thomson-reuters-legal-tax-and-accounting-australia.yaml
+++ b/styles/thomson-reuters-legal-tax-and-accounting-australia.yaml
@@ -46,35 +46,13 @@ citation:
       delimiter-precedes-last: never
   type-variants:
     entry-encyclopedia:
-    - contributor: author
-      form: short
-      name-order: family-first
-    - title: primary
-      prefix: ", "
-      wrap:
-        punctuation: quotes
-    - number: volume
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
+      remove:
+        - match:
+            date: issued
     patent:
-    - contributor: author
-      form: short
-      name-order: family-first
-    - title: primary
-      prefix: ", "
-      wrap:
-        punctuation: quotes
-    - number: volume
-    - title: parent-monograph
-    - title: parent-serial
-    - variable: publisher
-    - variable: publisher-place
-      prefix: ", "
-    - variable: url
+      remove:
+        - match:
+            date: issued
   template:
   - contributor: author
     form: short
@@ -100,83 +78,59 @@ citation:
   subsequent:
     type-variants:
       book:
-      - contributor: author
-        form: short
-        name-order: family-first
-      - title: primary
-        form: short
-        prefix: ", "
-        wrap:
-          punctuation: quotes
-        emph: true
-        quote: false
-      - variable: locator
-        prefix: " at "
+        modify:
+          - match:
+              title: primary
+            emph: true
+            quote: false
+            prefix: ', '
+            wrap:
+              punctuation: quotes
       legislation:
-      - contributor: author
-        form: short
-        name-order: family-first
-      - title: primary
-        form: short
-        prefix: ", "
-        wrap:
-          punctuation: quotes
-        emph: true
-        quote: false
-      - variable: locator
-        prefix: " at "
+        modify:
+          - match:
+              title: primary
+            emph: true
+            quote: false
+            prefix: ', '
+            wrap:
+              punctuation: quotes
       manuscript:
-      - contributor: author
-        form: short
-        name-order: family-first
-      - title: primary
-        form: short
-        prefix: ", "
-        wrap:
-          punctuation: quotes
-        emph: true
-        quote: false
-      - variable: locator
-        prefix: " at "
+        modify:
+          - match:
+              title: primary
+            emph: true
+            quote: false
+            prefix: ', '
+            wrap:
+              punctuation: quotes
       motion-picture:
-      - contributor: author
-        form: short
-        name-order: family-first
-      - title: primary
-        form: short
-        prefix: ", "
-        wrap:
-          punctuation: quotes
-        emph: true
-        quote: false
-      - variable: locator
-        prefix: " at "
+        modify:
+          - match:
+              title: primary
+            emph: true
+            quote: false
+            prefix: ', '
+            wrap:
+              punctuation: quotes
       thesis:
-      - contributor: author
-        form: short
-        name-order: family-first
-      - title: primary
-        form: short
-        prefix: ", "
-        wrap:
-          punctuation: quotes
-        emph: true
-        quote: false
-      - variable: locator
-        prefix: " at "
+        modify:
+          - match:
+              title: primary
+            emph: true
+            quote: false
+            prefix: ', '
+            wrap:
+              punctuation: quotes
       webpage:
-      - contributor: author
-        form: short
-        name-order: family-first
-      - title: primary
-        form: short
-        prefix: ", "
-        wrap:
-          punctuation: quotes
-        emph: true
-        quote: false
-      - variable: locator
-        prefix: " at "
+        modify:
+          - match:
+              title: primary
+            emph: true
+            quote: false
+            prefix: ', '
+            wrap:
+              punctuation: quotes
     template:
     - contributor: author
       form: short

--- a/styles/trends-journals.yaml
+++ b/styles/trends-journals.yaml
@@ -57,61 +57,15 @@ bibliography:
     separator: ", "
   type-variants:
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-      shorten:
-        min: 4
-        use-first: 1
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     paper-conference:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 3
-        use-first: 1
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: " "
-    - title: primary
-      prefix: " "
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - contributor: editor
-      form: verb
-      name-order: family-first
-      shorten:
-        min: 4
-        use-first: 1
-    - number: volume
-    - variable: publisher
-    - number: pages
-      prefix: "pp. "
+      modify:
+        - match:
+            number: pages
+          prefix: 'pp. '
     patent:
     - number: citation-number
       suffix: .


### PR DESCRIPTION
## Summary
- Updates `citum-migrate` and JS tooling to emit and resolve exact Template V3 diffs, including grouped selectors and same-section parent variant diffs.
- Converts safe `styles/` type variants to Template V3 diff form while preserving exact resolved templates.
- Updates report, oracle, and style-structure tooling so authored-vs-resolved metrics stay correct and concision does not regress.

## Stack
- Base: #623 / `codex/csl26-t3v1-template-v3-engine`
- This PR is intentionally stacked on the engine PR.

## LOC Impact in styles/
| | Original PR | This revision |
|---|---|---|
| Additions | +17,237 | +3,639 |
| Deletions | -22,662 | -13,056 |
| **Net** | **-5,425** | **-9,417** |

The original version used `yaml.dump` to write back the entire YAML file, causing a one-time full-file reformat (list indentation, quote normalization) that added ~14k lines of noise unrelated to compression. This revision uses surgical line-range replacement — only the converted `type-variants` blocks are modified, leaving every other byte in the file untouched. A size guard also prevents conversion when the diff YAML is larger than the full template YAML (19 previously over-converted files, 1,265 lines recovered).

## Verification
- Stacked Rust gate: `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run` - pass, 1190 tests.
- JS tooling: `node --test scripts/convert-template-v3.test.js scripts/oracle-yaml.test.js scripts/report-core.test.js scripts/style-structure-lint.test.js` - pass, 76 tests.
- Style lint: `node scripts/style-structure-lint.js --strict` - pass.
- Core report gate: `cargo build -q --bin citum && node scripts/report-core.js > /tmp/core-report.json && node scripts/check-core-quality.js --report /tmp/core-report.json --baseline scripts/report-data/core-quality-baseline.json` - pass, 154 styles, fidelity 1.0, warnings 0.
- Schema regeneration inherited from #623: `cargo run --bin citum --features schema -- schema --out-dir docs/schemas` - pass.

## Review / Feedback
- Copilot comments addressed: inherited same-key diff overlays, non-mutating JS resolution for authored/raw metrics, and honest conversion totals for 0/N scanned styles.
- Earlier automated review subagents failed due account usage limits before returning findings.
