### PR TITLE
docs(schema): add missing doc comments to 5 types

### DIFF
--- a/crates/citum-schema-style/src/legacy.rs
+++ b/crates/citum-schema-style/src/legacy.rs
@@ -464,11 +464,15 @@ pub enum TextDecoration {
     Underline,
 }
 
+/// Vertical text alignment relative to the baseline.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum VerticalAlign {
+    /// Render at the baseline (default).
     Baseline,
+    /// Render as superscript.
     Superscript,
+    /// Render as subscript.
     Subscript,
 }

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -345,6 +345,7 @@ pub struct NoteConfig {
     pub order: Option<NoteMarkerOrder>,
 }
 
+/// Controls where movable punctuation is placed relative to closing quotation marks.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
@@ -359,6 +360,7 @@ pub enum NoteQuotePlacement {
     Adaptive,
 }
 
+/// Controls where a footnote number marker is placed relative to closing quotation marks.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
@@ -372,6 +374,7 @@ pub enum NoteNumberPlacement {
     Same,
 }
 
+/// Controls whether a note marker appears before or after adjacent movable punctuation.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1201,7 +1201,7 @@ impl JsonSchema for DelimiterPunctuation {
     }
 
     fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        schemars::json_schema!({"type": "string"})
+        schemars::json_schema!({"type": "string", "description": "Delimiter punctuation options."})
     }
 }
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -962,11 +962,23 @@
       ]
     },
     "VerticalAlign": {
-      "type": "string",
-      "enum": [
-        "baseline",
-        "superscript",
-        "subscript"
+      "description": "Vertical text alignment relative to the baseline.",
+      "oneOf": [
+        {
+          "description": "Render at the baseline (default).",
+          "type": "string",
+          "const": "baseline"
+        },
+        {
+          "description": "Render as superscript.",
+          "type": "string",
+          "const": "superscript"
+        },
+        {
+          "description": "Render as subscript.",
+          "type": "string",
+          "const": "subscript"
+        }
       ]
     },
     "WrapConfig": {
@@ -2018,6 +2030,7 @@
       ]
     },
     "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
       "type": "string"
     },
     "TemplateTerm": {
@@ -4156,6 +4169,7 @@
       "additionalProperties": false
     },
     "NoteQuotePlacement": {
+      "description": "Controls where movable punctuation is placed relative to closing quotation marks.",
       "oneOf": [
         {
           "description": "Keep movable punctuation inside the closing quotation mark.",
@@ -4175,6 +4189,7 @@
       ]
     },
     "NoteNumberPlacement": {
+      "description": "Controls where a footnote number marker is placed relative to closing quotation marks.",
       "oneOf": [
         {
           "description": "Place the note marker inside the closing quotation mark.",
@@ -4194,6 +4209,7 @@
       ]
     },
     "NoteMarkerOrder": {
+      "description": "Controls whether a note marker appears before or after adjacent movable punctuation.",
       "oneOf": [
         {
           "description": "Place the note marker before the closest movable punctuation mark.",


### PR DESCRIPTION
## Summary

Five types in `citum-schema-style` were missing type-level `///` doc comments,
leaving their `description` fields blank in the generated JSON Schema.

- `NoteQuotePlacement` — added type doc comment
- `NoteNumberPlacement` — added type doc comment
- `NoteMarkerOrder` — added type doc comment
- `VerticalAlign` — added type doc comment + variant doc comments
- `DelimiterPunctuation` — added description to manual JsonSchema impl

The JSON Schema `description` fields are used by external AI agents (no local
citum-core checkout) as the primary field-validity anchor per the style-authoring
skill at `github.com/citum/skills`.

## Test plan

- [x] `python3` schema audit confirms all 5 types have `description`
- [x] `cargo nextest run` passes
- [x] `docs/schemas/style.json` is regenerated and staged
