### PR TITLE
fix(ci): fix yaml indentation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           cargo release --workspace --no-publish --no-push $TAG_FLAG --no-confirm --execute \
             -m "chore: release v{{version}}
 
-Automated workspace version bump for v{{version}}." \
+          Automated workspace version bump for v{{version}}." \
             "${{ steps.resolve.outputs.level }}"
           
           git push -f origin "$BRANCH"


### PR DESCRIPTION
Fixes the YAML syntax error at line 169 in .github/workflows/release.yml.