### PR TITLE
feat(docs): Dynamic WASM-powered demo

### DIFF
--- a/docs/assets/citum-interactive.js
+++ b/docs/assets/citum-interactive.js
@@ -1,13 +1,115 @@
 /*
  * Citum Interactive Behaviors
+ * Powered by Citum WASM Engine
  * SPDX-License-Identifier: MPL-2.0
  */
+
+import init, { renderCitation, renderBibliography } from './wasm/citum_bindings.js';
 
 (function() {
   'use strict';
 
   const CITUM = {
-    init: function() {
+    refsJson: null,
+    currentStyleYaml: null,
+    styles: {},
+
+    init: async function() {
+      console.log('Citum: Initializing WASM engine...');
+      try {
+        await init();
+        await this.loadData();
+        this.setupStyleSwitcher();
+        await this.updateContent();
+        this.setupInteractivity();
+      } catch (err) {
+        console.error('Citum initialization failed:', err);
+      }
+    },
+
+    loadData: async function() {
+      // Load references
+      const refsRes = await fetch('assets/data/refs.json');
+      this.refsJson = await refsRes.text();
+
+      // Load styles
+      const styleFiles = [
+        'apa-7th.yaml',
+        'ieee.yaml',
+        'nature.yaml',
+        'chicago-author-date-18th.yaml'
+      ];
+
+      for (const styleFile of styleFiles) {
+        const res = await fetch(`assets/data/${styleFile}`);
+        this.styles[styleFile] = await res.text();
+      }
+
+      this.currentStyleYaml = this.styles['apa-7th.yaml'];
+    },
+
+    setupStyleSwitcher: function() {
+      const select = document.getElementById('style-select');
+      if (select) {
+        select.addEventListener('change', async (e) => {
+          this.currentStyleYaml = this.styles[e.target.value];
+          await this.updateContent();
+          this.setupInteractivity(); // Re-bind events to new elements
+        });
+      }
+    },
+
+    updateContent: async function() {
+      if (!this.currentStyleYaml || !this.refsJson) return;
+
+      console.log('Citum: Re-rendering citations and bibliography...');
+
+      // Render all citations
+      const citationElements = document.querySelectorAll('.citum-citation');
+      for (const el of citationElements) {
+        const ids = el.getAttribute('data-ref').split(' ');
+        const mode = el.getAttribute('data-mode') || 'NonIntegral';
+        
+        const citationObj = {
+          id: ids.join('-'),
+          items: ids.map(id => ({ id }))
+        };
+
+        try {
+          const html = renderCitation(
+            this.currentStyleYaml,
+            this.refsJson,
+            JSON.stringify(citationObj),
+            mode
+          );
+          // Replace the element entirely to avoid nested .citum-citation spans
+          const temp = document.createElement('div');
+          temp.innerHTML = html;
+          const rendered = temp.firstElementChild;
+          if (rendered) {
+            // Restore metadata attributes for future re-renders
+            rendered.setAttribute('data-ref', ids.join(' '));
+            rendered.setAttribute('data-mode', mode);
+            el.replaceWith(rendered);
+          }
+        } catch (e) {
+          console.error(`Failed to render citation for [${ids}]:`, e);
+        }
+      }
+
+      // Render bibliography
+      const bibOutput = document.getElementById('bibliography-output');
+      if (bibOutput) {
+        try {
+          const html = renderBibliography(this.currentStyleYaml, this.refsJson);
+          bibOutput.innerHTML = html;
+        } catch (e) {
+          console.error('Failed to render bibliography:', e);
+        }
+      }
+    },
+
+    setupInteractivity: function() {
       this.setupCitations();
       this.setupBibliography();
       this.setupTooltips();
@@ -16,21 +118,26 @@
     setupCitations: function() {
       const citations = document.querySelectorAll('.citum-citation');
       citations.forEach(citation => {
-        citation.addEventListener('click', (e) => {
-          const refs = citation.getAttribute('data-ref').split(' ');
+        // Remove existing listeners by cloning (simple way to clear)
+        // Note: replaceWith above already creates fresh elements, but we clone for safety
+        const newCitation = citation.cloneNode(true);
+        citation.parentNode.replaceChild(newCitation, citation);
+
+        newCitation.addEventListener('click', (e) => {
+          const refs = newCitation.getAttribute('data-ref').split(' ');
           if (refs.length > 0) {
             this.scrollToEntry(refs[0]);
             this.highlightEntry(refs[0]);
           }
         });
 
-        citation.addEventListener('mouseenter', () => {
-          const refs = citation.getAttribute('data-ref').split(' ');
+        newCitation.addEventListener('mouseenter', () => {
+          const refs = newCitation.getAttribute('data-ref').split(' ');
           refs.forEach(ref => this.highlightEntry(ref, true));
         });
 
-        citation.addEventListener('mouseleave', () => {
-          const refs = citation.getAttribute('data-ref').split(' ');
+        newCitation.addEventListener('mouseleave', () => {
+          const refs = newCitation.getAttribute('data-ref').split(' ');
           refs.forEach(ref => this.highlightEntry(ref, false));
         });
       });
@@ -55,7 +162,6 @@
       const target = document.getElementById('ref-' + id);
       if (target) {
         target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        // Update URL fragment without jumping
         history.replaceState(null, null, '#ref-' + id);
       }
     },
@@ -83,6 +189,10 @@
     },
 
     setupTooltips: function() {
+      // Remove existing tooltip if any
+      const existing = document.querySelector('.citum-tooltip');
+      if (existing) existing.remove();
+
       const tooltip = document.createElement('div');
       tooltip.className = 'citum-tooltip';
       document.body.appendChild(tooltip);
@@ -93,20 +203,26 @@
           const refs = citation.getAttribute('data-ref').split(' ');
           if (refs.length === 0) return;
 
-          // For simplicity in the demo, we use the first reference for the tooltip
           const entry = document.getElementById('ref-' + refs[0]);
           if (!entry) return;
 
-          const author = entry.getAttribute('data-author') || '';
-          const year = entry.getAttribute('data-year') || '';
-          const title = entry.getAttribute('data-title') || '';
+          // Try to extract info from the rendered entry if data attributes aren't present
+          const author = entry.getAttribute('data-author') || entry.querySelector('.citum-author')?.textContent || '';
+          const title = entry.getAttribute('data-title') || entry.querySelector('.citum-title')?.textContent || '';
 
-          if (!author && !title) return;
-
-          tooltip.innerHTML = `
-            ${author ? `<span class="citum-tooltip-author">${author}${year ? ` (${year})` : ''}</span>` : ''}
-            ${title ? `<span class="citum-tooltip-title">${title}</span>` : ''}
-          `;
+          tooltip.innerHTML = '';
+          if (author) {
+            const authorEl = document.createElement('span');
+            authorEl.className = 'citum-tooltip-author';
+            authorEl.textContent = author;
+            tooltip.appendChild(authorEl);
+          }
+          if (title) {
+            const titleEl = document.createElement('span');
+            titleEl.className = 'citum-tooltip-title';
+            titleEl.textContent = title;
+            tooltip.appendChild(titleEl);
+          }
 
           tooltip.style.left = (e.pageX + 15) + 'px';
           tooltip.style.top = (e.pageY + 15) + 'px';
@@ -120,12 +236,8 @@
     }
   };
 
-  // Initialize when DOM is ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => CITUM.init());
-  } else {
-    CITUM.init();
-  }
+  // Initialize
+  CITUM.init();
 
   // Export to window
   window.CITUM = CITUM;

--- a/docs/assets/data/apa-7th.yaml
+++ b/docs/assets/data/apa-7th.yaml
@@ -1,0 +1,864 @@
+info:
+  title: American Psychological Association 7th edition
+  fields:
+  - anthropology
+  - communications
+  - law
+  - medicine
+  - psychology
+  - social-science
+  source:
+    csl-id: http://www.zotero.org/styles/apa
+    adapted-by: citum-migrate
+    license: http://creativecommons.org/licenses/by-sa/3.0/
+    original-authors:
+    - name: Brenton M. Wiernik
+      email: zotero@wiernik.org
+      uri: https://orcid.org/0000-0001-9560-6336
+    - name: Andrew Dunning
+      uri: https://orcid.org/0000-0003-0464-5036
+    links:
+    - href: http://www.zotero.org/styles/apa
+      rel: self
+    - href: http://www.zotero.org/styles/apa-6th-edition
+      rel: template
+    - href: https://apastyle.apa.org/style-grammar-guidelines/references
+      rel: documentation
+  short-name: "APA"
+  edition: "7th"
+options:
+  processing: author-date
+  substitute:
+    template:
+      - editor
+      - title
+      - translator
+    role-substitute:
+      container-author:
+        - editor
+        - editorial-director
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    role: short-suffix
+    demote-non-dropping-particle: never
+    delimiter-precedes-last: always
+    and: symbol
+    shorten:
+      min: 21
+      use-first: 19
+      use-last: 1
+  dates: long
+  titles:
+    component:
+      text-case: as-is
+    monograph:
+      text-case: as-is
+      emph: true
+    container-monograph:
+      text-case: as-is
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      text-case: as-is
+  multilingual:
+    title-mode: combined
+    name-mode: primary
+    preferred-script: Latn
+  page-range-format: expanded
+  punctuation-in-quote: true
+citation:
+  options:
+    contributors:
+      shorten: {min: 3, use-first: 1}
+  sort: author-date-title
+  non-integral:
+    wrap:
+      punctuation: parentheses
+    type-variants:
+      ? legal-case, treaty, hearing
+      : - title: primary
+          form: short
+          emph: true
+          quote: false
+        - date: issued
+          form: year
+        - variable: locator
+      personal-communication:
+      - contributor: author
+        form: long
+        name-order: given-first
+      - term: personal-communication
+      - date: issued
+        form: full
+      - variable: locator
+    template:
+    - contributor: author
+      form: short
+    - date: issued
+      form: year
+    - variable: locator
+  delimiter: ", "
+  multi-cite-delimiter: "; "
+  integral:
+    delimiter: " "
+    options:
+      contributors:
+        and: text
+    type-variants:
+      ? legal-case, treaty, hearing
+      : - title: primary
+          form: short
+          emph: true
+          quote: false
+        - delimiter: ", "
+          wrap:
+            punctuation: parentheses
+          group:
+          - date: issued
+            form: year
+          - variable: locator
+      personal-communication:
+      - contributor: author
+        form: long
+        name-order: given-first
+      - delimiter: ", "
+        wrap:
+          punctuation: parentheses
+        group:
+        - term: personal-communication
+        - date: issued
+          form: full
+        - variable: locator
+    template:
+    - contributor: author
+      form: short
+    - delimiter: ", "
+      wrap:
+        punctuation: parentheses
+      group:
+      - date: issued
+        form: year
+      - variable: locator
+bibliography:
+  options:
+    substitute: standard
+    hanging-indent: true
+    separator: ". "
+  type-variants:
+    personal-communication: []
+    article-journal:
+    - contributor: author
+      form: long
+      suffix: "."
+      name-order: family-first
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: true
+    - group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+      delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+    - number: edition
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - delimiter: "; "
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+      group:
+      - contributor: editor
+        form: long
+        name-order: given-first
+        label: {term: editor, form: long, placement: suffix}
+      - contributor: translator
+        form: long
+        name-order: given-first
+        label: {term: translator, form: short, placement: suffix}
+      - number: report-number
+        prefix: "No. "
+    - delimiter: ", "
+      group:
+      - title: parent-serial
+        emph: true
+      - group:
+        - number: volume
+          emph: true
+        - number: issue
+          wrap:
+            punctuation: parentheses
+        delimiter: ""
+    - number: pages
+      prefix: ", "
+      suffix: "."
+    - variable: doi
+      prefix: "https://doi.org/"
+    - variable: url
+      prefix: " "
+    article-magazine:
+    - contributor: author
+      form: long
+      suffix: "."
+      name-order: family-first
+    - date: issued
+      form: year-month-day
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - contributor: translator
+      form: long
+      name-order: given-first
+      label: {term: translator, form: short, placement: suffix}
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+      delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+    - delimiter: ", "
+      group:
+      - title: parent-serial
+        emph: true
+      - group:
+        - number: volume
+          emph: true
+        - number: issue
+          wrap:
+            punctuation: parentheses
+        delimiter: ""
+    - number: pages
+      prefix: ", "
+      suffix: "."
+    - variable: doi
+      prefix: "https://doi.org/"
+    - variable: url
+      prefix: " "
+    article-newspaper:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year-month-day
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - contributor: translator
+      form: long
+      name-order: given-first
+      label: {term: translator, form: short, placement: suffix}
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+      delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+    - title: parent-serial
+      emph: true
+      prefix: ". "
+    - number: pages
+      prefix: ", "
+      suffix: "."
+    - variable: doi
+      prefix: "https://doi.org/"
+    - variable: url
+      prefix: " "
+    chapter:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - contributor: translator
+      form: long
+      name-order: given-first
+      label: {term: translator, form: short, placement: suffix}
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - delimiter: " "
+      group:
+      - term: in
+        text-case: capitalize-first
+      - delimiter: ", "
+        group:
+        - contributor: container-author
+          form: long
+          name-order: given-first
+        - title: parent-monograph
+          emph: true
+    - delimiter: ", "
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+      suffix: "."
+      group:
+      - number: edition
+        suffix: " ed."
+      - number: collection-number
+        prefix: "Vol. "
+      - number: part-number
+        prefix: "Pt. "
+      - number: report-number
+        prefix: "Technical Report No. "
+      - number: pages
+        label-form: short
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - variable: doi
+      prefix: " https://doi.org/"
+    - variable: url
+      prefix: " "
+    paper-conference:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - contributor: translator
+      form: long
+      name-order: given-first
+      label: {term: translator, form: short, placement: suffix}
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - delimiter: ", "
+      prefix: ". In "
+      suffix: "."
+      group:
+      - contributor: editor
+        form: long
+        name-order: given-first
+        label: {term: editor, form: short, placement: suffix}
+      - delimiter: " "
+        group:
+        - title: parent-monograph
+          emph: true
+        - delimiter: ", "
+          wrap:
+            punctuation: parentheses
+          group:
+          - number: collection-number
+            prefix: "Vol. "
+          - number: pages
+            label-form: short
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - variable: doi
+      prefix: " https://doi.org/"
+    - variable: url
+      prefix: " "
+    event:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year-month
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - delimiter: ", "
+      prefix: ". In "
+      suffix: "."
+      group:
+      - contributor: chair
+        form: long
+        name-order: given-first
+      - delimiter: " "
+        group:
+        - title: parent-monograph
+          emph: false
+        - variable: genre
+          text-case: capitalize-first
+          wrap:
+            punctuation: brackets
+    - variable: url
+      prefix: " "
+    dataset:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+      suffix: " [Dataset]."
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - variable: url
+      prefix: " "
+    entry-dictionary:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - contributor: translator
+      form: long
+      name-order: given-first
+      label: {term: translator, form: short, placement: suffix}
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - delimiter: ", "
+      prefix: ". In "
+      suffix: "."
+      group:
+      - contributor: editor
+        form: long
+        name-order: given-first
+        label: {term: editor, form: short, placement: suffix}
+      - delimiter: " "
+        group:
+        - title: parent-monograph
+          emph: true
+        - delimiter: ", "
+          wrap:
+            punctuation: parentheses
+          group:
+          - number: edition
+            suffix: " ed."
+          - number: collection-number
+            prefix: "Vol. "
+          - number: pages
+            label-form: short
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - variable: doi
+      prefix: " https://doi.org/"
+    - variable: url
+      prefix: " "
+    entry-encyclopedia:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - contributor: translator
+      form: long
+      name-order: given-first
+      label: {term: translator, form: short, placement: suffix}
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - delimiter: ", "
+      prefix: ". In "
+      suffix: "."
+      group:
+      - contributor: editor
+        form: long
+        name-order: given-first
+        label: {term: editor, form: short, placement: suffix}
+      - delimiter: " "
+        group:
+        - title: parent-monograph
+          emph: true
+        - delimiter: ", "
+          wrap:
+            punctuation: parentheses
+          group:
+          - number: edition
+            suffix: " ed."
+          - number: collection-number
+            prefix: "Vol. "
+          - number: pages
+            label-form: short
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - variable: doi
+      prefix: " https://doi.org/"
+    - variable: url
+      prefix: " "
+    song:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - delimiter: "; "
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+      group:
+      - contributor: translator
+        form: long
+        name-order: given-first
+        label: {term: translator, form: short, placement: suffix}
+      - variable: number
+      - delimiter: ", "
+        group:
+        - delimiter: ""
+          group:
+          - term: volume
+            form: short
+            text-case: capitalize-first
+            suffix: " "
+          - number: volume
+        - number: chapter-number
+    - variable: medium
+      text-case: capitalize-first
+      wrap:
+        punctuation: brackets
+      prefix: " "
+    - variable: publisher
+      prefix: ". "
+      suffix: "."
+    - variable: url
+      prefix: " "
+    motion-picture:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: true
+    - delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+      group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+    - variable: publisher
+      prefix: ". "
+      suffix: "."
+    - variable: url
+      prefix: " "
+    broadcast:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year-month-day
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+      suffix: ""
+    - number: issue
+      prefix: " ("
+      suffix: ")"
+    - variable: medium
+      wrap:
+        punctuation: brackets
+      prefix: " "
+      suffix: "."
+    - title: parent-serial
+      emph: true
+      prefix: " In "
+      suffix: "."
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - variable: url
+      prefix: " "
+    interview:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year-month-day
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - contributor: interviewer
+      form: long
+      name-order: given-first
+      label: {term: interviewer, form: long, placement: suffix}
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+      suffix: "."
+      group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+    - variable: publisher
+      prefix: " "
+      suffix: "."
+    - group:
+      - variable: archive-collection
+      - variable: archive-location
+        wrap:
+          punctuation: parentheses
+        prefix: " "
+      delimiter: ""
+      suffix: ","
+      prefix: " "
+    - group:
+      - variable: archive-name
+      - variable: archive-place
+        prefix: ", "
+    - variable: url
+      prefix: " "
+    patent:
+    - contributor: author
+      form: long
+      name-order: family-first
+      suffix: "."
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: true
+      suffix: "."
+    - variable: patent-number
+      prefix: " U.S. Patent No. "
+      suffix: "."
+    preprint:
+    - contributor: author
+      form: long
+      suffix: "."
+      name-order: family-first
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - delimiter: "; "
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+      group:
+      - contributor: editor
+        form: long
+        name-order: given-first
+        label: {term: editor, form: short, placement: suffix}
+      - contributor: translator
+        form: long
+        name-order: given-first
+        label: {term: translator, form: short, placement: suffix}
+      - number: report-number
+        prefix: "No. "
+    - variable: publisher
+      prefix: ". "
+      suffix: "."
+    - variable: doi
+      prefix: " https://doi.org/"
+    - variable: url
+      prefix: " "
+    post:
+    - contributor: author
+      form: long
+      suffix: "."
+      name-order: family-first
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    - title: primary
+      emph: false
+    - group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+      delimiter: "; "
+      wrap:
+        punctuation: brackets
+      prefix: " "
+      suffix: "."
+    - title: parent-monograph
+      emph: false
+      text-case: title
+      prefix: " "
+      suffix: "."
+    - variable: url
+      prefix: " "
+    webpage:
+      extends: post
+      add:
+        - component:
+            delimiter: '; '
+            wrap:
+              punctuation: parentheses
+            prefix: ' '
+            group:
+              - contributor: editor
+                form: long
+                name-order: given-first
+                label:
+                  term: editor
+                  form: short
+                  placement: suffix
+              - contributor: translator
+                form: long
+                name-order: given-first
+                label:
+                  term: translator
+                  form: short
+                  placement: suffix
+          before:
+            group:
+              - variable: genre
+                text-case: capitalize-first
+              - variable: medium
+                text-case: capitalize-first
+  template:
+  - contributor: author
+    form: long
+    suffix: "."
+    name-order: family-first
+  - date: issued
+    form: year
+    wrap:
+      punctuation: parentheses
+    prefix: " "
+  - title: primary
+    emph: true
+  - delimiter: "; "
+    wrap:
+      punctuation: brackets
+    prefix: " "
+    group:
+      - variable: genre
+        text-case: capitalize-first
+      - variable: medium
+        text-case: capitalize-first
+  - number: edition
+    wrap:
+      punctuation: parentheses
+    prefix: " "
+  - delimiter: ""
+    wrap:
+      punctuation: parentheses
+    prefix: " "
+    group:
+    - term: volume
+      form: short
+      suffix: " "
+    - number: volume
+  - contributor: translator
+    form: long
+    name-order: given-first
+    label: {term: translator, form: short, placement: suffix}
+    wrap:
+      punctuation: parentheses
+    prefix: " "
+  - contributor: editor
+    form: long
+    name-order: given-first
+    prefix: ". In "
+  - title: parent-monograph
+    emph: true
+    prefix: ", "
+  - delimiter: ", "
+    group:
+    - title: parent-serial
+      emph: true
+    - delimiter: ""
+      group:
+      - number: volume
+        emph: true
+      - number: issue
+        wrap:
+          punctuation: parentheses
+  - number: pages
+    prefix: ", "
+    suffix: "."
+  - variable: publisher
+    prefix: ". "
+    suffix: "."
+  - variable: doi
+    prefix: "https://doi.org/"
+  - variable: url
+    prefix: " "
+  - group:
+    - variable: archive-name
+    - variable: archive-location
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    delimiter: ""
+    prefix: ". "

--- a/docs/assets/data/chicago-author-date-18th.yaml
+++ b/docs/assets/data/chicago-author-date-18th.yaml
@@ -1,0 +1,405 @@
+info:
+  title: Chicago Manual of Style 18th edition (author-date)
+  description: Chicago-style source citations (with Bluebook for legal citations), author-date system
+  fields:
+  - anthropology
+  - communications
+  - geography
+  - history
+  - humanities
+  - law
+  - linguistics
+  - literature
+  - philosophy
+  - science
+  - sociology
+  - theology
+  source:
+    csl-id: http://www.zotero.org/styles/chicago-author-date
+    adapted-by: citum-migrate
+    license: http://creativecommons.org/licenses/by-sa/3.0/
+    original-authors:
+    - name: Andrew Dunning
+      uri: https://orcid.org/0000-0003-0464-5036
+    links:
+    - href: http://www.zotero.org/styles/chicago-author-date
+      rel: self
+    - href: http://www.zotero.org/styles/chicago-notes-bibliography
+      rel: template
+    - href: https://www.chicagomanualofstyle.org/
+      rel: documentation
+  short-name: "Chicago Author-Date"
+  edition: "18th edition"
+options:
+  locators: note
+  processing:
+    disambiguate:
+      names: true
+      add-givenname: true
+      year-suffix: true
+    sort:
+      template:
+      - key: author
+        ascending: true
+      - key: year
+        ascending: true
+  contributors:
+    and: text
+    shorten:
+      min: 7
+      use-first: 3
+      and-others: et-al
+      delimiter-precedes-last: contextual
+    demote-non-dropping-particle: display-and-sort
+  dates: long
+  titles:
+    component:
+      text-case: title
+    monograph:
+      text-case: title
+      emph: true
+    container-monograph:
+      text-case: title
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      emph: true
+  page-range-format: chicago16
+  punctuation-in-quote: true
+citation:
+  options:
+    substitute:
+      template:
+      - editor
+      - translator
+      - title
+    contributors:
+      shorten:
+        min: 3
+        use-first: 1
+        and-others: et-al
+        delimiter-precedes-last: contextual
+  type-variants:
+    personal_communication:
+    - contributor: author
+      form: long
+      name-order: given-first
+      shorten:
+        min: 3
+        use-first: 1
+        and-others: et-al
+    - title: primary
+      wrap:
+        punctuation: quotes
+      prefix: ", "
+    - variable: locator
+      prefix: ", "
+  template:
+  - contributor: author
+    form: short
+    shorten:
+      min: 3
+      use-first: 1
+      and-others: et-al
+  - date: issued
+    form: year
+  - variable: locator
+    prefix: ", "
+  wrap:
+    punctuation: parentheses
+  delimiter: " "
+  multi-cite-delimiter: "; "
+bibliography:
+  options:
+    substitute:
+      contributor-role-form: short
+      template:
+      - editor
+      - translator
+      - title
+    contributors:
+      display-as-sort: first
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+        delimiter-precedes-last: contextual
+    hanging-indent: true
+    entry-suffix: .
+    separator: ". "
+  groups:
+  - id: primary-sources
+    heading:
+      localized:
+        en-US: Primary Sources
+        en: Primary Sources
+        de: Primärquellen
+        de-DE: Primärquellen
+    selector:
+      field:
+        note: primary
+  - id: archival
+    heading:
+      localized:
+        en-US: Archival Sources
+        en: Archival Sources
+        de: Archivalische Quellen
+        de-DE: Archivalische Quellen
+    selector:
+      field:
+        note: archival
+  - id: secondary
+    heading:
+      localized:
+        en-US: Secondary Sources
+        en: Secondary Sources
+        de: Sekundärquellen
+        de-DE: Sekundärquellen
+    selector:
+      not:
+        field:
+          note:
+          - primary
+          - archival
+  type-variants:
+    article-journal:
+      modify:
+        - match:
+            variable: doi
+          prefix: https://doi.org/
+    article-magazine:
+      remove:
+        - match:
+            group:
+              - number: volume
+              - number: issue
+                prefix: ' ('
+                suffix: )
+      add:
+        - component:
+            group:
+              - number: volume
+          before:
+            number: pages
+    bill-proceeding:
+    - title: primary
+    - variable: publisher
+      prefix: ", "
+    - number: chapter-number
+      prefix: " "
+    - variable: number
+      prefix: ", "
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    bill-record:
+    - group:
+      - number: volume
+      - title: primary
+      delimiter: " "
+    - variable: number
+      prefix: " "
+    - date: issued
+      form: year
+      wrap:
+        punctuation: parentheses
+      prefix: " "
+    book:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - date: issued
+      form: year
+    - title: primary
+    - contributor: translator
+      form: long
+      name-order: given-first
+      prefix: ". Translated by "
+    - group:
+      - contributor: editor
+        form: verb
+        name-order: given-first
+      - title: parent-monograph
+        emph: true
+    - title: parent-serial
+      emph: true
+    - group:
+      - number: volume
+      - number: issue
+        prefix: " ("
+        suffix: ")"
+    - variable: publisher
+    - variable: doi
+    - variable: url
+    broadcast:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - date: issued
+      form: year
+    - title: parent-serial
+      emph: true
+    - variable: number
+      prefix: ". "
+      text-case: capitalize-first
+    - title: primary
+      wrap:
+        punctuation: quotes
+      prefix: ", "
+    - date: issued
+      form: month-day
+      prefix: ". Aired "
+    - variable: publisher
+      prefix: ", on "
+    - variable: dimensions
+      prefix: ". "
+    - variable: url
+    manuscript:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - date: issued
+      form: year
+    - title: primary
+    - variable: genre
+    - variable: archive-location
+    - group:
+      - variable: archive-name
+      - variable: archive-place
+        prefix: ", "
+    - variable: url
+    webpage:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - variable: publisher
+    - date: issued
+      form: year
+    - title: primary
+      wrap:
+        punctuation: quotes
+    - variable: url
+    chapter:
+      remove:
+        - match:
+            number: pages
+    entry-dictionary:
+    - title: parent-monograph
+      emph: true
+      suffix: "."
+    - date: issued
+      form: year
+    - title: primary
+      quote: true
+      prefix: " "
+      suffix: "."
+    - variable: status
+      text-case: capitalize-first
+      prefix: " "
+      suffix: "."
+    - variable: publisher
+    - variable: doi
+      prefix: "https://doi.org/"
+    legal-case:
+      extends: book
+      modify:
+        - match:
+            title: primary
+          emph: true
+      remove:
+        - match:
+            contributor: translator
+      add:
+        - component:
+            number: pages
+            prefix: ': '
+          before:
+            variable: publisher
+    motion-picture:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - date: issued
+      form: year
+    - title: primary
+    - variable: publisher
+    - group:
+      - variable: medium
+      - variable: dimensions
+        prefix: ", "
+    - variable: url
+    patent:
+    - contributor: author
+      form: long
+      name-order: family-first
+    - date: issued
+      form: year
+    - title: primary
+    - prefix: ". "
+      delimiter: none
+      group:
+      - term: patent
+        suffix: " "
+      - number: number
+      - date: issued
+        form: full
+        prefix: ", issued "
+    report:
+      extends: book
+      remove:
+        - match:
+            contributor: translator
+    thesis:
+      extends: book
+      remove:
+        - match:
+            contributor: translator
+    personal-communication: []
+  template:
+  - contributor: author
+    form: long
+    name-order: family-first
+    shorten:
+      min: 8
+      use-first: 3
+  - date: issued
+    form: year
+  - title: primary
+    wrap:
+      punctuation: quotes
+  - group:
+    - contributor: editor
+      form: verb
+      name-order: given-first
+    - title: parent-monograph
+      emph: true
+  - title: parent-serial
+    emph: true
+  - group:
+    - number: volume
+    - number: issue
+      prefix: " ("
+      suffix: ")"
+  - number: pages
+    prefix: ": "
+  - variable: publisher
+  - variable: doi
+  - variable: url

--- a/docs/assets/data/ieee.yaml
+++ b/docs/assets/data/ieee.yaml
@@ -1,0 +1,325 @@
+info:
+  title: IEEE Reference Guide version 11.29.2023
+  description: IEEE style as per the 2023 guidelines.
+  fields:
+  - engineering
+  source:
+    csl-id: http://www.zotero.org/styles/ieee
+    adapted-by: citum-migrate
+    license: http://creativecommons.org/licenses/by-sa/3.0/
+    original-authors:
+    - name: Michael Berkowitz
+      email: mberkowi@gmu.edu
+    links:
+    - href: http://www.zotero.org/styles/ieee
+      rel: self
+    - href: https://journals.ieeeauthorcenter.ieee.org/your-role-in-article-production/ieee-editorial-style-manual/
+      rel: documentation
+  short-name: "IEEE"
+options:
+  substitute: editor-translator-short
+  processing: numeric
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    demote-non-dropping-particle: sort-only
+  dates: short
+  titles: humanities
+  punctuation-in-quote: true
+citation:
+  template:
+  - delimiter: none
+    wrap:
+      punctuation: brackets
+    group:
+    - number: citation-number
+    - variable: locator
+      prefix: ", "
+  multi-cite-delimiter: ", "
+bibliography:
+  options:
+    contributors:
+      name-form: initials
+      initialize-with: ". "
+      delimiter-precedes-last: never
+    separator: ", "
+  type-variants:
+    article-journal:
+      modify:
+        - match:
+            number: pages
+          label-form: short
+    article-magazine:
+      modify:
+        - match:
+            number: pages
+          label-form: short
+    book:
+    - delimiter: ""
+      group:
+      - number: citation-number
+        wrap:
+          punctuation: brackets
+      - contributor: author
+        form: long
+        and: text
+        name-order: given-first
+        shorten:
+          min: 8
+          use-first: 1
+    - title: primary
+    - title: parent-monograph
+      emph: true
+    - title: parent-serial
+      emph: true
+    - number: edition
+    - number: volume
+      prefix: ", vol. "
+    - number: issue
+      prefix: ", no. "
+    - variable: publisher-place
+      prefix: ". "
+    - variable: publisher
+      prefix: ": "
+    - number: pages
+    - date: issued
+      form: year
+    - variable: doi
+      prefix: ", doi: "
+    - variable: url
+    broadcast:
+    - delimiter: ""
+      group:
+      - number: citation-number
+        wrap:
+          punctuation: brackets
+      - contributor: author
+        form: long
+        and: text
+        name-order: given-first
+        shorten:
+          min: 8
+          use-first: 1
+    - title: primary
+    - title: parent-monograph
+      emph: true
+    - title: parent-serial
+      emph: true
+    - number: edition
+    - number: volume
+      prefix: ", vol. "
+    - number: issue
+      prefix: ", no. "
+    - variable: publisher-place
+    - variable: publisher
+      prefix: ": "
+    - number: pages
+    - date: issued
+      form: year
+    - variable: doi
+      prefix: ", doi: "
+    - variable: url
+    chapter:
+      modify:
+        - match:
+            number: pages
+          label-form: short
+    dataset:
+    - delimiter: ""
+      group:
+      - number: citation-number
+        wrap:
+          punctuation: brackets
+      - contributor: author
+        form: long
+        and: text
+        name-order: given-first
+        shorten:
+          min: 8
+          use-first: 1
+    - title: primary
+    - title: parent-monograph
+      emph: true
+    - title: parent-serial
+      emph: true
+    - number: edition
+    - number: volume
+      prefix: ", vol. "
+    - number: issue
+      prefix: ", no. "
+    - variable: publisher-place
+    - variable: publisher
+      prefix: ": "
+    - number: pages
+    - date: issued
+      form: year
+    - variable: doi
+      prefix: ", doi: "
+    - variable: url
+    entry-encyclopedia:
+      extends: broadcast
+      modify:
+        - match:
+            number: pages
+          label-form: short
+    motion-picture:
+    - delimiter: ""
+      group:
+      - number: citation-number
+        wrap:
+          punctuation: brackets
+      - contributor: author
+        form: long
+        and: text
+        name-order: given-first
+        shorten:
+          min: 8
+          use-first: 1
+    - title: primary
+    - title: parent-monograph
+      emph: true
+    - title: parent-serial
+      emph: true
+    - number: edition
+    - number: volume
+      prefix: ", vol. "
+    - number: issue
+      prefix: ", no. "
+    - variable: publisher-place
+    - variable: publisher
+      prefix: ": "
+    - number: pages
+    - date: issued
+      form: year
+    - variable: doi
+      prefix: ", doi: "
+    - variable: url
+    paper-conference:
+      modify:
+        - match:
+            number: pages
+          label-form: short
+    patent:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - contributor: author
+      form: long
+      shorten:
+        min: 7
+        use-first: 1
+        and-others: et-al
+        delimiter-precedes-last: contextual
+      and: text
+    - title: primary
+      quote: true
+      wrap:
+        punctuation: quotes
+    - date: issued
+      form: full
+    personal_communication:
+    - delimiter: ""
+      group:
+      - number: citation-number
+        wrap:
+          punctuation: brackets
+      - contributor: author
+        form: long
+        and: text
+        name-order: given-first
+        shorten:
+          min: 8
+          use-first: 1
+    - title: primary
+      wrap:
+        punctuation: quotes
+    - title: parent-monograph
+      emph: true
+    - title: parent-serial
+      emph: true
+    - number: edition
+    - number: volume
+      prefix: ", vol. "
+    - number: issue
+      prefix: ", no. "
+    - variable: publisher-place
+    - variable: publisher
+      prefix: ": "
+    - number: pages
+    - date: issued
+      form: year
+    - variable: doi
+      prefix: ", doi: "
+    - variable: url
+    report:
+    - delimiter: ""
+      group:
+      - number: citation-number
+        wrap:
+          punctuation: brackets
+      - contributor: author
+        form: long
+        and: text
+        name-order: given-first
+        shorten:
+          min: 8
+          use-first: 1
+    - title: primary
+    - title: parent-monograph
+      emph: true
+    - title: parent-serial
+      emph: true
+    - number: edition
+    - number: volume
+      prefix: ", vol. "
+    - number: issue
+      prefix: ", no. "
+    - variable: publisher-place
+    - variable: publisher
+      prefix: ": "
+    - number: pages
+    - date: issued
+      form: year
+    - variable: doi
+      prefix: ", doi: "
+    - variable: url
+    thesis:
+      extends: book
+      modify:
+        - match:
+            title: primary
+          emph: true
+  template:
+  - delimiter: ""
+    group:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 8
+        use-first: 1
+  - title: primary
+    wrap:
+      punctuation: quotes
+  - title: parent-monograph
+    emph: true
+  - title: parent-serial
+    emph: true
+  - number: edition
+  - number: volume
+    prefix: ", vol. "
+  - number: issue
+    prefix: ", no. "
+  - variable: publisher-place
+  - variable: publisher
+    prefix: ": "
+  - number: pages
+  - date: issued
+    form: year
+  - variable: doi
+    prefix: ", doi: "
+  - variable: url

--- a/docs/assets/data/nature.yaml
+++ b/docs/assets/data/nature.yaml
@@ -1,0 +1,88 @@
+info:
+  title: Nature
+  fields:
+  - science
+  source:
+    csl-id: http://www.zotero.org/styles/nature
+    adapted-by: citum-migrate
+    license: http://creativecommons.org/licenses/by-sa/3.0/
+    original-authors:
+    - name: Michael Berkowitz
+      email: mberkowi@gmu.edu
+    links:
+    - href: http://www.zotero.org/styles/nature
+      rel: self
+    - href: https://www.nature.com/nature/for-authors/formatting-guide
+      rel: documentation
+  short-name: "Nature"
+options:
+  processing: numeric
+  contributors:
+    display-as-sort: all
+    name-form: initials
+    initialize-with: ". "
+    shorten:
+      min: 6
+      use-first: 1
+      and-others: et-al
+      delimiter-precedes-last: contextual
+    delimiter: ", "
+    delimiter-precedes-last: never
+    demote-non-dropping-particle: sort-only
+    sort-separator: ", "
+  dates: long
+  titles: humanities
+citation:
+  template-ref: numeric-citation
+  collapse: citation-number
+  multi-cite-delimiter: ","
+bibliography:
+  options:
+    contributors:
+      display-as-sort: all
+      name-form: initials
+      initialize-with: ". "
+      shorten:
+        min: 6
+        use-first: 1
+        and-others: et-al
+        delimiter-precedes-last: contextual
+      delimiter: ", "
+      delimiter-precedes-last: never
+      sort-separator: ", "
+    entry-suffix: .
+    separator: ". "
+  type-variants:
+    report:
+      remove:
+        - match:
+            variable: publisher
+        - match:
+            variable: publisher-place
+  template:
+  - contributor: author
+    form: long
+    name-order: family-first
+    shorten:
+      min: 8
+      use-first: 1
+  - title: primary
+    prefix: " "
+  - group:
+    - contributor: editor
+      form: verb
+      name-order: family-first
+    - title: parent-monograph
+      emph: true
+  - title: parent-serial
+    emph: true
+  - number: pages
+  - variable: publisher
+    prefix: " ("
+  - variable: publisher-place
+    prefix: ", "
+  - date: issued
+    form: year
+    wrap:
+      punctuation: parentheses
+    prefix: ", "

--- a/docs/assets/data/refs.json
+++ b/docs/assets/data/refs.json
@@ -1,0 +1,112 @@
+{
+  "kuhn1962": {
+    "id": "kuhn1962",
+    "class": "serial-component",
+    "type": "article",
+    "title": "The Structure of Scientific Revolutions",
+    "author": [{ "family": "Kuhn", "given": "Thomas S." }],
+    "issued": "1962",
+    "container": {
+      "class": "serial",
+      "type": "academic-journal",
+      "title": "International Encyclopedia of Unified Science",
+      "publisher": { "name": "University of Chicago Press" }
+    },
+    "volume": "2",
+    "issue": "2",
+    "doi": "10.1234/example"
+  },
+  "watson1953": {
+    "id": "watson1953",
+    "class": "serial-component",
+    "type": "article",
+    "title": "Molecular Structure of Nucleic Acids: A Structure for Deoxyribose Nucleic Acid",
+    "author": [
+      { "family": "Watson", "given": "James D." },
+      { "family": "Crick", "given": "Francis H. C." }
+    ],
+    "issued": "1953-04-25",
+    "container": {
+      "class": "serial",
+      "type": "academic-journal",
+      "title": "Nature"
+    },
+    "volume": "171",
+    "issue": "4356",
+    "pages": "737-738"
+  },
+  "smith2010": {
+    "id": "smith2010",
+    "class": "monograph",
+    "type": "book",
+    "title": "Nationalism: Theory, Ideology, History",
+    "author": [{ "family": "Smith", "given": "Anthony D." }],
+    "issued": "2010",
+    "publisher": { "name": "Polity" }
+  },
+  "brown1954": {
+    "id": "brown1954",
+    "class": "monograph",
+    "type": "book",
+    "title": "Methods of Surveying and Measuring Vegetation",
+    "author": [{ "family": "Brown", "given": "Dorothy" }],
+    "issued": "1954",
+    "publisher": { "name": "Commonwealth Agricultural Bureaux" }
+  },
+  "doe2023": {
+    "id": "doe2023",
+    "class": "serial-component",
+    "type": "article",
+    "title": "Digital Humanities and Interactive Scholarly Communication",
+    "author": [{ "family": "Doe", "given": "John" }],
+    "issued": "2023",
+    "container": {
+      "class": "serial",
+      "type": "academic-journal",
+      "title": "Journal of Electronic Publishing"
+    },
+    "volume": "26",
+    "issue": "1",
+    "pages": "45-67"
+  },
+  "smith2020": {
+    "id": "smith2020",
+    "class": "monograph",
+    "type": "book",
+    "title": "Modern Web Standards for Academic Writing",
+    "author": [{ "family": "Smith", "given": "Alice" }],
+    "issued": "2020",
+    "publisher": { "name": "Web Press" }
+  },
+  "citum2026": {
+    "id": "citum2026",
+    "class": "monograph",
+    "type": "report",
+    "title": "Citum: A Declarative Future for Citations",
+    "author": [{ "family": "Citum Team", "given": "" }],
+    "issued": "2026",
+    "publisher": { "name": "GitHub" }
+  },
+  "doe2020": {
+    "id": "doe2020",
+    "class": "serial-component",
+    "type": "article",
+    "title": "Silent Paper",
+    "author": [{ "family": "Doe", "given": "Jane" }],
+    "issued": "2020",
+    "container": {
+      "class": "serial",
+      "type": "academic-journal",
+      "title": "Journal of Silence"
+    }
+  },
+  "bird1987": {
+    "id": "bird1987",
+    "class": "monograph",
+    "type": "book",
+    "title": "Ornithology",
+    "author": [{ "family": "Bird", "given": "Arthur" }],
+    "issued": "1987",
+    "publisher": { "name": "Nature Press" }
+  }
+}

--- a/docs/assets/wasm/citum_bindings.d.ts
+++ b/docs/assets/wasm/citum_bindings.d.ts
@@ -1,0 +1,112 @@
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Format a complete document's citations and bibliography in one call.
+ *
+ * Takes a JSON-encoded `FormatDocumentRequest` and returns a JSON-encoded
+ * `FormatDocumentResult`. In WASM, the resolver chain is unavailable —
+ * `StyleInput::Id` and `StyleInput::Uri` variants return an error; use
+ * `StyleInput::Yaml` (preferred) or `StyleInput::Path` (if filesystem
+ * access is available in the host).
+ *
+ * # Errors
+ *
+ * Returns a string error on request JSON parse failure, style resolution failure,
+ * or engine rendering error.
+ */
+export function formatDocument(request_json: string): string;
+
+/**
+ * Extract the `info` block from a YAML style string as JSON.
+ *
+ * # Errors
+ *
+ * Returns a string error if the YAML fails to parse or the info block cannot
+ * be serialized to JSON.
+ */
+export function getStyleMetadata(style_yaml: string): string;
+
+/**
+ * Materialize all template presets in a style and return the updated YAML.
+ *
+ * # Errors
+ *
+ * Returns a string error if the input YAML fails to parse or the materialized
+ * style cannot be serialized back to YAML.
+ */
+export function materializeStyle(style_yaml: string): string;
+
+/**
+ * Render a full bibliography to HTML.
+ *
+ * - `style_yaml` — Citum style as YAML
+ * - `refs_json` — bibliography as JSON object or CSL-JSON array
+ *
+ * # Errors
+ *
+ * Returns a string error on style or reference parse failure.
+ */
+export function renderBibliography(style_yaml: string, refs_json: string): string;
+
+/**
+ * Render a single citation to HTML.
+ *
+ * - `style_yaml` — Citum style as YAML
+ * - `refs_json` — bibliography as JSON object (`{id: Reference}`) or CSL-JSON array
+ * - `citation_json` — a single [`Citation`] as JSON
+ * - `mode` — optional mode override (e.g. `"Integral"`)
+ *
+ * # Errors
+ *
+ * Returns a string error on style/reference/citation parse failure, invalid
+ * mode string, or engine rendering error.
+ */
+export function renderCitation(style_yaml: string, refs_json: string, citation_json: string, mode?: string | null): string;
+
+/**
+ * Validate a Citum style string.
+ *
+ * # Errors
+ *
+ * Returns a string error describing the parse or schema validation failure.
+ */
+export function validateStyle(style_yaml: string): void;
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InitOutput {
+    readonly memory: WebAssembly.Memory;
+    readonly formatDocument: (a: number, b: number, c: number) => void;
+    readonly getStyleMetadata: (a: number, b: number, c: number) => void;
+    readonly materializeStyle: (a: number, b: number, c: number) => void;
+    readonly renderBibliography: (a: number, b: number, c: number, d: number, e: number) => void;
+    readonly renderCitation: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
+    readonly validateStyle: (a: number, b: number, c: number) => void;
+    readonly __wbindgen_add_to_stack_pointer: (a: number) => number;
+    readonly __wbindgen_export: (a: number, b: number) => number;
+    readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
+    readonly __wbindgen_export3: (a: number, b: number, c: number) => void;
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+
+/**
+ * Instantiates the given `module`, which can either be bytes or
+ * a precompiled `WebAssembly.Module`.
+ *
+ * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+ *
+ * @returns {InitOutput}
+ */
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
+/**
+ * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+ * for everything else, calls `WebAssembly.instantiate` directly.
+ *
+ * @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+ *
+ * @returns {Promise<InitOutput>}
+ */
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/docs/assets/wasm/citum_bindings.js
+++ b/docs/assets/wasm/citum_bindings.js
@@ -1,0 +1,460 @@
+/* @ts-self-types="./citum_bindings.d.ts" */
+
+/**
+ * Format a complete document's citations and bibliography in one call.
+ *
+ * Takes a JSON-encoded `FormatDocumentRequest` and returns a JSON-encoded
+ * `FormatDocumentResult`. In WASM, the resolver chain is unavailable —
+ * `StyleInput::Id` and `StyleInput::Uri` variants return an error; use
+ * `StyleInput::Yaml` (preferred) or `StyleInput::Path` (if filesystem
+ * access is available in the host).
+ *
+ * # Errors
+ *
+ * Returns a string error on request JSON parse failure, style resolution failure,
+ * or engine rendering error.
+ * @param {string} request_json
+ * @returns {string}
+ */
+export function formatDocument(request_json) {
+    let deferred3_0;
+    let deferred3_1;
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+        const ptr0 = passStringToWasm0(request_json, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len0 = WASM_VECTOR_LEN;
+        wasm.formatDocument(retptr, ptr0, len0);
+        var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+        var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        var ptr2 = r0;
+        var len2 = r1;
+        if (r3) {
+            ptr2 = 0; len2 = 0;
+            throw takeObject(r2);
+        }
+        deferred3_0 = ptr2;
+        deferred3_1 = len2;
+        return getStringFromWasm0(ptr2, len2);
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16);
+        wasm.__wbindgen_export3(deferred3_0, deferred3_1, 1);
+    }
+}
+
+/**
+ * Extract the `info` block from a YAML style string as JSON.
+ *
+ * # Errors
+ *
+ * Returns a string error if the YAML fails to parse or the info block cannot
+ * be serialized to JSON.
+ * @param {string} style_yaml
+ * @returns {string}
+ */
+export function getStyleMetadata(style_yaml) {
+    let deferred3_0;
+    let deferred3_1;
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+        const ptr0 = passStringToWasm0(style_yaml, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len0 = WASM_VECTOR_LEN;
+        wasm.getStyleMetadata(retptr, ptr0, len0);
+        var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+        var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        var ptr2 = r0;
+        var len2 = r1;
+        if (r3) {
+            ptr2 = 0; len2 = 0;
+            throw takeObject(r2);
+        }
+        deferred3_0 = ptr2;
+        deferred3_1 = len2;
+        return getStringFromWasm0(ptr2, len2);
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16);
+        wasm.__wbindgen_export3(deferred3_0, deferred3_1, 1);
+    }
+}
+
+/**
+ * Materialize all template presets in a style and return the updated YAML.
+ *
+ * # Errors
+ *
+ * Returns a string error if the input YAML fails to parse or the materialized
+ * style cannot be serialized back to YAML.
+ * @param {string} style_yaml
+ * @returns {string}
+ */
+export function materializeStyle(style_yaml) {
+    let deferred3_0;
+    let deferred3_1;
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+        const ptr0 = passStringToWasm0(style_yaml, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len0 = WASM_VECTOR_LEN;
+        wasm.materializeStyle(retptr, ptr0, len0);
+        var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+        var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        var ptr2 = r0;
+        var len2 = r1;
+        if (r3) {
+            ptr2 = 0; len2 = 0;
+            throw takeObject(r2);
+        }
+        deferred3_0 = ptr2;
+        deferred3_1 = len2;
+        return getStringFromWasm0(ptr2, len2);
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16);
+        wasm.__wbindgen_export3(deferred3_0, deferred3_1, 1);
+    }
+}
+
+/**
+ * Render a full bibliography to HTML.
+ *
+ * - `style_yaml` — Citum style as YAML
+ * - `refs_json` — bibliography as JSON object or CSL-JSON array
+ *
+ * # Errors
+ *
+ * Returns a string error on style or reference parse failure.
+ * @param {string} style_yaml
+ * @param {string} refs_json
+ * @returns {string}
+ */
+export function renderBibliography(style_yaml, refs_json) {
+    let deferred4_0;
+    let deferred4_1;
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+        const ptr0 = passStringToWasm0(style_yaml, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len0 = WASM_VECTOR_LEN;
+        const ptr1 = passStringToWasm0(refs_json, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len1 = WASM_VECTOR_LEN;
+        wasm.renderBibliography(retptr, ptr0, len0, ptr1, len1);
+        var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+        var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        var ptr3 = r0;
+        var len3 = r1;
+        if (r3) {
+            ptr3 = 0; len3 = 0;
+            throw takeObject(r2);
+        }
+        deferred4_0 = ptr3;
+        deferred4_1 = len3;
+        return getStringFromWasm0(ptr3, len3);
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16);
+        wasm.__wbindgen_export3(deferred4_0, deferred4_1, 1);
+    }
+}
+
+/**
+ * Render a single citation to HTML.
+ *
+ * - `style_yaml` — Citum style as YAML
+ * - `refs_json` — bibliography as JSON object (`{id: Reference}`) or CSL-JSON array
+ * - `citation_json` — a single [`Citation`] as JSON
+ * - `mode` — optional mode override (e.g. `"Integral"`)
+ *
+ * # Errors
+ *
+ * Returns a string error on style/reference/citation parse failure, invalid
+ * mode string, or engine rendering error.
+ * @param {string} style_yaml
+ * @param {string} refs_json
+ * @param {string} citation_json
+ * @param {string | null} [mode]
+ * @returns {string}
+ */
+export function renderCitation(style_yaml, refs_json, citation_json, mode) {
+    let deferred6_0;
+    let deferred6_1;
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+        const ptr0 = passStringToWasm0(style_yaml, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len0 = WASM_VECTOR_LEN;
+        const ptr1 = passStringToWasm0(refs_json, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len1 = WASM_VECTOR_LEN;
+        const ptr2 = passStringToWasm0(citation_json, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len2 = WASM_VECTOR_LEN;
+        var ptr3 = isLikeNone(mode) ? 0 : passStringToWasm0(mode, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        var len3 = WASM_VECTOR_LEN;
+        wasm.renderCitation(retptr, ptr0, len0, ptr1, len1, ptr2, len2, ptr3, len3);
+        var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+        var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+        var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+        var ptr5 = r0;
+        var len5 = r1;
+        if (r3) {
+            ptr5 = 0; len5 = 0;
+            throw takeObject(r2);
+        }
+        deferred6_0 = ptr5;
+        deferred6_1 = len5;
+        return getStringFromWasm0(ptr5, len5);
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16);
+        wasm.__wbindgen_export3(deferred6_0, deferred6_1, 1);
+    }
+}
+
+/**
+ * Validate a Citum style string.
+ *
+ * # Errors
+ *
+ * Returns a string error describing the parse or schema validation failure.
+ * @param {string} style_yaml
+ */
+export function validateStyle(style_yaml) {
+    try {
+        const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+        const ptr0 = passStringToWasm0(style_yaml, wasm.__wbindgen_export, wasm.__wbindgen_export2);
+        const len0 = WASM_VECTOR_LEN;
+        wasm.validateStyle(retptr, ptr0, len0);
+        var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+        var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+        if (r1) {
+            throw takeObject(r0);
+        }
+    } finally {
+        wasm.__wbindgen_add_to_stack_pointer(16);
+    }
+}
+function __wbg_get_imports() {
+    const import0 = {
+        __proto__: null,
+        __wbindgen_cast_0000000000000001: function(arg0, arg1) {
+            // Cast intrinsic for `Ref(String) -> Externref`.
+            const ret = getStringFromWasm0(arg0, arg1);
+            return addHeapObject(ret);
+        },
+    };
+    return {
+        __proto__: null,
+        "./citum_bindings_bg.js": import0,
+    };
+}
+
+function addHeapObject(obj) {
+    if (heap_next === heap.length) heap.push(heap.length + 1);
+    const idx = heap_next;
+    heap_next = heap[idx];
+
+    heap[idx] = obj;
+    return idx;
+}
+
+function dropObject(idx) {
+    if (idx < 1028) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+let cachedDataViewMemory0 = null;
+function getDataViewMemory0() {
+    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+    }
+    return cachedDataViewMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    return decodeText(ptr >>> 0, len);
+}
+
+let cachedUint8ArrayMemory0 = null;
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function getObject(idx) { return heap[idx]; }
+
+let heap = new Array(1024).fill(undefined);
+heap.push(undefined, null, true, false);
+
+let heap_next = heap.length;
+
+function isLikeNone(x) {
+    return x === undefined || x === null;
+}
+
+function passStringToWasm0(arg, malloc, realloc) {
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
+
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
+
+    const mem = getUint8ArrayMemory0();
+
+    let offset = 0;
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = cachedTextEncoder.encodeInto(arg, view);
+
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
+
+    WASM_VECTOR_LEN = offset;
+    return ptr;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
+}
+
+let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+cachedTextDecoder.decode();
+const MAX_SAFARI_DECODE_BYTES = 2146435072;
+let numBytesDecoded = 0;
+function decodeText(ptr, len) {
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+const cachedTextEncoder = new TextEncoder();
+
+if (!('encodeInto' in cachedTextEncoder)) {
+    cachedTextEncoder.encodeInto = function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+            read: arg.length,
+            written: buf.length
+        };
+    };
+}
+
+let WASM_VECTOR_LEN = 0;
+
+let wasmModule, wasmInstance, wasm;
+function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
+    wasm = instance.exports;
+    wasmModule = module;
+    cachedDataViewMemory0 = null;
+    cachedUint8ArrayMemory0 = null;
+    return wasm;
+}
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+            } catch (e) {
+                const validResponse = module.ok && expectedResponseType(module.type);
+
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                } else { throw e; }
+            }
+        }
+
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
+        } else {
+            return instance;
+        }
+    }
+
+    function expectedResponseType(type) {
+        switch (type) {
+            case 'basic': case 'cors': case 'default': return true;
+        }
+        return false;
+    }
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module !== undefined) {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+    const instance = new WebAssembly.Instance(module, imports);
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module_or_path !== undefined) {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
+
+    if (module_or_path === undefined) {
+        module_or_path = new URL('citum_bindings_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
+
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
+
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+export { initSync, __wbg_init as default };

--- a/docs/assets/wasm/citum_bindings_bg.wasm.d.ts
+++ b/docs/assets/wasm/citum_bindings_bg.wasm.d.ts
@@ -1,0 +1,13 @@
+/* tslint:disable */
+/* eslint-disable */
+export const memory: WebAssembly.Memory;
+export const formatDocument: (a: number, b: number, c: number) => void;
+export const getStyleMetadata: (a: number, b: number, c: number) => void;
+export const materializeStyle: (a: number, b: number, c: number) => void;
+export const renderBibliography: (a: number, b: number, c: number, d: number, e: number) => void;
+export const renderCitation: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
+export const validateStyle: (a: number, b: number, c: number) => void;
+export const __wbindgen_add_to_stack_pointer: (a: number) => number;
+export const __wbindgen_export: (a: number, b: number) => number;
+export const __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
+export const __wbindgen_export3: (a: number, b: number, c: number) => void;

--- a/docs/assets/wasm/package.json
+++ b/docs/assets/wasm/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "citum-bindings",
+  "type": "module",
+  "collaborators": [
+    "Bruce D'Arcus <bdarcus@gmail.com>"
+  ],
+  "description": "Citum cross-language bindings (WASM, cdylib)",
+  "version": "0.38.0",
+  "license": "MIT OR Apache-2.0",
+  "files": [
+    "citum_bindings_bg.wasm",
+    "citum_bindings_bg.wasm.d.ts",
+    "citum_bindings.js",
+    "citum_bindings.d.ts"
+  ],
+  "main": "citum_bindings.js",
+  "types": "citum_bindings.d.ts",
+  "sideEffects": [
+    "./snippets/*"
+  ]
+}

--- a/docs/interactive-demo.html
+++ b/docs/interactive-demo.html
@@ -166,18 +166,31 @@
       <p class="subtitle">A demonstration of how JS enriches Citum-generated HTML with bidirectional navigation and previews.</p>
     </header>
 
-  <div class="controls">
-    <span>Layout:</span>
-    <button class="btn active" id="btn-classic">Classic (Bottom)</button>
-    <button class="btn" id="btn-sidebar">Modern Sidebar</button>
+  <div class="controls flex flex-wrap gap-4">
+    <div class="flex items-center gap-2">
+        <label for="style-select" class="text-sm font-medium text-slate-600">Style:</label>
+        <select id="style-select" class="rounded border-slate-300 py-1.5 px-3 text-sm bg-white shadow-sm focus:ring-primary focus:border-primary">
+            <option value="apa-7th.yaml">APA 7th</option>
+            <option value="ieee.yaml">IEEE</option>
+            <option value="nature.yaml">Nature</option>
+            <option value="chicago-author-date-18th.yaml">Chicago (Author-Date)</option>
+        </select>
+    </div>
+    <div class="flex items-center gap-2">
+        <span class="text-sm font-medium text-slate-600">Layout:</span>
+        <div class="flex bg-slate-100 p-1 rounded-lg">
+            <button class="btn active px-3 py-1 text-sm font-medium rounded-md transition-all" id="btn-classic">Classic</button>
+            <button class="btn px-3 py-1 text-sm font-medium rounded-md transition-all text-slate-600" id="btn-sidebar">Sidebar</button>
+        </div>
+    </div>
   </div>
 
   <div id="demo-root" class="demo-container">
-    <article class="content">
+    <article class="content prose prose-slate max-w-none">
       <h2>The Paradigm Shift in Citation</h2>
       <p>
         The study of scientific history reveals that knowledge does not accumulate linearly. 
-        Instead, as <span class="citum-citation" data-ref="kuhn1962">Kuhn (1962)</span> argued, science 
+        Instead, as <span class="citum-citation" data-ref="kuhn1962" data-mode="Integral">Kuhn (1962)</span> argued, science 
         proceeds through revolutionary breaks with the past. This conceptual framework has 
         significant implications for how we attribute ideas.
       </p>
@@ -185,58 +198,27 @@
       <p>
         Recent developments in digital typography allow for more interactive engagement with 
         source materials. For instance, when citing multiple works 
-        <span class="citum-citation" data-ref="doe2023 smith2020">(Doe, 2023; Smith, 2020)</span>, 
+        <span class="citum-citation" data-ref="doe2023 smith2020" data-mode="NonIntegral">(Doe, 2023; Smith, 2020)</span>, 
         readers benefit from instant previews and bidirectional navigation.
       </p>
 
       <p>
         Interactivity is not merely a "gorgeous enhancement" but a functional necessity for 
         large documents. As noted in the Citum vision, we aim for "Total Stability" and 
-        "Explicit over Magic" <span class="citum-citation" data-ref="citum2026">(Citum, 2026)</span>.
+        "Explicit over Magic" <span class="citum-citation" data-ref="citum2026" data-mode="NonIntegral">(Citum, 2026)</span>.
       </p>
       
       <p>
-        Further research by <span class="citum-citation" data-ref="smith2020">Smith (2020)</span> 
+        Further research by <span class="citum-citation" data-ref="smith2020" data-mode="Integral">Smith (2020)</span> 
         confirms that sidebar bibliographies improve readability for note-style documents 
         by keeping references in context with the text.
       </p>
     </article>
 
-    <section class="citum-bibliography">
-      <h3>References</h3>
-      
-      <div class="citum-entry" id="ref-citum2026" 
-           data-author="Citum Team" data-year="2026" data-title="Citum: A Declarative Future for Citations">
-        <span class="citum-author">Citum Team.</span> 
-        <span class="citum-date">(2026).</span> 
-        <span class="citum-title">Citum: A Declarative Future for Citations.</span> 
-        <span class="citum-publisher">GitHub.</span>
-      </div>
-
-      <div class="citum-entry" id="ref-doe2023" 
-           data-author="Doe" data-year="2023" data-title="Digital Humanities and Interactive Scholarly Communication">
-        <span class="citum-author">Doe, J.</span> 
-        <span class="citum-date">(2023).</span> 
-        <span class="citum-title">Digital Humanities and Interactive Scholarly Communication.</span> 
-        <span class="citum-container-title">Journal of Electronic Publishing,</span> 
-        <span class="citum-volume">26</span>(1), 
-        <span class="citum-pages">45-67</span>.
-      </div>
-
-      <div class="citum-entry" id="ref-kuhn1962" 
-           data-author="Kuhn" data-year="1962" data-title="The Structure of Scientific Revolutions">
-        <span class="citum-author">Kuhn, T. S.</span> 
-        <span class="citum-date">(1962).</span> 
-        <span class="citum-title">The Structure of Scientific Revolutions.</span> 
-        <span class="citum-publisher">University of Chicago Press.</span>
-      </div>
-
-      <div class="citum-entry" id="ref-smith2020" 
-           data-author="Smith" data-year="2020" data-title="Modern Web Standards for Academic Writing">
-        <span class="citum-author">Smith, A.</span> 
-        <span class="citum-date">(2020).</span> 
-        <span class="citum-title">Modern Web Standards for Academic Writing.</span> 
-        <span class="citum-publisher">Web Press.</span>
+    <section id="bibliography-container" class="citum-bibliography">
+      <h3 class="text-xl font-bold mb-4">References</h3>
+      <div id="bibliography-output">
+        <!-- WASM generated content will go here -->
       </div>
     </section>
   </div>
@@ -263,7 +245,7 @@
             </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
 
-  <script src="assets/citum-interactive.js"></script>
+  <script type="module" src="assets/citum-interactive.js"></script>
   <script>
     const navToggle = document.querySelector('[data-nav-toggle]');
     const mobileMenu = document.querySelector('[data-mobile-menu]');
@@ -281,14 +263,18 @@
 
     btnClassic.addEventListener('click', () => {
       root.classList.remove('citum-with-sidebar');
-      btnClassic.classList.add('active');
-      btnSidebar.classList.remove('active');
+      btnClassic.classList.add('active', 'bg-white', 'shadow-sm');
+      btnClassic.classList.remove('text-slate-600');
+      btnSidebar.classList.remove('active', 'bg-white', 'shadow-sm');
+      btnSidebar.classList.add('text-slate-600');
     });
 
     btnSidebar.addEventListener('click', () => {
       root.classList.add('citum-with-sidebar');
-      btnSidebar.classList.add('active');
-      btnClassic.classList.remove('active');
+      btnSidebar.classList.add('active', 'bg-white', 'shadow-sm');
+      btnSidebar.classList.remove('text-slate-600');
+      btnClassic.classList.remove('active', 'bg-white', 'shadow-sm');
+      btnClassic.classList.add('text-slate-600');
     });
   </script>
 </body>


### PR DESCRIPTION
Enhances the interactive demo page to use Citum WASM bindings for dynamic citation and bibliography generation. 

Key changes:
- Integrated citum-bindings WASM module into the demo page.
- Added a style selection dropdown (APA, IEEE, Nature, Chicago).
- Updated citations to include both integral and non-integral examples.
- Automated re-rendering of the entire document when switching styles.
- Bundled a subset of styles and references for the demo.