### PR TITLE
fix(tooling): consolidate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       hygiene: ${{ steps.filter.outputs.hygiene }}
       semver: ${{ steps.filter.outputs.semver }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -69,7 +69,7 @@ jobs:
     if: ${{ needs.changes.outputs.hygiene == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -94,7 +94,7 @@ jobs:
           sudo install -m 0755 /tmp/beans /usr/local/bin/beans
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -139,7 +139,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -188,7 +188,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -224,7 +224,7 @@ jobs:
           needs.changes.outputs.semver == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -49,7 +49,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -30,7 +30,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -44,7 +44,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       bump-level: ${{ steps.infer.outputs.level }}
       should-release: ${{ steps.infer.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
     if: needs.detect.outputs.should-release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -214,7 +214,7 @@ jobs:
       github.event.pull_request.head.ref == 'release/next'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
  "citum-migrate",
  "citum-schema",
  "csl-legacy",
- "roxmltree",
+ "roxmltree 0.21.1",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -635,7 +635,7 @@ name = "citum-edtf"
 version = "0.40.1"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -653,7 +653,7 @@ dependencies = [
  "indexmap 2.14.0",
  "jotdown",
  "orgize",
- "roxmltree",
+ "roxmltree 0.21.1",
  "rstest",
  "serde",
  "serde_json",
@@ -662,7 +662,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-script",
  "url",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -690,7 +690,7 @@ dependencies = [
  "csl-legacy",
  "deno_core",
  "indexmap 2.14.0",
- "roxmltree",
+ "roxmltree 0.21.1",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -800,7 +800,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -1140,7 +1140,7 @@ name = "csl-legacy"
 version = "0.40.1"
 dependencies = [
  "indexmap 2.14.0",
- "roxmltree",
+ "roxmltree 0.21.1",
  "serde",
  "serde_json",
 ]
@@ -1725,7 +1725,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree",
+ "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -3837,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "jotdown"
-version = "0.5.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fff02adc563a0901266af314a47aa676f950a2f328a60b20691fdba0946fd98"
+checksum = "206bf4773a58f2a051a24fb77cb6c5eeaa84403c0dc5d072ec460ed1648db594"
 
 [[package]]
 name = "js-sys"
@@ -5133,22 +5133,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
-name = "rstest"
-version = "0.25.0"
+name = "roxmltree"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -5492,6 +5500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -6236,9 +6253,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6267,7 +6299,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -6299,6 +6331,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -6441,7 +6479,7 @@ dependencies = [
  "indexmap 2.14.0",
  "rustc-hash",
  "stacker",
- "toml",
+ "toml 0.8.23",
  "typst-library",
  "typst-macros",
  "typst-syntax",
@@ -6561,7 +6599,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rust_decimal",
  "rustc-hash",
  "rustybuzz",
@@ -6572,7 +6610,7 @@ dependencies = [
  "smallvec",
  "syntect",
  "time",
- "toml",
+ "toml 0.8.23",
  "ttf-parser",
  "two-face",
  "typed-arena",
@@ -6680,7 +6718,7 @@ dependencies = [
  "ecow",
  "rustc-hash",
  "serde",
- "toml",
+ "toml 0.8.23",
  "typst-timing",
  "typst-utils",
  "unicode-ident",
@@ -6909,7 +6947,7 @@ dependencies = [
  "kurbo 0.11.3",
  "log",
  "pico-args",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rustybuzz",
  "simplecss",
  "siphasher",

--- a/crates/citum-analyze/Cargo.toml
+++ b/crates/citum-analyze/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/batch_test.rs"
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 citum_schema = { package = "citum-schema", path = "../citum-schema" }
 citum_migrate = { package = "citum-migrate", path = "../citum-migrate" }
-roxmltree = "0.20"
+roxmltree = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }

--- a/crates/citum-edtf/Cargo.toml
+++ b/crates/citum-edtf/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository = "https://github.com/citum/citum-core"
 
 [dependencies]
-winnow = "0.7"
+winnow = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -20,8 +20,8 @@ thiserror = "2.0"
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
-winnow = "0.7"
-jotdown = "0.5"
+winnow = "1.0"
+jotdown = "0.10"
 orgize = "0.9"
 icu_collator = { version = "2.2.0", features = ["compiled_data"], optional = true }
 icu_locale = { version = "2.2.0", optional = true }
@@ -36,8 +36,8 @@ ffi = []
 criterion = { version = "0.5", features = ["html_reports"] }
 citum_migrate = { package = "citum-migrate", path = "../citum-migrate" }
 citum_io = { package = "citum-io", path = "../citum-io" }
-roxmltree = "0.20"
-rstest = "0.25"
+roxmltree = "0.21"
+rstest = "0.26"
 tempfile = "3.8"
 
 [[bench]]

--- a/crates/citum-engine/src/processor/document/djot/parsing.rs
+++ b/crates/citum-engine/src/processor/document/djot/parsing.rs
@@ -387,7 +387,7 @@ pub(crate) fn scan_bibliography_blocks(content: &str) -> Vec<BibliographyBlock> 
     for (event, range) in Parser::new(content).into_offset_iter() {
         match event {
             Event::Start(Container::Div { class }, attrs) if class.contains("bibliography") => {
-                div_stack.push((range.start, extract_group_from_attrs(class, attrs)));
+                div_stack.push((range.start, extract_group_from_attrs(&class, attrs)));
             }
             Event::End(Container::Div { class }) => {
                 if class.contains("bibliography")

--- a/crates/citum-migrate/Cargo.toml
+++ b/crates/citum-migrate/Cargo.toml
@@ -14,7 +14,7 @@ csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 citum_schema = { package = "citum-schema", path = "../citum-schema" }
 deno_core = "0.400.0"
 indexmap = "2.13.0"
-roxmltree = "0.20"
+roxmltree = "0.21"
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/citum-schema-style/Cargo.toml
+++ b/crates/citum-schema-style/Cargo.toml
@@ -32,7 +32,7 @@ bindings = ["dep:specta", "citum_schema_data/bindings"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-rstest = "0.25"
+rstest = "0.26"
 
 [[bench]]
 name = "formats"

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -14,7 +14,7 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 thiserror = "2.0"
 citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
-toml = "0.8"
+toml = "1.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
 sha2 = { version = "0.10", optional = true }
 tempfile = { version = "3", optional = true }

--- a/crates/csl-legacy/Cargo.toml
+++ b/crates/csl-legacy/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 indexmap = "2.13.0"
-roxmltree = "0.20"
+roxmltree = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "jotdown"
-version = "0.5.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fff02adc563a0901266af314a47aa676f950a2f328a60b20691fdba0946fd98"
+checksum = "206bf4773a58f2a051a24fb77cb6c5eeaa84403c0dc5d072ec460ed1648db594"
 
 [[package]]
 name = "lazy_static"
@@ -735,9 +735,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "roxmltree"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ryu"
@@ -992,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Summary
- consolidates the seven post-#670 dependency bump PRs into one human-owned change
- updates Cargo, GitHub Actions, root lockfile, and fuzz lockfile dependency state
- adapts Djot bibliography block parsing for the `jotdown` 0.10 `Cow<'_, str>` class value
- groups future Dependabot Cargo and GitHub Actions updates

## Root Cause
- Dependabot PRs #671 and #672 fail Hygiene because Dependabot's generated commit body exceeds the repo commit-message line-length rule.
- PR #677 exposes the real compile break: `jotdown` 0.10 changes the `Container::Div` class value shape, so the existing parser passed `Cow<'_, str>` where `&str` was expected.

## Validation
- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `node --test --test-timeout=180000 scripts/oracle.test.js scripts/report-core.test.js scripts/oracle-yaml.test.js`
- `cargo doc --no-deps --workspace --all-features`
- `cargo audit --deny warnings --ignore RUSTSEC-2024-0320 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0141`
- `cargo deny check advisories licenses bans sources`
- `cargo run --bin citum --all-features -- schema --out-dir <tmp> && diff -ru <tmp> docs/schemas`
- `cargo +nightly fuzz build`

## Notes
- The CI-exact Linux-target fuzz command could not be completed locally on macOS because `x86_64-linux-gnu-g++` is not installed. Native fuzz target compilation passed.
- Supersedes #671, #672, #673, #674, #675, #676, and #677.
