### PR TITLE
fix(migrate): collapse sort presets

### DIFF
--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -805,14 +805,15 @@ fn resolve_migrated_bibliography_sort(
     processing: Option<&citum_schema::options::Processing>,
     legacy_sort: Option<&csl_legacy::model::Sort>,
 ) -> Option<citum_schema::grouping::GroupSortEntry> {
-    let extracted = legacy_sort.and_then(
+    let extracted_entry = legacy_sort.and_then(
         citum_migrate::options_extractor::bibliography::extract_group_sort_from_bibliography,
     )?;
+    let extracted = extracted_entry.resolve();
 
     if bibliography_sort_matches_processing_default(processing, &extracted) {
         None
     } else {
-        Some(citum_schema::grouping::GroupSortEntry::Explicit(extracted))
+        Some(extracted_entry)
     }
 }
 
@@ -1671,29 +1672,8 @@ mod tests {
 
         assert_eq!(
             sort,
-            Some(citum_schema::grouping::GroupSortEntry::Explicit(
-                citum_schema::grouping::GroupSort {
-                    template: vec![
-                        citum_schema::grouping::GroupSortKey {
-                            key: citum_schema::grouping::SortKey::Author,
-                            ascending: true,
-                            order: None,
-                            sort_order: None,
-                        },
-                        citum_schema::grouping::GroupSortKey {
-                            key: citum_schema::grouping::SortKey::Issued,
-                            ascending: true,
-                            order: None,
-                            sort_order: None,
-                        },
-                        citum_schema::grouping::GroupSortKey {
-                            key: citum_schema::grouping::SortKey::Title,
-                            ascending: true,
-                            order: None,
-                            sort_order: None,
-                        },
-                    ],
-                }
+            Some(citum_schema::grouping::GroupSortEntry::Preset(
+                citum_schema::presets::SortPreset::AuthorDateTitle
             ))
         );
     }

--- a/crates/citum-migrate/src/options_extractor/bibliography.rs
+++ b/crates/citum-migrate/src/options_extractor/bibliography.rs
@@ -1,8 +1,11 @@
-use citum_schema::grouping::{GroupSort, GroupSortKey, SortKey as GroupSortKeyType};
+use citum_schema::grouping::{
+    GroupSort, GroupSortEntry, GroupSortKey, SortKey as GroupSortKeyType,
+};
 use citum_schema::options::{
     ArticleJournalBibliographyConfig, ArticleJournalNoPageFallback, BibliographyConfig, Sort,
     SortKey, SortSpec, SubsequentAuthorSubstituteRule,
 };
+use citum_schema::presets::SortPreset;
 use citum_schema::template::DelimiterPunctuation;
 use csl_legacy::model::{Choose, ChooseBranch, CslNode, Layout, Macro, Sort as LegacySort, Style};
 
@@ -476,34 +479,78 @@ pub fn extract_sort_from_bibliography(sort: &LegacySort) -> Option<Sort> {
 ///
 /// Converts CSL sort keys with grouping context to citum `GroupSort` format.
 #[must_use]
-pub fn extract_group_sort_from_bibliography(sort: &LegacySort) -> Option<GroupSort> {
-    let template: Vec<GroupSortKey> = sort
-        .keys
-        .iter()
-        .filter_map(|key| {
-            let key_kind = key
-                .variable
-                .as_ref()
-                .and_then(|name| parse_group_sort_key(name))
-                .or_else(|| {
-                    key.macro_name
-                        .as_ref()
-                        .and_then(|name| parse_group_sort_key(name))
-                })?;
+pub fn extract_group_sort_from_bibliography(sort: &LegacySort) -> Option<GroupSortEntry> {
+    let template = deduplicate_group_sort_keys(
+        sort.keys
+            .iter()
+            .filter_map(|key| {
+                let key_kind = key
+                    .variable
+                    .as_ref()
+                    .and_then(|name| parse_group_sort_key(name))
+                    .or_else(|| {
+                        key.macro_name
+                            .as_ref()
+                            .and_then(|name| parse_group_sort_key(name))
+                    })?;
 
-            Some(GroupSortKey {
-                key: key_kind,
-                ascending: key.sort.as_deref() != Some("descending"),
-                order: None,
-                sort_order: None,
+                Some(GroupSortKey {
+                    key: key_kind,
+                    ascending: key.sort.as_deref() != Some("descending"),
+                    order: None,
+                    sort_order: None,
+                })
             })
-        })
-        .collect();
+            .collect(),
+    );
 
     if template.is_empty() {
         None
+    } else if let Some(preset) = group_sort_preset_for_keys(&template) {
+        Some(GroupSortEntry::Preset(preset))
     } else {
-        Some(GroupSort { template })
+        Some(GroupSortEntry::Explicit(GroupSort { template }))
+    }
+}
+
+fn deduplicate_group_sort_keys(template: Vec<GroupSortKey>) -> Vec<GroupSortKey> {
+    let mut deduplicated = Vec::new();
+
+    for key in template {
+        if let Some(existing) = deduplicated
+            .iter_mut()
+            .find(|existing: &&mut GroupSortKey| existing.key == key.key)
+        {
+            existing.ascending &= key.ascending;
+            continue;
+        }
+        deduplicated.push(key);
+    }
+
+    deduplicated
+}
+
+fn group_sort_preset_for_keys(template: &[GroupSortKey]) -> Option<SortPreset> {
+    if template.iter().any(|key| !key.ascending) {
+        return None;
+    }
+
+    let keys: Vec<&GroupSortKeyType> = template.iter().map(|key| &key.key).collect();
+    match keys.as_slice() {
+        [GroupSortKeyType::Author]
+        | [GroupSortKeyType::Author, GroupSortKeyType::Issued]
+        | [
+            GroupSortKeyType::Author,
+            GroupSortKeyType::Issued,
+            GroupSortKeyType::Title,
+        ] => Some(SortPreset::AuthorDateTitle),
+        [GroupSortKeyType::Author, GroupSortKeyType::Title]
+        | [
+            GroupSortKeyType::Author,
+            GroupSortKeyType::Title,
+            GroupSortKeyType::Issued,
+        ] => Some(SortPreset::AuthorTitleDate),
+        _ => None,
     }
 }
 

--- a/crates/citum-migrate/src/options_extractor/processing.rs
+++ b/crates/citum-migrate/src/options_extractor/processing.rs
@@ -1,6 +1,7 @@
 use citum_schema::options::{
     Disambiguation, Group, Processing, ProcessingCustom, Sort, SortEntry, SortKey, SortSpec,
 };
+use citum_schema::presets::SortPreset;
 use csl_legacy::model::{CslNode, Style};
 use std::collections::HashSet;
 
@@ -58,10 +59,13 @@ pub fn detect_processing_mode(style: &Style) -> Option<Processing> {
         };
 
         let sort = style.citation.sort.as_ref().and_then(extract_sort);
-        let group = sort.as_ref().and_then(extract_group_from_sort);
+        let group = sort
+            .as_ref()
+            .map(SortEntry::resolve)
+            .and_then(|sort| extract_group_from_sort(&sort));
 
         return Some(Processing::Custom(ProcessingCustom {
-            sort: sort.map(SortEntry::Explicit),
+            sort,
             group,
             disambiguate: Some(disamb),
         }));
@@ -128,37 +132,76 @@ fn node_has_author_date_signal(
     }
 }
 
-fn extract_sort(legacy_sort: &csl_legacy::model::Sort) -> Option<Sort> {
-    let template: Vec<SortSpec> = legacy_sort
-        .keys
-        .iter()
-        .filter_map(|key| {
-            let key_kind = key
-                .variable
-                .as_ref()
-                .and_then(|name| parse_sort_key(name))
-                .or_else(|| {
-                    key.macro_name
-                        .as_ref()
-                        .and_then(|name| parse_sort_key(name))
-                })?;
+fn extract_sort(legacy_sort: &csl_legacy::model::Sort) -> Option<SortEntry> {
+    let template = deduplicate_sort_specs(
+        legacy_sort
+            .keys
+            .iter()
+            .filter_map(|key| {
+                let key_kind = key
+                    .variable
+                    .as_ref()
+                    .and_then(|name| parse_sort_key(name))
+                    .or_else(|| {
+                        key.macro_name
+                            .as_ref()
+                            .and_then(|name| parse_sort_key(name))
+                    })?;
 
-            let ascending = key.sort.as_deref() != Some("descending");
-            Some(SortSpec {
-                key: key_kind,
-                ascending,
+                let ascending = key.sort.as_deref() != Some("descending");
+                Some(SortSpec {
+                    key: key_kind,
+                    ascending,
+                })
             })
-        })
-        .collect();
+            .collect(),
+    );
 
     if template.is_empty() {
         None
+    } else if let Some(preset) = sort_preset_for_specs(&template) {
+        Some(SortEntry::Preset(preset))
     } else {
-        Some(Sort {
+        Some(SortEntry::Explicit(Sort {
             shorten_names: false,
             render_substitutions: false,
             template,
-        })
+        }))
+    }
+}
+
+fn deduplicate_sort_specs(template: Vec<SortSpec>) -> Vec<SortSpec> {
+    let mut deduplicated = Vec::new();
+
+    for spec in template {
+        if let Some(existing) = deduplicated
+            .iter_mut()
+            .find(|existing: &&mut SortSpec| existing.key == spec.key)
+        {
+            existing.ascending &= spec.ascending;
+            continue;
+        }
+        deduplicated.push(spec);
+    }
+
+    deduplicated
+}
+
+fn sort_preset_for_specs(template: &[SortSpec]) -> Option<SortPreset> {
+    if template.iter().any(|spec| !spec.ascending) {
+        return None;
+    }
+
+    let keys: Vec<&SortKey> = template.iter().map(|spec| &spec.key).collect();
+    match keys.as_slice() {
+        [SortKey::Author]
+        | [SortKey::Author, SortKey::Year]
+        | [SortKey::Author, SortKey::Year, SortKey::Title] => Some(SortPreset::AuthorDateTitle),
+        [SortKey::Author, SortKey::Title] | [SortKey::Author, SortKey::Title, SortKey::Year] => {
+            Some(SortPreset::AuthorTitleDate)
+        }
+        [SortKey::CitationNumber] => Some(SortPreset::CitationNumber),
+        _ => None,
     }
 }
 

--- a/crates/citum-migrate/src/options_extractor/tests.rs
+++ b/crates/citum-migrate/src/options_extractor/tests.rs
@@ -3,6 +3,7 @@ use citum_schema::grouping::SortKey as GroupSortKey;
 use citum_schema::options::{
     ArticleJournalNoPageFallback, Processing, SortKey, SubstituteConfig, SubstituteKey,
 };
+use citum_schema::presets::SortPreset;
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
 
@@ -124,6 +125,70 @@ fn test_extract_processing_sort_and_disambiguation() {
 }
 
 #[test]
+fn test_extract_processing_sort_uses_author_date_title_preset_for_duplicate_macro_keys() {
+    let xml = r#"<style class="in-text">
+        <citation>
+            <sort>
+                <key macro="author-sort"/>
+                <key macro="date-sort-group"/>
+                <key macro="date-sort"/>
+            </sort>
+            <layout><text macro="year"/></layout>
+        </citation>
+        <bibliography><layout><text variable="title"/></layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let config = OptionsExtractor::extract(&style);
+
+    let Processing::Custom(custom) = config.processing.unwrap() else {
+        panic!("expected custom processing mode");
+    };
+
+    assert!(matches!(
+        custom.sort,
+        Some(citum_schema::options::SortEntry::Preset(
+            SortPreset::AuthorDateTitle
+        ))
+    ));
+
+    let group = custom.group.unwrap();
+    assert_eq!(
+        group.template,
+        vec![SortKey::Author, SortKey::Year, SortKey::Title]
+    );
+}
+
+#[test]
+fn test_extract_processing_sort_keeps_conflicting_duplicate_direction_explicit() {
+    let xml = r#"<style class="in-text">
+        <citation>
+            <sort>
+                <key macro="author-sort"/>
+                <key macro="date-sort-group"/>
+                <key macro="date-sort" sort="descending"/>
+            </sort>
+            <layout><text macro="year"/></layout>
+        </citation>
+        <bibliography><layout><text variable="title"/></layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let config = OptionsExtractor::extract(&style);
+
+    let Processing::Custom(custom) = config.processing.unwrap() else {
+        panic!("expected custom processing mode");
+    };
+    let Some(citum_schema::options::SortEntry::Explicit(sort)) = custom.sort else {
+        panic!("expected conflicting duplicate sort directions to stay explicit");
+    };
+
+    assert_eq!(sort.template.len(), 2);
+    assert_eq!(sort.template[0].key, SortKey::Author);
+    assert!(sort.template[0].ascending);
+    assert_eq!(sort.template[1].key, SortKey::Year);
+    assert!(!sort.template[1].ascending);
+}
+
+#[test]
 fn test_extract_processing_disambiguation_defaults() {
     let xml = r#"<style class="in-text">
         <citation>
@@ -215,10 +280,79 @@ fn test_extract_group_sort_from_bibliography_macros() {
 
     let sort = super::bibliography::extract_group_sort_from_bibliography(legacy_sort)
         .expect("group sort should be extracted");
+    let sort = sort.resolve();
     assert_eq!(sort.template.len(), 3);
     assert!(matches!(sort.template[0].key, GroupSortKey::Author));
     assert!(matches!(sort.template[1].key, GroupSortKey::Title));
     assert!(matches!(sort.template[2].key, GroupSortKey::Issued));
+}
+
+#[test]
+fn test_extract_group_sort_uses_author_date_title_preset_for_duplicate_macro_keys() {
+    let xml = r#"<style class="in-text">
+        <citation><layout><text variable="title"/></layout></citation>
+        <bibliography>
+            <sort>
+                <key macro="author-sort"/>
+                <key macro="date-sort-group"/>
+                <key macro="date-sort"/>
+                <key macro="title"/>
+                <key variable="event-date"/>
+                <key variable="original-date"/>
+            </sort>
+            <layout><text variable="title"/></layout>
+        </bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let legacy_sort = style
+        .bibliography
+        .as_ref()
+        .and_then(|b| b.sort.as_ref())
+        .expect("legacy bibliography sort should exist");
+
+    let sort = super::bibliography::extract_group_sort_from_bibliography(legacy_sort)
+        .expect("group sort should be extracted");
+
+    assert!(matches!(
+        sort,
+        citum_schema::grouping::GroupSortEntry::Preset(SortPreset::AuthorDateTitle)
+    ));
+}
+
+#[test]
+fn test_extract_group_sort_keeps_conflicting_duplicate_direction_explicit() {
+    let xml = r#"<style class="in-text">
+        <citation><layout><text variable="title"/></layout></citation>
+        <bibliography>
+            <sort>
+                <key macro="author-sort"/>
+                <key macro="date-sort-group"/>
+                <key macro="date-sort" sort="descending"/>
+                <key macro="title"/>
+            </sort>
+            <layout><text variable="title"/></layout>
+        </bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let legacy_sort = style
+        .bibliography
+        .as_ref()
+        .and_then(|b| b.sort.as_ref())
+        .expect("legacy bibliography sort should exist");
+
+    let sort = super::bibliography::extract_group_sort_from_bibliography(legacy_sort)
+        .expect("group sort should be extracted");
+    let citum_schema::grouping::GroupSortEntry::Explicit(sort) = sort else {
+        panic!("expected conflicting duplicate sort directions to stay explicit");
+    };
+
+    assert_eq!(sort.template.len(), 3);
+    assert_eq!(sort.template[0].key, GroupSortKey::Author);
+    assert!(sort.template[0].ascending);
+    assert_eq!(sort.template[1].key, GroupSortKey::Issued);
+    assert!(!sort.template[1].ascending);
+    assert_eq!(sort.template[2].key, GroupSortKey::Title);
+    assert!(sort.template[2].ascending);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- deduplicate macro-expanded CSL sort keys during migration
- emit existing sort presets for covered normalized sort orders
- keep unsupported and descending sort patterns explicit

## Evidence
- APA now migrates citation and bibliography sort as `author-date-title`
- corpus scan of non-dependent legacy styles did not justify a new preset for this cluster

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`