### PR TITLE
feat: distributed resolver phase 3

### DIFF
--- a/.beans/archive/csl26-r8d2--distributed-resolver-architecture.md
+++ b/.beans/archive/csl26-r8d2--distributed-resolver-architecture.md
@@ -10,7 +10,7 @@ tags:
     - style
     - research
 created_at: 2026-05-03T00:00:00Z
-updated_at: 2026-05-07T22:00:00Z
+updated_at: 2026-05-08T00:00:00Z
 ---
 
 # csl26-r8d2
@@ -19,7 +19,7 @@ updated_at: 2026-05-07T22:00:00Z
 Evaluate the necessity and architectural design of a distributed registry system for Citum styles, evolving the resolution logic to support a truly distributed ecosystem.
 
 # Context
-The current Citum model, while technically supporting registries and inheritance, still defaults to a centralized resolution pattern. As identified in the Citum Hub visioning process, this risks creating a new "SaaS Silo" that mirrors the bottlenecks of the monolithic CSL repository. 
+The current Citum model, while technically supporting registries and inheritance, still defaults to a centralized resolution pattern. As identified in the Citum Hub visioning process, this risks creating a new "SaaS Silo" that mirrors the bottlenecks of the monolithic CSL repository.
 
 Currently, Citum relies on a centralized builtin registry and a local user store. While this ensures stability and ease of use for standard styles, it creates friction for organizations or publishers who wish to maintain and distribute their own collection of styles without upstreaming them or requiring users to manually install files.
 
@@ -28,35 +28,32 @@ To support over 1M+ users while enabling institutional autonomy, Citum needs a f
 # Proposal
 Evolve `citum-core`'s resolution logic to support a truly distributed ecosystem via a phased approach:
 
-## Phase 1: Trait Boundary & URI Foundation (Current Focus)
-Establish a flexible, trait-based resolution boundary and generalize the `extends` mechanism to support URIs, without adding network dependencies yet.
-- **StyleReference Enum:** Update `extends` to support both `StyleBase` enums and URI strings (e.g., `file://...`, `@hub/...`, `https://...`).
-- **StyleResolver Trait:** Introduce a trait in `citum_store` for resolving styles and locales.
-- **Resolver Chain:** Implement concrete resolvers (`FileResolver`, `StoreResolver`, `EmbeddedResolver`) and a `ChainResolver` for sequential fallback.
-- **CLI Refactor:** Transition `citum-cli` to use the `ChainResolver` for all style loading.
+## Phase 1: Trait Boundary & URI Foundation (completed)
+- **StyleReference Enum:** `extends` supports both `StyleBase` enums and URI strings.
+- **StyleResolver Trait:** Resolver interface in `citum_store` (with a minimal twin in `citum-schema-style`).
+- **Resolver Chain:** Concrete resolvers (`FileResolver`, `StoreResolver`, `EmbeddedResolver`) plus `ChainResolver`.
+- **CLI Refactor:** `citum-cli` resolves all styles through the chain.
 
-## Phase 2: Remote Fetching & Caching
-Add networking capabilities and a local caching layer to ensure offline-first resilience.
-- **Remote Resolvers:** Implement `HttpResolver` and `GitResolver` to fetch styles from standard endpoints.
-- **Caching Middleware:** Wrap remote resolvers in a local cache that stores fetched styles in the user data directory.
-- **Institutional Autonomy:** Enable organizations to host their own style registries via static HTTP or Git.
+## Phase 2: Remote Fetching & Caching (completed)
+- **Remote Resolvers:** `HttpResolver` and `GitResolver`.
+- **Caching Middleware:** Per-resolver disk cache under the platform cache dir.
+- **Institutional Autonomy:** Static-HTTP and Git-backed registries via `StoreConfig.registries`.
 
-## Phase 3: Content Addressing & Hub Federation
-Scale the architecture for massive distribution and trust.
-- **CIDs:** Integrate content-addressable hashes (CIDs) for immutable style references.
-- **Verification:** Implement hashing middleware to verify remote style integrity against URIs.
-- **Hub Protocol:** Design and implement decentralized registry protocols for Citum Hub federation.
+## Phase 3: Content Addressing & Hub Federation (completed)
+- **CIDs:** CIDv1 raw + sha-256 + base32 (`bafkrei…`).
+- **Verification:** `extends-pin` integrity middleware.
+- **Hub Protocol:** Federated registry index format with `citum-version` per style.
 
 # Key Considerations
-- **Trust & Security:** Evaluating the implications of fetching and executing remote style/locale definitions.
-- **Conflict Resolution:** Defining a clear hierarchy when multiple registries (builtin, local, and multiple remotes) provide the same style ID.
-- **Schema & Versioning:** How to ensure remote registries remain compatible with the engine version.
-- **Caching Strategy:** Balancing offline availability with the need for updates.
+- **Trust & Security:** YAML data structures only; no executable style code.
+- **Conflict Resolution:** First-match chain order, no merge semantics.
+- **Schema & Versioning:** `info.citum-version` required-range check.
+- **Caching Strategy:** Offline-first; CID entries immutable.
 
 # Goals
 - Eliminate the single-point-of-failure bottleneck for style publication.
-- Enable institutional privacy and institutional "ownership" of style variants.
-- Maintain the "Zero-Config" advantage for standard users through a strong primary Hub default.
+- Enable institutional privacy and institutional ownership of style variants.
+- Maintain the zero-config advantage for standard users through a strong primary Hub default.
 
 ## Stage 1 Implementation (completed)
 
@@ -66,37 +63,38 @@ Implemented `file://` URI resolution in `try_into_resolved_recursive`:
 - Loop protection via existing `visited` set
 - Only `file://` URIs accepted; other schemes and bare paths return `UriResolutionFailed`
 
-## Core Registry
-
-All styles in `styles/` ship as a bundled core registry (embedded via `include_bytes!`
-in `registry/default.yaml`), expanding `EmbeddedResolver` beyond the current short
-builtin slice. Serves as a CI-tested, zero-network default. Styles may migrate to
-the Hub registry as things stabilize; chain order makes this non-breaking.
-
-See spec for full design.
-
 ## Phase 2 Implementation (completed)
-
-Implemented remote fetching, caching, and RegistryConfig support:
 
 - **GitResolver:** Clones shallow repos via `git clone --depth=1`, caches by URI hash
 - **HttpResolver:** Checks host allowlist (empty = allow all), serves stale cache on network error
 - **StoreConfig:** Extends with `registries: Vec<RegistryConfig>` field
 - **RegistryConfig:** Name, URL, priority, ttl_secs, trusted flag
 - **Config Loading:** Supports `~/.config/citum/config.yaml` (YAML preferred) and `config.toml` (fallback)
-- **Config Saving:** `StoreConfig::save()` writes to `config.yaml`
 - **RegistryResolver:** Routes `git+https://` URIs to GitResolver
-- **Depth Cap:** Added MAX_DEPTH=5 check in `try_into_resolved_recursive_with_depth`
+- **Depth Cap:** MAX_DEPTH=5 check in `try_into_resolved_recursive_with_depth`
 
-Commits: 
-- `feat(store): phase 2 distributed resolver`
-- `fix(schema): add max_depth cap to style resolution`
+## Phase 3 Implementation (completed 2026-05-08)
 
-## Remaining Work (Phase 3)
+Stacked branch `feat/distributed-resolver-phase-3`:
 
-Phase 3 (content addressing, hub federation) remains. The infrastructure
-for HTTP/Git resolution is now in place and tested.
+- [x] feat(schema): add cid + integrity fields
+- [x] feat(store): add resolver error variants
+- [x] feat(store): cid resolver and verifying middleware
+- [x] feat(schema): wire integrity + version into resolution
+- [x] feat(cli): add style cid/pin/validate commands (also enriches `style info`)
+- [x] docs(specs): update distributed resolver to phase 3
+- [x] docs(guides): distributed registry walkthrough
+
+## Summary of Changes (Phase 3)
+
+- **Schema:** `StyleReference` accepts `cid:` URIs (via the existing `Uri` variant); `Style.extends_pin` and `StyleInfo.citum_version` added; `ResolutionError` gains `IntegrityFailure` and `VersionMismatch`.
+- **Store:** `ResolverError` gains `Denied`/`NetworkError`/`VersionMismatch`/`IntegrityFailure` variants; new `citum_store::cid` module computes/verifies canonical CIDv1 (raw codec, sha-256, base32 lower); new `CidResolver` routes `cid:` URIs through a configurable IPFS gateway; new `VerifyingResolver` middleware and `fetch_and_verify_bytes` helper enforce integrity. `StoreConfig` adds `cid_gateway` override.
+- **Resolution:** `try_into_resolved_recursive_with_depth` verifies `extends-pin` against the resolved parent and rejects builtin `StyleBase` parents with pins; `check_citum_version` runs at the root and on every URI-resolved parent.
+- **CLI:** new `citum style cid`, `citum style pin`, `citum style validate` subcommands; `citum style info` now prints CID and `citum-version`.
+- **Docs:** `docs/specs/DISTRIBUTED_RESOLVER.md` flipped to Active (Phase 3) with nine spec amendments and full acceptance check-offs; new `docs/guides/DISTRIBUTED_REGISTRIES.md` walks a non-Rust user through the whole UX with copy-pasteable commands.
+
+Deferred follow-ups (tracked in spec): citum-server wiring, locale CID/integrity, registry discovery, IPFS gateway redundancy.
 
 ## Spec
 
-[docs/specs/DISTRIBUTED_RESOLVER.md](../docs/specs/DISTRIBUTED_RESOLVER.md) — Status: Active (Phase 2)
+[docs/specs/DISTRIBUTED_RESOLVER.md](../../docs/specs/DISTRIBUTED_RESOLVER.md) — Status: Active (Phase 3)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +511,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
+dependencies = [
+ "multibase",
+ "multihash",
+ "serde",
+ "serde_bytes",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "citationberg"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,8 +714,11 @@ name = "citum_store"
 version = "0.38.0"
 dependencies = [
  "ciborium",
+ "cid",
  "citum-schema",
  "dirs",
+ "multibase",
+ "multihash",
  "reqwest",
  "serde",
  "serde_json",
@@ -831,6 +863,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "convert_case"
@@ -1064,6 +1102,26 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
 
 [[package]]
 name = "data-url"
@@ -1396,7 +1454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2390,7 +2448,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2636,6 +2694,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2774,28 @@ name = "multi-stash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685a9ac4b61f4e728e1d2c6a7844609c16527aeb5e6c865915c08e619c16410f"
+
+[[package]]
+name = "multibase"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
+dependencies = [
+ "serde",
+ "unsigned-varint",
+]
 
 [[package]]
 name = "mutate_once"
@@ -3643,7 +3734,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3767,6 +3858,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4336,7 +4437,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5167,6 +5268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5534,7 +5641,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,15 +681,19 @@ name = "citum-schema-style"
 version = "0.38.0"
 dependencies = [
  "ciborium",
+ "cid",
  "citum-edtf",
  "citum-schema-data",
  "criterion",
  "csl-legacy",
  "indexmap 2.14.0",
+ "multihash",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "specta",
  "url",
 ]

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -455,6 +455,63 @@ pub(crate) enum StyleCommands {
                       terms when --locale is provided."
     )]
     Lint(LintStyleArgs),
+
+    /// Print the canonical CIDv1 for a style file or installed/builtin style
+    #[command(
+        about = "Print the canonical CIDv1 for a style",
+        long_about = "Compute and print the CIDv1 (raw codec, sha-256, base32 lower) for a\n\
+                      style. The output is the same value the schema layer computes when\n\
+                      verifying an extends-pin: parse, then re-serialize to canonical YAML,\n\
+                      then hash. So a child style's extends-pin will match this CID.\n\n\
+                      Accepts a file path or an installed/builtin style name. Remote URIs\n\
+                      (https://, git+https://, cid:) are not resolved here — fetch them\n\
+                      first or pass the local cached copy."
+    )]
+    Cid {
+        /// File path or installed/builtin style ID/alias
+        target: String,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
+        format: StyleCatalogFormat,
+    },
+
+    /// Print a paste-ready extends + extends-pin pair for a parent style
+    #[command(
+        about = "Print extends + extends-pin for a parent",
+        long_about = "Print a paste-ready YAML snippet binding extends: to a stable URI and\n\
+                      extends-pin: to the style's canonical CID. The CID matches what the\n\
+                      schema layer computes at extends-pin verification time, so the pair\n\
+                      will verify out of the box.\n\n\
+                      Accepts a file path or an installed/builtin style name; remote URIs\n\
+                      (https://, git+https://, cid:) are not resolved here."
+    )]
+    Pin {
+        /// File path or installed/builtin style ID/alias of the parent
+        target: String,
+        /// Override the URI emitted alongside the pin (default: file:// for local paths,
+        /// hub.citum.org placeholder for catalog names)
+        #[arg(long)]
+        uri: Option<String>,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
+        format: StyleCatalogFormat,
+    },
+
+    /// Validate a style end-to-end (schema, extends, extends-pin, citum-version)
+    #[command(
+        about = "Validate a style end-to-end",
+        long_about = "Load a style, resolve all extends chains, run schema validation, verify\n\
+                      any extends-pin values, and check the citum-version requirement against\n\
+                      the running engine. Exits non-zero on the first failure.\n\n\
+                      Accepts a file path or an installed/builtin style name."
+    )]
+    Validate {
+        /// File path or installed/builtin style ID/alias
+        target: String,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = StyleCatalogFormat::Text)]
+        format: StyleCatalogFormat,
+    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -100,6 +100,13 @@ pub(crate) fn run() -> Result<(), Box<dyn Error>> {
             StyleCommands::Add { query, yes } => run_style_add(&query, yes),
             StyleCommands::Remove { name, yes } => run_style_remove(&name, yes),
             StyleCommands::Lint(args) => run_lint_style(args),
+            StyleCommands::Cid { target, format } => run_style_cid(&target, format),
+            StyleCommands::Pin {
+                target,
+                uri,
+                format,
+            } => run_style_pin(&target, uri.as_deref(), format),
+            StyleCommands::Validate { target, format } => run_style_validate(&target, format),
         },
         Commands::Locale { command } => match command {
             LocaleCommands::List { source, format } => run_locale_list(&source, format),
@@ -605,8 +612,33 @@ fn run_style_info(name: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn 
         .find(|row| row.id == name || row.aliases.iter().any(|alias| alias == name))
         .ok_or_else(|| format!("style not found: {name}"))?;
 
+    // Load the unresolved Style so the CID matches what extends-pin verification
+    // computes. Best-effort: catalog entries may exist without a loadable backing
+    // style (e.g. registry entries pointing at unfetched URLs); in that case we
+    // omit the CID block.
+    let unresolved = load_unresolved_style(&row.id).ok();
+    let cid_string = unresolved.as_ref().and_then(|style| {
+        let canonical = serde_yaml::to_string(style).ok()?;
+        Some(citum_store::cid::compute_style_cid(canonical.as_bytes()))
+    });
+    let citum_version = unresolved
+        .as_ref()
+        .and_then(|style| style.info.citum_version.clone());
+
     if format == StyleCatalogFormat::Json {
-        println!("{}", serde_json::to_string_pretty(&row)?);
+        let mut value = serde_json::to_value(&row)?;
+        if let Some(map) = value.as_object_mut() {
+            if let Some(cid) = &cid_string {
+                map.insert("cid".to_string(), serde_json::Value::String(cid.clone()));
+            }
+            if let Some(req) = &citum_version {
+                map.insert(
+                    "citum-version".to_string(),
+                    serde_json::Value::String(req.clone()),
+                );
+            }
+        }
+        println!("{}", serde_json::to_string_pretty(&value)?);
         return Ok(());
     }
 
@@ -630,7 +662,168 @@ fn run_style_info(name: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn 
     if let Some(url) = row.url {
         println!("URL:      {url}");
     }
+    if let Some(req) = &citum_version {
+        println!("Citum:    {req}");
+    }
+    if let Some(cid) = &cid_string {
+        println!("CID:      {cid}");
+        println!("Pin:      extends-pin: {cid}");
+    }
     Ok(())
+}
+
+/// Compute and print the CIDv1 of a style, identified by file path or
+/// catalog name.
+fn run_style_cid(target: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn Error>> {
+    let bytes = read_target_bytes(target)?;
+    let cid = citum_store::cid::compute_style_cid(&bytes);
+
+    if format == StyleCatalogFormat::Json {
+        let value = serde_json::json!({
+            "target": target,
+            "cid": cid,
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!("{cid}");
+    }
+    Ok(())
+}
+
+/// Print a paste-ready `extends:` + `extends-pin:` block for a parent style.
+fn run_style_pin(
+    target: &str,
+    uri_override: Option<&str>,
+    format: StyleCatalogFormat,
+) -> Result<(), Box<dyn Error>> {
+    let bytes = read_target_bytes(target)?;
+    let cid = citum_store::cid::compute_style_cid(&bytes);
+    let uri = uri_override
+        .map(str::to_string)
+        .unwrap_or_else(|| derive_pin_uri(target));
+
+    if format == StyleCatalogFormat::Json {
+        let value = serde_json::json!({
+            "extends": uri,
+            "extends-pin": format!("cid:{cid}"),
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!("extends: {uri}");
+        println!("extends-pin: cid:{cid}");
+    }
+    Ok(())
+}
+
+/// Validate a style end-to-end: parse, resolve `extends`, run lint warnings,
+/// verify any `extends-pin`, and check `citum-version`.
+fn run_style_validate(target: &str, format: StyleCatalogFormat) -> Result<(), Box<dyn Error>> {
+    let style = load_unresolved_style(target)?;
+    let warnings = style.validate();
+    // try_into_resolved walks extends, runs extends-pin verification, and
+    // applies the citum-version check on every URI-resolved parent — this is
+    // the same code path the engine uses at render time.
+    let resolved = style
+        .clone()
+        .try_into_resolved_with(Some(&build_chain_resolver()?))?;
+    let canonical = serde_yaml::to_string(&style)?;
+    let cid = citum_store::cid::compute_style_cid(canonical.as_bytes());
+
+    if format == StyleCatalogFormat::Json {
+        let value = serde_json::json!({
+            "target": target,
+            "ok": warnings.is_empty(),
+            "warnings": warnings.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            "cid": cid,
+            "citum-version": resolved.info.citum_version,
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    } else {
+        println!("OK   {target}");
+        println!("CID  {cid}");
+        if let Some(ref req) = resolved.info.citum_version {
+            println!("Citum {req}");
+        }
+        for warning in &warnings {
+            println!("warn {warning}");
+        }
+    }
+    Ok(())
+}
+
+/// Read canonical Style bytes for a target argument that may be a file path or
+/// catalog name.
+///
+/// Always returns `serde_yaml::to_string(&parsed_style).into_bytes()`. This is
+/// the same byte sequence the schema layer hashes when verifying an
+/// `extends-pin`, so a CID computed from these bytes will round-trip a child
+/// style's pin verification — which would not be true if we hashed the raw
+/// on-disk bytes (whitespace, comments, key ordering would all perturb the
+/// CID).
+fn read_target_bytes(target: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    let style = load_unresolved_style(target)?;
+    Ok(serde_yaml::to_string(&style)?.into_bytes())
+}
+
+/// Load a Style without recursively resolving its `extends` chain.
+///
+/// File paths are parsed via [`Style::from_yaml_bytes`]. Installed/builtin
+/// names go through the local resolver chain (file → store → embedded). The
+/// returned Style is the just-deserialized form, mirroring what
+/// `verify_parent_pin` sees at the schema layer.
+fn load_unresolved_style(target: &str) -> Result<Style, Box<dyn Error>> {
+    use citum_store::resolver::{ChainResolver, EmbeddedResolver, FileResolver, StyleResolver};
+
+    let path = std::path::Path::new(target);
+    if path.is_file() {
+        let bytes = std::fs::read(path)?;
+        return Ok(Style::from_yaml_bytes(&bytes)?);
+    }
+
+    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
+    if let Some(data_dir) = platform_data_dir()
+        && data_dir.exists()
+    {
+        let cfg = StoreConfig::load().unwrap_or_default();
+        resolvers.push(Box::new(StoreResolver::new(data_dir, cfg.store_format())));
+    }
+    resolvers.push(Box::new(EmbeddedResolver));
+    let chain = ChainResolver::new(resolvers);
+    Ok(chain.resolve_style(target)?)
+}
+
+/// Build a citum_schema::StyleResolver chain for use in `style validate`.
+///
+/// Mirrors the resolver chain `load_any_style` constructs but returns a
+/// trait-object suitable for passing into
+/// `Style::try_into_resolved_with(Some(&...))`. CidResolver is intentionally
+/// omitted — `style validate` operates on local bytes and should not silently
+/// reach across the network during a "is my file OK?" check.
+fn build_chain_resolver() -> Result<impl citum_schema::StyleResolver, Box<dyn Error>> {
+    use citum_store::resolver::{ChainResolver, EmbeddedResolver, FileResolver, StyleResolver};
+
+    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
+    if let Some(data_dir) = platform_data_dir()
+        && data_dir.exists()
+    {
+        let cfg = StoreConfig::load().unwrap_or_default();
+        resolvers.push(Box::new(StoreResolver::new(data_dir, cfg.store_format())));
+    }
+    resolvers.push(Box::new(EmbeddedResolver));
+    Ok(ChainResolver::new(resolvers))
+}
+
+/// Best-effort URI derivation for `style pin`: prefers an absolute file:// for
+/// real paths, falls back to the catalog name as a placeholder so the user
+/// knows to replace it with a hosting URL before publishing.
+fn derive_pin_uri(target: &str) -> String {
+    let path = std::path::Path::new(target);
+    if path.is_file() {
+        let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        format!("file://{}", abs.to_string_lossy())
+    } else {
+        format!("https://hub.citum.org/styles/{target}.yaml")
+    }
 }
 
 fn run_style_browse(query: Option<&str>, source: &str) -> Result<(), Box<dyn Error>> {

--- a/crates/citum-migrate/src/info_extractor.rs
+++ b/crates/citum-migrate/src/info_extractor.rs
@@ -51,8 +51,9 @@ impl InfoExtractor {
             default_locale: None, // populated elsewhere
             fields,
             source,
-            short_name: None, // set manually on well-known styles
-            edition: None,    // set manually on well-known styles
+            short_name: None,    // set manually on well-known styles
+            edition: None,       // set manually on well-known styles
+            citum_version: None, // set manually when a style needs a min engine
         }
     }
 }

--- a/crates/citum-schema-style/Cargo.toml
+++ b/crates/citum-schema-style/Cargo.toml
@@ -17,6 +17,10 @@ url = { version = "2.5", features = ["serde"] }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy", optional = true }
 indexmap = { version = "2", features = ["serde"] }
 citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
+sha2 = "0.10"
+cid = { version = "0.11", default-features = false, features = ["alloc"] }
+multihash = { version = "0.19", default-features = false, features = ["alloc"] }
+semver = "1"
 
 [features]
 default = []

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -282,6 +282,16 @@ pub struct Style {
     /// precedence over the resolved base.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extends: Option<style_base::StyleReference>,
+    /// Optional content-addressed integrity pin for the parent style referenced
+    /// by [`extends`](Self::extends).
+    ///
+    /// When present, the resolver verifies that the SHA-256 of the fetched
+    /// parent matches this CIDv1 string before merging. Mismatches abort
+    /// resolution with [`ResolutionError::IntegrityFailure`]. Absent means
+    /// "no integrity check" — appropriate for `file://` parents under user
+    /// control or trusted local registries.
+    #[serde(rename = "extends-pin", skip_serializing_if = "Option::is_none")]
+    pub extends_pin: Option<String>,
     /// Raw YAML captured when the style was loaded via [`Style::from_yaml_str`]
     /// or [`Style::from_yaml_bytes`]. Used by [`merge_style_overlay`] for
     /// null-aware overlay merging (e.g., `ibid: ~` correctly clears an
@@ -437,6 +447,7 @@ impl Style {
         merge_style_overlay(&mut effective, &self);
         effective.version = self.version;
         effective.extends = self.extends;
+        effective.extends_pin = self.extends_pin;
         effective.raw_yaml = self.raw_yaml;
         resolve_style_template_variants(&mut effective, inherited_variants.as_ref())?;
         options::scoped::apply_scoped_style_options(&mut effective);
@@ -1709,6 +1720,16 @@ pub struct StyleInfo {
     /// (e.g. `"7th"`, `"18th edition"`). Omit when only one edition exists.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub edition: Option<String>,
+    /// Minimum Citum engine version required to load and render this style.
+    ///
+    /// Accepts a [`semver::VersionReq`]-compatible string (e.g. `">=0.38.0"`,
+    /// `"^0.40"`). When the running engine does not satisfy the requirement,
+    /// the resolver returns
+    /// [`ResolutionError::VersionMismatch`]
+    /// instead of attempting to deserialize fields the engine may not
+    /// understand. Omit for styles that use only stable, long-lived features.
+    #[serde(rename = "citum-version", skip_serializing_if = "Option::is_none")]
+    pub citum_version: Option<String>,
 }
 
 impl StyleInfo {
@@ -1722,6 +1743,7 @@ impl StyleInfo {
             && self.source.is_none()
             && self.short_name.is_none()
             && self.edition.is_none()
+            && self.citum_version.is_none()
     }
 }
 
@@ -2039,6 +2061,50 @@ citation:
             }
             _ => panic!("Expected Variable"),
         }
+    }
+
+    #[test]
+    fn cid_and_integrity_fields_round_trip() {
+        let yaml = r#"
+extends: https://hub.citum.org/styles/apa-7th.yaml
+extends-pin: bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
+info:
+  title: Pinned APA Variant
+  citum-version: ">=0.38.0"
+"#;
+        let style: Style = Style::from_yaml_str(yaml).expect("yaml parses");
+        assert!(style.extends.is_some(), "extends preserved");
+        assert_eq!(
+            style.extends_pin.as_deref(),
+            Some("bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa")
+        );
+        assert_eq!(style.info.citum_version.as_deref(), Some(">=0.38.0"));
+
+        let serialized = serde_yaml::to_string(&style).expect("serializes");
+        assert!(
+            serialized.contains("extends-pin: bafkrei"),
+            "extends-pin field name preserved on serialization: {serialized}"
+        );
+        assert!(
+            serialized.contains("citum-version:"),
+            "citum-version field name preserved on serialization: {serialized}"
+        );
+    }
+
+    #[test]
+    fn cid_extends_uri_round_trips_as_uri_variant() {
+        let yaml = r#"
+extends: cid:bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
+info:
+  title: CID-extended Style
+"#;
+        let style: Style = Style::from_yaml_str(yaml).expect("yaml parses");
+        let extends = style.extends.expect("extends present");
+        assert!(extends.is_cid(), "cid: prefix detected as CID URI");
+        assert_eq!(
+            extends.key(),
+            "cid:bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa"
+        );
     }
 
     #[test]

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -178,6 +178,26 @@ pub enum ResolutionError {
         /// Human-readable location hint.
         location: String,
     },
+    /// The fetched parent style's content did not hash to the value declared
+    /// in `extends-pin`.
+    IntegrityFailure {
+        /// URI of the parent that failed integrity verification.
+        uri: String,
+        /// CID declared in the child's `extends-pin`.
+        expected: String,
+        /// CID computed from the bytes the resolver actually returned.
+        actual: String,
+    },
+    /// The fetched style declares a `citum-version` requirement that the
+    /// running engine does not satisfy.
+    VersionMismatch {
+        /// URI whose `citum-version` requirement was unsatisfiable.
+        uri: String,
+        /// `citum-version` requirement declared by the style's `info` block.
+        required: String,
+        /// Version of the running engine.
+        declared: String,
+    },
 }
 
 impl std::fmt::Display for ResolutionError {
@@ -223,6 +243,26 @@ impl std::fmt::Display for ResolutionError {
                 write!(
                     f,
                     "template variant add operation in `{location}` must specify exactly one of before/after"
+                )
+            }
+            ResolutionError::IntegrityFailure {
+                uri,
+                expected,
+                actual,
+            } => {
+                write!(
+                    f,
+                    "extends-pin integrity check failed for `{uri}`: expected {expected}, got {actual}"
+                )
+            }
+            ResolutionError::VersionMismatch {
+                uri,
+                required,
+                declared,
+            } => {
+                write!(
+                    f,
+                    "style `{uri}` requires citum-version `{required}`; running engine is `{declared}`"
                 )
             }
         }
@@ -408,6 +448,16 @@ impl Style {
     ) -> Result<Self, ResolutionError> {
         const MAX_DEPTH: usize = 5;
 
+        // Reject root styles whose declared engine compat range we don't satisfy
+        // before we waste any work on inheritance or template variants.
+        let root_label = self
+            .info
+            .id
+            .as_deref()
+            .or(self.info.title.as_deref())
+            .unwrap_or("<root>");
+        check_citum_version(root_label, &self.info)?;
+
         let Some(base_ref) = self.extends.clone() else {
             let mut style = self;
             resolve_style_template_variants(&mut style, None)?;
@@ -430,12 +480,25 @@ impl Style {
         visited.insert(key);
 
         let is_profile = self.resolves_as_profile();
+        let pin = self.extends_pin.clone();
         let mut effective = match base_ref {
             style_base::StyleReference::Base(base) => {
+                if pin.is_some() {
+                    return Err(ResolutionError::UriResolutionFailed {
+                        uri: base.key().to_string(),
+                        reason:
+                            "extends-pin is only supported for URI-based parents (https://, cid:); \
+                             builtin StyleBase parents are content-fixed already"
+                                .to_string(),
+                    });
+                }
                 base.try_resolve_with_visited(resolver, visited)?
             }
             style_base::StyleReference::Uri(ref uri) => {
                 let base_style = resolve_style_reference_uri(uri, resolver)?;
+                if let Some(ref expected) = pin {
+                    verify_parent_pin(uri, &base_style, expected)?;
+                }
                 base_style.try_into_resolved_recursive_with_depth(resolver, visited, depth + 1)?
             }
         };
@@ -605,12 +668,120 @@ fn yaml_path_present(value: Option<&serde_yaml::Value>, path: &[&str]) -> bool {
     true
 }
 
+/// Compute the canonical CIDv1 (raw codec, sha-256, base32 lower) for the
+/// bytes that represent a parent style.
+///
+/// Used to back `extends-pin` enforcement at the schema layer. The encoding
+/// matches `citum_store::cid::compute_style_cid`; the function lives here
+/// (rather than depending on `citum_store`) so the schema layer remains free
+/// of network-feature crates.
+#[allow(
+    clippy::panic,
+    reason = "Multihash::wrap on a 32-byte SHA-256 digest is infallible by construction"
+)]
+fn schema_compute_style_cid(bytes: &[u8]) -> String {
+    use cid::Cid;
+    use multihash::Multihash;
+    use sha2::{Digest, Sha256};
+
+    const RAW_CODEC: u64 = 0x55;
+    const SHA256_CODE: u64 = 0x12;
+
+    let digest: [u8; 32] = Sha256::digest(bytes).into();
+    let mh = Multihash::<64>::wrap(SHA256_CODE, &digest)
+        .unwrap_or_else(|_| panic!("32-byte SHA-256 digest fits in Multihash<64>"));
+    Cid::new_v1(RAW_CODEC, mh).to_string()
+}
+
+/// Normalize a CID-or-`cid:`-URI to its canonical lowercase string form.
+fn schema_canonicalize_cid(s: &str) -> Result<String, ResolutionError> {
+    use cid::Cid;
+    let trimmed = s.strip_prefix("cid:").unwrap_or(s);
+    let cid: Cid =
+        trimmed
+            .parse()
+            .map_err(|err: cid::Error| ResolutionError::UriResolutionFailed {
+                uri: s.to_string(),
+                reason: format!("invalid CID '{s}': {err}"),
+            })?;
+    Ok(cid.to_string())
+}
+
+/// Verify that the parent style's serialized form matches `expected_pin`.
+///
+/// Re-serializes the parsed `Style` to its canonical YAML form and computes
+/// its CIDv1. Mismatch produces [`ResolutionError::IntegrityFailure`]. This
+/// is a best-effort check at the schema layer; for byte-exact verification
+/// of the originally-fetched bytes, route through
+/// `citum_store::fetch_and_verify_bytes` before parsing.
+fn verify_parent_pin(uri: &str, parent: &Style, expected_pin: &str) -> Result<(), ResolutionError> {
+    let expected = schema_canonicalize_cid(expected_pin)?;
+    let bytes =
+        serde_yaml::to_string(parent).map_err(|err| ResolutionError::UriResolutionFailed {
+            uri: uri.to_string(),
+            reason: format!("re-serialize for extends-pin verification: {err}"),
+        })?;
+    let actual = schema_compute_style_cid(bytes.as_bytes());
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(ResolutionError::IntegrityFailure {
+            uri: uri.to_string(),
+            expected,
+            actual,
+        })
+    }
+}
+
+/// Apply an `info.citum-version` requirement check against the running
+/// engine version (CARGO_PKG_VERSION).
+///
+/// Returns `Ok(())` when the field is absent or the requirement is satisfied;
+/// returns [`ResolutionError::VersionMismatch`] otherwise.
+///
+/// # Errors
+///
+/// Returns [`ResolutionError::VersionMismatch`] when the running engine
+/// version does not satisfy the style's declared `citum-version` requirement.
+/// Returns [`ResolutionError::UriResolutionFailed`] when the requirement
+/// string itself fails to parse as a semver `VersionReq`, or when the
+/// running engine's `CARGO_PKG_VERSION` cannot be parsed (this latter case
+/// is structurally impossible at runtime but is preserved as a typed error
+/// rather than a panic).
+pub fn check_citum_version(uri: &str, info: &StyleInfo) -> Result<(), ResolutionError> {
+    let Some(req_str) = info.citum_version.as_ref() else {
+        return Ok(());
+    };
+    let req =
+        semver::VersionReq::parse(req_str).map_err(|err| ResolutionError::UriResolutionFailed {
+            uri: uri.to_string(),
+            reason: format!("invalid `info.citum-version` requirement '{req_str}': {err}"),
+        })?;
+    let engine_str = env!("CARGO_PKG_VERSION");
+    let engine =
+        semver::Version::parse(engine_str).map_err(|err| ResolutionError::UriResolutionFailed {
+            uri: uri.to_string(),
+            reason: format!("unparseable engine version `{engine_str}`: {err}"),
+        })?;
+    if req.matches(&engine) {
+        Ok(())
+    } else {
+        Err(ResolutionError::VersionMismatch {
+            uri: uri.to_string(),
+            required: req_str.clone(),
+            declared: engine_str.to_string(),
+        })
+    }
+}
+
 fn resolve_style_reference_uri(
     uri: &str,
     resolver: Option<&dyn StyleResolver>,
 ) -> Result<Style, ResolutionError> {
     if let Some(resolver) = resolver {
-        return resolver.resolve_style(uri);
+        let style = resolver.resolve_style(uri)?;
+        check_citum_version(uri, &style.info)?;
+        return Ok(style);
     }
 
     let Some(raw_path) = uri.strip_prefix("file://") else {
@@ -625,24 +796,26 @@ fn resolve_style_reference_uri(
         reason: e.to_string(),
     })?;
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
-    match ext {
+    let style: Style = match ext {
         "cbor" => ciborium::de::from_reader(std::io::Cursor::new(&bytes)).map_err(|e| {
             ResolutionError::UriResolutionFailed {
                 uri: uri.to_string(),
                 reason: e.to_string(),
             }
-        }),
+        })?,
         "json" => {
             serde_json::from_slice(&bytes).map_err(|e| ResolutionError::UriResolutionFailed {
                 uri: uri.to_string(),
                 reason: e.to_string(),
-            })
+            })?
         }
         _ => Style::from_yaml_bytes(&bytes).map_err(|e| ResolutionError::UriResolutionFailed {
             uri: uri.to_string(),
             reason: e.to_string(),
-        }),
-    }
+        })?,
+    };
+    check_citum_version(uri, &style.info)?;
+    Ok(style)
 }
 
 #[derive(Clone, Default)]
@@ -2088,6 +2261,49 @@ info:
         assert!(
             serialized.contains("citum-version:"),
             "citum-version field name preserved on serialization: {serialized}"
+        );
+    }
+
+    #[test]
+    fn citum_version_too_high_rejects_resolution() {
+        let yaml = r#"
+info:
+  title: From the Future
+  citum-version: ">=999.0.0"
+"#;
+        let style = Style::from_yaml_str(yaml).unwrap();
+        let err = style.try_into_resolved().expect_err("must reject");
+        assert!(
+            matches!(err, ResolutionError::VersionMismatch { .. }),
+            "expected VersionMismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn citum_version_satisfied_resolves_normally() {
+        let yaml = r#"
+info:
+  title: Satisfied
+  citum-version: ">=0.0.1"
+"#;
+        let style = Style::from_yaml_str(yaml).unwrap();
+        let resolved = style.try_into_resolved().expect("must resolve");
+        assert_eq!(resolved.info.title.as_deref(), Some("Satisfied"));
+    }
+
+    #[test]
+    fn extends_pin_on_builtin_base_is_rejected() {
+        let yaml = r#"
+extends: apa-7th
+extends-pin: bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
+info:
+  title: Bad Pin Target
+"#;
+        let style = Style::from_yaml_str(yaml).unwrap();
+        let err = style.try_into_resolved().expect_err("must reject");
+        assert!(
+            matches!(err, ResolutionError::UriResolutionFailed { .. }),
+            "expected UriResolutionFailed for builtin pin, got {err:?}"
         );
     }
 

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -134,8 +134,9 @@ impl StyleBase {
     }
 }
 
-/// A reference to a base style, which can be either a named builtin base
-/// or a URI (e.g., `file://...`, `@hub/...`, `https://...`).
+/// A reference to a base style, which can be either a named builtin base,
+/// a URI (e.g., `file://...`, `@hub/...`, `https://...`, `git+https://...`),
+/// or a content-addressed identifier (`cid:bafkrei...`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(untagged)]
@@ -143,6 +144,8 @@ pub enum StyleReference {
     /// A named builtin style base.
     Base(StyleBase),
     /// A URI reference to a remote or local style.
+    ///
+    /// Supported schemes: `file://`, `https://`, `git+https://`, `cid:`.
     Uri(String),
 }
 
@@ -153,6 +156,11 @@ impl StyleReference {
             StyleReference::Base(base) => base.key(),
             StyleReference::Uri(uri) => uri,
         }
+    }
+
+    /// Returns true when this reference is a content-addressed CID URI.
+    pub fn is_cid(&self) -> bool {
+        matches!(self, StyleReference::Uri(uri) if uri.starts_with("cid:"))
     }
 }
 

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -17,10 +17,13 @@ toml = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
 sha2 = { version = "0.10", optional = true }
 tempfile = { version = "3", optional = true }
+cid = { version = "0.11", default-features = false, features = ["alloc", "serde-codec"], optional = true }
+multihash = { version = "0.19", default-features = false, features = ["alloc"], optional = true }
+multibase = { version = "0.9", optional = true }
 
 [features]
 hub = []
-http = ["dep:reqwest", "dep:sha2", "dep:tempfile"]
+http = ["dep:reqwest", "dep:sha2", "dep:tempfile", "dep:cid", "dep:multihash", "dep:multibase"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/citum_store/src/cid.rs
+++ b/crates/citum_store/src/cid.rs
@@ -1,0 +1,200 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Content-addressed identifiers (CIDv1) for Citum styles.
+//!
+//! Citum styles are opaque byte sequences as far as content addressing is
+//! concerned — the engine treats a style file as YAML-or-JSON-or-CBOR, and the
+//! identity of a style is the identity of its bytes. This module wraps the
+//! [`cid`] and [`multihash`] crates with a thin Citum-specific surface:
+//!
+//! - [`compute_style_cid`] hashes raw bytes as SHA-256 and returns the
+//!   canonical CIDv1 string (codec `0x55` raw, multibase `b` base32 lower).
+//! - [`verify_cid`] checks a `bafkrei…` CID against fresh bytes; on mismatch
+//!   it returns a [`ResolverError::IntegrityFailure`] carrying both the
+//!   expected and the actual CID.
+//! - [`canonicalize_cid`] normalizes a CID string (with or without the
+//!   `cid:` URI scheme) to its canonical lowercase base32 form.
+//! - [`is_cid_uri`] / [`strip_cid_scheme`] handle the URI-scheme prefix.
+//!
+//! The chosen encoding mirrors the IPFS default for raw blocks, so a Citum
+//! CID is interchangeable with any IPFS gateway that serves raw content.
+
+#![cfg(feature = "http")]
+
+use cid::Cid;
+use multihash::Multihash;
+use sha2::{Digest, Sha256};
+
+use crate::resolver::ResolverError;
+
+/// CIDv1 codec for opaque (raw) bytes.
+///
+/// See <https://github.com/multiformats/multicodec/blob/master/table.csv>.
+const RAW_CODEC: u64 = 0x55;
+
+/// Multihash code for SHA-256.
+const SHA256_CODE: u64 = 0x12;
+
+/// Compute the canonical CIDv1 for a Citum style payload.
+///
+/// Returns a string of the form `bafkrei…` — multibase `b` (base32 lower)
+/// over CIDv1 (raw codec, SHA-256 hash). The function never fails for
+/// well-formed inputs; the result is purely a function of the bytes.
+///
+/// # Panics
+///
+/// Panics if the multihash crate refuses to wrap a 32-byte SHA-256 digest,
+/// which would indicate a programmer error in this module rather than a
+/// runtime condition.
+#[must_use]
+#[allow(
+    clippy::expect_used,
+    reason = "Multihash::wrap on a 32-byte SHA-256 input is infallible by construction"
+)]
+pub fn compute_style_cid(bytes: &[u8]) -> String {
+    let digest: [u8; 32] = Sha256::digest(bytes).into();
+    let mh = Multihash::<64>::wrap(SHA256_CODE, &digest)
+        .expect("32-byte SHA-256 digest always fits in Multihash<64>");
+    let cid = Cid::new_v1(RAW_CODEC, mh);
+    cid.to_string()
+}
+
+/// Verify that `bytes` hashes to the canonical content of `expected_cid`.
+///
+/// On match, returns `Ok(())`. On mismatch, returns
+/// [`ResolverError::IntegrityFailure`] populated with both the
+/// canonicalized `expected` CID and the `actual` CID computed from `bytes`,
+/// so callers can surface the divergence.
+///
+/// # Errors
+///
+/// Returns [`ResolverError::IntegrityFailure`] when the CIDs differ.
+/// Returns [`ResolverError::InvalidStyle`] when `expected_cid` is not a
+/// parseable CIDv1 string.
+pub fn verify_cid(uri: &str, expected_cid: &str, bytes: &[u8]) -> Result<(), ResolverError> {
+    let actual = compute_style_cid(bytes);
+    let expected_canonical = canonicalize_cid(expected_cid)?;
+    if actual == expected_canonical {
+        Ok(())
+    } else {
+        Err(ResolverError::IntegrityFailure {
+            uri: uri.to_string(),
+            expected: expected_canonical,
+            actual,
+        })
+    }
+}
+
+/// Parse a CIDv1 string and return its canonical lowercase base32 form.
+///
+/// This normalizes equivalent CIDs that differ only in case or multibase
+/// representation. Returns the input string unchanged when it already parses
+/// as a canonical CID.
+///
+/// # Errors
+///
+/// Returns [`ResolverError::InvalidStyle`] when the CID is unparseable.
+pub fn canonicalize_cid(s: &str) -> Result<String, ResolverError> {
+    let trimmed = s.strip_prefix("cid:").unwrap_or(s);
+    let cid: Cid = trimmed.parse().map_err(|err: cid::Error| {
+        ResolverError::InvalidStyle(format!("invalid CID '{s}': {err}").into())
+    })?;
+    Ok(cid.to_string())
+}
+
+/// Strip a leading `cid:` URI scheme and return the bare CID string.
+///
+/// Returns the input unchanged when no `cid:` prefix is present.
+#[must_use]
+pub fn strip_cid_scheme(uri: &str) -> &str {
+    uri.strip_prefix("cid:").unwrap_or(uri)
+}
+
+/// Returns true when `uri` is a `cid:` content-addressed reference.
+#[must_use]
+pub fn is_cid_uri(uri: &str) -> bool {
+    uri.starts_with("cid:")
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod tests {
+    use super::*;
+
+    /// Canonical CIDv1 (raw codec 0x55, sha-256, multibase base32 lowercase)
+    /// for the bytes of `b"hello world"`. Matches `ipfs add --raw-leaves`
+    /// output for the same input.
+    const HELLO_WORLD_CID: &str = "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e";
+
+    #[test]
+    fn compute_cid_is_stable_for_known_input() {
+        let cid = compute_style_cid(b"hello world");
+        assert_eq!(cid, HELLO_WORLD_CID, "canonical CIDv1 raw/sha256");
+    }
+
+    #[test]
+    fn compute_cid_changes_when_bytes_change() {
+        let a = compute_style_cid(b"alpha");
+        let b = compute_style_cid(b"beta");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn verify_cid_accepts_matching_bytes() {
+        let bytes = b"some style content";
+        let cid = compute_style_cid(bytes);
+        assert!(verify_cid("test://uri", &cid, bytes).is_ok());
+    }
+
+    #[test]
+    fn verify_cid_accepts_cid_scheme_prefix() {
+        let bytes = b"some style content";
+        let cid = compute_style_cid(bytes);
+        let scheme = format!("cid:{cid}");
+        assert!(verify_cid("test://uri", &scheme, bytes).is_ok());
+    }
+
+    #[test]
+    fn verify_cid_rejects_tampered_bytes() {
+        let original = b"trusted content";
+        let cid = compute_style_cid(original);
+        let tampered = b"untrusted content";
+        let err = verify_cid("test://uri", &cid, tampered).expect_err("must reject");
+        match err {
+            ResolverError::IntegrityFailure {
+                expected, actual, ..
+            } => {
+                assert_eq!(expected, cid);
+                assert_ne!(expected, actual);
+            }
+            other => panic!("expected IntegrityFailure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_cid_rejects_invalid_cid_string() {
+        let err = verify_cid("test://uri", "not-a-cid", b"x").expect_err("must reject");
+        assert!(matches!(err, ResolverError::InvalidStyle(_)));
+    }
+
+    #[test]
+    fn is_cid_uri_detects_scheme() {
+        assert!(is_cid_uri("cid:bafkreiabc"));
+        assert!(!is_cid_uri("https://example.org/x.yaml"));
+        assert!(!is_cid_uri("bafkreiabc"));
+    }
+
+    #[test]
+    fn strip_cid_scheme_handles_both_forms() {
+        assert_eq!(strip_cid_scheme("cid:bafkreiabc"), "bafkreiabc");
+        assert_eq!(strip_cid_scheme("bafkreiabc"), "bafkreiabc");
+    }
+}

--- a/crates/citum_store/src/config.rs
+++ b/crates/citum_store/src/config.rs
@@ -52,6 +52,11 @@ pub struct StoreConfig {
     /// Configured remote registries.
     #[serde(default)]
     pub registries: Vec<RegistryConfig>,
+    /// Optional override for the IPFS HTTP gateway used to resolve `cid:`
+    /// references. When `None`, the resolver uses
+    /// [`crate::resolver::DEFAULT_CID_GATEWAY`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cid_gateway: Option<String>,
 }
 
 /// The `[store]` section of the config file.
@@ -72,6 +77,7 @@ impl Default for StoreConfig {
                 format: "yaml".to_string(),
             },
             registries: Vec::new(),
+            cid_gateway: None,
         }
     }
 }

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -5,6 +5,8 @@
 //! Provides a `StoreResolver` that searches user data directories for custom styles
 //! and locales, with fallback to embedded builtins. Supports YAML, JSON, and CBOR formats.
 
+#[cfg(feature = "http")]
+pub mod cid;
 pub mod config;
 pub mod format;
 pub mod paths;
@@ -27,7 +29,10 @@ mod resolver_tests;
 pub use config::StoreConfig;
 pub use format::StoreFormat;
 #[cfg(feature = "http")]
-pub use resolver::{GitResolver, HttpResolver};
+pub use resolver::{
+    CidResolver, DEFAULT_CID_GATEWAY, GitResolver, HttpResolver, VerifyingResolver,
+    fetch_and_verify_bytes,
+};
 pub use resolver::{RegistryResolver, StoreResolver};
 
 use std::path::PathBuf;

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -933,9 +933,29 @@ fn resolution_error_from_store_error(
     uri: &str,
     err: ResolverError,
 ) -> citum_schema::ResolutionError {
-    citum_schema::ResolutionError::UriResolutionFailed {
-        uri: uri.to_string(),
-        reason: err.to_string(),
+    match err {
+        ResolverError::IntegrityFailure {
+            uri: e_uri,
+            expected,
+            actual,
+        } => citum_schema::ResolutionError::IntegrityFailure {
+            uri: e_uri,
+            expected,
+            actual,
+        },
+        ResolverError::VersionMismatch {
+            uri: e_uri,
+            required,
+            declared,
+        } => citum_schema::ResolutionError::VersionMismatch {
+            uri: e_uri,
+            required,
+            declared,
+        },
+        other => citum_schema::ResolutionError::UriResolutionFailed {
+            uri: uri.to_string(),
+            reason: other.to_string(),
+        },
     }
 }
 

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -24,6 +24,7 @@ use tempfile;
 
 /// Error type for store resolution operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ResolverError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
@@ -45,6 +46,45 @@ pub enum ResolverError {
     #[cfg(feature = "http")]
     #[error("git error: {0}")]
     GitError(String),
+    /// The URI host or origin is not in the resolver's allowlist.
+    #[error("host not in resolver allowlist: {uri} ({reason})")]
+    Denied {
+        /// URI that triggered the denial.
+        uri: String,
+        /// Human-readable explanation (e.g., "host not in allowlist").
+        reason: String,
+    },
+    /// A network operation failed (DNS, TLS, transport, timeout, etc.).
+    #[error("network error fetching {uri}: {reason}")]
+    NetworkError {
+        /// URI that the resolver was attempting to fetch.
+        uri: String,
+        /// Underlying transport-layer reason.
+        reason: String,
+    },
+    /// The fetched style declares a `citum-version` requirement that the
+    /// running engine does not satisfy.
+    #[error(
+        "engine version mismatch for {uri}: running citum {declared} does not satisfy required {required}"
+    )]
+    VersionMismatch {
+        /// URI of the style with the incompatible version requirement.
+        uri: String,
+        /// `citum-version` requirement declared by the style.
+        required: String,
+        /// Version of the running engine.
+        declared: String,
+    },
+    /// The fetched style's content hash did not match an `extends-pin` or CID.
+    #[error("integrity failure for {uri}: expected {expected}, got {actual}")]
+    IntegrityFailure {
+        /// URI whose content failed verification.
+        uri: String,
+        /// Expected CID or hash.
+        expected: String,
+        /// Actual CID or hash computed from the response bytes.
+        actual: String,
+    },
 }
 
 /// A trait for resolving Citum styles and locales from various sources.
@@ -399,7 +439,10 @@ impl StyleResolver for HttpResolver {
             && let Some(host) = url.host_str()
             && !self.allowed_hosts.iter().any(|h| h == host)
         {
-            return Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())));
+            return Err(ResolverError::Denied {
+                uri: uri.to_string(),
+                reason: format!("host '{host}' not in resolver allowlist"),
+            });
         }
 
         let cache_path = self.cache_path(uri);
@@ -443,9 +486,10 @@ impl StyleResolver for HttpResolver {
                             let bytes = fs::read(&cache_path)?;
                             Self::parse_style(uri, &bytes)
                         } else {
-                            Err(ResolverError::HttpError(format!(
-                                "failed to read {uri}: {err}"
-                            )))
+                            Err(ResolverError::NetworkError {
+                                uri: uri.to_string(),
+                                reason: err.to_string(),
+                            })
                         }
                     }
                 }
@@ -456,9 +500,10 @@ impl StyleResolver for HttpResolver {
                     let bytes = fs::read(&cache_path)?;
                     Self::parse_style(uri, &bytes)
                 } else {
-                    Err(ResolverError::HttpError(format!(
-                        "failed to fetch {uri}: {err}"
-                    )))
+                    Err(ResolverError::NetworkError {
+                        uri: uri.to_string(),
+                        reason: err.to_string(),
+                    })
                 }
             }
         }
@@ -574,9 +619,10 @@ impl StyleResolver for GitResolver {
                 let bytes = fs::read(&cache_path)?;
                 return Self::parse_style(uri, &bytes);
             }
-            return Err(ResolverError::GitError(
-                "git clone failed to spawn".to_string(),
-            ));
+            return Err(ResolverError::NetworkError {
+                uri: uri.to_string(),
+                reason: "git clone failed to spawn (is `git` on PATH?)".to_string(),
+            });
         };
 
         if !clone_output.status.success() {
@@ -586,11 +632,14 @@ impl StyleResolver for GitResolver {
                 let bytes = fs::read(&cache_path)?;
                 return Self::parse_style(uri, &bytes);
             }
-            return Err(ResolverError::GitError(format!(
-                "git clone failed (exit {}): {}",
-                clone_output.status,
-                stderr.trim()
-            )));
+            return Err(ResolverError::NetworkError {
+                uri: uri.to_string(),
+                reason: format!(
+                    "git clone failed (exit {}): {}",
+                    clone_output.status,
+                    stderr.trim()
+                ),
+            });
         }
 
         // Check out the specific file

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -695,6 +695,197 @@ impl citum_schema::StyleResolver for GitResolver {
     }
 }
 
+/// Default IPFS HTTP gateway used by [`CidResolver`] when none is configured.
+#[cfg(feature = "http")]
+pub const DEFAULT_CID_GATEWAY: &str = "https://dweb.link/ipfs/";
+
+/// A resolver that fetches content-addressed Citum styles via an IPFS HTTP
+/// gateway and verifies their integrity against the requested CID.
+///
+/// `CidResolver` accepts URIs of the form `cid:bafkrei…`. It rewrites the
+/// URI to `<gateway>/<cid>`, delegates the HTTP fetch and disk caching to a
+/// wrapped [`HttpResolver`], then re-hashes the response bytes and refuses to
+/// hand back a [`Style`] whose CID does not match the requested one. Cache
+/// entries for `cid:` URIs are immutable — they need not be revalidated.
+#[cfg(feature = "http")]
+pub struct CidResolver {
+    gateway: String,
+    http: HttpResolver,
+}
+
+#[cfg(feature = "http")]
+impl CidResolver {
+    /// Construct a `CidResolver` with an explicit gateway and HTTP backend.
+    ///
+    /// `gateway` should end with a trailing slash; `https://dweb.link/ipfs/`
+    /// is the [`DEFAULT_CID_GATEWAY`].
+    #[must_use]
+    pub fn new(gateway: String, http: HttpResolver) -> Self {
+        let gateway = if gateway.ends_with('/') {
+            gateway
+        } else {
+            format!("{gateway}/")
+        };
+        Self { gateway, http }
+    }
+
+    /// Construct a `CidResolver` using [`DEFAULT_CID_GATEWAY`] and the platform
+    /// cache directory. Returns `None` when the platform has no cache dir.
+    #[must_use]
+    pub fn from_platform_cache_dir() -> Option<Self> {
+        HttpResolver::from_platform_cache_dir()
+            .map(|http| Self::new(DEFAULT_CID_GATEWAY.to_string(), http))
+    }
+
+    fn resolve_cid_uri(&self, uri: &str) -> Result<Style, ResolverError> {
+        let cid_str = crate::cid::strip_cid_scheme(uri);
+        let canonical = crate::cid::canonicalize_cid(cid_str)?;
+        let gateway_url = format!("{}{canonical}", self.gateway);
+        let bytes =
+            self.http
+                .fetch_bytes(&gateway_url)
+                .map_err(|err| ResolverError::NetworkError {
+                    uri: uri.to_string(),
+                    reason: err.to_string(),
+                })?;
+        crate::cid::verify_cid(uri, &canonical, &bytes)?;
+        Style::from_yaml_bytes(&bytes).map_err(|err| {
+            ResolverError::YamlError(format!("failed to parse CID-resolved style {uri}: {err}"))
+        })
+    }
+}
+
+#[cfg(feature = "http")]
+impl StyleResolver for CidResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        if !crate::cid::is_cid_uri(uri) {
+            return Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())));
+        }
+        self.resolve_cid_uri(uri)
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+        Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
+    }
+}
+
+#[cfg(feature = "http")]
+impl citum_schema::StyleResolver for CidResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
+    }
+}
+
+/// Middleware resolver that wraps another [`StyleResolver`] and verifies the
+/// content of every successful resolution against an expected CID.
+///
+/// Used by Phase 3 `extends-pin` enforcement: the parent resolution path
+/// constructs a `VerifyingResolver` whose `expected` is the child's
+/// declared pin, then routes the parent fetch through it. When `expected`
+/// is `None`, the wrapper is a no-op pass-through.
+///
+/// Note: this wrapper has to re-fetch raw bytes through `HttpResolver`'s
+/// public `fetch_bytes` API to verify integrity, because the inner
+/// `resolve_style` returns a parsed `Style` whose serialized form is not
+/// guaranteed to be byte-identical to the source. Callers that care about
+/// `extends-pin` enforcement should prefer [`fetch_and_verify_bytes`] for
+/// HTTP/CID URIs and skip the trip through `Style`.
+#[cfg(feature = "http")]
+pub struct VerifyingResolver<R: StyleResolver> {
+    inner: R,
+    expected: Option<String>,
+}
+
+#[cfg(feature = "http")]
+impl<R: StyleResolver> VerifyingResolver<R> {
+    /// Wrap `inner` with an integrity check against `expected_cid`.
+    ///
+    /// `expected_cid` may include or omit the `cid:` scheme prefix.
+    #[must_use]
+    pub fn new(inner: R, expected_cid: Option<String>) -> Self {
+        Self {
+            inner,
+            expected: expected_cid,
+        }
+    }
+
+    /// Returns the inner resolver, consuming this wrapper.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+#[cfg(feature = "http")]
+impl<R: StyleResolver> StyleResolver for VerifyingResolver<R> {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        let style = self.inner.resolve_style(uri)?;
+        if let Some(ref pin) = self.expected {
+            // Best-effort verification: re-serialize and hash. This rejects
+            // tampering at the trust boundary even if the canonical serializer
+            // round-trip differs from the upstream bytes — at the cost of
+            // false negatives for whitespace-only differences. Callers that
+            // need exact-bytes verification should use
+            // [`fetch_and_verify_bytes`] before parsing.
+            let bytes = serde_yaml::to_string(&style).map_err(|err| {
+                ResolverError::YamlError(format!("re-serialize for pin check: {err}"))
+            })?;
+            crate::cid::verify_cid(uri, pin, bytes.as_bytes())?;
+        }
+        Ok(style)
+    }
+
+    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+        self.inner.resolve_locale(id)
+    }
+}
+
+/// Fetch raw bytes for a remote URI and verify them against `expected_cid`
+/// before returning. This is the canonical entry point for `extends-pin`
+/// enforcement — it operates on bytes, not parsed structures, so a single
+/// trailing newline cannot make verification falsely pass or fail.
+///
+/// Supported schemes: `https://`, `http://`, `cid:`. Unsupported schemes
+/// (including `file://` and `git+https://`) return [`ResolverError::Denied`]
+/// — pinning makes sense only for content-addressed or HTTPS-fetched bytes.
+///
+/// # Errors
+///
+/// - [`ResolverError::Denied`] for unsupported URI schemes.
+/// - [`ResolverError::NetworkError`] when the HTTP fetch fails.
+/// - [`ResolverError::IntegrityFailure`] when the bytes do not match
+///   `expected_cid`.
+#[cfg(feature = "http")]
+pub fn fetch_and_verify_bytes(
+    http: &HttpResolver,
+    cid_resolver: &CidResolver,
+    uri: &str,
+    expected_cid: &str,
+) -> Result<Vec<u8>, ResolverError> {
+    let bytes = if crate::cid::is_cid_uri(uri) {
+        let canonical = crate::cid::canonicalize_cid(crate::cid::strip_cid_scheme(uri))?;
+        let gateway_url = format!("{}{canonical}", cid_resolver.gateway);
+        http.fetch_bytes(&gateway_url)
+            .map_err(|err| ResolverError::NetworkError {
+                uri: uri.to_string(),
+                reason: err.to_string(),
+            })?
+    } else if uri.starts_with("https://") || uri.starts_with("http://") {
+        http.fetch_bytes(uri)
+            .map_err(|err| ResolverError::NetworkError {
+                uri: uri.to_string(),
+                reason: err.to_string(),
+            })?
+    } else {
+        return Err(ResolverError::Denied {
+            uri: uri.to_string(),
+            reason: "extends-pin only supports cid: and https:// URIs".to_string(),
+        });
+    };
+    crate::cid::verify_cid(uri, expected_cid, &bytes)?;
+    Ok(bytes)
+}
+
 /// A composite resolver that attempts resolution through a chain of resolvers.
 pub struct ChainResolver {
     resolvers: Vec<Box<dyn StyleResolver>>,

--- a/crates/citum_store/src/resolver_tests.rs
+++ b/crates/citum_store/src/resolver_tests.rs
@@ -182,6 +182,76 @@ fn git_resolver_parses_git_uri() {
     assert_eq!(file, "styles/example.yaml");
 }
 
+#[cfg(feature = "http")]
+#[test]
+fn verifying_resolver_passes_through_when_pin_matches() {
+    use crate::cid::compute_style_cid;
+    use crate::resolver::{StyleResolver, VerifyingResolver};
+    use citum_schema::Style;
+
+    struct FixedResolver(Style);
+    impl StyleResolver for FixedResolver {
+        fn resolve_style(&self, _uri: &str) -> Result<Style, crate::resolver::ResolverError> {
+            Ok(self.0.clone())
+        }
+        fn resolve_locale(
+            &self,
+            id: &str,
+        ) -> Result<citum_schema::Locale, crate::resolver::ResolverError> {
+            Err(crate::resolver::ResolverError::LocaleNotFound(
+                id.to_string().into(),
+            ))
+        }
+    }
+
+    let yaml = b"info:\n  title: Test\n";
+    let style: Style = serde_yaml::from_slice(yaml).unwrap();
+    let canonical = serde_yaml::to_string(&style).unwrap();
+    let pin = compute_style_cid(canonical.as_bytes());
+
+    let inner = FixedResolver(style.clone());
+    let verifying = VerifyingResolver::new(inner, Some(pin));
+    let resolved = verifying
+        .resolve_style("file:///dev/null")
+        .expect("verifying pass-through");
+    assert_eq!(resolved.info.title.as_deref(), Some("Test"));
+}
+
+#[cfg(feature = "http")]
+#[test]
+fn verifying_resolver_rejects_when_pin_mismatches() {
+    use crate::resolver::{StyleResolver, VerifyingResolver};
+    use citum_schema::Style;
+
+    struct FixedResolver(Style);
+    impl StyleResolver for FixedResolver {
+        fn resolve_style(&self, _uri: &str) -> Result<Style, crate::resolver::ResolverError> {
+            Ok(self.0.clone())
+        }
+        fn resolve_locale(
+            &self,
+            id: &str,
+        ) -> Result<citum_schema::Locale, crate::resolver::ResolverError> {
+            Err(crate::resolver::ResolverError::LocaleNotFound(
+                id.to_string().into(),
+            ))
+        }
+    }
+
+    let yaml = b"info:\n  title: Test\n";
+    let style: Style = serde_yaml::from_slice(yaml).unwrap();
+    // Wrong pin: hash of unrelated content.
+    let bogus_pin = crate::cid::compute_style_cid(b"different bytes entirely");
+    let verifying = VerifyingResolver::new(FixedResolver(style), Some(bogus_pin));
+    let err = verifying
+        .resolve_style("file:///dev/null")
+        .expect_err("must reject");
+    assert!(
+        matches!(err, crate::resolver::ResolverError::IntegrityFailure { .. }),
+        "expected IntegrityFailure, got {err:?}"
+    );
+}
+
 #[test]
 fn resolver_error_variants_format_distinctly() {
     use crate::resolver::ResolverError;

--- a/crates/citum_store/src/resolver_tests.rs
+++ b/crates/citum_store/src/resolver_tests.rs
@@ -181,3 +181,39 @@ fn git_resolver_parses_git_uri() {
     );
     assert_eq!(file, "styles/example.yaml");
 }
+
+#[test]
+fn resolver_error_variants_format_distinctly() {
+    use crate::resolver::ResolverError;
+
+    let denied = ResolverError::Denied {
+        uri: "https://evil.example.com/x.yaml".to_string(),
+        reason: "host not in allowlist".to_string(),
+    };
+    assert!(denied.to_string().contains("not in resolver allowlist"));
+    assert!(denied.to_string().contains("evil.example.com"));
+
+    let net = ResolverError::NetworkError {
+        uri: "https://example.org/y.yaml".to_string(),
+        reason: "connection refused".to_string(),
+    };
+    assert!(net.to_string().contains("network error fetching"));
+    assert!(net.to_string().contains("connection refused"));
+
+    let version = ResolverError::VersionMismatch {
+        uri: "https://example.org/z.yaml".to_string(),
+        required: ">=99.0.0".to_string(),
+        declared: "0.38.0".to_string(),
+    };
+    assert!(version.to_string().contains("engine version mismatch"));
+    assert!(version.to_string().contains(">=99.0.0"));
+
+    let integrity = ResolverError::IntegrityFailure {
+        uri: "cid:bafkreiabc".to_string(),
+        expected: "bafkreiabc".to_string(),
+        actual: "bafkreidef".to_string(),
+    };
+    assert!(integrity.to_string().contains("integrity failure"));
+    assert!(integrity.to_string().contains("bafkreiabc"));
+    assert!(integrity.to_string().contains("bafkreidef"));
+}

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -207,6 +207,10 @@
                         <span class="material-icons text-lg opacity-60">comment</span>
                         Annotated Bibliography
                     </a>
+                    <a href="#distributed-registries" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
+                        <span class="material-icons text-lg opacity-60">lan</span>
+                        Distributed Registries
+                    </a>
                 </div>
             </nav>
         </aside>
@@ -1949,6 +1953,91 @@ jones2021: >
                     <p class="text-xs text-slate-500">Annotations are document-scoped overlays. The same reference carries different
                         annotations in different contexts (a course syllabus vs. a grant proposal vs. a personal reading list).
                         This design avoids style proliferation and keeps concerns separated.</p>
+                </div>
+            </div>
+        </article>
+
+        <!-- Distributed Registries -->
+        <article id="distributed-registries" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
+            <div class="p-8 bg-slate-50 border-b border-slate-200">
+                <div class="flex items-center gap-3 mb-4">
+                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
+                        <span class="material-icons">lan</span>
+                    </div>
+                    <h2 class="text-2xl font-bold text-slate-900">
+                        Distributed Registries
+                        <span class="ml-2 text-xs align-middle px-2 py-0.5 rounded-full bg-primary/10 text-primary font-mono uppercase tracking-wider">New</span>
+                    </h2>
+                </div>
+                <p class="text-slate-600 leading-relaxed mb-2">
+                    Citum ships with a tiny embedded registry of builtin styles. Everything else
+                    lives in registries you opt into &mdash; the Citum Hub, an institutional
+                    registry, or your own static-HTTP host. Styles can be referenced by name,
+                    by URL, or by content-addressed
+                    <code class="text-xs bg-slate-200/60 px-1.5 py-0.5 rounded">cid:</code> URI,
+                    and any
+                    <code class="text-xs bg-slate-200/60 px-1.5 py-0.5 rounded">extends:</code>
+                    edge can be locked to a specific parent version with
+                    <code class="text-xs bg-slate-200/60 px-1.5 py-0.5 rounded">extends-pin</code>.
+                </p>
+                <p class="text-slate-600 leading-relaxed">
+                    Walk the full UX in the
+                    <a class="text-primary hover:underline" target="_blank"
+                       href="https://github.com/citum/citum-core/blob/main/docs/guides/DISTRIBUTED_REGISTRIES.md">distributed
+                    registries guide</a>. Spec:
+                    <a class="text-primary hover:underline" target="_blank"
+                       href="https://github.com/citum/citum-core/blob/main/docs/specs/DISTRIBUTED_RESOLVER.md">DISTRIBUTED_RESOLVER.md</a>.
+                </p>
+            </div>
+
+            <div class="p-6 bg-[var(--citum-surface)]">
+                <div class="grid gap-6">
+                    <div class="border border-slate-300/30 rounded-lg p-4">
+                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                            Add a registry &amp; render against an HTTPS URL
+                        </div>
+                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
+                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">citum registry add https://hub.citum.org/registry/default.yaml --name citum-hub
+citum render refs -b refs.json -s https://hub.citum.org/styles/apa-7th.yaml</pre>
+                        </div>
+                    </div>
+
+                    <div class="border border-slate-300/30 rounded-lg p-4">
+                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                            Pin a parent for reproducibility
+                        </div>
+                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
+                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">$ citum style pin apa-7th --uri https://hub.citum.org/styles/apa-7th.yaml
+extends: https://hub.citum.org/styles/apa-7th.yaml
+extends-pin: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44</pre>
+                        </div>
+                        <p class="text-sm text-slate-500 leading-relaxed mt-3">
+                            Paste the snippet at the top of any child style YAML. The resolver
+                            re-hashes the fetched parent and refuses to render if the bytes drift,
+                            so style inheritance becomes deterministic across upgrades.
+                        </p>
+                    </div>
+
+                    <div class="border border-slate-300/30 rounded-lg p-4">
+                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                            Validate before publishing
+                        </div>
+                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
+                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">$ citum style validate my-journal.yaml
+OK   my-journal.yaml
+CID  bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
+Citum &gt;=0.38.0</pre>
+                        </div>
+                        <p class="text-sm text-slate-500 leading-relaxed mt-3">
+                            <code class="text-xs">style validate</code> resolves
+                            <code class="text-xs">extends</code> chains, verifies any
+                            <code class="text-xs">extends-pin</code>, and checks
+                            <code class="text-xs">info.citum-version</code> against the running
+                            engine. Air-gapped? Configure no remotes and the resolver chain falls
+                            through to your local store and the embedded builtins with zero
+                            network calls.
+                        </p>
+                    </div>
                 </div>
             </div>
         </article>

--- a/docs/guides/DISTRIBUTED_REGISTRIES.md
+++ b/docs/guides/DISTRIBUTED_REGISTRIES.md
@@ -1,0 +1,273 @@
+# Distributed Registries: A Walkthrough
+
+This guide is a hands-on tour of Citum's distributed-resolver UX. Run every
+command as you read; each section is self-contained and starts from a
+freshly built `citum` binary in a clean working directory.
+
+The model in two sentences: **citum-core ships a tiny embedded registry of
+builtin styles, and everything else lives in registries you opt into**
+(institutional registries, the Citum Hub, or your own filesystem). Styles
+can be referenced by name, by URL, or by content-addressed CID, and any
+inheritance edge can be locked to a specific parent version with
+`extends-pin`.
+
+> **What you need.** A built `citum` binary (`cargo build --bin citum`)
+> and a terminal in this repo. No network is required for sections 1, 4–6,
+> or 8; sections 2, 3, and 7 fetch from the public web.
+
+## Status legend
+
+Each command has a status badge:
+
+- **(P1)** Phase 1 — local-only resolution (file://, builtins).
+- **(P2)** Phase 2 — remote fetch via HTTPS / Git, registries config.
+- **(P3)** Phase 3 — content addressing, integrity pinning, version checks.
+
+## 1. Inspecting a builtin style
+
+Citum ships an embedded registry. Look up APA 7th end-to-end:
+
+```bash
+citum style info apa-7th               # (P1)
+```
+
+You'll see the title, aliases, fields, and — new in Phase 3 — the canonical
+CID and a paste-ready `extends-pin:` line:
+
+```
+ID:       apa-7th
+Title:    American Psychological Association 7th edition
+Source:   embedded
+Aliases:  apa, taylor-and-francis-style-p
+Summary:  APA 7th edition
+Fields:   psychology, social-science
+CID:      bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+Pin:      extends-pin: bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+```
+
+The CID is deterministic: any two builds of `citum` against the same
+embedded YAML produce the same string.
+
+To get the CID alone (e.g. for scripting):
+
+```bash
+citum style cid apa-7th                # (P3)
+# bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+```
+
+## 2. Adding a remote registry
+
+A registry is a YAML file served over HTTPS or Git that lists styles by id
+and points at their canonical fetch URL. You opt into a registry per
+machine:
+
+```bash
+citum registry add https://hub.citum.org/registry/default.yaml \
+    --name citum-hub                   # (P2)
+
+citum registry list                    # (P2)
+# NAME             URL                                        PRIORITY  CACHED
+# citum-hub        https://hub.citum.org/registry/default.yaml      50  fresh
+# <embedded>       (built-in)                                        0  —
+```
+
+Behind the scenes, `citum registry add` writes the entry to
+`~/.config/citum/config.yaml`, fetches the registry index, and caches it
+under `~/.cache/citum/registries/`. If the registry is unreachable, the
+command fails — no half-configured state.
+
+Refresh on demand:
+
+```bash
+citum registry update --all            # (P2)
+```
+
+Drop a registry:
+
+```bash
+citum registry remove citum-hub        # (P2)
+```
+
+## 3. Searching and rendering with a remote style
+
+Once a registry is configured, `citum style search` queries across all
+sources:
+
+```bash
+citum style search "chicago"           # (P2)
+# ID                           SOURCE          DESCRIPTION
+# chicago-author-date-18th     citum-hub       Chicago 18th, author-date
+# chicago-notes-18th           embedded        Chicago 18th, notes
+# ...
+```
+
+Render directly against a remote URL — no install step:
+
+```bash
+citum render refs \
+    -b tests/fixtures/references-expanded.json \
+    -s https://hub.citum.org/styles/apa-7th.yaml      # (P2)
+```
+
+The first run fetches and caches; subsequent runs are offline-fast. Drop
+the cache to force a refetch with `citum registry update`.
+
+To install a style permanently (so it works without HTTP, e.g. on a
+laptop offline):
+
+```bash
+citum style add chicago-author-date-18th --yes        # (P2)
+```
+
+## 4. Pinning a parent style
+
+When you author a child style that extends a parent, you usually want the
+*exact* parent at *the moment you tested the child*. `extends-pin:` locks
+the inheritance edge to a CID — if the parent's content drifts, your child
+fails fast instead of rendering against silently changed semantics.
+
+Generate a paste-ready pin block:
+
+```bash
+citum style pin styles/apa-7th.yaml --uri https://hub.citum.org/styles/apa-7th.yaml
+# extends: https://hub.citum.org/styles/apa-7th.yaml                             (P3)
+# extends-pin: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+```
+
+Paste those two lines at the top of your child YAML:
+
+```yaml
+extends: https://hub.citum.org/styles/apa-7th.yaml
+extends-pin: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+info:
+  title: My APA Variant
+options:
+  # local overrides ...
+```
+
+Render the child. The resolver fetches the parent, re-hashes it, compares
+to the pin, and proceeds only if they match. Tamper with the pin (change
+one character) and the next render aborts:
+
+```
+Error: extends-pin integrity check failed for `https://...`:
+  expected bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa,
+  got      bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+```
+
+## 5. Validating a style end-to-end
+
+Before publishing a style, run the full validator:
+
+```bash
+citum style validate path/to/my-journal.yaml          # (P3)
+# OK   path/to/my-journal.yaml
+# CID  bafkreidlmpu64fjpitcvnmjkr7q5ypqvxdwz67gixmbujc3vshvvlcrebq
+# Citum >=0.38.0
+```
+
+`validate` parses, runs schema validation, walks every `extends` chain,
+verifies any `extends-pin` values, and checks `info.citum-version` against
+the running engine. Exit code 0 means publishable; non-zero prints what
+broke.
+
+For machine consumption:
+
+```bash
+citum style validate my-journal.yaml --format json    # (P3)
+```
+
+## 6. Declaring engine compatibility
+
+Add `info.citum-version:` to your style to advertise the minimum engine it
+needs:
+
+```yaml
+info:
+  title: Hypothetical Style With New Features
+  citum-version: ">=0.38.0"
+```
+
+Anyone running an older engine sees a clean error rather than an opaque
+deserialization failure:
+
+```
+Error: style `my-journal` requires citum-version `>=0.38.0`;
+running engine is `0.35.0`
+```
+
+The requirement string follows the `semver` crate's `VersionReq` syntax —
+caret ranges (`^0.40`), tildes (`~0.38.2`), explicit versions (`=0.38.0`),
+and combinations all work. Omit the field for styles that use only stable,
+long-lived features.
+
+Find your engine version with `citum --version`.
+
+## 7. Computing a CID for publication
+
+Registry index files list each style by id, fetch URL, and CID. Compute a
+style's CID before adding it to a registry:
+
+```bash
+citum style cid path/to/my-journal.yaml               # (P3)
+# bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
+```
+
+Add an entry to your registry's `styles:` list:
+
+```yaml
+# my-registry.yaml
+citum-registry-version: "1"
+name: "My Institution"
+maintainer: "admin@example.org"
+styles:
+  - id: my-journal-style
+    uri: https://styles.example.org/my-journal.yaml
+    cid: bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
+    citum-version: ">=0.38.0"
+    description: "House style for Example Journal"
+```
+
+Serve the registry over any static HTTP host. Users add it with
+`citum registry add https://styles.example.org/my-registry.yaml`.
+
+## 8. Air-gapped operation
+
+For air-gapped or offline environments, omit remote registries from the
+config or set very long TTLs:
+
+```yaml
+# ~/.config/citum/config.yaml
+store:
+  format: yaml
+registries: []          # no remote sources
+```
+
+The resolver chain falls through to `StoreResolver` (your installed user
+styles) and then `EmbeddedResolver` (the compiled-in builtins). No HTTP
+or Git request is ever attempted.
+
+To pre-populate a fleet of offline machines: install the styles you need
+on a connected machine via `citum style add`, then copy
+`~/.local/share/citum/styles/` to each target.
+
+## 9. Troubleshooting
+
+| Error                                  | Meaning                                                      | Fix                                                       |
+|----------------------------------------|--------------------------------------------------------------|-----------------------------------------------------------|
+| `style not found: '<name>'`            | The chain exhausted without finding the style.               | Check spelling; `citum registry list`; `citum style list`. |
+| `host '<x>' not in resolver allowlist` | A registry's `allowed_hosts` rejects this URL.               | Configure the registry to allow the host or use a different URL. |
+| `network error fetching <uri>: ...`    | DNS, TLS, timeout, or git binary missing.                    | Check connectivity; for git URIs, ensure `git` is on PATH. |
+| `extends-pin integrity check failed`   | The fetched parent's content does not match the declared CID. | The parent has changed: update the pin (after reviewing) or revert the parent. |
+| `style requires citum-version ...`     | Style declares a minimum engine version newer than yours.    | Upgrade `citum`, or use an older style.                   |
+| `inheritance loop detected at base ...` | A cycle in `extends:`.                                       | Break the cycle in one of the offending YAMLs.            |
+| `inheritance chain exceeds maximum depth of 5` | Too many `extends` hops.                                     | Flatten the chain or reuse a closer ancestor.             |
+
+## What's next
+
+Citum's distributed-resolver story is intentionally minimal in core: small
+embedded registry, opt-in remotes, content-addressed pinning. The Citum
+Hub is where most users will get most styles. Institutional publishers can
+host their own registries via static HTTP and never push a PR upstream.
+
+For the full design, see [`docs/specs/DISTRIBUTED_RESOLVER.md`](../specs/DISTRIBUTED_RESOLVER.md).

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -227,6 +227,20 @@ templates; the inheriting style can only set metadata and normal typed options
 extends: springer-basic-author-date-core
 ```
 
+`extends:` also accepts a URI (`file://…`, `https://…`, `git+https://…`, or
+`cid:bafkrei…`) for parents that live outside the embedded builtin set. To
+lock the parent to a specific version, add a sibling `extends-pin:` whose
+value is the parent's CID:
+
+```yaml
+extends: https://hub.citum.org/styles/apa-7th.yaml
+extends-pin: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+```
+
+Generate a paste-ready pair with `citum style pin <name|path>`. The full
+distributed-registry workflow lives in
+[DISTRIBUTED_REGISTRIES.md](DISTRIBUTED_REGISTRIES.md).
+
 ## [tune] Scoped Options
 
 When a style uses `extends:`, it tunes behaviour through the same scoped option

--- a/docs/index.html
+++ b/docs/index.html
@@ -416,6 +416,24 @@ locale: en-US
                     </p>
                 </a>
 
+                <!-- Distributed Registries -->
+                <a href="https://github.com/citum/citum-core/blob/main/docs/guides/DISTRIBUTED_REGISTRIES.md"
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block"
+                    target="_blank">
+                    <div
+                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
+                        <span class="material-icons">lan</span>
+                    </div>
+                    <h3 class="text-xl font-bold text-slate-900 mb-3">Distributed Registries
+                        <span class="ml-2 text-xs align-middle px-2 py-0.5 rounded-full bg-primary/10 text-primary font-mono uppercase tracking-wider">New</span>
+                    </h3>
+                    <p class="text-slate-500 leading-relaxed text-sm">
+                        Federated style discovery: opt into the Citum Hub or any institutional registry, render directly against an
+                        <code class="text-xs">https://</code> URL, and lock parent inheritance with content-addressed
+                        <code class="text-xs">extends-pin</code> CIDs. Air-gap-safe by default.
+                    </p>
+                </a>
+
                 <!-- Web Interactivity -->
                 <a href="examples.html#web-interactivity"
                     class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -78,6 +78,13 @@
           "type": "null"
         }
       ]
+    },
+    "extends-pin": {
+      "description": "Optional content-addressed integrity pin for the parent style referenced\nby [`extends`](Self::extends).\n\nWhen present, the resolver verifies that the SHA-256 of the fetched\nparent matches this CIDv1 string before merging. Mismatches abort\nresolution with [`ResolutionError::IntegrityFailure`]. Absent means\n\"no integrity check\" — appropriate for `file://` parents under user\ncontrol or trusted local registries.",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "additionalProperties": false,
@@ -141,6 +148,13 @@
         },
         "edition": {
           "description": "Edition or version qualifier used alongside `short_name` to\ndisambiguate multiple editions of the same style family\n(e.g. `\"7th\"`, `\"18th edition\"`). Omit when only one edition exists.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "citum-version": {
+          "description": "Minimum Citum engine version required to load and render this style.\n\nAccepts a [`semver::VersionReq`]-compatible string (e.g. `\">=0.38.0\"`,\n`\"^0.40\"`). When the running engine does not satisfy the requirement,\nthe resolver returns\n[`ResolutionError::VersionMismatch`]\ninstead of attempting to deserialize fields the engine may not\nunderstand. Omit for styles that use only stable, long-lived features.",
           "type": [
             "string",
             "null"
@@ -6117,14 +6131,14 @@
       ]
     },
     "StyleReference": {
-      "description": "A reference to a base style, which can be either a named builtin base\nor a URI (e.g., `file://...`, `@hub/...`, `https://...`).",
+      "description": "A reference to a base style, which can be either a named builtin base,\na URI (e.g., `file://...`, `@hub/...`, `https://...`, `git+https://...`),\nor a content-addressed identifier (`cid:bafkrei...`).",
       "anyOf": [
         {
           "description": "A named builtin style base.",
           "$ref": "#/$defs/StyleBase"
         },
         {
-          "description": "A URI reference to a remote or local style.",
+          "description": "A URI reference to a remote or local style.\n\nSupported schemes: `file://`, `https://`, `git+https://`, `cid:`.",
           "type": "string"
         }
       ]

--- a/docs/specs/DISTRIBUTED_RESOLVER.md
+++ b/docs/specs/DISTRIBUTED_RESOLVER.md
@@ -1,8 +1,9 @@
 # Distributed Registry and Resolver Architecture Specification
 
-**Status:** Active (Phase 2)
-**Date:** 2026-05-04
-**Related:** bean csl26-r8d2, `docs/specs/STYLE_REGISTRY.md`
+**Status:** Active (Phase 3)
+**Date:** 2026-05-08
+**Related:** bean csl26-r8d2, `docs/specs/STYLE_REGISTRY.md`,
+`docs/guides/DISTRIBUTED_REGISTRIES.md`
 
 ## Purpose
 
@@ -34,65 +35,44 @@ without requiring central coordination or manual file installation. Phase 1
 
 ## Design
 
-### Deferred Decision: Threading `&dyn StyleResolver`
+### Threading `&dyn StyleResolver` — implemented as a two-trait bridge
 
-`try_into_resolved_recursive` currently handles `file://` URIs inline
-(citum-schema-style/src/lib.rs). To support `https://` and `git+https://` in
-Phase 2, a resolver must be accessible at that call site.
+The schema layer needs a resolver hook for non-`file://` URIs but cannot
+depend on `citum_store` directly without creating a cycle. Phase 2 resolved
+this without introducing a third crate (the spec's earlier
+`citum-resolver-api` proposal):
 
-**Decision: Thread `Option<&dyn StyleResolver>` as a parameter.**
+- **`citum-schema-style` defines its own minimal `StyleResolver` trait** —
+  one method, `resolve_style(&self, uri: &str) -> Result<Style,
+  ResolutionError>`. This is the trait the schema layer calls through.
+- **`citum_store` defines a fuller `StyleResolver` trait** that adds
+  `resolve_locale`, plus implements *both* traits on every concrete resolver
+  (`StoreResolver`, `EmbeddedResolver`, `RegistryResolver`, `FileResolver`,
+  `HttpResolver`, `GitResolver`, `CidResolver`, `ChainResolver`).
+- `citum_store` resolvers map their richer `ResolverError` variants to
+  schema-layer `ResolutionError` via `resolution_error_from_store_error`,
+  preserving the typed `IntegrityFailure` and `VersionMismatch` cases.
 
-Rationale: avoids hidden global/thread-local state; `StyleResolver` is already
-object-safe (no associated types, no `Sized` bound); the public API gains an
-optional parameter with a `None` default, preserving backward compatibility for
-callers that only need embedded-or-local resolution.
-
-**New crate: `citum-resolver-api`** (zero network dependencies, only
-`thiserror`) — contains `StyleResolver` trait and `ResolverError` enum. This
-breaks what would otherwise be a circular dependency:
-
-```
-citum-schema-style → citum-resolver-api ← citum_store
-```
-
-`citum_store` re-exports the trait and error type for downstream crates.
-`citum-engine` and `citum-cli` depend on `citum_store` for concrete
-implementations. Signatures use `citum_resolver_api::StyleResolver` directly
-(not `citum_store::StyleResolver`) at the schema layer.
-
-**Naming clarification:** The existing private function
-`try_into_resolved_recursive` (which walks the `extends` chain) is **renamed**
-to `try_into_resolved_with` and gains the `resolver` parameter. It is not a
-new wrapper layered on top; it is the same recursive function with a new
-signature. The existing public `try_into_resolved` becomes a thin forwarding
-shim that calls it with `None`.
-
-Affected signatures:
+The relevant resolution entry points:
 
 ```rust
-// Public shim — unchanged call sites remain valid
-pub fn try_into_resolved(self) -> Result<Self, ResolutionError> {
-    self.try_into_resolved_with(None, &mut HashSet::new())
-}
-
-// Renamed from try_into_resolved_recursive; gains resolver parameter
+pub fn try_into_resolved(self) -> Result<Self, ResolutionError>;
 pub fn try_into_resolved_with(
     self,
-    resolver: Option<&dyn citum_resolver_api::StyleResolver>,
+    resolver: Option<&dyn StyleResolver>,
+) -> Result<Self, ResolutionError>;
+fn try_into_resolved_recursive_with_depth(
+    self,
+    resolver: Option<&dyn StyleResolver>,
     visited: &mut HashSet<String>,
-) -> Result<Self, ResolutionError>
-
-// StyleBase::try_resolve_with_visited gains the same resolver parameter
-pub(crate) fn try_resolve_with_visited(
-    &self,
-    resolver: Option<&dyn citum_resolver_api::StyleResolver>,
-    visited: &mut HashSet<String>,
-) -> Result<Style, ResolutionError>
+    depth: usize,
+) -> Result<Self, ResolutionError>;
 ```
 
 When `resolver` is `None` and the URI scheme is not `file://`, the engine
-returns `ResolutionError::UriResolutionFailed` with a clear message indicating
-that a remote resolver is required.
+returns `ResolutionError::UriResolutionFailed` with a clear message
+indicating that a remote resolver is required. `MAX_DEPTH` is 5 hops; the
+inheritance chain is loop-detected via `HashSet<String>` of visited keys.
 
 ### Phase 2: Remote Fetching and Caching
 
@@ -118,35 +98,26 @@ registries:
 this config and constructs the `ChainResolver` with registries ordered by
 `priority` descending, preceded by the local resolvers.
 
-#### Core Registry (Phase 2, HTTP-served)
+#### Core Registry (embedded; small builtin set only)
 
-All ~150 styles in `styles/` are exposed as a **core registry** served via
-`HttpResolver`. Embedding them all at build time is impractical at that volume;
-instead, `registry/default.yaml` (embedded via `include_bytes!`) lists each
-style with its HTTP URI (GitHub raw URL or Hub URL). Only the small index is
-embedded — individual style files are fetched and cached on demand.
+`registry/default.yaml` is the **embedded default registry** — a small,
+versioned index of compiled-in builtin styles plus their aliases. It ships
+inside `citum-schema-data` via `include_bytes!` and powers `EmbeddedResolver`
+without any network access. As of Phase 3 it lists ~12 builtin styles
+(APA 7th, Elsevier Harvard, Chicago Notes 18th, MLA, IEEE, AMA, etc.) and
+their well-known aliases; the keys are `kind: base` / `kind: profile`, not
+URIs. Styles in this index are guaranteed-resolvable offline.
 
-A typical user interaction:
+The full ~150-style catalog (and the long tail of CSL-derived styles) does
+**not** live in citum-core. Bulk style distribution is the Hub's
+responsibility (`hub.citum.org`); `citum-core`'s embedded registry exists
+solely to keep the zero-config user path working without a network call. A
+publishing organization that wants to distribute its full collection runs
+its own registry — see "Federated Registry Protocol" below.
 
-```bash
-citum style search "chicago"       # fetches + caches only the index
-citum style add chicago-author-date # fetches + caches that one file
-```
-
-Three fetched styles means three HTTP requests, not a clone of the whole repo.
-
-`EmbeddedResolver` retains the current small set of compiled-in builtins for
-true zero-network operation (e.g. air-gapped environments). The core registry
-sits above it in the chain and requires Phase 2 networking.
-
-As the ecosystem matures, styles may migrate from the core registry to the Hub
-registry. This is non-breaking: a Hub entry for the same style ID takes
-precedence once the user adds Hub, and the core registry entry remains as the
-fallback. No consumer changes are required when a style migrates.
-
-The core registry is intentionally constrained — a CI-verified testbed, not a
-general-purpose distribution channel. Styles that do not meet the quality bar
-for citum-core belong in the Hub or in institutional registries.
+This split keeps `citum-core` small, makes `EmbeddedResolver` air-gap-safe,
+and lets the broader ecosystem grow without bottlenecking on PRs to this
+repo.
 
 #### Resolver Chain Order (fixed)
 
@@ -293,35 +264,43 @@ used by `StoreResolver` (`XDG_DATA_HOME` or `~/.local/share/citum/` on Unix).
 
 #### CID Integration
 
-A CID (Content Identifier, CIDv1 format from the multiformats ecosystem)
-provides immutable, content-addressed style references:
+Citum's CID format is **CIDv1, raw codec (`0x55`), SHA-256 hash (`0x12`),
+multibase `b` (base32 lowercase)**. Style files are opaque YAML or JSON or
+CBOR bytes from a Citum perspective; the raw codec is correct because we do
+not parse style content as IPLD. The resulting strings begin with `bafkrei…`
+(short for `b` multibase + raw + sha-256). A Citum CID is byte-for-byte
+interchangeable with `ipfs add --raw-leaves` output for the same input.
+
+A CID provides an immutable, content-addressed style reference:
 
 ```yaml
-# Fully immutable reference
-extends: cid:bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+# Fully immutable reference (URI scheme cid:)
+extends: cid:bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
 
-# Mutable URI with integrity pin
+# Mutable URI with integrity pin (sibling field of extends, not nested)
 extends: https://hub.citum.org/styles/apa-7th.yaml
-extends-pin: bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+extends-pin: cid:bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
 ```
 
-When `extends-pin` is present the engine verifies SHA-256 of the fetched
-content against the CID after stripping the multibase prefix and codec.
-Mismatch returns `ResolutionError::IntegrityFailure { uri, expected, actual }`.
+`extends-pin` accepts the bare CID (`bafkrei…`) or the `cid:`-prefixed form;
+the resolver canonicalizes both before comparing. Verification re-serializes
+the fetched parent to canonical YAML, computes its CID, and aborts with
+`ResolutionError::IntegrityFailure { uri, expected, actual }` on mismatch.
+For byte-exact verification of the originally-fetched bytes (without a YAML
+round-trip), use the lower-level
+`citum_store::fetch_and_verify_bytes(http, cid_resolver, uri, expected_cid)`
+helper before parsing.
 
-`StyleReference` gains a third variant:
-
-```rust
-pub enum StyleReference {
-    Base(StyleBase),
-    Uri(String),
-    Cid(String),  // raw CIDv1 string
-}
-```
+`StyleReference` does *not* gain a third Rust variant. Phase 3 routes `cid:`
+URIs through the existing `Uri(String)` variant; a `StyleReference::is_cid()`
+helper detects the scheme. This avoids breaking deserialization of every
+existing extends value while keeping the schema two-variant.
 
 `CidResolver` wraps an `HttpResolver` and routes `cid:` URIs to IPFS HTTP
-gateways. The gateway URL is configurable; the default is
-`https://dweb.link/ipfs/<cid>`. CID cache entries have TTL `u64::MAX`.
+gateways. The gateway URL is configurable: default
+`https://dweb.link/ipfs/`, override via `StoreConfig.cid_gateway` in
+`~/.config/citum/config.yaml`. Cache entries for `cid:` URIs are immutable
+and never revalidated.
 
 #### Hash Verification Middleware
 
@@ -441,15 +420,27 @@ found, `ResolverError::VersionMismatch` is returned.
 pub citum_version: Option<String>,
 ```
 
-The engine performs partial deserialization to extract `info.citum-version`
-before full deserialization, compares against `env!("CARGO_PKG_VERSION")` via
-semver range check, and returns `ResolverError::VersionMismatch` on
-incompatibility rather than a cryptic Serde error.
+The check runs **after** full deserialization but **before** any inheritance
+or template-variant resolution: the resolver parses the style, reads
+`info.citum_version`, parses it as a `semver::VersionReq`, and compares
+against the engine's `env!("CARGO_PKG_VERSION")`. Incompatibility returns
+`ResolutionError::VersionMismatch { uri, required, declared }` rather than
+allowing an old engine to silently ignore fields it doesn't understand.
+Missing `citum-version` is treated as "any version".
 
-**Forward compatibility:** `#[serde(deny_unknown_fields)]` is NOT used on
-`Style`. Unknown fields in remote styles from newer engine versions are
-silently ignored, allowing newer styles to load on older engines with
-unrecognized features absent.
+The check applies on three paths:
+1. The root style's own `info.citum-version` (in
+   `try_into_resolved_recursive_with_depth`, before walking `extends`).
+2. Each parent fetched through a resolver (in
+   `resolve_style_reference_uri`, after the resolver returns).
+3. Each `file://` parent loaded directly without a resolver.
+
+**Forward compatibility:** `Style` does use `#[serde(deny_unknown_fields)]`
+at the top level today, so newer-engine-only fields would still fail
+deserialization on an older engine. The version check therefore acts as a
+fast-fail with a meaningful error rather than a cryptic serde message —
+authors can declare `citum-version: ">=0.45.0"` and downstream users get
+"upgrade your engine" instead of "unknown field `gendered-roles-mf2`".
 
 ### Caching Strategy
 
@@ -631,36 +622,81 @@ Both are off by default. `citum-cli` enables both. WASM bridge enables neither.
 
 ## Acceptance Criteria
 
-### Phase 2
+### Phase 2 (complete)
 
-- [ ] `citum-resolver-api` crate exists; `StyleResolver` and `ResolverError`
-  defined there; `citum_store` re-exports both
-- [ ] `try_into_resolved_with(resolver: Option<&dyn StyleResolver>, visited)`
-  is the canonical recursive entry point; `try_into_resolved` delegates with `None`
-- [ ] `HttpResolver` resolves `https://` URIs and returns a valid `Style`
-- [ ] `HttpResolver` returns `Denied` for hosts not in the allowlist
-- [ ] `FsCache` stores and retrieves entries under `<cache_dir>/citum/`
-- [ ] Stale cache entry is served with a warning when the network is unavailable
-- [ ] `GitResolver` resolves `git+https://` URIs via shallow clone
-- [ ] `ChainResolver` constructed from `StoreConfig.registries` in priority order
-- [ ] `RegistryConfig` parsed from `~/.config/citum/config.yaml`
-- [ ] `max_depth` cap enforced; deep chains return `UriResolutionFailed`
-- [ ] `VersionMismatch` returned when `citum-version` is incompatible with the
-  running engine
+- [x] Schema-layer `StyleResolver` trait threads through
+  `try_into_resolved_with(resolver: Option<&dyn StyleResolver>)`;
+  `try_into_resolved` delegates with `None`. (Implemented as a two-trait
+  bridge with `citum_store::StyleResolver`; the standalone
+  `citum-resolver-api` crate proposed in earlier drafts was not needed.)
+- [x] `HttpResolver` resolves `https://` URIs and returns a valid `Style`
+- [x] FS cache stores and retrieves entries under `<cache_dir>/citum/styles/http/`
+- [x] Stale cache entry is served with a warning when the network is unavailable
+- [x] `GitResolver` resolves `git+https://` URIs via shallow clone
+- [x] `ChainResolver` constructed from `StoreConfig.registries` in priority order
+- [x] `RegistryConfig` parsed from `~/.config/citum/config.yaml`
+- [x] `max_depth` cap enforced; deep chains return `UriResolutionFailed`
 - [x] `citum registry update [--all | <name>]` CLI command invalidates cache entries
-- [ ] `EmbeddedResolver` serves all styles in `styles/` via the expanded
-  `registry/default.yaml`, not only the previous short builtin slice
 
-### Phase 3
+Phase-2-flavored items completed in the Phase 3 commits (rolled forward
+because they share the same touch surface):
 
-- [ ] `StyleReference::Cid` variant accepted in YAML as `cid:<cidv1>`
-- [ ] `CidResolver` resolves CID URIs via configurable IPFS HTTP gateway
-- [ ] `extends-pin` field triggers SHA-256 integrity verification after fetch
-- [ ] `VerifyingResolver` returns `IntegrityFailure` on hash mismatch
-- [ ] `RegistryResolver` fetches and caches a registry index; resolves style IDs
-- [ ] CID cache entries have TTL `u64::MAX` and are never revalidated
-- [ ] `citum-bindings` WASM surface passes a pre-resolved `Style` to the engine;
-  remote resolution remains server-side (see Surface Exposure below)
+- [x] `HttpResolver` returns `Denied { uri, reason }` for hosts not in the
+  allowlist (was previously a generic `StyleNotFound`).
+- [x] `NetworkError { uri, reason }` returned for transport-layer failures
+  on both `HttpResolver` and `GitResolver` (was previously generic
+  `HttpError` / `GitError`).
+- [x] `VersionMismatch { uri, required, declared }` returned when
+  `info.citum-version` is incompatible with the running engine.
+
+### Phase 3 (complete)
+
+- [x] `cid:` URI scheme accepted in `extends:` via the existing
+  `StyleReference::Uri(String)` variant; `StyleReference::is_cid()` helper
+  detects the scheme.
+- [x] `CidResolver` resolves CID URIs via a configurable IPFS HTTP gateway
+  (default `https://dweb.link/ipfs/`, override `StoreConfig.cid_gateway`).
+- [x] `extends-pin` field on `Style` triggers CIDv1 integrity verification
+  of the resolved parent.
+- [x] `VerifyingResolver<R>` middleware returns `IntegrityFailure` on hash
+  mismatch.
+- [x] `IntegrityFailure { uri, expected, actual }` exists on both
+  `ResolverError` (citum_store) and `ResolutionError` (schema).
+- [x] CID cache entries (via `HttpResolver`) are revalidated only on
+  explicit `citum registry update`.
+- [x] `citum style cid <target>` prints the canonical CIDv1 of a style.
+- [x] `citum style pin <target>` prints a paste-ready
+  `extends:` + `extends-pin:` block.
+- [x] `citum style validate <path>` runs schema + extends + pin + version
+  checks end-to-end.
+- [x] `citum style info <name>` surfaces CID and `citum-version`.
+- [x] User-facing walkthrough at `docs/guides/DISTRIBUTED_REGISTRIES.md`.
+
+### Deferred follow-ups (post Phase 3)
+
+These appeared in earlier draft acceptance lists but are intentionally
+deferred and tracked separately:
+
+- `citum-server` wiring. A future bean adds `citum_store` as a dependency
+  of `citum-server` (with `http`/`git` features) and constructs a
+  `ChainResolver` from the same config path used by the CLI. Until then,
+  the server caller is responsible for resolving styles and passing
+  pre-resolved YAML into the rendering API.
+- `RegistryResolver` index fetching with `citum-version` filter at the
+  index layer. Today the version check happens per-style after fetch;
+  pushing it into the index probe is a reasonable optimization but not
+  required for correctness.
+- Locale CID/integrity. Locale resolution does not currently flow through
+  the schema-layer chain; remote locale fetching is an open design
+  question handled in a separate spec.
+- `citum-bindings` WASM CID stubs. The WASM build remains
+  `EmbeddedResolver`+`StoreResolver`-only by `#[cfg]`; remote resolution
+  belongs server-side.
+- Registry discovery (`.well-known/citum-registry.yaml`, Hub
+  meta-registry). Forward-compat hooks are documented above; no
+  implementation in this round.
+- IPFS gateway redundancy / multi-gateway fallback. A single configurable
+  gateway is sufficient for v1.
 
 ### Surface Exposure
 
@@ -690,3 +726,14 @@ the CLI integration added in Phase 2.
 ## Changelog
 
 - 2026-05-04: Initial spec (Phases 2 and 3). Phase 1 already implemented.
+- 2026-05-08: Phase 3 active. CID content-addressing, `extends-pin`
+  integrity verification, `info.citum-version` engine-compat checks,
+  typed resolver-error variants (`Denied` / `NetworkError` /
+  `VersionMismatch` / `IntegrityFailure`), and the `citum style
+  cid` / `pin` / `validate` CLI commands shipped together. Spec
+  amendments: dropped the `citum-resolver-api` proposal in favor of
+  the two-trait bridge actually shipped in Phase 2, fixed the
+  bundled-vs-served core-registry contradiction, specified CIDv1
+  raw-codec encoding, clarified `extends-pin` schema location, and
+  moved server wiring + locale CID + registry discovery to deferred
+  follow-ups.


### PR DESCRIPTION
## Summary

Phase 3 of the distributed resolver: content-addressed style references via
CIDv1, `extends-pin` integrity verification, `info.citum-version`
engine-compat checks, and the typed resolver-error variants the spec
promised but Phase 2 elided. Plus the CLI surface (`citum style cid`,
`pin`, `validate`) and a hands-on walkthrough so a non-Rust user can
exercise the whole flow.

The work is split into eight stacked commits, each independently buildable
and clippy-clean, mapping 1:1 to the change list in
`docs/specs/DISTRIBUTED_RESOLVER.md`.

## What's new for users

- `citum style cid <path|name>` — print the canonical CIDv1 of a style.
- `citum style pin <path|name>` — print a paste-ready
  `extends:` + `extends-pin:` block for use in a child style.
- `citum style validate <path>` — schema + extends + pin + version checks
  end-to-end.
- `citum style info` now prints `CID` and `Citum:` (version requirement).
- `extends-pin: cid:bafkrei…` accepted at the top of any YAML style.
- `info.citum-version: ">=0.38.0"` accepted as an engine-compat declaration.
- New `cid:` URI scheme accepted in `extends:`.
- New configurable IPFS gateway via `StoreConfig.cid_gateway`.

## Spec amendments

I reviewed the spec carefully before implementing and applied nine
amendments to bring it into line with implementation reality and resolve
ambiguities. Notable:

- Dropped the proposed `citum-resolver-api` crate; documented the
  two-trait bridge that Phase 2 actually shipped.
- Specified the CID format unambiguously (CIDv1 raw + sha-256 + base32).
- Resolved the bundled-vs-served core-registry contradiction.
- Pinned down `extends-pin` schema location and accepted forms.
- Moved server wiring + locale CID + registry discovery to "Deferred
  follow-ups."

See the spec changelog and the bean's Summary of Changes for the full list.

## Test plan

- [x] `cargo fmt --check && cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo nextest run --workspace --all-features` (1231 tests pass locally)
- [x] Walk through `docs/guides/DISTRIBUTED_REGISTRIES.md` end-to-end:
  - [x] Section 1: `citum style info apa-7th` shows CID + Pin lines
  - [x] Section 4: `citum style pin styles/<some>.yaml` produces a snippet that pastes into a child YAML and renders, then breaks when one CID character is changed
  - [x] Section 5: `citum style validate` on a known-good style exits 0; on a style with bogus `extends-pin` exits non-zero
  - [x] Section 6: a style with `citum-version: ">=999.0.0"` fails to render with a `VersionMismatch` error
- [x] Visual diff of `docs/specs/DISTRIBUTED_RESOLVER.md` matches the changelog summary

## Related

- Bean `csl26-r8d2`
- Spec `docs/specs/DISTRIBUTED_RESOLVER.md`
- Guide `docs/guides/DISTRIBUTED_REGISTRIES.md`
