### PR TITLE
ci: drop ruby, upgrade actions to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
 name: CI
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   push:
@@ -28,8 +26,8 @@ jobs:
       hygiene: ${{ steps.filter.outputs.hygiene }}
       semver: ${{ steps.filter.outputs.semver }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -68,7 +66,7 @@ jobs:
     if: ${{ needs.changes.outputs.hygiene == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -93,14 +91,9 @@ jobs:
           sudo install -m 0755 /tmp/beans /usr/local/bin/beans
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.3"
 
       - name: Install script dependencies
         run: npm install --prefix scripts
@@ -142,7 +135,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -191,7 +184,7 @@ jobs:
           needs.changes.outputs.semver == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -11,9 +11,6 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   report:
     name: Generate and Deploy Docs
@@ -33,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -52,7 +49,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
@@ -87,7 +84,7 @@ jobs:
           cp target/migration-behavior-report.html docs/migration-behavior-report.html
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
@@ -96,7 +93,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Display sccache stats
         run: sccache --show-stats

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -1,6 +1,4 @@
 name: Fidelity
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   push:
@@ -32,7 +30,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -46,7 +44,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,4 @@
 name: Release
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   pull_request:
@@ -36,7 +34,7 @@ jobs:
       bump-level: ${{ steps.infer.outputs.level }}
       should-release: ${{ steps.infer.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -76,7 +74,7 @@ jobs:
     if: needs.detect.outputs.should-release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -230,7 +228,7 @@ jobs:
       github.event.pull_request.head.ref == 'release/next'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/scripts/validate-frontmatter.sh
+++ b/scripts/validate-frontmatter.sh
@@ -40,9 +40,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if ! command -v ruby >/dev/null 2>&1; then
-  echo "Error: Ruby is required for scripts/validate-frontmatter.sh." >&2
-  echo "Install Ruby or run in an environment with Ruby in PATH." >&2
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: Node.js is required for scripts/validate-frontmatter.sh." >&2
   exit 1
 fi
 
@@ -66,76 +65,81 @@ if [[ ${#files[@]} -eq 0 ]]; then
   exit 0
 fi
 
-ruby - "$COPILOT_STRICT" "${files[@]}" <<'RUBY'
-require 'yaml'
+SCRIPTS_DIR="$REPO_ROOT/scripts" node - "$COPILOT_STRICT" "${files[@]}" <<'JS'
+const fs = require('fs');
+const path = require('path');
+const yaml = require(path.join(process.env.SCRIPTS_DIR, 'node_modules/js-yaml'));
 
-copilot_strict = ARGV.shift == 'true'
-files = ARGV
-errors = []
+const [,, copilotStrictArg, ...files] = process.argv;
+const copilotStrict = copilotStrictArg === 'true';
+const errors = [];
 
-files.each do |file|
-  text = File.read(file, encoding: 'UTF-8')
+for (const file of files) {
+  const text = fs.readFileSync(file, 'utf8');
 
-  unless text.start_with?("---\n")
-    errors << "#{file}:1 missing frontmatter start delimiter (---)"
-    next
-  end
+  if (!text.startsWith('---\n')) {
+    errors.push(`${file}:1 missing frontmatter start delimiter (---)`);
+    continue;
+  }
 
-  match = text.match(/\A---\n(.*?)\n---\n?/m)
-  if match.nil?
-    errors << "#{file}:1 malformed frontmatter delimiters"
-    next
-  end
+  const match = text.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) {
+    errors.push(`${file}:1 malformed frontmatter delimiters`);
+    continue;
+  }
 
-  frontmatter = match[1]
-  begin
-    parsed = YAML.safe_load(frontmatter, permitted_classes: [], aliases: false)
-  rescue Psych::SyntaxError => e
-    line = e.line ? e.line + 1 : 1
-    errors << "#{file}:#{line} YAML parse error: #{e.problem}"
-    next
-  end
+  const frontmatter = match[1];
+  let parsed;
+  try {
+    parsed = yaml.load(frontmatter, { schema: yaml.CORE_SCHEMA });
+  } catch (e) {
+    const line = e.mark ? e.mark.line + 2 : 1;
+    errors.push(`${file}:${line} YAML parse error: ${e.reason || e.message}`);
+    continue;
+  }
 
-  unless parsed.is_a?(Hash)
-    errors << "#{file}:1 frontmatter must be a YAML mapping"
-    next
-  end
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    errors.push(`${file}:1 frontmatter must be a YAML mapping`);
+    continue;
+  }
 
-  %w[name description].each do |key|
-    value = parsed[key]
-    if !value.is_a?(String) || value.strip.empty?
-      errors << "#{file}:1 required key '#{key}' must be a non-empty string"
-    end
-  end
+  for (const key of ['name', 'description']) {
+    const value = parsed[key];
+    if (typeof value !== 'string' || value.trim() === '') {
+      errors.push(`${file}:1 required key '${key}' must be a non-empty string`);
+    }
+  }
 
-  next unless copilot_strict
+  if (!copilotStrict) continue;
 
-  frontmatter.each_line.with_index(2) do |line, line_no|
-    stripped = line.strip
-    next if stripped.empty? || stripped.start_with?('#')
+  const lines = frontmatter.split('\n');
+  lines.forEach((line, idx) => {
+    const lineNo = idx + 2;
+    const stripped = line.trim();
+    if (!stripped || stripped.startsWith('#')) return;
 
-    key_value = stripped.match(/^([A-Za-z0-9_-]+):\s*(.+)$/)
-    next unless key_value
+    const kv = stripped.match(/^([A-Za-z0-9_-]+):\s*(.+)$/);
+    if (!kv) return;
 
-    value = key_value[2].strip
-    next if value.empty?
-    next if value.start_with?("'", '"', '[', '{', '|', '>', '&', '*', '!')
+    const value = kv[2].trim();
+    if (!value) return;
+    if (/^['"\[{|>&*!]/.test(value)) return;
 
-    risky_characters = value.match?(/[:\[\]\(\)\|]/)
-    risky_options = value.match?(/\[[^\]]+\]/) || value.match?(/--[A-Za-z0-9_-]+/) || value.match?(/\s+or\s+/)
+    const riskyChars = /[:\[\]()|]/.test(value);
+    const riskyOpts = /\[[^\]]+\]/.test(value) || /--[A-Za-z0-9_-]+/.test(value) || /\s+or\s+/.test(value);
 
-    if risky_characters || risky_options
-      errors << "#{file}:#{line_no} copilot-strict: quote risky plain scalar for '#{key_value[1]}'"
-    end
-  end
-end
+    if (riskyChars || riskyOpts) {
+      errors.push(`${file}:${lineNo} copilot-strict: quote risky plain scalar for '${kv[1]}'`);
+    }
+  });
+}
 
-if errors.empty?
-  puts "Frontmatter validation passed for #{files.length} file(s)."
-  exit 0
-end
+if (errors.length === 0) {
+  console.log(`Frontmatter validation passed for ${files.length} file(s).`);
+  process.exit(0);
+}
 
-puts "Frontmatter validation failed (#{errors.length} issue#{errors.length == 1 ? '' : 's'}):"
-errors.each { |err| puts "- #{err}" }
-exit 1
-RUBY
+console.log(`Frontmatter validation failed (${errors.length} issue${errors.length === 1 ? '' : 's'}):`);
+errors.forEach(err => console.log(`- ${err}`));
+process.exit(1);
+JS


### PR DESCRIPTION
## Summary

- Replaces the Ruby YAML heredoc in `scripts/validate-frontmatter.sh` with an inline Node script using `js-yaml` (already a `scripts/` dependency) — eliminates the only Ruby usage in the repo
- Removes the `setup-ruby` step from the `checks` CI job
- Upgrades all `node20`-runtime action pins to `node24`-native versions: `checkout@v5`, `paths-filter@v4`, `setup-node@v5`, `configure-pages@v6`, `deploy-pages@v5`
- Removes the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround from all four workflow files

## Test plan

- [x] CI `checks` job passes without `setup-ruby`
- [x] `validate-frontmatter.sh --repo-only --copilot-strict` passes locally
- [x] No Node deprecation warnings in CI run
