### PR TITLE
feat(store): implement XDG Base Directory paths for all Unix systems

### DIFF
--- a/crates/citum_store/src/config.rs
+++ b/crates/citum_store/src/config.rs
@@ -85,9 +85,7 @@ impl StoreConfig {
     ///
     /// Returns an error when the config file exists but cannot be read or parsed.
     pub fn load() -> Result<Self, ConfigError> {
-        if let Some(config_dir) = dirs::config_dir() {
-            let citum_dir = config_dir.join("citum");
-
+        if let Some(citum_dir) = crate::platform_config_dir() {
             // Try YAML first
             let yaml_path = citum_dir.join("config.yaml");
             if yaml_path.exists() {
@@ -111,8 +109,7 @@ impl StoreConfig {
     ///
     /// Returns an error if the directory cannot be created or the file cannot be written.
     pub fn save(&self) -> Result<(), ConfigError> {
-        if let Some(config_dir) = dirs::config_dir() {
-            let citum_dir = config_dir.join("citum");
+        if let Some(citum_dir) = crate::platform_config_dir() {
             std::fs::create_dir_all(&citum_dir)?;
             let config_path = citum_dir.join("config.yaml");
             let content =

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod config;
 pub mod format;
+pub mod paths;
 pub mod resolver;
 
 #[cfg(test)]
@@ -33,39 +34,36 @@ use std::path::PathBuf;
 
 /// Returns the platform-specific data directory for Citum user files.
 ///
-/// This path is derived from [`dirs::data_dir()`] with a `citum` subdirectory appended.
+/// This path is derived from [`paths::data_dir()`] with a `citum` subdirectory appended.
 ///
 /// Typical locations:
-/// - Linux:   `~/.local/share/citum/`
-/// - macOS:   `~/Library/Application Support/citum/`
+/// - Unix (incl. macOS): `~/.local/share/citum/`
 /// - Windows: `%APPDATA%\citum\`
 #[must_use]
 pub fn platform_data_dir() -> Option<PathBuf> {
-    dirs::data_dir().map(|d| d.join("citum"))
+    paths::data_dir().map(|d| d.join("citum"))
 }
 
 /// Returns the platform-specific configuration directory for Citum.
 ///
-/// This path is derived from [`dirs::config_dir()`] with a `citum` subdirectory appended.
+/// This path is derived from [`paths::config_dir()`] with a `citum` subdirectory appended.
 ///
 /// Typical locations:
-/// - Linux:   `~/.config/citum/`
-/// - macOS:   `~/Library/Application Support/citum/`
+/// - Unix (incl. macOS): `~/.config/citum/`
 /// - Windows: `%APPDATA%\citum\`
 #[must_use]
 pub fn platform_config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("citum"))
+    paths::config_dir().map(|d| d.join("citum"))
 }
 
 /// Returns the platform-specific cache directory for Citum.
 ///
-/// This path is derived from [`dirs::cache_dir()`] with a `citum` subdirectory appended.
+/// This path is derived from [`paths::cache_dir()`] with a `citum` subdirectory appended.
 ///
 /// Typical locations:
-/// - Linux:   `~/.cache/citum/`
-/// - macOS:   `~/Library/Caches/citum/`
+/// - Unix (incl. macOS): `~/.cache/citum/`
 /// - Windows: `%LOCALAPPDATA%\citum\`
 #[must_use]
 pub fn platform_cache_dir() -> Option<PathBuf> {
-    dirs::cache_dir().map(|d| d.join("citum"))
+    paths::cache_dir().map(|d| d.join("citum"))
 }

--- a/crates/citum_store/src/paths.rs
+++ b/crates/citum_store/src/paths.rs
@@ -1,0 +1,87 @@
+use std::env;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+pub fn data_dir() -> Option<PathBuf> {
+    xdg_dir("XDG_DATA_HOME", ".local/share")
+}
+
+#[cfg(unix)]
+pub fn config_dir() -> Option<PathBuf> {
+    xdg_dir("XDG_CONFIG_HOME", ".config")
+}
+
+#[cfg(unix)]
+pub fn cache_dir() -> Option<PathBuf> {
+    xdg_dir("XDG_CACHE_HOME", ".cache")
+}
+
+#[cfg(unix)]
+fn xdg_dir(var: &str, fallback: &str) -> Option<PathBuf> {
+    xdg_resolve(env::var_os(var), fallback, dirs::home_dir())
+}
+
+#[cfg(unix)]
+fn xdg_resolve(
+    env_val: Option<OsString>,
+    fallback: &str,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    env_val
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .or_else(|| home.map(|h| h.join(fallback)))
+}
+
+#[cfg(not(unix))]
+pub fn data_dir() -> Option<PathBuf> {
+    dirs::data_dir()
+}
+
+#[cfg(not(unix))]
+pub fn config_dir() -> Option<PathBuf> {
+    dirs::config_dir()
+}
+
+#[cfg(not(unix))]
+pub fn cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_xdg_resolve_absolute() {
+        let env_val = Some(OsString::from("/custom/path"));
+        let home = Some(PathBuf::from("/home/user"));
+        let res = xdg_resolve(env_val, ".config", home);
+        assert_eq!(res, Some(PathBuf::from("/custom/path")));
+    }
+
+    #[test]
+    fn test_xdg_resolve_relative_ignored() {
+        let env_val = Some(OsString::from("relative/path"));
+        let home = Some(PathBuf::from("/home/user"));
+        let res = xdg_resolve(env_val, ".config", home);
+        assert_eq!(res, Some(PathBuf::from("/home/user/.config")));
+    }
+
+    #[test]
+    fn test_xdg_resolve_fallback() {
+        let env_val = None;
+        let home = Some(PathBuf::from("/home/user"));
+        let res = xdg_resolve(env_val, ".cache", home);
+        assert_eq!(res, Some(PathBuf::from("/home/user/.cache")));
+    }
+
+    #[test]
+    fn test_xdg_resolve_no_home() {
+        let env_val = None;
+        let home = None;
+        let res = xdg_resolve(env_val, ".local/share", home);
+        assert_eq!(res, None);
+    }
+}

--- a/docs/specs/DISTRIBUTED_RESOLVER.md
+++ b/docs/specs/DISTRIBUTED_RESOLVER.md
@@ -265,10 +265,10 @@ pub struct CacheEntry {
 ```
 
 Default implementation `FsCache` stores entries under
-`<platform_cache_dir>/citum/`:
+`<platform_cache_dir>`:
 
 ```
-<cache_dir>/citum/
+<cache_dir>/
   styles/<sha256_of_uri>/
     content.yaml          # raw fetched bytes
     meta.json             # { uri, fetched_at, ttl_secs, sha256 }
@@ -284,8 +284,10 @@ to prevent path traversal in the filesystem.
 Default TTL: 24 hours. CID entries: `u64::MAX` (immutable, never revalidated).
 TTL `0` = always revalidate. Per-registry override via `ttl_secs:` in config.
 
-Cache location uses `dirs::cache_dir()` (separate from `dirs::data_dir()` used
-by `StoreResolver`).
+Cache location follows the XDG Base Directory specification on all Unix platforms
+(including macOS): `XDG_CACHE_HOME` or `~/.cache/citum/`. Windows continues to
+use native `%LOCALAPPDATA%\citum\`. This is separate from the data directory
+used by `StoreResolver` (`XDG_DATA_HOME` or `~/.local/share/citum/` on Unix).
 
 ### Phase 3: Content Addressing and Hub Federation
 


### PR DESCRIPTION
This replaces the default macOS Application Support and Caches paths
with XDG-compliant ~/.config, ~/.local/share, and ~/.cache paths,
ensuring a consistent developer experience across Linux and macOS.
Windows continues to use native paths.

Updated:
- Added crates/citum_store/src/paths.rs for custom path resolution.
- Refactored platform path functions in lib.rs.
- Refactored StoreConfig load/save in config.rs.
- Updated docs/specs/DISTRIBUTED_RESOLVER.md.
