### PR TITLE
fix(ci): replace Python heredoc in schema tag steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,23 +164,20 @@ jobs:
       - name: Tag schema release when schema changed
         if: steps.config.outputs.push_tags == 'true' && needs.detect.outputs.schema-changed == 'true'
         run: |
-            SCHEMA_VERSION=$(python3 - <<'PY'
-            from pathlib import Path
-            import re
-            content = Path("crates/citum-schema-style/src/lib.rs").read_text()
-            match = re.search(r'pub const STYLE_SCHEMA_VERSION: &str = "([^"]+)";', content)
-            if match is None:
-                raise SystemExit("STYLE_SCHEMA_VERSION not found")
-            print(match.group(1))
-            PY
-            )
-            TAG="schema-v${SCHEMA_VERSION}"
-            if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-              echo "Schema tag ${TAG} already exists."
-            else
-              git tag -a "$TAG" -m "Schema ${TAG}"
-              git push origin "$TAG"
-            fi
+          SCHEMA_VERSION=$(sed -n \
+            's/.*STYLE_SCHEMA_VERSION: \&str = "\([^"]*\)".*/\1/p' \
+            crates/citum-schema-style/src/lib.rs)
+          if [ -z "$SCHEMA_VERSION" ]; then
+            echo "Error: STYLE_SCHEMA_VERSION not found" >&2
+            exit 1
+          fi
+          TAG="schema-v${SCHEMA_VERSION}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Schema tag ${TAG} already exists."
+          else
+            git tag -a "$TAG" -m "Schema ${TAG}"
+            git push origin "$TAG"
+          fi
 
       - name: Create or update release PR
         if: steps.config.outputs.create_pr == 'true'
@@ -249,16 +246,13 @@ jobs:
         run: |
           if git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD \
             | grep -qE '^(crates/citum-schema-style/src/lib.rs|docs/schemas/)'; then
-            SCHEMA_VERSION=$(python3 - <<'PY'
-            from pathlib import Path
-            import re
-            content = Path("crates/citum-schema-style/src/lib.rs").read_text()
-            match = re.search(r'pub const STYLE_SCHEMA_VERSION: &str = "([^"]+)";', content)
-            if match is None:
-                raise SystemExit("STYLE_SCHEMA_VERSION not found")
-            print(match.group(1))
-            PY
-            )
+            SCHEMA_VERSION=$(sed -n \
+              's/.*STYLE_SCHEMA_VERSION: \&str = "\([^"]*\)".*/\1/p' \
+              crates/citum-schema-style/src/lib.rs)
+            if [ -z "$SCHEMA_VERSION" ]; then
+              echo "Error: STYLE_SCHEMA_VERSION not found" >&2
+              exit 1
+            fi
             TAG="schema-v${SCHEMA_VERSION}"
             if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
               echo "Schema tag ${TAG} already exists."

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import unittest
 from pathlib import Path
 
 
-WORKFLOW_PATH = Path(__file__).resolve().parent.parent / ".github/workflows/release.yml"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release.yml"
+SCHEMA_LIB = REPO_ROOT / "crates/citum-schema-style/src/lib.rs"
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
@@ -35,6 +38,42 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIsNotNone(bump_workspace_block)
         assert bump_workspace_block is not None
         self.assertNotIn(" -m ", bump_workspace_block.group(0))
+
+    def test_schema_tag_steps_do_not_use_heredoc(self) -> None:
+        """Heredoc closing delimiters can gain indentation via YAML processing,
+        causing 'unexpected EOF' shell errors. Both schema-tag steps must use
+        a plain command instead of a Python heredoc to extract the version."""
+        schema_tag_blocks = re.findall(
+            r"- name: Tag schema release when schema changed.*?(?=\n      -|\Z)",
+            self.workflow,
+            flags=re.DOTALL,
+        )
+        self.assertTrue(schema_tag_blocks, "Expected at least one 'Tag schema release' step")
+        for block in schema_tag_blocks:
+            self.assertNotIn("<<'PY'", block, "Python heredoc found in schema tag step")
+            self.assertNotIn("python3 -", block, "Python heredoc invocation found in schema tag step")
+            self.assertIn("STYLE_SCHEMA_VERSION", block, "Step must reference STYLE_SCHEMA_VERSION")
+
+    def test_schema_version_sed_pattern_extracts_correctly(self) -> None:
+        """The sed command used in auto-tag must extract the correct version
+        from the actual lib.rs file on disk."""
+        result = subprocess.run(
+            [
+                "sed",
+                "-n",
+                r"s/.*STYLE_SCHEMA_VERSION: \&str = \"\([^\"]*\)\".*/\1/p",
+                str(SCHEMA_LIB),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        version = result.stdout.strip()
+        self.assertRegex(
+            version,
+            r"^\d+\.\d+\.\d+$",
+            f"sed did not extract a valid semver from {SCHEMA_LIB}; got: {version!r}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The `Tag schema release` steps in both `release-pr` and `auto-tag` jobs
used a Python heredoc (`<<'PY'`) to extract `STYLE_SCHEMA_VERSION`.

When YAML processes the `run: |` block, it strips the *minimum* indentation
shared by all lines. In `auto-tag`, the surrounding `if`-branch sets the
minimum to 10 spaces. The heredoc's closing `PY` delimiter was at 12 spaces,
so bash saw `  PY` (two leading spaces) instead of `PY`. This caused:

```
unexpected EOF while looking for matching `)'
Process completed with exit code 2.
```

on *every* `auto-tag` run, meaning **schema tags were never created** even
when schemas changed.

## Fix

Replace both Python heredocs with a `sed` one-liner:

```bash
SCHEMA_VERSION=$(sed -n \
  's/.*STYLE_SCHEMA_VERSION: \&str = "\([^"]*\)".*/\1/p' \
  crates/citum-schema-style/src/lib.rs)
```

No heredoc, no delimiter indentation problem.

## Regression tests added

Two new tests in `scripts/test_release_workflow.py`:
- `test_schema_tag_steps_do_not_use_heredoc` — asserts neither schema-tag
  step contains a heredoc invocation
- `test_schema_version_sed_pattern_extracts_correctly` — runs the actual
  `sed` command against `lib.rs` and asserts it returns a valid semver

## Missing tags

Schema tags `schema-v0.42.0`, `schema-v0.43.0`, and `schema-v0.45.0` were
missed due to this bug. These are being pushed directly to `origin` as
part of this fix.