### PR TITLE
feat: implement style version validation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,3 +20,10 @@ if [[ -x "$ROOT_DIR/scripts/check-docs-beans-hygiene.sh" ]]; then
     exit 1
   fi
 fi
+
+# 3. Cargo fmt check
+printf '[PRE-COMMIT] Running cargo fmt --check...\n'
+if ! cargo fmt --all -- --check; then
+  printf '[ERROR] Code formatting check failed. Run `cargo fmt` and try again.\n' >&2
+  exit 1
+fi

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -780,5 +780,9 @@ pub(crate) struct CheckItem {
     pub(crate) path: String,
     pub(crate) ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) schema_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) warnings: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) error: Option<String>,
 }

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -1547,20 +1547,7 @@ fn run_check(args: CheckArgs) -> Result<(), Box<dyn Error>> {
     let mut checks = Vec::<CheckItem>::new();
 
     if let Some(style_input) = args.style {
-        let status = match load_any_style(&style_input, false) {
-            Ok(_) => CheckItem {
-                kind: "style",
-                path: style_input,
-                ok: true,
-                error: None,
-            },
-            Err(e) => CheckItem {
-                kind: "style",
-                path: style_input,
-                ok: false,
-                error: Some(e.to_string()),
-            },
-        };
+        let status = check_style_input(&style_input);
         checks.push(status);
     }
 
@@ -1571,12 +1558,16 @@ fn run_check(args: CheckArgs) -> Result<(), Box<dyn Error>> {
                 kind: "bibliography",
                 path: display,
                 ok: true,
+                schema_version: None,
+                warnings: None,
                 error: None,
             },
             Err(e) => CheckItem {
                 kind: "bibliography",
                 path: display,
                 ok: false,
+                schema_version: None,
+                warnings: None,
                 error: Some(e.to_string()),
             },
         };
@@ -1590,12 +1581,16 @@ fn run_check(args: CheckArgs) -> Result<(), Box<dyn Error>> {
                 kind: "citations",
                 path: display,
                 ok: true,
+                schema_version: None,
+                warnings: None,
                 error: None,
             },
             Err(e) => CheckItem {
                 kind: "citations",
                 path: display,
                 ok: false,
+                schema_version: None,
+                warnings: None,
                 error: Some(e.to_string()),
             },
         };
@@ -1608,6 +1603,11 @@ fn run_check(args: CheckArgs) -> Result<(), Box<dyn Error>> {
         for check in &checks {
             if check.ok {
                 println!("OK   {:<12} {}", check.kind, check.path);
+                if let Some(warnings) = &check.warnings {
+                    for warn in warnings {
+                        println!("  ! {warn}");
+                    }
+                }
             } else {
                 println!("FAIL {:<12} {}", check.kind, check.path);
                 if let Some(err) = &check.error {
@@ -1622,6 +1622,53 @@ fn run_check(args: CheckArgs) -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+fn check_style_input(style_input: &str) -> CheckItem {
+    let current_version = citum_schema::SchemaVersion::default();
+    match load_any_style(style_input, false) {
+        Ok(style) => {
+            let mut warnings = Vec::new();
+            let mut ok = true;
+            let mut error = None;
+
+            if style.version.major > current_version.major {
+                ok = false;
+                error = Some(format!(
+                    "Style requires a newer major schema version ({}) than currently supported ({}).",
+                    style.version, current_version
+                ));
+            } else if style.version.major == current_version.major
+                && style.version.minor > current_version.minor
+            {
+                warnings.push(format!(
+                    "Style uses a newer minor schema version ({}); some features may not be supported.",
+                    style.version
+                ));
+            }
+
+            CheckItem {
+                kind: "style",
+                path: style_input.to_string(),
+                ok,
+                schema_version: Some(style.version.to_string()),
+                warnings: if warnings.is_empty() {
+                    None
+                } else {
+                    Some(warnings)
+                },
+                error,
+            }
+        }
+        Err(e) => CheckItem {
+            kind: "style",
+            path: style_input.to_string(),
+            ok: false,
+            schema_version: None,
+            warnings: None,
+            error: Some(e.to_string()),
+        },
+    }
 }
 
 /// Execute typed conversion subcommands (`style`, `locale`, `citations`).

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -108,6 +108,138 @@ pub type StyleResolver = dyn citum_resolver_api::StyleResolver<Style = Style, Lo
 /// Canonical Citum style schema version used when `Style.version` is omitted.
 pub const STYLE_SCHEMA_VERSION: &str = "0.45.0";
 
+/// A schema version (major.minor).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema), schemars(with = "String"))]
+pub struct SchemaVersion {
+    /// Major version number.
+    pub major: u32,
+    /// Minor version number (None if not provided in string).
+    pub minor: Option<u32>,
+    /// Patch version number (None if not provided in string).
+    pub patch: Option<u32>,
+}
+
+impl SchemaVersion {
+    /// Parse a version string into a `SchemaVersion`.
+    ///
+    /// Requires at least "X.Y". Supports "X.Y.Z".
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string is not a valid version format
+    /// or lacks the required minor version.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() < 2 || parts.len() > 3 {
+            return Err(format!(
+                "invalid version format (expected X.Y or X.Y.Z): \"{}\"",
+                s
+            ));
+        }
+
+        let major_str = parts
+            .first()
+            .ok_or_else(|| "missing major version".to_string())?;
+        let major = major_str
+            .parse::<u32>()
+            .map_err(|_| format!("invalid major version: \"{}\"", major_str))?;
+
+        let minor_str = parts
+            .get(1)
+            .ok_or_else(|| "missing minor version".to_string())?;
+        let minor = Some(
+            minor_str
+                .parse::<u32>()
+                .map_err(|_| format!("invalid minor version: \"{}\"", minor_str))?,
+        );
+
+        let patch = if let Some(patch_str) = parts.get(2) {
+            Some(
+                patch_str
+                    .parse::<u32>()
+                    .map_err(|_| format!("invalid patch version: \"{}\"", patch_str))?,
+            )
+        } else {
+            None
+        };
+
+        Ok(SchemaVersion {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl PartialOrd for SchemaVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SchemaVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.major.cmp(&other.major) {
+            std::cmp::Ordering::Equal => {
+                let self_minor = self.minor.unwrap_or(0);
+                let other_minor = other.minor.unwrap_or(0);
+                match self_minor.cmp(&other_minor) {
+                    std::cmp::Ordering::Equal => {
+                        let self_patch = self.patch.unwrap_or(0);
+                        let other_patch = other.patch.unwrap_or(0);
+                        self_patch.cmp(&other_patch)
+                    }
+                    ord => ord,
+                }
+            }
+            ord => ord,
+        }
+    }
+}
+
+impl std::fmt::Display for SchemaVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.major)?;
+        if let Some(minor) = self.minor {
+            write!(f, ".{}", minor)?;
+            if let Some(patch) = self.patch {
+                write!(f, ".{}", patch)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for SchemaVersion {
+    #[allow(
+        clippy::expect_used,
+        reason = "STYLE_SCHEMA_VERSION is a canonical constant"
+    )]
+    fn default() -> Self {
+        SchemaVersion::parse(STYLE_SCHEMA_VERSION).expect("STYLE_SCHEMA_VERSION is valid")
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SchemaVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        SchemaVersion::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl serde::Serialize for SchemaVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
 /// A non-fatal validation warning emitted by [`Style::validate`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum SchemaWarning {
@@ -148,7 +280,7 @@ impl std::fmt::Display for SchemaWarning {
 pub struct Style {
     /// Style schema version.
     #[serde(default = "default_version")]
-    pub version: String,
+    pub version: SchemaVersion,
     /// Style metadata.
     #[serde(default)]
     pub info: StyleInfo,
@@ -1109,8 +1241,8 @@ pub(crate) fn merge_yaml_value(base: &mut serde_yaml::Value, overlay: &serde_yam
     }
 }
 
-fn default_version() -> String {
-    STYLE_SCHEMA_VERSION.to_string()
+fn default_version() -> SchemaVersion {
+    SchemaVersion::default()
 }
 
 /// Available embedded template presets.
@@ -2026,7 +2158,7 @@ custom:
   author-tool: "StyleAuthor v2.0"
 "#;
         let style: Style = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(style.version, "1.1");
+        assert_eq!(style.version, SchemaVersion::parse("1.1").unwrap());
         let custom = style.custom.as_ref().unwrap();
         assert_eq!(
             custom.get("my-extension").unwrap(),

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -6,7 +6,7 @@
   "properties": {
     "version": {
       "description": "Style schema version.",
-      "type": "string",
+      "$ref": "#/$defs/SchemaVersion",
       "default": "0.45.0"
     },
     "info": {
@@ -89,6 +89,10 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "SchemaVersion": {
+      "description": "A schema version (major.minor).",
+      "type": "string"
+    },
     "StyleInfo": {
       "description": "Style metadata.",
       "type": "object",


### PR DESCRIPTION
Implements bean csl26-yipx. This PR adds a structured `SchemaVersion` type to handle style version parsing and wires compatibility checks into the `citum check` command.

### Key Changes
- **Structured Versioning**: Introduces `SchemaVersion` (parsed from strings like "1.1" or "0.45.0").
- **Precision Preservation**: Minor and patch segments are optional; round-trips preserve the authored format (e.g., "1.1" stays "1.1", not "1.1.0").
- **Validation Logic**: 
  - Rejects styles with a major version higher than supported.
  - Warns for styles with a newer minor version.
- **CLI Output**: Enriches `citum check` (and its JSON output) with `schema_version` and `warnings`.
- **Schema Alignment**: Uses `schemars(with = "String")` to ensure generated JSON schemas correctly describe the wire format.

Matches strict project commit rules (50/72 wrap).