### PR TITLE
feat(cli): unify style registry workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,8 +518,10 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
+ "crossterm",
  "csl-legacy",
  "indexmap 2.14.0",
+ "ratatui",
  "schemars",
  "serde",
  "serde_json",
@@ -802,6 +819,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,9 +943,13 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",
+ "derive_more",
  "document-features",
+ "mio",
  "parking_lot",
  "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -980,6 +1024,40 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "data-encoding"
@@ -1124,6 +1202,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -1296,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1373,6 +1473,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
@@ -1633,7 +1739,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2106,6 +2223,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +2336,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,7 +2390,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2327,6 +2472,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +2545,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2456,6 +2621,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +2685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2580,6 +2755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3112,6 +3296,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.1",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,7 +3643,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3665,6 +3912,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -4068,7 +4336,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4159,7 +4427,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4856,6 +5126,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,7 +5534,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 clap = { version = "4.4", features = ["derive", "color"] }
 clap_complete = "4.4"
 comfy-table = "7.1"
+crossterm = "0.29.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
@@ -20,6 +21,7 @@ strsim = "0.10"
 walkdir = "2.4"
 schemars = { version = "1.2.1", features = ["indexmap2"], optional = true }
 indexmap = "2.2.3"
+ratatui = { version = "0.30.0", default-features = false, features = ["crossterm_0_29"] }
 citum_schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
 citum_engine = { package = "citum-engine", path = "../citum-engine" }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -28,8 +28,8 @@ const CLAP_STYLES: Styles = Styles::styled()
                   citum check -s apa-7th -b refs.json\n\n  \
                   Convert a style to binary CBOR:\n    \
                   citum convert style style.yaml -o style.cbor\n\n  \
-                  List all builtin styles:\n    \
-                  citum styles list\n\n\
+                  Search available styles:\n    \
+                  citum style search apa\n\n\
                   Run 'citum <COMMAND> --help' for more detailed examples and options.",
     styles = CLAP_STYLES,
     arg_required_else_help = true
@@ -139,30 +139,16 @@ pub(crate) enum Commands {
         command: ConvertCommands,
     },
 
-    /// List and inspect embedded (builtin) citation styles
-    #[command(
-        about = "List and inspect embedded (builtin) citation styles",
-        long_about = "Browse and inspect Citum's library of embedded citation styles.\n\n\
-                      Citum includes several standard styles (APA, MLA, Chicago, etc.)\n\
-                      built directly into the binary. You can reference these styles\n\
-                      by their alias (e.g., 'apa-7th') instead of a file path.\n\n\
-                      EXAMPLES:\n  \
-                      List all builtin styles and their aliases:\n    \
-                      citum styles list"
-    )]
-    Styles {
-        #[command(subcommand)]
-        command: Option<StylesCommands>,
-    },
-
     /// Manage and inspect the style registry
     #[command(
-        about = "Manage and inspect the style registry",
-        long_about = "Inspect and manage the citation style registry.\n\n\
-                      The registry maps style names and aliases to available styles.\n\n\
+        about = "Manage style registry sources",
+        long_about = "Manage style registry sources used for style discovery and resolution.\n\n\
+                      Registries map style names and aliases to available styles.\n\n\
                       EXAMPLES:\n  \
-                      List all styles in the registry:\n    \
+                      List configured registries:\n    \
                       citum registry list\n\n  \
+                      Add an institutional registry:\n    \
+                      citum registry add https://styles.example.org/citum-registry.yaml --name example\n\n  \
                       Resolve a style name or alias:\n    \
                       citum registry resolve apa"
     )]
@@ -171,37 +157,46 @@ pub(crate) enum Commands {
         command: RegistryCommands,
     },
 
-    /// Manage user-installed styles and locales
+    /// Find, inspect, install, remove, and lint citation styles
     #[command(
-        about = "Manage user-installed styles and locales",
-        long_about = "Install, remove, and list user-owned styles and locales.\n\n\
-                      Stored in the platform-specific user data directory (for example,\n\
-                      ~/.local/share/citum/ on Linux, ~/Library/Application Support/citum/ on\n\
-                      macOS, or %APPDATA%\\citum\\ on Windows) and checked before builtin styles\n\
-                      when resolving names.\n\n\
+        about = "Find, inspect, install, remove, and lint citation styles",
+        long_about = "Work with citation styles by task: search the catalog, inspect a style,\n\
+                      install a style, remove an installed style, or lint a style file.\n\n\
                       EXAMPLES:\n  \
-                      List all installed styles and locales:\n    \
-                      citum store list\n\n  \
-                      Install a style from a local file:\n    \
-                      citum store install /path/to/my-style.yaml\n\n  \
-                      Remove an installed style:\n    \
-                      citum store remove my-style"
+                      Search styles:\n    \
+                      citum style search chicago\n\n  \
+                      Install a style without copying a full ID:\n    \
+                      citum style add chicago\n\n  \
+                      List embedded styles only:\n    \
+                      citum style list --source embedded"
     )]
-    Store {
-        #[command(subcommand)]
-        command: StoreCommands,
-    },
-
-    /// Validate a style against a locale file
     Style {
         #[command(subcommand)]
         command: StyleCommands,
     },
 
-    /// Validate locale files and inspect locale-specific behavior
+    /// List, install, remove, and lint locale files
+    #[command(
+        about = "List, install, remove, and lint locale files",
+        long_about = "Manage installed locales and validate locale authoring files.\n\n\
+                      EXAMPLES:\n  \
+                      List installed locales:\n    \
+                      citum locale list --source installed\n\n  \
+                      Install a locale:\n    \
+                      citum locale add locales/en-US.yaml\n\n  \
+                      Lint a locale:\n    \
+                      citum locale lint locales/en-US.yaml"
+    )]
     Locale {
         #[command(subcommand)]
         command: LocaleCommands,
+    },
+
+    /// Diagnose local Citum configuration, cache, and installed resources
+    Doctor {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Generate JSON schema for Citum models
@@ -330,23 +325,45 @@ pub(crate) enum RefsFormat {
 }
 
 #[derive(Subcommand)]
-pub(crate) enum StylesCommands {
-    /// List all embedded (builtin) style names
-    List,
-}
-
-#[derive(Subcommand)]
 pub(crate) enum RegistryCommands {
     /// List available style registries
     #[command(
         about = "List available style registries",
-        long_about = "Display available style registries (embedded default\n\
-                      and local citum-registry.yaml if present)."
+        long_about = "Display available style registries (embedded default,\n\
+                      local citum-registry.yaml if present, and configured\n\
+                      registry sources)."
     )]
     List {
         /// Output format
         #[arg(long, default_value = "table")]
         format: String,
+    },
+
+    /// Add a registry source from a local path or HTTP(S) URL
+    Add {
+        /// Registry YAML path or HTTP(S) URL
+        source: String,
+        /// Registry name; defaults to the file stem or URL host
+        #[arg(long)]
+        name: Option<String>,
+    },
+
+    /// Remove a configured registry source
+    Remove {
+        /// Registry name to remove
+        name: String,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+
+    /// Refresh one configured registry or all registries
+    Update {
+        /// Registry name to refresh
+        name: Option<String>,
+        /// Refresh all configured registries
+        #[arg(long)]
+        all: bool,
     },
 
     /// Resolve a style name or alias to its canonical ID
@@ -362,53 +379,12 @@ pub(crate) enum RegistryCommands {
 }
 
 #[derive(Subcommand)]
-pub(crate) enum StoreCommands {
-    /// List all installed user styles and locales
-    #[command(
-        about = "List all installed user styles and locales",
-        long_about = "Display names of all styles and locales installed in the user store\n\
-                      directory. Does not include embedded/builtin styles."
-    )]
-    List,
-
-    /// Install a style or locale from a local file
-    #[command(
-        about = "Install a style or locale from a local file",
-        long_about = "Copy a local style or locale file into the user store directory.\n\
-                      The style/locale name is derived from the file stem (without extension).\n\
-                      Supports YAML, JSON, and CBOR formats.\n\n\
-                      EXAMPLES:\n  \
-                      Install a style:\n    \
-                      citum store install /path/to/my-custom-style.yaml\n\n  \
-                      Install a locale:\n    \
-                      citum store install /path/to/my-locale.yaml"
-    )]
-    Install {
-        /// Path to the style or locale file to install
-        #[arg(index = 1, required = true)]
-        source: PathBuf,
-    },
-
-    /// Remove an installed style or locale
-    #[command(
-        about = "Remove an installed style or locale",
-        long_about = "Delete a style or locale from the user store directory.\n\
-                      Requires confirmation before deletion."
-    )]
-    Remove {
-        /// Name of the style or locale to remove (without extension)
-        #[arg(index = 1, required = true)]
-        name: String,
-    },
-}
-
-#[derive(Subcommand)]
 pub(crate) enum StyleCommands {
-    /// List styles in the unified catalog
+    /// List styles in the style catalog
     List {
-        /// Catalog source to include
-        #[arg(long, value_enum, default_value_t = StyleCatalogSource::All)]
-        source: StyleCatalogSource,
+        /// Catalog source to include: all, embedded, installed, or registry:<name>
+        #[arg(long, default_value = "all")]
+        source: String,
         /// Output format
         #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
         format: StyleCatalogFormat,
@@ -419,13 +395,13 @@ pub(crate) enum StyleCommands {
         #[arg(long, default_value_t = 0)]
         offset: usize,
     },
-    /// Search styles in the unified catalog
+    /// Search styles in the style catalog
     Search {
         /// Search query matched against IDs, aliases, titles, descriptions, and fields
         query: String,
-        /// Catalog source to include
-        #[arg(long, value_enum, default_value_t = StyleCatalogSource::All)]
-        source: StyleCatalogSource,
+        /// Catalog source to include: all, embedded, installed, or registry:<name>
+        #[arg(long, default_value = "all")]
+        source: String,
         /// Output format
         #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
         format: StyleCatalogFormat,
@@ -436,7 +412,7 @@ pub(crate) enum StyleCommands {
         #[arg(long, default_value_t = 0)]
         offset: usize,
     },
-    /// Show details for a style in the unified catalog
+    /// Show details for a style in the style catalog
     Info {
         /// Style ID or alias
         name: String,
@@ -444,26 +420,41 @@ pub(crate) enum StyleCommands {
         #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
         format: StyleCatalogFormat,
     },
-    /// Validate that a style's locale-driven features resolve against a locale file
+
+    /// Browse styles interactively in the terminal
+    Browse {
+        /// Optional initial search query
+        query: Option<String>,
+        /// Catalog source to include: all, embedded, installed, or registry:<name>
+        #[arg(long, default_value = "all")]
+        source: String,
+    },
+
+    /// Install a style by search query, ID, path, or URL
+    Add {
+        /// Style search query, ID, path, or URL
+        query: String,
+        /// Non-interactive: fail on ambiguous queries
+        #[arg(long)]
+        yes: bool,
+    },
+
+    /// Remove an installed style
+    Remove {
+        /// Installed style ID or alias
+        name: String,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+
+    /// Validate style authoring rules, optionally against a locale file
+    #[command(
+        about = "Validate style authoring rules",
+        long_about = "Validate a style file or installed/builtin style, including locale-driven\n\
+                      terms when --locale is provided."
+    )]
     Lint(LintStyleArgs),
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-pub(crate) enum StyleCatalogSource {
-    All,
-    Embedded,
-    #[value(name = "core-http")]
-    CoreHttp,
-}
-
-impl std::fmt::Display for StyleCatalogSource {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            StyleCatalogSource::All => write!(f, "all"),
-            StyleCatalogSource::Embedded => write!(f, "embedded"),
-            StyleCatalogSource::CoreHttp => write!(f, "core-http"),
-        }
-    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
@@ -483,6 +474,31 @@ impl std::fmt::Display for StyleCatalogFormat {
 
 #[derive(Subcommand)]
 pub(crate) enum LocaleCommands {
+    /// List installed or embedded locales
+    List {
+        /// Locale source to include: all, embedded, or installed
+        #[arg(long, default_value = "all")]
+        source: String,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
+        format: StyleCatalogFormat,
+    },
+
+    /// Install a locale file
+    Add {
+        /// Path to the locale file to install
+        path: PathBuf,
+    },
+
+    /// Remove an installed locale
+    Remove {
+        /// Installed locale ID
+        name: String,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+
     /// Validate a locale file's message syntax and alias targets
     Lint(LintLocaleArgs),
 }

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -3,8 +3,8 @@ use crate::args::BindingsArgs;
 use crate::args::{
     CheckArgs, CheckItem, Cli, Commands, ConvertCommands, ConvertRefsArgs, ConvertTypedArgs,
     DataType, InputFormat, LintLocaleArgs, LintStyleArgs, LocaleCommands, OutputFormat, RefsFormat,
-    RegistryCommands, RenderCommands, RenderDocArgs, RenderMode, RenderRefsArgs, StoreCommands,
-    StyleCatalogFormat, StyleCatalogSource, StyleCommands, StylesCommands,
+    RegistryCommands, RenderCommands, RenderDocArgs, RenderMode, RenderRefsArgs,
+    StyleCatalogFormat, StyleCommands,
 };
 #[cfg(feature = "schema")]
 use crate::args::{SchemaArgs, SchemaType};
@@ -30,18 +30,20 @@ use citum_schema::lint::{lint_raw_locale, lint_style_against_locale};
 use citum_schema::locale::RawLocale;
 use citum_schema::options::Processing;
 use citum_schema::{RegistryEntry, Style};
-use citum_store::{StoreConfig, StoreResolver, platform_data_dir};
+use citum_store::{
+    StoreConfig, StoreResolver, platform_cache_dir, platform_config_dir, platform_data_dir,
+};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 #[cfg(feature = "schema")]
 use schemars::schema_for;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Write as _;
 use std::fs;
-use std::io::{self, Write};
-use std::path::Path;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
 
 impl From<RefsFormat> for EngineRefsFormat {
     fn from(format: RefsFormat) -> Self {
@@ -71,17 +73,12 @@ pub(crate) fn run() -> Result<(), Box<dyn Error>> {
             ConvertCommands::Citations(args) => run_convert_typed(args, DataType::Citations),
             ConvertCommands::Locale(args) => run_convert_typed(args, DataType::Locale),
         },
-        Commands::Styles { command } => match command.unwrap_or(StylesCommands::List) {
-            StylesCommands::List => run_styles_list(),
-        },
         Commands::Registry { command } => match command {
             RegistryCommands::List { format } => run_registry_list(&format),
+            RegistryCommands::Add { source, name } => run_registry_add(&source, name.as_deref()),
+            RegistryCommands::Remove { name, yes } => run_registry_remove(&name, yes),
+            RegistryCommands::Update { name, all } => run_registry_update(name.as_deref(), all),
             RegistryCommands::Resolve { name } => run_registry_resolve(&name),
-        },
-        Commands::Store { command } => match command {
-            StoreCommands::List => run_store_list(),
-            StoreCommands::Install { source } => run_store_install(&source),
-            StoreCommands::Remove { name } => run_store_remove(&name),
         },
         Commands::Style { command } => match command {
             StyleCommands::List {
@@ -89,20 +86,27 @@ pub(crate) fn run() -> Result<(), Box<dyn Error>> {
                 format,
                 limit,
                 offset,
-            } => run_style_list(source, format, limit, offset),
+            } => run_style_list(&source, format, limit, offset),
             StyleCommands::Search {
                 query,
                 source,
                 format,
                 limit,
                 offset,
-            } => run_style_search(&query, source, format, limit, offset),
+            } => run_style_search(&query, &source, format, limit, offset),
             StyleCommands::Info { name, format } => run_style_info(&name, format),
+            StyleCommands::Browse { query, source } => run_style_browse(query.as_deref(), &source),
+            StyleCommands::Add { query, yes } => run_style_add(&query, yes),
+            StyleCommands::Remove { name, yes } => run_style_remove(&name, yes),
             StyleCommands::Lint(args) => run_lint_style(args),
         },
         Commands::Locale { command } => match command {
+            LocaleCommands::List { source, format } => run_locale_list(&source, format),
+            LocaleCommands::Add { path } => run_locale_add(&path),
+            LocaleCommands::Remove { name, yes } => run_locale_remove(&name, yes),
             LocaleCommands::Lint(args) => run_lint_locale(args),
         },
+        Commands::Doctor { json } => run_doctor(json),
         #[cfg(feature = "schema")]
         Commands::Schema(args) => run_schema(args),
         #[cfg(feature = "typescript")]
@@ -187,131 +191,29 @@ fn run_bindings(args: BindingsArgs) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn run_styles_list() -> Result<(), Box<dyn Error>> {
-    println!("Embedded (builtin) citation styles:");
-    println!();
-
-    let mut rows = Vec::new();
-
-    for name in citum_schema::embedded::EMBEDDED_STYLE_NAMES {
-        let style = citum_schema::embedded::get_embedded_style(name)
-            .ok_or_else(|| format!("failed to load builtin style: {name}"))??;
-
-        let alias = citum_schema::embedded::EMBEDDED_STYLE_ALIASES
-            .iter()
-            .find(|(_, full)| *full == *name)
-            .map_or("-".to_string(), |(a, _)| a.to_string());
-
-        let title = style.info.title.as_deref().unwrap_or("-").to_string();
-
-        rows.push(vec![alias, title, name.to_string()]);
-    }
-
-    let table = build_table(&["Alias", "Title", "Full Name"], rows);
-    println!("{table}");
-
-    println!();
-    println!("Usage:");
-    println!("  citum render refs -s <alias|name> -b refs.json");
-    println!("  citum render doc <doc.dj> -s <alias|name> -b refs.json");
-    Ok(())
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct RegistrySourceRecord {
+    name: String,
+    source: String,
 }
 
-/// List available style registries.
-fn run_registry_list(format: &str) -> Result<(), Box<dyn Error>> {
-    #[derive(Serialize)]
-    struct RegistryInfo {
-        name: String,
-        source: String,
-        version: String,
-        styles: usize,
-    }
-
-    let mut registries = Vec::new();
-
-    // Always include the default embedded registry
-    let default_reg = citum_schema::embedded::default_registry();
-    registries.push(RegistryInfo {
-        name: "default".to_string(),
-        source: "embedded".to_string(),
-        version: default_reg.version.clone(),
-        styles: default_reg.styles.len(),
-    });
-
-    // Check for local registry in current working directory
-    let local_path = std::path::Path::new("citum-registry.yaml");
-    if local_path.exists() {
-        match citum_schema::StyleRegistry::load_from_file(local_path) {
-            Ok(local_reg) => {
-                registries.push(RegistryInfo {
-                    name: "local".to_string(),
-                    source: "local".to_string(),
-                    version: local_reg.version.clone(),
-                    styles: local_reg.styles.len(),
-                });
-            }
-            Err(_) => {
-                // If loading fails, show the row with error indicators
-                registries.push(RegistryInfo {
-                    name: "local".to_string(),
-                    source: "local".to_string(),
-                    version: "?".to_string(),
-                    styles: 0,
-                });
-            }
-        }
-    }
-
-    if format == "json" {
-        let json = serde_json::to_string_pretty(&registries)?;
-        println!("{}", json);
-    } else {
-        println!("Available Style Registries:");
-        println!();
-
-        let rows: Vec<Vec<String>> = registries
-            .iter()
-            .map(|reg| {
-                vec![
-                    reg.name.clone(),
-                    reg.source.clone(),
-                    reg.version.clone(),
-                    reg.styles.to_string(),
-                ]
-            })
-            .collect();
-
-        let table = build_table(&["Name", "Source", "Version", "Styles"], rows);
-        println!("{table}");
-        println!();
-    }
-
-    Ok(())
-}
-
-/// Resolve a style name or alias in the registry.
-fn run_registry_resolve(name: &str) -> Result<(), Box<dyn Error>> {
-    let registry = citum_schema::embedded::default_registry();
-
-    if let Some(entry) = registry.resolve(name) {
-        let source = if entry.builtin.is_some() {
-            "builtin"
-        } else if entry.url.is_some() {
-            "url"
-        } else if entry.path.is_some() {
-            "path"
-        } else {
-            "unknown"
-        };
-        println!("{} ({})", entry.id, source);
-        Ok(())
-    } else {
-        eprintln!("Error: style not found: {name}");
-        std::process::exit(1);
-    }
+#[derive(Clone, Debug)]
+struct LoadedRegistry {
+    name: String,
+    source: String,
+    registry: citum_schema::StyleRegistry,
 }
 
 #[derive(Serialize)]
+struct RegistryInfo {
+    name: String,
+    source: String,
+    version: String,
+    styles: usize,
+    status: String,
+}
+
+#[derive(Clone, Serialize)]
 struct StyleCatalogRow {
     source: String,
     id: String,
@@ -322,11 +224,50 @@ struct StyleCatalogRow {
     url: Option<String>,
 }
 
-fn style_entry_source(entry: &RegistryEntry) -> &'static str {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CatalogSourceFilter<'a> {
+    All,
+    Embedded,
+    Installed,
+    Registry(&'a str),
+}
+
+impl<'a> CatalogSourceFilter<'a> {
+    fn parse(source: &'a str) -> Result<Self, Box<dyn Error>> {
+        match source {
+            "all" => Ok(Self::All),
+            "embedded" => Ok(Self::Embedded),
+            "installed" => Ok(Self::Installed),
+            s if s.starts_with("registry:") => {
+                let name = s.trim_start_matches("registry:");
+                if name.is_empty() {
+                    Err("registry source filter requires a name: registry:<name>".into())
+                } else {
+                    Ok(Self::Registry(name))
+                }
+            }
+            _ => Err(format!(
+                "unknown source '{source}' (expected all, embedded, installed, or registry:<name>)"
+            )
+            .into()),
+        }
+    }
+
+    fn label(self) -> String {
+        match self {
+            Self::All => "all".to_string(),
+            Self::Embedded => "embedded".to_string(),
+            Self::Installed => "installed".to_string(),
+            Self::Registry(name) => format!("registry:{name}"),
+        }
+    }
+}
+
+fn style_entry_kind(entry: &RegistryEntry) -> &'static str {
     if entry.builtin.is_some() {
         "embedded"
     } else if entry.url.is_some() {
-        "core-http"
+        "url"
     } else if entry.path.is_some() {
         "path"
     } else {
@@ -334,15 +275,16 @@ fn style_entry_source(entry: &RegistryEntry) -> &'static str {
     }
 }
 
-fn style_entry_matches_source(entry: &RegistryEntry, source: StyleCatalogSource) -> bool {
+fn style_entry_matches_source(source_name: &str, source: CatalogSourceFilter<'_>) -> bool {
     match source {
-        StyleCatalogSource::All => true,
-        StyleCatalogSource::Embedded => entry.builtin.is_some(),
-        StyleCatalogSource::CoreHttp => entry.url.is_some(),
+        CatalogSourceFilter::All => true,
+        CatalogSourceFilter::Embedded => source_name == "embedded",
+        CatalogSourceFilter::Installed => source_name == "installed",
+        CatalogSourceFilter::Registry(name) => source_name == format!("registry:{name}"),
     }
 }
 
-fn style_catalog_row(entry: &RegistryEntry) -> StyleCatalogRow {
+fn style_catalog_row(source: &str, entry: &RegistryEntry) -> StyleCatalogRow {
     let title = entry.title.clone().or_else(|| {
         entry.builtin.as_ref().and_then(|builtin| {
             citum_schema::embedded::get_embedded_style(builtin)
@@ -352,13 +294,25 @@ fn style_catalog_row(entry: &RegistryEntry) -> StyleCatalogRow {
     });
 
     StyleCatalogRow {
-        source: style_entry_source(entry).to_string(),
+        source: source.to_string(),
         id: entry.id.clone(),
         aliases: entry.aliases.clone(),
         title,
         description: entry.description.clone(),
         fields: entry.fields.clone(),
         url: entry.url.clone(),
+    }
+}
+
+fn installed_style_catalog_row(id: String) -> StyleCatalogRow {
+    StyleCatalogRow {
+        source: "installed".to_string(),
+        id,
+        aliases: Vec::new(),
+        title: None,
+        description: None,
+        fields: Vec::new(),
+        url: None,
     }
 }
 
@@ -386,7 +340,7 @@ fn paginate_style_catalog_rows(
 fn print_style_catalog_rows(
     rows: &[StyleCatalogRow],
     total: usize,
-    source: StyleCatalogSource,
+    source: &str,
     format: StyleCatalogFormat,
 ) -> Result<(), Box<dyn Error>> {
     if format == StyleCatalogFormat::Json {
@@ -398,11 +352,7 @@ fn print_style_catalog_rows(
     Ok(())
 }
 
-fn format_style_catalog_text(
-    rows: &[StyleCatalogRow],
-    total: usize,
-    source: StyleCatalogSource,
-) -> String {
+fn format_style_catalog_text(rows: &[StyleCatalogRow], total: usize, source: &str) -> String {
     let mut output = String::new();
     let _ = writeln!(output, "{total} {source} styles");
     if rows.len() != total {
@@ -426,24 +376,188 @@ fn format_style_catalog_text(
     output
 }
 
-fn style_catalog_entries(source: StyleCatalogSource) -> Vec<StyleCatalogRow> {
-    citum_schema::embedded::default_registry()
-        .styles
-        .iter()
-        .filter(|entry| style_entry_matches_source(entry, source))
-        .map(style_catalog_row)
-        .collect()
+fn validate_resource_name(name: &str) -> Result<(), Box<dyn Error>> {
+    if name.is_empty() {
+        return Err("Name cannot be empty".into());
+    }
+    if name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        && !name.contains("..")
+        && !name.contains('/')
+        && !name.contains('\\')
+    {
+        Ok(())
+    } else {
+        Err(
+            format!("Invalid name: '{name}'. Names must be alphanumeric, hyphens, or underscores.")
+                .into(),
+        )
+    }
+}
+
+fn configured_registry_dir() -> Result<PathBuf, Box<dyn Error>> {
+    platform_config_dir()
+        .map(|dir| dir.join("registries"))
+        .ok_or_else(|| "Unable to determine Citum config directory".into())
+}
+
+fn registry_sources_path() -> Result<PathBuf, Box<dyn Error>> {
+    platform_config_dir()
+        .map(|dir| dir.join("registry-sources.json"))
+        .ok_or_else(|| "Unable to determine Citum config directory".into())
+}
+
+fn read_registry_source_records() -> Result<Vec<RegistrySourceRecord>, Box<dyn Error>> {
+    let path = registry_sources_path()?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let bytes = fs::read(path)?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+fn write_registry_source_records(records: &[RegistrySourceRecord]) -> Result<(), Box<dyn Error>> {
+    let path = registry_sources_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(records)?)?;
+    Ok(())
+}
+
+fn registry_file_path(name: &str) -> Result<PathBuf, Box<dyn Error>> {
+    Ok(configured_registry_dir()?.join(format!("{name}.yaml")))
+}
+
+fn fetch_registry_bytes(source: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    if source.starts_with("http://") || source.starts_with("https://") {
+        let resolver = citum_store::HttpResolver::from_platform_cache_dir()
+            .ok_or("Unable to determine platform cache directory")?;
+        return resolver.fetch_bytes(source);
+    }
+    Ok(fs::read(source)?)
+}
+
+fn parse_registry_bytes(bytes: &[u8]) -> Result<citum_schema::StyleRegistry, Box<dyn Error>> {
+    let registry: citum_schema::StyleRegistry = serde_yaml::from_slice(bytes)?;
+    registry.validate_sources()?;
+    Ok(registry)
+}
+
+fn infer_registry_name(source: &str) -> Result<String, Box<dyn Error>> {
+    if source.starts_with("http://") || source.starts_with("https://") {
+        let url = url::Url::parse(source)?;
+        return url
+            .host_str()
+            .map(|host| host.replace('.', "-"))
+            .ok_or_else(|| format!("URL has no host: {source}").into());
+    }
+    let path = Path::new(source);
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("cannot infer registry name from {source}").into())
+}
+
+fn load_configured_registries() -> Result<Vec<LoadedRegistry>, Box<dyn Error>> {
+    let records = read_registry_source_records()?;
+    let mut registries = Vec::new();
+    for record in records {
+        let path = registry_file_path(&record.name)?;
+        if !path.exists() {
+            continue;
+        }
+        let registry = citum_schema::StyleRegistry::load_from_file(&path)?;
+        registries.push(LoadedRegistry {
+            name: record.name,
+            source: record.source,
+            registry,
+        });
+    }
+    Ok(registries)
+}
+
+fn load_local_registry() -> Option<LoadedRegistry> {
+    let path = Path::new("citum-registry.yaml");
+    if !path.exists() {
+        return None;
+    }
+    let registry = citum_schema::StyleRegistry::load_from_file(path).ok()?;
+    Some(LoadedRegistry {
+        name: "local".to_string(),
+        source: path.display().to_string(),
+        registry,
+    })
+}
+
+fn load_registry_chain() -> Result<Vec<LoadedRegistry>, Box<dyn Error>> {
+    let mut registries = Vec::new();
+    if let Some(local) = load_local_registry() {
+        registries.push(local);
+    }
+    registries.extend(load_configured_registries()?);
+    registries.push(LoadedRegistry {
+        name: "embedded".to_string(),
+        source: "embedded".to_string(),
+        registry: citum_schema::embedded::default_registry(),
+    });
+    Ok(registries)
+}
+
+fn style_catalog_entries(
+    source: CatalogSourceFilter<'_>,
+) -> Result<Vec<StyleCatalogRow>, Box<dyn Error>> {
+    let mut rows = Vec::new();
+    for loaded in load_registry_chain()? {
+        for entry in &loaded.registry.styles {
+            let actual_kind = style_entry_kind(entry);
+            let row_source = if loaded.name == "embedded" {
+                if actual_kind == "embedded" {
+                    "embedded".to_string()
+                } else {
+                    "registry:default".to_string()
+                }
+            } else {
+                format!("registry:{}", loaded.name)
+            };
+
+            if style_entry_matches_source(&row_source, source) {
+                // Special case: if filtering for 'embedded', only show truly embedded entries
+                if matches!(source, CatalogSourceFilter::Embedded) && actual_kind != "embedded" {
+                    continue;
+                }
+                rows.push(style_catalog_row(&row_source, entry));
+            }
+        }
+    }
+
+    if style_entry_matches_source("installed", source)
+        && let Some(data_dir) = platform_data_dir()
+    {
+        let config = StoreConfig::load().unwrap_or_default();
+        let resolver = StoreResolver::new(data_dir, config.store_format());
+        rows.extend(
+            resolver
+                .list_styles()?
+                .into_iter()
+                .map(installed_style_catalog_row),
+        );
+    }
+
+    Ok(rows)
 }
 
 fn run_style_list(
-    source: StyleCatalogSource,
+    source: &str,
     format: StyleCatalogFormat,
     limit: Option<usize>,
     offset: usize,
 ) -> Result<(), Box<dyn Error>> {
-    let rows = style_catalog_entries(source);
+    let source_filter = CatalogSourceFilter::parse(source)?;
+    let rows = style_catalog_entries(source_filter)?;
     let (total, rows) = paginate_style_catalog_rows(rows, StyleCatalogPage { limit, offset });
-    print_style_catalog_rows(&rows, total, source, format)
+    print_style_catalog_rows(&rows, total, &source_filter.label(), format)
 }
 
 fn style_row_matches_query(row: &StyleCatalogRow, query: &str) -> bool {
@@ -469,133 +583,648 @@ fn style_row_matches_query(row: &StyleCatalogRow, query: &str) -> bool {
 
 fn run_style_search(
     query: &str,
-    source: StyleCatalogSource,
+    source: &str,
     format: StyleCatalogFormat,
     limit: Option<usize>,
     offset: usize,
 ) -> Result<(), Box<dyn Error>> {
-    let registry = citum_schema::embedded::default_registry();
-    let rows: Vec<_> = registry
-        .styles
-        .iter()
-        .filter(|entry| style_entry_matches_source(entry, source))
-        .map(style_catalog_row)
+    let source_filter = CatalogSourceFilter::parse(source)?;
+    let rows: Vec<_> = style_catalog_entries(source_filter)?
+        .into_iter()
         .filter(|row| style_row_matches_query(row, query))
         .collect();
     let (total, rows) = paginate_style_catalog_rows(rows, StyleCatalogPage { limit, offset });
-    print_style_catalog_rows(&rows, total, source, format)
+    print_style_catalog_rows(&rows, total, &source_filter.label(), format)
 }
 
 fn run_style_info(name: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn Error>> {
-    let registry = citum_schema::embedded::default_registry();
-    let entry = registry
-        .resolve(name)
+    let rows = style_catalog_entries(CatalogSourceFilter::All)?;
+    let row = rows
+        .into_iter()
+        .find(|row| row.id == name || row.aliases.iter().any(|alias| alias == name))
         .ok_or_else(|| format!("style not found: {name}"))?;
-    let row = style_catalog_row(entry);
-    print_style_catalog_rows(&[row], 1, StyleCatalogSource::All, format)
-}
 
-/// List all installed user styles and locales.
-fn run_store_list() -> Result<(), Box<dyn Error>> {
-    let Some(data_dir) = platform_data_dir() else {
-        return Err("Unable to determine platform data directory".into());
-    };
-
-    let config = StoreConfig::load().unwrap_or_default();
-    let resolver = StoreResolver::new(data_dir.clone(), config.store_format());
-
-    let styles = resolver.list_styles().unwrap_or_default();
-    let locales = resolver.list_locales().unwrap_or_default();
-
-    println!("User store location: {}", data_dir.display());
-    println!("Configured format: {}", config.store_format());
-    println!();
-
-    if styles.is_empty() {
-        println!("No installed styles.");
-        println!();
-    } else {
-        println!("Installed styles ({}):", styles.len());
-        for name in &styles {
-            println!("  - {name}");
-        }
-        println!();
-    }
-
-    if locales.is_empty() {
-        println!("No installed locales.");
-        println!();
-    } else {
-        println!("Installed locales ({}):", locales.len());
-        for name in &locales {
-            println!("  - {name}");
-        }
-        println!();
-    }
-
-    println!("Usage:");
-    println!("  Install a style:  citum store install <path>");
-    println!("  Remove a style:   citum store remove <name>");
-
-    Ok(())
-}
-
-/// Install a style or locale from a local file.
-fn run_store_install(source: &Path) -> Result<(), Box<dyn Error>> {
-    if !source.exists() || !source.is_file() {
-        return Err(format!("file not found: {}", source.display()).into());
-    }
-
-    let Some(data_dir) = platform_data_dir() else {
-        return Err("Unable to determine platform data directory".into());
-    };
-
-    let config = StoreConfig::load().unwrap_or_default();
-    let resolver = StoreResolver::new(data_dir, config.store_format());
-
-    let name = resolver
-        .install_style(source)
-        .or_else(|_| resolver.install_locale(source))?;
-
-    println!("Successfully installed: {name}");
-    Ok(())
-}
-
-/// Remove an installed style or locale.
-fn run_store_remove(name: &str) -> Result<(), Box<dyn Error>> {
-    let Some(data_dir) = platform_data_dir() else {
-        return Err("Unable to determine platform data directory".into());
-    };
-
-    let config = StoreConfig::load().unwrap_or_default();
-    let resolver = StoreResolver::new(data_dir, config.store_format());
-
-    // Check if style or locale exists
-    let styles = resolver.list_styles().unwrap_or_default();
-    let locales = resolver.list_locales().unwrap_or_default();
-
-    if !styles.contains(&name.to_string()) && !locales.contains(&name.to_string()) {
-        return Err(format!("style or locale not found: {name}").into());
-    }
-
-    // Ask for confirmation
-    print!("Are you sure you want to remove '{name}'? This cannot be undone. [y/N] ");
-    io::stdout().flush()?;
-
-    let mut response = String::new();
-    io::stdin().read_line(&mut response)?;
-
-    if response.trim().to_lowercase() != "y" && response.trim().to_lowercase() != "yes" {
-        println!("Cancelled.");
+    if format == StyleCatalogFormat::Json {
+        println!("{}", serde_json::to_string_pretty(&row)?);
         return Ok(());
     }
 
-    // Try removing as style first, then as locale
-    resolver
-        .remove_style(name)
-        .or_else(|_| resolver.remove_locale(name))?;
+    println!("ID:       {}", row.id);
+    println!("Title:    {}", row.title.as_deref().unwrap_or("-"));
+    println!("Source:   {}", row.source);
+    println!(
+        "Aliases:  {}",
+        if row.aliases.is_empty() {
+            "-".to_string()
+        } else {
+            row.aliases.join(", ")
+        }
+    );
+    if let Some(description) = row.description {
+        println!("Summary:  {description}");
+    }
+    if !row.fields.is_empty() {
+        println!("Fields:   {}", row.fields.join(", "));
+    }
+    if let Some(url) = row.url {
+        println!("URL:      {url}");
+    }
+    Ok(())
+}
 
-    println!("Successfully removed: {name}");
+fn run_style_browse(query: Option<&str>, source: &str) -> Result<(), Box<dyn Error>> {
+    let source_filter = CatalogSourceFilter::parse(source)?;
+    let all_rows = style_catalog_entries(source_filter)?;
+    if !io::stdin().is_terminal() {
+        let rows: Vec<_> = all_rows
+            .into_iter()
+            .filter(|row| query.is_none_or(|q| style_row_matches_query(row, q)))
+            .take(20)
+            .collect();
+        print_style_catalog_rows(
+            &rows,
+            rows.len(),
+            &source_filter.label(),
+            StyleCatalogFormat::Text,
+        )?;
+        return Ok(());
+    }
+
+    let mut filter = query.unwrap_or("").to_string();
+    let mut offset = 0usize;
+    loop {
+        let rows: Vec<_> = all_rows
+            .iter()
+            .filter(|row| filter.is_empty() || style_row_matches_query(row, &filter))
+            .cloned()
+            .collect();
+        if rows.is_empty() {
+            println!("No styles match '{filter}'.");
+        } else {
+            print_browse_page(&rows, offset, &filter);
+        }
+        println!();
+        println!("Commands: /text filter, n next, p previous, i <n> info, a <n> add, q quit");
+        print!("browse> ");
+        io::stdout().flush()?;
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        let command = input.trim();
+        match command {
+            "" => {}
+            "q" | "quit" => break,
+            "n" | "next" => {
+                if offset + 10 < rows.len() {
+                    offset += 10;
+                }
+            }
+            "p" | "prev" | "previous" => {
+                offset = offset.saturating_sub(10);
+            }
+            s if s.starts_with('/') => {
+                filter = s.trim_start_matches('/').trim().to_string();
+                offset = 0;
+            }
+            s if s.starts_with("i ") => {
+                let row = browse_row_by_number(&rows, offset, s.trim_start_matches("i "))?;
+                print_style_detail(&row);
+            }
+            s if s.starts_with("a ") => {
+                let row = browse_row_by_number(&rows, offset, s.trim_start_matches("a "))?;
+                let style = load_any_style(&row.id, false)?;
+                write_installed_style(&row.id, &style)?;
+                println!("Installed style: {}", row.id);
+            }
+            _ => {
+                filter = command.to_string();
+                offset = 0;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_browse_page(rows: &[StyleCatalogRow], offset: usize, filter: &str) {
+    let end = (offset + 10).min(rows.len());
+    println!(
+        "{} styles{}",
+        rows.len(),
+        if filter.is_empty() {
+            String::new()
+        } else {
+            format!(" matching '{filter}'")
+        }
+    );
+    for (idx, row) in rows.iter().enumerate().skip(offset).take(10) {
+        println!(
+            "{:>2}. {:<36} {}",
+            idx - offset + 1,
+            row.id,
+            row.title.as_deref().unwrap_or("-")
+        );
+    }
+    println!("Showing {}-{} of {}", offset + 1, end, rows.len());
+}
+
+fn browse_row_by_number(
+    rows: &[StyleCatalogRow],
+    offset: usize,
+    input: &str,
+) -> Result<StyleCatalogRow, Box<dyn Error>> {
+    let choice = input.trim().parse::<usize>()?;
+    if choice == 0 || choice > 10 {
+        return Err("selection out of range".into());
+    }
+    rows.get(offset + choice - 1)
+        .cloned()
+        .ok_or_else(|| "selection out of range".into())
+}
+
+fn print_style_detail(row: &StyleCatalogRow) {
+    println!("ID:       {}", row.id);
+    println!("Title:    {}", row.title.as_deref().unwrap_or("-"));
+    println!("Source:   {}", row.source);
+    println!(
+        "Aliases:  {}",
+        if row.aliases.is_empty() {
+            "-".to_string()
+        } else {
+            row.aliases.join(", ")
+        }
+    );
+    if let Some(description) = &row.description {
+        println!("Summary:  {description}");
+    }
+    if !row.fields.is_empty() {
+        println!("Fields:   {}", row.fields.join(", "));
+    }
+}
+
+fn style_install_name_from_url(input: &str) -> Result<String, Box<dyn Error>> {
+    let url = url::Url::parse(input)?;
+    url.path_segments()
+        .and_then(Iterator::last)
+        .and_then(|segment| segment.split('.').next())
+        .filter(|segment| !segment.is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("cannot infer style name from {input}").into())
+}
+
+fn write_installed_style(name: &str, style: &Style) -> Result<(), Box<dyn Error>> {
+    validate_resource_name(name)?;
+    let Some(data_dir) = platform_data_dir() else {
+        return Err("Unable to determine platform data directory".into());
+    };
+    let config = StoreConfig::load().unwrap_or_default();
+    let format = config.store_format();
+    let styles_dir = data_dir.join("styles");
+    fs::create_dir_all(&styles_dir)?;
+    let path = styles_dir.join(format!("{name}.{}", format.extension()));
+    let bytes = match format {
+        citum_store::StoreFormat::Yaml => serde_yaml::to_string(style)?.into_bytes(),
+        citum_store::StoreFormat::Json => serde_json::to_string(style)?.into_bytes(),
+        citum_store::StoreFormat::Cbor => {
+            let mut bytes = Vec::new();
+            ciborium::ser::into_writer(style, &mut bytes)?;
+            bytes
+        }
+    };
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn install_style_from_file(path: &Path) -> Result<String, Box<dyn Error>> {
+    if !path.exists() || !path.is_file() {
+        return Err(format!("file not found: {}", path.display()).into());
+    }
+    let _ = load_any_style(&path.display().to_string(), false)?;
+    let Some(data_dir) = platform_data_dir() else {
+        return Err("Unable to determine platform data directory".into());
+    };
+    let config = StoreConfig::load().unwrap_or_default();
+    let resolver = StoreResolver::new(data_dir, config.store_format());
+    Ok(resolver.install_style(path)?)
+}
+
+fn select_style_match(query: &str, yes: bool) -> Result<StyleCatalogRow, Box<dyn Error>> {
+    let rows = style_catalog_entries(CatalogSourceFilter::All)?;
+    let exact: Vec<_> = rows
+        .iter()
+        .filter(|row| row.id == query || row.aliases.iter().any(|alias| alias == query))
+        .cloned()
+        .collect();
+    if let [row] = exact.as_slice() {
+        return Ok(row.clone());
+    }
+
+    let mut matches: Vec<_> = rows
+        .into_iter()
+        .filter(|row| style_row_matches_query(row, query))
+        .collect();
+    matches.sort_by(|a, b| a.id.len().cmp(&b.id.len()).then_with(|| a.id.cmp(&b.id)));
+
+    match matches.as_slice() {
+        [] => Err(format!(
+            "style not found: {query}\n\nSearch styles with: citum style search {query}"
+        )
+        .into()),
+        [row] => Ok(row.clone()),
+        _ if yes || !io::stdin().is_terminal() => {
+            let mut msg = format!("style query is ambiguous: {query}\n\nMatches:");
+            for row in matches.iter().take(10) {
+                let _ = write!(
+                    msg,
+                    "\n  - {} ({})",
+                    row.id,
+                    row.title.as_deref().unwrap_or(&row.source)
+                );
+            }
+            msg.push_str("\n\nRerun with an exact ID or alias.");
+            Err(msg.into())
+        }
+        _ => {
+            println!("Multiple styles match '{query}':");
+            for (idx, row) in matches.iter().take(10).enumerate() {
+                println!(
+                    "  {}. {} - {}",
+                    idx + 1,
+                    row.id,
+                    row.title.as_deref().unwrap_or("-")
+                );
+            }
+            print!("Choose a style to install [1-{}]: ", matches.len().min(10));
+            io::stdout().flush()?;
+            let mut response = String::new();
+            io::stdin().read_line(&mut response)?;
+            let choice = response.trim().parse::<usize>()?;
+            if choice == 0 || choice > matches.len().min(10) {
+                return Err("selection out of range".into());
+            }
+            matches
+                .get(choice - 1)
+                .cloned()
+                .ok_or_else(|| "selection out of range".into())
+        }
+    }
+}
+
+fn run_style_add(query: &str, yes: bool) -> Result<(), Box<dyn Error>> {
+    let path = Path::new(query);
+    let name = if path.exists() || query.starts_with("file://") {
+        let raw_path = query.strip_prefix("file://").unwrap_or(query);
+        install_style_from_file(Path::new(raw_path))?
+    } else if query.starts_with("http://") || query.starts_with("https://") {
+        let style = load_any_style(query, false)?;
+        let name = style_install_name_from_url(query)?;
+        write_installed_style(&name, &style)?;
+        name
+    } else {
+        let row = select_style_match(query, yes)?;
+        let style = load_any_style(&row.id, false)?;
+        write_installed_style(&row.id, &style)?;
+        row.id
+    };
+
+    println!("Installed style: {name}");
+    Ok(())
+}
+
+fn run_style_remove(name: &str, yes: bool) -> Result<(), Box<dyn Error>> {
+    validate_resource_name(name)?;
+    let Some(data_dir) = platform_data_dir() else {
+        return Err("Unable to determine platform data directory".into());
+    };
+    let config = StoreConfig::load().unwrap_or_default();
+    let resolver = StoreResolver::new(data_dir, config.store_format());
+    let styles = resolver.list_styles()?;
+    if !styles.contains(&name.to_string()) {
+        return Err(format!("installed style not found: {name}").into());
+    }
+    if !yes && !confirm(&format!("Remove installed style '{name}'?"))? {
+        return Ok(());
+    }
+    resolver.remove_style(name)?;
+    println!("Removed style: {name}");
+    Ok(())
+}
+
+fn confirm(prompt: &str) -> Result<bool, Box<dyn Error>> {
+    if !io::stdin().is_terminal() {
+        return Err(format!("{prompt} Use --yes to run non-interactively.").into());
+    }
+    print!("{prompt} [y/N] ");
+    io::stdout().flush()?;
+    let mut response = String::new();
+    io::stdin().read_line(&mut response)?;
+    Ok(matches!(
+        response.trim().to_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn run_registry_list(format: &str) -> Result<(), Box<dyn Error>> {
+    let mut registries = Vec::new();
+    let default_reg = citum_schema::embedded::default_registry();
+    registries.push(RegistryInfo {
+        name: "embedded".to_string(),
+        source: "embedded".to_string(),
+        version: default_reg.version.clone(),
+        styles: default_reg.styles.len(),
+        status: "ok".to_string(),
+    });
+    if let Some(local) = load_local_registry() {
+        registries.push(RegistryInfo {
+            name: local.name,
+            source: local.source,
+            version: local.registry.version,
+            styles: local.registry.styles.len(),
+            status: "ok".to_string(),
+        });
+    }
+    for record in read_registry_source_records()? {
+        let path = registry_file_path(&record.name)?;
+        match citum_schema::StyleRegistry::load_from_file(&path) {
+            Ok(registry) => registries.push(RegistryInfo {
+                name: record.name,
+                source: record.source,
+                version: registry.version,
+                styles: registry.styles.len(),
+                status: "ok".to_string(),
+            }),
+            Err(err) => registries.push(RegistryInfo {
+                name: record.name,
+                source: record.source,
+                version: "-".to_string(),
+                styles: 0,
+                status: err.to_string(),
+            }),
+        }
+    }
+
+    if format == "json" {
+        println!("{}", serde_json::to_string_pretty(&registries)?);
+    } else {
+        let rows = registries
+            .iter()
+            .map(|reg| {
+                vec![
+                    reg.name.clone(),
+                    reg.source.clone(),
+                    reg.version.clone(),
+                    reg.styles.to_string(),
+                    reg.status.clone(),
+                ]
+            })
+            .collect();
+        println!(
+            "{}",
+            build_table(&["Name", "Source", "Version", "Styles", "Status"], rows)
+        );
+    }
+    Ok(())
+}
+
+fn run_registry_add(source: &str, name: Option<&str>) -> Result<(), Box<dyn Error>> {
+    let name = name.map_or_else(|| infer_registry_name(source), |name| Ok(name.to_string()))?;
+    validate_resource_name(&name)?;
+    let bytes = fetch_registry_bytes(source)?;
+    let registry = parse_registry_bytes(&bytes)?;
+    fs::create_dir_all(configured_registry_dir()?)?;
+    fs::write(registry_file_path(&name)?, bytes)?;
+
+    let mut records = read_registry_source_records()?;
+    records.retain(|record| record.name != name);
+    records.push(RegistrySourceRecord {
+        name: name.clone(),
+        source: source.to_string(),
+    });
+    write_registry_source_records(&records)?;
+
+    println!(
+        "Added registry '{name}' with {} styles.",
+        registry.styles.len()
+    );
+    Ok(())
+}
+
+fn run_registry_remove(name: &str, yes: bool) -> Result<(), Box<dyn Error>> {
+    let path = registry_file_path(name)?;
+    if !path.exists() {
+        return Err(format!("configured registry not found: {name}").into());
+    }
+    if !yes && !confirm(&format!("Remove registry '{name}'?"))? {
+        return Ok(());
+    }
+    fs::remove_file(path)?;
+    let mut records = read_registry_source_records()?;
+    records.retain(|record| record.name != name);
+    write_registry_source_records(&records)?;
+    println!("Removed registry: {name}");
+    Ok(())
+}
+
+fn run_registry_update(name: Option<&str>, all: bool) -> Result<(), Box<dyn Error>> {
+    if name.is_some() == all {
+        return Err("Specify either a registry name or --all.".into());
+    }
+    let records = read_registry_source_records()?;
+    let selected: Vec<_> = records
+        .iter()
+        .filter(|record| all || Some(record.name.as_str()) == name)
+        .cloned()
+        .collect();
+    if selected.is_empty() {
+        return Err("No configured registries matched.".into());
+    }
+    for record in selected {
+        let bytes = fetch_registry_bytes(&record.source)?;
+        let registry = parse_registry_bytes(&bytes)?;
+        fs::write(registry_file_path(&record.name)?, bytes)?;
+        println!(
+            "Updated registry '{}' ({} styles).",
+            record.name,
+            registry.styles.len()
+        );
+    }
+    Ok(())
+}
+
+fn run_registry_resolve(name: &str) -> Result<(), Box<dyn Error>> {
+    for loaded in load_registry_chain()? {
+        if let Some(entry) = loaded.registry.resolve(name) {
+            println!(
+                "{} (registry:{}, {})",
+                entry.id,
+                loaded.name,
+                style_entry_kind(entry)
+            );
+            return Ok(());
+        }
+    }
+    Err(format!("style not found: {name}").into())
+}
+
+#[derive(Serialize)]
+struct LocaleRow {
+    source: String,
+    id: String,
+}
+
+fn embedded_locale_ids() -> Vec<String> {
+    citum_schema::embedded::EMBEDDED_LOCALE_IDS
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn locale_rows(source: &str) -> Result<Vec<LocaleRow>, Box<dyn Error>> {
+    let mut rows = Vec::new();
+    if matches!(source, "all" | "embedded") {
+        rows.extend(embedded_locale_ids().into_iter().map(|id| LocaleRow {
+            source: "embedded".to_string(),
+            id,
+        }));
+    }
+    if matches!(source, "all" | "installed")
+        && let Some(data_dir) = platform_data_dir()
+    {
+        let config = StoreConfig::load().unwrap_or_default();
+        let resolver = StoreResolver::new(data_dir, config.store_format());
+        rows.extend(
+            resolver
+                .list_locales()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|id| LocaleRow {
+                    source: "installed".to_string(),
+                    id,
+                }),
+        );
+    }
+    if !matches!(source, "all" | "embedded" | "installed") {
+        return Err(
+            format!("unknown source '{source}' (expected all, embedded, or installed)").into(),
+        );
+    }
+    Ok(rows)
+}
+
+fn run_locale_list(source: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn Error>> {
+    let rows = locale_rows(source)?;
+    if format == StyleCatalogFormat::Json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+    let table_rows = rows
+        .iter()
+        .map(|row| vec![row.source.clone(), row.id.clone()])
+        .collect();
+    println!("{}", build_table(&["Source", "ID"], table_rows));
+    Ok(())
+}
+
+fn run_locale_add(path: &Path) -> Result<(), Box<dyn Error>> {
+    let _ = load_raw_locale(path)?;
+    let Some(data_dir) = platform_data_dir() else {
+        return Err("Unable to determine platform data directory".into());
+    };
+    let config = StoreConfig::load().unwrap_or_default();
+    let resolver = StoreResolver::new(data_dir, config.store_format());
+    let name = resolver.install_locale(path)?;
+    println!("Installed locale: {name}");
+    Ok(())
+}
+
+fn run_locale_remove(name: &str, yes: bool) -> Result<(), Box<dyn Error>> {
+    validate_resource_name(name)?;
+    let Some(data_dir) = platform_data_dir() else {
+        return Err("Unable to determine platform data directory".into());
+    };
+    let config = StoreConfig::load().unwrap_or_default();
+    let resolver = StoreResolver::new(data_dir, config.store_format());
+    let locales = resolver.list_locales()?;
+    if !locales.contains(&name.to_string()) {
+        return Err(format!("installed locale not found: {name}").into());
+    }
+    if !yes && !confirm(&format!("Remove installed locale '{name}'?"))? {
+        return Ok(());
+    }
+    resolver.remove_locale(name)?;
+    println!("Removed locale: {name}");
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct DoctorReport {
+    data_dir: Option<String>,
+    config_dir: Option<String>,
+    cache_dir: Option<String>,
+    installed_styles: usize,
+    installed_locales: usize,
+    registries: Vec<RegistryInfo>,
+}
+
+fn run_doctor(json: bool) -> Result<(), Box<dyn Error>> {
+    let data_dir = platform_data_dir();
+    let config = StoreConfig::load().unwrap_or_default();
+    let (installed_styles, installed_locales) = if let Some(dir) = data_dir.clone() {
+        let resolver = StoreResolver::new(dir, config.store_format());
+        (
+            resolver.list_styles().unwrap_or_default().len(),
+            resolver.list_locales().unwrap_or_default().len(),
+        )
+    } else {
+        (0, 0)
+    };
+    let mut registries = Vec::new();
+    let default_reg = citum_schema::embedded::default_registry();
+    registries.push(RegistryInfo {
+        name: "embedded".to_string(),
+        source: "embedded".to_string(),
+        version: default_reg.version,
+        styles: default_reg.styles.len(),
+        status: "ok".to_string(),
+    });
+    for record in read_registry_source_records().unwrap_or_default() {
+        let path = registry_file_path(&record.name)?;
+        let status = if path.exists() { "ok" } else { "missing" };
+        registries.push(RegistryInfo {
+            name: record.name,
+            source: record.source,
+            version: "-".to_string(),
+            styles: 0,
+            status: status.to_string(),
+        });
+    }
+    let report = DoctorReport {
+        data_dir: data_dir.map(|path| path.display().to_string()),
+        config_dir: platform_config_dir().map(|path| path.display().to_string()),
+        cache_dir: platform_cache_dir().map(|path| path.display().to_string()),
+        installed_styles,
+        installed_locales,
+        registries,
+    };
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!(
+            "Data dir:          {}",
+            report.data_dir.as_deref().unwrap_or("-")
+        );
+        println!(
+            "Config dir:        {}",
+            report.config_dir.as_deref().unwrap_or("-")
+        );
+        println!(
+            "Cache dir:         {}",
+            report.cache_dir.as_deref().unwrap_or("-")
+        );
+        println!("Installed styles:  {}", report.installed_styles);
+        println!("Installed locales: {}", report.installed_locales);
+        println!("Registries:        {}", report.registries.len());
+    }
     Ok(())
 }
 
@@ -1489,7 +2118,7 @@ mod tests {
         let registry = citum_schema::embedded::default_registry();
         let entry = registry.resolve("apa").expect("APA alias should resolve");
 
-        let row = style_catalog_row(entry);
+        let row = style_catalog_row("embedded", entry);
 
         assert_eq!(
             row.title.as_deref(),
@@ -1499,7 +2128,8 @@ mod tests {
 
     #[test]
     fn test_style_catalog_source_filter_and_pagination() {
-        let rows = style_catalog_entries(StyleCatalogSource::CoreHttp);
+        let rows = style_catalog_entries(CatalogSourceFilter::Embedded)
+            .expect("embedded catalog should load");
         let (total, page) = paginate_style_catalog_rows(
             rows,
             StyleCatalogPage {
@@ -1510,7 +2140,7 @@ mod tests {
 
         assert!(total > 2);
         assert_eq!(page.len(), 2);
-        assert!(page.iter().all(|row| row.source == "core-http"));
+        assert!(page.iter().all(|row| row.source == "embedded"));
     }
 
     #[test]
@@ -1519,7 +2149,7 @@ mod tests {
         let rows: Vec<_> = registry
             .styles
             .iter()
-            .map(style_catalog_row)
+            .map(|entry| style_catalog_row("embedded", entry))
             .filter(|row| style_row_matches_query(row, "Psychological Association"))
             .collect();
 
@@ -1529,7 +2159,7 @@ mod tests {
     #[test]
     fn test_style_catalog_text_output_contains_table() {
         let rows = vec![StyleCatalogRow {
-            source: "core-http".to_string(),
+            source: "embedded".to_string(),
             id: "alpha".to_string(),
             aliases: Vec::new(),
             title: Some("Alpha (biblatex-alpha)".to_string()),
@@ -1538,14 +2168,14 @@ mod tests {
             url: None,
         }];
 
-        let output = format_style_catalog_text(&rows, 3, StyleCatalogSource::CoreHttp);
+        let output = format_style_catalog_text(&rows, 3, "embedded");
 
-        assert!(output.contains("3 core-http styles"));
+        assert!(output.contains("3 embedded styles"));
         assert!(output.contains("showing 1"));
         assert!(output.contains("Source"));
         assert!(output.contains("ID"));
         assert!(output.contains("Title"));
-        assert!(output.contains("core-http"));
+        assert!(output.contains("embedded"));
         assert!(output.contains("alpha"));
         assert!(output.contains("Alpha (biblatex-alpha)"));
     }
@@ -1946,5 +2576,29 @@ grammar-options:
             parsed.legacy_term_aliases.get("page").map(String::as_str),
             Some("term.page-label")
         );
+    }
+
+    #[test]
+    fn test_validate_resource_name() {
+        assert!(validate_resource_name("apa").is_ok());
+        assert!(validate_resource_name("apa-7th").is_ok());
+        assert!(validate_resource_name("chicago_fullnote").is_ok());
+        assert!(validate_resource_name("").is_err());
+        assert!(validate_resource_name("..").is_err());
+        assert!(validate_resource_name("../../etc/passwd").is_err());
+        assert!(validate_resource_name("styles/apa").is_err());
+        assert!(validate_resource_name("apa.yaml").is_err()); // dots not allowed if we want to be strict
+        assert!(validate_resource_name("my registry!").is_err());
+    }
+
+    #[test]
+    fn test_registry_source_record_serialization() {
+        let record = RegistrySourceRecord {
+            name: "test".to_string(),
+            source: "https://example.com/registry.yaml".to_string(),
+        };
+        let json = serde_json::to_string(&record).expect("should serialize");
+        assert!(json.contains("\"name\":\"test\""));
+        assert!(json.contains("\"source\":\"https://example.com/registry.yaml\""));
     }
 }

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -9,6 +9,7 @@ use crate::args::{
 #[cfg(feature = "schema")]
 use crate::args::{SchemaArgs, SchemaType};
 use crate::output::{print_lint_report, write_output};
+use crate::style_browser::{StyleBrowserActions, StyleBrowserConfig, run_style_browser};
 use crate::style_resolver::{create_processor, load_any_style, load_locale_file};
 use crate::table::build_table;
 use crate::typst_pdf;
@@ -213,15 +214,15 @@ struct RegistryInfo {
     status: String,
 }
 
-#[derive(Clone, Serialize)]
-struct StyleCatalogRow {
-    source: String,
-    id: String,
-    aliases: Vec<String>,
-    title: Option<String>,
-    description: Option<String>,
-    fields: Vec<String>,
-    url: Option<String>,
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct StyleCatalogRow {
+    pub(crate) source: String,
+    pub(crate) id: String,
+    pub(crate) aliases: Vec<String>,
+    pub(crate) title: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) fields: Vec<String>,
+    pub(crate) url: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -650,116 +651,15 @@ fn run_style_browse(query: Option<&str>, source: &str) -> Result<(), Box<dyn Err
         return Ok(());
     }
 
-    let mut filter = query.unwrap_or("").to_string();
-    let mut offset = 0usize;
-    loop {
-        let rows: Vec<_> = all_rows
-            .iter()
-            .filter(|row| filter.is_empty() || style_row_matches_query(row, &filter))
-            .cloned()
-            .collect();
-        if rows.is_empty() {
-            println!("No styles match '{filter}'.");
-        } else {
-            print_browse_page(&rows, offset, &filter);
-        }
-        println!();
-        println!("Commands: /text filter, n next, p previous, i <n> info, a <n> add, q quit");
-        print!("browse> ");
-        io::stdout().flush()?;
-
-        let mut input = String::new();
-        io::stdin().read_line(&mut input)?;
-        let command = input.trim();
-        match command {
-            "" => {}
-            "q" | "quit" => break,
-            "n" | "next" => {
-                if offset + 10 < rows.len() {
-                    offset += 10;
-                }
-            }
-            "p" | "prev" | "previous" => {
-                offset = offset.saturating_sub(10);
-            }
-            s if s.starts_with('/') => {
-                filter = s.trim_start_matches('/').trim().to_string();
-                offset = 0;
-            }
-            s if s.starts_with("i ") => {
-                let row = browse_row_by_number(&rows, offset, s.trim_start_matches("i "))?;
-                print_style_detail(&row);
-            }
-            s if s.starts_with("a ") => {
-                let row = browse_row_by_number(&rows, offset, s.trim_start_matches("a "))?;
-                let style = load_any_style(&row.id, false)?;
-                write_installed_style(&row.id, &style)?;
-                println!("Installed style: {}", row.id);
-            }
-            _ => {
-                filter = command.to_string();
-                offset = 0;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn print_browse_page(rows: &[StyleCatalogRow], offset: usize, filter: &str) {
-    let end = (offset + 10).min(rows.len());
-    println!(
-        "{} styles{}",
-        rows.len(),
-        if filter.is_empty() {
-            String::new()
-        } else {
-            format!(" matching '{filter}'")
-        }
-    );
-    for (idx, row) in rows.iter().enumerate().skip(offset).take(10) {
-        println!(
-            "{:>2}. {:<36} {}",
-            idx - offset + 1,
-            row.id,
-            row.title.as_deref().unwrap_or("-")
-        );
-    }
-    println!("Showing {}-{} of {}", offset + 1, end, rows.len());
-}
-
-fn browse_row_by_number(
-    rows: &[StyleCatalogRow],
-    offset: usize,
-    input: &str,
-) -> Result<StyleCatalogRow, Box<dyn Error>> {
-    let choice = input.trim().parse::<usize>()?;
-    if choice == 0 || choice > 10 {
-        return Err("selection out of range".into());
-    }
-    rows.get(offset + choice - 1)
-        .cloned()
-        .ok_or_else(|| "selection out of range".into())
-}
-
-fn print_style_detail(row: &StyleCatalogRow) {
-    println!("ID:       {}", row.id);
-    println!("Title:    {}", row.title.as_deref().unwrap_or("-"));
-    println!("Source:   {}", row.source);
-    println!(
-        "Aliases:  {}",
-        if row.aliases.is_empty() {
-            "-".to_string()
-        } else {
-            row.aliases.join(", ")
-        }
-    );
-    if let Some(description) = &row.description {
-        println!("Summary:  {description}");
-    }
-    if !row.fields.is_empty() {
-        println!("Fields:   {}", row.fields.join(", "));
-    }
+    let mut actions = CliStyleBrowserActions;
+    run_style_browser(
+        StyleBrowserConfig {
+            rows: all_rows,
+            initial_query: query.unwrap_or("").to_string(),
+            source_label: source_filter.label(),
+        },
+        &mut actions,
+    )
 }
 
 fn style_install_name_from_url(input: &str) -> Result<String, Box<dyn Error>> {
@@ -793,6 +693,33 @@ fn write_installed_style(name: &str, style: &Style) -> Result<(), Box<dyn Error>
     };
     fs::write(path, bytes)?;
     Ok(())
+}
+
+fn remove_installed_style(name: &str) -> Result<(), Box<dyn Error>> {
+    let Some(data_dir) = platform_data_dir() else {
+        return Err("Unable to determine platform data directory".into());
+    };
+    let config = StoreConfig::load().unwrap_or_default();
+    let resolver = StoreResolver::new(data_dir, config.store_format());
+    let styles = resolver.list_styles()?;
+    if !styles.iter().any(|style| style == name) {
+        return Err(format!("installed style not found: {name}").into());
+    }
+    resolver.remove_style(name)?;
+    Ok(())
+}
+
+struct CliStyleBrowserActions;
+
+impl StyleBrowserActions for CliStyleBrowserActions {
+    fn install_style(&mut self, row: &StyleCatalogRow) -> Result<(), Box<dyn Error>> {
+        let style = load_any_style(&row.id, false)?;
+        write_installed_style(&row.id, &style)
+    }
+
+    fn remove_style(&mut self, row: &StyleCatalogRow) -> Result<(), Box<dyn Error>> {
+        remove_installed_style(&row.id)
+    }
 }
 
 fn install_style_from_file(path: &Path) -> Result<String, Box<dyn Error>> {

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -3,6 +3,7 @@
 mod args;
 mod commands;
 mod output;
+mod style_browser;
 mod style_resolver;
 mod table;
 mod typst_pdf;

--- a/crates/citum-cli/src/style_browser.rs
+++ b/crates/citum-cli/src/style_browser.rs
@@ -1,0 +1,995 @@
+use crate::commands::StyleCatalogRow;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Frame, Terminal,
+    backend::{Backend, CrosstermBackend},
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style as TuiStyle},
+    text::{Line, Span},
+    widgets::{
+        Block, Borders, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
+        Wrap,
+    },
+};
+use std::error::Error;
+use std::io;
+use std::time::Duration;
+
+/// Input data for the interactive style browser.
+pub(crate) struct StyleBrowserConfig {
+    /// Catalog rows from the shared style catalog service.
+    pub(crate) rows: Vec<StyleCatalogRow>,
+    /// Initial filter query from the command line.
+    pub(crate) initial_query: String,
+    /// User-facing label for the active source filter.
+    pub(crate) source_label: String,
+}
+
+/// Side effects available from the style browser.
+pub(crate) trait StyleBrowserActions {
+    /// Install the selected style.
+    fn install_style(&mut self, row: &StyleCatalogRow) -> Result<(), Box<dyn Error>>;
+
+    /// Remove the selected installed style.
+    fn remove_style(&mut self, row: &StyleCatalogRow) -> Result<(), Box<dyn Error>>;
+}
+
+/// Run the interactive style browser in an alternate terminal screen.
+pub(crate) fn run_style_browser<A: StyleBrowserActions>(
+    config: StyleBrowserConfig,
+    actions: &mut A,
+) -> Result<(), Box<dyn Error>> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    let mut app = StyleBrowserApp::new(config);
+
+    let run_result = run_browser_loop(&mut terminal, &mut app, actions);
+    let restore_result = restore_terminal(&mut terminal);
+    match (run_result, restore_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(restore_error)) => {
+            Err(format!("{error}; additionally failed to restore terminal: {restore_error}").into())
+        }
+    }
+}
+
+fn restore_terminal(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+) -> Result<(), Box<dyn Error>> {
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    Ok(())
+}
+
+fn run_browser_loop<B: Backend, A: StyleBrowserActions>(
+    terminal: &mut Terminal<B>,
+    app: &mut StyleBrowserApp,
+    actions: &mut A,
+) -> Result<(), Box<dyn Error>>
+where
+    B::Error: 'static,
+{
+    loop {
+        terminal.draw(|frame| app.render(frame))?;
+        if event::poll(Duration::from_millis(200))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+            && app.handle_key(key, actions)?
+        {
+            return Ok(());
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BrowserRow {
+    catalog: StyleCatalogRow,
+    installed: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BrowserFocus {
+    List,
+    Search,
+    Detail,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum PendingAction {
+    Remove(String),
+}
+
+#[derive(Clone, Debug)]
+struct StatusMessage {
+    text: String,
+    kind: StatusKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StatusKind {
+    Info,
+    Success,
+    Error,
+}
+
+struct StyleBrowserApp {
+    source_label: String,
+    query: String,
+    rows: Vec<BrowserRow>,
+    filtered: Vec<usize>,
+    selected: usize,
+    focus: BrowserFocus,
+    status: StatusMessage,
+    pending: Option<PendingAction>,
+}
+
+impl StyleBrowserApp {
+    fn new(config: StyleBrowserConfig) -> Self {
+        let rows = merge_catalog_rows(config.rows);
+        let installed_count = rows.iter().filter(|row| row.installed).count();
+        let mut app = Self {
+            source_label: config.source_label,
+            query: config.initial_query,
+            rows,
+            filtered: Vec::new(),
+            selected: 0,
+            focus: BrowserFocus::List,
+            status: StatusMessage {
+                text: format!(
+                    "Use / to filter, arrows to move, i to install, r to remove, q to quit. {installed_count} installed."
+                ),
+                kind: StatusKind::Info,
+            },
+            pending: None,
+        };
+        app.refresh_filter();
+        app
+    }
+
+    fn refresh_filter(&mut self) {
+        let query = self.query.to_lowercase();
+        self.filtered = self
+            .rows
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, row)| {
+                if query.is_empty() || browser_row_matches_query(row, &query) {
+                    Some(idx)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if self.filtered.is_empty() {
+            self.selected = 0;
+        } else if self.selected >= self.filtered.len() {
+            self.selected = self.filtered.len().saturating_sub(1);
+        }
+    }
+
+    fn current_row(&self) -> Option<&BrowserRow> {
+        self.filtered
+            .get(self.selected)
+            .and_then(|row_idx| self.rows.get(*row_idx))
+    }
+
+    fn handle_key<A: StyleBrowserActions>(
+        &mut self,
+        key: KeyEvent,
+        actions: &mut A,
+    ) -> Result<bool, Box<dyn Error>> {
+        if is_quit_key(key) {
+            return Ok(true);
+        }
+        if self.handle_pending_key(key, actions)? {
+            return Ok(false);
+        }
+
+        if self.focus == BrowserFocus::Search {
+            self.handle_search_key(key);
+            return Ok(false);
+        }
+
+        match key.code {
+            KeyCode::Char('/') => {
+                self.focus = BrowserFocus::Search;
+                self.set_info("Search mode. Type to filter, Enter to return to the list.");
+            }
+            KeyCode::Esc => {
+                self.focus = BrowserFocus::List;
+                self.set_info("List focus.");
+            }
+            KeyCode::Down | KeyCode::Char('j') => self.move_selection(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
+            KeyCode::PageDown => self.move_selection(10),
+            KeyCode::PageUp => self.move_selection(-10),
+            KeyCode::Home => self.selected = 0,
+            KeyCode::End => {
+                self.selected = self.filtered.len().saturating_sub(1);
+            }
+            KeyCode::Enter | KeyCode::Char('d') => {
+                self.focus = if self.focus == BrowserFocus::Detail {
+                    BrowserFocus::List
+                } else {
+                    BrowserFocus::Detail
+                };
+            }
+            KeyCode::Char('i') => self.install_selected(actions)?,
+            KeyCode::Char('r') => self.request_remove_selected(),
+            _ => {}
+        }
+        Ok(false)
+    }
+
+    fn handle_pending_key<A: StyleBrowserActions>(
+        &mut self,
+        key: KeyEvent,
+        actions: &mut A,
+    ) -> Result<bool, Box<dyn Error>> {
+        if self.pending.is_none() {
+            return Ok(false);
+        }
+        match key.code {
+            KeyCode::Char('y' | 'Y') => {
+                if matches!(self.pending, Some(PendingAction::Remove(_))) {
+                    self.remove_selected(actions)?;
+                }
+                self.pending = None;
+                Ok(true)
+            }
+            KeyCode::Char('n' | 'N') | KeyCode::Esc => {
+                self.pending = None;
+                self.set_info("Remove canceled.");
+                Ok(true)
+            }
+            _ => Ok(true),
+        }
+    }
+
+    fn handle_search_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => {
+                if self.query.is_empty() {
+                    self.focus = BrowserFocus::List;
+                    self.set_info("List focus.");
+                } else {
+                    self.query.clear();
+                    self.refresh_filter();
+                    self.set_info("Search cleared.");
+                }
+            }
+            KeyCode::Enter => {
+                self.focus = BrowserFocus::List;
+                self.set_info("List focus.");
+            }
+            KeyCode::Backspace => {
+                self.query.pop();
+                self.refresh_filter();
+            }
+            KeyCode::Char(ch) => {
+                self.query.push(ch);
+                self.refresh_filter();
+            }
+            _ => {}
+        }
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        if self.filtered.is_empty() {
+            self.selected = 0;
+            return;
+        }
+        let last = self.filtered.len().saturating_sub(1);
+        if delta < 0 {
+            self.selected = self.selected.saturating_sub(delta.unsigned_abs());
+        } else {
+            self.selected = self.selected.saturating_add(delta.unsigned_abs()).min(last);
+        }
+    }
+
+    fn install_selected<A: StyleBrowserActions>(
+        &mut self,
+        actions: &mut A,
+    ) -> Result<(), Box<dyn Error>> {
+        let Some(row) = self.current_row().cloned() else {
+            self.set_error("No style selected.");
+            return Ok(());
+        };
+        if row.installed {
+            self.set_info(format!("{} is already installed.", row.catalog.id));
+            return Ok(());
+        }
+        match actions.install_style(&row.catalog) {
+            Ok(()) => {
+                self.mark_installed(&row.catalog.id, true);
+                self.set_success(format!("Installed {}.", row.catalog.id));
+            }
+            Err(error) => self.set_error(format!("Install failed: {error}")),
+        }
+        Ok(())
+    }
+
+    fn request_remove_selected(&mut self) {
+        let Some(row) = self.current_row() else {
+            self.set_error("No style selected.");
+            return;
+        };
+        if !row.installed {
+            self.set_info(format!("{} is not installed.", row.catalog.id));
+            return;
+        }
+        let id = row.catalog.id.clone();
+        self.pending = Some(PendingAction::Remove(id.clone()));
+        self.set_info(format!("Remove installed style {id}? y/n"));
+    }
+
+    fn remove_selected<A: StyleBrowserActions>(
+        &mut self,
+        actions: &mut A,
+    ) -> Result<(), Box<dyn Error>> {
+        let Some(row) = self.current_row().cloned() else {
+            self.set_error("No style selected.");
+            return Ok(());
+        };
+        match actions.remove_style(&row.catalog) {
+            Ok(()) => {
+                self.mark_installed(&row.catalog.id, false);
+                self.set_success(format!("Removed {}.", row.catalog.id));
+            }
+            Err(error) => self.set_error(format!("Remove failed: {error}")),
+        }
+        Ok(())
+    }
+
+    fn mark_installed(&mut self, id: &str, installed: bool) {
+        for row in &mut self.rows {
+            if row.catalog.id == id {
+                row.installed = installed;
+            }
+        }
+        self.rows
+            .retain(|row| row.installed || row.catalog.source != "installed");
+        self.refresh_filter();
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        let root = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Min(8),
+                Constraint::Length(3),
+            ])
+            .split(area);
+        let &[header, body, footer] = root.as_ref() else {
+            return;
+        };
+        self.render_header(frame, header);
+        self.render_body(frame, body);
+        self.render_footer(frame, footer);
+    }
+
+    fn render_header(&self, frame: &mut Frame<'_>, area: Rect) {
+        let installed_count = self.rows.iter().filter(|row| row.installed).count();
+        let query = if self.query.is_empty() {
+            "-".to_string()
+        } else {
+            self.query.clone()
+        };
+        let line = Line::from(vec![
+            Span::styled(
+                "Citum Style Browser",
+                TuiStyle::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  source "),
+            Span::styled(
+                self.source_label.as_str(),
+                TuiStyle::default().fg(Color::Yellow),
+            ),
+            Span::raw("  query "),
+            Span::styled(query, TuiStyle::default().fg(Color::LightBlue)),
+            Span::raw("  results "),
+            Span::styled(
+                self.filtered.len().to_string(),
+                TuiStyle::default().fg(Color::Green),
+            ),
+            Span::raw("  installed "),
+            Span::styled(
+                installed_count.to_string(),
+                TuiStyle::default().fg(Color::Green),
+            ),
+        ]);
+        frame.render_widget(
+            Paragraph::new(line)
+                .block(Block::default().borders(Borders::ALL))
+                .wrap(Wrap { trim: true }),
+            area,
+        );
+    }
+
+    fn render_body(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        if area.width < 96 {
+            match self.focus {
+                BrowserFocus::Detail => self.render_detail(frame, area),
+                _ => self.render_list(frame, area),
+            }
+            return;
+        }
+
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+            .split(area);
+        let &[list, detail] = chunks.as_ref() else {
+            return;
+        };
+        self.render_list(frame, list);
+        self.render_detail(frame, detail);
+    }
+
+    fn render_list(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let title = if self.focus == BrowserFocus::Search {
+            "Styles - searching"
+        } else {
+            "Styles"
+        };
+        if area.width < 96 {
+            self.render_compact_list(frame, area, title);
+        } else {
+            self.render_table(frame, area, title);
+        }
+    }
+
+    fn render_table(&mut self, frame: &mut Frame<'_>, area: Rect, title: &str) {
+        let rows: Vec<Row<'_>> = self
+            .filtered
+            .iter()
+            .filter_map(|row_idx| self.rows.get(*row_idx))
+            .map(style_table_row)
+            .collect();
+        let header = Row::new([
+            Cell::from("Status"),
+            Cell::from("Source"),
+            Cell::from("ID"),
+            Cell::from("Title"),
+        ])
+        .style(
+            TuiStyle::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+        let widths = [
+            Constraint::Length(10),
+            Constraint::Length(18),
+            Constraint::Length(36),
+            Constraint::Min(20),
+        ];
+        let mut state = TableState::default();
+        if !rows.is_empty() {
+            state.select(Some(self.selected));
+        }
+        let table = Table::new(rows, widths)
+            .header(header)
+            .block(
+                Block::default()
+                    .title(title)
+                    .borders(Borders::ALL)
+                    .border_style(focus_border_style(self.focus == BrowserFocus::List)),
+            )
+            .column_spacing(2)
+            .highlight_symbol("> ")
+            .row_highlight_style(
+                TuiStyle::default()
+                    .bg(Color::DarkGray)
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            );
+        frame.render_stateful_widget(table, area, &mut state);
+    }
+
+    fn render_compact_list(&mut self, frame: &mut Frame<'_>, area: Rect, title: &str) {
+        let items: Vec<ListItem<'_>> = self
+            .filtered
+            .iter()
+            .filter_map(|row_idx| self.rows.get(*row_idx))
+            .map(compact_list_item)
+            .collect();
+        let mut state = ListState::default();
+        if !items.is_empty() {
+            state.select(Some(self.selected));
+        }
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .title(title)
+                    .borders(Borders::ALL)
+                    .border_style(focus_border_style(self.focus == BrowserFocus::List)),
+            )
+            .highlight_style(
+                TuiStyle::default()
+                    .bg(Color::DarkGray)
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("> ");
+        frame.render_stateful_widget(list, area, &mut state);
+    }
+
+    fn render_detail(&self, frame: &mut Frame<'_>, area: Rect) {
+        let lines = if let Some(row) = self.current_row() {
+            detail_lines(row)
+        } else {
+            vec![Line::from("No styles match the current query.")]
+        };
+        let paragraph = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .title("Details")
+                    .borders(Borders::ALL)
+                    .border_style(focus_border_style(self.focus == BrowserFocus::Detail)),
+            )
+            .wrap(Wrap { trim: true });
+        frame.render_widget(paragraph, area);
+    }
+
+    fn render_footer(&self, frame: &mut Frame<'_>, area: Rect) {
+        let keys = self.footer_keys(area.width);
+        let status = Line::from(Span::styled(
+            self.status.text.as_str(),
+            status_style(self.status.kind),
+        ));
+        let paragraph = Paragraph::new(vec![Line::from(keys), status])
+            .block(Block::default().borders(Borders::ALL))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(paragraph, area);
+        if self.pending.is_some() {
+            render_confirmation(frame, area, self.pending_remove_id());
+        }
+    }
+
+    fn footer_keys(&self, width: u16) -> &'static str {
+        if self.pending.is_some() {
+            return "Confirm remove: y Remove  n Cancel  q Quit";
+        }
+        if self.focus == BrowserFocus::Search {
+            return "Search mode: Enter apply  Esc clear/back  q Quit";
+        }
+        let Some(row) = self.current_row() else {
+            return "q Quit  / Search";
+        };
+        match (width < 96, row.installed) {
+            (true, true) => "q Quit  / Search  arrows/jk Move  d Details  r Remove",
+            (true, false) => "q Quit  / Search  arrows/jk Move  d Details  i Install",
+            (false, true) => {
+                "q Quit  / Search  esc Back  arrows/jk Move  pg/home/end Jump  d Details  r Remove"
+            }
+            (false, false) => {
+                "q Quit  / Search  esc Back  arrows/jk Move  pg/home/end Jump  d Details  i Install"
+            }
+        }
+    }
+
+    fn pending_remove_id(&self) -> Option<&str> {
+        match self.pending.as_ref() {
+            Some(PendingAction::Remove(id)) => Some(id.as_str()),
+            None => None,
+        }
+    }
+
+    fn set_info(&mut self, text: impl Into<String>) {
+        self.status = StatusMessage {
+            text: text.into(),
+            kind: StatusKind::Info,
+        };
+    }
+
+    fn set_success(&mut self, text: impl Into<String>) {
+        self.status = StatusMessage {
+            text: text.into(),
+            kind: StatusKind::Success,
+        };
+    }
+
+    fn set_error(&mut self, text: impl Into<String>) {
+        self.status = StatusMessage {
+            text: text.into(),
+            kind: StatusKind::Error,
+        };
+    }
+}
+
+fn is_quit_key(key: KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char('q' | 'Q'))
+        || (key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL))
+}
+
+fn merge_catalog_rows(rows: Vec<StyleCatalogRow>) -> Vec<BrowserRow> {
+    let mut merged: Vec<BrowserRow> = Vec::new();
+    for row in rows {
+        let is_installed = row.source == "installed";
+        if let Some(existing) = merged
+            .iter_mut()
+            .find(|candidate| candidate.catalog.id == row.id)
+        {
+            existing.installed |= is_installed;
+            if existing.catalog.source == "installed" && !is_installed {
+                existing.catalog = row;
+                existing.installed = true;
+            }
+        } else {
+            merged.push(BrowserRow {
+                catalog: row,
+                installed: is_installed,
+            });
+        }
+    }
+    merged
+}
+
+fn browser_row_matches_query(row: &BrowserRow, query: &str) -> bool {
+    row.catalog.id.to_lowercase().contains(query)
+        || row
+            .catalog
+            .aliases
+            .iter()
+            .any(|alias| alias.to_lowercase().contains(query))
+        || row
+            .catalog
+            .title
+            .as_ref()
+            .is_some_and(|title| title.to_lowercase().contains(query))
+        || row
+            .catalog
+            .description
+            .as_ref()
+            .is_some_and(|description| description.to_lowercase().contains(query))
+        || row
+            .catalog
+            .fields
+            .iter()
+            .any(|field| field.to_lowercase().contains(query))
+        || row.catalog.source.to_lowercase().contains(query)
+}
+
+fn style_table_row(row: &BrowserRow) -> Row<'_> {
+    Row::new([
+        Cell::from(status_label(row.installed)).style(status_cell_style(row.installed)),
+        Cell::from(row.catalog.source.clone()).style(source_style(&row.catalog.source)),
+        Cell::from(row.catalog.id.clone()).style(
+            TuiStyle::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from(row.catalog.title.clone().unwrap_or_else(|| "-".to_string()))
+            .style(TuiStyle::default().fg(Color::Gray)),
+    ])
+}
+
+fn compact_list_item(row: &BrowserRow) -> ListItem<'_> {
+    ListItem::new(vec![
+        Line::from(vec![
+            Span::styled(
+                status_label(row.installed),
+                status_cell_style(row.installed),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                row.catalog.source.as_str(),
+                source_style(&row.catalog.source),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                row.catalog.id.as_str(),
+                TuiStyle::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                row.catalog.title.as_deref().unwrap_or("-"),
+                TuiStyle::default().fg(Color::Gray),
+            ),
+        ]),
+    ])
+}
+
+fn status_label(installed: bool) -> &'static str {
+    if installed { "INSTALLED" } else { "available" }
+}
+
+fn status_cell_style(installed: bool) -> TuiStyle {
+    if installed {
+        TuiStyle::default()
+            .fg(Color::Black)
+            .bg(Color::Green)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        TuiStyle::default().fg(Color::DarkGray)
+    }
+}
+
+fn source_style(source: &str) -> TuiStyle {
+    let color = if source == "embedded" {
+        Color::LightBlue
+    } else if source == "installed" {
+        Color::Green
+    } else if source.starts_with("registry:") {
+        Color::Yellow
+    } else {
+        Color::Magenta
+    };
+    TuiStyle::default().fg(color)
+}
+
+fn detail_lines(row: &BrowserRow) -> Vec<Line<'static>> {
+    let aliases = if row.catalog.aliases.is_empty() {
+        "-".to_string()
+    } else {
+        row.catalog.aliases.join(", ")
+    };
+    let fields = if row.catalog.fields.is_empty() {
+        "-".to_string()
+    } else {
+        row.catalog.fields.join(", ")
+    };
+    let mut lines = vec![
+        label_value_line("ID", row.catalog.id.as_str()),
+        label_value_line("Title", row.catalog.title.as_deref().unwrap_or("-")),
+        label_value_line("Source", row.catalog.source.as_str()),
+        label_value_line("Status", status_label(row.installed)),
+        label_value_line("Aliases", aliases.as_str()),
+        label_value_line("Fields", fields.as_str()),
+    ];
+    if let Some(description) = &row.catalog.description {
+        lines.push(Line::from(""));
+        lines.push(label_value_line("Summary", description));
+    }
+    if let Some(url) = &row.catalog.url {
+        lines.push(Line::from(""));
+        lines.push(label_value_line("URL", url));
+    }
+    lines
+}
+
+fn label_value_line(label: &str, value: impl Into<String>) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:<8}"),
+            TuiStyle::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(value.into()),
+    ])
+}
+
+fn focus_border_style(active: bool) -> TuiStyle {
+    if active {
+        TuiStyle::default().fg(Color::Cyan)
+    } else {
+        TuiStyle::default().fg(Color::DarkGray)
+    }
+}
+
+fn status_style(kind: StatusKind) -> TuiStyle {
+    match kind {
+        StatusKind::Info => TuiStyle::default().fg(Color::Gray),
+        StatusKind::Success => TuiStyle::default().fg(Color::Green),
+        StatusKind::Error => TuiStyle::default().fg(Color::Red),
+    }
+}
+
+fn render_confirmation(frame: &mut Frame<'_>, area: Rect, style_id: Option<&str>) {
+    let popup_area = centered_rect(64, 5, area);
+    frame.render_widget(Clear, popup_area);
+    let prompt = if let Some(style_id) = style_id {
+        format!("Remove {style_id}?\ny Remove   n Cancel")
+    } else {
+        "Remove installed style?\ny Remove   n Cancel".to_string()
+    };
+    frame.render_widget(
+        Paragraph::new(prompt)
+            .block(Block::default().title("Confirm").borders(Borders::ALL))
+            .wrap(Wrap { trim: true }),
+        popup_area,
+    );
+}
+
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let popup_width = width.min(area.width);
+    let popup_height = height.min(area.height);
+    Rect {
+        x: area.x + area.width.saturating_sub(popup_width) / 2,
+        y: area.y + area.height.saturating_sub(popup_height) / 2,
+        width: popup_width,
+        height: popup_height,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "Panicking is acceptable and desired in focused CLI TUI tests."
+)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+
+    #[derive(Default)]
+    struct FakeActions {
+        installed: Vec<String>,
+        removed: Vec<String>,
+    }
+
+    impl StyleBrowserActions for FakeActions {
+        fn install_style(&mut self, row: &StyleCatalogRow) -> Result<(), Box<dyn Error>> {
+            self.installed.push(row.id.clone());
+            Ok(())
+        }
+
+        fn remove_style(&mut self, row: &StyleCatalogRow) -> Result<(), Box<dyn Error>> {
+            self.removed.push(row.id.clone());
+            Ok(())
+        }
+    }
+
+    fn catalog_row(id: &str, source: &str, title: &str) -> StyleCatalogRow {
+        StyleCatalogRow {
+            source: source.to_string(),
+            id: id.to_string(),
+            aliases: Vec::new(),
+            title: Some(title.to_string()),
+            description: None,
+            fields: Vec::new(),
+            url: None,
+        }
+    }
+
+    #[test]
+    fn merge_catalog_rows_marks_embedded_style_as_installed_once() {
+        let rows = merge_catalog_rows(vec![
+            catalog_row("apa-7th", "embedded", "APA"),
+            catalog_row("apa-7th", "installed", ""),
+        ]);
+
+        assert_eq!(rows.len(), 1);
+        let row = rows.first().expect("merged row should exist");
+        assert_eq!(row.catalog.source, "embedded");
+        assert!(row.installed);
+    }
+
+    #[test]
+    fn merge_catalog_rows_keeps_installed_only_style() {
+        let rows = merge_catalog_rows(vec![catalog_row("custom-style", "installed", "")]);
+
+        assert_eq!(rows.len(), 1);
+        let row = rows.first().expect("merged row should exist");
+        assert_eq!(row.catalog.source, "installed");
+        assert!(row.installed);
+    }
+
+    #[test]
+    fn browser_filter_matches_source_and_title() {
+        let row = BrowserRow {
+            catalog: catalog_row("apa-7th", "embedded", "American Psychological Association"),
+            installed: false,
+        };
+
+        assert!(browser_row_matches_query(&row, "psychological association"));
+        assert!(browser_row_matches_query(&row, "embedded"));
+        assert!(!browser_row_matches_query(&row, "vancouver numeric"));
+    }
+
+    #[test]
+    fn quit_key_is_global() {
+        let key = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE);
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+
+        assert!(is_quit_key(key));
+        assert!(is_quit_key(ctrl_c));
+    }
+
+    #[test]
+    fn remove_confirmation_marks_registry_row_available() {
+        let mut app = StyleBrowserApp::new(StyleBrowserConfig {
+            rows: vec![
+                catalog_row("apa-7th", "embedded", "American Psychological Association"),
+                catalog_row("apa-7th", "installed", ""),
+            ],
+            initial_query: String::new(),
+            source_label: "all".to_string(),
+        });
+        let mut actions = FakeActions::default();
+
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            &mut actions,
+        )
+        .expect("remove request should be handled");
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+            &mut actions,
+        )
+        .expect("remove confirmation should be handled");
+
+        assert_eq!(actions.removed, vec!["apa-7th"]);
+        let row = app
+            .current_row()
+            .expect("registry row should remain visible");
+        assert_eq!(row.catalog.source, "embedded");
+        assert!(!row.installed);
+    }
+
+    #[test]
+    fn remove_confirmation_drops_installed_only_row() {
+        let mut app = StyleBrowserApp::new(StyleBrowserConfig {
+            rows: vec![catalog_row("custom-style", "installed", "")],
+            initial_query: String::new(),
+            source_label: "all".to_string(),
+        });
+        let mut actions = FakeActions::default();
+
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            &mut actions,
+        )
+        .expect("remove request should be handled");
+        app.handle_key(
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+            &mut actions,
+        )
+        .expect("remove confirmation should be handled");
+
+        assert_eq!(actions.removed, vec!["custom-style"]);
+        assert!(app.current_row().is_none());
+    }
+
+    #[test]
+    fn wide_render_includes_source_and_installed_state() {
+        let mut app = StyleBrowserApp::new(StyleBrowserConfig {
+            rows: vec![
+                catalog_row("apa-7th", "embedded", "American Psychological Association"),
+                catalog_row("apa-7th", "installed", ""),
+            ],
+            initial_query: String::new(),
+            source_label: "all".to_string(),
+        });
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).expect("test backend should initialize");
+
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("test render should succeed");
+        let rendered =
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .fold(String::new(), |mut output, cell| {
+                    output.push_str(cell.symbol());
+                    output
+                });
+
+        assert!(rendered.contains("INSTALLED"));
+        assert!(rendered.contains("embedded"));
+        assert!(rendered.contains("apa-7th"));
+        assert!(rendered.contains("American Psychological Association"));
+    }
+}

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -1,9 +1,115 @@
 use citum_engine::{Processor, io::LoadedBibliography};
 use citum_schema::{Locale, Style, locale::types::LocaleOverride};
-use citum_store::{StoreConfig, StoreResolver, platform_data_dir};
+use citum_store::{StoreConfig, StoreResolver, platform_config_dir, platform_data_dir};
+use serde::Deserialize;
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+#[derive(Deserialize)]
+struct RegistrySourceRecord {
+    name: String,
+}
+
+fn registry_sources_path() -> Option<PathBuf> {
+    platform_config_dir().map(|dir| dir.join("registry-sources.json"))
+}
+
+fn configured_registry_path(name: &str) -> Option<PathBuf> {
+    platform_config_dir().map(|dir| dir.join("registries").join(format!("{name}.yaml")))
+}
+
+fn configured_registry_names() -> Vec<String> {
+    let Some(path) = registry_sources_path() else {
+        return Vec::new();
+    };
+    let Ok(bytes) = fs::read(path) else {
+        return Vec::new();
+    };
+    let Ok(records) = serde_json::from_slice::<Vec<RegistrySourceRecord>>(&bytes) else {
+        return Vec::new();
+    };
+    records.into_iter().map(|record| record.name).collect()
+}
+
+fn registry_candidate_names() -> Vec<String> {
+    let mut candidates = Vec::new();
+    let local_path = Path::new("citum-registry.yaml");
+    if local_path.exists()
+        && let Ok(registry) = citum_schema::StyleRegistry::load_from_file(local_path)
+    {
+        candidates.extend(registry.styles.iter().flat_map(|entry| {
+            std::iter::once(entry.id.clone()).chain(entry.aliases.iter().cloned())
+        }));
+    }
+    for name in configured_registry_names() {
+        let Some(path) = configured_registry_path(&name) else {
+            continue;
+        };
+        let Ok(registry) = citum_schema::StyleRegistry::load_from_file(&path) else {
+            continue;
+        };
+        candidates.extend(registry.styles.iter().flat_map(|entry| {
+            std::iter::once(entry.id.clone()).chain(entry.aliases.iter().cloned())
+        }));
+    }
+    candidates.extend(
+        citum_schema::embedded::default_registry()
+            .styles
+            .iter()
+            .flat_map(|entry| {
+                std::iter::once(entry.id.clone()).chain(entry.aliases.iter().cloned())
+            }),
+    );
+    candidates
+}
+
+fn registry_resolvers() -> Result<Vec<Box<dyn citum_store::resolver::StyleResolver>>, Box<dyn Error>>
+{
+    use citum_store::resolver::{HttpResolver, RegistryResolver, StyleResolver};
+
+    let mut resolvers: Vec<Box<dyn StyleResolver>> = Vec::new();
+
+    let local_path = Path::new("citum-registry.yaml");
+    if local_path.exists()
+        && let Ok(registry) = citum_schema::StyleRegistry::load_from_file(local_path)
+    {
+        resolvers.push(Box::new(
+            RegistryResolver::new(registry).with_base_dir(std::env::current_dir()?),
+        ));
+    }
+
+    for name in configured_registry_names() {
+        let Some(path) = configured_registry_path(&name) else {
+            continue;
+        };
+        if !path.exists() {
+            continue;
+        }
+        let Ok(registry) = citum_schema::StyleRegistry::load_from_file(&path) else {
+            continue;
+        };
+        let base_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
+        let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
+            resolver.with_http(http)
+        } else {
+            resolver
+        };
+        resolvers.push(Box::new(resolver));
+    }
+
+    let resolver = RegistryResolver::new(citum_schema::embedded::default_registry())
+        .with_base_dir(std::env::current_dir()?);
+    let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
+        resolver.with_http(http)
+    } else {
+        resolver
+    };
+    resolvers.push(Box::new(resolver));
+
+    Ok(resolvers)
+}
 
 pub(crate) fn load_locale_file(path: &Path) -> Result<Locale, Box<dyn Error>> {
     Locale::from_file(path)
@@ -93,8 +199,7 @@ pub(crate) fn load_any_style(
     _no_semantics: bool,
 ) -> Result<Style, Box<dyn Error>> {
     use citum_store::resolver::{
-        ChainResolver, EmbeddedResolver, FileResolver, HttpResolver, RegistryResolver,
-        StyleResolver,
+        ChainResolver, EmbeddedResolver, FileResolver, HttpResolver, StyleResolver,
     };
 
     let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
@@ -114,14 +219,7 @@ pub(crate) fn load_any_style(
         resolvers.push(Box::new(http));
     }
 
-    let registry_resolver = RegistryResolver::new(citum_schema::embedded::default_registry())
-        .with_base_dir(std::env::current_dir()?);
-    let registry_resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
-        registry_resolver.with_http(http)
-    } else {
-        registry_resolver
-    };
-    resolvers.push(Box::new(registry_resolver));
+    resolvers.extend(registry_resolvers()?);
 
     resolvers.push(Box::new(EmbeddedResolver));
 
@@ -134,18 +232,10 @@ pub(crate) fn load_any_style(
             Ok(resolved)
         }
         Err(citum_store::resolver::ResolverError::StyleNotFound(_)) => {
-            let registry = citum_schema::embedded::default_registry();
-            let candidates: Vec<_> = registry
-                .styles
-                .iter()
-                .flat_map(|entry| {
-                    std::iter::once(entry.id.as_str())
-                        .chain(entry.aliases.iter().map(String::as_str))
-                })
-                .collect();
+            let candidates = registry_candidate_names();
             let suggestions: Vec<_> = candidates
                 .iter()
-                .filter(|&&name| strsim::jaro_winkler(style_input, name) > 0.8)
+                .filter(|name| strsim::jaro_winkler(style_input, name) > 0.8)
                 .collect();
 
             let mut msg = format!("style not found: '{style_input}'");

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -43,3 +43,29 @@ use std::path::PathBuf;
 pub fn platform_data_dir() -> Option<PathBuf> {
     dirs::data_dir().map(|d| d.join("citum"))
 }
+
+/// Returns the platform-specific configuration directory for Citum.
+///
+/// This path is derived from [`dirs::config_dir()`] with a `citum` subdirectory appended.
+///
+/// Typical locations:
+/// - Linux:   `~/.config/citum/`
+/// - macOS:   `~/Library/Application Support/citum/`
+/// - Windows: `%APPDATA%\citum\`
+#[must_use]
+pub fn platform_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("citum"))
+}
+
+/// Returns the platform-specific cache directory for Citum.
+///
+/// This path is derived from [`dirs::cache_dir()`] with a `citum` subdirectory appended.
+///
+/// Typical locations:
+/// - Linux:   `~/.cache/citum/`
+/// - macOS:   `~/Library/Caches/citum/`
+/// - Windows: `%LOCALAPPDATA%\citum\`
+#[must_use]
+pub fn platform_cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir().map(|d| d.join("citum"))
+}

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -272,7 +272,21 @@ impl HttpResolver {
     /// Create a resolver using the platform cache directory.
     #[must_use]
     pub fn from_platform_cache_dir() -> Option<Self> {
-        dirs::cache_dir().map(|dir| Self::new(dir.join("citum")))
+        crate::platform_cache_dir().map(Self::new)
+    }
+
+    /// Fetch raw bytes from a URL.
+    ///
+    /// # Errors
+    /// Returns an error if the request fails.
+    pub fn fetch_bytes(&self, url: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let mut response = self.client.get(url).send()?;
+        if !response.status().is_success() {
+            return Err(format!("failed to fetch {url}: status {}", response.status()).into());
+        }
+        let mut bytes = Vec::new();
+        response.copy_to(&mut bytes)?;
+        Ok(bytes)
     }
 
     fn cache_path(&self, uri: &str) -> PathBuf {

--- a/docs/specs/CLI_UX_REDESIGN.md
+++ b/docs/specs/CLI_UX_REDESIGN.md
@@ -1,6 +1,6 @@
 # CLI UX Redesign Specification
 
-**Status:** Draft
+**Status:** Active
 **Date:** 2026-05-06
 **Related:** csl26-j242, docs/specs/STYLE_REGISTRY.md, docs/specs/DISTRIBUTED_RESOLVER.md
 

--- a/docs/specs/CLI_UX_REDESIGN.md
+++ b/docs/specs/CLI_UX_REDESIGN.md
@@ -1,0 +1,381 @@
+# CLI UX Redesign Specification
+
+**Status:** Draft
+**Date:** 2026-05-06
+**Related:** csl26-j242, docs/specs/STYLE_REGISTRY.md, docs/specs/DISTRIBUTED_RESOLVER.md
+
+## Purpose
+
+This specification defines a clearer command-line user experience for Citum. It
+evaluates the current CLI from a human interface design and CLI UX perspective,
+then defines a target command model that makes common user tasks discoverable:
+rendering documents, finding styles, installing styles, adding registries,
+validating inputs, and authoring style or locale files.
+
+The redesign optimizes for clean, consistent UX. Backward compatibility is not a
+goal for this work: confusing duplicate commands should be removed or reorganized
+rather than kept as aliases.
+
+## Scope
+
+In scope:
+
+- User-facing command names, grouping, help text, examples, and error guidance.
+- Style discovery, style installation, registry management, installed locale UX,
+  and diagnostics.
+- Command behavior where current behavior contradicts help text or user intent.
+- The `csl26-j242` interactive style browser as part of the style discovery UX.
+
+Out of scope:
+
+- Changes to citation rendering semantics.
+- Changes to style, locale, bibliography, or citation schema shape.
+- Distributed resolver protocol details beyond the CLI workflows already needed
+  by style and registry management.
+
+## Current UX Evaluation
+
+### Top-level command model
+
+The current command tree is:
+
+```text
+citum
+  render doc|refs
+  check
+  convert refs|style|citations|locale
+  styles list
+  registry list|resolve
+  store list|install|remove
+  style list|search|info|lint
+  locale lint
+  schema
+  bindings
+  completions
+  doc       (hidden legacy)
+  validate  (hidden legacy)
+```
+
+The main problem is that the command tree mixes object names, implementation
+layers, and user tasks. `style` and `styles` are nearly identical names but have
+different meanings. `registry` claims to manage sources but only inspects a
+partial view. `store` exposes the storage mechanism, while users usually want to
+add or remove styles and locales without learning where Citum stores them.
+
+### Command findings
+
+`render` is the clearest command group. `render doc` and `render refs` describe
+tasks users understand. Its main UX issue is style discovery: users who do not
+know a valid `--style` value must leave the render workflow and guess whether
+`styles`, `style`, `registry`, or `store` is the right next command.
+
+`check` is broad but acceptable. It validates styles, bibliography files, and
+citations. It should stay a top-level command because validation is a cross-file
+workflow. Help text should distinguish schema validation from style-locale linting.
+
+`convert` has a good object-oriented shape. `convert refs`, `convert style`,
+`convert citations`, and `convert locale` are predictable. It needs consistent
+input/output examples and should use the same singular/plural terms as the rest
+of the CLI: `refs` for bibliography/reference files, `style` for one style file,
+`locale` for one locale file, and `citations` for citation input files.
+
+`styles` is the most confusing command. It lists embedded builtins only, but the
+name looks like the general style browsing surface. Because `style` already owns
+the unified catalog commands, `styles` should be removed from the clean target
+UX. Embedded-only browsing should be expressed as `citum style list --source
+embedded`.
+
+`style` is conceptually correct as the main style namespace, but its current
+top-level help says "Validate a style against a locale file" even though the
+subcommands are `list`, `search`, `info`, and `lint`. This teaches users the
+wrong model before they see the useful discovery commands.
+
+`style lint` is too narrowly described as locale-file validation. It should be
+framed as style authoring validation, with `--locale` as one input to that
+validation. The command should explain what it checks and what it does not check.
+
+`registry` currently says "manage" but only provides `list` and `resolve`.
+`registry list` includes a local `citum-registry.yaml` if present, while
+`registry resolve` currently resolves only against the embedded default registry.
+That violates the user's expectation that commands under one noun share the same
+source model. A clean UX requires real management commands and consistent source
+resolution.
+
+`store` is an implementation-layer command exposed as a user-facing noun. It is
+useful because it reveals platform paths and installed files, but those are
+diagnostic concerns. Style installation should live under `style add/remove`,
+locale installation should live under `locale add/remove`, and store-path
+inspection should live under a diagnostic command.
+
+`locale` is a valid authoring namespace. `locale lint` is clear, but it should
+share validation language with `style lint` and should be discoverable from
+`check --help` when users are validating project inputs.
+
+`schema`, `bindings`, and `completions` are developer/tooling commands. They are
+acceptable as top-level commands, but help text should label them as tooling so
+new end users do not confuse them with citation workflows.
+
+Hidden `doc` and `validate` legacy commands should be removed in the clean target
+UX. If retained temporarily during implementation, they should not shape public
+documentation, examples, or tests.
+
+## Design
+
+### User stories
+
+1. As an author, I can render a document with a style I already know:
+   `citum render doc manuscript.djot -b refs.json -s apa`.
+2. As an author, I can search for a style by title, alias, field, or publisher:
+   `citum style search chicago`.
+3. As an author, I can inspect a style before using it:
+   `citum style info chicago-author-date-18th`.
+4. As an author, I can install a style without copying a full ID from terminal
+   output: `citum style add chicago` lets me choose from ranked matches.
+5. As an institutional admin, I can add a registry source:
+   `citum registry add https://styles.example.org/citum-registry.yaml --name example`.
+6. As an institutional admin, I can refresh or remove that source:
+   `citum registry update example` and `citum registry remove example`.
+7. As a style author, I can validate a style against locale-sensitive behavior:
+   `citum style lint my-style.yaml --locale locales/en-US.yaml`.
+8. As a locale author, I can validate locale messages and aliases:
+   `citum locale lint locales/en-US.yaml`.
+
+### Target command tree
+
+```text
+citum
+  render doc|refs
+  check
+  convert refs|style|citations|locale
+  style list|search|info|browse|add|remove|lint
+  registry list|add|remove|update|resolve
+  locale list|add|remove|lint
+  doctor
+  schema
+  bindings
+  completions
+```
+
+`citum style` is the main user-facing style namespace. It owns discovery,
+inspection, installation, removal, interactive browsing, and style authoring
+validation.
+
+`citum registry` owns registry source management. A registry is a source of style
+metadata and style locations, not a style itself.
+
+`citum locale` owns installed locale workflows and locale authoring validation.
+
+`citum doctor` owns diagnostics that are not citation tasks: data directory,
+cache directory, configured registries, installed counts, and environment
+problems.
+
+`citum styles` is removed from the target UX.
+
+`citum store` is removed from the target UX. The underlying store remains an
+implementation detail used by `style`, `locale`, and `doctor`.
+
+### Style catalog semantics
+
+The style catalog must have one documented source model. All of these commands
+must use that model unless a flag narrows it:
+
+- `citum style list`
+- `citum style search`
+- `citum style info`
+- `citum style browse`
+- `citum style add`
+- style-not-found suggestions from `render`, `check`, and `style add`
+
+The default catalog should include every style users can reasonably choose by
+name: embedded styles, configured registry styles, and installed user styles.
+`--source` may narrow the view, but source names must be user concepts rather
+than implementation leaks:
+
+```text
+--source all
+--source embedded
+--source installed
+--source registry:<name>
+```
+
+Rows should include enough information to choose confidently: ID, title, source,
+aliases when useful, kind, and field/domain tags when available. Text output
+should stay concise; JSON output should expose the full row.
+
+### Style commands
+
+`citum style list` lists catalog rows. It should default to a readable table and
+support `--format json`, `--source`, `--limit`, and `--offset`.
+
+`citum style search <query>` searches IDs, aliases, titles, descriptions, kind,
+and field tags. It should use the same output shape as `style list`.
+
+`citum style info <id-or-alias>` prints a detail view for one style. Text output
+should be field-oriented rather than a one-row table:
+
+```text
+ID:       apa-7th
+Title:    American Psychological Association 7th edition
+Source:   embedded
+Aliases:  apa
+Kind:     base
+```
+
+`citum style browse` implements `csl26-j242`. It is an interactive TUI over the
+same catalog rows used by `list`, `search`, and `info`. It should provide a
+scrollable list, incremental filtering, and a detail pane. It should not define a
+separate data model or registry path.
+
+`citum style add <query-or-url-or-path>` installs a style into the user store. If
+given a URL or path, it validates and installs that style directly. If given text
+that is not a path or URL, it first tries exact ID and alias resolution, then
+falls back to catalog search.
+
+The command must not require ordinary terminal users to copy and paste a full
+style ID. In an interactive terminal:
+
+- one exact or high-confidence match installs directly after showing the style
+  title and source;
+- multiple plausible matches show a numbered selection list;
+- no matches show the same next-step guidance as style-not-found errors.
+
+In non-interactive mode, ambiguous input fails with ranked matches and a clear
+instruction to rerun with an exact ID, alias, URL, or path. Automation can still
+use exact IDs, but the human workflow is query-first.
+
+`citum style browse` should include an install action so a user can search,
+inspect, and install without leaving the TUI.
+
+`citum style remove <id-or-alias>` removes an installed style. It must not remove
+embedded styles. For automation, it should support `--yes`.
+
+`citum style lint <style>` validates style authoring rules, including
+locale-driven terms when `--locale` is provided or when the style declares a
+default locale. Its help text should not imply that locale resolution is the only
+purpose of style linting.
+
+### Registry commands
+
+`citum registry list` lists configured registry sources and the embedded source.
+It should report name, URL/source, priority or precedence, cache status, style
+count, and last update where available.
+
+`citum registry add <url> --name <name>` fetches and validates a registry before
+adding it. It must fail clearly if the registry cannot be read or parsed.
+
+`citum registry remove <name>` removes a configured registry. It should support
+`--yes` for non-interactive use.
+
+`citum registry update [<name>|--all]` refreshes cached registry metadata.
+
+`citum registry resolve <id-or-alias>` resolves through the same registry source
+chain used by style catalog commands and prints the selected style plus source.
+It must not use a narrower source model than `registry list`.
+
+### Locale commands
+
+`citum locale list` lists installed and embedded locales. It should support
+`--source all|embedded|installed` and `--format text|json`.
+
+`citum locale add <path>` installs a locale file after validating it.
+
+`citum locale remove <id-or-name>` removes an installed locale. It must not
+remove embedded locales. For automation, it should support `--yes`.
+
+`citum locale lint <locale>` validates locale message syntax, alias targets, and
+supported MessageFormat behavior.
+
+### Diagnostics
+
+`citum doctor` reports local environment and configuration state. It should
+include the platform data directory, cache directory, configured registry
+sources, installed style count, installed locale count, and any unreadable or
+invalid local files. It should not be required for normal browse, install,
+render, or validation workflows.
+
+### Help text rules
+
+Every command summary should answer "what user task does this perform?" in one
+sentence. Avoid implementation-first phrases such as "unified catalog" unless
+the help text immediately defines what sources are included.
+
+Use consistent argument labels:
+
+- `<style>` for a path, URL, ID, or alias accepted by the style resolver.
+- `<style-id>` for a catalog ID or alias only.
+- `<registry>` for a configured registry name.
+- `<locale>` for a locale path or locale ID accepted by the command.
+
+Every command that accepts style names should include one example using `apa`
+and one example using a fully qualified style ID when space allows.
+
+Errors should point to the next useful command:
+
+```text
+style not found: "apaa"
+
+Did you mean "apa"?
+Search styles with: citum style search apaa
+List installed styles with: citum style list --source installed
+```
+
+## Implementation Notes
+
+The first implementation pass should focus on command semantics and help text
+before adding the TUI. A clean sequence is:
+
+1. Remove the public `styles` command and route embedded-only browsing through
+   `style list --source embedded`.
+2. Remove the public `store` command and move its user-facing behavior to
+   `style`, `locale`, and `doctor`.
+3. Update `style` top-level help and `style lint` copy.
+4. Make `registry list` and `registry resolve` use the same source chain.
+5. Add query-first `style add/remove` as the user-facing style installation path.
+6. Make `style list/search/info/add` include installed styles or document an
+   explicit source filter when a source cannot be loaded.
+7. Add `locale list/add/remove`.
+8. Add `registry add/remove/update`.
+9. Add `doctor` diagnostics.
+10. Implement `style browse` for `csl26-j242` over the finalized catalog model.
+
+The style catalog should be implemented as a shared service rather than rebuilt
+inside each command. The service should expose one row model for table, JSON, and
+TUI consumers.
+
+If implementation continues in this PR, keep commits scoped by user-visible
+workflow:
+
+1. `docs(cli): specify clean cli ux` - this spec.
+2. `refactor(cli): share style catalog resolution` - introduce the catalog row
+   service used by list, search, info, add, and errors.
+3. `feat(cli): simplify style discovery commands` - remove `styles`, fix style
+   help, and make list/search/info use the shared catalog.
+4. `feat(cli): add query-first style installation` - add `style add/remove` with
+   interactive disambiguation and non-interactive ambiguity errors.
+5. `feat(cli): manage locales outside store namespace` - add locale list/add/remove
+   and keep locale lint under the same namespace.
+6. `feat(cli): manage registries consistently` - add registry add/remove/update
+   and make resolve use the same sources as list.
+7. `feat(cli): add doctor diagnostics` - expose paths, cache, registry, and
+   installed-resource diagnostics without a public store noun.
+8. `feat(cli): add interactive style browser` - implement `csl26-j242` on top of
+   the shared catalog after the command model is stable.
+
+## Acceptance Criteria
+
+- [ ] The spec evaluates every current command group and identifies user-visible
+      confusion or confirms that the group is already coherent.
+- [ ] The target command tree has no duplicate `style`/`styles` split.
+- [ ] The target UX includes browse, inspect, query-first install,
+      registry-add, registry refresh, registry-remove, render, style-lint, and
+      locale-lint workflows.
+- [ ] `csl26-j242` is specified as `citum style browse` over the shared style
+      catalog.
+- [ ] The target command tree has no public `store` noun; diagnostics live under
+      `doctor`, styles under `style`, and locales under `locale`.
+- [ ] The implementation sequence is explicit enough that follow-up commits can
+      continue in the same PR after spec review.
+
+## Changelog
+
+- 2026-05-06: Initial version.

--- a/docs/specs/CLI_UX_REDESIGN.md
+++ b/docs/specs/CLI_UX_REDESIGN.md
@@ -221,10 +221,47 @@ Aliases:  apa
 Kind:     base
 ```
 
-`citum style browse` implements `csl26-j242`. It is an interactive TUI over the
-same catalog rows used by `list`, `search`, and `info`. It should provide a
-scrollable list, incremental filtering, and a detail pane. It should not define a
-separate data model or registry path.
+`citum style browse` implements `csl26-j242`. It is an interactive Ratatui TUI
+over the same catalog rows used by `list`, `search`, and `info`. It must provide
+a scrollable list, incremental filtering, a detail pane, and install/remove
+actions without defining a separate data model or registry path.
+
+The browser is a style discovery tool, not a monochrome table prompt. It should
+use restrained color to make state legible:
+
+- a header showing the active source filter, search query, result count, and
+  installed count;
+- a selectable table of styles with aligned `Status`, `Source`, `ID`, and
+  `Title` columns;
+- a visible installed indicator for styles already present in the user store,
+  shown as a high-contrast `INSTALLED` cell in the `Status` column rather than
+  appended after the ID;
+- a detail pane with ID, title, source, aliases, fields, description, and URL
+  when available;
+- a footer with the active key bindings and transient success/error messages.
+
+Catalog rows should be merged for display. If an embedded or registry style is
+already installed, it appears once with its original source and an installed
+status. Styles that only exist in the user store appear with source `installed`.
+The TUI must never require the user to copy a full style ID from terminal output.
+
+Required keys:
+
+- `/` focuses search and live-filters the list;
+- `Esc` clears search or returns focus to the list;
+- `Up`/`Down` and `j`/`k` move selection;
+- `PageUp`/`PageDown`, `Home`, and `End` page through results;
+- `Enter` or `d` focuses the detail pane;
+- `i` installs the selected style when it is not already installed;
+- `r` removes the selected installed style after a `y`/`n` confirmation modal;
+- `q` quits from any focus state.
+
+The command must keep a non-TTY fallback that prints the same rows as
+`style list/search`, because scripts and pipes should not enter alternate-screen
+mode. In a narrow terminal, the TUI should collapse to a single-pane list/detail
+toggle with each item split across two lines: status/source first, then ID/title.
+The footer must be mode-specific: search mode only shows search controls, while
+list/detail mode shows install or remove depending on the selected style state.
 
 `citum style add <query-or-url-or-path>` installs a style into the user store. If
 given a URL or path, it validates and installs that style directly. If given text
@@ -370,7 +407,7 @@ workflow:
       registry-add, registry refresh, registry-remove, render, style-lint, and
       locale-lint workflows.
 - [ ] `csl26-j242` is specified as `citum style browse` over the shared style
-      catalog.
+      catalog, including source badges and installed-state indicators.
 - [ ] The target command tree has no public `store` noun; diagnostics live under
       `doctor`, styles under `style`, and locales under `locale`.
 - [ ] The implementation sequence is explicit enough that follow-up commits can

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -54,6 +54,7 @@ to make sure the document should be a spec rather than architecture or policy.
 | File | Feature |
 |------|---------|
 | [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) | Federated registry and distributed resolver architecture (Phases 2–3) |
+| [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) | Clean command model for style discovery, registry management, and CLI validation UX |
 | [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Verification model for profile styles using external authority |
 | [`SERVER_INTERACTIVE_API.md`](./SERVER_INTERACTIVE_API.md) | Document-batch and session APIs for server and WASM |
 


### PR DESCRIPTION
## Summary

- add the CLI UX redesign spec for csl26-j242
- replace the confusing styles/store surfaces with task-oriented style, locale, registry, and doctor workflows
- add query-first style installation, interactive style browsing, installed locale management, registry source management, and shared catalog resolution

## Verification

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run
- cargo run --bin citum --features schema -- schema --out-dir docs/schemas
- ./scripts/validate-frontmatter.sh --repo-only --copilot-strict
- ./scripts/check-docs-beans-hygiene.sh
- python3 scripts/audit-rust-review-smells.py --changed
- GitHub CI: changes, Hygiene Checks, Rust CI, API Semver Check
