### PR TITLE
docs(index): link registries to examples

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -417,9 +417,8 @@ locale: en-US
                 </a>
 
                 <!-- Distributed Registries -->
-                <a href="https://github.com/citum/citum-core/blob/main/docs/guides/DISTRIBUTED_REGISTRIES.md"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block"
-                    target="_blank">
+                <a href="examples.html#distributed-registries"
+                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
                     <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
                         <span class="material-icons">lan</span>


### PR DESCRIPTION
Updates the Distributed Registries link in index.html to point to the local examples page anchor.