### PR TITLE
fix(ci): stabilize automated release versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,8 @@ jobs:
         run: |
           python3 -m unittest \
             scripts/test_infer_release_bump.py \
-            scripts/test_coverage_analysis.py
+            scripts/test_coverage_analysis.py \
+            scripts/test_release_workflow.py
 
   rust-ci:
     name: Rust CI (Lint + Test)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,15 +120,9 @@ jobs:
       - name: Configure branching and tagging
         id: config
         run: |
-          LEVEL="${{ steps.resolve.outputs.level }}"
-          if [ "$LEVEL" = "major" ]; then
-            echo "branch=release/next" >> "$GITHUB_OUTPUT"
-            echo "create_pr=true" >> "$GITHUB_OUTPUT"
-          else
-            # patch/minor: push directly to main (RELEASE_TOKEN has admin bypass)
-            echo "branch=main" >> "$GITHUB_OUTPUT"
-            echo "create_pr=false" >> "$GITHUB_OUTPUT"
-          fi
+          # All releases flow through a release PR on release/next.
+          echo "branch=release/next" >> "$GITHUB_OUTPUT"
+          echo "create_pr=true" >> "$GITHUB_OUTPUT"
           echo "push_tags=false" >> "$GITHUB_OUTPUT"
 
       - name: Create release branch
@@ -158,12 +152,7 @@ jobs:
             TAG_FLAG="--no-tag"
           fi
           
-          # We set a custom message to comply with the commit-msg hook.
-          # We place the level at the end to ensure correct argument parsing.
           cargo release --workspace --no-publish --no-push $TAG_FLAG --no-confirm --execute \
-            -m "chore: release v{{version}}
-
-          Automated workspace version bump for v{{version}}." \
             "${{ steps.resolve.outputs.level }}"
           
           git push -f origin "$BRANCH"

--- a/docs/guides/RELEASE_WORKFLOW.md
+++ b/docs/guides/RELEASE_WORKFLOW.md
@@ -12,7 +12,7 @@ The workflow does **not** trigger on direct pushes to `main` — all code arrive
 
 ## Conventional Commits and Bump Levels
 
-The release workflow infers the bump level from commit messages on the incoming PR. The first commit matching a conventional commit pattern determines the bump:
+The release workflow infers the bump level from conventional commit messages in the inspected commit range and applies the highest matching impact:
 
 | Commit Type | Bump Level | Note |
 |---|---|---|
@@ -37,20 +37,9 @@ The `release-pr` job then:
 2. Bumps all crate versions via `cargo-release`
 3. Updates schema versions and regenerates schema files
 4. Creates a pull request against `main` titled `chore: release v<version>`
-5. **Auto-merges for patch/minor bumps** (see below)
+5. Updates that PR on subsequent release-triggering merges until it is merged
 
-## Auto-Merge Behavior
-
-- **Patch and Minor releases**: The release PR auto-merges immediately after creation.
-- **Major releases**: The release PR is created but requires manual review and merge approval.
-
-This keeps the pipeline flowing for routine updates while giving maintainers a chance to review breaking changes before they go live.
-
-### Requirements for Auto-Merge
-
-- The repository must have auto-merge enabled in settings
-- The `release/next` branch must **not** be under branch protection rules
-- `GITHUB_TOKEN` must have `pull-requests:write` and `contents:write` permissions (automatically available to workflows)
+All release levels (`patch`, `minor`, pre-1.0-capped `major`) use this same `release/next` PR flow.
 
 ## Tag and Publish (Future)
 
@@ -123,10 +112,10 @@ These crates are marked `publish = false` in their `Cargo.toml`:
 2. Verify the commit message follows conventional commit format
 3. Check workflow logs under `.github/workflows/release.yml` for details
 
-**Auto-merge doesn't trigger:**
-1. Verify auto-merge is enabled in repo settings
-2. Check that `release/next` is not in branch protection rules
-3. Ensure the bump level is `patch` or `minor` (not `major`)
+**Release PR is not created or updated:**
+1. Verify the release workflow has `pull-requests: write` and `contents: write`
+2. Confirm `RELEASE_TOKEN` is available and has repo write permissions
+3. Check whether the release trigger inferred `should-release=false`
 
 **Tag not created after PR merges:**
 1. Ensure the `auto-tag` job has `contents:write` permission

--- a/docs/reference/VERSION_BUMPING.md
+++ b/docs/reference/VERSION_BUMPING.md
@@ -10,7 +10,7 @@ Citum keeps code and schema versioning separate:
 | Track | What | Source of truth | Automation |
 |-------|------|-----------------|------------|
 | **Code** | Rust workspace crates | `[workspace.package].version` in `Cargo.toml` | `cargo-release` via GitHub Actions release workflow |
-| **Schema** | Citum schema format | `STYLE_SCHEMA_VERSION` | automated release workflow + `Schema-Bump:` footer |
+| **Schema** | Citum schema format | `STYLE_SCHEMA_VERSION` | automated release workflow |
 
 ## How It Works
 
@@ -22,22 +22,16 @@ When code merges to `main`, the release workflow:
    - Schema crates (`citum-schema*`, `citum-cli`) → schema track
    - Other publishable crates → code track
 2. **Infers bump level** from conventional commit messages since the last tag:
-   - `fix:`, `perf:`, `refactor:` → patch
+   - `fix:`, `perf:` → patch
    - `feat:` → minor
    - `feat!:` or `BREAKING CHANGE:` → major (capped at minor for pre-1.0)
 3. **Runs `cargo-semver-checks`** as a safety net — if it detects breaking API changes
    but the commits only say `fix:`, the level is escalated.
-4. **Opens a release PR** (only for minor+ bumps; patches accumulate silently):
-   - Runs `cargo release <level> --workspace` to bump `Cargo.toml`
-   - Runs `git-cliff` to generate the changelog
-   - If schema paths changed, also bumps `STYLE_SCHEMA_VERSION`
+4. **Opens or updates a release PR** on `release/next` (for all release levels):
+    - Runs `cargo release <level> --workspace` to bump `Cargo.toml`
+    - Runs `git-cliff` to generate the changelog
+    - If schema paths changed, also bumps `STYLE_SCHEMA_VERSION`
 5. **Auto-tags** when the release PR is merged to `main`.
-
-### Schema-Bump footers (development-time)
-
-Individual commits that change schema crate code still require a `Schema-Bump:` footer,
-enforced by the pre-commit and commit-msg hooks. This catches schema changes during
-development. The release workflow handles the actual version bump.
 
 ### No Version-Bump footers
 

--- a/release.toml
+++ b/release.toml
@@ -3,4 +3,5 @@ consolidate-commits = true
 dependent-version = "upgrade"
 tag-prefix = "v"
 tag-message = "v{{version}}"
+pre-release-commit-message = "chore: release v{{version}}\n\nAutomated workspace version bump for v{{version}}."
 pre-release-hook = ["git-cliff", "-o", "CHANGELOG.md", "--tag", "v{{version}}"]

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Regression tests for release workflow invariants."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).resolve().parent.parent / ".github/workflows/release.yml"
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    """Ensure release workflow semantics stay aligned with policy."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_release_branch_is_always_release_next(self) -> None:
+        self.assertIn('echo "branch=release/next" >> "$GITHUB_OUTPUT"', self.workflow)
+        self.assertNotIn('echo "branch=main" >> "$GITHUB_OUTPUT"', self.workflow)
+
+    def test_release_pr_is_always_enabled(self) -> None:
+        self.assertIn('echo "create_pr=true" >> "$GITHUB_OUTPUT"', self.workflow)
+        self.assertNotIn('echo "create_pr=false" >> "$GITHUB_OUTPUT"', self.workflow)
+
+    def test_cargo_release_does_not_use_metadata_flag_for_commit_message(self) -> None:
+        bump_workspace_block = re.search(
+            r"- name: Bump workspace version.*?cargo release .*?\n",
+            self.workflow,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(bump_workspace_block)
+        assert bump_workspace_block is not None
+        self.assertNotIn(" -m ", bump_workspace_block.group(0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix release workflow failure by removing invalid cargo release -m usage
- configure release commit message via release.toml pre-release-commit-message
- enforce release PR flow on release/next for patch/minor/major
- align release/versioning docs to the actual workflow behavior
- add workflow regression test and wire it into CI Python test suite

## Validation
- python3 -m unittest scripts/test_infer_release_bump.py scripts/test_coverage_analysis.py scripts/test_release_workflow.py
- cargo release config confirms pre-release-commit-message is recognized
