### PR TITLE
docs: add architectural improvement tracking beans

### DIFF
--- a/.beans/csl26-bdd2--bdd-coverage-for-templatevariantdiff-inheritance.md
+++ b/.beans/csl26-bdd2--bdd-coverage-for-templatevariantdiff-inheritance.md
@@ -1,0 +1,30 @@
+---
+# csl26-bdd2
+title: Add comprehensive BDD coverage for TemplateVariantDiff inheritance chains
+status: todo
+type: task
+priority: high
+created_at: 2026-05-09T00:00:00Z
+updated_at: 2026-05-09T00:00:00Z
+---
+
+The declarative template V3 diff system (`TemplateVariantDiff`) is a core 
+architectural strength, but it introduces significant cognitive and logical 
+complexity when styles utilize deep inheritance or multiple structural overlays.
+
+## Scope
+
+- Design a suite of Behavioral Driven Development (BDD) tests specifically targeting 
+  complex inheritance scenarios in `merge_style_overlay`.
+- Test scenarios should include:
+    - Multiple levels of style inheritance with conflicting variant diffs.
+    - Partial overrides of complex template components.
+    - Interaction between global options and type-specific variant diffs.
+- Ensure that the resolution of structural exceptions remains deterministic and 
+  predictable as the style library grows.
+
+## Rationale
+
+As more complex styles are migrated to the Citum schema, the inheritance logic 
+becomes a critical failure point. Robust BDD coverage ensures that structural 
+integrity is maintained during refactoring or schema evolution.

--- a/.beans/csl26-mrg3--optimize-merge-style-overlay-serialization.md
+++ b/.beans/csl26-mrg3--optimize-merge-style-overlay-serialization.md
@@ -1,0 +1,31 @@
+---
+# csl26-mrg3
+title: Optimize merge_style_overlay to avoid serialization round-trips
+status: todo
+type: task
+priority: low
+created_at: 2026-05-09T00:00:00Z
+updated_at: 2026-05-09T00:00:00Z
+---
+
+The current implementation of `merge_style_overlay` in `citum-schema-style` relies 
+on re-serializing data structures (JSON/YAML) to perform deep merges. While 
+functional and flexible, this adds significant overhead to the style resolution 
+process.
+
+## Scope
+
+- Evaluate and implement a strongly-typed deep merge strategy for Citum styles 
+  that avoids intermediate serialization.
+- The solution must account for the project's multi-format support, which 
+  includes JSON, YAML, and CBOR.
+- Consider utilizing a custom macro or a specialized `Merge` trait to handle 
+  the recursive merging of templates and variants.
+- Baseline the performance of the current serialization-based approach against 
+  the new implementation to verify gains.
+
+## Rationale
+
+Eliminating the serialization round-trip during style merging will reduce 
+latency, particularly in the `citum-server` interactive mode where styles 
+may be resolved or overlaid frequently.

--- a/.beans/csl26-rapi--extract-style-resolver-api-crate.md
+++ b/.beans/csl26-rapi--extract-style-resolver-api-crate.md
@@ -1,0 +1,33 @@
+---
+# csl26-rapi
+title: Extract StyleResolver and related types to a dedicated API crate
+status: todo
+type: task
+priority: normal
+created_at: 2026-05-09T00:00:00Z
+updated_at: 2026-05-09T00:00:00Z
+---
+
+Currently, style resolution uses a "two-trait bridge" to avoid cyclic dependencies 
+between `citum-schema-style` and `citum_store`. This adds mental overhead and 
+boilerplate as both crates define and implement their own version of a 
+`StyleResolver` trait.
+
+## Scope
+
+- Create a new, lightweight `citum-resolver-api` (or `citum-resolve`) crate 
+  with minimal dependencies.
+- Move the `StyleResolver` trait, `ResolverError`, `ResolutionError`, and 
+  related types (like `ResolverCache` interfaces) into this crate.
+- Update `citum-schema`, `citum-engine`, and `citum_store` to import the 
+  canonical traits from the new API crate.
+- Ensure the API crate is zero-dependency (or near-zero) to facilitate 
+  integration by third-party tool authors who don't need the full store logic.
+
+## Rationale
+
+A dedicated API crate provides a single source of truth for resolution 
+interfaces. It simplifies the implementation of remote resolvers (HTTP, Git, CID) 
+and makes the engine more extensible for external integrators who need to 
+provide custom style resolution logic without pulling in the heavy dependency 
+tree of `citum_store`.

--- a/.beans/csl26-xio1--extract-biblatex-conversion-to-io-crate.md
+++ b/.beans/csl26-xio1--extract-biblatex-conversion-to-io-crate.md
@@ -1,0 +1,29 @@
+---
+# csl26-xio1
+title: Extract Biblatex and external input conversions to dedicated I/O crate
+status: todo
+type: task
+priority: normal
+created_at: 2026-05-09T00:00:00Z
+updated_at: 2026-05-09T00:00:00Z
+---
+
+Currently, `InputReference::from_biblatex()` lives within `citum-engine`. To maintain 
+clean architectural boundaries, the engine should strictly focus on processing and 
+rendering logic, while I/O and format conversion should be decoupled.
+
+## Scope
+
+- Create a new `citum-io` or `citum-convert` crate, or evaluate expanding 
+  `citum-migrate` to handle modern external format ingest.
+- Move the `biblatex` dependency and all related conversion logic out of 
+  `citum-engine`.
+- Update the engine API and any server/binding adapters to use the new conversion 
+  pipeline.
+- Ensure that the engine remains agnostic of external metadata formats.
+
+## Rationale
+
+Decoupling I/O from the core engine reduces the engine's dependency tree and 
+allows format-specific conversion logic to evolve independently of the rendering 
+pipeline.


### PR DESCRIPTION
This PR adds four new tracking beans to document and schedule the architectural improvements identified during the recent system review:

1. Extract Biblatex Conversion (csl26-xio1): Move conversion logic out of the core engine to a dedicated I/O crate.
2. BDD Coverage for Template Variants (csl26-bdd2): Add robust testing for complex style inheritance chains.
3. Optimize Style Merging (csl26-mrg3): Replace serialization-based merging with a strongly-typed approach (supporting JSON, YAML, and CBOR).
4. Extract StyleResolver API (csl26-rapi): Decouple the resolution interface from citum_store into a dedicated API crate to eliminate the two-trait bridge.