### PR TITLE
Audit SQI authorship and expose wrapper output plans

### DIFF
--- a/crates/citum-migrate/README.md
+++ b/crates/citum-migrate/README.md
@@ -18,6 +18,14 @@ may emit `extends:`-based wrapper output instead of flattening everything into a
 standalone style. Unknown or unresolved styles still fall back to standalone
 output.
 
+Migration output is now planned explicitly. The default CLI still writes one
+style document to stdout, but lineage analysis classifies the target as either a
+standalone style or an existing wrapper over a checked-in parent. Future
+embedded-root workflows must opt into multi-artifact output and prove the
+resolved public wrapper matches the intended effective style before writing the
+hidden root plus wrapper pair. See
+`docs/specs/EMBEDDED_ROOT_WRAPPER_MIGRATION.md`.
+
 ## CLI Usage
 
 ```bash

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -33,6 +33,47 @@ pub enum ImplementationForm {
     Unknown,
 }
 
+/// Explicit artifact plan for migration output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationOutputPlan {
+    /// Emit a single standalone style without an inherited parent.
+    Standalone,
+    /// Emit a single wrapper over an established checked-in parent style.
+    ExistingWrapper {
+        /// Established parent style ID from repo truth.
+        parent_style_id: String,
+        /// Current wrapper implementation form.
+        implementation_form: ImplementationForm,
+        /// Whether local template-bearing deltas are allowed in the wrapper.
+        preserve_template_deltas: bool,
+    },
+    /// Emit a new hidden embedded root and a public wrapper.
+    CreateEmbeddedRootAndWrapper {
+        /// Hidden embedded root style ID to create.
+        root_style_id: String,
+        /// Public style ID for the wrapper.
+        public_style_id: String,
+    },
+    /// Update an existing hidden embedded root and its public wrapper.
+    UpgradeEmbeddedRootAndWrapper {
+        /// Hidden embedded root style ID to update.
+        root_style_id: String,
+        /// Public style ID for the wrapper.
+        public_style_id: String,
+    },
+}
+
+impl MigrationOutputPlan {
+    /// Return whether this plan writes more than one style artifact.
+    #[must_use]
+    pub fn requires_multi_artifact_write(&self) -> bool {
+        matches!(
+            self,
+            Self::CreateEmbeddedRootAndWrapper { .. } | Self::UpgradeEmbeddedRootAndWrapper { .. }
+        )
+    }
+}
+
 /// Migration-time lineage for one style target.
 #[derive(Debug, Clone)]
 pub struct StyleLineage {
@@ -147,21 +188,19 @@ impl StyleLineage {
     /// Returns an error when the rewritten wrapper cannot be serialized or
     /// deserialized as a valid `Style`.
     pub fn apply_to_migrated_style(&self, style: Style) -> Result<Style, LineageError> {
-        let Some(parent_style_id) = self.parent_style_id.as_deref() else {
+        let MigrationOutputPlan::ExistingWrapper {
+            parent_style_id,
+            preserve_template_deltas,
+            ..
+        } = self.output_plan()
+        else {
             return Ok(style);
         };
         let Some(parent_style) = self.parent_style.as_ref() else {
             return Ok(style);
         };
 
-        let exclude_template_paths = match (self.semantic_class, self.implementation_form) {
-            (
-                SemanticClass::Profile | SemanticClass::Journal,
-                ImplementationForm::ConfigWrapper,
-            ) => true,
-            (SemanticClass::Journal, ImplementationForm::StructuralWrapper) => false,
-            _ => return Ok(style),
-        };
+        let exclude_template_paths = !preserve_template_deltas;
 
         let child = serde_yaml::to_value(&style)?;
         let parent = serde_yaml::to_value(parent_style.clone().into_resolved())?;
@@ -178,12 +217,39 @@ impl StyleLineage {
 
         diff.insert(
             Value::String("extends".to_string()),
-            Value::String(parent_style_id.to_string()),
+            Value::String(parent_style_id),
         );
 
         let mut rebuilt: Style = serde_yaml::from_value(Value::Mapping(diff))?;
         rebuilt.raw_yaml = None;
         Ok(rebuilt)
+    }
+
+    /// Return the explicit migration artifact plan derived from repo truth.
+    #[must_use]
+    pub fn output_plan(&self) -> MigrationOutputPlan {
+        let Some(parent_style_id) = self.parent_style_id.clone() else {
+            return MigrationOutputPlan::Standalone;
+        };
+
+        match (self.semantic_class, self.implementation_form) {
+            (
+                SemanticClass::Profile | SemanticClass::Journal,
+                ImplementationForm::ConfigWrapper,
+            ) => MigrationOutputPlan::ExistingWrapper {
+                parent_style_id,
+                implementation_form: self.implementation_form,
+                preserve_template_deltas: false,
+            },
+            (SemanticClass::Journal, ImplementationForm::StructuralWrapper) => {
+                MigrationOutputPlan::ExistingWrapper {
+                    parent_style_id,
+                    implementation_form: self.implementation_form,
+                    preserve_template_deltas: true,
+                }
+            }
+            _ => MigrationOutputPlan::Standalone,
+        }
     }
 }
 
@@ -439,6 +505,14 @@ mod tests {
             lineage.parent_style_id.as_deref(),
             Some("elsevier-harvard-core")
         );
+        assert_eq!(
+            lineage.output_plan(),
+            MigrationOutputPlan::ExistingWrapper {
+                parent_style_id: "elsevier-harvard-core".to_string(),
+                implementation_form: ImplementationForm::ConfigWrapper,
+                preserve_template_deltas: false,
+            }
+        );
     }
 
     #[test]
@@ -458,6 +532,14 @@ mod tests {
             lineage.parent_style_id.as_deref(),
             Some("elsevier-with-titles")
         );
+        assert_eq!(
+            lineage.output_plan(),
+            MigrationOutputPlan::ExistingWrapper {
+                parent_style_id: "elsevier-with-titles".to_string(),
+                implementation_form: ImplementationForm::ConfigWrapper,
+                preserve_template_deltas: false,
+            }
+        );
     }
 
     #[test]
@@ -474,6 +556,14 @@ mod tests {
             ImplementationForm::StructuralWrapper
         );
         assert_eq!(lineage.parent_style_id.as_deref(), Some("ieee"));
+        assert_eq!(
+            lineage.output_plan(),
+            MigrationOutputPlan::ExistingWrapper {
+                parent_style_id: "ieee".to_string(),
+                implementation_form: ImplementationForm::StructuralWrapper,
+                preserve_template_deltas: true,
+            }
+        );
     }
 
     #[test]
@@ -485,6 +575,33 @@ mod tests {
         assert_eq!(lineage.semantic_class, SemanticClass::Unknown);
         assert_eq!(lineage.implementation_form, ImplementationForm::Unknown);
         assert!(lineage.parent_style_id.is_none());
+        assert_eq!(lineage.output_plan(), MigrationOutputPlan::Standalone);
+    }
+
+    #[test]
+    fn embedded_root_wrapper_plans_require_multi_artifact_writes() {
+        assert!(
+            MigrationOutputPlan::CreateEmbeddedRootAndWrapper {
+                root_style_id: "publisher-core".to_string(),
+                public_style_id: "publisher".to_string(),
+            }
+            .requires_multi_artifact_write()
+        );
+        assert!(
+            MigrationOutputPlan::UpgradeEmbeddedRootAndWrapper {
+                root_style_id: "publisher-core".to_string(),
+                public_style_id: "publisher".to_string(),
+            }
+            .requires_multi_artifact_write()
+        );
+        assert!(
+            !MigrationOutputPlan::ExistingWrapper {
+                parent_style_id: "publisher-core".to_string(),
+                implementation_form: ImplementationForm::ConfigWrapper,
+                preserve_template_deltas: false,
+            }
+            .requires_multi_artifact_write()
+        );
     }
 
     #[test]

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -14,7 +14,7 @@ use citum_migrate::{
         note_citation_template_is_underfit, scrub_inferred_literal_artifacts,
         should_merge_inferred_type_template,
     },
-    lineage::StyleLineage,
+    lineage::{MigrationOutputPlan, StyleLineage},
     options_extractor::MigrationOptions,
     provenance::ProvenanceTracker,
     template_resolver,
@@ -652,6 +652,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         lineage.implementation_form,
         lineage.parent_style_id.as_deref().unwrap_or("none")
     );
+    log_migration_output_plan(&lineage);
 
     let text = fs::read_to_string(path)?;
     let doc = Document::parse(&text)?;
@@ -736,6 +737,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     output_style_and_debug(&style, cli.debug_variable.as_deref(), &tracker)?;
     Ok(())
+}
+
+fn log_migration_output_plan(lineage: &StyleLineage) {
+    match lineage.output_plan() {
+        MigrationOutputPlan::Standalone => {
+            eprintln!("Migration output plan: standalone");
+        }
+        MigrationOutputPlan::ExistingWrapper {
+            parent_style_id,
+            implementation_form,
+            preserve_template_deltas,
+        } => {
+            eprintln!(
+                "Migration output plan: existing-wrapper parent={parent_style_id} form={implementation_form:?} preserve-template-deltas={preserve_template_deltas}"
+            );
+        }
+        plan if plan.requires_multi_artifact_write() => {
+            eprintln!("Migration output plan: multi-artifact {plan:?}");
+        }
+        plan => {
+            eprintln!("Migration output plan: {plan:?}");
+        }
+    }
 }
 
 fn output_style_and_debug(

--- a/docs/architecture/2026-05-07_SQI_INTEGRITY_AUDIT.md
+++ b/docs/architecture/2026-05-07_SQI_INTEGRITY_AUDIT.md
@@ -1,0 +1,72 @@
+# SQI Integrity Audit
+
+**Date:** 2026-05-07
+**Scope:** `scripts/report-core.js`, full `styles/` report corpus
+**Related:** `docs/reference/SQI.md`, `docs/specs/EMBEDDED_ROOT_WRAPPER_MIGRATION.md`
+
+## Summary
+
+The pre-audit SQI average was not a reliable maintainability signal for inherited
+styles. Root `extends:` wrappers with no authored templates were scored from
+resolved parent templates, so inherited parent complexity was charged to the
+thin wrapper. Diff-form `type-variants` were also excluded from component
+budgets but still participated in duplicate and near-duplicate penalties.
+
+The audited calculation keeps fidelity unchanged, scores authored wrapper shape
+from authored YAML, and treats Template V3 diff variants as patch operations
+rather than copied full templates.
+
+## Measurements
+
+Commands:
+
+```bash
+node scripts/report-core.js --timings > /tmp/core-report-current.json
+node scripts/report-core.js --timings > /tmp/core-report-audited.json
+node scripts/check-core-quality.js \
+  --report /tmp/core-report-audited.json \
+  --baseline scripts/report-data/core-quality-baseline.json
+```
+
+Results:
+
+| Metric | Before | After |
+|---|---:|---:|
+| Styles | 154 | 154 |
+| Average SQI | 0.929591 | 0.957409 |
+| Reported SQI | 0.930 | 0.957 |
+| Minimum SQI | 0.776 | 0.831 |
+| Median SQI | 0.938 | 0.968 |
+| Styles below 0.90 SQI | 34 | 15 |
+| Styles below 0.95 SQI | 92 | 52 |
+| Quality-gate warnings | 0 | 0 |
+
+The audited average improved by `+0.027818`, exceeding the `+0.010` PR target.
+
+## Findings
+
+1. Root wrappers were misattributed.
+   - `cell-numeric`, `disability-and-rehabilitation`, and
+     `elsevier-with-titles` all inherited the same resolved parent concision
+     burden: 236 components, 19 scopes, and SQI concision `22.3`.
+   - After the fix, those wrappers report `inheritedPreset` and score local
+     concision as a pure root wrapper.
+
+2. Diff variants were over-penalized.
+   - Object-form `modify`, `remove`, and `add` operations are now reported as
+     `diffVariantScopes` and `diffVariantOperations`.
+   - They still count selector breadth, but no longer create duplicate,
+     near-duplicate, or repeated-pattern penalties.
+
+3. Preset reuse needed the same authorship boundary.
+   - Pure root wrappers now treat top-level `extends:` as strong embedded preset
+     reuse.
+   - This prevents the corrected authorship data from producing false preset
+     usage regressions against the CI baseline.
+
+## Residual Risk
+
+The audit corrects SQI attribution; it does not claim remaining low-tail SQI
+styles are clean. The low tail after this pass is more meaningful: styles such
+as `mhra-notes-publisher-place-no-url`, `ieee`, and structural journal wrappers
+still require style or infrastructure work rather than metric repair.

--- a/docs/reference/SQI.md
+++ b/docs/reference/SQI.md
@@ -20,14 +20,16 @@ SQI is computed per style from four subscores:
 1. `typeCoverage`: how broadly the style succeeds across observed reference types.
 2. `fallbackRobustness`: whether core types still render correctly via shared templates/fallback paths.
 3. `concision`: measures how efficiently the style achieves its rendering goals through template reuse.
-   - Counts all template-bearing scopes in the resolved style, including `type-variants` and `type-templates`.
-   - Penalizes high variant-selector counts, exact duplicate scopes, near-duplicate scopes, and repeated copied component/group patterns across scopes.
+   - Scores authored style structure. Thin root `extends:` wrappers are scored as inherited preset use instead of being charged for resolved parent complexity.
+   - Counts full authored template-bearing scopes, including full `type-variants` and `type-templates`.
+   - Reports diff-form `type-variants` as patch operations. They still count selector breadth, but do not create duplicate, near-duplicate, or repeated-pattern penalties.
+   - Penalizes high variant-selector counts, exact duplicate scopes, near-duplicate scopes, and repeated copied component/group patterns across full template scopes.
    - Uses structural fingerprints of whole components and groups rather than coarse field-name matching, so copied template forks are visible to the metric.
-4. `presetUsage`: reuse of shared presets (`processing`, `contributors`, `dates`, `titles`, `substitute`, template presets).
+4. `presetUsage`: reuse of shared presets (`processing`, `contributors`, `dates`, `titles`, `substitute`, template presets). Root `extends:` is treated as strong embedded preset reuse when the authored wrapper has no local template scopes.
 
 Overall SQI is reported as a 0.0-1.0 score in JSON and as a percentage in `docs/compat.html`.
 
-`qualityBreakdown.subscores.concision` now includes supporting diagnostics such as scope count, variant count, exact duplicates, near-duplicates, and repeated-pattern totals so score changes are explainable.
+`qualityBreakdown.subscores.concision` now includes supporting diagnostics such as scope count, variant count, exact duplicates, near-duplicates, repeated-pattern totals, inherited preset ID, diff variant scope count, and diff operation count so score changes are explainable.
 
 ## Working Thresholds
 
@@ -63,5 +65,6 @@ node scripts/check-core-quality.js \
 ## Related
 
 - [SQI refinement plan](../policies/SQI_REFINEMENT_PLAN.md)
+- [SQI integrity audit](../architecture/2026-05-07_SQI_INTEGRITY_AUDIT.md)
 - [Rendering workflow](../guides/RENDERING_WORKFLOW.md)
 - [Style author guide](../guides/style-author-guide.md)

--- a/docs/specs/EMBEDDED_ROOT_WRAPPER_MIGRATION.md
+++ b/docs/specs/EMBEDDED_ROOT_WRAPPER_MIGRATION.md
@@ -1,0 +1,114 @@
+# Embedded Root Wrapper Migration Specification
+
+**Status:** Active
+**Date:** 2026-05-07
+**Related:** `STYLE_TAXONOMY.md`, `MIGRATION_TAXONOMY_AWARE_WRAPPERS.md`, `STYLE_PRESET_ARCHITECTURE.md`, `../architecture/2026-05-07_SQI_INTEGRITY_AUDIT.md`
+
+## Purpose
+
+Define how migration and upgrade workflows produce a corpus made of embedded
+style roots plus thin public wrappers. The workflow must preserve fidelity and
+authority. It must not infer parentage from output similarity alone.
+
+## Scope
+
+In scope:
+
+- explicit migration output plans
+- embedded-root plus public-wrapper artifact production
+- proof gates for wrapper emission
+- SQI interaction with root `extends:` and diff-form `type-variants`
+
+Out of scope:
+
+- automatic alias discovery
+- similarity-only parent selection
+- changing schema merge semantics for arrays
+- broad corpus rewrites without a bounded, verified wave
+
+## Design
+
+Migration output is classified before writing artifacts:
+
+| Plan | Artifacts | Use |
+|---|---:|---|
+| `Standalone` | 1 | no safe parent/root relationship is established |
+| `ExistingWrapper` | 1 | repo truth already establishes `extends:` parentage |
+| `CreateEmbeddedRootAndWrapper` | 2 | workflow explicitly creates a hidden root and public wrapper |
+| `UpgradeEmbeddedRootAndWrapper` | 2 | workflow updates an existing hidden root and its public wrapper |
+
+Parent/root selection must come from one of:
+
+1. current publisher or journal guidance
+2. current publisher house rules or submission instructions
+3. named parent manual or standards reference
+4. existing repo registry, embedded root, or checked-in wrapper truth
+
+CSL XML structure and output similarity may support verification, but they are
+not sufficient authority for selecting a parent.
+
+### Wrapper Rules
+
+Config wrappers:
+
+- must set top-level `extends:`
+- may keep local metadata and scoped options
+- must not keep local templates, local `type-variants`, or template-clearing
+  `null` values
+
+Structural wrappers:
+
+- must set top-level `extends:`
+- may keep schema-backed structural deltas
+- should prefer Template V3 diff-form `type-variants` over copied full variants
+  when the diff resolves mechanically
+
+Embedded-root plans:
+
+- are opt-in multi-artifact writes
+- create or update the hidden root under `styles/embedded/`
+- keep the public style as a wrapper over that root
+- must update embedded style loading and registry-facing metadata consistently
+
+### Proof Gates
+
+Before accepting root/wrapper output, the workflow must:
+
+1. generate the intended standalone or effective style
+2. generate the root plus wrapper artifacts
+3. resolve the wrapper through normal schema resolution
+4. compare the resolved wrapper against the intended effective style on
+   schema-relevant fields
+5. run the style oracle or the bounded wave report
+6. reject the wrapper if fidelity regresses or if the profile contract is broken
+
+If proof fails, the workflow keeps `Standalone` or `StructuralWrapper` output and
+records the infrastructure constraint.
+
+## Implementation Notes
+
+`citum-migrate` exposes `MigrationOutputPlan` from lineage analysis so callers
+can distinguish single-artifact existing wrappers from explicit multi-artifact
+embedded-root work. The default CLI remains single-artifact and does not create
+hidden roots unless a future workflow-facing command opts into that plan.
+
+SQI reports must score authored wrapper shape, not inherited parent complexity.
+Root `extends:` is strong preset reuse. Diff-form `type-variants` are patch
+operations for concision analysis, while selector breadth remains real
+complexity.
+
+## Acceptance Criteria
+
+- [x] SQI scores root `extends:` wrappers from authored wrapper structure.
+- [x] SQI reports diff-form `type-variants` without duplicate penalties.
+- [x] Migration lineage exposes an explicit output plan.
+- [x] Existing config wrappers strip template-bearing fields during migration.
+- [x] Existing structural wrappers preserve structural deltas during migration.
+- [ ] Multi-artifact embedded-root writes are available behind an explicit
+      workflow command.
+- [ ] Embedded-root writes mechanically prove resolved wrapper equivalence before
+      writing.
+
+## Changelog
+
+- 2026-05-07: Initial active specification for SQI-audited root/wrapper migration.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -74,6 +74,7 @@ to make sure the document should be a spec rather than architecture or policy.
 | [`EDTF_ERA_LABEL_PROFILES.md`](./EDTF_ERA_LABEL_PROFILES.md) | Era label profiles and unspecified historical-year display |
 | [`EDTF_HISTORICAL_ERA_RENDERING.md`](./EDTF_HISTORICAL_ERA_RENDERING.md) | Locale-backed rendering of valid historical EDTF years |
 | [`EMBEDDED_JS_TEMPLATE_INFERENCE.md`](./EMBEDDED_JS_TEMPLATE_INFERENCE.md) | Embedded JS runtime for live template inference in migrator |
+| [`EMBEDDED_ROOT_WRAPPER_MIGRATION.md`](./EMBEDDED_ROOT_WRAPPER_MIGRATION.md) | Proof-gated embedded roots plus thin public wrappers for style migration |
 | [`ENGINE_MIGRATE_COEVOLUTION_WAVE.md`](./ENGINE_MIGRATE_COEVOLUTION_WAVE.md) | Engine-first co-evolution wave for style-fidelity fixes |
 | [`FIDELITY_RICH_INPUTS.md`](./FIDELITY_RICH_INPUTS.md) | Fidelity pipeline support for relational benchmark inputs |
 | [`GENDERED_LOCALE_TERMS.md`](./GENDERED_LOCALE_TERMS.md) | Multi-dimensional locale terms with grammatical gender support |

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -1880,6 +1880,10 @@ function countOptionsPresetUses(styleData) {
   return { uses, fields };
 }
 
+function hasRootExtends(styleData) {
+  return typeof styleData?.extends === 'string' && styleData.extends.trim().length > 0;
+}
+
 function computeTypeCoverageScore(citationsByType) {
   const entries = Object.entries(citationsByType || {})
     .filter(([, stats]) => (stats?.total || 0) > 0);
@@ -1971,11 +1975,35 @@ function computeConcisionScore(styleData, format) {
       originalComponents: scope.components,
     }))
     .filter((scope) => scope.components.length > 0);
+  const diffScopes = scopedComponents.filter((scope) => scope.isDiffForm);
+  const duplicateAnalysisScopes = scopedComponents.filter((scope) => !scope.isDiffForm);
+  const diffVariantOperations = diffScopes.reduce((sum, scope) => sum + scope.components.length, 0);
   const flattened = scopedComponents
     .filter((scope) => !scope.isDiffForm)
     .flatMap((scope) => scope.components);
 
   if (flattened.length === 0) {
+    if (hasRootExtends(styleData)) {
+      return {
+        score: 100,
+        scopeCount: scopedComponents.length,
+        totalComponents: 0,
+        duplicates: 0,
+        withinScopeDuplicates: 0,
+        crossScopeRepeats: 0,
+        exactDuplicateScopes: 0,
+        nearDuplicateScopes: 0,
+        repeatedPatterns: 0,
+        diffVariantScopes: diffScopes.length,
+        diffVariantOperations,
+        variantSelectors: variantSelectorCount,
+        overrideDensity: 0,
+        targetComponents: 0,
+        inheritedPreset: styleData.extends,
+        note: `root extends: ${styleData.extends}`,
+      };
+    }
+
     return {
       score: 0,
       scopeCount: 0,
@@ -1986,6 +2014,8 @@ function computeConcisionScore(styleData, format) {
       exactDuplicateScopes: 0,
       nearDuplicateScopes: 0,
       repeatedPatterns: 0,
+      diffVariantScopes: diffScopes.length,
+      diffVariantOperations,
       variantSelectors: 0,
       overrideDensity: 0,
       targetComponents: 0,
@@ -1996,11 +2026,10 @@ function computeConcisionScore(styleData, format) {
   let withinScopeDuplicates = 0;
   const keyScopeCount = new Map();
 
-  for (const scope of scopedComponents) {
+  for (const scope of duplicateAnalysisScopes) {
     const keys = scope.components.map(componentSemanticKey);
     const uniqueInScope = new Set(keys);
     withinScopeDuplicates += Math.max(0, keys.length - uniqueInScope.size);
-    if (scope.isDiffForm) continue;
     for (const key of uniqueInScope) {
       keyScopeCount.set(key, (keyScopeCount.get(key) || 0) + 1);
     }
@@ -2012,7 +2041,7 @@ function computeConcisionScore(styleData, format) {
   }
 
   const scopeFingerprintCounts = new Map();
-  for (const scope of scopedComponents) {
+  for (const scope of duplicateAnalysisScopes) {
     scopeFingerprintCounts.set(
       scope.scopeFingerprint,
       (scopeFingerprintCounts.get(scope.scopeFingerprint) || 0) + 1
@@ -2025,7 +2054,7 @@ function computeConcisionScore(styleData, format) {
 
   let nearDuplicateScopes = 0;
   const lengthBuckets = new Map();
-  for (const scope of scopedComponents) {
+  for (const scope of duplicateAnalysisScopes) {
     const len = scope.originalComponents.length;
     if (!lengthBuckets.has(len)) lengthBuckets.set(len, []);
     lengthBuckets.get(len).push(scope);
@@ -2046,7 +2075,7 @@ function computeConcisionScore(styleData, format) {
   }
 
   const patternCounts = new Map();
-  for (const scope of scopedComponents) {
+  for (const scope of duplicateAnalysisScopes) {
     const uniquePatterns = new Set(scope.patternFingerprints);
     for (const fingerprint of uniquePatterns) {
       patternCounts.set(fingerprint, (patternCounts.get(fingerprint) || 0) + 1);
@@ -2113,6 +2142,8 @@ function computeConcisionScore(styleData, format) {
     exactDuplicateScopes,
     nearDuplicateScopes,
     repeatedPatterns,
+    diffVariantScopes: diffScopes.length,
+    diffVariantOperations,
     variantSelectors: variantSelectorCount,
     overrideDensity: parseFloat(overrideDensity.toFixed(2)),
     targetComponents: parseFloat(target.toFixed(1)),
@@ -2122,6 +2153,23 @@ function computeConcisionScore(styleData, format) {
 function computePresetUsageScore(styleData, concisionScore) {
   const templateUses = countTemplatePresetUses(styleData);
   const { uses: optionUses, fields: optionPresetFields } = countOptionsPresetUses(styleData);
+  const hasInheritedPreset = hasRootExtends(styleData);
+  const hasAuthoredTemplateScopes = collectTemplateScopes(styleData).scopes.length > 0;
+
+  if (hasInheritedPreset && !hasAuthoredTemplateScopes) {
+    const uses = templateUses + optionUses;
+    return {
+      score: 100,
+      uses,
+      templateUses,
+      optionUses,
+      weightedUses: 5 + optionUses,
+      optionPresetFields,
+      inheritedPreset: styleData.extends,
+      note: `root extends: ${styleData.extends}`,
+    };
+  }
+
   const weightedUses = (templateUses * 2) + optionUses;
   const uses = templateUses + optionUses;
 
@@ -2151,6 +2199,9 @@ function computePresetUsageScore(styleData, concisionScore) {
 
 function selectQualityAuthorshipData(authoredStyleData, effectiveStyleData) {
   const authoredScopes = collectTemplateScopes(authoredStyleData).scopes;
+  if (authoredScopes.length === 0 && hasRootExtends(authoredStyleData)) {
+    return authoredStyleData;
+  }
   if (authoredScopes.length === 0 && effectiveStyleData) {
     return effectiveStyleData;
   }
@@ -3690,6 +3741,7 @@ module.exports = {
   collectTemplateScopes,
   computeConcisionScore,
   computeFallbackRobustness,
+  computePresetUsageScore,
   computeFidelityScore,
   createReportRuntime,
   discoverCoreStyles,
@@ -3700,6 +3752,7 @@ module.exports = {
   getCslSnapshotStatus,
   generateHtml,
   generateReport,
+  hasRootExtends,
   getComparisonEntryTexts,
   loadStyleYaml,
   mapWithConcurrency,

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -19,6 +19,7 @@ const {
   collectTemplateScopes,
   computeConcisionScore,
   computeFallbackRobustness,
+  computePresetUsageScore,
   discoverCoreStyles,
   computeFidelityScore,
   buildEmptyOracleResult,
@@ -43,6 +44,7 @@ const {
   runCachedJsonJob,
   selectPrimaryComparator,
   selectQualityAuthorshipData,
+  hasRootExtends,
   toPublishedBenchmarkRunRecord,
   determineBenchmarkStatus,
 } = require('./report-core');
@@ -287,7 +289,7 @@ test('computeConcisionScore rewards preset-backed compact structures', () => {
   assert.ok(score.score >= 90, `expected concision >= 90, got ${score.score}`);
 });
 
-test('selectQualityAuthorshipData falls back for inherited wrapper styles', () => {
+test('selectQualityAuthorshipData keeps root wrapper authorship for SQI', () => {
   const authored = {
     extends: 'apa-7th',
   };
@@ -300,7 +302,44 @@ test('selectQualityAuthorshipData falls back for inherited wrapper styles', () =
     },
   };
 
+  assert.equal(selectQualityAuthorshipData(authored, resolved), authored);
+  assert.equal(hasRootExtends(authored), true);
+});
+
+test('selectQualityAuthorshipData still falls back for template-free non-wrappers', () => {
+  const authored = {
+    info: {
+      title: 'Template-free draft',
+    },
+  };
+  const resolved = {
+    bibliography: {
+      template: [
+        { contributor: 'author' },
+        { title: 'primary' },
+      ],
+    },
+  };
+
   assert.equal(selectQualityAuthorshipData(authored, resolved), resolved);
+  assert.equal(hasRootExtends(authored), false);
+});
+
+test('computeConcisionScore treats pure root wrappers as inherited presets', () => {
+  const score = computeConcisionScore({ extends: 'elsevier-with-titles-core' }, 'numeric');
+
+  assert.equal(score.score, 100);
+  assert.equal(score.totalComponents, 0);
+  assert.equal(score.inheritedPreset, 'elsevier-with-titles-core');
+  assert.match(score.note, /root extends/);
+});
+
+test('computePresetUsageScore treats pure root wrappers as strong preset reuse', () => {
+  const score = computePresetUsageScore({ extends: 'springer-vancouver-brackets-core' }, 100);
+
+  assert.equal(score.score, 100);
+  assert.equal(score.inheritedPreset, 'springer-vancouver-brackets-core');
+  assert.match(score.note, /root extends/);
 });
 
 test('selectQualityAuthorshipData keeps authored Template V3 diff scopes', () => {
@@ -360,7 +399,7 @@ test('computeConcisionScore does not penalize surgical diff variants as cross-sc
     `surgical diff variants should not reduce concision; base=${baseScore.score} diff=${diffScore.score}`);
 });
 
-test('computeConcisionScore detects duplication across parallel diff variants', () => {
+test('computeConcisionScore reports but does not penalize parallel diff variants', () => {
   const styleData = {
     bibliography: {
       template: [
@@ -379,8 +418,11 @@ test('computeConcisionScore detects duplication across parallel diff variants', 
 
   const score = computeConcisionScore(styleData, 'author-date');
 
-  assert.ok(score.exactDuplicateScopes >= 4,
-    `parallel identical diff variants should register as duplicates, got ${score.exactDuplicateScopes}`);
+  assert.equal(score.diffVariantScopes, 5);
+  assert.equal(score.diffVariantOperations, 5);
+  assert.equal(score.exactDuplicateScopes, 0);
+  assert.ok(score.score >= 95,
+    `parallel diff variants should not be duplicate-penalized, got ${score.score}`);
 });
 
 test('computeFallbackRobustness treats type-variants as explicit type coverage', () => {


### PR DESCRIPTION
## Summary
- audit and correct SQI authorship scoring for root `extends:` wrappers
- treat diff-form `type-variants` as patch operations for concision scoring
- expose explicit migration output plans and document proof-gated embedded root/wrapper migration

## Verification
- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict`
- `node --test scripts/report-core.test.js`
- `node scripts/report-core.js --timings > /tmp/core-report-audited.json`
- `node scripts/check-core-quality.js --report /tmp/core-report-audited.json --baseline scripts/report-data/core-quality-baseline.json`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- pre-push hook reran Rust gate and passed
