### PR TITLE
feat(server): rpc discovery + schema endpoint

### DIFF
--- a/.beans/archive/csl26-7m9n--citum-server-rpc-discovery-schemars-schema-endpoin.md
+++ b/.beans/archive/csl26-7m9n--citum-server-rpc-discovery-schemars-schema-endpoin.md
@@ -1,0 +1,19 @@
+---
+# csl26-7m9n
+title: 'citum-server: RPC discovery + schemars schema endpoint'
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-14T10:33:40Z
+updated_at: 2026-05-14T10:39:21Z
+---
+
+Add GET /rpc (405 hint), GET /rpc/methods discovery, GET /rpc/schema (schemars, feature-gated). Create typed param structs for schemars derives. Fix stale README (add format_document, inject_ast_indices). Branch: feat/server-rpc-discovery.
+
+## Summary of Changes
+
+- Added typed param structs (RenderCitationParams, RenderBibliographyParams, ValidateStyleParams) with schemars::JsonSchema derives gated on schema feature
+- Added GET /rpc → 405 hint, GET /rpc/methods → static descriptor list, GET /rpc/schema → schemars-generated (schema feature)
+- Added schema feature to Cargo.toml (implies http)
+- Fixed README: added format_document row, inject_ast_indices note, Discovery section, schema feature row
+- All 21 tests pass

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -37,8 +37,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   # Internal commits may use any scope, but everything pushed must be clean.
   # Validate scopes against the canonical allowlist.
   # Use sed to extract scope (avoids bash =~ ERE paren ambiguity).
-  VALID_SCOPES_RE='^(engine|schema|migrate|store|cli|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security)$'
-  VALID_SCOPES_LIST="engine, schema, migrate, store, cli, styles, locale, i18n, ci, hooks, beans, scripts, tooling, spec, docs, release, report, examples, bindings, security"
+  VALID_SCOPES_RE='^(engine|schema|migrate|store|cli|server|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security)$'
+  VALID_SCOPES_LIST="engine, schema, migrate, store, cli, server, styles, locale, i18n, ci, hooks, beans, scripts, tooling, spec, docs, release, report, examples, bindings, security"
   scope_errors=()
   while IFS= read -r subject; do
     # Extract scope: "type(scope)[!]: ..." -> scope, empty if unscoped.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "citum-schema",
  "citum_store",
  "clap",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -29,6 +29,9 @@ tokio = { version = "1", features = ["full"], optional = true }
 # http feature dependencies (implies async)
 axum = { version = "0.8", optional = true }
 
+# schema feature dependencies
+schemars = { version = "1.2.1", features = ["derive"], optional = true }
+
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 
@@ -36,6 +39,7 @@ tower = { version = "0.5", features = ["util"] }
 default = []
 async = ["tokio"]
 http = ["async", "axum"]
+schema = ["http", "dep:schemars"]
 
 [lints]
 workspace = true

--- a/crates/citum-server/README.md
+++ b/crates/citum-server/README.md
@@ -71,9 +71,10 @@ node scripts/benchmark-rpc-workflow.js
 
 | Method | Params | Result |
 |---|---|---|
-| `render_citation` | `style_path`, `refs`, `citation`, `output_format?` | `String` |
-| `render_bibliography` | `style_path`, `refs`, `output_format?` | `{format, content, entries?}` |
+| `render_citation` | `style_path`, `refs`, `citation`, `output_format?`, `inject_ast_indices?` | `String` |
+| `render_bibliography` | `style_path`, `refs`, `output_format?`, `inject_ast_indices?` | `{format, content, entries?}` |
 | `validate_style` | `style_path` | `{valid, warnings}` |
+| `format_document` | `style`, `refs`, `citations`, `output_format?` | `{citations, bibliography}` |
 
 Supported `output_format` values:
 
@@ -82,6 +83,8 @@ Supported `output_format` values:
 - `djot`
 - `latex`
 - `typst`
+
+**Debug Parameters:** The `inject_ast_indices` parameter (optional, default `false`) is accepted by `render_citation` and `render_bibliography` for debug use. When enabled, AST node indices are embedded in the output.
 
 ### Request / response envelope
 
@@ -92,12 +95,27 @@ Supported `output_format` values:
 {"id": 2, "error": "style not found: missing.yaml"}
 ```
 
+## Discovery
+
+When running in HTTP mode, two read-only discovery endpoints are available:
+
+```sh
+# List all supported methods
+curl http://localhost:8080/rpc/methods
+
+# JSON Schema for method parameters (requires --features schema build)
+curl http://localhost:8080/rpc/schema
+```
+
+Sending a `GET` request to `/rpc` returns a `405 Method Not Allowed` response with a JSON hint explaining POST usage.
+
 ## Features
 
 | Feature | Default | Description |
 |---|---|---|
 | `async` | off | Wraps `Processor` in `tokio::task::spawn_blocking` |
 | `http` | off | Enables axum HTTP server; implies `async` |
+| `schema` | off | Enables GET /rpc/schema endpoint with schemars-generated JSON Schema; implies `http` |
 
 ## Usage
 

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use crate::rpc::{RpcRequest, dispatch};
 use axum::{
-    Json, Router, extract::DefaultBodyLimit, http::StatusCode, response::IntoResponse,
-    routing::post,
+    Json, Router,
+    extract::DefaultBodyLimit,
+    http::{StatusCode, header},
+    response::IntoResponse,
+    routing::{get, post},
 };
 use serde_json::json;
 use std::net::SocketAddr;
@@ -29,11 +32,78 @@ async fn rpc_handler(Json(payload): Json<RpcRequest>) -> impl IntoResponse {
     }
 }
 
+/// GET /rpc — returns 405 with a JSON hint about POST usage.
+///
+/// Includes `Allow: POST` as required by RFC 9110 §15.5.6.
+async fn rpc_get_hint() -> impl IntoResponse {
+    (
+        StatusCode::METHOD_NOT_ALLOWED,
+        [(header::ALLOW, "POST")],
+        Json(json!({
+            "error": "POST required",
+            "hint": "Send a JSON-RPC envelope via POST. See GET /rpc/methods for available methods."
+        })),
+    )
+}
+
+/// GET /rpc/methods — returns a static descriptor list of all supported methods.
+async fn rpc_methods() -> impl IntoResponse {
+    Json(json!([
+        {
+            "method": "render_citation",
+            "description": "Render a single citation.",
+            "required": ["style_path", "refs", "citation"],
+            "optional": ["output_format", "inject_ast_indices"]
+        },
+        {
+            "method": "render_bibliography",
+            "description": "Render a complete bibliography.",
+            "required": ["style_path", "refs"],
+            "optional": ["output_format", "inject_ast_indices"]
+        },
+        {
+            "method": "validate_style",
+            "description": "Validate a Citum YAML style file.",
+            "required": ["style_path"],
+            "optional": []
+        },
+        {
+            "method": "format_document",
+            "description": "Format all citations and bibliography in a document.",
+            "required": ["style", "refs", "citations"],
+            "optional": ["output_format"]
+        }
+    ]))
+}
+
+#[cfg(feature = "schema")]
+async fn rpc_schema() -> impl IntoResponse {
+    use crate::rpc::{
+        FormatDocumentParams, RenderBibliographyParams, RenderCitationParams, ValidateStyleParams,
+    };
+    use schemars::schema_for;
+
+    let schema = serde_json::json!({
+        "render_citation": schema_for!(RenderCitationParams),
+        "render_bibliography": schema_for!(RenderBibliographyParams),
+        "validate_style": schema_for!(ValidateStyleParams),
+        "format_document": schema_for!(FormatDocumentParams),
+    });
+    Json(schema)
+}
+
 /// Build the HTTP router for JSON-RPC requests.
 pub fn app() -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/rpc", post(rpc_handler))
-        .layer(DefaultBodyLimit::max(DEFAULT_HTTP_BODY_LIMIT_BYTES))
+        .route("/rpc", get(rpc_get_hint))
+        .route("/rpc/methods", get(rpc_methods))
+        .layer(DefaultBodyLimit::max(DEFAULT_HTTP_BODY_LIMIT_BYTES));
+
+    #[cfg(feature = "schema")]
+    let router = router.route("/rpc/schema", get(rpc_schema));
+
+    router
 }
 
 /// Start the HTTP server on the given port.
@@ -217,5 +287,82 @@ mod tests {
         let response = app().oneshot(request).await.expect("request should run");
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn get_rpc_returns_405_with_hint_and_allow_header() {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/rpc")
+            .body(Body::empty())
+            .expect("request should build");
+
+        let response = app().oneshot(request).await.expect("request should run");
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            response
+                .headers()
+                .get("allow")
+                .and_then(|v| v.to_str().ok()),
+            Some("POST"),
+        );
+
+        let body = response_body_json(response).await;
+        assert!(body["hint"].as_str().unwrap_or("").contains("POST"));
+    }
+
+    #[cfg(feature = "schema")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn get_rpc_schema_returns_all_four_method_schemas() {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/rpc/schema")
+            .body(Body::empty())
+            .expect("request should build");
+
+        let response = app().oneshot(request).await.expect("request should run");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response_body_json(response).await;
+        assert!(
+            body["render_citation"].is_object(),
+            "render_citation schema missing"
+        );
+        assert!(
+            body["render_bibliography"].is_object(),
+            "render_bibliography schema missing"
+        );
+        assert!(
+            body["validate_style"].is_object(),
+            "validate_style schema missing"
+        );
+        assert!(
+            body["format_document"].is_object(),
+            "format_document schema missing"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn get_rpc_methods_returns_all_four_methods() {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/rpc/methods")
+            .body(Body::empty())
+            .expect("request should build");
+
+        let response = app().oneshot(request).await.expect("request should run");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response_body_json(response).await;
+        let methods: Vec<&str> = body
+            .as_array()
+            .expect("should be array")
+            .iter()
+            .filter_map(|m| m["method"].as_str())
+            .collect();
+        assert!(methods.contains(&"render_citation"));
+        assert!(methods.contains(&"render_bibliography"));
+        assert!(methods.contains(&"validate_style"));
+        assert!(methods.contains(&"format_document"));
     }
 }

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -15,6 +15,7 @@ use std::io::{self, BufRead, Write};
 
 /// JSON-RPC request envelope.
 #[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct RpcRequest {
     /// The request identifier echoed back in success and error responses.
     pub id: Value,
@@ -24,32 +25,76 @@ pub struct RpcRequest {
     pub params: Value,
 }
 
+/// Output format for rendered citations and bibliographies.
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-enum OutputFormat {
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum OutputFormat {
+    /// Plain text output.
     #[default]
     Plain,
+    /// HTML output.
     Html,
+    /// Djot markup output.
     Djot,
+    /// LaTeX output.
     Latex,
+    /// Typst output.
     Typst,
 }
 
-impl OutputFormat {
-    fn parse(params: &Value) -> Result<Self, ServerError> {
-        match params.get("output_format") {
-            Some(value) => serde_json::from_value(value.clone())
-                .map_err(|_| ServerError::UnsupportedOutputFormat(value.to_string().into())),
-            None => Ok(Self::default()),
-        }
-    }
+/// Parameters for the `render_citation` method.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RenderCitationParams {
+    /// Path to the Citum YAML style file.
+    pub style_path: String,
+    /// Bibliography (references) as a map of reference objects.
+    pub refs: serde_json::Value,
+    /// Citation object specifying which references to cite.
+    pub citation: serde_json::Value,
+    /// Output format for the rendered citation.
+    pub output_format: Option<OutputFormat>,
+    /// Debug: embed AST node indices in output.
+    pub inject_ast_indices: Option<bool>,
 }
 
-fn parse_inject_ast_indices(params: &Value) -> bool {
-    params
-        .get("inject_ast_indices")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+/// Parameters for the `render_bibliography` method.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RenderBibliographyParams {
+    /// Path to the Citum YAML style file.
+    pub style_path: String,
+    /// Bibliography (references) as a map of reference objects.
+    pub refs: serde_json::Value,
+    /// Output format for the rendered bibliography.
+    pub output_format: Option<OutputFormat>,
+    /// Debug: embed AST node indices in output.
+    pub inject_ast_indices: Option<bool>,
+}
+
+/// Parameters for the `validate_style` method.
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ValidateStyleParams {
+    /// Path to the Citum YAML style file to validate.
+    pub style_path: String,
+}
+
+/// Parameters for the `format_document` method (schema mirror of `FormatDocumentRequest`).
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct FormatDocumentParams {
+    /// Style identifier, path, URI, or inline YAML.
+    pub style: String,
+    /// Optional BCP 47 locale override.
+    pub locale: Option<String>,
+    /// Output format (plain, html, djot, latex, typst). Defaults to plain.
+    pub output_format: Option<OutputFormat>,
+    /// Bibliography (references) as a map of reference objects.
+    pub refs: serde_json::Value,
+    /// Ordered citations as they appear in the document.
+    pub citations: serde_json::Value,
 }
 
 #[derive(Debug, Serialize)]
@@ -58,6 +103,25 @@ struct BibliographyResult {
     content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     entries: Option<Vec<String>>,
+}
+
+/// Return `MissingField` if `field` is absent from `params`.
+fn require_field(params: &Value, field: &'static str) -> Result<(), ServerError> {
+    if params.get(field).is_none() {
+        return Err(ServerError::MissingField(field.into()));
+    }
+    Ok(())
+}
+
+/// Validate the optional `output_format` field before full deserialization.
+fn validate_output_format(params: &Value) -> Result<(), ServerError> {
+    if let Some(v) = params.get("output_format") {
+        serde_json::from_value::<OutputFormat>(v.clone()).map_err(|_| {
+            let raw = v.as_str().unwrap_or("unknown").to_string();
+            ServerError::UnsupportedOutputFormat(raw.into())
+        })?;
+    }
+    Ok(())
 }
 
 /// Main RPC dispatcher that processes a single request.
@@ -92,35 +156,29 @@ pub fn dispatch(req: RpcRequest) -> Result<Value, (Option<Value>, String)> {
 
 /// Render a single citation.
 fn render_citation(params: &Value, id: Value) -> Result<Value, ServerError> {
-    let style_path = params
-        .get("style_path")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| ServerError::MissingField("style_path".into()))?;
-
-    let refs = params
-        .get("refs")
-        .ok_or_else(|| ServerError::MissingField("refs".into()))?;
-
-    let citation_obj = params
-        .get("citation")
-        .ok_or_else(|| ServerError::MissingField("citation".into()))?;
-    let output_format = OutputFormat::parse(params)?;
-    let inject_ast_indices = parse_inject_ast_indices(params);
+    require_field(params, "style_path")?;
+    require_field(params, "refs")?;
+    require_field(params, "citation")?;
+    validate_output_format(params)?;
+    let params: RenderCitationParams = serde_json::from_value(params.clone())
+        .map_err(|e| ServerError::CitationError(e.to_string()))?;
 
     // Load the style.
-    let style = load_style(style_path)?;
+    let style = load_style(&params.style_path)?;
 
     // Deserialize references and citation from JSON.
-    let bibliography: Bibliography = serde_json::from_value(refs.clone())
+    let bibliography: Bibliography = serde_json::from_value(params.refs.clone())
         .map_err(|e| ServerError::BibliographyError(e.to_string()))?;
 
-    let citation: Citation = serde_json::from_value(citation_obj.clone())
+    let citation: Citation = serde_json::from_value(params.citation.clone())
         .map_err(|e| ServerError::CitationError(e.to_string()))?;
 
     // Create processor and render.
     let mut processor = Processor::new(style, bibliography);
+    let inject_ast_indices = params.inject_ast_indices.unwrap_or(false);
     processor.set_inject_ast_indices(inject_ast_indices);
 
+    let output_format = params.output_format.unwrap_or_default();
     let result = render_citation_with_format(&processor, &citation, output_format)
         .map_err(|e| ServerError::CitationError(e.to_string()))?;
 
@@ -132,28 +190,25 @@ fn render_citation(params: &Value, id: Value) -> Result<Value, ServerError> {
 
 /// Render a bibliography.
 fn render_bibliography(params: &Value, id: Value) -> Result<Value, ServerError> {
-    let style_path = params
-        .get("style_path")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| ServerError::MissingField("style_path".into()))?;
-
-    let refs = params
-        .get("refs")
-        .ok_or_else(|| ServerError::MissingField("refs".into()))?;
-    let output_format = OutputFormat::parse(params)?;
-    let inject_ast_indices = parse_inject_ast_indices(params);
+    require_field(params, "style_path")?;
+    require_field(params, "refs")?;
+    validate_output_format(params)?;
+    let params: RenderBibliographyParams = serde_json::from_value(params.clone())
+        .map_err(|e| ServerError::CitationError(e.to_string()))?;
 
     // Load the style.
-    let style = load_style(style_path)?;
+    let style = load_style(&params.style_path)?;
 
     // Deserialize bibliography from JSON.
-    let bibliography: Bibliography = serde_json::from_value(refs.clone())
+    let bibliography: Bibliography = serde_json::from_value(params.refs.clone())
         .map_err(|e| ServerError::BibliographyError(e.to_string()))?;
 
     // Create processor and render bibliography.
     let mut processor = Processor::new(style, bibliography);
+    let inject_ast_indices = params.inject_ast_indices.unwrap_or(false);
     processor.set_inject_ast_indices(inject_ast_indices);
 
+    let output_format = params.output_format.unwrap_or_default();
     let content = render_bibliography_with_format(&processor, output_format)?;
     let entries = matches!(output_format, OutputFormat::Plain).then(|| {
         content
@@ -203,12 +258,11 @@ fn render_bibliography_with_format(
 
 /// Validate a style YAML file.
 fn validate_style(params: &Value, id: Value) -> Result<Value, ServerError> {
-    let style_path = params
-        .get("style_path")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| ServerError::MissingField("style_path".into()))?;
+    require_field(params, "style_path")?;
+    let params: ValidateStyleParams = serde_json::from_value(params.clone())
+        .map_err(|e| ServerError::CitationError(e.to_string()))?;
 
-    match load_style(style_path) {
+    match load_style(&params.style_path) {
         Ok(_) => Ok(json!({
             "id": id,
             "result": {


### PR DESCRIPTION
## Summary

  - GET /rpc now returns 405 with a JSON hint pointing to /rpc/methods
  - GET /rpc/methods returns a static descriptor list of all four RPC methods
  - GET /rpc/schema (new schema feature, implies http) returns schemars-generated JSON Schema; feature-gated behind --features schema
  - Typed param structs replace manual Value extraction; JsonSchema derives are feature-gated
  - README fixed: format_document added, inject_ast_indices documented, Discovery section added
  - server added to commit scope allowlist in .githooks/pre-push

  ## Test plan

  - cargo nextest run -p citum-server --features schema: all 21 tests pass
  - cargo clippy -p citum-server --all-targets --all-features -- -D warnings: clean
  - GET /rpc returns 405 with JSON hint pointing to /rpc/methods
  - GET /rpc/methods returns array of 4 method descriptors
  - GET /rpc/schema (schema feature) returns JSON Schema object