### PR TITLE
docs(docs): restructure docs IA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ __pycache__/
 *.pyc
 scripts/x-bench.js
 docs/guides/style-author-guide.html
+docs/guides/style-authoring/*.html
 
 .claude/scheduled_tasks.lock
 clippy_errors.log

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,12 +5,15 @@ then drill into strategy and implementation details only as needed.
 
 ## Start Here (Canonical)
 
-1. [`TIER_STATUS.md`](./TIER_STATUS.md) - current official style status, with baseline gate metrics and supplemental rich-input evidence notes.
-2. [`compat.html`](https://citum.github.io/citum-core/compat.html) - published compatibility snapshot, including official supplemental rich benchmark evidence for configured styles.
-3. `behavior-report.html` - published engine behavior coverage page generated in CI, with source locations for the selected engine behavior suites.
-4. `migration-behavior-report.html` - published CSL-to-Citum migration behavior coverage page generated in CI, with source locations for reviewer-facing `citum-migrate` suites.
-5. [`guides/RENDERING_WORKFLOW.md`](./guides/RENDERING_WORKFLOW.md) - operational rendering and verification workflow.
-6. [`architecture/ROADMAP.md`](./architecture/ROADMAP.md) - strategic direction and phase sequencing.
+1. [`index.html`](./index.html) - public docs overview and task-oriented entrypoints.
+2. [`guides/style-authoring/start.md`](./guides/style-authoring/start.md) - style-authoring guide source for the generated public guide.
+3. [`reference/FEATURES.md`](./reference/FEATURES.md) - docs-facing feature metadata and version badge policy.
+4. [`TIER_STATUS.md`](./TIER_STATUS.md) - current official style status, with baseline gate metrics and supplemental rich-input evidence notes.
+5. [`compat.html`](https://citum.github.io/citum-core/compat.html) - published compatibility snapshot, including official supplemental rich benchmark evidence for configured styles.
+6. `behavior-report.html` - published engine behavior coverage page generated in CI, with source locations for the selected engine behavior suites.
+7. `migration-behavior-report.html` - published CSL-to-Citum migration behavior coverage page generated in CI, with source locations for reviewer-facing `citum-migrate` suites.
+8. [`guides/RENDERING_WORKFLOW.md`](./guides/RENDERING_WORKFLOW.md) - operational rendering and verification workflow.
+9. [`architecture/ROADMAP.md`](./architecture/ROADMAP.md) - strategic direction and phase sequencing.
 
 Generate the compatibility snapshot locally with `node scripts/report-core.js --output-html docs/compat.html`.
 Generate an official single-style report for workflow consumption with `node scripts/report-core.js --style <style-name>`.
@@ -22,7 +25,8 @@ Generate the local CSL-to-Citum migration behavior report with `./scripts/migrat
 1. [`guides/CODING_STANDARDS.md`](./guides/CODING_STANDARDS.md)
 2. [`guides/STYLE_EVOLVE_WORKFLOW.md`](./guides/STYLE_EVOLVE_WORKFLOW.md)
 3. [`guides/DOMAIN_EXPERT.md`](./guides/DOMAIN_EXPERT.md)
-4. [`guides/style-author-guide.md`](./guides/style-author-guide.md)
+4. [`guides/style-authoring/`](./guides/style-authoring/) - split source pages for the generated style authoring guide.
+5. [`guides/style-author-guide.md`](./guides/style-author-guide.md) - legacy monolithic source retained for historical reference.
 
 ## Architecture (Entry)
 

--- a/docs/assets/citum-interactive.js
+++ b/docs/assets/citum-interactive.js
@@ -8,9 +8,22 @@
 
   const CITUM = {
     init: function() {
+      this.setupMobileNav();
       this.setupCitations();
       this.setupBibliography();
       this.setupTooltips();
+    },
+
+    setupMobileNav: function() {
+      const navToggle = document.querySelector('[data-nav-toggle]');
+      const mobileMenu = document.querySelector('[data-mobile-menu]');
+      if (!navToggle || !mobileMenu) return;
+
+      navToggle.addEventListener('click', () => {
+        const isOpen = navToggle.getAttribute('aria-expanded') === 'true';
+        navToggle.setAttribute('aria-expanded', String(!isOpen));
+        mobileMenu.classList.toggle('hidden', isOpen);
+      });
     },
 
     setupCitations: function() {

--- a/docs/assets/citum-theme.css
+++ b/docs/assets/citum-theme.css
@@ -248,6 +248,11 @@ a {
   overflow-x: auto;
 }
 
+.workshop-block pre {
+  margin: 0;
+  padding: 1.25rem;
+}
+
 .workshop-label,
 .citum-label {
   color: var(--citum-muted);
@@ -256,6 +261,403 @@ a {
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+.site-nav {
+  background: oklch(0.985 0.012 86 / 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--citum-border);
+  position: fixed;
+  inset-inline: 0;
+  top: 0;
+  z-index: 50;
+}
+
+.site-nav-inner {
+  align-items: center;
+  display: flex;
+  height: 4rem;
+  justify-content: space-between;
+  margin-inline: auto;
+  max-width: 80rem;
+  padding-inline: 1.5rem;
+}
+
+.site-brand,
+.site-brand-wrap {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.5rem;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.site-brand-mark {
+  align-items: center;
+  background: var(--citum-blue);
+  border-radius: var(--citum-radius-sm);
+  color: oklch(0.985 0.008 238);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: var(--citum-font-mono);
+  font-weight: 800;
+  height: 2rem;
+  justify-content: center;
+  width: 2rem;
+}
+
+.site-brand-small .site-brand-mark {
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.site-brand-name {
+  color: var(--citum-ink-strong);
+  font-family: var(--citum-font-mono);
+  font-size: 1.2rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.site-nav-links {
+  align-items: center;
+  display: flex;
+  gap: 0.35rem;
+  min-width: 0;
+  overflow-x: auto;
+  padding-left: 1rem;
+  white-space: nowrap;
+}
+
+.site-nav-link {
+  border-radius: 999px;
+  color: var(--citum-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.5rem 0.8rem;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.site-nav-link:hover,
+.site-nav-link.active {
+  background: var(--citum-blue-soft);
+  color: var(--citum-ink-strong);
+}
+
+.site-source-link {
+  align-items: center;
+  background: var(--citum-blue);
+  border-radius: var(--citum-radius-sm);
+  color: oklch(0.985 0.008 238);
+  display: inline-flex;
+  font-size: 0.9rem;
+  font-weight: 800;
+  gap: 0.45rem;
+  margin-left: 0.25rem;
+  padding: 0.55rem 0.9rem;
+  text-decoration: none;
+}
+
+.site-source-icon {
+  height: 1rem;
+  width: 1rem;
+}
+
+.mobile-nav-toggle {
+  align-items: center;
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-ink);
+  display: none;
+  justify-content: center;
+  padding: 0.5rem 0.75rem;
+}
+
+.mobile-nav {
+  border-top: 1px solid var(--citum-border);
+  background: oklch(0.985 0.012 86 / 0.98);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.5rem;
+}
+
+.site-footer-inner {
+  align-items: center;
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+  margin-inline: auto;
+  max-width: 80rem;
+  padding-inline: 1.5rem;
+}
+
+.site-footer-links {
+  color: var(--citum-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  font-weight: 700;
+  gap: 1.5rem;
+}
+
+.site-footer-links a {
+  text-decoration: none;
+}
+
+.site-footer-links a:hover {
+  color: var(--citum-blue-dark);
+}
+
+.site-footer-note {
+  color: var(--citum-faint);
+  font-size: 0.9rem;
+}
+
+.doc-shell {
+  margin-inline: auto;
+  max-width: 80rem;
+  padding: 7rem 1.5rem 5rem;
+}
+
+.doc-hero {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.75fr);
+  padding-block: 2rem 3rem;
+}
+
+.doc-hero h1 {
+  font-size: clamp(3rem, 8vw, 5.8rem);
+  line-height: 0.95;
+  margin: 1rem 0;
+  max-width: 11ch;
+}
+
+.doc-lede {
+  color: var(--citum-muted);
+  font-size: 1.18rem;
+  line-height: 1.65;
+  max-width: 44rem;
+}
+
+.doc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 2rem;
+}
+
+.doc-section {
+  border-top: 1px solid var(--citum-border);
+  padding-block: 3.5rem;
+}
+
+.doc-section-header {
+  margin-bottom: 1.5rem;
+  max-width: 48rem;
+}
+
+.doc-section-header p {
+  color: var(--citum-muted);
+  line-height: 1.65;
+}
+
+.doc-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.doc-card,
+.feature-link {
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  box-shadow: var(--citum-shadow);
+  display: block;
+  padding: 1.25rem;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.doc-card:hover,
+.feature-link:hover {
+  border-color: var(--citum-border-strong);
+  box-shadow: var(--citum-shadow-lift);
+  transform: translateY(-1px);
+}
+
+.doc-card h3,
+.feature-link h3 {
+  font-family: var(--citum-font-sans);
+  font-size: 1rem;
+  letter-spacing: 0;
+  margin: 0 0 0.45rem;
+}
+
+.doc-card p,
+.feature-link p {
+  color: var(--citum-muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.version-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-block: 0.75rem 1rem;
+}
+
+.version-badge {
+  align-items: center;
+  background: var(--citum-blue-soft);
+  border: 1px solid var(--citum-border-strong);
+  border-radius: 999px;
+  color: var(--citum-blue-dark);
+  display: inline-flex;
+  font-family: var(--citum-font-mono);
+  font-size: 0.72rem;
+  font-weight: 800;
+  gap: 0.3rem;
+  padding: 0.28rem 0.55rem;
+}
+
+.version-badge[data-status="preview"] {
+  background: oklch(0.95 0.04 74);
+  border-color: oklch(0.82 0.08 74);
+  color: oklch(0.42 0.1 74);
+}
+
+.version-badge[data-status="experimental"] {
+  background: oklch(0.95 0.035 28);
+  border-color: oklch(0.82 0.08 28);
+  color: oklch(0.42 0.1 28);
+}
+
+.callout {
+  align-items: flex-start;
+  background: var(--citum-blue-soft);
+  border: 1px solid var(--citum-border-strong);
+  border-radius: var(--citum-radius-md);
+  color: var(--citum-ink);
+  display: flex;
+  gap: 0.75rem;
+  margin-block: 1.25rem;
+  padding: 1rem 1.1rem;
+}
+
+.callout.warning {
+  background: oklch(0.96 0.04 74);
+  border-color: oklch(0.82 0.08 74);
+}
+
+.doc-sidebar-layout {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: 16rem minmax(0, 1fr);
+}
+
+.doc-sidebar {
+  align-self: start;
+  position: sticky;
+  top: 5.5rem;
+}
+
+.doc-sidebar-title {
+  color: var(--citum-faint);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.doc-sidebar-link {
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-muted);
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.55rem 0.75rem;
+  text-decoration: none;
+}
+
+.doc-sidebar-link:hover,
+.doc-sidebar-link.active {
+  background: var(--citum-blue-soft);
+  color: var(--citum-ink-strong);
+}
+
+.doc-prose {
+  max-width: 70ch;
+}
+
+.doc-prose h2,
+.doc-prose h3 {
+  font-family: var(--citum-font-sans);
+  letter-spacing: 0;
+}
+
+.doc-prose p,
+.doc-prose li {
+  line-height: 1.7;
+}
+
+.doc-table-shell {
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  margin-block: 1.5rem;
+  overflow-x: auto;
+}
+
+.doc-table {
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  width: 100%;
+}
+
+.doc-table th,
+.doc-table td {
+  border-bottom: 1px solid var(--citum-border);
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc-table th {
+  background: var(--citum-surface-cool);
+  color: var(--citum-ink-strong);
+}
+
+@media (max-width: 900px) {
+  .site-nav-links,
+  .site-source-link {
+    display: none;
+  }
+
+  .mobile-nav-toggle {
+    display: inline-flex;
+  }
+
+  .site-footer-inner,
+  .doc-hero,
+  .doc-sidebar-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .site-footer-inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .doc-sidebar {
+    position: static;
+  }
 }
 
 .citum-table-shell {

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -71,46 +71,40 @@
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
     <!-- Navigation -->
     <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="interactive-demo.html">Demo</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link active" href="examples.html">Examples</a>
+                <a class="site-nav-link " href="reference.html">Reference</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-nav-link " href="operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
                     Source
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="interactive-demo.html">Demo</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link active" href="examples.html">Examples</a>
+            <a class="site-nav-link " href="reference.html">Reference</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link " href="operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
 
     <!-- Header -->
@@ -2127,21 +2121,18 @@ Citum &gt;=0.38.0</pre>
     <!-- Footer -->
     <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
         <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="reference.html">Reference</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">© 2026 Citum Project.</div>
             </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
 

--- a/docs/guides/style-author-guide.template.html
+++ b/docs/guides/style-author-guide.template.html
@@ -1,258 +1,57 @@
-<!-- PAGE_ID: style -->
+<!-- PAGE_ID: {{PAGE_ID}} -->
 <!doctype html>
 <html lang="en" class="scroll-smooth">
     <head>
         <meta charset="utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-        <title>Style Author Guide | Citum</title>
-
+        <title>{{TITLE}} | Citum Docs</title>
+        <meta name="description" content="{{DESCRIPTION}}" />
         <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
-        <link
-            href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
-            rel="stylesheet"
-        />
-        <link
-            href="https://fonts.googleapis.com/icon?family=Material+Icons"
-            rel="stylesheet"
-        />
-        <link
-            href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
-            rel="stylesheet"
-        />
-
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
         <script>
             tailwind.config = {
-                darkMode: "class",
                 theme: {
                     extend: {
                         colors: {
                             primary: "#2a94d6",
                             "background-light": "#fdfbf7",
-                            "accent-cream": "#f5f2eb",
-                        },
-                        fontFamily: {
-                            display: ["Libre Franklin", "sans-serif"],
-                            mono: ["JetBrains Mono", "monospace"],
-                        },
-                        borderRadius: {
-                            DEFAULT: "0.25rem",
-                            lg: "0.5rem",
-                            xl: "0.75rem",
-                            full: "9999px",
                         },
                     },
                 },
             };
         </script>
-        <style type="text/tailwindcss">
-            body {
-                font-family: "Libre Franklin", sans-serif;
-                color: #374151;
-            }
-            .font-mono {
-                font-family: "JetBrains Mono", monospace;
-            }
-            .glass-nav {
-                background: rgba(253, 251, 247, 0.85);
-                backdrop-filter: blur(12px);
-                border-bottom: 1px solid rgba(42, 148, 214, 0.1);
-            }
-            .sidebar-link {
-                @apply flex items-center gap-2 px-3 py-2 rounded text-sm text-slate-600 hover:text-primary hover:bg-primary/5 transition-all;
-            }
-            .sidebar-link.active {
-                @apply text-primary bg-primary/10 font-medium;
-            }
-            .toc-section {
-                @apply mb-6;
-            }
-            .toc-section-title {
-                @apply text-xs font-semibold uppercase tracking-widest text-slate-500 mb-2;
-            }
-        </style>
-        <link rel="stylesheet" href="../assets/citum-theme.css">
-</head>
-
+        <link rel="stylesheet" href="{{ROOT}}assets/citum-theme.css">
+    </head>
     <body class="bg-background-light text-slate-700 selection:bg-primary/20">
-        <!-- Navigation -->
-        <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="../index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
-                </a>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+            <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>{{TITLE}}</h1>
+                <p>{{DESCRIPTION}}</p>
+                {{FEATURE_BADGES}}
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    {{SIDEBAR}}
+                </aside>
+                <article class="doc-prose prose prose-slate prose-blue max-w-none">
+                    {{CONTENT}}
+                </article>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
-                    </svg>
-                    Source
-                </a>
-            </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
-                <span class="material-icons text-[20px]">menu</span>
-            </button>
-        </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
-        </div>        <!-- LAYOUT_NAV_END -->
+        </main>
 
-        <!-- Header -->
-        <header class="pt-32 pb-16 px-6 border-b border-slate-200">
-            <div class="max-w-7xl mx-auto">
-                <h1
-                    class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6"
-                >
-                    Style Author Guide
-                </h1>
-                <p
-                    class="text-xl text-slate-500 max-w-3xl leading-relaxed"
-                >
-                    Learn how to write Citum styles from scratch. This guide covers the YAML syntax, component types, template structure, and best practices for creating citation and bibliography styles.
-                </p>
-            </div>
-        </header>
-
-        <!-- Two-Column Layout -->
-        <div class="flex flex-col lg:flex-row max-w-7xl mx-auto px-6 py-12 gap-12">
-            <!-- Left Sidebar: Table of Contents -->
-            <aside class="w-full lg:w-64 flex-shrink-0">
-                <div class="sticky top-24 space-y-8">
-                    <nav class="space-y-1">
-                        <div class="toc-section">
-                            <div class="toc-section-title">Getting Started</div>
-                            <a href="#how-citum-differs" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                How Citum Differs from CSL 1.0
-                            </a>
-                            <a href="#style-anatomy" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Style File Anatomy
-                            </a>
-                        </div>
-
-                        <div class="toc-section">
-                            <div class="toc-section-title">Core Concepts</div>
-                            <a href="#global-options" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Global Options
-                            </a>
-                            <a href="#template-components" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Template Components
-                            </a>
-                            <a href="#rendering-options" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Rendering Options
-                            </a>
-                        </div>
- 
-                        <div class="toc-section">
-                            <div class="toc-section-title">Configuration</div>
-                            <a href="#style-presets" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Style-Level Presets
-                            </a>
-                        </div>
- 
-                        <div class="toc-section">
-                            <div class="toc-section-title">Advanced Patterns</div>
-                            <a href="#type-variants" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Type Variants
-                            </a>
-                            <a href="#citation-modes" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Citation Modes
-                            </a>
-                            <a href="#options-inheritance" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Options Inheritance
-                            </a>
-                            <a href="#bib-sort-groups" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Bibliography Sort &amp; Groups
-                            </a>
-                        </div>
-
-                        <div class="toc-section">
-                            <div class="toc-section-title">Reference</div>
-                            <a href="#reference-types" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Reference Types
-                            </a>
-                            <a href="#complete-examples" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Complete Examples
-                            </a>
-                            <a href="#workflow-tips" class="sidebar-link">
-                                <span class="material-icons text-sm">chevron_right</span>
-                                Workflow & Tips
-                            </a>
-                        </div>
-                    </nav>
-                </div>
-            </aside>
-
-            <!-- Main Content -->
-            <main class="flex-1 min-w-0 space-y-16 pb-24 prose prose-slate prose-blue max-w-none prose-headings:m-0 prose-p:leading-relaxed prose-pre:p-0 prose-pre:bg-transparent">
-{{CONTENT}}
-</main>
-        </div>
-
-        <!-- Footer -->
-        <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
+        <footer class="py-12 border-t border-slate-200 bg-[var(--citum-surface)]">
             <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
-                </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="../examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="../reports.html">Reports</a>
-                </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
-            </div>        <!-- LAYOUT_FOOTER_END -->
+            <!-- LAYOUT_FOOTER_END -->
         </footer>
-
-        <script>
-            const navToggle = document.querySelector("[data-nav-toggle]");
-            const mobileMenu = document.querySelector("[data-mobile-menu]");
-
-            if (navToggle && mobileMenu) {
-                navToggle.addEventListener("click", () => {
-                    const expanded = navToggle.getAttribute("aria-expanded") === "true";
-                    navToggle.setAttribute("aria-expanded", String(!expanded));
-                    mobileMenu.classList.toggle("hidden", expanded);
-                });
-            }
-        </script>
+        <script src="{{ROOT}}assets/citum-interactive.js"></script>
     </body>
 </html>

--- a/docs/guides/style-authoring/inheritance-and-registries.md
+++ b/docs/guides/style-authoring/inheritance-and-registries.md
@@ -1,0 +1,54 @@
+---
+title: Inheritance and Registries
+nav: Inheritance
+description: Reuse base styles, pin remote parents, and validate distributed style dependencies.
+features:
+  - style-inheritance-pins
+  - distributed-registries
+---
+
+## [auto_awesome] Extending a style
+
+Use `extends` when a style is mainly a tuned wrapper around an existing base.
+The parent supplies templates. The wrapper supplies metadata and scoped options.
+
+```yaml
+info:
+  title: Springer - Basic (author-date)
+
+extends: springer-basic-author-date-core
+options:
+  contributors: springer
+bibliography:
+  options:
+    date-position: after-author
+```
+
+## [lock] Pinning a parent
+
+Remote parents should be pinned by content identifier so the wrapper stays
+deterministic across upgrades.
+
+```yaml
+extends: https://hub.citum.org/styles/apa-7th.yaml
+extends-pin: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44
+```
+
+Generate a paste-ready pair with:
+
+```bash
+citum style pin styles/apa-7th.yaml
+```
+
+## [hub] Distributed registries
+
+Resolver chains can fetch styles from embedded styles, local files, remote
+registries, and content identifiers. Validation walks the inheritance chain,
+checks pins, and applies `info.citum-version` requirements.
+
+```bash
+citum style validate path/to/my-journal.yaml
+```
+
+For the full operational workflow, see
+[`DISTRIBUTED_REGISTRIES.md`](../DISTRIBUTED_REGISTRIES.md).

--- a/docs/guides/style-authoring/locales.md
+++ b/docs/guides/style-authoring/locales.md
@@ -1,0 +1,95 @@
+---
+title: Locales and Gender-Aware Terms
+nav: Locales
+description: Use locale terms for roles, labels, locators, and grammatical agreement.
+features:
+  - gender-aware-locale-terms
+---
+
+## [translate] Locale-owned text
+
+Use locale terms for text that varies by language: page labels, role labels,
+and other bibliographic terms. Style templates should express structure; locale
+files should own language.
+
+```yaml
+- term: volume
+  form: short
+  suffix: " "
+- number: volume
+```
+
+## [wc] Contributor gender metadata
+
+Contributor-driven role labels can use contributor gender metadata where the
+locale provides gendered forms.
+
+```yaml
+contributors:
+  - role: editor
+    contributor:
+      family: "Martinez"
+      given: "Ana"
+    gender: feminine
+```
+
+Mixed-gender contributor groups prefer a locale's neutral or common form when
+one exists. Citum does not silently choose a masculine-specific label for a
+mixed group when only gendered forms are available.
+
+## [settings] Template gender overrides
+
+Use a template-level `gender` override when the style needs to request a
+specific agreement form directly.
+
+```yaml
+- contributor: editor
+  form: long
+  gender: feminine
+
+- term: volume
+  form: short
+  gender: masculine
+
+- number: volume
+  label-form: short
+  gender: feminine
+```
+
+## [language] Locale YAML
+
+Locale terms can be plain strings or gendered maps.
+
+```yaml
+roles:
+  editor:
+    long:
+      singular:
+        masculine: editor
+        feminine: editora
+        common: persona editora
+      plural:
+        masculine: editores
+        feminine: editoras
+        common: equipo editorial
+```
+
+Locator terms can also declare lexical gender metadata.
+
+```yaml
+locators:
+  page:
+    long:
+      singular: página
+      plural: páginas
+    short:
+      singular: p.
+      plural: pp.
+    gender: feminine
+```
+
+> [!TIP]
+> **Current scope**
+> Gender-aware rendering applies to locale term selection and contributor role
+> labels. Verb-form role terms remain ungendered until the follow-up adds the
+> required plumbing.

--- a/docs/guides/style-authoring/options.md
+++ b/docs/guides/style-authoring/options.md
@@ -1,0 +1,90 @@
+---
+title: Options, Sorting, and Document Inputs
+nav: Options
+description: Configure shared formatting behavior without duplicating templates.
+features:
+  - style-authoring
+  - abbreviation-map
+---
+
+## [tune] Global options
+
+Global options apply across citation and bibliography rendering unless a
+section or component overrides them.
+
+```yaml
+options:
+  processing: author-date
+  contributors: apa
+  dates: long
+```
+
+| Option family | Controls |
+|---|---|
+| `processing` | author-date, numeric, note, or label behavior |
+| `contributors` | name order, initials, conjunctions, shortening |
+| `dates` | long, short, numeric, or ISO date rendering |
+| `titles` | title casing and title form behavior |
+
+## [formatting] Component rendering options
+
+Use component options for punctuation, wrapping, and emphasis.
+
+```yaml
+- title: parent-serial
+  prefix: ". "
+  emph: true
+
+- number: pages
+  prefix: ", "
+  label-form: short
+```
+
+> [!WARNING]
+> **Do not hardcode localized labels**
+> Avoid `prefix: "pp. "` or `prefix: "In: "`. Use `term` components or
+> label options so locale files own language-specific text.
+
+## [share] Options inheritance
+
+More local options override broader options:
+
+1. component-level options
+2. citation or bibliography section options
+3. global options
+
+```yaml
+options:
+  contributors: apa
+
+citation:
+  options:
+    contributors:
+      shorten: { min: 3, use-first: 1 }
+```
+
+## [sort] Bibliography sort and groups
+
+```yaml
+bibliography:
+  sort: author-date-title
+  groups:
+    - id: primary
+      heading:
+        localized:
+          en-US: "Primary Sources"
+      selector:
+        type: legal-case
+```
+
+## [short_text] Document-level abbreviation maps
+
+Abbreviation maps belong to the document input, not the style. They replace
+full rendered strings after value extraction and before output assembly.
+
+```yaml
+abbreviation-map:
+  Estates Gazette: EG
+  "Lloyd's Law Reports": "Lloyd's Rep"
+  "World Health Organization": WHO
+```

--- a/docs/guides/style-authoring/start.md
+++ b/docs/guides/style-authoring/start.md
@@ -1,0 +1,69 @@
+---
+title: Start Writing Citum Styles
+nav: Start
+description: Learn the mental model for Citum styles and why the YAML format is different from CSL 1.0.
+features:
+  - style-authoring
+---
+
+## [compare_arrows] How Citum Differs
+
+Citum replaces procedural CSL XML with declarative YAML. A style describes the
+formatting contract directly: metadata, processing options, citation templates,
+bibliography templates, and explicit variants for types that need different
+structure.
+
+| Aspect | CSL 1.0 | Citum |
+|---|---|---|
+| Format | Procedural XML markup | Declarative YAML |
+| Logic | `choose` / `if` / `else` trees | type variants and scoped options |
+| Name formatting | Inline attributes | global presets and component options |
+| Dates | structured year/month/day object | EDTF strings |
+| Reuse | parent aliases | explicit `extends` plus scoped overrides |
+| Validation | external conventions | schema-backed editor and CLI validation |
+
+> [!TIP]
+> **Explicit over hidden processor behavior**
+> If journals, books, legal cases, or web pages need different output, put that
+> distinction in the style. The engine should not silently guess style intent.
+
+## [rocket_launch] First workflow
+
+1. Pick the closest existing style or preset-backed core style.
+2. Write `info`, especially `title`, `id`, and `default-locale`.
+3. Set `options.processing` to `author-date`, `numeric`, `note`, or `label`.
+4. Add the citation and bibliography templates.
+5. Run `citum style validate path/to/style.yaml`.
+6. Compare rendered output against CSL, biblatex, or publisher examples.
+
+```yaml
+# yaml-language-server: $schema=https://citum.github.io/citum-core/schemas/style.json
+
+info:
+  title: "My Style"
+  id: "my-style"
+  default-locale: "en-US"
+
+options:
+  processing: author-date
+
+citation:
+  template:
+    - contributor: author
+    - date: issued
+
+bibliography:
+  template:
+    - contributor: author
+    - date: issued
+    - title: primary
+```
+
+## [route] Where to go next
+
+- Use **Style Anatomy** when starting a new file.
+- Use **Templates** when deciding what a citation or bibliography renders.
+- Use **Options** when changing punctuation, names, dates, sorting, or groups.
+- Use **Locales** when terms, roles, locators, or grammatical gender matter.
+- Use **Inheritance and Registries** when wrapping an existing style.
+- Use **Validation** before publishing or comparing fidelity.

--- a/docs/guides/style-authoring/style-anatomy.md
+++ b/docs/guides/style-authoring/style-anatomy.md
@@ -1,0 +1,69 @@
+---
+title: Style File Anatomy
+nav: Style Anatomy
+description: The required top-level pieces of a Citum style file.
+features:
+  - style-authoring
+---
+
+## [folder_special] Top-level structure
+
+Every Citum style has four practical layers:
+
+- `info`: human metadata and compatibility declarations
+- `options`: processing mode and shared defaults
+- `citation`: citation rendering rules
+- `bibliography`: bibliography rendering rules
+
+```yaml
+info:
+  title: "APA 7th Edition"
+  id: "apa-7th"
+  default-locale: "en-US"
+
+options:
+  processing: author-date
+  contributors: apa
+
+citation:
+  template:
+    - contributor: author
+    - date: issued
+      form: year
+
+bibliography:
+  template:
+    - contributor: author
+    - date: issued
+    - title: primary
+```
+
+## [badge] Info fields
+
+Use `info` for identity and compatibility, not formatting.
+
+| Field | Purpose |
+|---|---|
+| `title` | human-readable style name |
+| `id` | stable kebab-case style identifier |
+| `description` | short catalog or search description |
+| `default-locale` | BCP 47 language tag |
+| `fields` | discipline categories |
+| `citum-version` | minimum Citum engine requirement |
+
+```yaml
+info:
+  title: "Hypothetical Journal Style"
+  id: "hypothetical-journal"
+  default-locale: "en-US"
+  citum-version: ">=0.49.0"
+```
+
+## [schema] Editor validation
+
+Add the schema comment at the top of hand-authored styles. Editors that support
+YAML Language Server use it for autocomplete and inline validation.
+
+```yaml
+# yaml-language-server: $schema=https://citum.github.io/citum-core/schemas/style.json
+```

--- a/docs/guides/style-authoring/templates.md
+++ b/docs/guides/style-authoring/templates.md
@@ -1,0 +1,98 @@
+---
+title: Templates and Type Variants
+nav: Templates
+description: Build citation and bibliography output from explicit template components.
+features:
+  - style-authoring
+---
+
+## [layers] Template components
+
+Templates are ordered component lists. Each component names the data it renders
+and optional formatting around that data.
+
+```yaml
+bibliography:
+  template:
+    - contributor: author
+    - date: issued
+      form: year
+      wrap: parentheses
+      prefix: " "
+    - title: primary
+      prefix: " "
+    - title: parent-serial
+      emph: true
+      prefix: ". "
+```
+
+| Component | Common use |
+|---|---|
+| `contributor` | author, editor, translator, and other contributor roles |
+| `date` | issued, accessed, original-date, and other date fields |
+| `title` | primary title, parent title, collection title |
+| `number` | volume, issue, pages, edition, citation number |
+| `term` | localized labels such as page, volume, or editor |
+| `variable` | direct field output such as publisher, DOI, URL |
+
+## [category] Type variants
+
+Use `type-variants` when a reference type needs a different bibliography
+structure. Prefer small diff variants when the default template is mostly
+right.
+
+```yaml
+bibliography:
+  template:
+    - contributor: author
+    - title: primary
+    - variable: publisher
+      prefix: ". "
+
+  type-variants:
+    article-journal:
+      modify:
+        - match:
+            title: primary
+          suffix: ". "
+      add:
+        - after:
+            title: primary
+          component:
+            title: parent-serial
+            emph: true
+      remove:
+        - match:
+            variable: publisher
+```
+
+Selectors are partial component matches. `{ title: primary }` matches a primary
+title component even when that component also has affixes or emphasis.
+
+## [article] Citation modes
+
+Use mode-specific citation blocks when narrative and parenthetical citations
+diverge.
+
+```yaml
+citation:
+  non-integral:
+    wrap: parentheses
+    template:
+      - contributor: author
+        form: short
+      - date: issued
+        form: year
+        prefix: ", "
+  integral:
+    delimiter: " "
+    template:
+      - contributor: author
+        form: short
+      - date: issued
+        form: year
+        wrap: parentheses
+```
+
+Note styles can also define `subsequent` and `ibid` templates for repeated
+citations.

--- a/docs/guides/style-authoring/validation.md
+++ b/docs/guides/style-authoring/validation.md
@@ -1,0 +1,59 @@
+---
+title: Validation and Compatibility
+nav: Validation
+description: Check styles before publishing and understand the existing version enforcement boundaries.
+features:
+  - style-authoring
+  - style-inheritance-pins
+---
+
+## [fact_check] Validate before publishing
+
+Run the end-to-end style validator before publishing or comparing fidelity.
+
+```bash
+citum style validate path/to/my-journal.yaml
+```
+
+The validator parses the style, runs schema validation, resolves `extends`,
+verifies any `extends-pin` values, and checks `info.citum-version` against the
+running engine.
+
+Machine-readable output is available for tools:
+
+```bash
+citum style validate path/to/my-journal.yaml --format json
+```
+
+## [upgrade] Engine compatibility
+
+Use `info.citum-version` when a style depends on an engine feature that older
+versions should not try to render.
+
+```yaml
+info:
+  title: Hypothetical Style With New Features
+  citum-version: ">=0.49.0"
+```
+
+An older engine returns a direct version mismatch instead of an opaque
+deserialization or rendering failure.
+
+## [schema] Schema compatibility
+
+Style schema versioning and engine versioning are related but separate:
+
+- schema version describes the YAML wire format
+- engine version describes the Rust processor release
+- generated schemas in `docs/schemas/` remain the committed validation
+  artifacts
+
+For policy details, see [`SCHEMA_VERSIONING.md`](../../reference/SCHEMA_VERSIONING.md).
+
+## [analytics] Fidelity reports
+
+Use the generated reports when checking whether a style is production-ready:
+
+- [`compat.html`](../../compat.html) for style-level fidelity and SQI status
+- [`reports.html`](../../reports.html) for generated report entrypoints
+- [`TIER_STATUS.md`](../../TIER_STATUS.md) for the current style status table

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,891 +1,206 @@
 <!-- PAGE_ID: docs -->
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="scroll-smooth">
-
 <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <title>Citum | Rust Citation Formatting for Modern Workflows</title>
-    <meta name="description"
-        content="A Rust citation engine and YAML style system for modern publishing workflows.">
-
+    <title>Citum Docs | Citation Styles You Can Check</title>
+    <meta name="description" content="Documentation for Citum: grouped bibliographies, multilingual terms, reusable style families, and citation output that can be checked against real examples." />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
-        rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <link
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
-        rel="stylesheet" />
-
     <script>
         tailwind.config = {
-            darkMode: "class",
             theme: {
                 extend: {
                     colors: {
-                        "primary": "#2a94d6", // Desaturated blue
-                        "background-light": "#fdfbf7", // Soft cream off-white
-                        "accent-cream": "#f5f2eb",
-                    },
-                    fontFamily: {
-                        "display": ["Libre Franklin", "sans-serif"],
-                        "mono": ["JetBrains Mono", "monospace"]
-                    },
-                    borderRadius: {
-                        "DEFAULT": "0.25rem",
-                        "lg": "0.5rem",
-                        "xl": "0.75rem",
-                        "full": "9999px"
+                        primary: "#2a94d6",
+                        "background-light": "#fdfbf7",
                     },
                 },
             },
-        }
+        };
     </script>
-    <style type="text/tailwindcss">
-        body {
-            font-family: 'Libre Franklin', sans-serif;
-            color: #374151;
-        }
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        .glass-nav {
-            background: rgba(253, 251, 247, 0.85);
-            backdrop-filter: blur(12px);
-            border-bottom: 1px solid rgba(42, 148, 214, 0.1);
-        }
-        .code-gradient {
-            background: linear-gradient(135deg, rgba(42, 148, 214, 0.05) 0%, rgba(253, 251, 247, 0) 100%);
-        }
-        .citum-panel {
-            background: var(--citum-surface);
-            transition: all 0.3s ease;
-        }
-        .citum-panel:hover {
-            border-color: #2a94d6;
-            transform: translateY(-2px);
-            box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
-        }
-        
-        /* Command Copy Button */
-        .copy-btn {
-            opacity: 0;
-            transition: opacity 0.2s;
-        }
-        .code-block:hover .copy-btn {
-            opacity: 1;
-        }
-    </style>
     <link rel="stylesheet" href="assets/citum-theme.css">
 </head>
-
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
-
-    <!-- Navigation -->
-    <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+    <nav class="site-nav">
+        <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="https://citum.org/news/">News</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="https://hub.citum.org">Hub</a>
-                <a class="nav-link text-slate-600" href="https://citum.org/demo/">Demo</a>
-                <a class="nav-link text-slate-600" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link active" href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="examples.html">Examples</a>
+                <a class="site-nav-link " href="reference.html">Reference</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-nav-link " href="operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
                     Source
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="hover:text-primary transition-colors" href="https://citum.org/news/">News</a>
-                <a class="hover:text-primary transition-colors" href="index.html">Docs</a>
-                <a class="hover:text-primary transition-colors" href="https://hub.citum.org">Hub</a>
-                <a class="hover:text-primary transition-colors" href="https://citum.org/demo/">Demo</a>
-                <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                <a class="hover:text-primary transition-colors" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link active" href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="examples.html">Examples</a>
+            <a class="site-nav-link " href="reference.html">Reference</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link " href="operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
+    </nav>
 
-    <!-- Hero Section -->
-    <header class="pt-32 pb-20 px-6 relative overflow-hidden">
-        <div class="absolute top-0 left-1/2 -translate-x-1/2 w-full h-full pointer-events-none opacity-30">
-            <div
-                class="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[800px] bg-primary/10 rounded-full blur-[120px]">
-            </div>
-        </div>
-        <div class="max-w-7xl mx-auto relative z-10 grid lg:grid-cols-[1.1fr_0.9fr] gap-12 items-center">
+    <main class="doc-shell">
+        <header class="doc-hero">
             <div>
-            <div class="mb-8 flex flex-wrap items-center gap-2 text-sm">
                 <span class="citum-kicker">Docs workshop</span>
-                <a class="rounded-full border border-slate-200 bg-[var(--citum-surface)]/80 px-4 py-2 text-slate-700 hover:border-primary/40 hover:text-primary transition-colors"
-                    href="#features">Features</a>
-                <a class="rounded-full border border-slate-200 bg-[var(--citum-surface)]/80 px-4 py-2 text-slate-700 hover:border-primary/40 hover:text-primary transition-colors"
-                    href="#roadmap">Current Status</a>
-            </div>
-            <h1 class="text-6xl md:text-8xl font-bold tracking-tight text-slate-900 mb-6 max-w-[9ch]">
-                Citum docs
-            </h1>
-            <p class="text-xl md:text-2xl text-slate-500 mb-10 max-w-2xl leading-relaxed">
-                A Rust citation engine and YAML style system for
-                rendering documents, styling references, and validating
-                bibliographic data.
-            </p>
-
-            <!-- Getting Started Command -->
-            <div class="max-w-xl mb-10">
-                <div
-                    class="workshop-block bg-slate-900 rounded-lg p-4 flex items-center justify-between group cursor-text border border-slate-700 shadow-lg text-left">
-                    <code
-                        class="font-mono text-emerald-400 text-sm">$ cargo install --git https://github.com/citum/citum-core --bin citum</code>
-                    <button class="text-slate-500 hover:text-white transition-colors"
-                        onclick="navigator.clipboard.writeText('cargo install --git https://github.com/citum/citum-core --bin citum')"
-                        title="Copy to clipboard">
-                        <span class="material-icons text-base">content_copy</span>
-                    </button>
+                <h1>Citum docs</h1>
+                <p class="doc-lede">
+                    Citum is for citation styles that need grouped
+                    bibliographies, multilingual terms, reusable journal
+                    families, and output that can be checked against real
+                    examples. It keeps CSL compatibility in view without
+                    making CSL the full scope of the project.
+                </p>
+                <div class="doc-actions">
+                    <a class="citum-button-primary" href="guides/style-authoring/start.html">
+                        Write a style
+                        <span class="material-icons text-sm" aria-hidden="true">arrow_forward</span>
+                    </a>
+                    <a class="citum-button-secondary" href="reference.html">Browse reference</a>
                 </div>
-                <p class="text-slate-400 text-xs mt-2 font-mono">Requires Rust toolchain</p>
             </div>
-
-            <div class="flex flex-col sm:flex-row items-start gap-4">
-                <a class="w-full sm:w-auto citum-button-primary"
-                    href="#features">
-                    Explore Features
-                    <span class="material-icons text-sm">arrow_downward</span>
-                </a>
-                <a class="w-full sm:w-auto citum-button-secondary"
-                    href="https://github.com/citum/citum-core/tree/main/docs">
-                    View Documentation
-                </a>
-            </div>
-            </div>
-            <aside class="workshop-block p-6 rotate-1">
+            <aside class="workshop-block">
                 <div class="workshop-label">Rendering trace</div>
-                <pre class="text-sm leading-relaxed"><span class="text-slate-400"># Input</span>
+                <pre><code># Input
 [@kuhn1962, pp. 10-12]
 
-<span class="text-slate-400"># Resolver</span>
-style: chicago-author-date
-position: first
+# Style
+processing: author-date
 locale: en-US
 
-<span class="text-slate-400"># Output</span>
-<span class="text-primary">(Kuhn 1962, 10-12)</span></pre>
+# Output
+(Kuhn 1962, 10-12)</code></pre>
             </aside>
-        </div>
-    </header>
+        </header>
 
-    <!-- YAML Example Section -->
-    <section class="px-6 py-12">
-        <div class="max-w-5xl mx-auto bg-slate-50 rounded-xl border border-slate-200 shadow-xl overflow-hidden">
-            <div class="flex items-center justify-between px-4 py-3 border-b border-slate-200 bg-slate-100/50">
-                <div class="flex gap-2">
-                    <div class="w-3 h-3 rounded-full bg-slate-300"></div>
-                    <div class="w-3 h-3 rounded-full bg-slate-300"></div>
-                    <div class="w-3 h-3 rounded-full bg-slate-300"></div>
-                </div>
-                <div class="text-xs font-mono text-slate-400">citation_config.citum.yaml</div>
-                <div class="w-12"></div>
-            </div>
-            <div class="p-8 overflow-x-auto bg-[#fafafa]">
-                <pre class="font-mono text-sm leading-relaxed"><span class="text-indigo-600">info</span>:
-  <span class="text-primary">title</span>: <span class="text-emerald-600">"APA 7th Edition"</span>
-<span class="text-indigo-600">options</span>:
-  <span class="text-primary">processing</span>: <span class="text-emerald-600">author-date</span>
-  <span class="text-primary">contributors</span>:
-    <span class="text-primary">initialize-with</span>: <span class="text-emerald-600">". "</span>
-    <span class="text-primary">and</span>: <span class="text-emerald-600">symbol</span>
-  <span class="text-primary">dates</span>: <span class="text-emerald-600">long</span>
-<span class="text-indigo-600">citation</span>:
-  <span class="text-primary">integral</span>:
-    <span class="text-primary">options</span>:
-      <span class="text-primary">contributors</span>:
-        <span class="text-primary">and</span>: <span class="text-emerald-600">text</span></pre>
-            </div>
-        </div>
-    </section>
-
-    <!-- Features Grid -->
-    <section class="py-24 px-6" id="features">
-        <div class="max-w-7xl mx-auto">
-            <div class="text-center mb-16">
-                <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Built for Current Citation Workflows</h2>
-                <p class="text-slate-500">Style authoring, document rendering, validation, and compatibility reporting in one toolchain.</p>
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-
-                <!-- Document Processing -->
-                <a href="examples.html#document-processing"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">description</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Document Processing</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Render Djot documents end to end, or process Markdown documents with Pandoc-style citation markers through the same CLI output targets.
-                    </p>
-                </a>
-
-                <!-- Advanced Citations -->
-                <a href="examples.html#advanced-citations"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">auto_awesome</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Advanced Citations</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Integral and parenthetical citation modes, multi-cites, locators, and style-specific name handling.
-                    </p>
-                </a>
-
-                <!-- Bibliography Grouping -->
-                <a href="examples.html#bibliography-grouping"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">library_books</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Bibliography Grouping</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Configurable bibliography sections with per-group sorting. Essential for legal hierarchies,
-                        multilingual bibliographies, and primary/secondary source divisions.
-                    </p>
-                </a>
-
-                <!-- Compound Numeric Sets -->
-                <a href="examples.html#compound-numeric-sets"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">view_agenda</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Compound Numeric Sets</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Optional top-level bibliography <code class="text-xs">sets</code> model for chemistry-style
-                        grouped numeric entries with shared number slots and configurable whole-set vs sub-entry citations.
-                    </p>
-                </a>
-
-                <!-- Multilingual Support -->
-                <a href="examples.html#multilingual-support"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">translate</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Multilingual Support</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        First-class support for multilingual citations, RTL languages, locale-aware title casing,
-                        transliterations, and shipped locale overrides for style-specific language variants.
-                        Locale messages use Unicode MessageFormat 2 (MF2) syntax for plural and select
-                        dispatch, with a one-struct upgrade path to ICU4X when it stabilizes.
-                    </p>
-                </a>
-
-                <!-- Advanced Dates -->
-                <a href="examples.html#advanced-dates"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">event</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Advanced Dates</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Handle complex historical ranges, uncertain dates, and non-Gregorian calendars with native EDTF
-                        precision.
-                    </p>
-                </a>
-
-                <!-- Smart Presets -->
-                <a href="examples.html#options-presets"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">tune</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Presets &amp; Inheritance</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Reusable presets for contributors, dates, and titles. Inherit a full style with
-                        <code class="text-xs bg-slate-100 px-1 rounded">extends:</code> and tune declared
-                        axes — date position, name lists, label wrapping — via
-                        <code class="text-xs bg-slate-100 px-1 rounded">options.*</code>, <code class="text-xs bg-slate-100 px-1 rounded">citation.options.*</code>, and <code class="text-xs bg-slate-100 px-1 rounded">bibliography.options.*</code>.
-                    </p>
-                </a>
-
-                <!-- Title Formatting -->
-                <a href="examples.html#titles-links"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">title</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Title Formatting</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Distinct title/subtitle formatting and declarative rules for text transformations and automatic
-                        linking.
-                    </p>
-                </a>
-
-                <!-- Type-Specific Overrides -->
-                <a href="examples.html#overrides"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">sync_alt</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Type Overrides</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Declaratively render components differently for each reference type without procedural
-                        conditional logic.
-                    </p>
-                </a>
-
-                <!-- Pluggable Output Formats -->
-                <a href="examples.html#output-formats"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">html</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Pluggable Output</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Generate plain text, HTML, Djot, LaTeX, or Typst output and move into PDF workflows from the same CLI.
-                    </p>
-                </a>
-
-                <!-- Universal C-FFI -->
-                <a href="examples.html#lualatex-integration"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">settings_input_component</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">LuaLaTeX via FFI</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        A LuaLaTeX proof-of-concept lets TeX documents call the Citum engine directly for citations and bibliography rendering.
-                    </p>
-                </a>
-
-                <!-- Performance -->
-                <a href="examples.html#binary-performance"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">speed</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Performance</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Convert styles and bibliographies to CBOR for faster load paths in larger rendering workflows.
-                    </p>
-                </a>
-
-                <!-- JSON Server Mode -->
-                <a href="https://github.com/citum/citum-core/tree/main/crates/citum-server"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block"
-                    target="_blank">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">hub</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">JSON-RPC Server</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Long-running RPC and HTTP entrypoints for editor integrations, plugins, and web applications that need live formatting.
-                    </p>
-                </a>
-
-                <!-- Distributed Registries -->
-                <a href="examples.html#distributed-registries"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">lan</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Distributed Registries
-                        <span class="ml-2 text-xs align-middle px-2 py-0.5 rounded-full bg-primary/10 text-primary font-mono uppercase tracking-wider">New</span>
-                    </h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Federated style discovery: opt into the Citum Hub or any institutional registry, render directly against an
-                        <code class="text-xs">https://</code> URL, and lock parent inheritance with content-addressed
-                        <code class="text-xs">extends-pin</code> CIDs. Air-gap-safe by default.
-                    </p>
-                </a>
-
-                <!-- Web Interactivity -->
-                <a href="examples.html#web-interactivity"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">mouse</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Web Interactivity</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Progressive enhancement for HTML citations. Add bidirectional navigation, hover tooltips, and
-                        responsive sidebars to any Citum-generated HTML view.
-                    </p>
-                </a>
-
-                <!-- Annotated Bibliographies -->
-                <a href="examples.html#annotated-bibliography"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">comment</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Annotated Bibliographies</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Pass a YAML or JSON annotation map at render time. Any citation style becomes an annotated bibliography
-                        without style variants. Control indentation, italic rendering, and paragraph spacing per render.
-                    </p>
-                </a>
-
-                <!-- Abbreviation Maps -->
-                <a href="examples.html#abbreviation-map"
-                    class="citum-panel p-8 rounded-xl border border-slate-200 transition-all group block">
-                    <div
-                        class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-6 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons">find_replace</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Abbreviation Maps</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm">
-                        Substitute full rendered strings with abbreviations at document scope. A flat YAML map covers journal titles, institutional names, and corporate authors — no style variants needed.
-                    </p>
-                </a>
-
-            </div>
-        </div>
-    </section>
-
-    <!-- Why Citum & CLI Examples -->
-    <section class="py-24 px-6 bg-accent-cream" id="examples">
-        <div class="max-w-7xl mx-auto">
-            <div class="grid lg:grid-cols-2 gap-16 items-start">
-
-                <!-- Why Text -->
-                <div>
-                    <h2 class="text-4xl font-bold text-slate-900 mb-6">CLI Workflow</h2>
-                    <p class="text-lg text-slate-500 mb-8 leading-relaxed">
-                        Use the same binary to render references, process documents, inspect styles, and generate output for downstream publishing tools.
-                    </p>
-
-                    <div class="space-y-6">
-                        <!-- Example 1 -->
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Render references (HTML)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f html</span>
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum render refs -b tests/fixtures/references-expanded.json -s mla -f html')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <!-- Example 1b (Djot) -->
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Render for static sites (Djot)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f djot</span>
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum render refs -b tests/fixtures/references-expanded.json -s mla -f djot')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <!-- Example 1c (LaTeX) -->
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Render for LaTeX (Native Escaping)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f latex</span>
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum render refs -b tests/fixtures/references-expanded.json -s mla -f latex')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Render for Typst (Native Markup)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum render refs -b tests/fixtures/references-expanded.json -s mla <span class="text-emerald-400">-f typst</span>
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum render refs -b tests/fixtures/references-expanded.json -s mla -f typst')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Compile a Typst PDF (Pure Rust)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> cargo run -p citum --features typst-pdf -- render doc examples/document.djot -b examples/document-refs.json -s mla <span class="text-emerald-400">-f typst --pdf -o paper.pdf</span>
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('cargo run -p citum --features typst-pdf -- render doc examples/document.djot -b examples/document-refs.json -s mla -f typst --pdf -o paper.pdf')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <!-- Example 1d (Document) -->
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Render full document (Djot draft syntax)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum render doc examples/document.djot -b examples/document-refs.json -s mla
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum render doc examples/document.djot -b examples/document-refs.json -s mla')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <!-- Example 1e (Builtin) -->
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Use a builtin style (no file needed)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum render refs -b refs.json <span class="text-emerald-400">-s apa</span>
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum render refs -b refs.json -s apa')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <!-- Example 1f (List styles) -->
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">List all embedded styles</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum styles list
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum styles list')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-
-                        <!-- Example 2 -->
-                        <div>
-                            <h4 class="font-bold text-slate-900 mb-2">Convert to binary (Performance Mode)</h4>
-                            <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                                <code class="font-mono text-sm text-slate-300">
-                                    <span class="text-primary">$</span> citum convert style styles/embedded/apa-7th.yaml --output /tmp/apa-7th.cbor
-                                </code>
-                                <button class="text-slate-500 hover:text-white transition-colors"
-                                    onclick="navigator.clipboard.writeText('citum convert style styles/embedded/apa-7th.yaml --output /tmp/apa-7th.cbor')"
-                                    title="Copy to clipboard">
-                                    <span class="material-icons text-base">content_copy</span>
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Simple Visual/Image Placeholder -->
-                <div class="relative mt-8 lg:mt-0">
-                    <div
-                        class="aspect-square md:aspect-video lg:aspect-square bg-slate-800 rounded-xl overflow-hidden shadow-2xl relative flex items-center justify-center p-8">
-                        <div class="text-slate-400 font-mono text-sm">
-                            <div class="mb-4 text-emerald-400"># Output Preview</div>
-                            <div class="pl-4 border border-slate-700/30 rounded-lg">
-                                <p class="mb-2">Smith, J. A. (2023). <span class="italic">The Future of
-                                        Citations</span>. Academic Press.</p>
-                                <p class="mb-2">Doe, A., & Lee, B. (2024). Rust in Publishing. <span
-                                        class="italic">Journal of Open Source</span>, 12(4), 45-67.
-                                    https://doi.org/10.1234/jos.2024.12</p>
-                                <p class="text-primary/50 text-xs mt-4">... generated in 4ms</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-    </section>
-
-    <!-- Language Bindings -->
-    <section class="py-24 px-6 border-t border-slate-200 bg-slate-50" id="bindings">
-        <div class="max-w-7xl mx-auto">
-            <div class="text-center mb-16">
-                <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Language Bindings</h2>
-                <p class="text-slate-500">Integrate the Citum engine into your favorite language or framework.</p>
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-
-                <!-- Rust Native -->
-                <div class="p-8 rounded-xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-md">
-                    <div class="flex items-center justify-between mb-6">
-                        <div class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                            <span class="material-icons">terminal</span>
-                        </div>
-                        <span class="text-[10px] font-mono font-bold uppercase tracking-wider px-2 py-1 rounded-full bg-slate-100 text-slate-500 border border-slate-200">Git</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Rust Native</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm mb-4">
-                        The core engine is available as a standalone Rust crate (<code class="text-xs">citum-engine</code>) for seamless integration into Rust projects.
-                    </p>
-                    <p class="text-xs font-mono text-slate-400 italic">Available via git dependency</p>
-                </div>
-
-                <!-- WebAssembly & TypeScript -->
-                <div class="p-8 rounded-xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-md">
-                    <div class="flex items-center justify-between mb-6">
-                        <div class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                            <span class="material-icons">javascript</span>
-                        </div>
-                        <span class="text-[10px] font-mono font-bold uppercase tracking-wider px-2 py-1 rounded-full bg-amber-100 text-amber-700 border border-amber-200">Coming Soon</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">WebAssembly &amp; TS</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm mb-4">
-                        Full-featured WASM package with TypeScript definitions, generated via <code class="text-xs">wasm-bindgen</code>, for browser or Node.js environments.
-                    </p>
-                    <p class="text-xs font-mono text-slate-400 italic">Pre-release development</p>
-                </div>
-
-                <!-- C-FFI -->
-                <div class="p-8 rounded-xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-md">
-                    <div class="flex items-center justify-between mb-6">
-                        <div class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                            <span class="material-icons">settings_input_component</span>
-                        </div>
-                        <span class="text-[10px] font-mono font-bold uppercase tracking-wider px-2 py-1 rounded-full bg-primary/10 text-primary border border-primary/20">Preview</span>
-                    </div>
-                    <h3 class="text-xl font-bold text-slate-900 mb-3">Universal C-FFI</h3>
-                    <p class="text-slate-500 leading-relaxed text-sm mb-4">
-                        Shared dynamic library (<code class="text-xs">cdylib</code>) exposing a C-ABI, enabling integration with LuaLaTeX, Python, C++, and Ruby.
-                    </p>
-                    <p class="text-xs font-mono text-slate-400 italic">Built from source</p>
-                </div>
-
-            </div>
-        </div>
-    </section>
-
-    <!-- Status Section -->
-    <section class="py-24 px-6 border-t border-slate-200" id="roadmap">
-        <div class="max-w-7xl mx-auto">
-            <div class="text-center mb-16">
-                <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">Current Status</h2>
-                <p class="text-slate-500">Compatibility and quality reports are published from CI so current progress stays visible.</p>
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-
-                <!-- Compatibility Report -->
-                <a href="https://docs.citum.org/compat.html" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
-                    <div class="flex items-center gap-3 mb-4">
-                        <span
-                            class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
-                            <span class="material-icons text-sm">analytics</span>
-                        </span>
-                        <h3 class="font-bold text-slate-900">Compatibility Dashboard</h3>
-                    </div>
-                    <p class="text-sm text-slate-500 mb-4">
-                        Per-style fidelity and SQI metrics for the core production style set.
-                    </p>
-                    <p class="text-[10px] font-mono text-slate-400">Source: scripts/report-core.js -> docs/compat.html</p>
-                </a>
-
-                <!-- Behavior Coverage -->
-                <a href="https://docs.citum.org/behavior-report.html" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
-                    <div class="flex items-center gap-3 mb-4">
-                        <span
-                            class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
-                            <span class="material-icons text-sm">fact_check</span>
-                        </span>
-                        <h3 class="font-bold text-slate-900">Engine Behavior Coverage</h3>
-                    </div>
-                    <p class="text-sm text-slate-500 mb-4">
-                        Human-readable scenario coverage for selected engine behavior suites, with source file and line references.
-                    </p>
-                    <p class="text-[10px] font-mono text-slate-400">Source: scripts/test-report.sh -> docs/behavior-report.html</p>
-                </a>
-
-                <!-- Migration Behavior Coverage -->
-                <a href="https://docs.citum.org/migration-behavior-report.html" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
-                    <div class="flex items-center gap-3 mb-4">
-                        <span
-                            class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
-                            <span class="material-icons text-sm">swap_horiz</span>
-                        </span>
-                        <h3 class="font-bold text-slate-900">Migration Behavior Coverage</h3>
-                    </div>
-                    <p class="text-sm text-slate-500 mb-4">
-                        Reviewer-facing migration scenarios for selected `citum-migrate` suites, with source file and line references.
-                    </p>
-                    <p class="text-[10px] font-mono text-slate-400">Source: scripts/migration-test-report.sh -> docs/migration-behavior-report.html</p>
-                </a>
-
-                <!-- Tier Tracking -->
-                <a href="TIER_STATUS.md" class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
-                    <div class="flex items-center gap-3 mb-4">
-                        <span
-                            class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
-                            <span class="material-icons text-sm">list_alt</span>
-                        </span>
-                        <h3 class="font-bold text-slate-900">Tier Status</h3>
-                    </div>
-                    <p class="text-sm text-slate-500 mb-4">
-                        Current tracking for top parent styles, strict citation scenarios, and migration priorities.
-                    </p>
-                    <p class="text-[10px] font-mono text-slate-400">Source: docs/TIER_STATUS.md</p>
-                </a>
-
-                <!-- Quality Gates -->
-                <a href="https://github.com/citum/citum-core/blob/main/docs/architecture/SQI_REFINEMENT_PLAN.md"
-                    class="p-6 rounded-xl border border-slate-100 bg-[var(--citum-surface)] block hover:border-primary/40 transition-colors">
-                    <div class="flex items-center gap-3 mb-4">
-                        <span
-                            class="w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center">
-                            <span class="material-icons text-sm">rule</span>
-                        </span>
-                        <h3 class="font-bold text-slate-900">Fidelity + SQI Gates</h3>
-                    </div>
-                    <p class="text-sm text-slate-500 mb-4">
-                        Fidelity remains the release gate, while SQI helps track maintainability and style quality.
-                    </p>
-                    <p class="text-[10px] font-mono text-slate-400">Policy: no SQI gain may regress fidelity</p>
-                </a>
-
-                <!-- User Style Store -->
-                <div class="p-6 rounded-xl border border-emerald-100 bg-emerald-50">
-                    <div class="flex items-center gap-3 mb-4">
-                        <span
-                            class="w-8 h-8 rounded-full bg-emerald-500/10 text-emerald-600 flex items-center justify-center">
-                            <span class="material-icons text-sm">folder_open</span>
-                        </span>
-                        <h3 class="font-bold text-slate-900">User Style Store <span class="text-xs font-normal text-emerald-600 ml-1">new</span></h3>
-                    </div>
-                    <p class="text-sm text-slate-500 mb-4">
-                        Install and manage your own styles and locales locally in YAML, JSON, or CBOR formats.
-                        <code class="text-xs bg-[var(--citum-surface)] px-1 rounded border border-slate-200">citum store install</code>
-                        <code class="text-xs bg-[var(--citum-surface)] px-1 rounded border border-slate-200">citum store list</code>
-                    </p>
-                    <p class="text-[10px] font-mono text-slate-400">Works across CLI, desktop, web, and mobile</p>
-                </div>
-
-            </div>
-        </div>
-    </section>
-
-    <!-- JSON Schemas Section -->
-    <section class="py-24 px-6 border-t border-slate-200" id="schemas">
-        <div class="max-w-7xl mx-auto text-center">
-            <h2 class="text-3xl md:text-4xl font-bold text-slate-900 mb-4">JSON Schemas</h2>
-            <p class="text-slate-500 max-w-2xl mx-auto mb-8">
-                Citum publishes schemas for every data format — styles, locales, bibliographies, citations,
-                the registry, abbreviation maps, and the JSON-RPC server API. Use them in your editor for
-                autocomplete and real-time validation.
-            </p>
-            <a href="schemas/"
-                class="inline-flex items-center gap-2 bg-primary text-white px-6 py-3 rounded-lg font-semibold hover:brightness-110 transition-all">
-                <span class="material-icons text-base">schema</span>
-                Browse all schemas
-            </a>
-        </div>
-    </section>
-
-    <!-- Project Origins -->
-    <section class="py-24 px-6 border-t border-slate-100 bg-slate-50/50">
-        <div class="max-w-3xl mx-auto text-center">
-            <h2 class="text-2xl font-bold text-slate-900 mb-6 font-mono">Origins & Direction</h2>
-            <div class="space-y-4 text-slate-600 leading-relaxed">
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>What Citum is for</h2>
                 <p>
-                    Citum is led by Bruce D'Arcus, who created the initial CSL prototype in 2005. It grows out of that
-                    work while focusing on current needs: new features, clearer style definitions, stronger validation, and a faster Rust implementation.
+                    CSL remains the compatibility baseline. Citum's goal is
+                    to make citation behavior easier to describe:
+                    bibliography grouping, multilingual terms, reusable style
+                    families, and output that can be checked against real
+                    examples.
                 </p>
-                <p>
-                    The project replaces procedural XML with declarative, type-safe YAML so style authors can express behavior more directly and tool builders can rely on explicit schemas and reproducible rendering.
-                </p>
-                <div class="pt-4">
-                    <a href="https://github.com/citum/citum-core"
-                        class="text-primary font-medium hover:underline inline-flex items-center gap-1">
-                        Follow development on GitHub
-                        <span class="material-icons text-xs">open_in_new</span>
-                    </a>
-                </div>
             </div>
-        </div>
-    </section>
+            <div class="doc-grid">
+                <a class="doc-card" href="examples.html#bibliography-grouping">
+                    <h3>Handle real bibliography structure</h3>
+                    <p>A bibliography is not always one sequence. Citum has room for grouping, sorting, type variants, note behavior, and specialized reference shapes without burying that logic in renderer-specific conventions.</p>
+                </a>
+                <a class="doc-card" href="guides/style-authoring/locales.html">
+                    <h3>Render across languages and locales</h3>
+                    <p>Citation terms are not just English strings. Locale files own role labels, locators, grammatical gender, and the multilingual details that styles should not hardcode.</p>
+                </a>
+                <a class="doc-card" href="guides/style-authoring/inheritance-and-registries.html">
+                    <h3>Reuse styles without hidden inheritance</h3>
+                    <p>A dependent style should not become a mystery fork. Base styles, scoped overrides, version requirements, registries, and `extends-pin` make reuse inspectable.</p>
+                </a>
+                <a class="doc-card" href="reports.html">
+                    <h3>Check the output</h3>
+                    <p>A style is only useful if its output can be checked. Citum pairs validation with oracle comparisons, strict fixtures, and CI-generated compatibility reports.</p>
+                </a>
+            </div>
+        </section>
 
-    <!-- Footer -->
-    <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Start where your problem is</h2>
+                <p>Pick the path that matches the citation problem in front of you.</p>
+            </div>
+            <div class="doc-grid">
+                <a class="feature-link" href="guides/style-authoring/start.html">
+                    <h3>Author or adapt a style</h3>
+                    <p>Start from the style anatomy, then choose templates, type variants, and scoped options for the behavior you need.</p>
+                </a>
+                <a class="feature-link" href="guides/style-authoring/locales.html">
+                    <h3>Localize terms and labels</h3>
+                    <p>Use locale-owned terms for roles, locators, grammatical gender, and language-specific labels.</p>
+                </a>
+                <a class="feature-link" href="guides/style-authoring/validation.html">
+                    <h3>Validate and compare output</h3>
+                    <p>Run style validation, then use compatibility reports and examples to check rendered output against evidence.</p>
+                </a>
+                <a class="feature-link" href="guides/style-authoring/inheritance-and-registries.html">
+                    <h3>Reuse or publish a style</h3>
+                    <p>Wrap a base style, pin remote parents, declare engine requirements, and validate before publishing.</p>
+                </a>
+            </div>
+        </section>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Know what a style depends on</h2>
+                <p>
+                    Styles can say which Citum version they need, and the docs
+                    can show when support for a capability landed. That matters
+                    when styles are shared across journals, registries, and
+                    local publishing workflows.
+                </p>
+            </div>
+            <div class="version-badges">
+                <span class="version-badge" data-feature="style-authoring">active</span>
+                <span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span>
+                <span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span>
+            </div>
+            <div class="doc-grid">
+                <a class="doc-card" href="reference/FEATURES.md">
+                    <h3>Capability status</h3>
+                    <p>See which documented capabilities are active, preview, or experimental, and which versions introduced them.</p>
+                </a>
+                <a class="doc-card" href="reference/SCHEMA_VERSIONING.md">
+                    <h3>Style format versions</h3>
+                    <p>Understand how Citum changes the style format, how compatibility is tracked, and how tools can pin versions.</p>
+                </a>
+                <a class="doc-card" href="guides/style-authoring/validation.html">
+                    <h3>Runtime requirements</h3>
+                    <p>`info.citum-version` gives users a direct upgrade message when a style needs newer Citum behavior.</p>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="py-12 border-t border-slate-200 bg-[var(--citum-surface)]">
         <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="reference.html">Reference</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">© 2026 Citum Project.</div>
             </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
-
-    <script>
-        const navToggle = document.querySelector("[data-nav-toggle]");
-        const mobileMenu = document.querySelector("[data-mobile-menu]");
-
-        if (navToggle && mobileMenu) {
-            navToggle.addEventListener("click", () => {
-                const expanded = navToggle.getAttribute("aria-expanded") === "true";
-                navToggle.setAttribute("aria-expanded", String(!expanded));
-                mobileMenu.classList.toggle("hidden", expanded);
-            });
-        }
-    </script>
-
+    <script src="assets/citum-interactive.js"></script>
 </body>
-
 </html>

--- a/docs/interactive-demo.html
+++ b/docs/interactive-demo.html
@@ -111,46 +111,40 @@
 
   <!-- Navigation -->
   <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="examples.html">Examples</a>
+                <a class="site-nav-link " href="reference.html">Reference</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-nav-link " href="operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
                     Source
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="examples.html">Examples</a>
+            <a class="site-nav-link " href="reference.html">Reference</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link " href="operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
 
   <div class="container-demo pt-24">
@@ -245,21 +239,18 @@
     <!-- Footer -->
     <footer class="py-12 px-6 border-t border-slate-200 bg-white/50">
         <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="reference.html">Reference</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">© 2026 Citum Project.</div>
             </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
 

--- a/docs/operating.html
+++ b/docs/operating.html
@@ -1,0 +1,93 @@
+<!-- PAGE_ID: operating -->
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Operating | Citum Docs</title>
+    <meta name="description" content="Contributor, migration, policy, and architecture entrypoints for Citum operators." />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <script>
+        tailwind.config = { theme: { extend: { colors: { primary: "#2a94d6", "background-light": "#fdfbf7" } } } };
+    </script>
+    <link rel="stylesheet" href="assets/citum-theme.css">
+</head>
+<body class="bg-background-light text-slate-700 selection:bg-primary/20">
+    <nav class="site-nav">
+        <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="examples.html">Examples</a>
+                <a class="site-nav-link " href="reference.html">Reference</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-nav-link active" href="operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    Source
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="material-icons text-[20px]">menu</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="examples.html">Examples</a>
+            <a class="site-nav-link " href="reference.html">Reference</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link active" href="operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+    </nav>
+    <main class="doc-shell">
+        <header class="doc-section-header">
+            <span class="citum-kicker">Contributing / Operating</span>
+            <h1>Operating Citum</h1>
+            <p>Internal workflows, migration practice, policy, architecture, and quality gates for people moving the project forward.</p>
+        </header>
+        <section class="doc-section">
+            <div class="doc-grid">
+                <a class="doc-card" href="TIER_STATUS.md"><h3>Tier Status</h3><p>Canonical style status, fidelity metrics, and current known gaps.</p></a>
+                <a class="doc-card" href="guides/STYLE_EVOLVE_WORKFLOW.md"><h3>Style Evolve Workflow</h3><p>Process for migrating, upgrading, and refining Citum styles.</p></a>
+                <a class="doc-card" href="guides/RENDERING_WORKFLOW.md"><h3>Rendering Workflow</h3><p>Operational rendering and verification commands.</p></a>
+                <a class="doc-card" href="guides/CODING_STANDARDS.md"><h3>Coding Standards</h3><p>Rust verification and test style expectations for contributors.</p></a>
+                <a class="doc-card" href="guides/DOCUMENT_CLASSIFICATION.md"><h3>Document Classification</h3><p>Rules for specs, architecture notes, policies, guides, and reference docs.</p></a>
+                <a class="doc-card" href="policies/TYPE_ADDITION_POLICY.md"><h3>Type Addition Policy</h3><p>Active policy for adding data-model and style-discriminated types.</p></a>
+                <a class="doc-card" href="architecture/DESIGN_PRINCIPLES.md"><h3>Design Principles</h3><p>Architectural principles behind explicit templates, typed data, and processor boundaries.</p></a>
+                <a class="doc-card" href="architecture/MIGRATION_STRATEGY_ANALYSIS.md"><h3>Migration Strategy</h3><p>Current strategy for migrating CSL styles into Citum.</p></a>
+            </div>
+        </section>
+    </main>
+    <footer class="py-12 border-t border-slate-200 bg-[var(--citum-surface)]">
+        <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="reference.html">Reference</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">© 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+    </footer>
+    <script src="assets/citum-interactive.js"></script>
+</body>
+</html>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1,0 +1,93 @@
+<!-- PAGE_ID: reference -->
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Reference | Citum Docs</title>
+    <meta name="description" content="Schemas, versioning, feature metadata, and reference tables for Citum." />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <script>
+        tailwind.config = { theme: { extend: { colors: { primary: "#2a94d6", "background-light": "#fdfbf7" } } } };
+    </script>
+    <link rel="stylesheet" href="assets/citum-theme.css">
+</head>
+<body class="bg-background-light text-slate-700 selection:bg-primary/20">
+    <nav class="site-nav">
+        <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="examples.html">Examples</a>
+                <a class="site-nav-link active" href="reference.html">Reference</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-nav-link " href="operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    Source
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="material-icons text-[20px]">menu</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="examples.html">Examples</a>
+            <a class="site-nav-link active" href="reference.html">Reference</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link " href="operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+    </nav>
+    <main class="doc-shell">
+        <header class="doc-section-header">
+            <span class="citum-kicker">Reference</span>
+            <h1>Reference</h1>
+            <p>Schemas, versioning rules, feature metadata, and domain reference tables.</p>
+        </header>
+        <section class="doc-section">
+            <div class="doc-grid">
+                <a class="doc-card" href="schemas/"><h3>JSON Schemas</h3><p>Canonical generated schemas for styles, locales, bibliographies, citations, registries, and server APIs.</p></a>
+                <a class="doc-card" href="reference/FEATURES.md"><h3>Feature Metadata</h3><p>Docs-facing registry for feature status and minimum schema or engine versions.</p></a>
+                <a class="doc-card" href="reference/SCHEMA_VERSIONING.md"><h3>Schema Versioning</h3><p>Compatibility policy and release automation for Citum schema changes.</p></a>
+                <a class="doc-card" href="reference/VERSION_BUMPING.md"><h3>Workspace Versioning</h3><p>How release impact is inferred from conventional commits and path changes.</p></a>
+                <a class="doc-card" href="reference/BIBLATEX_MAPPING.md"><h3>BibLaTeX Mapping</h3><p>Reference mapping between biblatex concepts and Citum data fields.</p></a>
+                <a class="doc-card" href="reference/GENRE_AND_MEDIUM_VALUES.md"><h3>Genre and Medium Values</h3><p>Canonical value guidance for genre and medium fields.</p></a>
+                <a class="doc-card" href="reference/DISAMBIGUATION.md"><h3>Disambiguation</h3><p>Reference notes for author-date disambiguation behavior.</p></a>
+                <a class="doc-card" href="reference/SQI.md"><h3>SQI</h3><p>Style Quality Index scoring and reporting model.</p></a>
+            </div>
+        </section>
+    </main>
+    <footer class="py-12 border-t border-slate-200 bg-[var(--citum-surface)]">
+        <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="reference.html">Reference</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">© 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+    </footer>
+    <script src="assets/citum-interactive.js"></script>
+</body>
+</html>

--- a/docs/reference/FEATURES.md
+++ b/docs/reference/FEATURES.md
@@ -1,0 +1,26 @@
+# Feature Metadata
+
+User-visible feature maturity is tracked in
+[`features.yaml`](features.yaml). The file is a docs-facing registry, not a
+runtime compatibility mechanism.
+
+Runtime compatibility remains enforced by the schema and engine:
+
+- `info.citum-version` declares the minimum Citum engine requirement for a
+  style.
+- style schema major/minor checks report incompatible or possibly unsupported
+  schema versions.
+- `extends-pin` locks inherited remote styles by content identifier.
+- `citum style validate` runs schema validation, inheritance resolution,
+  pin verification, and `citum-version` checks.
+
+The registry adds a stable place for docs pages and examples to show when a
+feature became available:
+
+- `since_schema`: minimum style schema version for the documented surface
+- `since_engine`: minimum engine version for the documented behavior
+- `status`: `active`, `preview`, `experimental`, or `planned`
+- `spec`: optional source document for the underlying design or policy
+
+The first pass is warning-only. Missing metadata should be fixed as docs are
+touched, then promoted to a stricter build gate once coverage is complete.

--- a/docs/reference/features.yaml
+++ b/docs/reference/features.yaml
@@ -1,0 +1,64 @@
+features:
+  - id: style-authoring
+    title: Style authoring
+    status: active
+    since_schema: "0.1.0"
+    since_engine: "0.1.0"
+    spec: docs/guides/style-author-guide.md
+    summary: Declarative YAML styles with explicit citation and bibliography templates.
+  - id: gender-aware-locale-terms
+    title: Gender-aware locale terms
+    status: active
+    since_schema: "0.49.0"
+    since_engine: "0.49.0"
+    spec: docs/specs/LOCALE_MESSAGES.md
+    summary: Locale role and locator terms can select gendered forms where the locale provides them.
+  - id: style-inheritance-pins
+    title: Style inheritance and pins
+    status: active
+    since_schema: "0.38.0"
+    since_engine: "0.38.0"
+    spec: docs/specs/DISTRIBUTED_RESOLVER.md
+    summary: Styles can extend parent styles and lock remote parents with content identifiers.
+  - id: distributed-registries
+    title: Distributed registries
+    status: active
+    since_schema: "0.38.0"
+    since_engine: "0.38.0"
+    spec: docs/specs/DISTRIBUTED_RESOLVER.md
+    summary: Resolver chains can fetch, verify, and validate styles outside the built-in catalog.
+  - id: typst-output
+    title: Typst output
+    status: preview
+    since_schema: "0.47.0"
+    since_engine: "0.47.0"
+    spec: docs/specs/DOCUMENT_INPUT_PARSER_BOUNDARY.md
+    summary: Citum can feed rendered citations and bibliographies into a Typst PDF workflow.
+  - id: lualatex-ffi
+    title: LuaLaTeX and FFI
+    status: experimental
+    since_schema: "0.47.0"
+    since_engine: "0.47.0"
+    spec: docs/architecture/design/WASM_SUPPORT.md
+    summary: Native bindings expose the engine to non-Rust hosts and TeX integration experiments.
+  - id: web-interactivity
+    title: Web interactivity
+    status: preview
+    since_schema: "0.46.0"
+    since_engine: "0.46.0"
+    spec: docs/specs/SERVER_INTERACTIVE_API.md
+    summary: Citum HTML output can be enriched with citation navigation and bibliography previews.
+  - id: annotated-bibliography
+    title: Annotated bibliography
+    status: active
+    since_schema: "0.48.0"
+    since_engine: "0.48.0"
+    spec: docs/specs/ANNOTATED_BIBLIOGRAPHY.md
+    summary: Bibliographies can include annotation content as a first-class rendering concern.
+  - id: abbreviation-map
+    title: Abbreviation map
+    status: active
+    since_schema: "0.49.0"
+    since_engine: "0.49.0"
+    spec: docs/specs/ABBREVIATION_MAP.md
+    summary: Document-level abbreviation maps can substitute rendered names and titles without changing styles.

--- a/docs/reports.html
+++ b/docs/reports.html
@@ -65,46 +65,40 @@
 
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
     <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="examples.html">Examples</a>
+                <a class="site-nav-link " href="reference.html">Reference</a>
+                <a class="site-nav-link active" href="reports.html">Reports</a>
+                <a class="site-nav-link " href="operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
                     Source
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="examples.html">Examples</a>
+            <a class="site-nav-link " href="reference.html">Reference</a>
+            <a class="site-nav-link active" href="reports.html">Reports</a>
+            <a class="site-nav-link " href="operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
 
     <header class="pt-32 pb-16 px-6 border-b border-slate-200">
@@ -161,21 +155,18 @@
 
     <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
         <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="reference.html">Reference</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">© 2026 Citum Project.</div>
             </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
 

--- a/scripts/build-author-guide.js
+++ b/scripts/build-author-guide.js
@@ -1,202 +1,187 @@
 const fs = require('fs');
 const path = require('path');
 const { marked } = require('marked');
+const yaml = require('js-yaml');
 
-const MD_PATH = path.join(__dirname, '../docs/guides/style-author-guide.md');
-const TEMPLATE_PATH = path.join(__dirname, '../docs/guides/style-author-guide.template.html');
-const HTML_PATH = path.join(__dirname, '../docs/guides/style-author-guide.html');
+const ROOT = path.join(__dirname, '..');
+const SOURCE_DIR = path.join(ROOT, 'docs/guides/style-authoring');
+const TEMPLATE_PATH = path.join(ROOT, 'docs/guides/style-author-guide.template.html');
+const LEGACY_HTML_PATH = path.join(ROOT, 'docs/guides/style-author-guide.html');
+const FEATURES_PATH = path.join(ROOT, 'docs/reference/features.yaml');
 
-const renderer = new marked.Renderer();
+const GUIDE_PAGES = [
+    'start',
+    'style-anatomy',
+    'templates',
+    'options',
+    'locales',
+    'inheritance-and-registries',
+    'validation',
+];
 
-// Helper to generate IDs consistent with the sidebar
+function parseFrontmatter(raw) {
+    if (!raw.startsWith('---\n')) return [{}, raw];
+    const end = raw.indexOf('\n---\n', 4);
+    if (end === -1) return [{}, raw];
+    const data = yaml.load(raw.slice(4, end)) || {};
+    return [data, raw.slice(end + 5)];
+}
+
 function slugify(text) {
     return text
         .toLowerCase()
-        .replace(/\[[a-z0-9_]+\]/, '') // strip icons
+        .replace(/\[[a-z0-9_]+\]/, '')
         .trim()
         .replace(/[^\w]+/g, '-')
         .replace(/^-+|-+$/g, '');
 }
 
-// Simple YAML syntax highlighter using regex and project Tailwind colors
-function highlightYaml(code) {
-    const escaped = code
+function escapeHtml(text) {
+    return String(text)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;');
+}
 
-    return escaped
-        // 1. Comments (slate-500)
+function highlightYaml(code) {
+    return escapeHtml(code)
         .replace(/(#.*$)/gm, '<span class="text-slate-500">$1</span>')
-        // 2. Keys (indigo-400 for top-level, primary/sky-400 for nested)
-        // Now handles both "key:" and "- key:"
         .replace(/^(\s*)(-?\s*)([a-z0-9_-]+)(:)/gm, (match, indent, dash, key, colon) => {
             const colorClass = indent.length === 0 && dash.length === 0 ? 'text-indigo-400' : 'text-primary';
             const dashHtml = dash.length > 0 ? `<span class="text-slate-400">${dash}</span>` : '';
             return `${indent}${dashHtml}<span class="${colorClass}">${key}</span>${colon}`;
         })
-        // 3. String values (emerald-400)
         .replace(/(: )("[^"]*"|'[^']*'|[a-z0-9_.-]+)(?=\s|$|<)/gi, (match, separator, value) => {
             if (value === '~' || value === 'null') return `${separator}<span class="text-slate-400">${value}</span>`;
             return `${separator}<span class="text-emerald-400">${value}</span>`;
         });
 }
 
-let firstHeading = true;
+function createRenderer() {
+    const renderer = new marked.Renderer();
 
-renderer.heading = function(arg1, arg2) {
-    let text, level;
-    if (typeof arg1 === 'object') {
-        text = arg1.text;
-        level = arg1.depth;
-    } else {
-        text = arg1;
-        level = arg2;
-    }
-    
-    const iconMatch = text.match(/^\[([a-z0-9_]+)\]\s*(.*)/);
-    const id = slugify(text);
-    
-    if (iconMatch && level === 2) {
-        const icon = iconMatch[1];
-        const title = iconMatch[2];
-        
-        let output = '';
-        if (!firstHeading) {
-            output += '</section>\n';
-        }
-        firstHeading = false;
-        
-        output += `
-            <section id="${id}" class="scroll-mt-24">
-                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
-                    <span class="material-icons text-primary">${icon}</span>
-                    ${title}
-                </h2>
-        `;
-        return output;
-    }
-    return `<h${level} id="${id}" class="font-bold text-slate-900 mt-8 mb-4">${text}</h${level}>`;
-};
+    renderer.heading = function(arg1, arg2) {
+        const text = typeof arg1 === 'object' ? arg1.text : arg1;
+        const level = typeof arg1 === 'object' ? arg1.depth : arg2;
+        const iconMatch = text.match(/^\[([a-z0-9_]+)\]\s*(.*)/);
+        const cleanTitle = iconMatch ? iconMatch[2] : text;
+        const id = slugify(text);
+        const icon = iconMatch ? `<span class="material-icons text-primary" aria-hidden="true">${iconMatch[1]}</span>` : '';
+        return `<h${level} id="${id}">${icon}${cleanTitle}</h${level}>`;
+    };
 
-renderer.blockquote = function(arg1) {
-    let text;
-    if (typeof arg1 === 'object') {
-        text = arg1.text;
-    } else {
-        text = arg1;
-    }
-
-    const content = marked.parseInline(text.replace(/\[!(TIP|WARNING)\]\s*/, ''));
-
-    if (text.includes('[!TIP]')) {
+    renderer.blockquote = function(arg1) {
+        const text = typeof arg1 === 'object' ? arg1.text : arg1;
+        const kind = text.includes('[!WARNING]') ? 'warning' : 'tip';
+        const label = kind === 'warning' ? 'warning' : 'tips_and_updates';
+        const content = marked.parseInline(text.replace(/\[!(TIP|WARNING)\]\s*/, ''));
         return `
-            <div class="mb-8 bg-blue-50 border border-blue-200 rounded-lg p-5 not-prose citum-callout">
-                <div class="flex items-start gap-3">
-                    <span class="material-icons text-blue-600 mt-0.5">tips_and_updates</span>
-                    <div class="flex-1 text-blue-800 text-sm">
-                        ${content}
-                    </div>
-                </div>
+            <div class="callout ${kind}">
+                <span class="material-icons" aria-hidden="true">${label}</span>
+                <div>${content}</div>
             </div>
         `;
-    }
-    if (text.includes('[!WARNING]')) {
+    };
+
+    renderer.code = function(arg1, arg2) {
+        const code = typeof arg1 === 'object' ? arg1.text : arg1;
+        const lang = typeof arg1 === 'object' ? arg1.lang : arg2;
+        const highlighted = (lang === 'yaml' || lang === 'yml') ? highlightYaml(code) : escapeHtml(code);
         return `
-            <div class="border border-amber-500/30 bg-amber-50 p-4 rounded-lg mb-6 not-prose">
-                <div class="flex gap-3">
-                    <span class="material-icons text-amber-600 flex-shrink-0">warning</span>
-                    <div class="text-amber-800 text-sm">
-                        ${content}
-                    </div>
-                </div>
+            <div class="workshop-block">
+                <pre><code class="language-${lang || 'text'}">${highlighted}</code></pre>
             </div>
         `;
-    }
-    return `<blockquote>${content}</blockquote>`;
-};
+    };
 
-renderer.code = function(arg1, arg2) {
-    let code, lang;
-    if (typeof arg1 === 'object') {
-        code = arg1.text;
-        lang = arg1.lang;
-    } else {
-        code = arg1;
-        lang = arg2;
-    }
+    renderer.table = function(token) {
+        const header = token.header
+            .map((cell) => `<th>${marked.parseInline(cell.text)}</th>`)
+            .join('');
+        const body = token.rows
+            .map((row) => `<tr>${row.map((cell) => `<td>${marked.parseInline(cell.text)}</td>`).join('')}</tr>`)
+            .join('');
+        return `
+            <div class="doc-table-shell">
+                <table class="doc-table">
+                    <thead><tr>${header}</tr></thead>
+                    <tbody>${body}</tbody>
+                </table>
+            </div>
+        `;
+    };
 
-    const highlighted = (lang === 'yaml' || lang === 'yml')
-        ? highlightYaml(code)
-        : code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return renderer;
+}
 
-    return `
-        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
-            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-${lang}">${highlighted}</code></pre>
-        </div>
-    `;
-};
+function loadFeatures() {
+    if (!fs.existsSync(FEATURES_PATH)) return new Map();
+    const doc = yaml.load(fs.readFileSync(FEATURES_PATH, 'utf8'));
+    return new Map((doc.features || []).map((feature) => [feature.id, feature]));
+}
 
-// Handle tables with Tailwind styles
-renderer.table = function(token) {
-    let header = '';
-    let body = '';
+function readPage(slug) {
+    const sourcePath = path.join(SOURCE_DIR, `${slug}.md`);
+    const [frontmatter, body] = parseFrontmatter(fs.readFileSync(sourcePath, 'utf8'));
+    return { slug, sourcePath, frontmatter, body };
+}
 
-    for (let i = 0; i < token.header.length; i++) {
-        header += `<th class="px-4 py-3 text-left font-semibold text-slate-900">${marked.parseInline(token.header[i].text)}</th>`;
-    }
+function renderSidebar(currentSlug, pages, rootPrefix) {
+    return pages.map((page) => {
+        const active = page.slug === currentSlug ? ' active' : '';
+        return `<a class="doc-sidebar-link${active}" href="${rootPrefix}guides/style-authoring/${page.slug}.html">${page.frontmatter.nav || page.frontmatter.title}</a>`;
+    }).join('\n');
+}
 
-    for (let i = 0; i < token.rows.length; i++) {
-        body += '<tr class="hover:bg-slate-50">';
-        for (let j = 0; j < token.rows[i].length; j++) {
-            body += `<td class="px-4 py-3 text-slate-600">${marked.parseInline(token.rows[i][j].text)}</td>`;
+function renderFeatureBadges(featureIds, featureMap) {
+    if (!Array.isArray(featureIds) || featureIds.length === 0) return '';
+    const badges = [];
+    for (const id of featureIds) {
+        const feature = featureMap.get(id);
+        if (!feature) {
+            badges.push(`<span class="version-badge" data-feature="${id}">unknown feature: ${id}</span>`);
+            continue;
         }
-        body += '</tr>';
+        badges.push(`<span class="version-badge" data-feature="${id}" data-status="${feature.status}">${feature.status}</span>`);
+        badges.push(`<span class="version-badge" data-feature="${id}">schema ${feature.since_schema}+</span>`);
+        badges.push(`<span class="version-badge" data-feature="${id}">engine ${feature.since_engine}+</span>`);
     }
+    return `<div class="version-badges">${badges.join('')}</div>`;
+}
 
-    return `
-        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
-            <table class="w-full text-sm">
-                <thead class="bg-slate-50">
-                    <tr>${header}</tr>
-                </thead>
-                <tbody class="divide-y divide-slate-200">
-                    ${body}
-                </tbody>
-            </table>
-        </div>
-    `;
-};
+function renderPage(page, pages, featureMap, options = {}) {
+    const renderer = createRenderer();
+    marked.setOptions({ renderer });
+    const rootPrefix = options.rootPrefix || '../../';
+    const content = marked.parse(page.body);
+    const featureBadges = renderFeatureBadges(page.frontmatter.features, featureMap);
+    const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
 
-marked.setOptions({ renderer });
+    return template
+        .replace(/{{PAGE_ID}}/g, 'style')
+        .replace(/{{ROOT}}/g, rootPrefix)
+        .replace(/{{TITLE}}/g, escapeHtml(page.frontmatter.title || 'Style Authoring'))
+        .replace(/{{DESCRIPTION}}/g, escapeHtml(page.frontmatter.description || 'Citum style authoring documentation.'))
+        .replace(/{{SIDEBAR}}/g, renderSidebar(page.slug, pages, rootPrefix))
+        .replace(/{{FEATURE_BADGES}}/g, featureBadges)
+        .replace(/{{CONTENT}}/g, content)
+        .replace(/[ \t]+$/gm, '');
+}
 
 function build() {
-    console.log('Building Style Author Guide...');
-    firstHeading = true;
-    
-    if (!fs.existsSync(MD_PATH)) {
-        console.error(`Markdown file not found: ${MD_PATH}`);
-        process.exit(1);
-    }
-    if (!fs.existsSync(TEMPLATE_PATH)) {
-        console.error(`Template file not found: ${TEMPLATE_PATH}`);
-        process.exit(1);
+    console.log('Building Style Authoring Guide...');
+    const featureMap = loadFeatures();
+    const pages = GUIDE_PAGES.map(readPage);
+
+    for (const page of pages) {
+        const htmlPath = path.join(SOURCE_DIR, `${page.slug}.html`);
+        fs.writeFileSync(htmlPath, renderPage(page, pages, featureMap));
+        console.log(`Wrote ${path.relative(ROOT, htmlPath)}`);
     }
 
-    const mdContent = fs.readFileSync(MD_PATH, 'utf8');
-    const templateContent = fs.readFileSync(TEMPLATE_PATH, 'utf8');
-    
-    let bodyHtml = marked.parse(mdContent);
-    
-    // Close the last section
-    if (!firstHeading) {
-        bodyHtml += '</section>';
-    }
-    
-    const finalHtml = templateContent.replace('{{CONTENT}}', bodyHtml);
-    
-    fs.writeFileSync(HTML_PATH, finalHtml);
-    console.log('Done!');
+    const start = pages[0];
+    fs.writeFileSync(LEGACY_HTML_PATH, renderPage(start, pages, featureMap, { rootPrefix: '../' }));
+    console.log(`Wrote ${path.relative(ROOT, LEGACY_HTML_PATH)}`);
 }
 
 build();

--- a/scripts/build-layout.js
+++ b/scripts/build-layout.js
@@ -4,65 +4,58 @@ const path = require('path');
 const DOCS_DIR = path.join(__dirname, '../docs');
 
 const NAV_TEMPLATE = `
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="{{ROOT}}index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="{{ROOT}}index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link" href="https://citum.org/news/index.html">News</a>
-                <a class="nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Docs</a>
-                <a class="nav-link {{ACTIVE_DEMO}}" href="{{ROOT}}interactive-demo.html">Demo</a>
-                <a class="nav-link {{ACTIVE_EXAMPLES}}" href="{{ROOT}}examples.html">Examples</a>
-                <a class="nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Overview</a>
+                <a class="site-nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link {{ACTIVE_EXAMPLES}}" href="{{ROOT}}examples.html">Examples</a>
+                <a class="site-nav-link {{ACTIVE_REFERENCE}}" href="{{ROOT}}reference.html">Reference</a>
+                <a class="site-nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
+                <a class="site-nav-link {{ACTIVE_OPERATING}}" href="{{ROOT}}operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
                     Source
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="hover:text-primary transition-colors" href="https://citum.org/news/index.html">News</a>
-                <a class="nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Docs</a>
-                <a class="nav-link {{ACTIVE_DEMO}}" href="{{ROOT}}interactive-demo.html">Demo</a>
-                <a class="nav-link {{ACTIVE_EXAMPLES}}" href="{{ROOT}}examples.html">Examples</a>
-                <a class="nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Overview</a>
+            <a class="site-nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link {{ACTIVE_EXAMPLES}}" href="{{ROOT}}examples.html">Examples</a>
+            <a class="site-nav-link {{ACTIVE_REFERENCE}}" href="{{ROOT}}reference.html">Reference</a>
+            <a class="site-nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
+            <a class="site-nav-link {{ACTIVE_OPERATING}}" href="{{ROOT}}operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>`;
 
 const FOOTER_TEMPLATE = `
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="{{ROOT}}examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="{{ROOT}}reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="{{ROOT}}guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="{{ROOT}}reference.html">Reference</a>
+                    <a href="{{ROOT}}reports.html">Reports</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">© 2026 Citum Project.</div>
             </div>`;
+
+const ACTIVE_CLASS = 'active';
 
 function getFiles(dir, fileList = []) {
     const files = fs.readdirSync(dir);
@@ -70,11 +63,15 @@ function getFiles(dir, fileList = []) {
         const filepath = path.join(dir, file);
         if (fs.statSync(filepath).isDirectory()) {
             getFiles(filepath, fileList);
-        } else if (filepath.endsWith('.html') && !filepath.includes('/news/posts/')) {
+        } else if (filepath.endsWith('.html') && !filepath.endsWith('.template.html') && !filepath.includes('/news/posts/')) {
             fileList.push(filepath);
         }
     }
     return fileList;
+}
+
+function activeFor(pageId, target) {
+    return pageId === target ? ACTIVE_CLASS : '';
 }
 
 function buildLayouts() {
@@ -85,36 +82,30 @@ function buildLayouts() {
         let content = fs.readFileSync(file, 'utf8');
         let modified = false;
 
-        // Determine active tab via <!-- PAGE_ID: xxx -->
         const idMatch = content.match(/<!-- PAGE_ID:\s*([a-zA-Z0-9-]+)\s*-->/);
         const pageId = idMatch ? idMatch[1] : '';
-
-        // Calculate root prefix
         const relative = path.relative(path.dirname(file), DOCS_DIR);
-        const rootPrefix = relative ? relative + '/' : '';
+        const rootPrefix = relative ? `${relative}/` : '';
 
-        const activeClass = 'active bg-primary/10 text-primary font-semibold';
-        
-        let navHtml = NAV_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix)
-            .replace(/{{ACTIVE_DOCS}}/g, pageId === 'docs' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_DEMO}}/g, pageId === 'demo' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_EXAMPLES}}/g, pageId === 'examples' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_STYLE}}/g, pageId === 'style' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_REPORTS}}/g, pageId === 'reports' ? activeClass : 'text-slate-600');
-            
-        let footerHtml = FOOTER_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix);
+        const navHtml = NAV_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix)
+            .replace(/{{ACTIVE_DOCS}}/g, activeFor(pageId, 'docs'))
+            .replace(/{{ACTIVE_STYLE}}/g, activeFor(pageId, 'style'))
+            .replace(/{{ACTIVE_EXAMPLES}}/g, activeFor(pageId, 'examples'))
+            .replace(/{{ACTIVE_REFERENCE}}/g, activeFor(pageId, 'reference'))
+            .replace(/{{ACTIVE_REPORTS}}/g, activeFor(pageId, 'reports'))
+            .replace(/{{ACTIVE_OPERATING}}/g, activeFor(pageId, 'operating'));
 
-        // Inject Nav
+        const footerHtml = FOOTER_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix);
+
         const navRegex = /(<!-- LAYOUT_NAV_START -->)([\s\S]*?)(<!-- LAYOUT_NAV_END -->)/;
         if (navRegex.test(content)) {
-            content = content.replace(navRegex, '$1' + navHtml + '        $3');
+            content = content.replace(navRegex, `$1${navHtml}        $3`);
             modified = true;
         }
 
-        // Inject Footer
         const footerRegex = /(<!-- LAYOUT_FOOTER_START -->)([\s\S]*?)(<!-- LAYOUT_FOOTER_END -->)/;
         if (footerRegex.test(content)) {
-            content = content.replace(footerRegex, '$1' + footerHtml + '        $3');
+            content = content.replace(footerRegex, `$1${footerHtml}        $3`);
             modified = true;
         }
 

--- a/scripts/check-docs-metadata.js
+++ b/scripts/check-docs-metadata.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const FEATURES_PATH = path.join(ROOT, 'docs/reference/features.yaml');
+const DOCS_DIR = path.join(ROOT, 'docs');
+const VALID_STATUS = new Set(['active', 'preview', 'experimental', 'planned']);
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+function warn(message) {
+    console.warn(`docs-metadata warning: ${message}`);
+}
+
+function readFeatures() {
+    const doc = yaml.load(fs.readFileSync(FEATURES_PATH, 'utf8'));
+    const features = Array.isArray(doc?.features) ? doc.features : [];
+    const ids = new Set();
+
+    for (const feature of features) {
+        if (!feature || typeof feature !== 'object') {
+            warn('feature entry must be an object');
+            continue;
+        }
+        if (!feature.id) warn('feature entry missing id');
+        if (feature.id && ids.has(feature.id)) warn(`duplicate feature id '${feature.id}'`);
+        if (feature.id) ids.add(feature.id);
+        if (!feature.title) warn(`feature '${feature.id}' missing title`);
+        if (!VALID_STATUS.has(feature.status)) {
+            warn(`feature '${feature.id}' has invalid status '${feature.status}'`);
+        }
+        if (!SEMVER.test(String(feature.since_schema || ''))) {
+            warn(`feature '${feature.id}' missing semver since_schema`);
+        }
+        if (!SEMVER.test(String(feature.since_engine || ''))) {
+            warn(`feature '${feature.id}' missing semver since_engine`);
+        }
+        if (feature.spec) {
+            const specPath = path.join(ROOT, feature.spec);
+            if (!fs.existsSync(specPath)) warn(`feature '${feature.id}' spec does not exist: ${feature.spec}`);
+        }
+    }
+
+    return ids;
+}
+
+function walk(dir, files = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules') continue;
+        const target = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(target, files);
+        if (entry.isFile() && /\.(md|html)$/.test(entry.name)) files.push(target);
+    }
+    return files;
+}
+
+function checkFeatureReferences(featureIds) {
+    for (const file of walk(DOCS_DIR)) {
+        const rel = path.relative(ROOT, file);
+        const content = fs.readFileSync(file, 'utf8');
+        const refs = [...content.matchAll(/data-feature="([^"]+)"/g)].map((match) => match[1]);
+        for (const ref of refs) {
+            if (!featureIds.has(ref)) warn(`${rel} references unknown feature '${ref}'`);
+        }
+
+        if (/docs\/guides\/style-authoring\/.+\.md$/.test(rel) && !content.includes('features:')) {
+            warn(`${rel} has no feature metadata`);
+        }
+    }
+}
+
+function main() {
+    if (!fs.existsSync(FEATURES_PATH)) {
+        warn(`missing ${path.relative(ROOT, FEATURES_PATH)}`);
+        return;
+    }
+    const featureIds = readFeatures();
+    checkFeatureReferences(featureIds);
+}
+
+main();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,8 +1,9 @@
 {
   "scripts": {
-    "build:docs": "node build-author-guide.js",
+    "build:docs": "node build-author-guide.js && node build-layout.js",
     "build:layout": "node build-layout.js",
-    "build:embedded-template-runtime": "node build-embedded-template-runtime.js"
+    "build:embedded-template-runtime": "node build-embedded-template-runtime.js",
+    "check:docs-metadata": "node check-docs-metadata.js"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -2771,48 +2771,35 @@ function generateHtmlHeader(report) {
 <body class="bg-background-light text-slate-700 selection:bg-primary/20">
 
     <!-- Navigation -->
-    <nav class="fixed top-0 w-full z-50 glass-nav">
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+    <nav class="site-nav">
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="https://citum.org">Home</a>
-                <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="index.html">Docs</a>
-                <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="interactive-demo.html">Demo</a>
-                <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="examples.html">Examples</a>
-                <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="guides/style-author-guide.html">Style Guide</a>
-                <a class="text-sm font-medium text-primary font-semibold"
-                    href="reports.html">Reports</a>
-                <a class="text-sm font-medium hover:text-primary transition-colors text-slate-600"
-                    href="https://github.com/citum/citum-core">GitHub</a>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="index.html">Overview</a>
+                <a class="site-nav-link" href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link" href="examples.html">Examples</a>
+                <a class="site-nav-link" href="reference.html">Reference</a>
+                <a class="site-nav-link active" href="reports.html">Reports</a>
+                <a class="site-nav-link" href="operating.html">Operating</a>
+                <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
             </div>
-            <button type="button"
-                class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700"
-                data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
                 <span class="material-icons text-[20px]">menu</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="hover:text-primary transition-colors" href="index.html">Docs</a>
-                <a class="hover:text-primary transition-colors" href="interactive-demo.html">Demo</a>
-                <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                <a class="hover:text-primary transition-colors" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="text-primary font-semibold" href="reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="index.html">Overview</a>
+            <a class="site-nav-link" href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link" href="examples.html">Examples</a>
+            <a class="site-nav-link" href="reference.html">Reference</a>
+            <a class="site-nav-link active" href="reports.html">Reports</a>
+            <a class="site-nav-link" href="operating.html">Operating</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>
     </nav>
 
@@ -3498,26 +3485,18 @@ function generateHtmlFooter() {
 
     <!-- Footer -->
     <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
-        <div class="max-w-7xl mx-auto">
-            <div class="flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <a href="index.html" class="flex items-center gap-2 group">
-                        <div class="w-6 h-6 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                            <span class="text-white font-mono text-xs font-bold">C</span>
-                        </div>
-                        <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
-                    </a>
-                </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="index.html">Docs</a>
-                    <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
-                </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project. MIT Licensed.
-                </div>
+        <div class="site-footer-inner">
+            <div class="site-brand site-brand-small">
+                <div class="site-brand-mark"><span>C</span></div>
+                <span class="site-brand-name">Citum</span>
             </div>
+            <div class="site-footer-links">
+                <a href="guides/style-authoring/start.html">Style Authoring</a>
+                <a href="reference.html">Reference</a>
+                <a href="reports.html">Reports</a>
+                <a href="https://github.com/citum/citum-core">GitHub</a>
+            </div>
+            <div class="site-footer-note">© 2026 Citum Project. MIT Licensed.</div>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- reframe the docs index around high-level citation capabilities
- split style authoring into generated Markdown guide sources
- add reference and operating entrypoints, semantic docs CSS, and feature metadata
- keep generated style-authoring HTML out of the committed diff; Pages regenerates it in CI

## Verification
- npm run build:docs --prefix scripts
- npm run check:docs-metadata --prefix scripts
- git diff --check
- local HTTP 200 checks for index, style-authoring start, reference, and reports pages