### PR TITLE
chore: ignore submodules in alint configuration

### DIFF
--- a/.alint.yml
+++ b/.alint.yml
@@ -5,6 +5,10 @@
 
 version: 1
 
+ignore:
+  - "styles-legacy/**"
+  - "tests/csl-test-suite/**"
+
 extends:
   - alint://bundled/oss-baseline@v1
   - alint://bundled/rust@v1


### PR DESCRIPTION
Reset dirty submodules (styles-legacy and tests/csl-test-suite) and configured alint to ignore them to prevent unintended whitespace changes.