### PR TITLE
feat: extract BibLaTeX and I/O to dedicated citum-io crate

### DIFF
--- a/.beans/archive/csl26-xio1--extract-biblatex-conversion-to-io-crate.md
+++ b/.beans/archive/csl26-xio1--extract-biblatex-conversion-to-io-crate.md
@@ -1,7 +1,7 @@
 ---
 # csl26-xio1
 title: Extract Biblatex and external input conversions to dedicated I/O crate
-status: todo
+status: done
 type: task
 priority: normal
 created_at: 2026-05-09T00:00:00Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ dependencies = [
  "ciborium",
  "citum-bindings",
  "citum-engine",
+ "citum-io",
  "citum-pdf",
  "citum-resolver-api",
  "citum-schema",
@@ -635,9 +636,8 @@ dependencies = [
 name = "citum-engine"
 version = "0.38.0"
 dependencies = [
- "biblatex 0.11.0",
- "ciborium",
  "citum-edtf",
+ "citum-io",
  "citum-migrate",
  "citum-schema",
  "criterion",
@@ -658,6 +658,23 @@ dependencies = [
  "unicode-script",
  "url",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "citum-io"
+version = "0.38.0"
+dependencies = [
+ "biblatex 0.11.0",
+ "ciborium",
+ "citum-engine",
+ "citum-schema",
+ "csl-legacy",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ members = [
     "crates/citum-edtf",
     "crates/citum_store",
     "crates/citum-bindings",
-    "crates/citum-resolver-api"
+    "crates/citum-resolver-api",
+    "crates/citum-io"
 ]
 resolver = "2"
 

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -25,6 +25,7 @@ indexmap = "2.2.3"
 ratatui = { version = "0.30.0", default-features = false, features = ["crossterm_0_29"] }
 citum_schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
 citum_engine = { package = "citum-engine", path = "../citum-engine" }
+citum_io = { package = "citum-io", path = "../citum-io" }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 biblatex = "0.11"
 citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -382,7 +382,7 @@ pub(crate) enum RegistryCommands {
 pub(crate) enum StyleCommands {
     /// List styles in the style catalog
     List {
-        /// Catalog source to include: all, embedded, installed, or registry:<name>
+        /// Catalog source to include: all, embedded, installed, or registry:`<name>`
         #[arg(long, default_value = "all")]
         source: String,
         /// Output format
@@ -399,7 +399,7 @@ pub(crate) enum StyleCommands {
     Search {
         /// Search query matched against IDs, aliases, titles, descriptions, and fields
         query: String,
-        /// Catalog source to include: all, embedded, installed, or registry:<name>
+        /// Catalog source to include: all, embedded, installed, or registry:`<name>`
         #[arg(long, default_value = "all")]
         source: String,
         /// Output format
@@ -425,7 +425,7 @@ pub(crate) enum StyleCommands {
     Browse {
         /// Optional initial search query
         query: Option<String>,
-        /// Catalog source to include: all, embedded, installed, or registry:<name>
+        /// Catalog source to include: all, embedded, installed, or registry:`<name>`
         #[arg(long, default_value = "all")]
         source: String,
     },

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -15,15 +15,15 @@ use crate::table::build_table;
 use crate::typst_pdf;
 use citum_engine::{
     Citation, CitationItem, DocumentFormat, Processor,
-    io::{
-        AnnotationFormat, AnnotationStyle, RefsFormat as EngineRefsFormat,
-        infer_refs_input_format as infer_engine_refs_input_format,
-        infer_refs_output_format as infer_engine_refs_output_format, load_annotations,
-        load_bibliography, load_citations, load_input_bibliography, load_merged_bibliography,
-        load_merged_citations, write_output_bibliography,
-    },
     processor::document::{djot::DjotParser, markdown::MarkdownParser},
     render::{djot::Djot, html::Html, latex::Latex, plain::PlainText, typst::Typst},
+};
+use citum_io::{
+    AnnotationFormat, AnnotationStyle, RefsFormat as EngineRefsFormat,
+    infer_refs_input_format as infer_engine_refs_input_format,
+    infer_refs_output_format as infer_engine_refs_output_format, load_annotations,
+    load_bibliography, load_citations, load_input_bibliography, load_merged_bibliography,
+    load_merged_citations, write_output_bibliography,
 };
 #[cfg(feature = "schema")]
 use citum_schema::InputBibliography;
@@ -1775,7 +1775,7 @@ struct RenderContext<'a> {
     /// Optional annotation map (reference ID → annotation text).
     annotations: Option<&'a HashMap<String, String>>,
     /// Formatting style for annotations.
-    annotation_style: &'a citum_engine::io::AnnotationStyle,
+    annotation_style: &'a citum_io::AnnotationStyle,
 }
 
 /// Render bibliography/citation output as a human-readable string.
@@ -2244,7 +2244,8 @@ where
 mod tests {
     use super::*;
     use crate::style_resolver::parse_locale_override_bytes;
-    use citum_engine::{Bibliography, io::LoadedBibliography};
+    use citum_engine::Bibliography;
+    use citum_io::LoadedBibliography;
     use citum_schema::citation::CitationMode;
     use citum_schema::grouping::{GroupSort, GroupSortEntry, GroupSortKey, SortKey};
     use citum_schema::options::{Config, Processing};

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -1,4 +1,5 @@
-use citum_engine::{Processor, io::LoadedBibliography};
+use citum_engine::Processor;
+use citum_io::LoadedBibliography;
 use citum_schema::{Locale, Style, locale::types::LocaleOverride};
 use citum_store::platform_config_dir;
 use serde::Deserialize;

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -16,10 +16,8 @@ csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
-ciborium = "0.2"
 thiserror = "2.0"
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }
-biblatex = "0.11"
 url = { version = "2.5", features = ["serde"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 regex = "1.10"
@@ -36,6 +34,7 @@ ffi = []
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 citum_migrate = { package = "citum-migrate", path = "../citum-migrate" }
+citum_io = { package = "citum-io", path = "../citum-io" }
 roxmltree = "0.20"
 rstest = "0.25"
 tempfile = "3.8"

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -24,8 +24,7 @@ fn main() {
     let style_str = fs::read_to_string("styles/embedded/apa-7th.yaml").unwrap();
     let style: Style = serde_yaml::from_str(&style_str).unwrap();
 
-    let bib =
-        citum_engine::io::load_bibliography(Path::new("bindings/latex/example-refs.yaml")).unwrap();
+    let bib = citum_io::load_bibliography(Path::new("bindings/latex/example-refs.yaml")).unwrap();
     let processor = Processor::new(style, bib);
 
     let cite = Citation {

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -5,8 +5,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Document-level batch formatting API.
 
+use crate::api::AnnotationStyle;
 use crate::error::ProcessorError;
-use crate::io::AnnotationStyle;
 use crate::processor::Processor;
 use crate::reference::Bibliography;
 use crate::render::djot::Djot;

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -19,6 +19,7 @@ pub use document::{
 };
 pub use style_input::StyleInput;
 pub use types::{
-    BibliographyEntry, CitationOccurrence, CitationOccurrenceItem, DocumentOptions, EntryMetadata,
-    FormattedBibliography, FormattedCitation, OutputFormatKind, Warning, WarningLevel,
+    AnnotationFormat, AnnotationStyle, BibliographyEntry, CitationOccurrence,
+    CitationOccurrenceItem, DocumentOptions, EntryMetadata, FormattedBibliography,
+    FormattedCitation, OutputFormatKind, Warning, WarningLevel,
 };

--- a/crates/citum-engine/src/api/types.rs
+++ b/crates/citum-engine/src/api/types.rs
@@ -50,6 +50,35 @@ pub enum OutputFormatKind {
     Typst,
 }
 
+/// Controls how annotation text is rendered in an annotated bibliography.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnotationStyle {
+    /// Markup format for annotation text. Default: Djot.
+    #[serde(default)]
+    pub format: AnnotationFormat,
+}
+
+impl Default for AnnotationStyle {
+    fn default() -> Self {
+        Self {
+            format: AnnotationFormat::Djot,
+        }
+    }
+}
+
+/// Markup format for annotation text.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnnotationFormat {
+    /// Parse annotation as djot inline markup (default).
+    #[default]
+    Djot,
+    /// Treat annotation as plain text with no markup interpretation.
+    Plain,
+    /// Parse annotation as org-mode markup.
+    Org,
+}
+
 /// A single item within a citation occurrence.
 ///
 /// Maps to `CitationItem` from `citum-schema-data`.
@@ -154,7 +183,7 @@ pub struct DocumentOptions {
     pub annotations: Option<HashMap<String, String>>,
     /// Format for annotation text (djot, plain, org).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotation_format: Option<crate::io::AnnotationFormat>,
+    pub annotation_format: Option<AnnotationFormat>,
 }
 
 /// A single formatted citation.

--- a/crates/citum-engine/src/ffi/mod.rs
+++ b/crates/citum-engine/src/ffi/mod.rs
@@ -22,7 +22,6 @@ use citum_schema::locale::Locale;
 use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-use std::path::Path;
 use std::ptr;
 
 thread_local! {
@@ -67,13 +66,6 @@ fn parse_bibliography_json(bib_str: &str) -> Result<Bibliography, String> {
             serde_json::from_str(bib_str).map_err(|e| format!("Bibliography JSON parse error: {e}"))
         }
     }
-}
-
-/// Load and parse a Citum YAML style file from disk.
-fn load_style_yaml(path: &str) -> Result<Style, String> {
-    let src = std::fs::read_to_string(Path::new(path))
-        .map_err(|e| format!("Failed to read style YAML: {e}"))?;
-    Style::from_yaml_str(&src).map_err(|e| format!("Style YAML parse error: {e}"))
 }
 
 /// Get the last error message.
@@ -170,111 +162,6 @@ pub unsafe extern "C" fn citum_processor_new_with_locale(
     };
 
     let processor = Box::new(Processor::with_locale(style, bib, locale));
-    Box::into_raw(processor)
-}
-
-/// Create a new processor from Citum YAML files on disk (primary format).
-///
-/// Reads the style from `style_yaml_path` and the bibliography from
-/// `bib_yaml_path`. Both are Citum YAML files.
-///
-/// # Safety
-/// Both path pointers must be valid null-terminated UTF-8 C strings.
-/// The returned pointer must be freed with `citum_processor_free`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_processor_new_from_yaml(
-    style_yaml_path: *const c_char,
-    bib_yaml_path: *const c_char,
-) -> *mut Processor {
-    if style_yaml_path.is_null() || bib_yaml_path.is_null() {
-        return ptr::null_mut();
-    }
-
-    let style_path_str = parse_c_str!(style_yaml_path);
-    let bib_path_str = parse_c_str!(bib_yaml_path);
-
-    let style: Style = match load_style_yaml(style_path_str) {
-        Ok(s) => s,
-        Err(e) => {
-            set_error(e);
-            return ptr::null_mut();
-        }
-    };
-
-    let loaded = match crate::io::load_bibliography_with_sets(Path::new(bib_path_str)) {
-        Ok(b) => b,
-        Err(e) => {
-            set_error(format!("Failed to load bibliography: {e}"));
-            return ptr::null_mut();
-        }
-    };
-
-    let processor = match Processor::try_with_compound_sets(
-        style,
-        loaded.references,
-        loaded.sets.unwrap_or_default(),
-    ) {
-        Ok(p) => Box::new(p),
-        Err(e) => {
-            set_error(format!("Invalid compound sets: {e}"));
-            return ptr::null_mut();
-        }
-    };
-    Box::into_raw(processor)
-}
-
-/// Create a new processor from a Citum YAML style and a biblatex `.bib` file.
-///
-/// Reads the style from `style_yaml_path` (Citum YAML) and the bibliography
-/// from `bib_path` (biblatex `.bib`). Entries are converted via
-/// `input_reference_from_biblatex`.
-///
-/// # Safety
-/// Both path pointers must be valid null-terminated UTF-8 C strings.
-/// The returned pointer must be freed with `citum_processor_free`.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_processor_new_from_bib(
-    style_yaml_path: *const c_char,
-    bib_path: *const c_char,
-) -> *mut Processor {
-    if style_yaml_path.is_null() || bib_path.is_null() {
-        return ptr::null_mut();
-    }
-
-    let style_path_str = parse_c_str!(style_yaml_path);
-    let bib_path_str = parse_c_str!(bib_path);
-
-    let style: Style = match load_style_yaml(style_path_str) {
-        Ok(s) => s,
-        Err(e) => {
-            set_error(e);
-            return ptr::null_mut();
-        }
-    };
-
-    let bib_src = match std::fs::read_to_string(Path::new(bib_path_str)) {
-        Ok(s) => s,
-        Err(e) => {
-            set_error(format!("Failed to read bibliography: {e}"));
-            return ptr::null_mut();
-        }
-    };
-    let bibliography_parsed = match ::biblatex::Bibliography::parse(&bib_src) {
-        Ok(b) => b,
-        Err(e) => {
-            set_error(format!("BibLaTeX parse error: {e}"));
-            return ptr::null_mut();
-        }
-    };
-
-    let mut bib: Bibliography = indexmap::IndexMap::new();
-    for entry in bibliography_parsed.iter() {
-        let key = entry.key.clone();
-        let reference = crate::biblatex::input_reference_from_biblatex(entry);
-        bib.insert(key, reference);
-    }
-
-    let processor = Box::new(Processor::new(style, bib));
     Box::into_raw(processor)
 }
 

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -88,14 +88,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /// Interactive document-level API for batch citation formatting.
 pub mod api;
-mod biblatex;
 /// Error types returned by citation and bibliography processing.
 pub mod error;
 #[cfg(feature = "ffi")]
 pub mod ffi;
 pub mod grouping;
-/// File loading and deserialization helpers for processor inputs.
-pub mod io;
 /// Citation, bibliography, sorting, and document processing logic.
 pub mod processor;
 pub mod reference;

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -6,8 +6,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Grouped bibliography rendering with configurable selectors and sorting.
 
 use super::RenderedBibliographyGroup;
+use crate::api::AnnotationStyle;
 use crate::grouping::{GroupSorter, SelectorEvaluator};
-use crate::io::AnnotationStyle;
 use crate::processor::Processor;
 use crate::processor::disambiguation::Disambiguator;
 use crate::processor::rendering::{CompoundRenderData, Renderer, RendererResources};

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -15,7 +15,7 @@ mod grouping;
 use super::matching::Matcher;
 use super::rendering::{CompoundRenderData, Renderer, RendererResources};
 use super::{ProcessedReferences, Processor};
-use crate::io::AnnotationStyle;
+use crate::api::AnnotationStyle;
 use crate::reference::Reference;
 use crate::render::format::OutputFormat;
 use crate::render::{ProcEntry, ProcTemplate};

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -127,3 +127,54 @@ pub struct ProcessedReferences {
     /// None if no citations were processed; Some(vec) otherwise.
     pub citations: Option<Vec<String>>,
 }
+
+/// Validate optional compound sets against the loaded bibliography.
+///
+/// Validation rules:
+/// - Every member ID must exist in `bibliography`.
+/// - A member ID must not appear more than once in a single set.
+/// - A member ID must not appear across multiple sets.
+///
+/// # Errors
+///
+/// Returns an error when a compound set references an unknown ID or reuses the
+/// same member within or across sets.
+pub fn validate_compound_sets(
+    sets: Option<IndexMap<String, Vec<String>>>,
+    bibliography: &Bibliography,
+) -> Result<Option<IndexMap<String, Vec<String>>>, crate::error::ProcessorError> {
+    let Some(sets) = sets else {
+        return Ok(None);
+    };
+
+    let mut member_owner: HashMap<String, String> = HashMap::new();
+    for (set_id, members) in &sets {
+        let mut seen_in_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for member in members {
+            if !seen_in_set.insert(member.clone()) {
+                return Err(crate::error::ProcessorError::ParseError(
+                    "BIBLIOGRAPHY".to_string(),
+                    format!(
+                        "reference '{member}' appears more than once in compound set '{set_id}'"
+                    ),
+                ));
+            }
+            if !bibliography.contains_key(member) {
+                return Err(crate::error::ProcessorError::ParseError(
+                    "BIBLIOGRAPHY".to_string(),
+                    format!("compound set '{set_id}' references unknown id '{member}'"),
+                ));
+            }
+            if let Some(existing) = member_owner.insert(member.clone(), set_id.clone()) {
+                return Err(crate::error::ProcessorError::ParseError(
+                    "BIBLIOGRAPHY".to_string(),
+                    format!(
+                        "reference '{member}' appears in both compound sets '{existing}' and '{set_id}'"
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(Some(sets))
+}

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -101,7 +101,7 @@ impl Processor {
         bibliography: &Bibliography,
         compound_sets: IndexMap<String, Vec<String>>,
     ) -> Result<IndexMap<String, Vec<String>>, ProcessorError> {
-        crate::io::validate_compound_sets(Some(compound_sets), bibliography)
+        super::validate_compound_sets(Some(compound_sets), bibliography)
             .map(Option::unwrap_or_default)
     }
 

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -751,8 +751,8 @@ fn test_springer_locator_label_survives_sorting() {
     let style = Style::from_yaml_str(&style_yaml)
         .expect("style should parse")
         .into_resolved();
-    let bibliography = crate::io::load_bibliography(&bib_path).expect("bib should load");
-    let citations = crate::io::load_citations(&cite_path).expect("citations should load");
+    let bibliography = citum_io::load_bibliography(&bib_path).expect("bib should load");
+    let citations = citum_io::load_citations(&cite_path).expect("citations should load");
 
     let processor = Processor::new(style.clone(), bibliography);
     let citation = citations
@@ -789,7 +789,7 @@ fn test_springer_locator_label_survives_sorting() {
     let loaded_locale = citum_schema::locale::Locale::load("en-US", &locales_dir);
     let with_loaded = Processor::with_locale(
         style,
-        crate::io::load_bibliography(&bib_path).unwrap(),
+        citum_io::load_bibliography(&bib_path).unwrap(),
         loaded_locale,
     );
     let rendered_loaded_locale = with_loaded.process_citation(&citation).unwrap();
@@ -813,8 +813,8 @@ fn test_harvard_cite_them_right_grouped_citations_render_cleanly() {
     let style = Style::from_yaml_str(&style_yaml)
         .expect("style should parse")
         .into_resolved();
-    let bibliography = crate::io::load_bibliography(&bib_path).expect("bib should load");
-    let citations = crate::io::load_citations(&cite_path).expect("citations should load");
+    let bibliography = citum_io::load_bibliography(&bib_path).expect("bib should load");
+    let citations = citum_io::load_citations(&cite_path).expect("citations should load");
 
     let processor = Processor::new(style, bibliography);
 
@@ -857,8 +857,8 @@ fn test_parsed_style_no_date_terms_match_expected_variants() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let bib_path = root.join("tests/fixtures/references-expanded.json");
     let cite_path = root.join("tests/fixtures/citations-expanded.json");
-    let bibliography = crate::io::load_bibliography(&bib_path).expect("bib should load");
-    let citations = crate::io::load_citations(&cite_path).expect("citations should load");
+    let bibliography = citum_io::load_bibliography(&bib_path).expect("bib should load");
+    let citations = citum_io::load_citations(&cite_path).expect("citations should load");
     let no_date = citations
         .iter()
         .find(|c| c.id.as_deref() == Some("no-date-single"))

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -6,7 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use crate::io::{AnnotationFormat, AnnotationStyle};
+use crate::api::{AnnotationFormat, AnnotationStyle};
 use crate::render::component::{ProcEntry, ProcTemplateComponent, render_component_with_format};
 use crate::render::format::OutputFormat;
 use crate::render::plain::PlainText;

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -2230,7 +2230,7 @@ fn anonymous_entry_type_variants_reorder_online_entries_and_drop_print_fallback_
 #[test]
 fn elsevier_harvard_entry_encyclopedia_uses_entry_template_instead_of_chapter_detail() {
     let style = load_style("styles/embedded/elsevier-harvard.yaml");
-    let bibliography = citum_engine::io::load_bibliography(
+    let bibliography = citum_io::load_bibliography(
         &project_root().join("tests/fixtures/references-expanded.json"),
     )
     .expect("expanded bibliography should load");
@@ -2826,7 +2826,7 @@ fn nested_inline_article_journal_detail_group_suppresses_missing_issue_without_e
 
 fn royal_society_of_chemistry_restores_legacy_page_less_doi_behavior() {
     let style = load_style("styles/royal-society-of-chemistry.yaml");
-    let bib = citum_engine::io::load_bibliography(
+    let bib = citum_io::load_bibliography(
         &project_root().join("tests/fixtures/references-expanded.json"),
     )
     .expect("expanded bibliography should load");
@@ -3518,7 +3518,9 @@ fn archive_location_string_bypasses_assembly() {
 
 #[test]
 fn processor_renders_bibliography_annotations() {
-    use citum_engine::{Processor, io::AnnotationStyle, render::plain::PlainText};
+    use citum_engine::Processor;
+    use citum_engine::render::plain::PlainText;
+    use citum_io::AnnotationStyle;
     use citum_schema::reference::{InputReference, Monograph, MonographType, RefID, Title};
     use indexmap::IndexMap;
     use std::collections::HashMap;

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -19,7 +19,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use std::{fs, path::PathBuf};
 
 use citum_engine::Processor;
-use citum_engine::io::load_bibliography;
+use citum_io::load_bibliography;
 use citum_schema::{
     CitationSpec, Style, StyleInfo,
     citation::{Citation, CitationItem, CitationMode},

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -19,13 +19,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 mod common;
 use common::*;
 
-use citum_engine::{
-    Processor,
-    io::load_bibliography,
-    processor::document::{
-        CitationParser, DocumentFormat, djot::DjotParser, markdown::MarkdownParser,
-    },
+use citum_engine::Processor;
+use citum_engine::processor::document::{
+    CitationParser, DocumentFormat, djot::DjotParser, markdown::MarkdownParser,
 };
+use citum_io::load_bibliography;
 use citum_schema::{
     BibliographySpec, Locale, Style, StyleInfo,
     options::{

--- a/crates/citum-engine/tests/domain_fixtures.rs
+++ b/crates/citum-engine/tests/domain_fixtures.rs
@@ -17,7 +17,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
 use citum_engine::Processor;
-use citum_engine::io::load_bibliography;
+use citum_io::load_bibliography;
 use citum_schema::Style;
 use citum_schema::citation::{Citation, CitationItem, CitationLocator, LocatorType};
 use citum_schema::reference::{InputReference, MultilingualString};

--- a/crates/citum-engine/tests/io.rs
+++ b/crates/citum-engine/tests/io.rs
@@ -20,7 +20,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use citum_engine::io::load_bibliography_with_sets;
+use citum_io::load_bibliography_with_sets;
 use rstest::rstest;
 
 /// Generate a temp file path with unique suffix.

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -20,7 +20,7 @@ mod common;
 use common::announce_behavior;
 
 use citum_engine::Processor;
-use citum_engine::io::load_bibliography;
+use citum_io::load_bibliography;
 use citum_schema::Style;
 use citum_schema::citation::{Citation, CitationItem};
 use std::fs;

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -20,7 +20,7 @@ mod common;
 use common::announce_behavior;
 
 use citum_engine::Processor;
-use citum_engine::io::load_bibliography;
+use citum_io::load_bibliography;
 use citum_schema::Style;
 use citum_schema::citation::{Citation, CitationItem};
 use std::fs;

--- a/crates/citum-io/Cargo.toml
+++ b/crates/citum-io/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "citum-io"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Citum I/O and format conversion library"
+
+[dependencies]
+citum-schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
+citum-engine = { package = "citum-engine", path = "../citum-engine" }
+csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
+biblatex = "0.11"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
+ciborium = "0.2"
+indexmap = { version = "2.2.6", features = ["serde"] }
+url = { version = "2.5", features = ["serde"] }
+thiserror = "2.0"
+
+[lints]
+workspace = true

--- a/crates/citum-io/src/biblatex.rs
+++ b/crates/citum-io/src/biblatex.rs
@@ -149,7 +149,7 @@ fn build_article_reference(ctx: BibRefContext<'_>) -> InputReference {
 /// Maps biblatex entry types (book, article, inproceedings, etc.) to
 /// appropriate Citum reference types. Extracts all relevant fields
 /// including contributors, dates, and metadata.
-pub(crate) fn input_reference_from_biblatex(entry: &biblatex_crate::Entry) -> InputReference {
+pub fn input_reference_from_biblatex(entry: &biblatex_crate::Entry) -> InputReference {
     let id = Some(entry.key.clone().into());
     let field_str = |key: &str| {
         entry.fields.get(key).map(|f| {
@@ -280,9 +280,7 @@ fn biblatex_monograph(
 ///
 /// Maps biblatex Person data (given name, family name, prefix, suffix)
 /// to Citum's `StructuredName` contributors wrapped in a `ContributorList`.
-pub(crate) fn contributors_from_biblatex_persons(
-    persons: &[biblatex_crate::Person],
-) -> Contributor {
+pub fn contributors_from_biblatex_persons(persons: &[biblatex_crate::Person]) -> Contributor {
     let contributors: Vec<Contributor> = persons
         .iter()
         .map(|p| {

--- a/crates/citum-io/src/lib.rs
+++ b/crates/citum-io/src/lib.rs
@@ -3,6 +3,11 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
+//! Citum I/O and format conversion library.
+//!
+//! Provides functions to load bibliographies and citations from various formats
+//! (Citum YAML/JSON/CBOR, CSL-JSON, BibLaTeX, RIS) into Citum's internal types.
+
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::fs;
@@ -15,9 +20,13 @@ use citum_schema::reference::types::{ArchiveInfo, EprintInfo};
 use csl_legacy::csl_json::Reference as LegacyReference;
 use indexmap::IndexMap;
 
-use crate::render::format::OutputFormat;
-use crate::render::rich_text::render_djot_inline;
-use crate::{Bibliography, Citation, ProcessorError, Reference};
+pub use citum_engine::api::{AnnotationFormat, AnnotationStyle};
+use citum_engine::processor::validate_compound_sets;
+use citum_engine::render::format::OutputFormat;
+use citum_engine::render::rich_text::render_djot_inline;
+use citum_engine::{Bibliography, Citation, ProcessorError, Reference};
+
+pub mod biblatex;
 
 /// Bibliography formats supported by reusable reference conversion helpers.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -50,35 +59,6 @@ struct LegacyBibliographyWrapper {
     references: Vec<LegacyReference>,
     #[serde(default)]
     sets: Option<IndexMap<String, Vec<String>>>,
-}
-
-/// Controls how annotation text is rendered in an annotated bibliography.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct AnnotationStyle {
-    /// Markup format for annotation text. Default: Djot.
-    #[serde(default)]
-    pub format: AnnotationFormat,
-}
-
-impl Default for AnnotationStyle {
-    fn default() -> Self {
-        Self {
-            format: AnnotationFormat::Djot,
-        }
-    }
-}
-
-/// Markup format for annotation text.
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AnnotationFormat {
-    /// Parse annotation as djot inline markup (default).
-    #[default]
-    Djot,
-    /// Treat annotation as plain text with no markup interpretation.
-    Plain,
-    /// Parse annotation as org-mode markup.
-    Org,
 }
 
 /// Render a free-text reference field with djot inline markup.
@@ -168,57 +148,6 @@ pub fn load_annotations(path: &Path) -> Result<HashMap<String, String>, Processo
         serde_yaml::from_str::<HashMap<String, String>>(&content)
             .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))
     }
-}
-
-/// Validate optional compound sets against the loaded bibliography.
-///
-/// Validation rules:
-/// - Every member ID must exist in `bibliography`.
-/// - A member ID must not appear more than once in a single set.
-/// - A member ID must not appear across multiple sets.
-///
-/// # Errors
-///
-/// Returns an error when a compound set references an unknown ID or reuses the
-/// same member within or across sets.
-pub fn validate_compound_sets(
-    sets: Option<IndexMap<String, Vec<String>>>,
-    bibliography: &Bibliography,
-) -> Result<Option<IndexMap<String, Vec<String>>>, ProcessorError> {
-    let Some(sets) = sets else {
-        return Ok(None);
-    };
-
-    let mut member_owner: HashMap<String, String> = HashMap::new();
-    for (set_id, members) in &sets {
-        let mut seen_in_set: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for member in members {
-            if !seen_in_set.insert(member.clone()) {
-                return Err(ProcessorError::ParseError(
-                    "BIBLIOGRAPHY".to_string(),
-                    format!(
-                        "reference '{member}' appears more than once in compound set '{set_id}'"
-                    ),
-                ));
-            }
-            if !bibliography.contains_key(member) {
-                return Err(ProcessorError::ParseError(
-                    "BIBLIOGRAPHY".to_string(),
-                    format!("compound set '{set_id}' references unknown id '{member}'"),
-                ));
-            }
-            if let Some(existing) = member_owner.insert(member.clone(), set_id.clone()) {
-                return Err(ProcessorError::ParseError(
-                    "BIBLIOGRAPHY".to_string(),
-                    format!(
-                        "reference '{member}' appears in both compound sets '{existing}' and '{set_id}'"
-                    ),
-                ));
-            }
-        }
-    }
-
-    Ok(Some(sets))
 }
 
 fn loaded_from_input_bibliography(
@@ -752,8 +681,7 @@ fn load_citum_json_bibliography(bytes: &[u8]) -> Result<InputBibliography, Proce
                 .cloned()
                 .map(serde_json::from_value)
                 .transpose()
-                .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?
-                .unwrap_or_default(),
+                .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?,
             ..Default::default()
         });
     }
@@ -844,11 +772,11 @@ fn load_csl_json_bibliography(path: &Path) -> Result<InputBibliography, Processo
 
 fn load_biblatex_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
     let src = fs::read_to_string(path)?;
-    let bibliography = biblatex::Bibliography::parse(&src)
+    let bibliography = ::biblatex::Bibliography::parse(&src)
         .map_err(|e| ProcessorError::ParseError("BibLaTeX".to_string(), e.to_string()))?;
     let references = bibliography
         .iter()
-        .map(crate::biblatex::input_reference_from_biblatex)
+        .map(biblatex::input_reference_from_biblatex)
         .collect();
     Ok(InputBibliography {
         references,
@@ -1161,7 +1089,7 @@ fn render_ris(input: &InputBibliography) -> String {
 )]
 mod tests {
     use super::*;
-    use crate::render::plain::PlainText;
+    use citum_engine::render::plain::PlainText;
     use indexmap::IndexMap;
     use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/citum-schema-style/src/embedded/apa.rs
+++ b/crates/citum-schema-style/src/embedded/apa.rs
@@ -112,7 +112,7 @@ pub fn citation() -> Vec<TemplateComponent> {
 /// Embedded bibliography template for APA style.
 ///
 /// Renders the full bibliographic entry in APA format:
-/// Author, A. A., & Author, B. B. (Year). Title of work. *Journal Title*, *Volume*(Issue), Pages. https://doi.org/xxx
+/// Author, A. A., & Author, B. B. (Year). Title of work. *Journal Title*, *Volume*(Issue), Pages. <https://doi.org/xxx>
 ///
 /// # Panics
 ///

--- a/crates/citum-schema-style/src/embedded/chicago.rs
+++ b/crates/citum-schema-style/src/embedded/chicago.rs
@@ -30,7 +30,7 @@ pub fn author_date_citation() -> Vec<TemplateComponent> {
 /// Embedded bibliography template for Chicago author-date style.
 ///
 /// Renders the full bibliographic entry in Chicago format:
-/// Author, First. Year. "Article Title." *Journal Title* Volume (Issue): Pages. https://doi.org/xxx
+/// Author, First. Year. "Article Title." *Journal Title* Volume (Issue): Pages. <https://doi.org/xxx>
 pub fn author_date_bibliography() -> Vec<TemplateComponent> {
     vec![
         // Author

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -186,7 +186,7 @@ pub struct Style {
     #[serde(rename = "extends-pin", skip_serializing_if = "Option::is_none")]
     pub extends_pin: Option<String>,
     /// Raw YAML captured when the style was loaded via [`Style::from_yaml_str`]
-    /// or [`Style::from_yaml_bytes`]. Used by [`merge_style_overlay`] for
+    /// or [`Style::from_yaml_bytes`]. Used during style resolution for
     /// null-aware overlay merging (e.g., `ibid: ~` correctly clears an
     /// inherited preset value). Absent in programmatically-constructed styles.
     #[cfg_attr(feature = "schema", schemars(skip))]


### PR DESCRIPTION
Extracts BibLaTeX and all file I/O from citum-engine to a new citum-io crate. Updates CLI and tests accordingly. Completes bean csl26-xio1.