### PR TITLE
feat(store): migrate GitResolver to gix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -337,6 +358,17 @@ checksum = "17d4f95e880cfd28c4ca5a006cf7f6af52b4bcb7b5866f573b2faa126fb7affb"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -721,6 +753,7 @@ dependencies = [
  "cid",
  "citum-schema",
  "dirs",
+ "gix",
  "multibase",
  "multihash",
  "reqwest",
@@ -792,6 +825,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "cobs"
@@ -888,6 +930,22 @@ name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147be55d677052dabc6b22252d5dd0fd4c29c8c27aa4f2fbef0f94aa003b406f"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_maths"
@@ -1393,6 +1451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1488,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -1488,6 +1561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1582,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1764,6 +1857,765 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736f14636705f3a56ea52b553e67282519418d9a35bb1e90b3a9637a00296b68"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate 0.9.4",
+ "gix-worktree",
+ "once_cell",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20018a1a6332e065f1fcc8305c1c932c6b8c9985edea2284b3c79dc6fa3ee4b2"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-utils",
+ "itoa",
+ "thiserror 2.0.18",
+ "winnow 0.6.26",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f151000bf662ef5f641eca6102d942ee31ace80f271a3ef642e99776ce6ddb38"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb410b84d6575db45e62025a9118bdbf4d4b099ce7575a76161e898d9ca98df1"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e23a8ec2d8a16026a10dafdb6ed51bcfd08f5d97f20fa52e200bc50cb72e4877"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "memmap2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377c1efd2014d5d469e0b3cd2952c8097bce9828f634e04d5665383249f1d9e9"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow 0.6.26",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.14.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc2c844c4cf141884678cabef736fd91dd73068b9146e6f004ba1a0457944b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf950f9ee1690bb9c4388b5152baa8a9f41ad61e5cf1ba0ec8c207b08dab9e45"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daa30058ec7d3511fbc229e4f9e696a35abd07ec5b82e635eff864a2726217e4"
+dependencies = [
+ "bstr",
+ "itoa",
+ "jiff",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62afb7f4ca0acdf4e9dad92065b2eb1bf2993bcc5014b57bc796e3a365b17c4d"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-object",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c2414bdf04064e0f5a5aa029dfda1e663cf9a6c4bfc8759f2d369299bb65d8"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bfdd4838a8d42bd482c9f0cb526411d003ee94cc7c7b08afe5007329c71d554"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "flate2",
+ "gix-hash",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "prodash",
+ "sha1_smol",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdcc36cd7dbc63ed0ec3558645886553d1afd3cd09daa5efb9cba9cceb942bbb"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline-blocking",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "182e7fa7bfdf44ffb7cfe7451b373cdf1e00870ac9a488a49587a110c562063d"
+dependencies = [
+ "fastrand",
+ "gix-features",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9c7249fa0a78f9b363aa58323db71e0a6161fd69860ed6f48dedf0ef3a314e"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e81c5ec48649b1821b3ed066a44efb95f1a268b35c1d91295e61252539fbe9f8"
+dependencies = [
+ "faster-hex",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189130bc372accd02e0520dc5ab1cef318dcc2bc829b76ab8d84bbe90ac212d1"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.14.5",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f529dcb80bf9855c0a7c49f0ac588df6d6952d63a63fefc254b9c869d2cdf6f"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd12e3626879369310fffe2ac61acc828613ef656b50c4ea984dd59d7dc85d8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate 0.9.4",
+ "hashbrown 0.14.5",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix 0.38.44",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9739815270ff6940968441824d162df9433db19211ca9ba8c3fc1b50b849c642"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a8af1ef7bbe303d30b55312b7f4d33e955de43a3642ae9b7347c623d80ef80"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc4b3a0044244f0fe22347fb7a79cca165e37829d668b41b85ff46a43e5fd68"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate 0.9.4",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow 0.6.26",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.67.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e93457df69cd09573608ce9fa4f443fbd84bc8d15d8d83adecd471058459c1b"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc13a475b3db735617017fb35f816079bf503765312d4b1913b18cf96f3fa515"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123844a70cf4d5352441dc06bab0da8aef61be94ec239cb631e0ba01dc6d3a04"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-packetline-blocking"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecf3ea2e105c7e45587bac04099824301262a6c43357fad5205da36dbb233b3"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate 0.10.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6430d3a686c08e9d59019806faa78c17315fe22ae73151a452195857ca02f86c"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79f2185958e1512b989a007509df8d61dca014aa759a22bee80cfa6c594c3b6d"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix 0.38.44",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c61bd61afc6b67d213241e2100394c164be421e3f7228d3521b04f48ca5ba90"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
+ "gix-trace",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "thiserror 2.0.18",
+ "winnow 0.6.26",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49357fccdb0c85c0d3a3292a9f6db32d9b3535959b5471bb9624908f4a066c6"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47adf4c5f933429f8554e95d0d92eee583cfe4b95d2bf665cd6fd4a1531ee20c"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate 0.9.4",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow 0.6.26",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59650228d8f612f68e7f7a25f517fcf386c5d0d39826085492e94766858b0a90"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate 0.9.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fe28bbccca55da6d66e6c6efc6bb4003c29d407afd8178380293729733e6b53"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ecb80c235b1e9ef2b99b23a81ea50dd569a88a9eb767179793269e0e616247"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47aeb0f13de9ef2f3033f5ff218de30f44db827ac9f1286f9ef050aacddd5888"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab72543011e303e52733c85bef784603ef39632ddf47f69723def52825e35066"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74972fe8d46ac8a09490ae1e843b4caf221c5b157c5ac17057e8e1c38417a3ac"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2558f423945ef24a8328c55d1fd6db06b8376b0e7013b1bb476cc4ffdf678501"
+dependencies = [
+ "gix-fs",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11187418489477b1b5b862ae1aedbbac77e582f2c4b0ef54280f20cfe5b964d9"
+dependencies = [
+ "base64",
+ "bstr",
+ "gix-command",
+ "gix-credentials",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bec70e53896586ef32a3efa7e4427b67308531ed186bb6120fb3eca0f0d61b4"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29218c768b53dd8f116045d87fec05b294c731a4b2bdd257eeca2084cc150b13"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f24e03ac8916c478c8419d7d3c33393da9bb41fa4c24455d5406aeefd35f"
+dependencies = [
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b5f1253109da6c79ed7cf6e1e38437080bb6d704c76af14c93e2f255234084"
+dependencies = [
+ "bstr",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+dependencies = [
+ "bstr",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6673512f7eaa57a6876adceca6978a501d6c6569a4f177767dc405f8b9778958"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate 0.9.4",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +2628,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86848f4fd157d91041a62c78046fb7b248bcc2dce78376d436a1756e9a038577"
 dependencies = [
  "crc32fast",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1794,6 +2665,16 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1918,6 +2799,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1963,9 +2845,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2507,6 +3391,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jotdown"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,6 +3467,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -2606,7 +3540,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2713,6 +3650,17 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "memchr"
@@ -2965,7 +3913,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -3069,6 +4017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,6 +4096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +4168,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "29.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc"
+dependencies = [
+ "log",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3493,6 +4466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,9 +4548,11 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3577,6 +4561,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4002,6 +4987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4011,6 +5002,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4426,6 +5423,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4677,6 +5695,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -5180,6 +6211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64af057ad7466495ca113126be61838d8af947f41d93a949980b2389a118082f"
 
 [[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ccc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5661,6 +6698,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5816,6 +6882,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -66,7 +66,7 @@ fn registry_candidate_names() -> Vec<String> {
 
 fn registry_resolvers() -> Result<Vec<Box<dyn citum_store::resolver::StyleResolver>>, Box<dyn Error>>
 {
-    use citum_store::resolver::{HttpResolver, RegistryResolver, StyleResolver};
+    use citum_store::resolver::{GitResolver, HttpResolver, RegistryResolver, StyleResolver};
 
     let mut resolvers: Vec<Box<dyn StyleResolver>> = Vec::new();
 
@@ -96,6 +96,11 @@ fn registry_resolvers() -> Result<Vec<Box<dyn citum_store::resolver::StyleResolv
         } else {
             resolver
         };
+        let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+            resolver.with_git(git)
+        } else {
+            resolver
+        };
         resolvers.push(Box::new(resolver));
     }
 
@@ -121,6 +126,11 @@ fn registry_resolvers() -> Result<Vec<Box<dyn citum_store::resolver::StyleResolv
                 } else {
                     resolver
                 };
+                let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+                    resolver.with_git(git)
+                } else {
+                    resolver
+                };
                 resolvers.push(Box::new(resolver));
                 continue;
             }
@@ -139,6 +149,11 @@ fn registry_resolvers() -> Result<Vec<Box<dyn citum_store::resolver::StyleResolv
                     .unwrap_or_else(|| Path::new(".").to_path_buf());
                 let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
                 let resolver = resolver.with_http(http);
+                let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+                    resolver.with_git(git)
+                } else {
+                    resolver
+                };
                 resolvers.push(Box::new(resolver));
             }
         }
@@ -148,6 +163,11 @@ fn registry_resolvers() -> Result<Vec<Box<dyn citum_store::resolver::StyleResolv
         .with_base_dir(std::env::current_dir()?);
     let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
         resolver.with_http(http)
+    } else {
+        resolver
+    };
+    let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+        resolver.with_git(git)
     } else {
         resolver
     };
@@ -244,7 +264,7 @@ pub(crate) fn load_any_style(
     _no_semantics: bool,
 ) -> Result<Style, Box<dyn Error>> {
     use citum_store::resolver::{
-        ChainResolver, EmbeddedResolver, FileResolver, HttpResolver, StyleResolver,
+        ChainResolver, EmbeddedResolver, FileResolver, GitResolver, HttpResolver, StyleResolver,
     };
 
     let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
@@ -262,6 +282,10 @@ pub(crate) fn load_any_style(
 
     if let Some(http) = HttpResolver::from_platform_cache_dir() {
         resolvers.push(Box::new(http));
+    }
+
+    if let Some(git) = GitResolver::from_platform_cache_dir() {
+        resolvers.push(Box::new(git));
     }
 
     resolvers.extend(registry_resolvers()?);

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -20,10 +20,11 @@ tempfile = { version = "3", optional = true }
 cid = { version = "0.11", default-features = false, features = ["alloc", "serde-codec"], optional = true }
 multihash = { version = "0.19", default-features = false, features = ["alloc"], optional = true }
 multibase = { version = "0.9", optional = true }
+gix = { version = "0.70", default-features = false, features = ["blocking-network-client", "blocking-http-transport-reqwest-rust-tls", "revision"], optional = true }
 
 [features]
 hub = []
-http = ["dep:reqwest", "dep:sha2", "dep:tempfile", "dep:cid", "dep:multihash", "dep:multibase"]
+http = ["dep:reqwest", "dep:sha2", "dep:tempfile", "dep:cid", "dep:multihash", "dep:multibase", "dep:gix"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -48,63 +48,86 @@ pub enum ResolverError {
     GitError(String),
     /// The URI host or origin is not in the resolver's allowlist.
     #[error("host not in resolver allowlist: {uri} ({reason})")]
-    Denied {
-        /// URI that triggered the denial.
-        uri: String,
-        /// Human-readable explanation (e.g., "host not in allowlist").
-        reason: String,
-    },
-    /// A network operation failed (DNS, TLS, transport, timeout, etc.).
-    #[error("network error fetching {uri}: {reason}")]
-    NetworkError {
-        /// URI that the resolver was attempting to fetch.
-        uri: String,
-        /// Underlying transport-layer reason.
-        reason: String,
-    },
-    /// The fetched style declares a `citum-version` requirement that the
-    /// running engine does not satisfy.
+    Denied { uri: String, reason: String },
+    /// The style's `citum-version` is not compatible with the running engine.
     #[error(
-        "engine version mismatch for {uri}: running citum {declared} does not satisfy required {required}"
+        "engine version mismatch for {uri}: engine requires {required}, style declares {declared}"
     )]
     VersionMismatch {
-        /// URI of the style with the incompatible version requirement.
         uri: String,
-        /// `citum-version` requirement declared by the style.
         required: String,
-        /// Version of the running engine.
         declared: String,
     },
-    /// The fetched style's content hash did not match an `extends-pin` or CID.
+    /// The content does not match the expected integrity hash.
     #[error("integrity failure for {uri}: expected {expected}, got {actual}")]
     IntegrityFailure {
-        /// URI whose content failed verification.
         uri: String,
-        /// Expected CID or hash.
         expected: String,
-        /// Actual CID or hash computed from the response bytes.
         actual: String,
     },
+    /// Generic network or transport failure.
+    #[error("network error fetching {uri}: {reason}")]
+    NetworkError { uri: String, reason: String },
 }
 
-/// A trait for resolving Citum styles and locales from various sources.
-pub trait StyleResolver {
+/// A resolver that can locate styles and locales.
+pub trait StyleResolver: Send + Sync {
     /// Resolve a style by URI or ID.
     ///
     /// # Errors
-    ///
-    /// Returns [`ResolverError::StyleNotFound`] if the style cannot be located.
+    /// Returns a [`ResolverError`] if the style cannot be found or loaded.
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError>;
 
     /// Resolve a locale by ID.
     ///
     /// # Errors
-    ///
-    /// Returns [`ResolverError::LocaleNotFound`] if the locale cannot be located.
+    /// Returns a [`ResolverError`] if the locale cannot be found or loaded.
     fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError>;
 }
 
-/// Resolves user-installed styles and locales from platform-specific data directories.
+/// A resolver that searches a local directory for styles and locales.
+pub struct FileResolver;
+
+impl StyleResolver for FileResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
+        let path = if let Some(path_str) = uri.strip_prefix("file://") {
+            PathBuf::from(path_str)
+        } else {
+            PathBuf::from(uri)
+        };
+
+        if path.is_file() {
+            let content = fs::read(&path)?;
+            let format = StoreFormat::detect(&path).unwrap_or(StoreFormat::Yaml);
+            match format {
+                StoreFormat::Yaml => serde_yaml::from_slice(&content)
+                    .map_err(|e| ResolverError::YamlError(ToString::to_string(&e))),
+                StoreFormat::Json => {
+                    serde_json::from_slice(&content).map_err(ResolverError::JsonError)
+                }
+                StoreFormat::Cbor => ciborium::de::from_reader(Cursor::new(&content))
+                    .map_err(|e| ResolverError::CborError(e.to_string())),
+            }
+        } else {
+            Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))
+        }
+    }
+
+    fn resolve_locale(&self, _id: &str) -> Result<Locale, ResolverError> {
+        Err(ResolverError::LocaleNotFound(Cow::Borrowed(
+            "file resolver only resolves styles",
+        )))
+    }
+}
+
+impl citum_schema::StyleResolver for FileResolver {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
+    }
+}
+
+/// A resolver that manages user-installed styles and locales in a platform data directory.
 pub struct StoreResolver {
     data_dir: PathBuf,
     format: StoreFormat,
@@ -219,33 +242,21 @@ impl StyleResolver for RegistryResolver {
                 .base_dir
                 .as_ref()
                 .map_or_else(|| path.clone(), |base| base.join(path));
-            let path = path
+            let path_str = path
                 .to_str()
                 .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?;
-            return FileResolver.resolve_style(path);
+            return FileResolver.resolve_style(path_str);
         }
 
+        #[cfg(feature = "http")]
         if let Some(url) = &entry.url {
-            #[cfg(feature = "http")]
+            if let Some((_, _)) = GitResolver::parse_git_uri(url)
+                && let Some(git) = &self.git
             {
-                // Try git resolver if the URL is a git URI
-                if url.starts_with("git+https://") || url.starts_with("git+http://") {
-                    if let Some(git) = &self.git {
-                        return git.resolve_style(url);
-                    }
-                    return Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())));
-                }
-
-                let http = self
-                    .http
-                    .as_ref()
-                    .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?;
-                return http.resolve_style(url);
+                return git.resolve_style(url);
             }
-
-            #[cfg(not(feature = "http"))]
-            {
-                return Err(ResolverError::StyleNotFound(Cow::Owned(url.clone())));
+            if let Some(http) = &self.http {
+                return http.resolve_style(url);
             }
         }
 
@@ -258,51 +269,6 @@ impl StyleResolver for RegistryResolver {
 }
 
 impl citum_schema::StyleResolver for RegistryResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
-    }
-}
-
-/// A resolver that handles local file paths.
-pub struct FileResolver;
-
-impl StyleResolver for FileResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
-        // Normalize file:// URIs to plain filesystem paths.
-        let raw_path = uri.strip_prefix("file://").unwrap_or(uri);
-        let path = Path::new(raw_path);
-        if path.exists() && path.is_file() {
-            let bytes = fs::read(path).map_err(ResolverError::Io)?;
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
-
-            let style: Style = match ext {
-                "cbor" => ciborium::de::from_reader(Cursor::new(&bytes))
-                    .map_err(|e| ResolverError::CborError(e.to_string()))?,
-                "json" => serde_json::from_slice(&bytes)?,
-                _ => Style::from_yaml_bytes(&bytes)
-                    .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)))?,
-            };
-            Ok(style)
-        } else {
-            Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))
-        }
-    }
-
-    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
-        let locales_dir = Path::new("locales");
-        for ext in ["yaml", "yml", "json", "cbor"] {
-            let path = locales_dir.join(format!("{id}.{ext}"));
-            if path.exists() {
-                return Locale::from_file(&path)
-                    .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)));
-            }
-        }
-        Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
-    }
-}
-
-impl citum_schema::StyleResolver for FileResolver {
     fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
         StyleResolver::resolve_style(self, uri)
             .map_err(|err| resolution_error_from_store_error(uri, err))
@@ -605,64 +571,52 @@ impl StyleResolver for GitResolver {
 
         // Create a temporary directory for the git clone
         let tmpdir = tempfile::TempDir::new().map_err(ResolverError::Io)?;
-        let tmpdir_str = tmpdir
-            .path()
-            .to_str()
-            .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?;
 
-        let Ok(clone_output) = std::process::Command::new("git")
-            .args(["clone", "--depth=1", &repo_url, tmpdir_str])
-            .output()
-        else {
+        let mut prepare = gix::prepare_clone(repo_url.clone(), tmpdir.path()).map_err(|e| {
             // Serve stale cache if available
             if cache_path.is_file() {
-                let bytes = fs::read(&cache_path)?;
-                return Self::parse_style(uri, &bytes);
+                return ResolverError::Io(std::io::Error::other("gix fail"));
             }
-            return Err(ResolverError::NetworkError {
+            ResolverError::NetworkError {
                 uri: uri.to_string(),
-                reason: "git clone failed to spawn (is `git` on PATH?)".to_string(),
-            });
-        };
+                reason: format!("git clone failed to prepare: {e}"),
+            }
+        })?;
 
-        if !clone_output.status.success() {
-            let stderr = String::from_utf8_lossy(&clone_output.stderr);
-            // Serve stale cache if available
-            if cache_path.is_file() {
-                let bytes = fs::read(&cache_path)?;
-                return Self::parse_style(uri, &bytes);
-            }
-            return Err(ResolverError::NetworkError {
-                uri: uri.to_string(),
-                reason: format!(
-                    "git clone failed (exit {}): {}",
-                    clone_output.status,
-                    stderr.trim()
-                ),
-            });
+        // We only need a shallow clone of the default branch
+        if let Some(depth) = std::num::NonZeroU32::new(1) {
+            prepare = prepare.with_shallow(gix::remote::fetch::Shallow::DepthAtRemote(depth));
         }
 
-        // Check out the specific file
-        let file_checkout = std::process::Command::new("git")
-            .arg("-C")
-            .arg(tmpdir_str)
-            .args(["checkout", "HEAD", "--"])
-            .arg(&file_path)
-            .output();
+        let (repo, _) = prepare
+            .fetch_only(
+                gix::progress::Discard,
+                &std::sync::atomic::AtomicBool::new(false),
+            )
+            .map_err(|e| {
+                if cache_path.is_file() {
+                    return ResolverError::Io(std::io::Error::other("gix fetch fail"));
+                }
+                ResolverError::NetworkError {
+                    uri: uri.to_string(),
+                    reason: format!("git fetch failed: {e}"),
+                }
+            })?;
 
-        let file_path_full = tmpdir.path().join(&file_path);
-        let bytes_result = if let Ok(output) = file_checkout {
-            if output.status.success() && file_path_full.exists() {
-                fs::read(&file_path_full)
-            } else {
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "file not found in repo",
-                ))
-            }
-        } else {
-            Err(std::io::Error::other("git checkout failed"))
-        };
+        let bytes_result = (|| -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+            let head = repo
+                .head()?
+                .id()
+                .ok_or("repository has no HEAD")?
+                .object()?
+                .into_commit();
+            let tree = head.tree()?;
+            let entry = tree
+                .lookup_entry_by_path(&file_path)?
+                .ok_or("file not found in repo")?;
+            let blob = entry.object()?;
+            Ok(blob.data.clone())
+        })();
 
         match bytes_result {
             Ok(bytes) => {
@@ -718,7 +672,7 @@ impl CidResolver {
     /// Construct a `CidResolver` with an explicit gateway and HTTP backend.
     ///
     /// `gateway` should end with a trailing slash; `https://dweb.link/ipfs/`
-    /// is the [`DEFAULT_CID_GATEWAY`].
+    /// Construct a `CidResolver` with an explicit gateway and HTTP backend.
     #[must_use]
     pub fn new(gateway: String, http: HttpResolver) -> Self {
         let gateway = if gateway.ends_with('/') {
@@ -886,13 +840,22 @@ pub fn fetch_and_verify_bytes(
     Ok(bytes)
 }
 
-/// A composite resolver that attempts resolution through a chain of resolvers.
+#[cfg(feature = "http")]
+impl<R: StyleResolver> citum_schema::StyleResolver for VerifyingResolver<R> {
+    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
+        StyleResolver::resolve_style(self, uri)
+            .map_err(|err| resolution_error_from_store_error(uri, err))
+    }
+}
+
+/// A resolver that chains multiple resolvers and tries them in order.
 pub struct ChainResolver {
     resolvers: Vec<Box<dyn StyleResolver>>,
 }
 
 impl ChainResolver {
-    /// Create a new chain resolver with the given list of resolvers.
+    /// Create a new `ChainResolver` with the given list of resolvers.
+    #[must_use]
     pub fn new(resolvers: Vec<Box<dyn StyleResolver>>) -> Self {
         ChainResolver { resolvers }
     }
@@ -935,26 +898,22 @@ fn resolution_error_from_store_error(
 ) -> citum_schema::ResolutionError {
     match err {
         ResolverError::IntegrityFailure {
-            uri: e_uri,
-            expected,
-            actual,
+            expected, actual, ..
         } => citum_schema::ResolutionError::IntegrityFailure {
-            uri: e_uri,
+            uri: uri.into(),
             expected,
             actual,
         },
         ResolverError::VersionMismatch {
-            uri: e_uri,
-            required,
-            declared,
+            required, declared, ..
         } => citum_schema::ResolutionError::VersionMismatch {
-            uri: e_uri,
+            uri: uri.into(),
             required,
             declared,
         },
-        other => citum_schema::ResolutionError::UriResolutionFailed {
-            uri: uri.to_string(),
-            reason: other.to_string(),
+        _ => citum_schema::ResolutionError::UriResolutionFailed {
+            uri: uri.into(),
+            reason: err.to_string(),
         },
     }
 }

--- a/docs/guides/DISTRIBUTED_REGISTRIES.md
+++ b/docs/guides/DISTRIBUTED_REGISTRIES.md
@@ -257,7 +257,7 @@ on a connected machine via `citum style add`, then copy
 |----------------------------------------|--------------------------------------------------------------|-----------------------------------------------------------|
 | `style not found: '<name>'`            | The chain exhausted without finding the style.               | Check spelling; `citum registry list`; `citum style list`. |
 | `host '<x>' not in resolver allowlist` | A registry's `allowed_hosts` rejects this URL.               | Configure the registry to allow the host or use a different URL. |
-| `network error fetching <uri>: ...`    | DNS, TLS, timeout, or git binary missing.                    | Check connectivity; for git URIs, ensure `git` is on PATH. |
+| `network error fetching <uri>: ...`    | DNS, TLS, timeout, or remote unreachable.                    | Check connectivity and URI validity.                      |
 | `extends-pin integrity check failed`   | The fetched parent's content does not match the declared CID. | The parent has changed: update the pin (after reviewing) or revert the parent. |
 | `style requires citum-version ...`     | Style declares a minimum engine version newer than yours.    | Upgrade `citum`, or use an older style.                   |
 | `inheritance loop detected at base ...` | A cycle in `extends:`.                                       | Break the cycle in one of the offending YAMLs.            |

--- a/docs/specs/DISTRIBUTED_RESOLVER.md
+++ b/docs/specs/DISTRIBUTED_RESOLVER.md
@@ -190,23 +190,19 @@ URI scheme: `git+https://github.com/org/repo/styles/apa-7th.yaml@main`
 
 ```rust
 pub struct GitResolver {
-    repo_url: Url,
-    branch: String,         // default: "main"
-    styles_dir: String,     // path within repo, default: "styles/"
-    cache: Arc<dyn ResolverCache>,
-    allowed_origins: Vec<String>,
+    cache_dir: PathBuf,
 }
 ```
 
 Maintains a local shallow clone in the cache directory
 (`<cache_dir>/citum/git/<sha256_of_repo_url>/`). First access runs
-`git clone --depth=1 --filter=blob:none --sparse`; subsequent accesses run
-`git fetch --depth=1` if the TTL has expired.
+a shallow clone (`--depth=1`); subsequent accesses re-use the cache if fresh.
 
-Git operations use `std::process::Command` against the system `git` binary. If
-`git` is unavailable, returns `ResolverError::NetworkError` with reason "git
-binary not found". The `git` feature is opt-in in `citum_store/Cargo.toml`
-(no additional library dependencies).
+Git operations are handled internally by the `gix` (Gitoxide) library. It
+performs a shallow clone and extracts the requested file directly from the
+`HEAD` tree. This removes the dependency on an external `git` binary. The
+`http` feature (which includes `gix`) is opt-in in `citum_store/Cargo.toml`
+to keep WASM and embedded builds lean.
 
 **When to use GitResolver vs HttpResolver.** `GitResolver` is best suited to
 institutional registries where a publisher maintains a private collection and


### PR DESCRIPTION
Removes the system Git CLI dependency by using the pure-Rust gix library for remote registry resolution. This ensures the citum binary is self-contained and functions in environments without git installed.