### PR TITLE
feat(report): support type-variants in SQI scoring

### DIFF
--- a/.beans/archive/csl26-ur17--fix-sqi-duplication-penalty-discount-for-diff-vari.md
+++ b/.beans/archive/csl26-ur17--fix-sqi-duplication-penalty-discount-for-diff-vari.md
@@ -1,0 +1,23 @@
+---
+# csl26-ur17
+title: Fix SQI duplication-penalty discount for diff variants
+status: completed
+type: bug
+priority: high
+created_at: 2026-05-07T11:21:07Z
+updated_at: 2026-05-07T11:23:35Z
+---
+
+PR #632 partially discounted diff-variant components from concision penalties: componentPenalty and overridePenalty are correctly reduced but duplication penalties (crossScopeRepeats, fingerprint accumulators) still over-penalize surgical type-variants. Also strip __isDiff flag from fingerprint hashes and add regression tests for surgical-modify case and type-variants-only fallback robustness.
+
+## Summary of Changes
+
+- Track `isDiffForm` at scope level in `addVariantScopes` so nested children inside diff `add` ops are also discounted (the previous per-component `__isDiff` flag missed nested groups/items).
+- Filter diff-form scopes from `flattened` (component-count budget and override density) and from `keyScopeCount` (cross-scope repeat detection). `withinScopeDuplicates`, `exactDuplicateScopes`, `nearDuplicateScopes`, and `repeatedPatterns` still iterate all scopes — parallel identical diff ops are real duplication and should still register.
+- Strip `__isDiff` flag in fingerprint helpers (`fingerprintComponent`, `fingerprintScopeComponents`, `collectPatternFingerprints`) so the synthetic flag doesn't leak into hashes.
+- Export `computeFallbackRobustness` for direct testing.
+- Add 4 regression tests:
+  - surgical diff variants don't register as cross-scope repeats and don't inflate component count
+  - parallel identical diff variants do register as duplicates (real duplication caught)
+  - type-variants alone satisfy fallback robustness coverage
+  - `extends` short-circuit still scores 100

--- a/docs/policies/SQI_REFINEMENT_PLAN.md
+++ b/docs/policies/SQI_REFINEMENT_PLAN.md
@@ -156,13 +156,19 @@ For each style in a wave:
 
 Improve SQI so it rewards real maintainability changes:
 
+0. Type Coverage & Fallback Robustness:
+   - incorporate diff-based `type-variants` into explicit type coverage accounting.
+   - ensure `type-variants` satisfy fallback robustness checks the same as full `type-templates`.
+
 1. Preset detection:
    - count template-level `extends` and `preset` entries.
    - count options-level preset strings plus object-form preset references.
    - weight by impact (template preset > options preset).
 2. Concision:
    - normalize component target thresholds by style class (`author-date`/`numeric`/`note`).
-   - apply dynamic target bonuses when styles intentionally cover many type templates.
+   - apply dynamic target bonuses when styles intentionally cover many type templates
+     or diff-based `type-variants`.
+   - discount diff operations (`modify`, `remove`, `add`, etc.) within `type-variants`     from component count and duplication penalties to reward surgical overrides.
    - reduce over-penalization for cross-template structural reuse.
 3. Note style handling:
    - avoid forcing bibliography-centric penalties when bibliography is intentionally absent.

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -1645,12 +1645,14 @@ function collectTemplateScopes(styleData) {
 
   function addVariantScopes(prefix, variants, kind) {
     for (const [rawKey, template] of Object.entries(variants || {})) {
+      const isDiffForm = !Array.isArray(template) && Boolean(template) && typeof template === 'object';
       const components = Array.isArray(template) ? template : templateVariantAuthoredComponents(template);
       if (!Array.isArray(components)) continue;
       const typeSelectors = parseOverrideKey(rawKey).filter((key) => key !== 'default');
       variantSelectorCount += typeSelectors.length || 1;
       addScope(`${prefix}.${rawKey}`, components, {
         kind,
+        isDiffForm,
         typeSelectors,
         typeSelectorCount: typeSelectors.length || 1,
       });
@@ -1683,17 +1685,19 @@ function templateVariantAuthoredComponents(variant) {
   if (!variant || typeof variant !== 'object' || Array.isArray(variant)) return null;
   const components = [];
   for (const operation of variant.modify || []) {
-    const component = { ...(operation.match || {}) };
+    const component = { ...(operation.match || {}), __isDiff: true };
     for (const [key, value] of Object.entries(operation)) {
       if (key !== 'match') component[key] = value;
     }
     components.push(component);
   }
   for (const operation of variant.remove || []) {
-    components.push({ ...(operation.match || {}), suppress: true });
+    components.push({ ...(operation.match || {}), suppress: true, __isDiff: true });
   }
   for (const operation of variant.add || []) {
-    if (operation.component) components.push(operation.component);
+    if (operation.component) {
+      components.push({ ...operation.component, __isDiff: true });
+    }
   }
   return components.length > 0 ? components : null;
 }
@@ -1757,6 +1761,7 @@ function stableStructure(value) {
   }
   const normalized = {};
   for (const key of Object.keys(value).sort()) {
+    if (key === '__isDiff') continue;
     normalized[key] = stableStructure(value[key]);
   }
   return normalized;
@@ -1905,8 +1910,18 @@ function computeTypeCoverageScore(citationsByType) {
 function computeFallbackRobustness(styleData) {
   const bibliography = styleData?.bibliography || {};
   const typeTemplates = bibliography['type-templates'] || {};
-  const typeTemplateSet = new Set(Object.keys(typeTemplates));
-  const assessedTypes = CORE_FALLBACK_TYPES.filter((type) => !typeTemplateSet.has(type));
+  const typeVariants = bibliography['type-variants'] || {};
+  const explicitTypes = new Set();
+
+  [typeTemplates, typeVariants].forEach((map) => {
+    for (const rawKey of Object.keys(map)) {
+      for (const type of parseOverrideKey(rawKey)) {
+        if (type !== 'default') explicitTypes.add(type);
+      }
+    }
+  });
+
+  const assessedTypes = CORE_FALLBACK_TYPES.filter((type) => !explicitTypes.has(type));
   if (typeof bibliography['extends'] === 'string' && bibliography['extends'].trim()) {
     return {
       score: 100,
@@ -1922,7 +1937,7 @@ function computeFallbackRobustness(styleData) {
       score: 100,
       assessedTypes: 0,
       passingTypes: 0,
-      note: 'all core types have explicit type-templates',
+      note: 'all core types have explicit type-templates or type-variants',
     };
   }
 
@@ -1947,6 +1962,7 @@ function computeConcisionScore(styleData, format) {
     .map((scope) => ({
       name: scope.name,
       kind: scope.kind,
+      isDiffForm: Boolean(scope.isDiffForm),
       typeSelectors: scope.typeSelectors || [],
       typeSelectorCount: scope.typeSelectorCount || 0,
       scopeFingerprint: fingerprintScopeComponents(scope.components),
@@ -1955,7 +1971,9 @@ function computeConcisionScore(styleData, format) {
       originalComponents: scope.components,
     }))
     .filter((scope) => scope.components.length > 0);
-  const flattened = scopedComponents.flatMap((scope) => scope.components);
+  const flattened = scopedComponents
+    .filter((scope) => !scope.isDiffForm)
+    .flatMap((scope) => scope.components);
 
   if (flattened.length === 0) {
     return {
@@ -1982,6 +2000,7 @@ function computeConcisionScore(styleData, format) {
     const keys = scope.components.map(componentSemanticKey);
     const uniqueInScope = new Set(keys);
     withinScopeDuplicates += Math.max(0, keys.length - uniqueInScope.size);
+    if (scope.isDiffForm) continue;
     for (const key of uniqueInScope) {
       keyScopeCount.set(key, (keyScopeCount.get(key) || 0) + 1);
     }
@@ -2049,11 +2068,15 @@ function computeConcisionScore(styleData, format) {
     0
   );
   const overrideDensity = overrideCount / flattened.length;
-  const typeTemplateCoverage = Object.keys(styleData?.bibliography?.['type-templates'] || {})
-    .reduce((sum, rawKey) => {
+  const typeTemplateCoverage = [
+    styleData?.bibliography?.['type-templates'] || {},
+    styleData?.bibliography?.['type-variants'] || {},
+  ].reduce((total, map) => {
+    return total + Object.keys(map).reduce((sum, rawKey) => {
       const parsed = parseOverrideKey(rawKey).filter((key) => key !== 'default');
       return sum + (parsed.length || 1);
     }, 0);
+  }, 0);
 
   const componentTargets = {
     'author-date': 52,
@@ -3666,6 +3689,7 @@ module.exports = {
   buildNoteStyleLookup,
   collectTemplateScopes,
   computeConcisionScore,
+  computeFallbackRobustness,
   computeFidelityScore,
   createReportRuntime,
   discoverCoreStyles,

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -18,6 +18,7 @@ const {
   buildNoteStyleLookup,
   collectTemplateScopes,
   computeConcisionScore,
+  computeFallbackRobustness,
   discoverCoreStyles,
   computeFidelityScore,
   buildEmptyOracleResult,
@@ -220,9 +221,9 @@ test('collectTemplateScopes scores authored Template V3 diff components', () => 
 
   assert.equal(Boolean(scope), true);
   assert.deepEqual(scope.components, [
-    { title: 'primary', suffix: '.' },
-    { contributor: 'author', suppress: true },
-    { date: 'issued', form: 'year' },
+    { title: 'primary', suffix: '.', __isDiff: true },
+    { contributor: 'author', suppress: true, __isDiff: true },
+    { date: 'issued', form: 'year', __isDiff: true },
   ]);
   assert.equal(variantSelectorCount, 1);
 });
@@ -323,13 +324,112 @@ test('selectQualityAuthorshipData keeps authored Template V3 diff scopes', () =>
   assert.equal(selectQualityAuthorshipData(authored, resolved), authored);
 });
 
+test('computeConcisionScore does not penalize surgical diff variants as cross-scope repeats', () => {
+  const baseStyle = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { date: 'issued', form: 'year' },
+        { title: 'primary' },
+      ],
+    },
+  };
+  const diffStyle = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { date: 'issued', form: 'year' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        book: { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+        chapter: { remove: [{ match: { contributor: 'author' } }] },
+        article: { add: [{ component: { variable: 'doi' } }] },
+      },
+    },
+  };
+
+  const baseScore = computeConcisionScore(baseStyle, 'author-date');
+  const diffScore = computeConcisionScore(diffStyle, 'author-date');
+
+  assert.equal(diffScore.crossScopeRepeats, baseScore.crossScopeRepeats,
+    'modify ops referencing a base component must not register as cross-scope repeats');
+  assert.equal(diffScore.totalComponents, baseScore.totalComponents,
+    'diff scopes must not inflate the component count budget');
+  assert.ok(diffScore.score >= baseScore.score - 0.5,
+    `surgical diff variants should not reduce concision; base=${baseScore.score} diff=${diffScore.score}`);
+});
+
+test('computeConcisionScore detects duplication across parallel diff variants', () => {
+  const styleData = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        book: { add: [{ component: { variable: 'doi' } }] },
+        chapter: { add: [{ component: { variable: 'doi' } }] },
+        article: { add: [{ component: { variable: 'doi' } }] },
+        report: { add: [{ component: { variable: 'doi' } }] },
+        thesis: { add: [{ component: { variable: 'doi' } }] },
+      },
+    },
+  };
+
+  const score = computeConcisionScore(styleData, 'author-date');
+
+  assert.ok(score.exactDuplicateScopes >= 4,
+    `parallel identical diff variants should register as duplicates, got ${score.exactDuplicateScopes}`);
+});
+
+test('computeFallbackRobustness treats type-variants as explicit type coverage', () => {
+  const styleData = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+      'type-variants': {
+        'article-journal': { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+        book: { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+        chapter: { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+        report: { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+        thesis: { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+        'paper-conference': { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+        webpage: { modify: [{ match: { title: 'primary' }, suffix: '.' }] },
+      },
+    },
+  };
+
+  const result = computeFallbackRobustness(styleData);
+
+  assert.equal(result.score, 100);
+  assert.equal(result.assessedTypes, 0);
+  assert.match(result.note, /type-variants/);
+});
+
+test('computeFallbackRobustness honors extends short-circuit', () => {
+  const styleData = {
+    bibliography: {
+      'extends': 'apa',
+      template: [{ contributor: 'author' }],
+    },
+  };
+
+  const result = computeFallbackRobustness(styleData);
+
+  assert.equal(result.score, 100);
+  assert.match(result.note, /embedded bibliography preset/);
+});
+
 test('apa-7th concision regression reflects preset-first success', () => {
   const style = loadStyleMap().get('apa-7th');
   const loaded = loadStyleYaml(style.name);
   const concision = computeConcisionScore(loaded.resolvedStyleData, style.format);
 
   assert.equal(concision.variantSelectors, 26, 'resolved APA should reflect the embedded authored variant selectors');
-  assert.equal(concision.score, 57.6, `expected embedded APA concision, got ${concision.score}`);
+  assert.equal(concision.score, 62.9, `expected embedded APA concision, got ${concision.score}`);
 });
 
 test('report-core exposes expected benchmark labels for representative styles', () => {


### PR DESCRIPTION
This PR updates the SQI (Style Quality Index) metric to correctly account for diff-based type-variants.

### Changes
- **Coverage:** Merges keys from `type-templates` and `type-variants` in fallback robustness checks.
- **Budget:** Includes `type-variants` in the component target budget bonus (up to 35 points).
- **Concision:** Discounts diff-based components (`add`, `remove`, `modify`) from duplication and component count penalties.
- **Policy:** Updates `docs/policies/SQI_REFINEMENT_PLAN.md` to reflect these alignments.

These changes ensure that styles adopting modern schema features are rewarded for maintainability rather than penalized for structural complexity.