### PR TITLE
feat/server chain wiring

### DIFF
--- a/.beans/archive/csl26-9iag--wire-chainresolver-into-citum-server-via-store-hel.md
+++ b/.beans/archive/csl26-9iag--wire-chainresolver-into-citum-server-via-store-hel.md
@@ -1,10 +1,18 @@
 ---
 # csl26-9iag
 title: Wire ChainResolver into citum-server via store helper
-status: in-progress
+status: completed
 type: feature
 created_at: 2026-05-08T20:51:53Z
 updated_at: 2026-05-08T20:51:53Z
 ---
 
 Extract build_standard_chain() into citum_store so both CLI and server share the same resolver construction. Three commits: (A) refactor(store): extract standard chain builder into chain.rs module; (B) refactor(cli): delegate load_any_style to store helper; (C) feat(server): wire ChainResolver into style loading. Closes the deferred follow-up in docs/specs/DISTRIBUTED_RESOLVER.md lines 671-682.
+
+## Summary of Changes
+
+- Added chain.rs to citum_store (http feature) with build_standard_chain() and registry_resolvers()
+- CLI load_any_style() now delegates chain construction to store; keeps strsim suggestion logic
+- citum-server gains citum_store http dep; load_style() uses build_standard_chain()
+- Server can now resolve styles by name, path, or URI (not just absolute file paths)
+- All 1225 workspace tests pass

--- a/.beans/csl26-9iag--wire-chainresolver-into-citum-server-via-store-hel.md
+++ b/.beans/csl26-9iag--wire-chainresolver-into-citum-server-via-store-hel.md
@@ -1,0 +1,10 @@
+---
+# csl26-9iag
+title: Wire ChainResolver into citum-server via store helper
+status: in-progress
+type: feature
+created_at: 2026-05-08T20:51:53Z
+updated_at: 2026-05-08T20:51:53Z
+---
+
+Extract build_standard_chain() into citum_store so both CLI and server share the same resolver construction. Three commits: (A) refactor(store): extract standard chain builder into chain.rs module; (B) refactor(cli): delegate load_any_style to store helper; (C) feat(server): wire ChainResolver into style loading. Closes the deferred follow-up in docs/specs/DISTRIBUTED_RESOLVER.md lines 671-682.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "axum",
  "citum-engine",
  "citum-schema",
+ "citum_store",
  "clap",
  "serde",
  "serde_json",

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -1,6 +1,6 @@
 use citum_engine::{Processor, io::LoadedBibliography};
 use citum_schema::{Locale, Style, locale::types::LocaleOverride};
-use citum_store::{StoreConfig, StoreResolver, platform_config_dir, platform_data_dir};
+use citum_store::platform_config_dir;
 use serde::Deserialize;
 use std::error::Error;
 use std::fs;
@@ -62,118 +62,6 @@ fn registry_candidate_names() -> Vec<String> {
             }),
     );
     candidates
-}
-
-fn registry_resolvers() -> Result<Vec<Box<dyn citum_store::resolver::StyleResolver>>, Box<dyn Error>>
-{
-    use citum_store::resolver::{GitResolver, HttpResolver, RegistryResolver, StyleResolver};
-
-    let mut resolvers: Vec<Box<dyn StyleResolver>> = Vec::new();
-
-    let local_path = Path::new("citum-registry.yaml");
-    if local_path.exists()
-        && let Ok(registry) = citum_schema::StyleRegistry::load_from_file(local_path)
-    {
-        resolvers.push(Box::new(
-            RegistryResolver::new(registry).with_base_dir(std::env::current_dir()?),
-        ));
-    }
-
-    for name in configured_registry_names() {
-        let Some(path) = configured_registry_path(&name) else {
-            continue;
-        };
-        if !path.exists() {
-            continue;
-        }
-        let Ok(registry) = citum_schema::StyleRegistry::load_from_file(&path) else {
-            continue;
-        };
-        let base_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
-        let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
-        let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
-            resolver.with_http(http)
-        } else {
-            resolver
-        };
-        let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
-            resolver.with_git(git)
-        } else {
-            resolver
-        };
-        resolvers.push(Box::new(resolver));
-    }
-
-    // Wire StoreConfig.registries entries not yet tracked in registry-sources.json
-    if let Ok(config) = StoreConfig::load() {
-        let tracked_names = configured_registry_names();
-
-        for registry_config in &config.registries {
-            // Skip if already tracked in registry-sources.json
-            if tracked_names.contains(&registry_config.name) {
-                continue;
-            }
-
-            // Try to load from cache
-            if let Some(path) = configured_registry_path(&registry_config.name)
-                && path.exists()
-                && let Ok(registry) = citum_schema::StyleRegistry::load_from_file(&path)
-            {
-                let base_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
-                let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
-                let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
-                    resolver.with_http(http)
-                } else {
-                    resolver
-                };
-                let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
-                    resolver.with_git(git)
-                } else {
-                    resolver
-                };
-                resolvers.push(Box::new(resolver));
-                continue;
-            }
-
-            // Fetch from URL and cache it
-            if let Some(http) = HttpResolver::from_platform_cache_dir()
-                && let Ok(bytes) = http.fetch_bytes(&registry_config.url)
-                && let Ok(registry) = serde_yaml::from_slice::<citum_schema::StyleRegistry>(&bytes)
-            {
-                if let Some(path) = configured_registry_path(&registry_config.name) {
-                    let _ = fs::create_dir_all(path.parent().unwrap_or(Path::new(".")));
-                    let _ = fs::write(&path, &bytes);
-                }
-                let base_dir = configured_registry_path(&registry_config.name)
-                    .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-                    .unwrap_or_else(|| Path::new(".").to_path_buf());
-                let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
-                let resolver = resolver.with_http(http);
-                let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
-                    resolver.with_git(git)
-                } else {
-                    resolver
-                };
-                resolvers.push(Box::new(resolver));
-            }
-        }
-    }
-
-    let resolver = RegistryResolver::new(citum_schema::embedded::default_registry())
-        .with_base_dir(std::env::current_dir()?);
-    let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
-        resolver.with_http(http)
-    } else {
-        resolver
-    };
-    let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
-        resolver.with_git(git)
-    } else {
-        resolver
-    };
-    resolvers.push(Box::new(resolver));
-
-    Ok(resolvers)
 }
 
 pub(crate) fn load_locale_file(path: &Path) -> Result<Locale, Box<dyn Error>> {
@@ -263,36 +151,10 @@ pub(crate) fn load_any_style(
     style_input: &str,
     _no_semantics: bool,
 ) -> Result<Style, Box<dyn Error>> {
-    use citum_store::resolver::{
-        ChainResolver, EmbeddedResolver, FileResolver, GitResolver, HttpResolver, StyleResolver,
-    };
+    use citum_store::resolver::{ResolverError, StyleResolver};
 
-    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
-
-    // Try user store if it exists
-    if let Some(data_dir) = platform_data_dir()
-        && data_dir.exists()
-    {
-        let config = StoreConfig::load().unwrap_or_default();
-        resolvers.push(Box::new(StoreResolver::new(
-            data_dir,
-            config.store_format(),
-        )));
-    }
-
-    if let Some(http) = HttpResolver::from_platform_cache_dir() {
-        resolvers.push(Box::new(http));
-    }
-
-    if let Some(git) = GitResolver::from_platform_cache_dir() {
-        resolvers.push(Box::new(git));
-    }
-
-    resolvers.extend(registry_resolvers()?);
-
-    resolvers.push(Box::new(EmbeddedResolver));
-
-    let chain = ChainResolver::new(resolvers);
+    let chain = citum_store::build_standard_chain()
+        .map_err(|e| -> Box<dyn Error> { Box::new(std::io::Error::other(e.to_string())) })?;
 
     match chain.resolve_style(style_input) {
         Ok(style) => {
@@ -300,7 +162,7 @@ pub(crate) fn load_any_style(
             resolved.extends = None;
             Ok(resolved)
         }
-        Err(citum_store::resolver::ResolverError::StyleNotFound(_)) => {
+        Err(ResolverError::StyleNotFound(_)) => {
             let candidates = registry_candidate_names();
             let suggestions: Vec<_> = candidates
                 .iter()

--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 citum-engine = { package = "citum-engine", path = "../citum-engine" }
 citum-schema = { package = "citum-schema", path = "../citum-schema" }
+citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }

--- a/crates/citum-server/src/error.rs
+++ b/crates/citum-server/src/error.rs
@@ -11,13 +11,21 @@ use thiserror::Error;
 /// Server-level errors.
 #[derive(Error, Debug)]
 pub enum ServerError {
-    /// The style file loaded successfully but failed schema validation.
+    /// The style YAML was found but failed to parse or validate against the schema.
     #[error("style validation failed: {0}")]
     StyleValidation(String),
 
-    /// The requested style file could not be found on disk.
+    /// No resolver in the chain could locate the requested style name, path, or URI.
     #[error("style not found: {0}")]
     StyleNotFound(String),
+
+    /// The style was found but inheritance or template resolution failed.
+    #[error("style resolution failed: {0}")]
+    StyleResolution(String),
+
+    /// The chain resolver itself failed to initialize or run.
+    #[error("resolver error: {0}")]
+    ResolverError(String),
 
     /// Bibliography input could not be deserialized or rendered.
     #[error("bibliography processing failed: {0}")]

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -11,9 +11,7 @@ use citum_engine::{
 use citum_schema::Style;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::fs;
 use std::io::{self, BufRead, Write};
-use std::path::Path;
 
 /// JSON-RPC request envelope.
 #[derive(Debug, Deserialize)]
@@ -225,19 +223,30 @@ fn validate_style(params: &Value, id: Value) -> Result<Value, ServerError> {
     }
 }
 
-/// Load a style from a YAML file.
-fn load_style(style_path: &str) -> Result<Style, ServerError> {
-    let path = Path::new(style_path);
+/// Load a style through the standard resolver chain.
+///
+/// The chain includes file, store, HTTP, git, and registry resolvers.
+/// This server is intended for local use only; do not expose it to untrusted
+/// clients, as `style_input` can trigger outbound network requests (SSRF risk).
+fn load_style(style_input: &str) -> Result<Style, ServerError> {
+    use citum_store::resolver::{ResolverError, StyleResolver};
 
-    // Check if file exists.
-    if !path.exists() {
-        return Err(ServerError::StyleNotFound(style_path.to_string()));
+    let chain = citum_store::build_standard_chain()
+        .map_err(|e| ServerError::ResolverError(e.to_string()))?;
+
+    match chain.resolve_style(style_input) {
+        Ok(style) => {
+            let mut resolved = style
+                .try_into_resolved_with(Some(&chain))
+                .map_err(|e| ServerError::StyleResolution(e.to_string()))?;
+            resolved.extends = None;
+            Ok(resolved)
+        }
+        Err(ResolverError::StyleNotFound(_)) => {
+            Err(ServerError::StyleNotFound(style_input.to_string()))
+        }
+        Err(e) => Err(ServerError::ResolverError(e.to_string())),
     }
-
-    let content =
-        fs::read_to_string(path).map_err(|_| ServerError::StyleNotFound(style_path.to_string()))?;
-
-    Style::from_yaml_str(&content).map_err(|e| ServerError::StyleValidation(e.to_string()))
 }
 
 /// Run the JSON-RPC server on stdin/stdout.

--- a/crates/citum_store/src/chain.rs
+++ b/crates/citum_store/src/chain.rs
@@ -1,0 +1,183 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Standard ChainResolver construction for platform-aware style resolution.
+
+use crate::{
+    StoreConfig, StoreResolver, platform_config_dir, platform_data_dir,
+    resolver::{
+        ChainResolver, EmbeddedResolver, FileResolver, GitResolver, HttpResolver, RegistryResolver,
+        StyleResolver,
+    },
+};
+use std::{error::Error, fs, path::Path};
+
+/// Construct a `ChainResolver` with the standard platform resolver stack.
+///
+/// Order: FileResolver → StoreResolver → HttpResolver → GitResolver →
+/// registry resolvers (local + configured + embedded default) → EmbeddedResolver.
+///
+/// # Errors
+///
+/// Returns an error if the current working directory cannot be determined.
+pub fn build_standard_chain() -> Result<ChainResolver, Box<dyn Error + Send + Sync>> {
+    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
+
+    if let Some(data_dir) = platform_data_dir()
+        && data_dir.exists()
+    {
+        let config = StoreConfig::load().unwrap_or_default();
+        resolvers.push(Box::new(StoreResolver::new(
+            data_dir,
+            config.store_format(),
+        )));
+    }
+
+    if let Some(http) = HttpResolver::from_platform_cache_dir() {
+        resolvers.push(Box::new(http));
+    }
+
+    if let Some(git) = GitResolver::from_platform_cache_dir() {
+        resolvers.push(Box::new(git));
+    }
+
+    resolvers.extend(registry_resolvers()?);
+
+    resolvers.push(Box::new(EmbeddedResolver));
+
+    Ok(ChainResolver::new(resolvers))
+}
+
+#[derive(serde::Deserialize)]
+struct RegistrySourceRecord {
+    name: String,
+}
+
+fn registry_sources_path() -> Option<std::path::PathBuf> {
+    platform_config_dir().map(|dir| dir.join("registry-sources.json"))
+}
+
+fn configured_registry_path(name: &str) -> Option<std::path::PathBuf> {
+    platform_config_dir().map(|dir| dir.join("registries").join(format!("{name}.yaml")))
+}
+
+fn configured_registry_names() -> Vec<String> {
+    let Some(path) = registry_sources_path() else {
+        return Vec::new();
+    };
+    let Ok(bytes) = fs::read(path) else {
+        return Vec::new();
+    };
+    let Ok(records) = serde_json::from_slice::<Vec<RegistrySourceRecord>>(&bytes) else {
+        return Vec::new();
+    };
+    records.into_iter().map(|record| record.name).collect()
+}
+
+fn registry_resolvers() -> Result<Vec<Box<dyn StyleResolver>>, Box<dyn Error + Send + Sync>> {
+    let mut resolvers: Vec<Box<dyn StyleResolver>> = Vec::new();
+
+    let local_path = Path::new("citum-registry.yaml");
+    if local_path.exists()
+        && let Ok(registry) = citum_schema::StyleRegistry::load_from_file(local_path)
+    {
+        resolvers.push(Box::new(
+            RegistryResolver::new(registry).with_base_dir(std::env::current_dir()?),
+        ));
+    }
+
+    for name in configured_registry_names() {
+        let Some(path) = configured_registry_path(&name) else {
+            continue;
+        };
+        if !path.exists() {
+            continue;
+        }
+        let Ok(registry) = citum_schema::StyleRegistry::load_from_file(&path) else {
+            continue;
+        };
+        let base_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
+        let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
+            resolver.with_http(http)
+        } else {
+            resolver
+        };
+        let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+            resolver.with_git(git)
+        } else {
+            resolver
+        };
+        resolvers.push(Box::new(resolver));
+    }
+
+    // Wire StoreConfig.registries entries not yet tracked in registry-sources.json
+    if let Ok(config) = StoreConfig::load() {
+        let tracked_names = configured_registry_names();
+
+        for registry_config in &config.registries {
+            if tracked_names.contains(&registry_config.name) {
+                continue;
+            }
+
+            if let Some(path) = configured_registry_path(&registry_config.name)
+                && path.exists()
+                && let Ok(registry) = citum_schema::StyleRegistry::load_from_file(&path)
+            {
+                let base_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+                let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
+                let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
+                    resolver.with_http(http)
+                } else {
+                    resolver
+                };
+                let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+                    resolver.with_git(git)
+                } else {
+                    resolver
+                };
+                resolvers.push(Box::new(resolver));
+                continue;
+            }
+
+            if let Some(http) = HttpResolver::from_platform_cache_dir()
+                && let Ok(bytes) = http.fetch_bytes(&registry_config.url)
+                && let Ok(registry) = serde_yaml::from_slice::<citum_schema::StyleRegistry>(&bytes)
+            {
+                if let Some(path) = configured_registry_path(&registry_config.name) {
+                    let _ = fs::create_dir_all(path.parent().unwrap_or(Path::new(".")));
+                    let _ = fs::write(&path, &bytes);
+                }
+                let base_dir = configured_registry_path(&registry_config.name)
+                    .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+                    .unwrap_or_else(|| Path::new(".").to_path_buf());
+                let resolver = RegistryResolver::new(registry).with_base_dir(base_dir);
+                let resolver = resolver.with_http(http);
+                let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+                    resolver.with_git(git)
+                } else {
+                    resolver
+                };
+                resolvers.push(Box::new(resolver));
+            }
+        }
+    }
+
+    let resolver = RegistryResolver::new(citum_schema::embedded::default_registry())
+        .with_base_dir(std::env::current_dir()?);
+    let resolver = if let Some(http) = HttpResolver::from_platform_cache_dir() {
+        resolver.with_http(http)
+    } else {
+        resolver
+    };
+    let resolver = if let Some(git) = GitResolver::from_platform_cache_dir() {
+        resolver.with_git(git)
+    } else {
+        resolver
+    };
+    resolvers.push(Box::new(resolver));
+
+    Ok(resolvers)
+}

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -6,6 +6,8 @@
 //! and locales, with fallback to embedded builtins. Supports YAML, JSON, and CBOR formats.
 
 #[cfg(feature = "http")]
+pub mod chain;
+#[cfg(feature = "http")]
 pub mod cid;
 pub mod config;
 pub mod format;
@@ -26,14 +28,20 @@ pub mod resolver;
 )]
 mod resolver_tests;
 
+#[cfg(feature = "http")]
+pub use chain::build_standard_chain;
 pub use config::StoreConfig;
 pub use format::StoreFormat;
+#[cfg(feature = "http")]
+pub use resolver::ChainResolver;
 #[cfg(feature = "http")]
 pub use resolver::{
     CidResolver, DEFAULT_CID_GATEWAY, GitResolver, HttpResolver, VerifyingResolver,
     fetch_and_verify_bytes,
 };
-pub use resolver::{RegistryResolver, StoreResolver};
+pub use resolver::{
+    EmbeddedResolver, FileResolver, RegistryResolver, ResolverError, StoreResolver,
+};
 
 use std::path::PathBuf;
 

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -284,10 +284,13 @@ pub struct GitResolver {
 }
 
 /// A resolver that fetches HTTP(S) style URLs and caches them on disk.
+///
+/// The underlying HTTP client is initialized lazily on first use so that
+/// constructing a [`ChainResolver`] is safe inside async Tokio contexts.
 #[cfg(feature = "http")]
 pub struct HttpResolver {
     cache_dir: PathBuf,
-    client: reqwest::blocking::Client,
+    client: std::sync::OnceLock<reqwest::blocking::Client>,
     allowed_hosts: Vec<String>,
 }
 
@@ -300,17 +303,24 @@ const HTTP_CACHE_MAX_AGE: Duration = Duration::from_hours(24);
 #[cfg(feature = "http")]
 impl HttpResolver {
     /// Create a resolver using the provided cache directory.
+    ///
+    /// The HTTP client is not created here; it is initialized lazily on first use.
     #[must_use]
     pub fn new(cache_dir: PathBuf) -> Self {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(HTTP_TIMEOUT)
-            .build()
-            .unwrap_or_else(|_| reqwest::blocking::Client::new());
         Self {
             cache_dir,
-            client,
+            client: std::sync::OnceLock::new(),
             allowed_hosts: Vec::new(),
         }
+    }
+
+    fn client(&self) -> &reqwest::blocking::Client {
+        self.client.get_or_init(|| {
+            reqwest::blocking::Client::builder()
+                .timeout(HTTP_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::blocking::Client::new())
+        })
     }
 
     /// Create a resolver using the platform cache directory.
@@ -331,7 +341,7 @@ impl HttpResolver {
     /// # Errors
     /// Returns an error if the request fails.
     pub fn fetch_bytes(&self, url: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-        let mut response = self.client.get(url).send()?;
+        let mut response = self.client().get(url).send()?;
         if !response.status().is_success() {
             return Err(format!("failed to fetch {url}: status {}", response.status()).into());
         }
@@ -417,7 +427,7 @@ impl StyleResolver for HttpResolver {
             return Self::parse_style(uri, &bytes);
         }
 
-        let fetch_result = self.client.get(uri).send();
+        let fetch_result = self.client().get(uri).send();
 
         match fetch_result {
             Ok(response) => {


### PR DESCRIPTION
## Summary

  - Extracts build_standard_chain() into citum_store::chain (http feature) so the resolver stack is defined once and shared
  - CLI load_any_style() is now a thin wrapper; strsim suggestion logic stays CLI-side
  - citum-server gains a citum_store (http) dep; load_style() now resolves styles by name, path, or URI through the full chain

Closes the deferred follow-up in docs/specs/DISTRIBUTED_RESOLVER.md (lines 671-682).

## Test plan

  - [x] cargo nextest run --workspace -- 1225 tests pass
  - [x] cargo clippy --all-targets clean on all three crates
  - [x] CLI style resolution behaviour unchanged (delegates to same chain logic)
  - [x] Server now resolves named styles (e.g. apa-7th) not just absolute file paths