### PR TITLE
chore(beans): archive stale completed beans

### DIFF
--- a/.beans/archive/csl26-f9nh--wire-storeconfigregistries-into-resolution-and-reg.md
+++ b/.beans/archive/csl26-f9nh--wire-storeconfigregistries-into-resolution-and-reg.md
@@ -1,7 +1,7 @@
 ---
 # csl26-f9nh
 title: Wire StoreConfig.registries into resolution and registry update
-status: in-progress
+status: completed
 type: bug
 created_at: 2026-05-08T09:25:25Z
 updated_at: 2026-05-08T09:25:25Z

--- a/.beans/archive/csl26-rapi--extract-style-resolver-api-crate.md
+++ b/.beans/archive/csl26-rapi--extract-style-resolver-api-crate.md
@@ -1,7 +1,7 @@
 ---
 # csl26-rapi
 title: Extract StyleResolver and related types to a dedicated API crate
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-05-09T00:00:00Z

--- a/.beans/archive/csl26-v2k9--citum-authoring-agent-skill-specification.md
+++ b/.beans/archive/csl26-v2k9--citum-authoring-agent-skill-specification.md
@@ -1,7 +1,7 @@
 ---
 # csl26-v2k9
 title: 'Citum Authoring Agent Skill Specification'
-status: todo
+status: completed
 type: spec
 priority: high
 tags:

--- a/.beans/archive/csl26-yipx--wire-styleversion-to-schema-validation-in-csln-che.md
+++ b/.beans/archive/csl26-yipx--wire-styleversion-to-schema-validation-in-csln-che.md
@@ -1,14 +1,14 @@
 ---
 # csl26-yipx
 title: wire Style.version to schema validation in citum check
-status: todo
+status: completed
 type: feature
 priority: normal
 tags:
     - schema
     - cli
 created_at: 2026-02-24T17:28:12Z
-updated_at: 2026-04-25T20:20:06Z
+updated_at: 2026-05-11T12:00:00Z
 parent: csl26-li63
 ---
 


### PR DESCRIPTION
This PR synchronizes the workspace state by marking four stale beans as completed and moving them to the archive. These tasks were previously implemented and merged, but their tracking beans remained in the active `.beans/` directory.

### Affected Beans:
- `csl26-yipx` (Style version validation)
- `csl26-f9nh` (Store configuration resolution)
- `csl26-v2k9` (Authoring Agent Skill spec)
- `csl26-rapi` (Resolver API crate extraction)