### PR TITLE
refactor(migrate): extract modules from main.rs

### DIFF
--- a/.beans/archive/csl26-19em--refactor-citum-migrate-mainrs.md
+++ b/.beans/archive/csl26-19em--refactor-citum-migrate-mainrs.md
@@ -1,0 +1,24 @@
+---
+# csl26-19em
+title: Refactor citum-migrate main.rs
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-13T23:10:05Z
+updated_at: 2026-05-13T23:22:13Z
+---
+
+Extract template_diff, cli, bib_postprocess, and citation_validate modules from main.rs (2090 lines → ~400). Refactor validate_and_normalize_inferred_citations into smaller focused functions.
+
+## Summary of Changes
+
+Extracted 4 modules from 2090-line main.rs:
+- template_diff.rs (341 lines): LCS-based template variant diff computation
+- cli.rs (159 lines): CLI arg parsing + help text
+- bib_postprocess.rs (241 lines): bibliography postprocessing, component predicates, type template repair
+- citation_validate.rs (161 lines): refactored validate_and_normalize_inferred_citations
+
+validate_and_normalize_inferred_citations split into reject_invalid_inferred_citation + normalize_inferred_citation_contributors, eliminating repeated is_inferred_source checks.
+
+main.rs: 2090 -> 545 lines of logic. All 113 tests pass.
+PR: https://github.com/citum/citum-core/pull/690

--- a/crates/citum-migrate/src/bib_postprocess.rs
+++ b/crates/citum-migrate/src/bib_postprocess.rs
@@ -1,0 +1,241 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Inferred bibliography template postprocessing and repair.
+
+use citum_migrate::{
+    fixups::{
+        ensure_inferred_media_type_templates, ensure_inferred_patent_type_template,
+        normalize_legal_case_type_template, scrub_inferred_literal_artifacts,
+        should_merge_inferred_type_template,
+    },
+    template_resolver,
+};
+use citum_schema::{
+    locale::GeneralTerm,
+    template::{
+        ContributorRole, DateVariable, SimpleVariable, TemplateComponent, TitleType, TypeSelector,
+    },
+};
+
+use super::template_diff::TypeTemplateMap;
+
+/// Extension trait to enumerate concrete type names from a `TypeSelector`.
+pub(crate) trait TypeSelectorNames {
+    fn type_names(&self) -> Vec<String>;
+}
+
+impl TypeSelectorNames for TypeSelector {
+    fn type_names(&self) -> Vec<String> {
+        match self {
+            TypeSelector::Single(name) => vec![name.clone()],
+            TypeSelector::Multiple(names) => names.clone(),
+        }
+    }
+}
+
+pub(crate) fn postprocess_inferred_bibliography(
+    new_bib: &mut Vec<TemplateComponent>,
+    type_templates: &mut Option<TypeTemplateMap>,
+    legacy_style: &csl_legacy::model::Style,
+) {
+    for component in &mut *new_bib {
+        scrub_inferred_literal_artifacts(component);
+    }
+    relax_inferred_bibliography_date_suppression(new_bib);
+    if let Some(type_templates) = type_templates.as_mut() {
+        for template in type_templates.values_mut() {
+            for component in template.iter_mut() {
+                scrub_inferred_literal_artifacts(component);
+            }
+            relax_inferred_bibliography_date_suppression(template);
+        }
+        repair_inferred_bibliography_type_templates(new_bib, type_templates);
+    }
+    normalize_legal_case_type_template(legacy_style, type_templates);
+    ensure_inferred_media_type_templates(legacy_style, type_templates, new_bib);
+    ensure_inferred_patent_type_template(legacy_style, type_templates, new_bib);
+}
+
+pub(crate) fn merge_inferred_type_templates(
+    xml_fallback: &citum_migrate::compilation::XmlCompilationOutput,
+    resolved_bib_template: &[TemplateComponent],
+) -> Option<TypeTemplateMap> {
+    xml_fallback
+        .type_templates
+        .clone()
+        .map(|type_templates| {
+            type_templates
+                .into_iter()
+                .filter(|(selector, type_template)| {
+                    selector.type_names().iter().any(|type_name| {
+                        should_merge_inferred_type_template(
+                            type_name,
+                            resolved_bib_template,
+                            type_template,
+                        )
+                    })
+                })
+                .collect::<indexmap::IndexMap<_, _>>()
+        })
+        .filter(|m| !m.is_empty())
+}
+
+pub(crate) fn is_inferred_bib_source(source: &template_resolver::TemplateSource) -> bool {
+    matches!(
+        source,
+        template_resolver::TemplateSource::InferredCached(_)
+            | template_resolver::TemplateSource::InferredLive
+    )
+}
+
+pub(crate) fn repair_inferred_bibliography_type_templates(
+    default_template: &[TemplateComponent],
+    type_templates: &mut TypeTemplateMap,
+) {
+    let base_title = default_template
+        .iter()
+        .find(|component| component_is_primary_title(component))
+        .cloned();
+    let base_publisher = default_template
+        .iter()
+        .find(|component| component_is_publisher(component))
+        .cloned();
+
+    for (selector, template) in type_templates.iter_mut() {
+        let type_names = selector.type_names();
+
+        if should_inherit_primary_title(&type_names)
+            && !template.iter().any(component_is_primary_title)
+            && let Some(base_title) = base_title.clone()
+        {
+            let insert_at = template
+                .iter()
+                .position(|component| {
+                    component_is_container_title(component) || component_is_in_term(component)
+                })
+                .or_else(|| {
+                    template
+                        .iter()
+                        .rposition(|component| {
+                            component_is_author(component) || component_is_issued_date(component)
+                        })
+                        .map(|index| index + 1)
+                })
+                .unwrap_or(0);
+            template.insert(insert_at, base_title);
+        }
+
+        if should_inherit_publisher(&type_names)
+            && !template.iter().any(component_is_publisher)
+            && let Some(base_publisher) = base_publisher.clone()
+        {
+            let insert_at = template
+                .iter()
+                .rposition(component_is_publisher_place)
+                .map(|index| index + 1)
+                .or_else(|| {
+                    template
+                        .iter()
+                        .rposition(component_is_primary_title)
+                        .map(|index| index + 1)
+                })
+                .unwrap_or(template.len());
+            template.insert(insert_at, base_publisher);
+        }
+    }
+}
+
+fn should_inherit_primary_title(type_names: &[String]) -> bool {
+    type_names.iter().any(|type_name| {
+        matches!(
+            type_name.as_str(),
+            "article-magazine"
+                | "article-newspaper"
+                | "book"
+                | "broadcast"
+                | "motion_picture"
+                | "motion-picture"
+                | "report"
+        )
+    })
+}
+
+fn should_inherit_publisher(type_names: &[String]) -> bool {
+    type_names.iter().any(|type_name| {
+        matches!(
+            type_name.as_str(),
+            "book" | "motion_picture" | "motion-picture" | "report" | "thesis"
+        )
+    })
+}
+
+pub(crate) fn component_is_primary_title(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Title(title)
+            if title.title == TitleType::Primary
+    )
+}
+
+fn component_is_container_title(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Title(title)
+            if matches!(
+                title.title,
+                citum_schema::template::TitleType::ParentMonograph
+                    | citum_schema::template::TitleType::ParentSerial
+            )
+    )
+}
+
+fn component_is_author(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Contributor(contributor)
+            if contributor.contributor == ContributorRole::Author
+    )
+}
+
+fn component_is_issued_date(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Date(date)
+            if date.date == DateVariable::Issued
+    )
+}
+
+pub(crate) fn component_is_in_term(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Term(term)
+            if term.term == GeneralTerm::In
+    )
+}
+
+pub(crate) fn component_is_publisher(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Variable(variable)
+            if variable.variable == SimpleVariable::Publisher
+    )
+}
+
+pub(crate) fn component_is_publisher_place(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Variable(variable)
+            if variable.variable == SimpleVariable::PublisherPlace
+    )
+}
+
+pub(crate) fn relax_inferred_bibliography_date_suppression(template: &mut [TemplateComponent]) {
+    for component in template {
+        if let TemplateComponent::Group(list) = component {
+            relax_inferred_bibliography_date_suppression(&mut list.group);
+        }
+    }
+}

--- a/crates/citum-migrate/src/citation_validate.rs
+++ b/crates/citum-migrate/src/citation_validate.rs
@@ -1,0 +1,161 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Inferred citation template validation and contributor normalization.
+
+use citum_migrate::{
+    fixups::{
+        citation_template_has_citation_number, citation_template_is_author_year_only,
+        normalize_author_date_inferred_contributors, normalize_contributor_form_to_short,
+        note_citation_template_is_underfit,
+    },
+    template_resolver,
+};
+use citum_schema::template::TemplateComponent;
+
+pub(crate) fn is_inferred_source(source: &template_resolver::TemplateSource) -> bool {
+    matches!(
+        source,
+        template_resolver::TemplateSource::InferredCached(_)
+            | template_resolver::TemplateSource::InferredLive
+    )
+}
+
+/// Validates the inferred citation template and normalizes contributor forms.
+///
+/// Rejects invalid inferred templates (falling back to XML), then applies
+/// contributor form normalization for note, author-date, and in-text styles.
+pub(crate) fn validate_and_normalize_inferred_citations(
+    resolved: &mut template_resolver::ResolvedTemplates,
+    options: &citum_schema::options::Config,
+    legacy_style: &csl_legacy::model::Style,
+    style_name: &str,
+    citation_has_scope_shorten: bool,
+) {
+    reject_invalid_inferred_citation(resolved, options, legacy_style, style_name);
+    normalize_inferred_citation_contributors(
+        resolved,
+        options,
+        legacy_style,
+        style_name,
+        citation_has_scope_shorten,
+    );
+}
+
+fn reject_invalid_inferred_citation(
+    resolved: &mut template_resolver::ResolvedTemplates,
+    options: &citum_schema::options::Config,
+    legacy_style: &csl_legacy::model::Style,
+    style_name: &str,
+) {
+    let Some(resolved_cit) = resolved.citation.as_ref() else {
+        return;
+    };
+    if !is_inferred_source(&resolved_cit.source) {
+        return;
+    }
+    if let Some(reason) =
+        inferred_citation_reject_reason(&resolved_cit.template, options, legacy_style)
+    {
+        tracing::debug!(
+            "Rejecting inferred citation template for {style_name}: {reason}. Falling back to XML citation template."
+        );
+        resolved.citation = None;
+    }
+}
+
+fn inferred_citation_reject_reason(
+    template: &[TemplateComponent],
+    options: &citum_schema::options::Config,
+    legacy_style: &csl_legacy::model::Style,
+) -> Option<&'static str> {
+    if template.is_empty() {
+        Some("empty citation template")
+    } else if matches!(
+        options.processing,
+        Some(citum_schema::options::Processing::Numeric)
+    ) && !citation_template_has_citation_number(template)
+    {
+        Some("numeric style citation template missing citation-number")
+    } else if legacy_style.class == "note" && note_citation_template_is_underfit(template) {
+        Some("note style citation template is contributor-only underfit")
+    } else {
+        None
+    }
+}
+
+fn normalize_inferred_citation_contributors(
+    resolved: &mut template_resolver::ResolvedTemplates,
+    options: &citum_schema::options::Config,
+    legacy_style: &csl_legacy::model::Style,
+    style_name: &str,
+    citation_has_scope_shorten: bool,
+) {
+    normalize_note_or_author_date_citation(resolved, options, legacy_style, style_name);
+    normalize_in_text_citation(
+        resolved,
+        legacy_style,
+        style_name,
+        citation_has_scope_shorten,
+    );
+}
+
+fn normalize_note_or_author_date_citation(
+    resolved: &mut template_resolver::ResolvedTemplates,
+    options: &citum_schema::options::Config,
+    legacy_style: &csl_legacy::model::Style,
+    style_name: &str,
+) {
+    let should_normalize = legacy_style.class == "note"
+        || matches!(
+            options.processing,
+            Some(citum_schema::options::Processing::AuthorDate)
+        );
+    if !should_normalize {
+        return;
+    }
+    let Some(resolved_cit) = resolved.citation.as_mut() else {
+        return;
+    };
+    if !is_inferred_source(&resolved_cit.source) {
+        return;
+    }
+    if citation_template_is_author_year_only(&resolved_cit.template)
+        && normalize_contributor_form_to_short(&mut resolved_cit.template)
+    {
+        tracing::debug!(
+            "Normalized citation contributor form to short for {style_name} (author-year inferred citation template)."
+        );
+    }
+}
+
+fn normalize_in_text_citation(
+    resolved: &mut template_resolver::ResolvedTemplates,
+    legacy_style: &csl_legacy::model::Style,
+    style_name: &str,
+    citation_has_scope_shorten: bool,
+) {
+    if legacy_style.class != "in-text" {
+        return;
+    }
+    let Some(resolved_cit) = resolved.citation.as_mut() else {
+        return;
+    };
+    if !is_inferred_source(&resolved_cit.source) {
+        return;
+    }
+    let is_author_year_shape = citation_template_is_author_year_only(&resolved_cit.template)
+        && !citation_template_has_citation_number(&resolved_cit.template);
+    if is_author_year_shape
+        && normalize_author_date_inferred_contributors(
+            &mut resolved_cit.template,
+            citation_has_scope_shorten,
+        )
+    {
+        tracing::debug!(
+            "Normalized inferred author-date citation contributors for {style_name} (family-short + scoped shorten)."
+        );
+    }
+}

--- a/crates/citum-migrate/src/cli.rs
+++ b/crates/citum-migrate/src/cli.rs
@@ -1,0 +1,159 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! CLI argument parsing for citum-migrate.
+
+use citum_migrate::template_resolver;
+use std::path::PathBuf;
+
+pub(crate) struct CliArgs {
+    pub(crate) path: String,
+    pub(crate) debug_variable: Option<String>,
+    pub(crate) template_mode: template_resolver::TemplateMode,
+    pub(crate) live_infer_backend: template_resolver::LiveInferBackend,
+    pub(crate) template_dir: Option<PathBuf>,
+    pub(crate) min_template_confidence: f64,
+}
+
+fn parse_template_mode_arg(value: &str) -> template_resolver::TemplateMode {
+    match value.parse::<template_resolver::TemplateMode>() {
+        Ok(mode) => mode,
+        Err(msg) => {
+            tracing::debug!("Error: {msg}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn parse_live_infer_backend_arg(value: &str) -> template_resolver::LiveInferBackend {
+    match value.parse::<template_resolver::LiveInferBackend>() {
+        Ok(backend) => backend,
+        Err(msg) => {
+            tracing::debug!("Error: {msg}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn parse_min_template_confidence_arg(value: &str) -> f64 {
+    match value.parse::<f64>() {
+        Ok(parsed) if (0.0..=1.0).contains(&parsed) => parsed,
+        _ => {
+            tracing::debug!("Error: --min-template-confidence requires a number in [0.0, 1.0]");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
+pub(crate) fn parse_cli_args(args: &[String]) -> CliArgs {
+    let program_name = args
+        .first()
+        .and_then(|arg| std::path::Path::new(arg).file_name())
+        .and_then(|name| name.to_str())
+        .unwrap_or("citum-migrate");
+
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        print_help(program_name);
+        std::process::exit(0);
+    }
+
+    let mut path = "styles-legacy/apa.csl".to_string();
+    let mut debug_variable: Option<String> = None;
+    let mut template_mode = template_resolver::TemplateMode::Auto;
+    let mut live_infer_backend = template_resolver::LiveInferBackend::Auto;
+    let mut template_dir: Option<PathBuf> = None;
+    let mut min_template_confidence = 0.70_f64;
+
+    let mut iter = args.iter().skip(1).peekable();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--debug-variable" => {
+                if let Some(val) = iter.next() {
+                    debug_variable = Some(val.clone());
+                } else {
+                    tracing::debug!("Error: --debug-variable requires an argument");
+                    std::process::exit(1);
+                }
+            }
+            "--template-source" => {
+                if let Some(val) = iter.next() {
+                    template_mode = parse_template_mode_arg(val);
+                } else {
+                    tracing::debug!(
+                        "Error: --template-source requires an argument (auto|hand|inferred|xml)"
+                    );
+                    std::process::exit(1);
+                }
+            }
+            "--live-infer-backend" => {
+                if let Some(val) = iter.next() {
+                    live_infer_backend = parse_live_infer_backend_arg(val);
+                } else {
+                    tracing::debug!(
+                        "Error: --live-infer-backend requires an argument (auto|embedded|node)"
+                    );
+                    std::process::exit(1);
+                }
+            }
+            "--min-template-confidence" => {
+                if let Some(val) = iter.next() {
+                    min_template_confidence = parse_min_template_confidence_arg(val);
+                } else {
+                    tracing::debug!("Error: --min-template-confidence requires a numeric argument");
+                    std::process::exit(1);
+                }
+            }
+            "--template-dir" => {
+                if let Some(val) = iter.next() {
+                    template_dir = Some(PathBuf::from(val));
+                } else {
+                    tracing::debug!("Error: --template-dir requires a path argument");
+                    std::process::exit(1);
+                }
+            }
+            arg if !arg.starts_with('-') => {
+                path = arg.to_string();
+            }
+            _ => {
+                tracing::debug!("Error: unknown argument '{}'", arg);
+                tracing::debug!("");
+                print_help(program_name);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    CliArgs {
+        path,
+        debug_variable,
+        template_mode,
+        live_infer_backend,
+        template_dir,
+        min_template_confidence,
+    }
+}
+
+#[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
+pub(super) fn print_help(program_name: &str) {
+    tracing::debug!("Citum style migration tool");
+    tracing::debug!("");
+    tracing::debug!("Usage:");
+    tracing::debug!("  {program_name} [STYLE.csl] [options]");
+    tracing::debug!("");
+    tracing::debug!("Arguments:");
+    tracing::debug!("  STYLE.csl                       Input CSL 1.0 style path");
+    tracing::debug!("                                  (default: styles-legacy/apa.csl)");
+    tracing::debug!("");
+    tracing::debug!("Options:");
+    tracing::debug!("  -h, --help                      Show this help text");
+    tracing::debug!("  --debug-variable <name>         Print provenance details for one variable");
+    tracing::debug!("  --template-source <mode>        Template source: auto|hand|inferred|xml");
+    tracing::debug!("  --live-infer-backend <mode>     Live inference backend: auto|embedded|node");
+    tracing::debug!(
+        "  --template-dir <path>           Override directory for hand-authored templates"
+    );
+    tracing::debug!("  --min-template-confidence <n>   Minimum inferred confidence [0.0, 1.0]");
+}

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -5,19 +5,26 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 #![allow(missing_docs, reason = "bin")]
 
+mod bib_postprocess;
+mod citation_validate;
+mod cli;
+mod template_diff;
+
+use bib_postprocess::{
+    is_inferred_bib_source, merge_inferred_type_templates, postprocess_inferred_bibliography,
+};
+use citation_validate::validate_and_normalize_inferred_citations;
+use cli::{CliArgs, parse_cli_args};
+use template_diff::{TypeTemplateMap, build_type_variants};
+
 use citum_migrate::{
     OptionsExtractor, analysis,
     compilation::{self, XmlCompilationOutput as XmlFallback},
     debug_output::DebugOutputFormatter,
     fixups::{
-        citation_template_has_citation_number, citation_template_is_author_year_only,
-        ensure_inferred_media_type_templates, ensure_inferred_patent_type_template,
         ensure_numeric_locator_citation_component, ensure_personal_communication_omitted,
-        move_group_wrap_to_citation_items, normalize_author_date_inferred_contributors,
-        normalize_author_date_locator_citation_component, normalize_contributor_form_to_short,
-        normalize_legal_case_type_template, normalize_wrapped_numeric_locator_citation_component,
-        note_citation_template_is_underfit, scrub_inferred_literal_artifacts,
-        should_merge_inferred_type_template,
+        move_group_wrap_to_citation_items, normalize_author_date_locator_citation_component,
+        normalize_wrapped_numeric_locator_citation_component,
     },
     lineage::{MigrationOutputPlan, StyleLineage},
     options_extractor::MigrationOptions,
@@ -26,350 +33,13 @@ use citum_migrate::{
 };
 use citum_schema::{
     BibliographySpec, CitationCollapse, CitationSpec, Style, StyleInfo,
-    template::{
-        Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
-        TemplateModifyOperation, TemplateRemoveOperation, TemplateVariant, TemplateVariantDiff,
-        TypeSelector, WrapPunctuation,
-    },
+    template::{TemplateComponent, WrapPunctuation},
 };
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
-use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-
-/// Shorthand for the per-type template map used throughout the migration pipeline.
-type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
-
-type TypeVariantMap = indexmap::IndexMap<TypeSelector, TemplateVariant>;
-
-fn build_type_variants(
-    default_template: &[TemplateComponent],
-    type_templates: TypeTemplateMap,
-) -> TypeVariantMap {
-    let mut variants = TypeVariantMap::new();
-    let mut candidate_parents: Vec<(TypeSelector, Vec<TemplateComponent>)> = Vec::new();
-
-    for (selector, template) in type_templates {
-        let variant = template_variant_from_full_template(
-            default_template,
-            &candidate_parents,
-            &selector,
-            template.clone(),
-        );
-        variants.insert(selector.clone(), variant);
-        candidate_parents.push((selector, template));
-    }
-
-    variants
-}
-
-fn template_variant_from_full_template(
-    default_template: &[TemplateComponent],
-    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
-    selector: &TypeSelector,
-    target_template: Vec<TemplateComponent>,
-) -> TemplateVariant {
-    let Some(diff) =
-        derive_best_template_variant_diff(default_template, candidate_parents, &target_template)
-    else {
-        return TemplateVariant::Full(target_template);
-    };
-
-    if diff_resolves_to_template(
-        default_template,
-        candidate_parents,
-        selector,
-        &diff,
-        &target_template,
-    ) {
-        TemplateVariant::Diff(diff)
-    } else {
-        TemplateVariant::Full(target_template)
-    }
-}
-
-fn derive_best_template_variant_diff(
-    default_template: &[TemplateComponent],
-    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
-    target_template: &[TemplateComponent],
-) -> Option<TemplateVariantDiff> {
-    let mut best_diff = derive_template_variant_diff(default_template, target_template);
-    let mut best_weight = best_diff
-        .as_ref()
-        .map(diff_operation_weight)
-        .unwrap_or(usize::MAX);
-
-    for (parent_selector, parent_template) in candidate_parents {
-        let Some(mut parent_diff) = derive_template_variant_diff(parent_template, target_template)
-        else {
-            continue;
-        };
-        let weight = diff_operation_weight(&parent_diff);
-        if weight >= best_weight {
-            continue;
-        }
-        parent_diff.extends = Some(parent_selector.clone());
-        best_diff = Some(parent_diff);
-        best_weight = weight;
-    }
-
-    best_diff
-}
-
-fn diff_operation_weight(diff: &TemplateVariantDiff) -> usize {
-    diff.modify.len() + diff.remove.len() + diff.add.len()
-}
-
-fn diff_resolves_to_template(
-    default_template: &[TemplateComponent],
-    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
-    selector: &TypeSelector,
-    diff: &TemplateVariantDiff,
-    expected_template: &[TemplateComponent],
-) -> bool {
-    let mut variants = TypeVariantMap::new();
-    for (parent_selector, parent_template) in candidate_parents {
-        variants.insert(
-            parent_selector.clone(),
-            TemplateVariant::Full(parent_template.clone()),
-        );
-    }
-    variants.insert(selector.clone(), TemplateVariant::Diff(diff.clone()));
-    let style = Style {
-        bibliography: Some(BibliographySpec {
-            template: Some(default_template.to_vec()),
-            type_variants: Some(variants),
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
-
-    style
-        .try_into_resolved()
-        .ok()
-        .and_then(|style| style.bibliography)
-        .and_then(|bibliography| bibliography.type_variants)
-        .and_then(|variants| variants.get(selector).cloned())
-        .and_then(TemplateVariant::into_template)
-        .is_some_and(|resolved| resolved == expected_template)
-}
-
-fn derive_template_variant_diff(
-    default_template: &[TemplateComponent],
-    target_template: &[TemplateComponent],
-) -> Option<TemplateVariantDiff> {
-    if default_template.is_empty() {
-        return None;
-    }
-
-    let default_keys = component_keys(default_template)?;
-    let target_keys = component_keys(target_template)?;
-    let common_pairs = lcs_pairs(&default_keys, &target_keys);
-    let mut diff = TemplateVariantDiff::default();
-
-    for (index, component) in default_template.iter().enumerate() {
-        if !common_pairs
-            .iter()
-            .any(|(base_index, _)| *base_index == index)
-        {
-            diff.remove.push(TemplateRemoveOperation {
-                match_selector: component_selector(component)?,
-            });
-        }
-    }
-
-    for (base_index, target_index) in &common_pairs {
-        let base_component = default_template.get(*base_index)?;
-        let target_component = target_template.get(*target_index)?;
-        if base_component != target_component {
-            if !is_rendering_only_change(base_component, target_component) {
-                return None;
-            }
-            diff.modify.push(TemplateModifyOperation {
-                match_selector: component_selector(base_component)?,
-                label_form: modified_number_label_form(base_component, target_component),
-                rendering: target_component.rendering().clone(),
-            });
-        }
-    }
-
-    let mut last_anchor: Option<TemplateComponentSelector> = None;
-    for (target_index, component) in target_template.iter().enumerate() {
-        if let Some((base_index, _)) = common_pairs
-            .iter()
-            .find(|(_, common_target_index)| *common_target_index == target_index)
-        {
-            last_anchor = default_template
-                .get(*base_index)
-                .and_then(component_selector);
-            continue;
-        }
-
-        let next_anchor = common_pairs
-            .iter()
-            .find(|(_, common_target_index)| *common_target_index > target_index)
-            .and_then(|(base_index, _)| default_template.get(*base_index))
-            .and_then(component_selector);
-
-        let component_selector = component_selector(component)?;
-        let add = if let Some(before) = next_anchor {
-            TemplateAddOperation {
-                before: Some(before),
-                after: None,
-                component: component.clone(),
-            }
-        } else if let Some(after) = last_anchor.clone() {
-            TemplateAddOperation {
-                before: None,
-                after: Some(after),
-                component: component.clone(),
-            }
-        } else {
-            return None;
-        };
-        diff.add.push(add);
-        last_anchor = Some(component_selector);
-    }
-
-    Some(diff)
-}
-
-fn component_keys(template: &[TemplateComponent]) -> Option<Vec<String>> {
-    template
-        .iter()
-        .map(|component| serde_json::to_string(&component_selector(component)?.fields).ok())
-        .collect()
-}
-
-fn component_selector(component: &TemplateComponent) -> Option<TemplateComponentSelector> {
-    let serde_json::Value::Object(fields) = serde_json::to_value(component).ok()? else {
-        return None;
-    };
-    for key in [
-        "contributor",
-        "date",
-        "title",
-        "number",
-        "variable",
-        "term",
-        "group",
-    ] {
-        if let Some(value) = fields.get(key) {
-            let mut selector = BTreeMap::new();
-            selector.insert(key.to_string(), value.clone());
-            return Some(TemplateComponentSelector { fields: selector });
-        }
-    }
-    None
-}
-
-fn modified_number_label_form(
-    base: &TemplateComponent,
-    target: &TemplateComponent,
-) -> Option<citum_schema::template::LabelForm> {
-    match (base, target) {
-        (TemplateComponent::Number(base_number), TemplateComponent::Number(target_number))
-            if base_number.label_form != target_number.label_form =>
-        {
-            target_number.label_form.clone()
-        }
-        _ => None,
-    }
-}
-
-fn is_rendering_only_change(base: &TemplateComponent, target: &TemplateComponent) -> bool {
-    let mut normalized_base = base.clone();
-    let mut normalized_target = target.clone();
-    *normalized_base.rendering_mut() = Rendering::default();
-    *normalized_target.rendering_mut() = Rendering::default();
-
-    match (&mut normalized_base, &mut normalized_target) {
-        (TemplateComponent::Number(base_number), TemplateComponent::Number(target_number))
-            if base_number.label_form != target_number.label_form =>
-        {
-            if target_number.label_form.is_none() {
-                return false;
-            }
-            base_number.label_form = None;
-            target_number.label_form = None;
-        }
-        _ => {}
-    }
-
-    normalized_base == normalized_target
-}
-
-fn lcs_pairs(left: &[String], right: &[String]) -> Vec<(usize, usize)> {
-    let mut lengths = vec![vec![0usize; right.len() + 1]; left.len() + 1];
-
-    for i in (0..left.len()).rev() {
-        for j in (0..right.len()).rev() {
-            let diagonal = lengths
-                .get(i + 1)
-                .and_then(|row| row.get(j + 1))
-                .copied()
-                .unwrap_or(0);
-            let down = lengths
-                .get(i + 1)
-                .and_then(|row| row.get(j))
-                .copied()
-                .unwrap_or(0);
-            let right_value = lengths
-                .get(i)
-                .and_then(|row| row.get(j + 1))
-                .copied()
-                .unwrap_or(0);
-            let value = if left.get(i) == right.get(j) {
-                diagonal + 1
-            } else {
-                down.max(right_value)
-            };
-            if let Some(cell) = lengths.get_mut(i).and_then(|row| row.get_mut(j)) {
-                *cell = value;
-            }
-        }
-    }
-
-    let mut pairs = Vec::new();
-    let mut i = 0;
-    let mut j = 0;
-    while i < left.len() && j < right.len() {
-        if left.get(i) == right.get(j) {
-            pairs.push((i, j));
-            i += 1;
-            j += 1;
-            continue;
-        }
-
-        let down = lengths
-            .get(i + 1)
-            .and_then(|row| row.get(j))
-            .copied()
-            .unwrap_or(0);
-        let right_value = lengths
-            .get(i)
-            .and_then(|row| row.get(j + 1))
-            .copied()
-            .unwrap_or(0);
-        if down >= right_value {
-            i += 1;
-        } else {
-            j += 1;
-        }
-    }
-    pairs
-}
-
-struct CliArgs {
-    path: String,
-    debug_variable: Option<String>,
-    template_mode: template_resolver::TemplateMode,
-    live_infer_backend: template_resolver::LiveInferBackend,
-    template_dir: Option<PathBuf>,
-    min_template_confidence: f64,
-}
 
 /// All compiled template and option data needed to build the final Style.
 struct CompiledOutput {
@@ -388,164 +58,6 @@ struct CompiledOutput {
     citation_ibid_override: Option<Vec<TemplateComponent>>,
 }
 
-fn parse_template_mode_arg(value: &str) -> template_resolver::TemplateMode {
-    match value.parse::<template_resolver::TemplateMode>() {
-        Ok(mode) => mode,
-        Err(msg) => {
-            tracing::debug!("Error: {msg}");
-            std::process::exit(1);
-        }
-    }
-}
-
-fn parse_live_infer_backend_arg(value: &str) -> template_resolver::LiveInferBackend {
-    match value.parse::<template_resolver::LiveInferBackend>() {
-        Ok(backend) => backend,
-        Err(msg) => {
-            tracing::debug!("Error: {msg}");
-            std::process::exit(1);
-        }
-    }
-}
-
-fn parse_min_template_confidence_arg(value: &str) -> f64 {
-    match value.parse::<f64>() {
-        Ok(parsed) if (0.0..=1.0).contains(&parsed) => parsed,
-        _ => {
-            tracing::debug!("Error: --min-template-confidence requires a number in [0.0, 1.0]");
-            std::process::exit(1);
-        }
-    }
-}
-
-#[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
-fn parse_cli_args(args: &[String]) -> CliArgs {
-    let program_name = args
-        .first()
-        .and_then(|arg| std::path::Path::new(arg).file_name())
-        .and_then(|name| name.to_str())
-        .unwrap_or("citum-migrate");
-
-    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
-        print_help(program_name);
-        std::process::exit(0);
-    }
-
-    let mut path = "styles-legacy/apa.csl".to_string();
-    let mut debug_variable: Option<String> = None;
-    let mut template_mode = template_resolver::TemplateMode::Auto;
-    let mut live_infer_backend = template_resolver::LiveInferBackend::Auto;
-    let mut template_dir: Option<PathBuf> = None;
-    let mut min_template_confidence = 0.70_f64;
-
-    let mut iter = args.iter().skip(1).peekable();
-    while let Some(arg) = iter.next() {
-        match arg.as_str() {
-            "--debug-variable" => {
-                if let Some(val) = iter.next() {
-                    debug_variable = Some(val.clone());
-                } else {
-                    tracing::debug!("Error: --debug-variable requires an argument");
-                    std::process::exit(1);
-                }
-            }
-            "--template-source" => {
-                if let Some(val) = iter.next() {
-                    template_mode = parse_template_mode_arg(val);
-                } else {
-                    tracing::debug!(
-                        "Error: --template-source requires an argument (auto|hand|inferred|xml)"
-                    );
-                    std::process::exit(1);
-                }
-            }
-            "--live-infer-backend" => {
-                if let Some(val) = iter.next() {
-                    live_infer_backend = parse_live_infer_backend_arg(val);
-                } else {
-                    tracing::debug!(
-                        "Error: --live-infer-backend requires an argument (auto|embedded|node)"
-                    );
-                    std::process::exit(1);
-                }
-            }
-            "--min-template-confidence" => {
-                if let Some(val) = iter.next() {
-                    min_template_confidence = parse_min_template_confidence_arg(val);
-                } else {
-                    tracing::debug!("Error: --min-template-confidence requires a numeric argument");
-                    std::process::exit(1);
-                }
-            }
-            "--template-dir" => {
-                if let Some(val) = iter.next() {
-                    template_dir = Some(PathBuf::from(val));
-                } else {
-                    tracing::debug!("Error: --template-dir requires a path argument");
-                    std::process::exit(1);
-                }
-            }
-            arg if !arg.starts_with('-') => {
-                path = arg.to_string();
-            }
-            _ => {
-                tracing::debug!("Error: unknown argument '{}'", arg);
-                tracing::debug!("");
-                print_help(program_name);
-                std::process::exit(1);
-            }
-        }
-    }
-
-    CliArgs {
-        path,
-        debug_variable,
-        template_mode,
-        live_infer_backend,
-        template_dir,
-        min_template_confidence,
-    }
-}
-
-/// Extracts style name from path and resolves templates.
-fn resolve_style_name_and_templates(
-    path: &str,
-    cli: &CliArgs,
-) -> (String, template_resolver::ResolvedTemplates) {
-    let style_name = std::path::Path::new(path)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown")
-        .to_string();
-
-    let workspace_root = workspace_root_for_style_path(path);
-
-    let resolved = template_resolver::resolve_templates(
-        path,
-        style_name.as_str(),
-        cli.template_dir.as_deref(),
-        &workspace_root,
-        cli.template_mode,
-        cli.min_template_confidence,
-        cli.live_infer_backend,
-    );
-
-    (style_name, resolved)
-}
-
-fn workspace_root_for_style_path(path: &str) -> PathBuf {
-    let style_path = Path::new(path);
-    if style_path.is_absolute() {
-        style_path
-            .ancestors()
-            .find(|p| p.join("Cargo.toml").exists())
-            .unwrap_or(style_path.parent().unwrap_or(Path::new(".")))
-            .to_path_buf()
-    } else {
-        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
-    }
-}
-
 fn extract_citation_collapse(citation: &csl_legacy::model::Citation) -> Option<CitationCollapse> {
     match citation.collapse.as_deref() {
         Some("citation-number") => Some(CitationCollapse::CitationNumber),
@@ -553,7 +65,7 @@ fn extract_citation_collapse(citation: &csl_legacy::model::Citation) -> Option<C
     }
 }
 
-/// Assemble the final Citum Style from compiled output and legacy metadata.
+/// Assembles the final Citum Style from compiled output and legacy metadata.
 fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOutput) -> Style {
     let citation_scope_options =
         c.citation_contributor_overrides
@@ -576,7 +88,7 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
             .and_then(|bib| bib.sort.as_ref()),
     );
 
-    // [PRUNING] Remove bibliography type-variants that are identical to the primary template.
+    // [PRUNING] Remove bibliography type-variants identical to the primary template.
     if let Some(type_templates) = c.type_templates.as_mut() {
         type_templates.retain(|_, template| template != &c.new_bib);
     }
@@ -646,7 +158,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = parse_cli_args(&args);
     let path = &cli.path;
 
-    // Initialize provenance tracking if debug variable is specified
     let enable_provenance = cli.debug_variable.is_some();
     let tracker = ProvenanceTracker::new(enable_provenance);
     let workspace_root = workspace_root_for_style_path(path);
@@ -665,7 +176,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let doc = Document::parse(&text)?;
     let legacy_style = parse_style(doc.root_element())?;
 
-    // 0. Extract global options (new Citum Config)
     let MigrationOptions {
         mut options,
         mut bibliography_options,
@@ -674,8 +184,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         citation_has_scope_shorten,
     } = OptionsExtractor::extract_migration_options(&legacy_style);
 
-    // Resolve template: try hand-authored, cached inferred, or live inference
-    // before falling back to the XML compiler pipeline.
     let (style_name, mut resolved) = resolve_style_name_and_templates(path, &cli);
 
     validate_and_normalize_inferred_citations(
@@ -721,7 +229,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (citation_wrap, citation_prefix, citation_suffix, citation_delimiter) =
         resolve_citation_metadata(&resolved, &legacy_style, &options, &mut new_cit);
 
-    // 5. Build Style in correct format for citum_engine
     let standalone_style = build_final_style(
         &legacy_style,
         CompiledOutput {
@@ -744,6 +251,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     output_style_and_debug(&style, cli.debug_variable.as_deref(), &tracker)?;
     Ok(())
+}
+
+/// Extracts style name from path and resolves templates.
+fn resolve_style_name_and_templates(
+    path: &str,
+    cli: &CliArgs,
+) -> (String, template_resolver::ResolvedTemplates) {
+    let style_name = std::path::Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let workspace_root = workspace_root_for_style_path(path);
+
+    let resolved = template_resolver::resolve_templates(
+        path,
+        style_name.as_str(),
+        cli.template_dir.as_deref(),
+        &workspace_root,
+        cli.template_mode,
+        cli.min_template_confidence,
+        cli.live_infer_backend,
+    );
+
+    (style_name, resolved)
+}
+
+fn workspace_root_for_style_path(path: &str) -> PathBuf {
+    let style_path = Path::new(path);
+    if style_path.is_absolute() {
+        style_path
+            .ancestors()
+            .find(|p| p.join("Cargo.toml").exists())
+            .unwrap_or(style_path.parent().unwrap_or(Path::new(".")))
+            .to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    }
 }
 
 #[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
@@ -784,28 +330,6 @@ fn output_style_and_debug(
     }
 
     Ok(())
-}
-
-#[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
-fn print_help(program_name: &str) {
-    tracing::debug!("Citum style migration tool");
-    tracing::debug!("");
-    tracing::debug!("Usage:");
-    tracing::debug!("  {program_name} [STYLE.csl] [options]");
-    tracing::debug!("");
-    tracing::debug!("Arguments:");
-    tracing::debug!("  STYLE.csl                       Input CSL 1.0 style path");
-    tracing::debug!("                                  (default: styles-legacy/apa.csl)");
-    tracing::debug!("");
-    tracing::debug!("Options:");
-    tracing::debug!("  -h, --help                      Show this help text");
-    tracing::debug!("  --debug-variable <name>         Print provenance details for one variable");
-    tracing::debug!("  --template-source <mode>        Template source: auto|hand|inferred|xml");
-    tracing::debug!("  --live-infer-backend <mode>     Live inference backend: auto|embedded|node");
-    tracing::debug!(
-        "  --template-dir <path>           Override directory for hand-authored templates"
-    );
-    tracing::debug!("  --min-template-confidence <n>   Minimum inferred confidence [0.0, 1.0]");
 }
 
 fn resolve_migrated_bibliography_sort(
@@ -867,35 +391,14 @@ fn select_and_process_bibliography_template(
 ) -> (Vec<TemplateComponent>, Option<TypeTemplateMap>, bool) {
     let (mut new_bib, mut type_templates, inferred_bib_source) =
         if let Some(ref resolved_bib) = resolved.bibliography {
-            let inferred_bib = matches!(
-                resolved_bib.source,
-                template_resolver::TemplateSource::InferredCached(_)
-                    | template_resolver::TemplateSource::InferredLive
-            );
-
+            let inferred_bib = is_inferred_bib_source(&resolved_bib.source);
             let merged_type_templates = if inferred_bib {
                 xml_fallback
                     .as_ref()
-                    .and_then(|out| out.type_templates.clone())
-                    .map(|type_templates| {
-                        type_templates
-                            .into_iter()
-                            .filter(|(selector, type_template)| {
-                                selector.type_names().iter().any(|type_name| {
-                                    should_merge_inferred_type_template(
-                                        type_name,
-                                        &resolved_bib.template,
-                                        type_template,
-                                    )
-                                })
-                            })
-                            .collect::<indexmap::IndexMap<_, _>>()
-                    })
-                    .filter(|m| !m.is_empty())
+                    .and_then(|out| merge_inferred_type_templates(out, &resolved_bib.template))
             } else {
                 None
             };
-
             (
                 resolved_bib.template.clone(),
                 merged_type_templates,
@@ -959,12 +462,8 @@ fn override_bibliography_options_if_inferred(
     options: &mut Option<citum_schema::BibliographyOptions>,
 ) {
     if let Some(ref resolved_bib) = resolved.bibliography {
-        let is_inferred_source = matches!(
-            resolved_bib.source,
-            template_resolver::TemplateSource::InferredCached(_)
-                | template_resolver::TemplateSource::InferredLive
-        );
-        let allow_bib_punctuation_override = !(legacy_style.class == "note" && is_inferred_source);
+        let allow_bib_punctuation_override =
+            !(legacy_style.class == "note" && is_inferred_bib_source(&resolved_bib.source));
 
         if allow_bib_punctuation_override {
             if let Some(ref delim) = resolved_bib.delimiter {
@@ -1046,276 +545,6 @@ fn resolve_citation_metadata(
     )
 }
 
-fn postprocess_inferred_bibliography(
-    new_bib: &mut Vec<TemplateComponent>,
-    type_templates: &mut Option<TypeTemplateMap>,
-    legacy_style: &csl_legacy::model::Style,
-) {
-    for component in &mut *new_bib {
-        scrub_inferred_literal_artifacts(component);
-    }
-    relax_inferred_bibliography_date_suppression(new_bib);
-    if let Some(type_templates) = type_templates.as_mut() {
-        for template in type_templates.values_mut() {
-            for component in template.iter_mut() {
-                scrub_inferred_literal_artifacts(component);
-            }
-            relax_inferred_bibliography_date_suppression(template);
-        }
-        repair_inferred_bibliography_type_templates(new_bib, type_templates);
-    }
-    normalize_legal_case_type_template(legacy_style, type_templates);
-    ensure_inferred_media_type_templates(legacy_style, type_templates, new_bib);
-    ensure_inferred_patent_type_template(legacy_style, type_templates, new_bib);
-}
-
-fn repair_inferred_bibliography_type_templates(
-    default_template: &[TemplateComponent],
-    type_templates: &mut TypeTemplateMap,
-) {
-    let base_title = default_template
-        .iter()
-        .find(|component| component_is_primary_title(component))
-        .cloned();
-    let base_publisher = default_template
-        .iter()
-        .find(|component| component_is_publisher(component))
-        .cloned();
-
-    for (selector, template) in type_templates.iter_mut() {
-        let type_names = selector.type_names();
-
-        if should_inherit_primary_title(&type_names)
-            && !template.iter().any(component_is_primary_title)
-            && let Some(base_title) = base_title.clone()
-        {
-            let insert_at = template
-                .iter()
-                .position(|component| {
-                    component_is_container_title(component) || component_is_in_term(component)
-                })
-                .or_else(|| {
-                    template
-                        .iter()
-                        .rposition(|component| {
-                            component_is_author(component) || component_is_issued_date(component)
-                        })
-                        .map(|index| index + 1)
-                })
-                .unwrap_or(0);
-            template.insert(insert_at, base_title);
-        }
-
-        if should_inherit_publisher(&type_names)
-            && !template.iter().any(component_is_publisher)
-            && let Some(base_publisher) = base_publisher.clone()
-        {
-            let insert_at = template
-                .iter()
-                .rposition(component_is_publisher_place)
-                .map(|index| index + 1)
-                .or_else(|| {
-                    template
-                        .iter()
-                        .rposition(component_is_primary_title)
-                        .map(|index| index + 1)
-                })
-                .unwrap_or(template.len());
-            template.insert(insert_at, base_publisher);
-        }
-    }
-}
-
-fn should_inherit_primary_title(type_names: &[String]) -> bool {
-    type_names.iter().any(|type_name| {
-        matches!(
-            type_name.as_str(),
-            "article-magazine"
-                | "article-newspaper"
-                | "book"
-                | "broadcast"
-                | "motion_picture"
-                | "motion-picture"
-                | "report"
-        )
-    })
-}
-
-fn should_inherit_publisher(type_names: &[String]) -> bool {
-    type_names.iter().any(|type_name| {
-        matches!(
-            type_name.as_str(),
-            "book" | "motion_picture" | "motion-picture" | "report" | "thesis"
-        )
-    })
-}
-
-fn component_is_primary_title(component: &TemplateComponent) -> bool {
-    matches!(
-        component,
-        TemplateComponent::Title(title)
-            if title.title == citum_schema::template::TitleType::Primary
-    )
-}
-
-fn component_is_container_title(component: &TemplateComponent) -> bool {
-    matches!(
-        component,
-        TemplateComponent::Title(title)
-            if matches!(
-                title.title,
-                citum_schema::template::TitleType::ParentMonograph
-                    | citum_schema::template::TitleType::ParentSerial
-            )
-    )
-}
-
-fn component_is_author(component: &TemplateComponent) -> bool {
-    matches!(
-        component,
-        TemplateComponent::Contributor(contributor)
-            if contributor.contributor == citum_schema::template::ContributorRole::Author
-    )
-}
-
-fn component_is_issued_date(component: &TemplateComponent) -> bool {
-    matches!(
-        component,
-        TemplateComponent::Date(date)
-            if date.date == citum_schema::template::DateVariable::Issued
-    )
-}
-
-fn component_is_in_term(component: &TemplateComponent) -> bool {
-    matches!(
-        component,
-        TemplateComponent::Term(term)
-            if term.term == citum_schema::locale::GeneralTerm::In
-    )
-}
-
-fn component_is_publisher(component: &TemplateComponent) -> bool {
-    matches!(
-        component,
-        TemplateComponent::Variable(variable)
-            if variable.variable == citum_schema::template::SimpleVariable::Publisher
-    )
-}
-
-fn component_is_publisher_place(component: &TemplateComponent) -> bool {
-    matches!(
-        component,
-        TemplateComponent::Variable(variable)
-            if variable.variable == citum_schema::template::SimpleVariable::PublisherPlace
-    )
-}
-
-#[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
-fn validate_and_normalize_inferred_citations(
-    resolved: &mut template_resolver::ResolvedTemplates,
-    options: &citum_schema::options::Config,
-    legacy_style: &csl_legacy::model::Style,
-    style_name: &str,
-    citation_has_scope_shorten: bool,
-) {
-    if let Some(resolved_cit) = resolved.citation.as_ref() {
-        let is_inferred_source = matches!(
-            resolved_cit.source,
-            template_resolver::TemplateSource::InferredCached(_)
-                | template_resolver::TemplateSource::InferredLive
-        );
-        if is_inferred_source {
-            let reject_reason = if resolved_cit.template.is_empty() {
-                Some("empty citation template")
-            } else if matches!(
-                options.processing,
-                Some(citum_schema::options::Processing::Numeric)
-            ) && !citation_template_has_citation_number(&resolved_cit.template)
-            {
-                Some("numeric style citation template missing citation-number")
-            } else if legacy_style.class == "note"
-                && note_citation_template_is_underfit(&resolved_cit.template)
-            {
-                Some("note style citation template is contributor-only underfit")
-            } else {
-                None
-            };
-            if let Some(reason) = reject_reason {
-                tracing::debug!(
-                    "Rejecting inferred citation template for {style_name}: {reason}. Falling back to XML citation template."
-                );
-                resolved.citation = None;
-            }
-        }
-    }
-
-    let should_normalize = legacy_style.class == "note"
-        || matches!(
-            options.processing,
-            Some(citum_schema::options::Processing::AuthorDate)
-        );
-
-    if should_normalize && let Some(resolved_cit) = resolved.citation.as_mut() {
-        let is_inferred_source = matches!(
-            resolved_cit.source,
-            template_resolver::TemplateSource::InferredCached(_)
-                | template_resolver::TemplateSource::InferredLive
-        );
-        if is_inferred_source
-            && citation_template_is_author_year_only(&resolved_cit.template)
-            && normalize_contributor_form_to_short(&mut resolved_cit.template)
-        {
-            tracing::debug!(
-                "Normalized citation contributor form to short for {style_name} (author-year inferred citation template)."
-            );
-        }
-    }
-
-    if legacy_style.class == "in-text"
-        && let Some(resolved_cit) = resolved.citation.as_mut()
-    {
-        let is_inferred_source = matches!(
-            resolved_cit.source,
-            template_resolver::TemplateSource::InferredCached(_)
-                | template_resolver::TemplateSource::InferredLive
-        );
-        let is_author_year_shape = citation_template_is_author_year_only(&resolved_cit.template)
-            && !citation_template_has_citation_number(&resolved_cit.template);
-        if is_inferred_source
-            && is_author_year_shape
-            && normalize_author_date_inferred_contributors(
-                &mut resolved_cit.template,
-                citation_has_scope_shorten,
-            )
-        {
-            tracing::debug!(
-                "Normalized inferred author-date citation contributors for {style_name} (family-short + scoped shorten)."
-            );
-        }
-    }
-}
-
-fn relax_inferred_bibliography_date_suppression(template: &mut [TemplateComponent]) {
-    for component in template {
-        if let TemplateComponent::Group(list) = component {
-            relax_inferred_bibliography_date_suppression(&mut list.group);
-        }
-    }
-}
-
-trait TypeSelectorNames {
-    fn type_names(&self) -> Vec<String>;
-}
-
-impl TypeSelectorNames for TypeSelector {
-    fn type_names(&self) -> Vec<String> {
-        match self {
-            TypeSelector::Single(name) => vec![name.clone()],
-            TypeSelector::Multiple(names) => names.clone(),
-        }
-    }
-}
-
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -1329,12 +558,17 @@ impl TypeSelectorNames for TypeSelector {
     reason = "Panicking is acceptable and often desired in tests."
 )]
 mod tests {
+    use super::bib_postprocess::{
+        component_is_in_term, component_is_primary_title, component_is_publisher,
+        component_is_publisher_place, repair_inferred_bibliography_type_templates,
+    };
+    use super::template_diff::template_variant_from_full_template;
     use super::*;
     use citum_schema::locale::GeneralTerm;
     use citum_schema::template::{
         ContributorRole, DateVariable, Rendering, SimpleVariable, TemplateComponent,
         TemplateContributor, TemplateDate, TemplateTerm, TemplateTitle, TemplateVariable,
-        TitleType, TypeSelector,
+        TemplateVariant, TitleType, TypeSelector,
     };
     use csl_legacy::model::{
         Citation, CslNode, Formatting, Group, Info, Layout, Sort as LegacySort,

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -1,0 +1,341 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Template variant diff computation for bibliography type-variant generation.
+
+use citum_schema::{
+    BibliographySpec, Style,
+    template::{
+        Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
+        TemplateModifyOperation, TemplateRemoveOperation, TemplateVariant, TemplateVariantDiff,
+        TypeSelector,
+    },
+};
+use std::collections::BTreeMap;
+
+/// Per-type template map used throughout the migration pipeline.
+pub(crate) type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
+
+pub(crate) type TypeVariantMap = indexmap::IndexMap<TypeSelector, TemplateVariant>;
+
+pub(crate) fn build_type_variants(
+    default_template: &[TemplateComponent],
+    type_templates: TypeTemplateMap,
+) -> TypeVariantMap {
+    let mut variants = TypeVariantMap::new();
+    let mut candidate_parents: Vec<(TypeSelector, Vec<TemplateComponent>)> = Vec::new();
+
+    for (selector, template) in type_templates {
+        let variant = template_variant_from_full_template(
+            default_template,
+            &candidate_parents,
+            &selector,
+            template.clone(),
+        );
+        variants.insert(selector.clone(), variant);
+        candidate_parents.push((selector, template));
+    }
+
+    variants
+}
+
+pub(crate) fn template_variant_from_full_template(
+    default_template: &[TemplateComponent],
+    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
+    selector: &TypeSelector,
+    target_template: Vec<TemplateComponent>,
+) -> TemplateVariant {
+    let Some(diff) =
+        derive_best_template_variant_diff(default_template, candidate_parents, &target_template)
+    else {
+        return TemplateVariant::Full(target_template);
+    };
+
+    if diff_resolves_to_template(
+        default_template,
+        candidate_parents,
+        selector,
+        &diff,
+        &target_template,
+    ) {
+        TemplateVariant::Diff(diff)
+    } else {
+        TemplateVariant::Full(target_template)
+    }
+}
+
+fn derive_best_template_variant_diff(
+    default_template: &[TemplateComponent],
+    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
+    target_template: &[TemplateComponent],
+) -> Option<TemplateVariantDiff> {
+    let mut best_diff = derive_template_variant_diff(default_template, target_template);
+    let mut best_weight = best_diff
+        .as_ref()
+        .map(diff_operation_weight)
+        .unwrap_or(usize::MAX);
+
+    for (parent_selector, parent_template) in candidate_parents {
+        let Some(mut parent_diff) = derive_template_variant_diff(parent_template, target_template)
+        else {
+            continue;
+        };
+        let weight = diff_operation_weight(&parent_diff);
+        if weight >= best_weight {
+            continue;
+        }
+        parent_diff.extends = Some(parent_selector.clone());
+        best_diff = Some(parent_diff);
+        best_weight = weight;
+    }
+
+    best_diff
+}
+
+fn diff_operation_weight(diff: &TemplateVariantDiff) -> usize {
+    diff.modify.len() + diff.remove.len() + diff.add.len()
+}
+
+fn diff_resolves_to_template(
+    default_template: &[TemplateComponent],
+    candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
+    selector: &TypeSelector,
+    diff: &TemplateVariantDiff,
+    expected_template: &[TemplateComponent],
+) -> bool {
+    let mut variants = TypeVariantMap::new();
+    for (parent_selector, parent_template) in candidate_parents {
+        variants.insert(
+            parent_selector.clone(),
+            TemplateVariant::Full(parent_template.clone()),
+        );
+    }
+    variants.insert(selector.clone(), TemplateVariant::Diff(diff.clone()));
+    let style = Style {
+        bibliography: Some(BibliographySpec {
+            template: Some(default_template.to_vec()),
+            type_variants: Some(variants),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    style
+        .try_into_resolved()
+        .ok()
+        .and_then(|style| style.bibliography)
+        .and_then(|bibliography| bibliography.type_variants)
+        .and_then(|variants| variants.get(selector).cloned())
+        .and_then(TemplateVariant::into_template)
+        .is_some_and(|resolved| resolved == expected_template)
+}
+
+fn derive_template_variant_diff(
+    default_template: &[TemplateComponent],
+    target_template: &[TemplateComponent],
+) -> Option<TemplateVariantDiff> {
+    if default_template.is_empty() {
+        return None;
+    }
+
+    let default_keys = component_keys(default_template)?;
+    let target_keys = component_keys(target_template)?;
+    let common_pairs = lcs_pairs(&default_keys, &target_keys);
+    let mut diff = TemplateVariantDiff::default();
+
+    for (index, component) in default_template.iter().enumerate() {
+        if !common_pairs
+            .iter()
+            .any(|(base_index, _)| *base_index == index)
+        {
+            diff.remove.push(TemplateRemoveOperation {
+                match_selector: component_selector(component)?,
+            });
+        }
+    }
+
+    for (base_index, target_index) in &common_pairs {
+        let base_component = default_template.get(*base_index)?;
+        let target_component = target_template.get(*target_index)?;
+        if base_component != target_component {
+            if !is_rendering_only_change(base_component, target_component) {
+                return None;
+            }
+            diff.modify.push(TemplateModifyOperation {
+                match_selector: component_selector(base_component)?,
+                label_form: modified_number_label_form(base_component, target_component),
+                rendering: target_component.rendering().clone(),
+            });
+        }
+    }
+
+    let mut last_anchor: Option<TemplateComponentSelector> = None;
+    for (target_index, component) in target_template.iter().enumerate() {
+        if let Some((base_index, _)) = common_pairs
+            .iter()
+            .find(|(_, common_target_index)| *common_target_index == target_index)
+        {
+            last_anchor = default_template
+                .get(*base_index)
+                .and_then(component_selector);
+            continue;
+        }
+
+        let next_anchor = common_pairs
+            .iter()
+            .find(|(_, common_target_index)| *common_target_index > target_index)
+            .and_then(|(base_index, _)| default_template.get(*base_index))
+            .and_then(component_selector);
+
+        let component_selector = component_selector(component)?;
+        let add = if let Some(before) = next_anchor {
+            TemplateAddOperation {
+                before: Some(before),
+                after: None,
+                component: component.clone(),
+            }
+        } else if let Some(after) = last_anchor.clone() {
+            TemplateAddOperation {
+                before: None,
+                after: Some(after),
+                component: component.clone(),
+            }
+        } else {
+            return None;
+        };
+        diff.add.push(add);
+        last_anchor = Some(component_selector);
+    }
+
+    Some(diff)
+}
+
+fn component_keys(template: &[TemplateComponent]) -> Option<Vec<String>> {
+    template
+        .iter()
+        .map(|component| serde_json::to_string(&component_selector(component)?.fields).ok())
+        .collect()
+}
+
+pub(crate) fn component_selector(
+    component: &TemplateComponent,
+) -> Option<TemplateComponentSelector> {
+    let serde_json::Value::Object(fields) = serde_json::to_value(component).ok()? else {
+        return None;
+    };
+    for key in [
+        "contributor",
+        "date",
+        "title",
+        "number",
+        "variable",
+        "term",
+        "group",
+    ] {
+        if let Some(value) = fields.get(key) {
+            let mut selector = BTreeMap::new();
+            selector.insert(key.to_string(), value.clone());
+            return Some(TemplateComponentSelector { fields: selector });
+        }
+    }
+    None
+}
+
+fn modified_number_label_form(
+    base: &TemplateComponent,
+    target: &TemplateComponent,
+) -> Option<citum_schema::template::LabelForm> {
+    match (base, target) {
+        (TemplateComponent::Number(base_number), TemplateComponent::Number(target_number))
+            if base_number.label_form != target_number.label_form =>
+        {
+            target_number.label_form.clone()
+        }
+        _ => None,
+    }
+}
+
+fn is_rendering_only_change(base: &TemplateComponent, target: &TemplateComponent) -> bool {
+    let mut normalized_base = base.clone();
+    let mut normalized_target = target.clone();
+    *normalized_base.rendering_mut() = Rendering::default();
+    *normalized_target.rendering_mut() = Rendering::default();
+
+    match (&mut normalized_base, &mut normalized_target) {
+        (TemplateComponent::Number(base_number), TemplateComponent::Number(target_number))
+            if base_number.label_form != target_number.label_form =>
+        {
+            if target_number.label_form.is_none() {
+                return false;
+            }
+            base_number.label_form = None;
+            target_number.label_form = None;
+        }
+        _ => {}
+    }
+
+    normalized_base == normalized_target
+}
+
+fn lcs_pairs(left: &[String], right: &[String]) -> Vec<(usize, usize)> {
+    let mut lengths = vec![vec![0usize; right.len() + 1]; left.len() + 1];
+
+    for i in (0..left.len()).rev() {
+        for j in (0..right.len()).rev() {
+            let diagonal = lengths
+                .get(i + 1)
+                .and_then(|row| row.get(j + 1))
+                .copied()
+                .unwrap_or(0);
+            let down = lengths
+                .get(i + 1)
+                .and_then(|row| row.get(j))
+                .copied()
+                .unwrap_or(0);
+            let right_value = lengths
+                .get(i)
+                .and_then(|row| row.get(j + 1))
+                .copied()
+                .unwrap_or(0);
+            let value = if left.get(i) == right.get(j) {
+                diagonal + 1
+            } else {
+                down.max(right_value)
+            };
+            if let Some(cell) = lengths.get_mut(i).and_then(|row| row.get_mut(j)) {
+                *cell = value;
+            }
+        }
+    }
+
+    let mut pairs = Vec::new();
+    let mut i = 0;
+    let mut j = 0;
+    while i < left.len() && j < right.len() {
+        if left.get(i) == right.get(j) {
+            pairs.push((i, j));
+            i += 1;
+            j += 1;
+            continue;
+        }
+
+        let down = lengths
+            .get(i + 1)
+            .and_then(|row| row.get(j))
+            .copied()
+            .unwrap_or(0);
+        let right_value = lengths
+            .get(i)
+            .and_then(|row| row.get(j + 1))
+            .copied()
+            .unwrap_or(0);
+        if down >= right_value {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    pairs
+}


### PR DESCRIPTION
Extracted 4 modules from 2090-line main.rs: template_diff (LCS diff), cli (arg parsing), bib_postprocess (bib postprocessing + predicates), citation_validate (refactored validate_and_normalize). main.rs logic 2090 -> 545 lines. All 113 tests pass.