### PR TITLE
Include I/O tests in behavior report

### DIFF
--- a/.beans/archive/csl26-9pui--add-behavioral-bdd-tests-for-bibliography-loading.md
+++ b/.beans/archive/csl26-9pui--add-behavioral-bdd-tests-for-bibliography-loading.md
@@ -1,7 +1,7 @@
 ---
 # csl26-9pui
 title: Add behavioral BDD tests for bibliography loading
-status: in-progress
+status: completed
 type: task
 priority: normal
 tags:

--- a/scripts/test-report.sh
+++ b/scripts/test-report.sh
@@ -7,7 +7,7 @@ REPORT_PATH="${ROOT_DIR}/target/test-report.md"
 REPORT_HTML_PATH="${ROOT_DIR}/target/test-report.html"
 
 if [[ $# -eq 0 ]]; then
-  set -- --test bibliography --test citations --test document --test i18n --test metadata --test multilingual --test sort_oracle
+  set -- --test bibliography --test citations --test document --test i18n --test io --test metadata --test multilingual --test sort_oracle
 fi
 
 mkdir -p "$(dirname "${JUNIT_PATH}")" "$(dirname "${REPORT_PATH}")"


### PR DESCRIPTION
This PR adds the missing '--test io' target to the behavior report script and marks the corresponding bean csl26-9pui as completed.