### PR TITLE
feat(resolver): extract style resolver API crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "citum-bindings",
  "citum-engine",
  "citum-pdf",
+ "citum-resolver-api",
  "citum-schema",
  "citum_store",
  "clap",
@@ -763,6 +764,7 @@ version = "0.38.0"
 dependencies = [
  "ciborium",
  "cid",
+ "citum-resolver-api",
  "citum-schema",
  "dirs",
  "gix",
@@ -774,7 +776,7 @@ dependencies = [
  "serde_yaml_ng",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "toml",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "citum-resolver-api"
+version = "0.38.0"
+dependencies = [
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "citum-schema"
 version = "0.38.0"
 dependencies = [
@@ -716,6 +724,7 @@ dependencies = [
  "ciborium",
  "cid",
  "citum-edtf",
+ "citum-resolver-api",
  "citum-schema-data",
  "criterion",
  "csl-legacy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ members = [
     "crates/citum-server",
     "crates/citum-edtf",
     "crates/citum_store",
-    "crates/citum-bindings"
+    "crates/citum-bindings",
+    "crates/citum-resolver-api"
 ]
 resolver = "2"
 

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -28,6 +28,7 @@ citum_engine = { package = "citum-engine", path = "../citum-engine" }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 biblatex = "0.11"
 citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }
+citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
 citum-pdf = { path = "../citum-pdf", optional = true }
 citum-bindings = { path = "../citum-bindings", optional = true }
 url = { version = "2.5", features = ["serde"] }

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -30,7 +30,7 @@ use citum_schema::InputBibliography;
 use citum_schema::lint::{lint_raw_locale, lint_style_against_locale};
 use citum_schema::locale::RawLocale;
 use citum_schema::options::Processing;
-use citum_schema::{RegistryEntry, Style};
+use citum_schema::{Locale, RegistryEntry, Style};
 use citum_store::{
     StoreConfig, StoreResolver, platform_cache_dir, platform_config_dir, platform_data_dir,
 };
@@ -780,7 +780,8 @@ fn load_unresolved_style(target: &str) -> Result<Style, Box<dyn Error>> {
         return Ok(Style::from_yaml_bytes(&bytes)?);
     }
 
-    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
+    let mut resolvers: Vec<Box<dyn StyleResolver<Style = Style, Locale = Locale>>> =
+        vec![Box::new(FileResolver)];
     if let Some(data_dir) = platform_data_dir()
         && data_dir.exists()
     {
@@ -799,10 +800,12 @@ fn load_unresolved_style(target: &str) -> Result<Style, Box<dyn Error>> {
 /// `Style::try_into_resolved_with(Some(&...))`. CidResolver is intentionally
 /// omitted — `style validate` operates on local bytes and should not silently
 /// reach across the network during a "is my file OK?" check.
-fn build_chain_resolver() -> Result<impl citum_schema::StyleResolver, Box<dyn Error>> {
+fn build_chain_resolver()
+-> Result<impl citum_resolver_api::StyleResolver<Style = Style, Locale = Locale>, Box<dyn Error>> {
     use citum_store::resolver::{ChainResolver, EmbeddedResolver, FileResolver, StyleResolver};
 
-    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
+    let mut resolvers: Vec<Box<dyn StyleResolver<Style = Style, Locale = Locale>>> =
+        vec![Box::new(FileResolver)];
     if let Some(data_dir) = platform_data_dir()
         && data_dir.exists()
     {

--- a/crates/citum-resolver-api/Cargo.toml
+++ b/crates/citum-resolver-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "citum-resolver-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Citum style resolution interfaces and error types"
+
+[dependencies]
+thiserror = "2.0"
+serde_json = { version = "1.0", optional = true }
+
+[features]
+default = ["serde_json"]
+http = []

--- a/crates/citum-resolver-api/Cargo.toml
+++ b/crates/citum-resolver-api/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = { version = "1.0", optional = true }
 [features]
 default = ["serde_json"]
 http = []
+
+[lints]
+workspace = true

--- a/crates/citum-resolver-api/src/error.rs
+++ b/crates/citum-resolver-api/src/error.rs
@@ -1,0 +1,138 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+use std::borrow::Cow;
+use thiserror::Error;
+
+/// Error type for style resolution operations at the store layer.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum ResolverError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid style: {0}")]
+    InvalidStyle(Cow<'static, str>),
+    #[error("style not found: {0}")]
+    StyleNotFound(Cow<'static, str>),
+    #[error("locale not found: {0}")]
+    LocaleNotFound(Cow<'static, str>),
+    #[error("yaml error: {0}")]
+    YamlError(String),
+    #[cfg(feature = "serde_json")]
+    #[error("json error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("cbor error: {0}")]
+    CborError(String),
+    #[cfg(feature = "http")]
+    #[error("http error: {0}")]
+    HttpError(String),
+    #[cfg(feature = "http")]
+    #[error("git error: {0}")]
+    GitError(String),
+    /// The URI host or origin is not in the resolver's allowlist.
+    #[error("host not in resolver allowlist: {uri} ({reason})")]
+    Denied { uri: String, reason: String },
+    /// The style's `citum-version` is not compatible with the running engine.
+    #[error(
+        "engine version mismatch for {uri}: engine requires {required}, style declares {declared}"
+    )]
+    VersionMismatch {
+        uri: String,
+        required: String,
+        declared: String,
+    },
+    /// The content does not match the expected integrity hash.
+    #[error("integrity failure for {uri}: expected {expected}, got {actual}")]
+    IntegrityFailure {
+        uri: String,
+        expected: String,
+        actual: String,
+    },
+    /// Generic network or transport failure.
+    #[error("network error fetching {uri}: {reason}")]
+    NetworkError { uri: String, reason: String },
+}
+
+/// Error type for style resolution and inheritance processing at the schema layer.
+#[derive(Error, Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ResolutionError {
+    /// A `profile` style attempted to override template-bearing structure.
+    #[error("profile styles may not override template-bearing field `{location}`")]
+    InvalidProfileOverride {
+        /// Human-readable location hint.
+        location: String,
+    },
+    /// An inheritance loop was detected.
+    #[error("inheritance loop detected at base `{base}`")]
+    InheritanceLoop {
+        /// Base key that closed the cycle.
+        base: String,
+    },
+    /// A `file://` URI could not be resolved.
+    #[error("failed to resolve URI `{uri}`: {reason}")]
+    UriResolutionFailed {
+        /// The URI that failed to resolve.
+        uri: String,
+        /// Reason for failure.
+        reason: String,
+    },
+    /// A Template V3 variant references a missing parent variant.
+    #[error("template variant `{location}` extends missing variant `{selector}`")]
+    MissingTemplateVariantParent {
+        /// Human-readable location hint.
+        location: String,
+        /// Parent selector that could not be found.
+        selector: String,
+    },
+    /// A Template V3 variant parent chain contains a cycle.
+    #[error("template variant inheritance loop at `{location}` through `{selector}`")]
+    TemplateVariantCycle {
+        /// Human-readable location hint.
+        location: String,
+        /// Selector that closed the cycle.
+        selector: String,
+    },
+    /// A Template V3 operation matched no components.
+    #[error("template variant operation in `{location}` matched no component")]
+    TemplateVariantAnchorNotFound {
+        /// Human-readable location hint.
+        location: String,
+    },
+    /// A Template V3 operation matched more than one component.
+    #[error("template variant operation in `{location}` matched multiple components")]
+    TemplateVariantAmbiguousAnchor {
+        /// Human-readable location hint.
+        location: String,
+    },
+    /// A Template V3 add operation does not define exactly one anchor.
+    #[error("template variant add operation in `{location}` must specify exactly one of before/after")]
+    InvalidTemplateVariantAdd {
+        /// Human-readable location hint.
+        location: String,
+    },
+    /// The fetched parent style's content did not hash to the value declared
+    /// in `extends-pin`.
+    #[error("extends-pin integrity check failed for `{uri}`: expected {expected}, got {actual}")]
+    IntegrityFailure {
+        /// URI of the parent that failed integrity verification.
+        uri: String,
+        /// CID declared in the child's `extends-pin`.
+        expected: String,
+        /// CID computed from the bytes the resolver actually returned.
+        actual: String,
+    },
+    /// The fetched style declares a `citum-version` requirement that the
+    /// running engine does not satisfy.
+    #[error("style `{uri}` requires citum-version `{required}`; running engine is `{declared}`")]
+    VersionMismatch {
+        /// URI whose `citum-version` requirement was unsatisfiable.
+        uri: String,
+        /// `citum-version` requirement declared by the style's `info` block.
+        required: String,
+        /// Version of the running engine.
+        declared: String,
+    },
+}

--- a/crates/citum-resolver-api/src/error.rs
+++ b/crates/citum-resolver-api/src/error.rs
@@ -136,3 +136,29 @@ pub enum ResolutionError {
         declared: String,
     },
 }
+
+impl ResolutionError {
+    /// Convert a [`ResolverError`] into a [`ResolutionError`] for a specific URI.
+    pub fn from_resolver_error(uri: &str, err: ResolverError) -> Self {
+        match err {
+            ResolverError::IntegrityFailure {
+                expected, actual, ..
+            } => ResolutionError::IntegrityFailure {
+                uri: uri.into(),
+                expected,
+                actual,
+            },
+            ResolverError::VersionMismatch {
+                required, declared, ..
+            } => ResolutionError::VersionMismatch {
+                uri: uri.into(),
+                required,
+                declared,
+            },
+            _ => ResolutionError::UriResolutionFailed {
+                uri: uri.into(),
+                reason: err.to_string(),
+            },
+        }
+    }
+}

--- a/crates/citum-resolver-api/src/error.rs
+++ b/crates/citum-resolver-api/src/error.rs
@@ -10,49 +10,74 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum ResolverError {
+    /// An underlying I/O error occurred.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    /// The style content is malformed or invalid for the target version.
     #[error("invalid style: {0}")]
     InvalidStyle(Cow<'static, str>),
+    /// The requested style could not be located.
     #[error("style not found: {0}")]
     StyleNotFound(Cow<'static, str>),
+    /// The requested locale could not be located.
     #[error("locale not found: {0}")]
     LocaleNotFound(Cow<'static, str>),
+    /// Failure during YAML deserialization.
     #[error("yaml error: {0}")]
     YamlError(String),
+    /// Failure during JSON deserialization.
     #[cfg(feature = "serde_json")]
     #[error("json error: {0}")]
     JsonError(#[from] serde_json::Error),
+    /// Failure during CBOR deserialization.
     #[error("cbor error: {0}")]
     CborError(String),
+    /// A network failure occurred during HTTP fetch.
     #[cfg(feature = "http")]
     #[error("http error: {0}")]
     HttpError(String),
+    /// A failure occurred during a Git operation.
     #[cfg(feature = "http")]
     #[error("git error: {0}")]
     GitError(String),
     /// The URI host or origin is not in the resolver's allowlist.
     #[error("host not in resolver allowlist: {uri} ({reason})")]
-    Denied { uri: String, reason: String },
+    Denied {
+        /// The URI that was denied.
+        uri: String,
+        /// Reason for the denial.
+        reason: String,
+    },
     /// The style's `citum-version` is not compatible with the running engine.
     #[error(
         "engine version mismatch for {uri}: engine requires {required}, style declares {declared}"
     )]
     VersionMismatch {
+        /// URI of the style with the incompatible version.
         uri: String,
+        /// Version requirement declared by the style.
         required: String,
+        /// Version of the running engine.
         declared: String,
     },
     /// The content does not match the expected integrity hash.
     #[error("integrity failure for {uri}: expected {expected}, got {actual}")]
     IntegrityFailure {
+        /// URI of the content that failed verification.
         uri: String,
+        /// The expected CIDv1 string.
         expected: String,
+        /// The CID computed from the actual content bytes.
         actual: String,
     },
     /// Generic network or transport failure.
     #[error("network error fetching {uri}: {reason}")]
-    NetworkError { uri: String, reason: String },
+    NetworkError {
+        /// URI of the failed fetch.
+        uri: String,
+        /// Reason for the network failure.
+        reason: String,
+    },
 }
 
 /// Error type for style resolution and inheritance processing at the schema layer.
@@ -108,7 +133,9 @@ pub enum ResolutionError {
         location: String,
     },
     /// A Template V3 add operation does not define exactly one anchor.
-    #[error("template variant add operation in `{location}` must specify exactly one of before/after")]
+    #[error(
+        "template variant add operation in `{location}` must specify exactly one of before/after"
+    )]
     InvalidTemplateVariantAdd {
         /// Human-readable location hint.
         location: String,
@@ -139,6 +166,7 @@ pub enum ResolutionError {
 
 impl ResolutionError {
     /// Convert a [`ResolverError`] into a [`ResolutionError`] for a specific URI.
+    #[must_use]
     pub fn from_resolver_error(uri: &str, err: ResolverError) -> Self {
         match err {
             ResolverError::IntegrityFailure {

--- a/crates/citum-resolver-api/src/lib.rs
+++ b/crates/citum-resolver-api/src/lib.rs
@@ -5,10 +5,13 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Canonical style resolution interfaces for the Citum citation engine.
 //!
-//! This crate provides a lightweight, zero-dependency (by default) bridge
-//! between the schema layer (which defines style models) and the store layer
-//! (which implements persistence and network resolution).
+//! This crate provides a lightweight bridge between the schema layer
+//! (which defines style models) and the store layer (which implements
+//! persistence and network resolution). It minimizes dependencies
+//! to facilitate integration by third-party tool authors who don't
+//! need the full store logic.
 
+/// Error types and conversion helpers.
 pub mod error;
 pub use error::{ResolutionError, ResolverError};
 

--- a/crates/citum-resolver-api/src/lib.rs
+++ b/crates/citum-resolver-api/src/lib.rs
@@ -1,0 +1,36 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Canonical style resolution interfaces for the Citum citation engine.
+//!
+//! This crate provides a lightweight, zero-dependency (by default) bridge
+//! between the schema layer (which defines style models) and the store layer
+//! (which implements persistence and network resolution).
+
+pub mod error;
+pub use error::{ResolutionError, ResolverError};
+
+/// A resolver that can locate styles and locales.
+///
+/// This trait uses associated types to break cyclic dependencies between
+/// schema models and resolution logic.
+pub trait StyleResolver: Send + Sync {
+    /// The style type resolved by this implementation.
+    type Style;
+    /// The locale type resolved by this implementation.
+    type Locale;
+
+    /// Resolve a style by URI or ID.
+    ///
+    /// # Errors
+    /// Returns a [`ResolverError`] if the style cannot be found or loaded.
+    fn resolve_style(&self, uri: &str) -> Result<Self::Style, ResolverError>;
+
+    /// Resolve a locale by ID.
+    ///
+    /// # Errors
+    /// Returns a [`ResolverError`] if the locale cannot be found or loaded.
+    fn resolve_locale(&self, id: &str) -> Result<Self::Locale, ResolverError>;
+}

--- a/crates/citum-schema-style/Cargo.toml
+++ b/crates/citum-schema-style/Cargo.toml
@@ -17,6 +17,7 @@ url = { version = "2.5", features = ["serde"] }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy", optional = true }
 indexmap = { version = "2", features = ["serde"] }
 citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
+citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
 sha2 = "0.10"
 cid = { version = "0.11", default-features = false, features = ["alloc"] }
 multihash = { version = "0.19", default-features = false, features = ["alloc"] }

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -2585,19 +2585,20 @@ bibliography:
             type Style = Style;
             type Locale = Locale;
 
-            fn resolve_style(&self, uri: &str) -> Result<Style, ResolutionError> {
+            fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
                 if uri == "parent-style" {
                     Ok(self.style.clone())
                 } else {
-                    Err(ResolutionError::UriResolutionFailed {
-                        uri: uri.to_string(),
-                        reason: "missing test style".to_string(),
-                    })
+                    Err(ResolverError::StyleNotFound(std::borrow::Cow::Owned(
+                        uri.to_string(),
+                    )))
                 }
             }
 
-            fn resolve_locale(&self, _id: &str) -> Result<Self::Locale, ResolverError> {
-                unimplemented!()
+            fn resolve_locale(&self, id: &str) -> Result<Self::Locale, ResolverError> {
+                Err(ResolverError::LocaleNotFound(std::borrow::Cow::Owned(
+                    id.to_string(),
+                )))
             }
         }
 

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -99,15 +99,11 @@ pub type Template = Vec<TemplateComponent>;
 /// Type-specific template variants keyed by reference-type selector.
 pub type TemplateVariants = IndexMap<TypeSelector, TemplateVariant>;
 
+/// Canonical style resolution interfaces and error types.
+pub use citum_resolver_api::{ResolutionError, ResolverError};
+
 /// Resolver interface used by schema-layer style inheritance.
-pub trait StyleResolver {
-    /// Resolve a style by URI, registry ID, or implementation-specific key.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ResolutionError`] when the style cannot be loaded or parsed.
-    fn resolve_style(&self, uri: &str) -> Result<Style, ResolutionError>;
-}
+pub type StyleResolver = dyn citum_resolver_api::StyleResolver<Style = Style, Locale = Locale>;
 
 /// Canonical Citum style schema version used when `Style.version` is omitted.
 pub const STYLE_SCHEMA_VERSION: &str = "0.44.0";
@@ -127,149 +123,6 @@ pub enum SchemaWarning {
         location: String,
     },
 }
-
-/// Failure modes while resolving a style with inheritance.
-#[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
-pub enum ResolutionError {
-    /// A `profile` style attempted to override template-bearing structure.
-    InvalidProfileOverride {
-        /// Human-readable location hint.
-        location: String,
-    },
-    /// An inheritance loop was detected.
-    InheritanceLoop {
-        /// Base key that closed the cycle.
-        base: String,
-    },
-    /// A `file://` URI could not be resolved.
-    UriResolutionFailed {
-        /// The URI that failed to resolve.
-        uri: String,
-        /// Reason for failure.
-        reason: String,
-    },
-    /// A Template V3 variant references a missing parent variant.
-    MissingTemplateVariantParent {
-        /// Human-readable location hint.
-        location: String,
-        /// Parent selector that could not be found.
-        selector: String,
-    },
-    /// A Template V3 variant parent chain contains a cycle.
-    TemplateVariantCycle {
-        /// Human-readable location hint.
-        location: String,
-        /// Selector that closed the cycle.
-        selector: String,
-    },
-    /// A Template V3 operation matched no components.
-    TemplateVariantAnchorNotFound {
-        /// Human-readable location hint.
-        location: String,
-    },
-    /// A Template V3 operation matched more than one component.
-    TemplateVariantAmbiguousAnchor {
-        /// Human-readable location hint.
-        location: String,
-    },
-    /// A Template V3 add operation does not define exactly one anchor.
-    InvalidTemplateVariantAdd {
-        /// Human-readable location hint.
-        location: String,
-    },
-    /// The fetched parent style's content did not hash to the value declared
-    /// in `extends-pin`.
-    IntegrityFailure {
-        /// URI of the parent that failed integrity verification.
-        uri: String,
-        /// CID declared in the child's `extends-pin`.
-        expected: String,
-        /// CID computed from the bytes the resolver actually returned.
-        actual: String,
-    },
-    /// The fetched style declares a `citum-version` requirement that the
-    /// running engine does not satisfy.
-    VersionMismatch {
-        /// URI whose `citum-version` requirement was unsatisfiable.
-        uri: String,
-        /// `citum-version` requirement declared by the style's `info` block.
-        required: String,
-        /// Version of the running engine.
-        declared: String,
-    },
-}
-
-impl std::fmt::Display for ResolutionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ResolutionError::InvalidProfileOverride { location } => {
-                write!(
-                    f,
-                    "profile styles may not override template-bearing field `{location}`"
-                )
-            }
-            ResolutionError::InheritanceLoop { base } => {
-                write!(f, "inheritance loop detected at base `{base}`")
-            }
-            ResolutionError::UriResolutionFailed { uri, reason } => {
-                write!(f, "failed to resolve URI `{uri}`: {reason}")
-            }
-            ResolutionError::MissingTemplateVariantParent { location, selector } => {
-                write!(
-                    f,
-                    "template variant `{location}` extends missing variant `{selector}`"
-                )
-            }
-            ResolutionError::TemplateVariantCycle { location, selector } => {
-                write!(
-                    f,
-                    "template variant inheritance loop at `{location}` through `{selector}`"
-                )
-            }
-            ResolutionError::TemplateVariantAnchorNotFound { location } => {
-                write!(
-                    f,
-                    "template variant operation in `{location}` matched no component"
-                )
-            }
-            ResolutionError::TemplateVariantAmbiguousAnchor { location } => {
-                write!(
-                    f,
-                    "template variant operation in `{location}` matched multiple components"
-                )
-            }
-            ResolutionError::InvalidTemplateVariantAdd { location } => {
-                write!(
-                    f,
-                    "template variant add operation in `{location}` must specify exactly one of before/after"
-                )
-            }
-            ResolutionError::IntegrityFailure {
-                uri,
-                expected,
-                actual,
-            } => {
-                write!(
-                    f,
-                    "extends-pin integrity check failed for `{uri}`: expected {expected}, got {actual}"
-                )
-            }
-            ResolutionError::VersionMismatch {
-                uri,
-                required,
-                declared,
-            } => {
-                write!(
-                    f,
-                    "style `{uri}` requires citum-version `{required}`; running engine is `{declared}`"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for ResolutionError {}
 
 impl std::fmt::Display for SchemaWarning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -390,7 +243,7 @@ impl Style {
     /// resolution fails.
     pub fn try_into_resolved_with(
         self,
-        resolver: Option<&dyn StyleResolver>,
+        resolver: Option<&StyleResolver>,
     ) -> Result<Self, ResolutionError> {
         self.try_into_resolved_recursive_with_depth(resolver, &mut HashSet::new(), 0)
     }
@@ -433,7 +286,7 @@ impl Style {
     /// resolution fails.
     pub fn try_into_resolved_recursive_with(
         self,
-        resolver: Option<&dyn StyleResolver>,
+        resolver: Option<&StyleResolver>,
         visited: &mut HashSet<String>,
     ) -> Result<Self, ResolutionError> {
         self.try_into_resolved_recursive_with_depth(resolver, visited, 0)
@@ -442,7 +295,7 @@ impl Style {
     /// Internal recursive resolver with depth limit.
     fn try_into_resolved_recursive_with_depth(
         self,
-        resolver: Option<&dyn StyleResolver>,
+        resolver: Option<&StyleResolver>,
         visited: &mut HashSet<String>,
         depth: usize,
     ) -> Result<Self, ResolutionError> {
@@ -776,10 +629,12 @@ pub fn check_citum_version(uri: &str, info: &StyleInfo) -> Result<(), Resolution
 
 fn resolve_style_reference_uri(
     uri: &str,
-    resolver: Option<&dyn StyleResolver>,
+    resolver: Option<&StyleResolver>,
 ) -> Result<Style, ResolutionError> {
     if let Some(resolver) = resolver {
-        let style = resolver.resolve_style(uri)?;
+        let style = resolver
+            .resolve_style(uri)
+            .map_err(|e| ResolutionError::from_resolver_error(uri, e))?;
         check_citum_version(uri, &style.info)?;
         return Ok(style);
     }
@@ -2726,7 +2581,10 @@ bibliography:
             style: Style,
         }
 
-        impl StyleResolver for FakeResolver {
+        impl citum_resolver_api::StyleResolver for FakeResolver {
+            type Style = Style;
+            type Locale = Locale;
+
             fn resolve_style(&self, uri: &str) -> Result<Style, ResolutionError> {
                 if uri == "parent-style" {
                     Ok(self.style.clone())
@@ -2736,6 +2594,10 @@ bibliography:
                         reason: "missing test style".to_string(),
                     })
                 }
+            }
+
+            fn resolve_locale(&self, _id: &str) -> Result<Self::Locale, ResolverError> {
+                unimplemented!()
             }
         }
 

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -270,7 +270,7 @@ impl StyleBase {
     /// Internal resolver with loop protection that preserves profile errors.
     pub(crate) fn try_resolve_with_visited(
         &self,
-        resolver: Option<&dyn crate::StyleResolver>,
+        resolver: Option<&crate::StyleResolver>,
         visited: &mut HashSet<String>,
     ) -> Result<Style, crate::ResolutionError> {
         self.base()

--- a/crates/citum-schema-style/tests/bdd_inheritance.rs
+++ b/crates/citum-schema-style/tests/bdd_inheritance.rs
@@ -131,15 +131,17 @@ fn test_template_variant_inheritance(#[case] overlay_yaml: &str, #[case] asserti
         type Style = Style;
         type Locale = citum_schema_style::locale::Locale;
 
-        fn resolve_style(&self, _uri: &str) -> Result<Style, citum_schema_style::ResolutionError> {
+        fn resolve_style(&self, _uri: &str) -> Result<Style, citum_schema_style::ResolverError> {
             Ok(self.0.clone())
         }
 
         fn resolve_locale(
             &self,
-            _id: &str,
+            id: &str,
         ) -> Result<Self::Locale, citum_schema_style::ResolverError> {
-            unimplemented!()
+            Err(citum_schema_style::ResolverError::LocaleNotFound(
+                std::borrow::Cow::Owned(id.to_string()),
+            ))
         }
     }
 
@@ -228,22 +230,23 @@ bibliography:
         type Style = Style;
         type Locale = citum_schema_style::locale::Locale;
 
-        fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema_style::ResolutionError> {
+        fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema_style::ResolverError> {
             match uri {
                 "base" => Ok(self.base.clone()),
                 "mid" => Ok(self.mid.clone()),
-                _ => Err(citum_schema_style::ResolutionError::UriResolutionFailed {
-                    uri: uri.to_string(),
-                    reason: "unknown style in test".to_string(),
-                }),
+                _ => Err(citum_schema_style::ResolverError::StyleNotFound(
+                    std::borrow::Cow::Owned(uri.to_string()),
+                )),
             }
         }
 
         fn resolve_locale(
             &self,
-            _id: &str,
+            id: &str,
         ) -> Result<Self::Locale, citum_schema_style::ResolverError> {
-            unimplemented!()
+            Err(citum_schema_style::ResolverError::LocaleNotFound(
+                std::borrow::Cow::Owned(id.to_string()),
+            ))
         }
     }
 

--- a/crates/citum-schema-style/tests/bdd_inheritance.rs
+++ b/crates/citum-schema-style/tests/bdd_inheritance.rs
@@ -127,9 +127,19 @@ fn test_template_variant_inheritance(#[case] overlay_yaml: &str, #[case] asserti
     let overlay = Style::from_yaml_str(overlay_yaml).expect("valid overlay style");
 
     struct MockResolver(Style);
-    impl citum_schema_style::StyleResolver for MockResolver {
+    impl citum_resolver_api::StyleResolver for MockResolver {
+        type Style = Style;
+        type Locale = citum_schema_style::locale::Locale;
+
         fn resolve_style(&self, _uri: &str) -> Result<Style, citum_schema_style::ResolutionError> {
             Ok(self.0.clone())
+        }
+
+        fn resolve_locale(
+            &self,
+            _id: &str,
+        ) -> Result<Self::Locale, citum_schema_style::ResolverError> {
+            unimplemented!()
         }
     }
 
@@ -214,7 +224,10 @@ bibliography:
         base: Style,
         mid: Style,
     }
-    impl citum_schema_style::StyleResolver for MultiResolver {
+    impl citum_resolver_api::StyleResolver for MultiResolver {
+        type Style = Style;
+        type Locale = citum_schema_style::locale::Locale;
+
         fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema_style::ResolutionError> {
             match uri {
                 "base" => Ok(self.base.clone()),
@@ -224,6 +237,13 @@ bibliography:
                     reason: "unknown style in test".to_string(),
                 }),
             }
+        }
+
+        fn resolve_locale(
+            &self,
+            _id: &str,
+        ) -> Result<Self::Locale, citum_schema_style::ResolverError> {
+            unimplemented!()
         }
     }
 

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -12,7 +12,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
-thiserror = "1.0"
+thiserror = "2.0"
+citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
 toml = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
 sha2 = { version = "0.10", optional = true }
@@ -24,7 +25,7 @@ gix = { version = "0.70", default-features = false, features = ["blocking-networ
 
 [features]
 hub = []
-http = ["dep:reqwest", "dep:sha2", "dep:tempfile", "dep:cid", "dep:multihash", "dep:multibase", "dep:gix"]
+http = ["citum_resolver_api/http", "dep:reqwest", "dep:sha2", "dep:tempfile", "dep:cid", "dep:multihash", "dep:multibase", "dep:gix"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/citum_store/src/chain.rs
+++ b/crates/citum_store/src/chain.rs
@@ -12,7 +12,10 @@ use crate::{
         StyleResolver,
     },
 };
+use citum_schema::{Locale, Style};
 use std::{error::Error, fs, path::Path};
+
+type DynStyleResolver = dyn StyleResolver<Style = Style, Locale = Locale>;
 
 /// Construct a `ChainResolver` with the standard platform resolver stack.
 ///
@@ -23,7 +26,7 @@ use std::{error::Error, fs, path::Path};
 ///
 /// Returns an error if the current working directory cannot be determined.
 pub fn build_standard_chain() -> Result<ChainResolver, Box<dyn Error + Send + Sync>> {
-    let mut resolvers: Vec<Box<dyn StyleResolver>> = vec![Box::new(FileResolver)];
+    let mut resolvers: Vec<Box<DynStyleResolver>> = vec![Box::new(FileResolver)];
 
     if let Some(data_dir) = platform_data_dir()
         && data_dir.exists()
@@ -76,8 +79,8 @@ fn configured_registry_names() -> Vec<String> {
     records.into_iter().map(|record| record.name).collect()
 }
 
-fn registry_resolvers() -> Result<Vec<Box<dyn StyleResolver>>, Box<dyn Error + Send + Sync>> {
-    let mut resolvers: Vec<Box<dyn StyleResolver>> = Vec::new();
+fn registry_resolvers() -> Result<Vec<Box<DynStyleResolver>>, Box<dyn Error + Send + Sync>> {
+    let mut resolvers: Vec<Box<DynStyleResolver>> = Vec::new();
 
     let local_path = Path::new("citum-registry.yaml");
     if local_path.exists()

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -15,80 +15,21 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 #[cfg(feature = "http")]
 use std::time::{Duration, SystemTime};
-use thiserror::Error;
 
 #[cfg(feature = "http")]
 use sha2::{Digest, Sha256};
 #[cfg(feature = "http")]
 use tempfile;
 
-/// Error type for store resolution operations.
-#[derive(Error, Debug)]
-#[non_exhaustive]
-pub enum ResolverError {
-    #[error("io error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("invalid style: {0}")]
-    InvalidStyle(Cow<'static, str>),
-    #[error("style not found: {0}")]
-    StyleNotFound(Cow<'static, str>),
-    #[error("locale not found: {0}")]
-    LocaleNotFound(Cow<'static, str>),
-    #[error("yaml error: {0}")]
-    YamlError(String),
-    #[error("json error: {0}")]
-    JsonError(#[from] serde_json::Error),
-    #[error("cbor error: {0}")]
-    CborError(String),
-    #[cfg(feature = "http")]
-    #[error("http error: {0}")]
-    HttpError(String),
-    #[cfg(feature = "http")]
-    #[error("git error: {0}")]
-    GitError(String),
-    /// The URI host or origin is not in the resolver's allowlist.
-    #[error("host not in resolver allowlist: {uri} ({reason})")]
-    Denied { uri: String, reason: String },
-    /// The style's `citum-version` is not compatible with the running engine.
-    #[error(
-        "engine version mismatch for {uri}: engine requires {required}, style declares {declared}"
-    )]
-    VersionMismatch {
-        uri: String,
-        required: String,
-        declared: String,
-    },
-    /// The content does not match the expected integrity hash.
-    #[error("integrity failure for {uri}: expected {expected}, got {actual}")]
-    IntegrityFailure {
-        uri: String,
-        expected: String,
-        actual: String,
-    },
-    /// Generic network or transport failure.
-    #[error("network error fetching {uri}: {reason}")]
-    NetworkError { uri: String, reason: String },
-}
-
-/// A resolver that can locate styles and locales.
-pub trait StyleResolver: Send + Sync {
-    /// Resolve a style by URI or ID.
-    ///
-    /// # Errors
-    /// Returns a [`ResolverError`] if the style cannot be found or loaded.
-    fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError>;
-
-    /// Resolve a locale by ID.
-    ///
-    /// # Errors
-    /// Returns a [`ResolverError`] if the locale cannot be found or loaded.
-    fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError>;
-}
+pub use citum_resolver_api::{ResolutionError, ResolverError, StyleResolver};
 
 /// A resolver that searches a local directory for styles and locales.
 pub struct FileResolver;
 
 impl StyleResolver for FileResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         let path = if let Some(path_str) = uri.strip_prefix("file://") {
             PathBuf::from(path_str)
@@ -120,13 +61,6 @@ impl StyleResolver for FileResolver {
     }
 }
 
-impl citum_schema::StyleResolver for FileResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
-    }
-}
-
 /// A resolver that manages user-installed styles and locales in a platform data directory.
 pub struct StoreResolver {
     data_dir: PathBuf,
@@ -134,6 +68,9 @@ pub struct StoreResolver {
 }
 
 impl StyleResolver for StoreResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         StoreResolver::resolve_style(self, uri)
     }
@@ -143,17 +80,13 @@ impl StyleResolver for StoreResolver {
     }
 }
 
-impl citum_schema::StyleResolver for StoreResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
-    }
-}
-
 /// A resolver that checks for embedded styles and locales.
 pub struct EmbeddedResolver;
 
 impl StyleResolver for EmbeddedResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         citum_schema::embedded::get_embedded_style(uri)
             .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?
@@ -168,13 +101,6 @@ impl StyleResolver for EmbeddedResolver {
         } else {
             Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
         }
-    }
-}
-
-impl citum_schema::StyleResolver for EmbeddedResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
     }
 }
 
@@ -227,6 +153,9 @@ impl RegistryResolver {
 }
 
 impl StyleResolver for RegistryResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         let entry = self
             .registry
@@ -265,13 +194,6 @@ impl StyleResolver for RegistryResolver {
 
     fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
         Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
-    }
-}
-
-impl citum_schema::StyleResolver for RegistryResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
     }
 }
 
@@ -404,6 +326,9 @@ fn hex_digit(nibble: u8) -> char {
 
 #[cfg(feature = "http")]
 impl StyleResolver for HttpResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         if !uri.starts_with("http://") && !uri.starts_with("https://") {
             return Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())));
@@ -491,14 +416,6 @@ impl StyleResolver for HttpResolver {
 }
 
 #[cfg(feature = "http")]
-impl citum_schema::StyleResolver for HttpResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
-    }
-}
-
-#[cfg(feature = "http")]
 impl GitResolver {
     /// Create a resolver using the provided cache directory.
     #[must_use]
@@ -569,6 +486,9 @@ impl GitResolver {
 
 #[cfg(feature = "http")]
 impl StyleResolver for GitResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         let (repo_url, file_path) = Self::parse_git_uri(uri)
             .ok_or_else(|| ResolverError::StyleNotFound(Cow::Owned(uri.to_string())))?;
@@ -651,14 +571,6 @@ impl StyleResolver for GitResolver {
     }
 }
 
-#[cfg(feature = "http")]
-impl citum_schema::StyleResolver for GitResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
-    }
-}
-
 /// Default IPFS HTTP gateway used by [`CidResolver`] when none is configured.
 #[cfg(feature = "http")]
 pub const DEFAULT_CID_GATEWAY: &str = "https://dweb.link/ipfs/";
@@ -721,6 +633,9 @@ impl CidResolver {
 
 #[cfg(feature = "http")]
 impl StyleResolver for CidResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         if !crate::cid::is_cid_uri(uri) {
             return Err(ResolverError::StyleNotFound(Cow::Owned(uri.to_string())));
@@ -730,14 +645,6 @@ impl StyleResolver for CidResolver {
 
     fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
         Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
-    }
-}
-
-#[cfg(feature = "http")]
-impl citum_schema::StyleResolver for CidResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
     }
 }
 
@@ -781,7 +688,10 @@ impl<R: StyleResolver> VerifyingResolver<R> {
 }
 
 #[cfg(feature = "http")]
-impl<R: StyleResolver> StyleResolver for VerifyingResolver<R> {
+impl<R: StyleResolver<Style = Style, Locale = Locale>> StyleResolver for VerifyingResolver<R> {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         let style = self.inner.resolve_style(uri)?;
         if let Some(ref pin) = self.expected {
@@ -850,28 +760,23 @@ pub fn fetch_and_verify_bytes(
     Ok(bytes)
 }
 
-#[cfg(feature = "http")]
-impl<R: StyleResolver> citum_schema::StyleResolver for VerifyingResolver<R> {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
-    }
-}
-
 /// A resolver that chains multiple resolvers and tries them in order.
 pub struct ChainResolver {
-    resolvers: Vec<Box<dyn StyleResolver>>,
+    resolvers: Vec<Box<dyn StyleResolver<Style = Style, Locale = Locale>>>,
 }
 
 impl ChainResolver {
     /// Create a new `ChainResolver` with the given list of resolvers.
     #[must_use]
-    pub fn new(resolvers: Vec<Box<dyn StyleResolver>>) -> Self {
+    pub fn new(resolvers: Vec<Box<dyn StyleResolver<Style = Style, Locale = Locale>>>) -> Self {
         ChainResolver { resolvers }
     }
 }
 
 impl StyleResolver for ChainResolver {
+    type Style = Style;
+    type Locale = Locale;
+
     fn resolve_style(&self, uri: &str) -> Result<Style, ResolverError> {
         for resolver in &self.resolvers {
             match resolver.resolve_style(uri) {
@@ -892,39 +797,6 @@ impl StyleResolver for ChainResolver {
             }
         }
         Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
-    }
-}
-
-impl citum_schema::StyleResolver for ChainResolver {
-    fn resolve_style(&self, uri: &str) -> Result<Style, citum_schema::ResolutionError> {
-        StyleResolver::resolve_style(self, uri)
-            .map_err(|err| resolution_error_from_store_error(uri, err))
-    }
-}
-
-fn resolution_error_from_store_error(
-    uri: &str,
-    err: ResolverError,
-) -> citum_schema::ResolutionError {
-    match err {
-        ResolverError::IntegrityFailure {
-            expected, actual, ..
-        } => citum_schema::ResolutionError::IntegrityFailure {
-            uri: uri.into(),
-            expected,
-            actual,
-        },
-        ResolverError::VersionMismatch {
-            required, declared, ..
-        } => citum_schema::ResolutionError::VersionMismatch {
-            uri: uri.into(),
-            required,
-            declared,
-        },
-        _ => citum_schema::ResolutionError::UriResolutionFailed {
-            uri: uri.into(),
-            reason: err.to_string(),
-        },
     }
 }
 

--- a/crates/citum_store/src/resolver_tests.rs
+++ b/crates/citum_store/src/resolver_tests.rs
@@ -191,6 +191,9 @@ fn verifying_resolver_passes_through_when_pin_matches() {
 
     struct FixedResolver(Style);
     impl StyleResolver for FixedResolver {
+        type Style = Style;
+        type Locale = citum_schema::Locale;
+
         fn resolve_style(&self, _uri: &str) -> Result<Style, crate::resolver::ResolverError> {
             Ok(self.0.clone())
         }
@@ -225,6 +228,9 @@ fn verifying_resolver_rejects_when_pin_mismatches() {
 
     struct FixedResolver(Style);
     impl StyleResolver for FixedResolver {
+        type Style = Style;
+        type Locale = citum_schema::Locale;
+
         fn resolve_style(&self, _uri: &str) -> Result<Style, crate::resolver::ResolverError> {
             Ok(self.0.clone())
         }


### PR DESCRIPTION
## Objective
Extract the style resolution interfaces into a dedicated, lightweight `citum-resolver-api` crate. This removes the "two-trait bridge" between `citum-schema-style` and `citum_store`, simplifies third-party integrations, and centralizes error types (`ResolverError` and `ResolutionError`) without pulling in heavy dependencies.

## Key Changes
- **New Crate**: Created `crates/citum-resolver-api` defining the canonical `StyleResolver` trait with associated types (`Style` and `Locale`).
- **Schema Refactor**: Updated `citum-schema-style` to use the API crate's trait and error types.
- **Store Refactor**: Updated all concrete resolvers in `citum_store` to implement the new unified trait.
- **Workspace Fixes**: Adjusted `citum-cli`, `citum-server`, and `citum-engine` to match the new trait signatures.

## Verification
- `cargo test --workspace` passes (700+ tests).
- All components compile and link correctly.