### PR TITLE
docs: redesign docs site IA and CSS

### DIFF
--- a/.beans/csl26-0y0z--docs-version-badge-injection-from-featuresyaml.md
+++ b/.beans/csl26-0y0z--docs-version-badge-injection-from-featuresyaml.md
@@ -1,0 +1,30 @@
+---
+# csl26-0y0z
+title: 'Docs: version badge injection from features.yaml'
+status: todo
+type: task
+priority: low
+created_at: 2026-05-14T13:23:56Z
+updated_at: 2026-05-14T13:23:56Z
+---
+
+Inject per-feature version badges into guide pages at build time, sourced from docs/reference/features.yaml.
+
+## Approach ideas
+
+**Build-time injection (preferred)**
+- Extend build-author-guide.js (or a new build-docs.js) to read features.yaml
+- Match features by id to guide page sections (via frontmatter or heading convention)
+- Inject a `.citum-version-since` badge at the relevant H2/section: 'since schema X.X / engine X.X'
+- Status (active/preview/experimental) maps to a badge variant already in citum-theme.css
+
+**Convention for mapping**
+- Each markdown guide section declares `feature: <id>` in frontmatter or an HTML comment
+- The build script looks up that id in features.yaml and injects the badge
+
+**What NOT to do**
+- Do not hardcode badges as static HTML in index.html or other pages (current broken approach)
+- Do not add a standalone 'Know what a style depends on' homepage section
+
+**Also consider**
+- Markdown-as-source-of-truth for the top-level HTML pages (index, developer, reference, operating). Currently these are hand-authored HTML. A future step could use markdown+frontmatter source files, with CI building to HTML for GitHub Pages deployment. This pairs naturally with badge injection since the build script would process all pages uniformly.

--- a/.beans/csl26-xbr3--migrate-docs-to-markdown-as-source-of-truth.md
+++ b/.beans/csl26-xbr3--migrate-docs-to-markdown-as-source-of-truth.md
@@ -1,0 +1,27 @@
+---
+# csl26-xbr3
+title: Migrate docs to markdown as source of truth
+status: draft
+type: feature
+created_at: 2026-05-14T14:13:29Z
+updated_at: 2026-05-14T14:13:29Z
+---
+
+Currently the docs site uses hand-authored HTML files in docs/. These should be replaced with markdown source files compiled to HTML via a static site generator (SSG) or build step, keeping HTML out of the repo.
+
+Viable pages for markdown-first approach:
+- developer.html (mostly prose + code blocks)
+- reference.html (index-like, links out)
+- operating.html (prose)
+- reports.html (metrics/tables)
+
+Pages needing SSG template layer (layout-heavy or data-driven):
+- index.html (hero, feature cards)
+- examples.html (sidebar + interactive IO panels)
+- guides/style-authoring/*.html (sidebar nav + inline callouts)
+
+Design decision: use a lightweight SSG (e.g. Eleventy or Vite + markdown-it) that supports:
+- Shared nav/footer layouts (replace current build-layout.js)
+- Callout/table shortcodes or remark plugins
+- Sidebar generation from frontmatter
+- Build-time schema badge injection (replaces deferred bean csl26-0y0z)

--- a/docs/assets/citum-interactive.js
+++ b/docs/assets/citum-interactive.js
@@ -8,9 +8,21 @@
 
   const CITUM = {
     init: function() {
+      this.setupNavToggle();
       this.setupCitations();
       this.setupBibliography();
       this.setupTooltips();
+    },
+
+    setupNavToggle: function() {
+      const toggle = document.querySelector('[data-nav-toggle]');
+      const menu = document.querySelector('[data-mobile-menu]');
+      if (!toggle || !menu) return;
+      toggle.addEventListener('click', function() {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        menu.classList.toggle('hidden', expanded);
+      });
     },
 
     setupCitations: function() {

--- a/docs/assets/citum-theme.css
+++ b/docs/assets/citum-theme.css
@@ -1,3 +1,13 @@
+/* ------------------------------------------------------------------ */
+/* Utilities                                                            */
+/* ------------------------------------------------------------------ */
+
+.hidden { display: none !important; }
+
+/* ------------------------------------------------------------------ */
+/* Design tokens                                                        */
+/* ------------------------------------------------------------------ */
+
 :root {
   --citum-blue: oklch(0.64 0.13 238);
   --citum-blue-dark: oklch(0.47 0.12 238);
@@ -6,6 +16,7 @@
   --citum-paper-deep: oklch(0.955 0.018 86);
   --citum-surface: oklch(0.995 0.006 86);
   --citum-surface-cool: oklch(0.965 0.013 247);
+  --citum-surface-dark: oklch(0.18 0.02 255);
   --citum-ink: oklch(0.29 0.025 255);
   --citum-ink-strong: oklch(0.19 0.025 255);
   --citum-muted: oklch(0.47 0.025 255);
@@ -25,7 +36,13 @@
   --citum-font-mono: "JetBrains Mono", monospace;
 }
 
-* {
+/* ------------------------------------------------------------------ */
+/* Base                                                                 */
+/* ------------------------------------------------------------------ */
+
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
@@ -34,26 +51,21 @@ html {
 }
 
 body {
-  font-family: var(--citum-font-sans);
   background:
     radial-gradient(circle at 14% -10%, oklch(0.93 0.04 238 / 0.72), transparent 30rem),
     linear-gradient(180deg, var(--citum-paper) 0%, oklch(0.975 0.011 86) 52%, var(--citum-paper-deep) 100%);
   color: var(--citum-ink);
+  font-family: var(--citum-font-sans);
   -webkit-font-smoothing: antialiased;
 }
 
-h1,
-h2,
-h3,
-h4 {
+h1, h2, h3, h4 {
   color: var(--citum-ink-strong);
   font-family: var(--citum-font-serif);
   letter-spacing: -0.012em;
 }
 
-code,
-pre,
-.font-mono {
+code, pre {
   font-family: var(--citum-font-mono);
 }
 
@@ -61,91 +73,546 @@ a {
   color: inherit;
 }
 
-.glass-nav,
-.citum-nav {
-  background: oklch(0.985 0.012 86 / 0.88);
+/* ------------------------------------------------------------------ */
+/* Site nav                                                             */
+/* ------------------------------------------------------------------ */
+
+.site-nav {
+  background: oklch(0.985 0.012 86 / 0.9);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--citum-border);
+  inset-inline: 0;
+  position: fixed;
+  top: 0;
+  z-index: 50;
 }
 
-.citum-brand-mark,
-.bg-primary {
-  background: var(--citum-blue);
+.site-nav-inner {
+  align-items: center;
+  display: flex;
+  height: 4rem;
+  justify-content: space-between;
+  margin-inline: auto;
+  max-width: 80rem;
+  padding-inline: 1.5rem;
 }
 
-.text-primary {
-  color: var(--citum-blue-dark);
-}
-
-.border-primary {
-  border-color: var(--citum-blue);
-}
-
-.bg-background-light {
-  background-color: var(--citum-paper);
-}
-
-.bg-accent-cream {
-  background-color: var(--citum-paper-deep);
-}
-
-.bg-white {
-  background-color: var(--citum-surface);
-}
-
-.text-white {
-  color: oklch(0.985 0.008 238);
-}
-
-.text-slate-900,
-.text-gray-900 {
-  color: var(--citum-ink-strong);
-}
-
-.text-slate-700,
-.text-gray-700 {
-  color: var(--citum-ink);
-}
-
-.text-slate-600,
-.text-gray-600,
-.text-slate-500,
-.text-gray-500 {
-  color: var(--citum-muted);
-}
-
-.text-slate-400,
-.text-gray-400 {
-  color: var(--citum-faint);
-}
-
-.border-slate-100,
-.border-slate-200,
-.border-gray-100 {
-  border-color: var(--citum-border);
-}
-
-.nav-link,
-.citum-doc-link {
-  color: var(--citum-muted);
-  font-size: 0.92rem;
-  font-weight: 600;
-  padding: 8px 14px;
-  border-radius: 999px;
+.site-brand,
+.site-brand-wrap {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.5rem;
+  min-width: 0;
   text-decoration: none;
-  white-space: nowrap;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.nav-link:hover,
-.nav-link[aria-current="page"],
-.citum-doc-link:hover,
-.citum-doc-link[aria-current="page"] {
+.site-brand-mark {
+  align-items: center;
+  background: var(--citum-blue);
+  border-radius: var(--citum-radius-sm);
+  color: oklch(0.985 0.008 238);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: var(--citum-font-mono);
+  font-weight: 800;
+  height: 2rem;
+  justify-content: center;
+  width: 2rem;
+}
+
+.site-brand-small .site-brand-mark {
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.site-brand-name {
+  color: var(--citum-ink-strong);
+  font-family: var(--citum-font-mono);
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+.site-nav-links {
+  align-items: center;
+  display: flex;
+  gap: 0.35rem;
+  min-width: 0;
+  overflow-x: auto;
+  padding-left: 1rem;
+  white-space: nowrap;
+}
+
+.site-nav-link {
+  border-radius: 999px;
+  color: var(--citum-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.5rem 0.8rem;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.site-nav-link:hover,
+.site-nav-link.active {
   background: var(--citum-blue-soft);
   color: var(--citum-ink-strong);
 }
 
-.btn-primary,
+.site-source-link {
+  align-items: center;
+  background: var(--citum-blue);
+  border-radius: var(--citum-radius-sm);
+  color: oklch(0.985 0.008 238);
+  display: inline-flex;
+  font-size: 0.9rem;
+  font-weight: 800;
+  gap: 0.45rem;
+  margin-left: 0.25rem;
+  padding: 0.55rem 0.9rem;
+  text-decoration: none;
+}
+
+.site-source-icon {
+  height: 1rem;
+  width: 1rem;
+}
+
+.mobile-nav-toggle {
+  align-items: center;
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-ink);
+  cursor: pointer;
+  display: none;
+  font-size: 1.25rem;
+  justify-content: center;
+  line-height: 1;
+  padding: 0.5rem 0.75rem;
+}
+
+.mobile-nav-icon {
+  display: block;
+  font-style: normal;
+}
+
+.mobile-nav {
+  background: oklch(0.985 0.012 86 / 0.98);
+  border-top: 1px solid var(--citum-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.5rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* Site footer                                                          */
+/* ------------------------------------------------------------------ */
+
+.site-footer-inner {
+  align-items: center;
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+  margin-inline: auto;
+  max-width: 80rem;
+  padding-inline: 1.5rem;
+}
+
+.site-footer-links {
+  color: var(--citum-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  font-weight: 700;
+  gap: 1.5rem;
+}
+
+.site-footer-links a {
+  text-decoration: none;
+}
+
+.site-footer-links a:hover {
+  color: var(--citum-blue-dark);
+}
+
+.site-footer-note {
+  color: var(--citum-faint);
+  font-size: 0.9rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* Page shell                                                           */
+/* ------------------------------------------------------------------ */
+
+.doc-shell {
+  margin-inline: auto;
+  max-width: 80rem;
+  padding: 7rem 1.5rem 5rem;
+}
+
+.doc-hero {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1.05fr) minmax(18rem, 0.75fr);
+  padding-block: 2rem 3rem;
+}
+
+.doc-hero h1 {
+  font-size: clamp(3rem, 8vw, 5.8rem);
+  line-height: 0.95;
+  margin: 0.75rem 0;
+  max-width: 11ch;
+}
+
+.doc-lede {
+  color: var(--citum-muted);
+  font-size: 1.18rem;
+  line-height: 1.65;
+  max-width: 44rem;
+}
+
+.doc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 2rem;
+}
+
+.doc-section {
+  border-top: 1px solid var(--citum-border);
+  padding-block: 3.5rem;
+}
+
+.doc-section-header {
+  margin-bottom: 1.5rem;
+  max-width: 48rem;
+}
+
+.doc-section-header h1,
+.doc-section-header h2 {
+  margin-top: 0.5rem;
+}
+
+.doc-section-header p {
+  color: var(--citum-muted);
+  line-height: 1.65;
+  margin-top: 0.5rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* Cards and grids                                                      */
+/* ------------------------------------------------------------------ */
+
+.doc-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.doc-card,
+.feature-link {
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  box-shadow: var(--citum-shadow);
+  display: block;
+  padding: 1.25rem;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.doc-card:hover,
+.feature-link:hover {
+  border-color: var(--citum-border-strong);
+  box-shadow: var(--citum-shadow-lift);
+  transform: translateY(-1px);
+}
+
+.doc-card h3,
+.feature-link h3 {
+  font-family: var(--citum-font-sans);
+  font-size: 1rem;
+  letter-spacing: 0;
+  margin: 0 0 0.45rem;
+}
+
+.doc-card p,
+.feature-link p {
+  color: var(--citum-muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.doc-card code {
+  color: var(--citum-faint);
+  font-size: 0.75rem;
+}
+
+.citum-note {
+  color: var(--citum-muted);
+  font-size: 0.88rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* Sidebar layout                                                       */
+/* ------------------------------------------------------------------ */
+
+.doc-sidebar-layout {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: 16rem minmax(0, 1fr);
+}
+
+.doc-sidebar {
+  align-self: start;
+  position: sticky;
+  top: 5.5rem;
+}
+
+.doc-sidebar-title {
+  color: var(--citum-faint);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.doc-sidebar-title--spaced {
+  margin-top: 1rem;
+}
+
+.doc-sidebar-link {
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-muted);
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.55rem 0.75rem;
+  text-decoration: none;
+}
+
+.doc-sidebar-link:hover,
+.doc-sidebar-link.active {
+  background: var(--citum-blue-soft);
+  color: var(--citum-ink-strong);
+}
+
+.doc-main {
+  min-width: 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Prose                                                                */
+/* ------------------------------------------------------------------ */
+
+.doc-prose {
+  max-width: 70ch;
+}
+
+.doc-prose h2,
+.doc-prose h3 {
+  font-family: var(--citum-font-sans);
+  letter-spacing: 0;
+}
+
+.doc-prose p,
+.doc-prose li {
+  line-height: 1.7;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tables                                                               */
+/* ------------------------------------------------------------------ */
+
+.doc-table-shell {
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  margin-block: 1.5rem;
+  overflow-x: auto;
+}
+
+.doc-table {
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  width: 100%;
+}
+
+.doc-table th,
+.doc-table td {
+  border-bottom: 1px solid var(--citum-border);
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc-table th {
+  background: var(--citum-surface-cool);
+  color: var(--citum-ink-strong);
+}
+
+/* ------------------------------------------------------------------ */
+/* Code blocks                                                          */
+/* ------------------------------------------------------------------ */
+
+.workshop-block {
+  background: var(--citum-surface-cool);
+  border: 1px solid oklch(0.86 0.018 247);
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-ink);
+  font-family: var(--citum-font-mono);
+  overflow-x: auto;
+}
+
+.workshop-block pre {
+  margin: 0;
+  padding: 1.25rem;
+}
+
+.workshop-label {
+  color: var(--citum-muted);
+  font-family: var(--citum-font-sans);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0.75rem 1.25rem 0;
+  text-transform: uppercase;
+}
+
+.citum-copy-btn {
+  background: none;
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-sm);
+  color: var(--citum-muted);
+  cursor: pointer;
+  font-family: var(--citum-font-sans);
+  font-size: 0.8rem;
+  margin: 0 1.25rem 0.75rem;
+  padding: 0.25rem 0.75rem;
+}
+
+.citum-copy-btn:hover {
+  color: var(--citum-blue);
+  border-color: var(--citum-blue);
+}
+
+.code-dark {
+  background: var(--citum-surface-dark);
+  border-radius: var(--citum-radius-sm);
+  overflow-x: auto;
+}
+
+.code-dark pre {
+  color: oklch(0.82 0.018 247);
+  font-family: var(--citum-font-mono);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  margin: 0;
+  padding: 1rem;
+}
+
+.code-dark-label {
+  color: oklch(0.55 0.018 247);
+  font-family: var(--citum-font-sans);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0.65rem 1rem 0;
+  text-transform: uppercase;
+}
+
+/* ------------------------------------------------------------------ */
+/* Example cards                                                        */
+/* ------------------------------------------------------------------ */
+
+.example-card {
+  background: var(--citum-surface);
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-md);
+  box-shadow: var(--citum-shadow);
+  overflow: hidden;
+  scroll-margin-top: 5.5rem;
+}
+
+.example-card-header {
+  background: var(--citum-paper-deep);
+  border-bottom: 1px solid var(--citum-border);
+  padding: 1.75rem 2rem;
+}
+
+.example-card-header h2 {
+  font-family: var(--citum-font-sans);
+  font-size: 1.35rem;
+  letter-spacing: 0;
+  margin: 0 0 0.6rem;
+}
+
+.example-card-header p {
+  color: var(--citum-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+  max-width: 52ch;
+}
+
+.example-card-body {
+  padding: 1.25rem 1.5rem;
+}
+
+.example-subsection-header {
+  background: var(--citum-surface-cool);
+  border-bottom: 1px solid var(--citum-border);
+  color: var(--citum-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  padding: 0.75rem 1.5rem;
+  text-transform: uppercase;
+}
+
+.example-io-grid {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.example-io-panel {
+  border: 1px solid var(--citum-border);
+  border-radius: var(--citum-radius-sm);
+  overflow: hidden;
+}
+
+.example-io-panel.output {
+  border-color: oklch(0.82 0.06 158);
+}
+
+/* ------------------------------------------------------------------ */
+/* Callouts                                                             */
+/* ------------------------------------------------------------------ */
+
+.callout {
+  align-items: flex-start;
+  background: var(--citum-blue-soft);
+  border: 1px solid var(--citum-border-strong);
+  border-radius: var(--citum-radius-md);
+  color: var(--citum-ink);
+  display: flex;
+  gap: 0.75rem;
+  margin-block: 1.25rem;
+  padding: 1rem 1.1rem;
+}
+
+.callout.warning {
+  background: oklch(0.96 0.04 74);
+  border-color: oklch(0.82 0.08 74);
+}
+
+/* ------------------------------------------------------------------ */
+/* Buttons                                                              */
+/* ------------------------------------------------------------------ */
+
 .citum-button-primary {
   align-items: center;
   background: var(--citum-blue);
@@ -161,13 +628,11 @@ a {
   transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.2s ease;
 }
 
-.btn-primary:hover,
 .citum-button-primary:hover {
   box-shadow: 0 8px 22px oklch(0.64 0.13 238 / 0.32);
   transform: translateY(-1px);
 }
 
-.btn-secondary,
 .citum-button-secondary {
   align-items: center;
   background: var(--citum-surface);
@@ -183,13 +648,15 @@ a {
   transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
-.btn-secondary:hover,
 .citum-button-secondary:hover {
   background: var(--citum-blue-soft);
   border-color: var(--citum-blue);
 }
 
-.kicker,
+/* ------------------------------------------------------------------ */
+/* Badges and labels                                                    */
+/* ------------------------------------------------------------------ */
+
 .citum-kicker {
   background: var(--citum-blue-soft);
   border: 1px solid var(--citum-border-strong);
@@ -203,59 +670,22 @@ a {
   padding: 4px 12px;
 }
 
-.asymmetric-grid,
-.citum-asymmetric {
-  display: grid;
-  gap: clamp(1.5rem, 4vw, 3rem);
-  grid-template-columns: minmax(0, 1.18fr) minmax(280px, 0.82fr);
-}
+/* ------------------------------------------------------------------ */
+/* Misc components                                                      */
+/* ------------------------------------------------------------------ */
 
-.citum-section {
-  padding-block: clamp(3rem, 8vw, 6rem);
-}
-
-.citum-panel,
-.panel,
-.card,
-.report-card,
-.example-card {
+.citum-panel {
   background: var(--citum-surface);
   border: 1px solid var(--citum-border);
   border-radius: var(--citum-radius-md);
   box-shadow: var(--citum-shadow);
 }
 
-.report-card,
-.example-card {
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.report-card:hover,
-.example-card:hover {
-  border-color: var(--citum-border-strong);
-  box-shadow: var(--citum-shadow-lift);
-  transform: translateY(-1px);
-}
-
-.workshop-block,
-.citum-workshop,
-.code-block {
-  background: var(--citum-surface-cool);
-  border: 1px solid oklch(0.86 0.018 247);
-  border-radius: var(--citum-radius-sm);
-  color: var(--citum-ink);
-  font-family: var(--citum-font-mono);
-  overflow-x: auto;
-}
-
-.workshop-label,
-.citum-label {
-  color: var(--citum-muted);
-  font-family: var(--citum-font-sans);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+.citum-callout {
+  background: var(--citum-blue-soft);
+  border: 1px solid var(--citum-border-strong);
+  border-radius: var(--citum-radius-md);
+  padding: 1.25rem 1.5rem;
 }
 
 .citum-table-shell {
@@ -266,74 +696,67 @@ a {
   overflow-x: auto;
 }
 
-.citum-callout {
-  background: var(--citum-blue-soft);
-  border: 1px solid var(--citum-border-strong);
-  border-radius: var(--citum-radius-md);
-  padding: 1.25rem 1.5rem;
-}
-
-.citum-status-row {
-  align-items: start;
+.report-card {
   background: var(--citum-surface);
   border: 1px solid var(--citum-border);
   border-radius: var(--citum-radius-md);
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: auto 1fr;
-  padding: 1rem;
+  box-shadow: var(--citum-shadow);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.citum-leading-number {
-  background: var(--citum-blue);
-  border-radius: 999px;
-  color: oklch(0.985 0.008 238);
-  display: grid;
+.report-card:hover {
+  border-color: var(--citum-border-strong);
+  box-shadow: var(--citum-shadow-lift);
+  transform: translateY(-1px);
+}
+
+.install-block {
+  background: var(--citum-surface-dark);
+  border-radius: var(--citum-radius-sm);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+}
+
+.install-block code {
+  color: oklch(0.72 0.12 158);
+  flex: 1;
   font-family: var(--citum-font-mono);
+  font-size: 0.88rem;
+}
+
+.install-block-note {
+  color: var(--citum-faint);
   font-size: 0.78rem;
-  font-weight: 800;
-  height: 2rem;
-  place-items: center;
-  width: 2rem;
+  margin-top: 0.4rem;
 }
 
-.citum-no-side-stripe {
-  border-left-width: 1px;
-}
-
-@keyframes citum-fade-up {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.animate-in,
-.citum-animate-in {
-  animation: citum-fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  opacity: 0;
-}
-
-.delay-1 {
-  animation-delay: 0.1s;
-}
-
-.delay-2 {
-  animation-delay: 0.2s;
-}
+/* ------------------------------------------------------------------ */
+/* Responsive                                                           */
+/* ------------------------------------------------------------------ */
 
 @media (max-width: 768px) {
-  .asymmetric-grid,
-  .citum-asymmetric {
+  .site-nav-links,
+  .site-source-link {
+    display: none;
+  }
+
+  .mobile-nav-toggle {
+    display: inline-flex;
+  }
+
+  .doc-hero,
+  .doc-sidebar-layout {
     grid-template-columns: 1fr;
   }
 
-  .citum-doc-link,
-  .nav-link {
-    padding-inline: 10px;
+  .site-footer-inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .doc-sidebar {
+    position: static;
   }
 }

--- a/docs/developer.html
+++ b/docs/developer.html
@@ -1,0 +1,215 @@
+<!-- PAGE_ID: developer -->
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Developer | Citum Docs</title>
+    <meta name="description" content="Integrate Citum into your application via WASM, C FFI, CLI, or JSON-RPC server." />
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/citum-theme.css" />
+</head>
+<body>
+    <nav class="site-nav">
+        <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link active" href="developer.html">Developer</a>
+                <a class="site-nav-link " href="schemas/">Schemas</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link active" href="developer.html">Developer</a>
+            <a class="site-nav-link " href="schemas/">Schemas</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+    </nav>
+
+    <main class="doc-shell">
+        <header class="doc-section-header">
+            <span class="citum-kicker">Integration</span>
+            <h1>Developer</h1>
+            <p>
+                Citum exposes several integration surfaces depending on your runtime.
+                Pick the one that fits your environment.
+            </p>
+        </header>
+
+        <section class="doc-section">
+            <div class="doc-grid">
+                <a class="doc-card" href="#cli">
+                    <h3>CLI</h3>
+                    <p>Render references, process Djot documents, validate styles, and inspect schemas from the command line. The simplest integration path for build pipelines and scripted workflows.</p>
+                </a>
+                <a class="doc-card" href="#wasm">
+                    <h3>WASM</h3>
+                    <p>Run the engine in a browser or Node.js application. The WASM bridge exposes rendering and validation as async functions with TypeScript types.</p>
+                </a>
+                <a class="doc-card" href="#ffi">
+                    <h3>C FFI</h3>
+                    <p>Call the engine from any language with a C FFI. Current bindings cover Lua (for LuaLaTeX). The shared library exports a stable C-compatible surface.</p>
+                </a>
+                <a class="doc-card" href="#server">
+                    <h3>JSON-RPC server</h3>
+                    <p>Run Citum as a long-lived process and call it over stdin/stdout or HTTP. Suitable for editor integrations, language-server patterns, and applications that need live formatting without process-spawn overhead.</p>
+                </a>
+            </div>
+        </section>
+
+        <section class="doc-section" id="cli">
+            <div class="doc-section-header">
+                <h2>CLI</h2>
+                <p>Install with Cargo and use the <code>citum</code> binary directly.</p>
+            </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Install</div>
+                <pre><code>cargo install --git https://github.com/citum/citum-core --bin citum</code></pre>
+            </div>
+            <div class="workshop-block" style="margin-top: 1rem;">
+                <div class="workshop-label">Common commands</div>
+                <pre><code># Render a bibliography (plain text)
+citum render refs -b references.json -s styles/apa-7th.yaml
+
+# Render a bibliography (HTML)
+citum render refs -b references.json -s styles/apa-7th.yaml -f html
+
+# Process a Djot document with citations
+citum render doc -d paper.djot -b references.json -s styles/apa-7th.yaml
+
+# Validate a style
+citum style validate styles/my-style.yaml
+
+# Inspect the style schema
+citum schema --out-dir ./schemas</code></pre>
+            </div>
+            <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                See <a href="examples.html">feature examples</a> for input and output samples across citation modes, bibliography grouping, multilingual terms, and output formats.
+            </p>
+        </section>
+
+        <section class="doc-section" id="wasm">
+            <div class="doc-section-header">
+                <h2>WASM</h2>
+                <p>
+                    The WASM bridge is built from
+                    <code>citum-hub/server/crates/wasm-bridge</code> using
+                    <code>wasm-pack</code> with the <code>nodejs</code> target.
+                    It is the integration layer used by <a href="https://hub.citum.org">Citum Hub</a>.
+                </p>
+            </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Build</div>
+                <pre><code>cd citum-hub/server/crates/wasm-bridge
+wasm-pack build --target nodejs</code></pre>
+            </div>
+            <div class="workshop-block" style="margin-top: 1rem;">
+                <div class="workshop-label">Usage (Node.js)</div>
+                <pre><code>import { render_bibliography } from './pkg/wasm_bridge.js';
+
+const result = render_bibliography({
+  style: styleYamlString,
+  references: referencesJson,
+  locale: 'en-US',
+});</code></pre>
+            </div>
+            <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                The WASM module requires rebuilding when the engine changes. TypeScript types are generated by <code>wasm-pack</code> alongside the module.
+            </p>
+        </section>
+
+        <section class="doc-section" id="ffi">
+            <div class="doc-section-header">
+                <h2>C FFI</h2>
+                <p>
+                    The <code>crates/citum-engine</code> crate exposes a C-compatible FFI surface in
+                    <code>src/ffi/mod.rs</code>. Build the shared library first, then link against
+                    it from your target language.
+                </p>
+            </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Build shared library</div>
+                <pre><code>cargo build --release --lib
+# Output: target/release/libcitum_engine.{so,dylib,dll}</code></pre>
+            </div>
+            <div style="margin-top: 1.5rem;">
+                <div class="citum-panel" style="padding: 1.25rem; max-width: 36rem;">
+                    <h3 style="font-family: var(--citum-font-sans); font-size: 1rem; letter-spacing: 0; margin: 0 0 0.5rem;">Lua / LuaLaTeX</h3>
+                    <p style="color: var(--citum-muted); font-size: 0.88rem; line-height: 1.55; margin: 0;">
+                        Proof-of-concept bindings let a LuaLaTeX document call the Citum engine
+                        directly for citations and bibliography rendering. See
+                        <a href="https://github.com/citum/citum-labs/tree/main/bindings/lua">citum-labs/bindings/lua</a>
+                        for the binding source.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section class="doc-section" id="server">
+            <div class="doc-section-header">
+                <h2>JSON-RPC server</h2>
+                <p>
+                    The <code>citum-server</code> crate provides a long-running process that
+                    accepts JSON-RPC requests over stdin/stdout or HTTP. Use it for editor
+                    integrations, plugins, or web applications that need live citation formatting
+                    without process-spawn overhead per request.
+                </p>
+            </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Start the server (stdin/stdout)</div>
+                <pre><code>citum serve --stdio</code></pre>
+            </div>
+            <div class="workshop-block" style="margin-top: 1rem;">
+                <div class="workshop-label">Start the server (HTTP, feature-gated)</div>
+                <pre><code>citum serve --http --port 8765</code></pre>
+            </div>
+            <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                The HTTP server is behind the <code>citum-server/http</code> feature flag (axum).
+                See <a href="reference.html">Reference → JSON Schemas</a> for the
+                <code>server.json</code> schema describing the RPC surface, or browse
+                <a href="schemas/">docs/schemas/</a> directly.
+            </p>
+        </section>
+    </main>
+
+    <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+        <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="developer.html">Developer</a>
+                    <a href="schemas/">Schemas</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+    </footer>
+    <script src="assets/citum-interactive.js"></script>
+</body>
+</html>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -1,234 +1,125 @@
 <!-- PAGE_ID: examples -->
 <!doctype html>
-<html lang="en" class="scroll-smooth">
+<html lang="en">
 
 <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <meta name="description" content="Feature examples for Citum: document processing, advanced citations, bibliography grouping, multilingual support, and more." />
     <title>Examples | Citum</title>
 
-    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
-    <link
+        <link
         href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
         rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <link
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
-        rel="stylesheet" />
 
-    <script>
-        tailwind.config = {
-            darkMode: "class",
-            theme: {
-                extend: {
-                    colors: {
-                        primary: "#2a94d6", // Desaturated blue
-                        "background-light": "#fdfbf7", // Soft cream off-white
-                        "accent-cream": "#f5f2eb",
-                    },
-                    fontFamily: {
-                        display: ["Libre Franklin", "sans-serif"],
-                        mono: ["JetBrains Mono", "monospace"],
-                    },
-                    borderRadius: {
-                        DEFAULT: "0.25rem",
-                        lg: "0.5rem",
-                        xl: "0.75rem",
-                        full: "9999px",
-                    },
-                },
-            },
-        };
-    </script>
-    <style type="text/tailwindcss">
-        body {
-                font-family: "Libre Franklin", sans-serif;
-                color: #374151;
-            }
-            .font-mono {
-                font-family: "JetBrains Mono", monospace;
-            }
-            .glass-nav {
-                background: rgba(253, 251, 247, 0.85);
-                backdrop-filter: blur(12px);
-                border-bottom: 1px solid rgba(42, 148, 214, 0.1);
-            }
-            .example-card {
-                background: var(--citum-surface);
-                border: 1px solid #e2e8f0;
-                transition: all 0.3s ease;
-            }
-            .example-card:hover {
-                border-color: #2a94d6;
-                box-shadow:
-                    0 4px 6px -1px rgba(0, 0, 0, 0.1),
-                    0 2px 4px -1px rgba(0, 0, 0, 0.06);
-            }
-        </style>
     <link rel="stylesheet" href="assets/citum-theme.css">
 </head>
 
-<body class="bg-background-light text-slate-700 selection:bg-primary/20">
+<body>
     <!-- Navigation -->
+        <nav class="site-nav">
     <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="interactive-demo.html">Demo</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="schemas/">Schemas</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
-                    Source
+                    GitHub
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
-                <span class="material-icons text-[20px]">menu</span>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="interactive-demo.html">Demo</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="schemas/">Schemas</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
+    </nav>
 
     <!-- Header -->
-    <header class="pt-32 pb-16 px-6">
-        <div class="max-w-4xl mx-auto text-center">
-            <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-slate-900 mb-6">
-                Feature Examples
-            </h1>
-            <p class="text-xl text-slate-500 max-w-2xl mx-auto leading-relaxed">
-                Verified examples drawn from current styles, schemas,
-                and checked-in sample data.
-            </p>
-            <p class="text-sm text-slate-500 mt-5">
-                For current oracle fidelity and SQI status, see
-                <a class="text-primary hover:underline" href="https://docs.citum.org/compat.html">compatibility report</a>
-                and
-                <a class="text-primary hover:underline" href="TIER_STATUS.md">tier status</a>.
-            </p>
-        </div>
+    <header class="doc-section-header">
+        <span class="citum-kicker">Examples</span>
+        <h1>Feature Examples</h1>
+        <p>Verified examples drawn from current styles, schemas, and checked-in sample data.</p>
+        <p style="font-size: 0.9rem; color: var(--citum-muted);">
+            For current oracle fidelity and SQI status, see
+            <a href="compat.html">compatibility report</a> and
+            <a href="TIER_STATUS.md">tier status</a>.
+        </p>
     </header>
 
     <!-- Main Content Layout -->
-    <div class="max-w-7xl mx-auto px-6 pb-24 flex flex-col lg:flex-row gap-12 relative">
+    <div class="doc-shell doc-sidebar-layout">
         <!-- Sticky Sidebar Navigation -->
-        <aside class="hidden lg:block w-64 flex-shrink-0 sticky top-24 h-fit self-start">
-            <nav class="space-y-1">
-                <h3 class="text-xs font-bold text-slate-400 uppercase tracking-widest mb-4 px-3">Sections</h3>
-                <div class="space-y-0.5">
-                    <a href="#document-processing" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">description</span>
-                        Document Processing
+        <aside class="doc-sidebar">
+            <nav>
+                <div class="doc-sidebar-title">Sections</div>
+                                <div>
+                    <a class="doc-sidebar-link" href="#document-processing">Document Processing
                     </a>
-                    <a href="#advanced-citations" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">auto_awesome</span>
-                        Advanced Citations
+                    <a class="doc-sidebar-link" href="#advanced-citations">Advanced Citations
                     </a>
-                    <a href="#bibliography-grouping" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">library_books</span>
-                        Bibliography Grouping
+                    <a class="doc-sidebar-link" href="#bibliography-grouping">Bibliography Grouping
                     </a>
-                    <a href="#archival-eprints" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">inventory_2</span>
-                        Archival & Eprints
+                    <a class="doc-sidebar-link" href="#archival-eprints">Archival & Eprints
                     </a>
-                    <a href="#compound-numeric-sets" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">view_agenda</span>
-                        Compound Numeric Sets
+                    <a class="doc-sidebar-link" href="#compound-numeric-sets">Compound Numeric Sets
                     </a>
-                    <a href="#multilingual-support" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">translate</span>
-                        Multilingual Support
+                    <a class="doc-sidebar-link" href="#multilingual-support">Multilingual Support
                     </a>
-                    <a href="#advanced-dates" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">event</span>
-                        Advanced Dates
+                    <a class="doc-sidebar-link" href="#advanced-dates">Advanced Dates
                     </a>
-                    <a href="#options-presets" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">tune</span>
-                        Options &amp; Inheritance
+                    <a class="doc-sidebar-link" href="#options-presets">Options &amp; Inheritance
                     </a>
-                    <a href="#titles-links" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">title</span>
-                        Titles & Links
+                    <a class="doc-sidebar-link" href="#titles-links">Titles & Links
                     </a>
-                    <a href="#overrides" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">settings_input_component</span>
-                        Overrides
+                    <a class="doc-sidebar-link" href="#overrides">Overrides
                     </a>
-                    <a href="#output-formats" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">html</span>
-                        Output Formats
+                    <a class="doc-sidebar-link" href="#output-formats">Output Formats
                     </a>
-                    <a href="#typst-pdf-publishing" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">picture_as_pdf</span>
-                        Typst PDF
+                    <a class="doc-sidebar-link" href="#typst-pdf-publishing">Typst PDF
                     </a>
-                    <a href="#lualatex-integration" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">integration_instructions</span>
-                        LuaLaTeX
+                    <a class="doc-sidebar-link" href="#lualatex-integration">LuaLaTeX
                     </a>
-                    <a href="#binary-performance" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">speed</span>
-                        Binary Perf
+                    <a class="doc-sidebar-link" href="#binary-performance">Binary Perf
                     </a>
-                    <a href="#schema-generation" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-symbols-outlined text-lg opacity-60">schema</span>
-                        Schema Gen
+                    <a class="doc-sidebar-link" href="#web-interactivity">Web Interactivity
                     </a>
-                    <a href="#web-interactivity" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">mouse</span>
-                        Web Interactivity
+                    <a class="doc-sidebar-link" href="#annotated-bibliography">Annotated Bibliography
                     </a>
-                    <a href="#annotated-bibliography" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">comment</span>
-                        Annotated Bibliography
-                    </a>
-                    <a href="#distributed-registries" class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-slate-600 hover:text-primary hover:bg-primary/5 rounded-lg transition-all">
-                        <span class="material-icons text-lg opacity-60">lan</span>
-                        Distributed Registries
+                    <a class="doc-sidebar-link" href="#distributed-registries">Distributed Registries
                     </a>
                 </div>
             </nav>
         </aside>
 
         <!-- Examples Grid -->
-        <main class="flex-1 min-w-0 grid gap-12">
+        <div class="doc-main">
             <!-- Document Processing -->
-            <article id="document-processing" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">description</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+            <article id="document-processing" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Document Processing
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Citum processes full documents from checked-in Djot inputs, and also accepts
                     Markdown documents that use Pandoc-style citation markers in prose. The current
                     Djot example demonstrates multi-cites, locators, integral citations, visibility modifiers,
@@ -236,15 +127,15 @@
                 </p>
             </div>
 
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="grid gap-6">
+            <div class="example-card-body">
+                <div>
                     <!-- Djot Input -->
-                    <div class="border border-slate-300/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div>
+                        <div class="example-io-label">
                             Djot Input (paper.djot)
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">
+                        <div class="code-dark">
+                            <pre>
 Multi-cite with locator: [@kuhn1962; @watson1953, ch. 2].
 Structured locator: [@kuhn1962, section: 5].
 First narrative mention: [+@smith2010, p. 10] surveys the broader literature.
@@ -253,11 +144,11 @@ Suppress author with locator: [-@kuhn1962, p. 10].</pre>
                     </div>
 
                     <!-- Rendered Output -->
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Rendered Output (Plain Text)
                         </div>
-                        <div class="font-mono text-sm text-slate-900 mt-1">
+                        <div>
                             Multi-cite with locator: (Kuhn; Watson and Crick, ch. 2).<br />
                             Structured locator: (Kuhn, sec. 5).<br />
                             First narrative mention: John Smith (10) surveys the broader literature.<br />
@@ -269,127 +160,120 @@ Suppress author with locator: [-@kuhn1962, p. 10].</pre>
         </article>
 
         <!-- Advanced Citations: Narrative, Infix & Conjunctions -->
-        <article id="advanced-citations" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">auto_awesome</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="advanced-citations" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Advanced Citations
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Current styles use explicit integral and non-integral branches, per-mode contributor
                     options, and document-scoped integral-name memory where the style opts in.
                 </p>
             </div>
 
             <!-- Integral vs Non-Integral -->
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Integral vs Non-Integral (APA 7th)
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">citation</span>:
-  <span class="text-primary">non-integral</span>:
-    <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span>
-    <span class="text-primary">template</span>:
-      - <span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
-        <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
-      - <span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
-        <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>
-  <span class="text-primary">integral</span>:
-    <span class="text-primary">options</span>:
-      <span class="text-primary">contributors</span>:
-        <span class="text-primary">and</span>: <span class="text-emerald-400">text</span></pre>
+                <div class="code-dark">
+                    <pre>
+<span class="token-key">citation</span>:
+  <span class="token-value">non-integral</span>:
+    <span class="token-value">wrap</span>: <span class="token-string">parentheses</span>
+    <span class="token-value">template</span>:
+      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
+        <span class="token-value">form</span>: <span class="token-string">short</span>
+      - <span class="token-value">date</span>: <span class="token-string">issued</span>
+        <span class="token-value">form</span>: <span class="token-string">year</span>
+  <span class="token-value">integral</span>:
+    <span class="token-value">options</span>:
+      <span class="token-value">contributors</span>:
+        <span class="token-value">and</span>: <span class="token-string">text</span></pre>
                 </div>
             </div>
 
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Integral Name Memory (MLA Default)
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">options</span>:
-  <span class="text-primary">integral-names</span>:
-    <span class="text-primary">rule</span>: <span class="text-emerald-400">full-then-short</span>
-    <span class="text-primary">scope</span>: <span class="text-emerald-400">document</span>
-    <span class="text-primary">contexts</span>: <span class="text-emerald-400">body-and-notes</span>
-    <span class="text-primary">subsequent-form</span>: <span class="text-emerald-400">short</span>
+                <div class="code-dark">
+                    <pre>
+<span class="token-key">options</span>:
+  <span class="token-value">integral-names</span>:
+    <span class="token-value">rule</span>: <span class="token-string">full-then-short</span>
+    <span class="token-value">scope</span>: <span class="token-string">document</span>
+    <span class="token-value">contexts</span>: <span class="token-string">body-and-notes</span>
+    <span class="token-value">subsequent-form</span>: <span class="token-string">short</span>
 
-<span class="text-indigo-400">citation</span>:
-  <span class="text-primary">integral</span>:
-    <span class="text-primary">template</span>:
-      - <span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
-        <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>
-      - <span class="text-primary">variable</span>: <span class="text-emerald-400">locator</span>
-        <span class="text-primary">show-label</span>: <span class="text-emerald-400">false</span>
-        <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span></pre>
+<span class="token-key">citation</span>:
+  <span class="token-value">integral</span>:
+    <span class="token-value">template</span>:
+      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
+        <span class="token-value">form</span>: <span class="token-string">long</span>
+      - <span class="token-value">variable</span>: <span class="token-string">locator</span>
+        <span class="token-value">show-label</span>: <span class="token-string">false</span>
+        <span class="token-value">wrap</span>: <span class="token-string">parentheses</span></pre>
                 </div>
             </div>
 
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Document Override from Front Matter
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
+                <div class="code-dark">
+                    <pre>
 ---
-<span class="text-primary">integral-names</span>:
-  <span class="text-primary">enabled</span>: <span class="text-emerald-400">true</span>
-  <span class="text-primary">scope</span>: <span class="text-emerald-400">chapter</span>
-  <span class="text-primary">contexts</span>: <span class="text-emerald-400">body-and-notes</span>
+<span class="token-value">integral-names</span>:
+  <span class="token-value">enabled</span>: <span class="token-string">true</span>
+  <span class="token-value">scope</span>: <span class="token-string">chapter</span>
+  <span class="token-value">contexts</span>: <span class="token-string">body-and-notes</span>
 ---
 
-<span class="text-slate-500"># Later in the document</span>
-First narrative mention: <span class="text-emerald-400">[+@smith2010, p. 10]</span>
-Later in same chapter: <span class="text-emerald-400">[+@smith2010, p. 12]</span>
-New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></pre>
+<span class="token-comment"># Later in the document</span>
+First narrative mention: <span class="token-string">[+@smith2010, p. 10]</span>
+Later in same chapter: <span class="token-string">[+@smith2010, p. 12]</span>
+New chapter reset: <span class="token-string">[+@smith2010, p. 14]</span></pre>
                 </div>
             </div>
 
             <!-- Visual Output -->
             <div>
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+                <div>
+                    <h3>
                         Rendered Examples (Current Djot Input)
                     </h3>
                 </div>
-                <div class="p-6 bg-[var(--citum-surface)]">
-                    <div class="grid gap-4">
-                        <div class="border border-primary/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Multi-Cite with Locator</div>
-                            <div class="font-mono text-xs text-slate-400 mb-1">Source: [@kuhn1962; @watson1953, ch. 2]</div>
-                            <div class="font-mono text-sm text-slate-900">(Kuhn; Watson and Crick, ch. 2)</div>
+                <div class="example-card-body">
+                    <div>
+                        <div class="example-io-panel">
+                            <div class="example-io-label">Multi-Cite with Locator</div>
+                            <div>Source: [@kuhn1962; @watson1953, ch. 2]</div>
+                            <div>(Kuhn; Watson and Crick, ch. 2)</div>
                         </div>
-                        <div class="border border-emerald-500/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Structured Locator</div>
-                            <div class="font-mono text-xs text-slate-400 mb-1">Source: [@kuhn1962, section: 5]</div>
-                            <div class="font-mono text-sm text-slate-900">(Kuhn, sec. 5)</div>
+                        <div class="example-io-panel">
+                            <div class="example-io-label">Structured Locator</div>
+                            <div>Source: [@kuhn1962, section: 5]</div>
+                            <div>(Kuhn, sec. 5)</div>
                         </div>
-                        <div class="border border-amber-500/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Narrative Name Memory</div>
-                            <div class="font-mono text-xs text-slate-400 mb-1">Source: [+@smith2010, p. 10] ... later [+@smith2010, p. 12] ... then in Chapter 2 [+@smith2010, p. 14]</div>
-                            <div class="font-mono text-sm text-slate-900">John Smith (10) ... later Smith (12) ... then John Smith (14) again</div>
+                        <div class="example-io-panel">
+                            <div class="example-io-label">Narrative Name Memory</div>
+                            <div>Source: [+@smith2010, p. 10] ... later [+@smith2010, p. 12] ... then in Chapter 2 [+@smith2010, p. 14]</div>
+                            <div>John Smith (10) ... later Smith (12) ... then John Smith (14) again</div>
                         </div>
-                        <div class="border border-indigo-500/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Integral Citation</div>
-                            <div class="font-mono text-xs text-slate-400 mb-1">Source: [+@kuhn1962, p. 10]</div>
-                            <div class="font-mono text-sm text-slate-900">Thomas S. Kuhn (10)</div>
+                        <div class="example-io-panel">
+                            <div class="example-io-label">Integral Citation</div>
+                            <div>Source: [+@kuhn1962, p. 10]</div>
+                            <div>Thomas S. Kuhn (10)</div>
                         </div>
-                        <div class="border border-rose-500/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Visibility Modifier</div>
-                            <div class="font-mono text-xs text-slate-400 mb-1">Source: [-@kuhn1962, p. 10]</div>
-                            <div class="font-mono text-sm text-slate-900">(10)</div>
+                        <div class="example-io-panel">
+                            <div class="example-io-label">Visibility Modifier</div>
+                            <div>Source: [-@kuhn1962, p. 10]</div>
+                            <div>(10)</div>
                         </div>
                     </div>
                 </div>
@@ -397,217 +281,210 @@ New chapter reset: <span class="text-emerald-400">[+@smith2010, p. 14]</span></p
         </article>
 
         <!-- Bibliography Grouping -->
-        <article id="bibliography-grouping" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">library_books</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="bibliography-grouping" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Bibliography Grouping
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Divide bibliographies into labeled sections with distinct sorting rules. Essential for legal
                     hierarchies (Bluebook), multilingual bibliographies, and primary/secondary source divisions.
                 </p>
             </div>
 
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="grid gap-6">
+            <div class="example-card-body">
+                <div>
                     <!-- Legal Hierarchy Example -->
-                    <div class="border border-indigo-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Legal Hierarchy (Type-Based Grouping)
                         </div>
-                        <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">bibliography</span>:
-  <span class="text-primary">groups</span>:
-    - <span class="text-primary">id</span>: <span class="text-emerald-400">primary-legal</span>
-      <span class="text-primary">heading</span>: <span class="text-emerald-400">"Primary Sources"</span>
-      <span class="text-primary">selector</span>:
-        <span class="text-primary">type</span>: [<span class="text-emerald-400">legal-case, statute, treaty</span>]
-      <span class="text-primary">sort</span>:
-        <span class="text-primary">template</span>:
-          - <span class="text-primary">key</span>: <span class="text-emerald-400">type</span>
-            <span class="text-primary">order</span>: [<span class="text-emerald-400">legal-case, statute, treaty</span>]
-          - <span class="text-primary">key</span>: <span class="text-emerald-400">issued</span></pre>
+                        <div class="code-dark">
+                            <pre><span class="token-key">bibliography</span>:
+  <span class="token-value">groups</span>:
+    - <span class="token-value">id</span>: <span class="token-string">primary-legal</span>
+      <span class="token-value">heading</span>: <span class="token-string">"Primary Sources"</span>
+      <span class="token-value">selector</span>:
+        <span class="token-value">type</span>: [<span class="token-string">legal-case, statute, treaty</span>]
+      <span class="token-value">sort</span>:
+        <span class="token-value">template</span>:
+          - <span class="token-value">key</span>: <span class="token-string">type</span>
+            <span class="token-value">order</span>: [<span class="token-string">legal-case, statute, treaty</span>]
+          - <span class="token-value">key</span>: <span class="token-string">issued</span></pre>
                         </div>
-                        <p class="text-xs text-slate-500 mt-2">
+                        <p class="text-xs">
                             Explicit type ordering ensures legal-case appears before statute, regardless of alphabetical
                             content.
                         </p>
                     </div>
 
                     <!-- Multilingual Example -->
-                    <div class="border border-purple-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Multilingual (Per-Group Name Ordering)
                         </div>
-                        <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
+                        <div class="code-dark">
                             <pre
-                                class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">bibliography</span>:
-  <span class="text-primary">groups</span>:
-    - <span class="text-primary">id</span>: <span class="text-emerald-400">vietnamese</span>
-      <span class="text-primary">heading</span>:
-        <span class="text-primary">localized</span>:
-          <span class="text-primary">vi</span>: <span class="text-emerald-400">"Tài liệu tiếng Việt"</span>
-          <span class="text-primary">en-US</span>: <span class="text-emerald-400">"Vietnamese Sources"</span>
-      <span class="text-primary">selector</span>:
-        <span class="text-primary">field</span>:
-          <span class="text-primary">language</span>: <span class="text-emerald-400">vi</span>
-      <span class="text-primary">sort</span>:
-        <span class="text-primary">template</span>:
-          - <span class="text-primary">key</span>: <span class="text-emerald-400">author</span>
-            <span class="text-primary">sort-order</span>: <span class="text-emerald-400">given-family</span>  <span class="text-slate-500"># Vietnamese convention</span>
-          - <span class="text-primary">key</span>: <span class="text-emerald-400">issued</span>
-            <span class="text-primary">ascending</span>: <span class="text-emerald-400">false</span>
-      <span class="text-primary">disambiguate</span>: <span class="text-emerald-400">locally</span>
+                                class="font-mono text-xs"><span class="token-key">bibliography</span>:
+  <span class="token-value">groups</span>:
+    - <span class="token-value">id</span>: <span class="token-string">vietnamese</span>
+      <span class="token-value">heading</span>:
+        <span class="token-value">localized</span>:
+          <span class="token-value">vi</span>: <span class="token-string">"Tài liệu tiếng Việt"</span>
+          <span class="token-value">en-US</span>: <span class="token-string">"Vietnamese Sources"</span>
+      <span class="token-value">selector</span>:
+        <span class="token-value">field</span>:
+          <span class="token-value">language</span>: <span class="token-string">vi</span>
+      <span class="token-value">sort</span>:
+        <span class="token-value">template</span>:
+          - <span class="token-value">key</span>: <span class="token-string">author</span>
+            <span class="token-value">sort-order</span>: <span class="token-string">given-family</span>  <span class="token-comment"># Vietnamese convention</span>
+          - <span class="token-value">key</span>: <span class="token-string">issued</span>
+            <span class="token-value">ascending</span>: <span class="token-string">false</span>
+      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span>
 
-    - <span class="text-primary">id</span>: <span class="text-emerald-400">western</span>
-      <span class="text-primary">heading</span>:
-        <span class="text-primary">literal</span>: <span class="text-emerald-400">"Western Sources"</span>
-      <span class="text-primary">selector</span>:
-        <span class="text-primary">not</span>:
-          <span class="text-primary">field</span>:
-            <span class="text-primary">language</span>: <span class="text-emerald-400">vi</span>
-      <span class="text-primary">sort</span>:
-        <span class="text-primary">template</span>:
-          - <span class="text-primary">key</span>: <span class="text-emerald-400">author</span>
-            <span class="text-primary">sort-order</span>: <span class="text-emerald-400">family-given</span>  <span class="text-slate-500"># Western convention</span>
-          - <span class="text-primary">key</span>: <span class="text-emerald-400">issued</span>
-            <span class="text-primary">ascending</span>: <span class="text-emerald-400">false</span>
-      <span class="text-primary">disambiguate</span>: <span class="text-emerald-400">locally</span></pre>
+    - <span class="token-value">id</span>: <span class="token-string">western</span>
+      <span class="token-value">heading</span>:
+        <span class="token-value">literal</span>: <span class="token-string">"Western Sources"</span>
+      <span class="token-value">selector</span>:
+        <span class="token-value">not</span>:
+          <span class="token-value">field</span>:
+            <span class="token-value">language</span>: <span class="token-string">vi</span>
+      <span class="token-value">sort</span>:
+        <span class="token-value">template</span>:
+          - <span class="token-value">key</span>: <span class="token-string">author</span>
+            <span class="token-value">sort-order</span>: <span class="token-string">family-given</span>  <span class="token-comment"># Western convention</span>
+          - <span class="token-value">key</span>: <span class="token-string">issued</span>
+            <span class="token-value">ascending</span>: <span class="token-string">false</span>
+      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span></pre>
                         </div>
-                        <p class="text-xs text-slate-500 mt-2">
+                        <p class="text-xs">
                             Vietnamese names use given-family ordering, Western names use family-given ordering.
                         </p>
                     </div>
 
                     <!-- Localized Disambiguation Example -->
-                    <div class="border border-amber-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Localized Disambiguation (Per-Group Year Suffixes)
                         </div>
-                        <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">bibliography</span>:
-  <span class="text-primary">groups</span>:
-    - <span class="text-primary">id</span>: <span class="text-emerald-400">cited</span>
-      <span class="text-primary">heading</span>: <span class="text-emerald-400">"Cited Works"</span>
-      <span class="text-primary">disambiguate</span>: <span class="text-emerald-400">locally</span>  <span class="text-slate-500"># Reset suffixes for this group</span>
-      <span class="text-primary">selector</span>:
-        <span class="text-primary">status</span>: <span class="text-emerald-400">visible</span>
+                        <div class="code-dark">
+                            <pre><span class="token-key">bibliography</span>:
+  <span class="token-value">groups</span>:
+    - <span class="token-value">id</span>: <span class="token-string">cited</span>
+      <span class="token-value">heading</span>: <span class="token-string">"Cited Works"</span>
+      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span>  <span class="token-comment"># Reset suffixes for this</span>
+      <span class="token-value">selector</span>:
+        <span class="token-value">status</span>: <span class="token-string">visible</span>
 
-    - <span class="text-primary">id</span>: <span class="text-emerald-400">reading</span>
-      <span class="text-primary">heading</span>: <span class="text-emerald-400">"Further Reading"</span>
-      <span class="text-primary">disambiguate</span>: <span class="text-emerald-400">locally</span>  <span class="text-slate-500"># Start fresh from "a"</span>
-      <span class="text-primary">selector</span>:
-        <span class="text-primary">status</span>: <span class="text-emerald-400">silent</span></pre>
+    - <span class="token-value">id</span>: <span class="token-string">reading</span>
+      <span class="token-value">heading</span>: <span class="token-string">"Further Reading"</span>
+      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span>  <span class="token-comment"># Start fresh from "a"</span>
+      <span class="token-value">selector</span>:
+        <span class="token-value">status</span>: <span class="token-string">silent</span></pre>
                         </div>
-                        <p class="text-xs text-slate-500 mt-2">
+                        <p class="text-xs">
                             Isolating disambiguation prevents collisions across bibliography sections, allowing
-                            independent suffix assignment in each group.
+                            independent suffix assignment in each.
                         </p>
                     </div>
                 </div>
             </div>
 
-            <div class="bg-slate-50 p-6 border-t border-slate-200">
-                <div class="flex items-start gap-3">
+            <div class="bg-slate-50 border-t">
+                <div class="flex items-start">
                     <div
-                        class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center text-primary flex-shrink-0 mt-1">
-                        <span class="material-icons text-sm">lightbulb</span>
-                    </div>
-                    <div class="text-sm text-slate-600 leading-relaxed">
+                        class="w-8-lg-shrink-0">
+                        </div>
+                    <div>
                         <strong class="text-slate-900">Key Features:</strong>
                         First-match semantics prevent duplication. Selectors support type matching, field matching
                         (language, keywords), citation status (visible/silent), and negation for fallback groups. See <a
                             href="https://github.com/citum/citum-core/blob/main/docs/architecture/design/BIBLIOGRAPHY_GROUPING.md"
-                            class="text-primary hover:underline">design document</a> for full details.
+                            class="text-primary">design document</a> for full details.
                     </div>
                 </div>
             </div>
 
-            <div class="border-t border-slate-200 bg-[var(--citum-surface)] p-6">
-                <div class="flex items-center gap-2 mb-4">
-                    <span class="material-icons text-sm text-primary">record_voice_over</span>
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="border-t bg-[var(--citum-surface)]">
+                <div class="flex">
+                    <h3>
                         Gender-Aware Spanish Locale Terms
                     </h3>
                 </div>
-                <div class="grid gap-4">
-                    <div class="border border-primary/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                <div>
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Checked-In Locale
                         </div>
-                        <div class="font-mono text-sm text-slate-900">
-                            <code class="text-xs bg-slate-100 px-1 rounded">locales/es-ES.yaml</code>
+                        <div>
+                            <code>locales/es-ES.yaml</code>
                             now ships gendered role labels such as
-                            <code class="text-xs bg-slate-100 px-1 rounded">editor / editora / persona editora</code>.
+                            <code>editor / editora / persona editora</code>.
                         </div>
                     </div>
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Contributor-Driven Role Label
                         </div>
-                        <div class="font-mono text-sm text-slate-900">
+                        <div>
                             Ana Martinez, editora
                         </div>
-                        <div class="text-xs text-slate-500 mt-1">
+                        <div class="text-xs">
                             A feminine contributor entry selects the feminine role label from the Spanish locale.
                         </div>
                     </div>
-                    <div class="border border-indigo-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Mixed-Gender Group
                         </div>
-                        <div class="font-mono text-sm text-slate-900">
+                        <div>
                             Ana Martinez y Luis Pérez, equipo editorial
                         </div>
-                        <div class="text-xs text-slate-500 mt-1">
+                        <div class="text-xs">
                             Mixed contributor genders prefer the locale's neutral/common form instead of falling back to a masculine-specific label.
                         </div>
                     </div>
-                    <div class="border border-amber-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Template Override
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-2">
-                            <pre class="font-mono text-xs text-slate-300"><span class="text-indigo-400">template</span>:
-  - <span class="text-primary">contributor</span>: <span class="text-emerald-400">editor</span>
-    <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>
-    <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span>
-  - <span class="text-primary">number</span>: <span class="text-emerald-400">volume</span>
-    <span class="text-primary">label-form</span>: <span class="text-emerald-400">short</span>
-    <span class="text-primary">gender</span>: <span class="text-emerald-400">masculine</span></pre>
+                        <div class="code-dark">
+                            <pre><span class="token-key">template</span>:
+  - <span class="token-value">contributor</span>: <span class="token-string">editor</span>
+    <span class="token-value">form</span>: <span class="token-string">long</span>
+    <span class="token-value">gender</span>: <span class="token-string">feminine</span>
+  - <span class="token-value">number</span>: <span class="token-string">volume</span>
+    <span class="token-value">label-form</span>: <span class="token-string">short</span>
+    <span class="token-value">gender</span>: <span class="token-string">masculine</span></pre>
                         </div>
                     </div>
                 </div>
             </div>
 
             <!-- Try It Yourself -->
-            <div class="bg-[var(--citum-surface)] p-6 border-t border-slate-200">
-                <div class="flex items-center gap-2 mb-4">
-                    <span class="material-icons text-sm text-emerald-600">terminal</span>
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="bg-[var(--citum-surface)] border-t">
+                <div class="flex">
+                    <h3>
                         Try It Yourself
                     </h3>
                 </div>
 
                 <!-- English Grouping Example -->
-                <div class="border border-emerald-500/30 rounded-lg p-4 mb-6">
-                    <p class="text-xs text-slate-600 mb-2">
+                <div>
+                    <p class="text-xs">
                         Render a grouped bibliography with primary, archival, and secondary sources in English:
                     </p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+                    <div class="code-dark">
+                        <pre><span class="token-string">citum</span> render refs \
   -b examples/bib-grouping-refs.yaml \
   -s chicago-author-date</pre>
                     </div>
-                    <p class="text-xs text-slate-500 mt-2">
+                    <p class="text-xs">
                         Expected output with English headings:
                     </p>
-                    <div class="bg-slate-50 border border-slate-200 rounded p-3 mt-2 text-xs font-mono text-slate-700 overflow-x-auto">
+                    <div class="bg-slate-50 border text-xs">
                         <pre># Primary Sources
 
 Darwin, Charles. 1859. _On the Origin of Species_. John Murray.
@@ -629,16 +506,16 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </div>
 
                 <!-- German Grouping Example -->
-                <div class="border border-emerald-500/30 rounded-lg p-4">
-                    <p class="text-xs text-slate-600 mb-2">
+                <div class="example-io-panel">
+                    <p class="text-xs">
                         Render the multilingual grouping example shipped in the repo:
                     </p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+                    <div class="code-dark">
+                        <pre><span class="token-string">citum</span> render refs \
   -b examples/multilingual-refs.yaml \
   -s styles/experimental/multilingual-academic.yaml</pre>
                     </div>
-                    <p class="text-xs text-slate-500 mt-2">
+                    <p class="text-xs">
                         This style groups Vietnamese and non-Vietnamese records separately and applies per-group sort
                         behavior against the checked-in mixed-language sample corpus.
                     </p>
@@ -647,139 +524,133 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
         </article>
 
         <!-- Archival & Eprints -->
-        <article id="archival-eprints" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">inventory_2</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="archival-eprints" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Archival &amp; Eprints
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-4">
-                    Citum now accepts structured <code class="text-xs bg-slate-100 px-1 rounded">archive-info</code>
+                <p class="text-slate-600">
+                    Citum now accepts structured <code>archive-info</code>
                     data for manuscripts and related records, plus a structured
-                    <code class="text-xs bg-slate-100 px-1 rounded">eprint</code> object for preprint-style identifiers.
+                    <code>eprint</code> object for preprint-style identifiers.
                 </p>
-                <p class="text-slate-600 leading-relaxed">
-                    Legacy flat <code class="text-xs bg-slate-100 px-1 rounded">archive</code> and
-                    <code class="text-xs bg-slate-100 px-1 rounded">archive_location</code> fields still load for
-                    compatibility, but new inputs should use <code class="text-xs bg-slate-100 px-1 rounded">archive-info</code>.
-                    Within <code class="text-xs bg-slate-100 px-1 rounded">archive-info</code>, structured hierarchy
-                    fields such as <code class="text-xs bg-slate-100 px-1 rounded">collection-id</code>,
-                    <code class="text-xs bg-slate-100 px-1 rounded">series</code>,
-                    <code class="text-xs bg-slate-100 px-1 rounded">box</code>,
-                    <code class="text-xs bg-slate-100 px-1 rounded">folder</code>, and
-                    <code class="text-xs bg-slate-100 px-1 rounded">item</code> are canonical;
-                    <code class="text-xs bg-slate-100 px-1 rounded">location</code> is the display-override and
+                <p class="text-slate-600">
+                    Legacy flat <code>archive</code> and
+                    <code>archive_location</code> fields still load for
+                    compatibility, but new inputs should use <code>archive-info</code>.
+                    Within <code>archive-info</code>, structured hierarchy
+                    fields such as <code>collection-id</code>,
+                    <code>series</code>,
+                    <code>box</code>,
+                    <code>folder</code>, and
+                    <code>item</code> are canonical;
+                    <code>location</code> is the display-override and
                     legacy-fallback escape hatch for shelfmarks that cannot be decomposed cleanly.
                 </p>
             </div>
 
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Reference Data (YAML)
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">references</span>:
-  - <span class="text-primary">id</span>: <span class="text-emerald-400">dead-sea-scrolls-demo</span>
-    <span class="text-primary">class</span>: <span class="text-emerald-400">monograph</span>
-    <span class="text-primary">type</span>: <span class="text-emerald-400">manuscript</span>
-    <span class="text-primary">title</span>: <span class="text-emerald-400">"The Community Rule (1QS)"</span>
-    <span class="text-primary">issued</span>: <span class="text-emerald-400">"-0099"</span>
-    <span class="text-primary">genre</span>: <span class="text-emerald-400">"Manuscript scroll"</span>
-    <span class="text-primary">archive-info</span>:
-      <span class="text-primary">name</span>: <span class="text-emerald-400">"Israel Antiquities Authority"</span>
-      <span class="text-primary">location</span>: <span class="text-emerald-400">"Shrine of the Book"</span>
-      <span class="text-primary">place</span>: <span class="text-emerald-400">"Jerusalem"</span>
+                <div class="code-dark">
+                    <pre>
+<span class="token-key">references</span>:
+  - <span class="token-value">id</span>: <span class="token-string">dead-sea-scrolls-demo</span>
+    <span class="token-value">class</span>: <span class="token-string">monograph</span>
+    <span class="token-value">type</span>: <span class="token-string">manuscript</span>
+    <span class="token-value">title</span>: <span class="token-string">"The Community Rule (1QS)"</span>
+    <span class="token-value">issued</span>: <span class="token-string">"-0099"</span>
+    <span class="token-value">genre</span>: <span class="token-string">"Manuscript scroll"</span>
+    <span class="token-value">archive-info</span>:
+      <span class="token-value">name</span>: <span class="token-string">"Israel Antiquities Authority"</span>
+      <span class="token-value">location</span>: <span class="token-string">"Shrine of the Book"</span>
+      <span class="token-value">place</span>: <span class="token-string">"Jerusalem"</span>
 
-  - <span class="text-primary">id</span>: <span class="text-emerald-400">archive-aware-preprint</span>
-    <span class="text-primary">class</span>: <span class="text-emerald-400">monograph</span>
-    <span class="text-primary">type</span>: <span class="text-emerald-400">preprint</span>
-    <span class="text-primary">title</span>: <span class="text-emerald-400">"Archive-Aware Preprint"</span>
-    <span class="text-primary">issued</span>: <span class="text-emerald-400">"2026-02"</span>
-    <span class="text-primary">url</span>: <span class="text-emerald-400">"https://arxiv.org/abs/2602.01234"</span>
-    <span class="text-primary">archive-info</span>:
-      <span class="text-primary">name</span>: <span class="text-emerald-400">"Houghton Library"</span>
-      <span class="text-primary">collection</span>: <span class="text-emerald-400">"Ada Lovelace Papers"</span>
-      <span class="text-primary">collection-id</span>: <span class="text-emerald-400">"MS Am 1280"</span>
-      <span class="text-primary">series</span>: <span class="text-emerald-400">"Correspondence"</span>
-      <span class="text-primary">box</span>: <span class="text-emerald-400">"12"</span>
-      <span class="text-primary">folder</span>: <span class="text-emerald-400">"4"</span>
-      <span class="text-primary">item</span>: <span class="text-emerald-400">"7"</span>
-      <span class="text-primary">place</span>: <span class="text-emerald-400">"Cambridge, MA"</span>
-      <span class="text-primary">url</span>: <span class="text-emerald-400">"https://example.com/archive"</span>
-    <span class="text-primary">eprint</span>:
-      <span class="text-primary">id</span>: <span class="text-emerald-400">"2602.01234"</span>
-      <span class="text-primary">server</span>: <span class="text-emerald-400">"arxiv"</span>
-      <span class="text-primary">class</span>: <span class="text-emerald-400">"cs.DL"</span></pre>
+  - <span class="token-value">id</span>: <span class="token-string">archive-aware-preprint</span>
+    <span class="token-value">class</span>: <span class="token-string">monograph</span>
+    <span class="token-value">type</span>: <span class="token-string">preprint</span>
+    <span class="token-value">title</span>: <span class="token-string">"Archive-Aware Preprint"</span>
+    <span class="token-value">issued</span>: <span class="token-string">"2026-02"</span>
+    <span class="token-value">url</span>: <span class="token-string">"https://arxiv.org/abs/2602.01234"</span>
+    <span class="token-value">archive-info</span>:
+      <span class="token-value">name</span>: <span class="token-string">"Houghton Library"</span>
+      <span class="token-value">collection</span>: <span class="token-string">"Ada Lovelace Papers"</span>
+      <span class="token-value">collection-id</span>: <span class="token-string">"MS Am 1280"</span>
+      <span class="token-value">series</span>: <span class="token-string">"Correspondence"</span>
+      <span class="token-value">box</span>: <span class="token-string">"12"</span>
+      <span class="token-value">folder</span>: <span class="token-string">"4"</span>
+      <span class="token-value">item</span>: <span class="token-string">"7"</span>
+      <span class="token-value">place</span>: <span class="token-string">"Cambridge, MA"</span>
+      <span class="token-value">url</span>: <span class="token-string">"https://example.com/archive"</span>
+    <span class="token-value">eprint</span>:
+      <span class="token-value">id</span>: <span class="token-string">"2602.01234"</span>
+      <span class="token-value">server</span>: <span class="token-string">"arxiv"</span>
+      <span class="token-value">class</span>: <span class="token-string">"cs.DL"</span></pre>
                 </div>
             </div>
 
-            <div class="p-6 bg-[var(--citum-surface)] border-b border-slate-200">
-                <div class="grid gap-4">
-                    <div class="border border-primary/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+            <div class="p-6 bg-[var(--citum-surface)] border-b">
+                <div>
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Historical Manuscript Demo Output
                         </div>
-                        <div class="font-mono text-sm text-slate-900">
+                        <div>
                             The Community Rule (1QS). Manuscript scroll, 100 BC, Israel Antiquities Authority, Shrine of the Book, Jerusalem
                         </div>
-                        <div class="text-xs text-slate-500 mt-1">
+                        <div class="text-xs">
                             Verified with the checked-in
-                            <code class="text-xs bg-slate-100 px-1 rounded">archive-eprint-demo-style</code>
+                            <code>archive-eprint-demo-style</code>
                             so the examples page reflects current branch behavior. The example uses valid EDTF
-                            astronomical year numbering, where <code class="text-xs bg-slate-100 px-1 rounded">-0099</code>
-                            renders as <code class="text-xs bg-slate-100 px-1 rounded">100 BC</code>.
+                            astronomical year numbering, where <code>-0099</code>
+                            renders as <code>100 BC</code>.
                         </div>
                     </div>
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Archive + Eprint Demo Output
                         </div>
-                        <div class="font-mono text-sm text-slate-900 break-all">
+                        <div class="font-mono text-sm break-all">
                             Archive-Aware Preprint. February 2026, Houghton Library, Ada Lovelace Papers, MS Am 1280, Series Correspondence, Box 12, Folder 4, Item 7, Cambridge, MA, https://example.com/archive, arxiv:2602.01234 [cs.DL]
                         </div>
-                        <div class="text-xs text-slate-500 mt-1">
+                        <div class="text-xs">
                             Verified with the checked-in demo style that surfaces
-                            <code class="text-xs bg-slate-100 px-1 rounded">archive-*</code> and
-                            <code class="text-xs bg-slate-100 px-1 rounded">eprint-*</code> variables directly from
+                            <code>archive-*</code> and
+                            <code>eprint-*</code> variables directly from
                             the structured hierarchy, without collapsing them into a precomposed
-                            <code class="text-xs bg-slate-100 px-1 rounded">location</code> string.
+                            <code>location</code> string.
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="bg-[var(--citum-surface)] p-6">
-                <div class="flex items-center gap-2 mb-4">
-                    <span class="material-icons text-sm text-emerald-600">terminal</span>
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="bg-[var(--citum-surface)]">
+                <div class="flex">
+                    <h3>
                         Try It Yourself
                     </h3>
                 </div>
-                <div class="border border-emerald-500/30 rounded-lg p-4 mb-6">
-                    <p class="text-xs text-slate-600 mb-2">
+                <div>
+                    <p class="text-xs">
                         Render the archival manuscript with the current Chicago notes style:
                     </p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+                    <div class="code-dark">
+                        <pre><span class="token-string">citum</span> render refs \
   -b tests/fixtures/references-humanities-note.json \
   -s chicago-notes \
   -k dead-sea-scrolls</pre>
                     </div>
                 </div>
-                <div class="border border-indigo-500/30 rounded-lg p-4">
-                    <p class="text-xs text-slate-600 mb-2">
-                        Render the structured <code class="text-xs bg-slate-100 px-1 rounded">archive-info</code> +
-                        <code class="text-xs bg-slate-100 px-1 rounded">eprint</code> example with the demo style:
+                <div class="example-io-panel">
+                    <p class="text-xs">
+                        Render the structured <code>archive-info</code> +
+                        <code>eprint</code> example with the demo style:
                     </p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+                    <div class="code-dark">
+                        <pre><span class="token-string">citum</span> render refs \
   -b examples/archival-eprints.yaml \
   -s examples/archive-eprint-demo-style.yaml \
   -k archive-aware-preprint</pre>
@@ -789,177 +660,165 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
         </article>
 
         <!-- Compound Numeric Sets -->
-        <article id="compound-numeric-sets" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">view_agenda</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="compound-numeric-sets" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Compound Numeric Sets
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Chemistry-style compound numeric output is modeled via top-level bibliography
-                    <code class="text-xs bg-slate-200 px-1 rounded">sets</code>, not per-reference fields.
-                    Styles opt in with <code class="text-xs bg-slate-200 px-1 rounded">compound-numeric</code>.
+                    <code>sets</code>, not per-reference fields.
+                    Styles opt in with <code>compound-numeric</code>.
                 </p>
             </div>
 
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Input Bibliography (Independent Sets)
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">references</span>:
-  - <span class="text-primary">id</span>: <span class="text-emerald-400">doe2024a</span>
-    <span class="text-primary">class</span>: <span class="text-emerald-400">monograph</span>
-    <span class="text-primary">type</span>: <span class="text-emerald-400">book</span>
-    <span class="text-primary">title</span>: <span class="text-emerald-400">"Catalysis I"</span>
-    <span class="text-primary">issued</span>: <span class="text-emerald-400">"2024"</span>
-  - <span class="text-primary">id</span>: <span class="text-emerald-400">doe2024b</span>
-    <span class="text-primary">class</span>: <span class="text-emerald-400">monograph</span>
-    <span class="text-primary">type</span>: <span class="text-emerald-400">book</span>
-    <span class="text-primary">title</span>: <span class="text-emerald-400">"Catalysis II"</span>
-    <span class="text-primary">issued</span>: <span class="text-emerald-400">"2024"</span>
+                <div class="code-dark">
+                    <pre>
+<span class="token-key">references</span>:
+  - <span class="token-value">id</span>: <span class="token-string">doe2024a</span>
+    <span class="token-value">class</span>: <span class="token-string">monograph</span>
+    <span class="token-value">type</span>: <span class="token-string">book</span>
+    <span class="token-value">title</span>: <span class="token-string">"Catalysis I"</span>
+    <span class="token-value">issued</span>: <span class="token-string">"2024"</span>
+  - <span class="token-value">id</span>: <span class="token-string">doe2024b</span>
+    <span class="token-value">class</span>: <span class="token-string">monograph</span>
+    <span class="token-value">type</span>: <span class="token-string">book</span>
+    <span class="token-value">title</span>: <span class="token-string">"Catalysis II"</span>
+    <span class="token-value">issued</span>: <span class="token-string">"2024"</span>
 
-<span class="text-indigo-400">sets</span>:
-  <span class="text-primary">catalysis-series</span>: [<span class="text-emerald-400">doe2024a, doe2024b</span>]</pre>
+<span class="token-key">sets</span>:
+  <span class="token-value">catalysis-series</span>: [<span class="token-string">doe2024a, doe2024b</span>]</pre>
                 </div>
             </div>
 
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Style Opt-In
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">options</span>:
-  <span class="text-primary">processing</span>: <span class="text-emerald-400">numeric</span>
-  <span class="text-primary">bibliography</span>:
-    <span class="text-primary">compound-numeric</span>:
-      <span class="text-primary">subentry</span>: <span class="text-emerald-400">true</span>
-      <span class="text-primary">sub-label</span>: <span class="text-emerald-400">alphabetic</span>
-      <span class="text-primary">sub-label-suffix</span>: <span class="text-emerald-400">")"</span>
-      <span class="text-primary">sub-delimiter</span>: <span class="text-emerald-400">", "</span></pre>
+                <div class="code-dark">
+                    <pre>
+<span class="token-key">options</span>:
+  <span class="token-value">processing</span>: <span class="token-string">numeric</span>
+  <span class="token-value">bibliography</span>:
+    <span class="token-value">compound-numeric</span>:
+      <span class="token-value">subentry</span>: <span class="token-string">true</span>
+      <span class="token-value">sub-label</span>: <span class="token-string">alphabetic</span>
+      <span class="token-value">sub-label-suffix</span>: <span class="token-string">")"</span>
+      <span class="token-value">sub-delimiter</span>: <span class="token-string">", "</span></pre>
                 </div>
             </div>
 
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="grid gap-4">
-                    <div class="border border-indigo-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Citation Behavior</div>
-                        <div class="font-mono text-sm text-slate-900">subentry=true: [2a]/[2b], subentry=false: [2]</div>
+            <div class="example-card-body">
+                <div>
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Citation Behavior</div>
+                        <div>subentry=true: [2a]/[2b], subentry=false: [2]</div>
                     </div>
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Loader Validation</div>
-                        <div class="text-sm text-slate-700">Unknown IDs and duplicate membership across sets are rejected.</div>
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Loader Validation</div>
+                        <div>Unknown IDs and duplicate membership across sets are rejected.</div>
                     </div>
-                    <div class="border border-amber-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">Design Note</div>
-                        <div class="text-sm text-slate-700">No per-reference <code class="text-xs bg-slate-100 px-1 rounded">group-key</code> is required or supported.</div>
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Design Note</div>
+                        <div>No per-reference <code>group-key</code> is required or supported.</div>
                     </div>
                 </div>
             </div>
         </article>
 
         <!-- Multilingual Support -->
-        <article id="multilingual-support" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">translate</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="multilingual-support" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Multilingual Support
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Current bibliography data can carry original text, transliterations, and translations.
                     Styles then declare how titles and contributor names should render for a given workflow,
                     and locale overrides can ship style-specific term and phrasing adjustments without cloning
                     an entire style.
                 </p>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     The checked-in multilingual example now includes Vietnamese records for the grouped-bibliography
                     demo, alongside accented Latin-script surnames so bibliography sorting can be verified against
                     Unicode-aware collation, not raw byte ordering.
                 </p>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Locale term messages use <strong>Unicode MessageFormat 2 (MF2)</strong> syntax. The current
-                    evaluator supports a focused subset: variable substitution (<code class="text-xs bg-slate-100 px-1 rounded">{$var}</code>),
-                    plural dispatch (<code class="text-xs bg-slate-100 px-1 rounded">.match {$count :plural}</code> with
-                    <code class="text-xs bg-slate-100 px-1 rounded">one</code>/<code class="text-xs bg-slate-100 px-1 rounded">*</code>),
-                    and select dispatch (<code class="text-xs bg-slate-100 px-1 rounded">.match {$var :select}</code>).
+                    evaluator supports a focused subset: variable substitution (<code>{$var}</code>),
+                    plural dispatch (<code>.match {$count :plural}</code> with
+                    <code>one</code>/<code>*</code>),
+                    and select dispatch (<code>.match {$var :select}</code>).
                     Full CLDR plural rules and custom function annotations are deferred to a future ICU4X upgrade.
                 </p>
             </div>
 
             <!-- Style Configuration -->
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Style Configuration
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">options</span>:
-  <span class="text-primary">multilingual</span>:
-    <span class="text-primary">title-mode</span>: <span class="text-emerald-400">combined</span>
-    <span class="text-primary">name-mode</span>: <span class="text-emerald-400">primary</span>
-    <span class="text-primary">preferred-script</span>: <span class="text-emerald-400">Latn</span></pre>
+                <div class="code-dark">
+                    <pre>
+<span class="token-key">options</span>:
+  <span class="token-value">multilingual</span>:
+    <span class="token-value">title-mode</span>: <span class="token-string">combined</span>
+    <span class="token-value">name-mode</span>: <span class="token-string">primary</span>
+    <span class="token-value">preferred-script</span>: <span class="token-string">Latn</span></pre>
                 </div>
             </div>
 
             <!-- Reference Data -->
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Automatic Script &amp; Language Partitioning
                     </h3>
                 </div>
-                <div class="p-8 bg-slate-50">
-                    <p class="text-sm text-slate-600 mb-6">
+                <div class="p-8">
+                    <p>
                         Bibliographies can be automatically partitioned by script or language. This ensures that
                         references in different scripts (e.g., Latin and Arabic) are grouped together, and that
                         subsequent-author substitutions correctly reset for each new partition section.
                     </p>
-                    <div class="grid lg:grid-cols-2 gap-8">
+                    <div class="grid">
                         <!-- Config -->
                         <div class="space-y-4">
-                            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Style Configuration</div>
-                            <div class="bg-slate-900 rounded p-4 overflow-x-auto">
-                                <pre class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">bibliography</span>:
-  <span class="text-primary">options</span>:
-    <span class="text-primary">sort-partitioning</span>:
-      <span class="text-primary">by</span>: <span class="text-emerald-400">script</span>
-      <span class="text-primary">mode</span>: <span class="text-emerald-400">sort-and-sections</span>
-      <span class="text-primary">headings</span>:
-        <span class="text-primary">Latn</span>:
-          <span class="text-primary">literal</span>: <span class="text-emerald-400">"Western Sources"</span>
-        <span class="text-primary">Arab</span>:
-          <span class="text-primary">literal</span>: <span class="text-emerald-400">"Arabic Sources"</span></pre>
+                            <div class="text-[10px]">Style Configuration</div>
+                            <div class="code-dark">
+                                <pre><span class="token-key">bibliography</span>:
+  <span class="token-value">options</span>:
+    <span class="token-value">sort-partitioning</span>:
+      <span class="token-value">by</span>: <span class="token-string">script</span>
+      <span class="token-value">mode</span>: <span class="token-string">sort-and-sections</span>
+      <span class="token-value">headings</span>:
+        <span class="token-value">Latn</span>:
+          <span class="token-value">literal</span>: <span class="token-string">"Western Sources"</span>
+        <span class="token-value">Arab</span>:
+          <span class="token-value">literal</span>: <span class="token-string">"Arabic Sources"</span></pre>
                             </div>
                         </div>
                         <!-- Mock Output -->
                         <div class="space-y-4">
-                            <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest">Partitioned Output</div>
-                            <div class="bg-white border border-slate-200 rounded p-4 text-xs font-mono text-slate-700 shadow-inner overflow-x-auto h-[220px]">
-                                <div class="font-bold text-slate-400 mb-2"># Western Sources</div>
+                            <div class="text-[10px]">Partitioned Output</div>
+                            <div class="bg-white border text-xs h-[220px]">
+                                <div class="font-bold"># Western Sources</div>
                                 <div class="mb-2">Smith, John. 2024. _First Book_.</div>
                                 <div class="mb-4">———. 2025. _Second Book_.</div>
 
-                                <div class="font-bold text-slate-400 mb-2"># Arabic Sources</div>
+                                <div class="font-bold"># Arabic Sources</div>
                                 <div class="mb-2">محمود, علي. 2023. _الكتاب الأول_.</div>
                                 <div class="mb-2">———. 2024. _الكتاب الثاني_.</div>
                             </div>
-                            <p class="text-[11px] text-slate-500 italic">
+                            <p class="text-[11px] italic">
                                 Subsequent author dashes (———) are automatically reset when entering a new script partition.
                             </p>
                         </div>
@@ -968,89 +827,88 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
             </div>
 
             <!-- Reference Data -->
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Reference Data (YAML)
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">id</span>: genji_tale
-<span class="text-indigo-400">class</span>: monograph
-<span class="text-indigo-400">type</span>: book
-<span class="text-indigo-400">title</span>:
-  <span class="text-primary">original</span>: <span class="text-emerald-400">"源氏物語"</span>
-  <span class="text-primary">lang</span>: <span class="text-emerald-400">"ja"</span>
-  <span class="text-primary">transliterations</span>:
-    <span class="text-primary">ja-Latn-hepburn</span>: <span class="text-emerald-400">"Genji Monogatari"</span>
-  <span class="text-primary">translations</span>:
-    <span class="text-primary">en</span>: <span class="text-emerald-400">"The Tale of Genji"</span>
-<span class="text-indigo-400">author</span>:
-  - <span class="text-primary">original</span>:
-      <span class="text-primary">family</span>: <span class="text-emerald-400">"紫式部"</span>
-      <span class="text-primary">given</span>: <span class="text-emerald-400">""</span>
-    <span class="text-primary">lang</span>: <span class="text-emerald-400">"ja"</span>
-    <span class="text-primary">transliterations</span>:
-      <span class="text-primary">ja-Latn-hepburn</span>:
-        <span class="text-primary">family</span>: <span class="text-emerald-400">"Murasaki"</span>
-        <span class="text-primary">given</span>: <span class="text-emerald-400">"Shikibu"</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"1010"</span>
-<span class="text-indigo-400">publisher</span>:
-  <span class="text-primary">name</span>: <span class="text-emerald-400">"古典文学之友"</span></pre>
+                <div class="code-dark">
+                    <pre>
+<span class="token-key">id</span>: genji_tale
+<span class="token-key">class</span>: monograph
+<span class="token-key">type</span>: book
+<span class="token-key">title</span>:
+  <span class="token-value">original</span>: <span class="token-string">"源氏物語"</span>
+  <span class="token-value">lang</span>: <span class="token-string">"ja"</span>
+  <span class="token-value">transliterations</span>:
+    <span class="token-value">ja-Latn-hepburn</span>: <span class="token-string">"Genji Monogatari"</span>
+  <span class="token-value">translations</span>:
+    <span class="token-value">en</span>: <span class="token-string">"The Tale of Genji"</span>
+<span class="token-key">author</span>:
+  - <span class="token-value">original</span>:
+      <span class="token-value">family</span>: <span class="token-string">"紫式部"</span>
+      <span class="token-value">given</span>: <span class="token-string">""</span>
+    <span class="token-value">lang</span>: <span class="token-string">"ja"</span>
+    <span class="token-value">transliterations</span>:
+      <span class="token-value">ja-Latn-hepburn</span>:
+        <span class="token-value">family</span>: <span class="token-string">"Murasaki"</span>
+        <span class="token-value">given</span>: <span class="token-string">"Shikibu"</span>
+<span class="token-key">issued</span>: <span class="token-string">"1010"</span>
+<span class="token-key">publisher</span>:
+  <span class="token-value">name</span>: <span class="token-string">"古典文学之友"</span></pre>
                 </div>
             </div>
 
             <!-- Rendering Examples -->
             <div>
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+                <div>
+                    <h3>
                         Rendered with MLA
                     </h3>
                 </div>
-                <div class="p-6 bg-[var(--citum-surface)]">
-                    <div class="grid gap-4">
-                        <div class="border border-primary/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                <div class="example-card-body">
+                    <div>
+                        <div class="example-io-panel">
+                            <div class="example-io-label">
                                 Non-Integral Citation
                             </div>
-                            <div class="font-mono text-sm text-slate-900">
+                            <div>
                                 (紫式部)
                             </div>
-                            <div class="text-xs text-slate-500 mt-1">
+                            <div class="text-xs">
                                 Current MLA rendering for the checked-in multilingual record
                             </div>
                         </div>
-                        <div class="border border-emerald-500/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                        <div class="example-io-panel">
+                            <div class="example-io-label">
                                 Integral Citation
                             </div>
-                            <div class="font-mono text-sm text-slate-900">
+                            <div>
                                 紫式部
                             </div>
-                            <div class="text-xs text-slate-500 mt-1">
+                            <div class="text-xs">
                                 Integral rendering uses the same checked-in data
                             </div>
                         </div>
-                        <div class="border border-indigo-500/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                        <div class="example-io-panel">
+                            <div class="example-io-label">
                                 Bibliography Entry
                             </div>
-                            <div class="font-mono text-sm text-slate-900">
+                            <div>
                                 紫式部. _Genji Monogatari_. 古典文学之友, 1010.
                             </div>
-                            <div class="text-xs text-slate-500 mt-1">
-                                Verified with <code class="text-xs bg-slate-100 px-1 rounded">citum render refs -b examples/multilingual-refs.yaml -s mla -k genji_tale</code>
+                            <div class="text-xs">
+                                Verified with <code>citum render refs -b examples/multilingual-refs.yaml -s mla -k genji_tale</code>
                             </div>
                         </div>
-                        <div class="border border-amber-500/30 rounded-lg p-4">
-                            <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                        <div class="example-io-panel">
+                            <div class="example-io-label">
                                 Mixed Corpus
                             </div>
-                            <div class="font-mono text-sm text-slate-900">
+                            <div>
                                 Çelik, Zeynep. _Streets: critical perspectives on public space_. University of California Press, 1996.
                             </div>
-                            <div class="text-xs text-slate-500 mt-1">
+                            <div class="text-xs">
                                 Plain English, multilingual, and accented Latin-script records can coexist in the same bibliography input
                             </div>
                         </div>
@@ -1059,139 +917,133 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
             </div>
 
             <!-- Try It Yourself -->
-            <div class="bg-[var(--citum-surface)] p-6 border-t border-slate-200">
-                <div class="flex items-center gap-2 mb-4">
-                    <span class="material-icons text-sm text-emerald-600">terminal</span>
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="bg-[var(--citum-surface)] border-t">
+                <div class="flex">
+                    <h3>
                         Try It Yourself
                     </h3>
                 </div>
-                <div class="border border-emerald-500/30 rounded-lg p-4 mb-3">
-                    <p class="text-xs text-slate-600 mb-2">
+                <div>
+                    <p class="text-xs">
                         Render the checked-in multilingual bibliography with a builtin style:
                     </p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+                    <div class="code-dark">
+                        <pre><span class="token-string">citum</span> render refs \
   -b examples/multilingual-refs.yaml \
   -s mla</pre>
                     </div>
-                    <p class="text-xs text-slate-500 mt-2">
+                    <p class="text-xs">
                         For style-authoring work, compare this data with a style that sets different
-                        <code class="text-xs bg-slate-200 px-1 rounded">options.multilingual</code> values.
+                        <code>options.multilingual</code> values.
                     </p>
                 </div>
-                <div class="border border-indigo-500/30 rounded-lg p-4 mb-3">
-                    <p class="text-xs text-slate-600 mb-2">
+                <div class="border border-indigo-500/30-lg">
+                    <p class="text-xs">
                         Render the script-partitioned bibliography example:
                     </p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+                    <div class="code-dark">
+                        <pre><span class="token-string">citum</span> render refs \
   -b examples/multilingual-refs.yaml \
   -s styles/experimental/multilingual-partitioned.yaml</pre>
                     </div>
-                    <p class="text-xs text-slate-500 mt-2">
-                        This style demonstrates <code class="text-xs bg-slate-200 px-1 rounded">sort-partitioning</code>
+                    <p class="text-xs">
+                        This style demonstrates <code>sort-partitioning</code>
                         by script, which separates Latin and Non-Latin records into distinct sections with reset subsequent-author substitutions.
                     </p>
                 </div>
-                <div class="border border-primary/30 rounded-lg p-4">
-                    <p class="text-xs text-slate-600 mb-2">
+                <div class="example-io-panel">
+                    <p class="text-xs">
                         Render the shipped German Chicago locale-override example:
                     </p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-slate-300"><span class="text-emerald-400">citum</span> render refs \
+                    <div class="code-dark">
+                        <pre><span class="token-string">citum</span> render refs \
   -b tests/fixtures/references-expanded.json \
   -s examples/preset-chicago-de.yaml</pre>
                     </div>
-                    <p class="text-xs text-slate-500 mt-2">
+                    <p class="text-xs">
                         This example keeps Chicago Author-Date as the base style while switching to the shipped
-                        <code class="text-xs bg-slate-200 px-1 rounded">de-DE-chicago</code> locale override.
+                        <code>de-DE-chicago</code> locale override.
                     </p>
                 </div>
             </div>
         </article>
 
         <!-- Advanced Dates -->
-        <article id="advanced-dates" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">event</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="advanced-dates" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Advanced Dates
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Citum supports native <strong class="text-slate-900">EDTF (Extended Date/Time Format)</strong>
                     for handling complex historical ranges, uncertain or approximate dates,
                     and seasons.
                 </p>
-                <p class="text-slate-600 leading-relaxed mt-3">
+                <p class="text-slate-600">
                     Historical EDTF years use astronomical numbering, so
-                    <code class="text-xs bg-slate-100 px-1 rounded">-0099</code> means
-                    <code class="text-xs bg-slate-100 px-1 rounded">100 BC</code>.
+                    <code>-0099</code> means
+                    <code>100 BC</code>.
                 </p>
             </div>
 
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="grid gap-8">
+            <div class="example-card-body">
+                <div class="grid">
                     <!-- Date Ranges -->
-                    <div class="border border-primary/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Date Intervals (Level 0)</div>
-                        <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Date Intervals (Level 0)</div>
+                        <div class="code-dark">
                             <pre
-                                class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2023-05/2024-06"</span>  <span class="text-slate-500"># Closed interval</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2023-05/.."</span>        <span class="text-slate-500"># Open start</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"../2023-05"</span>        <span class="text-slate-500"># Open end</span></pre>
+                                class="font-mono text-xs"><span class="token-key">issued</span>: <span class="token-string">"2023-05/2024-06"</span>  <span class="token-comment"># Closed interval</span>
+<span class="token-key">issued</span>: <span class="token-string">"2023-05/.."</span>        <span class="token-comment"># Open start</span>
+<span class="token-key">issued</span>: <span class="token-string">"../2023-05"</span>        <span class="token-comment"># Open end</span></pre>
                         </div>
                     </div>
 
                     <!-- Uncertain & Approximate -->
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Uncertain & Approximate (Level
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Uncertain & Approximate (Level
                             1)</div>
-                        <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
+                        <div class="code-dark">
                             <pre
-                                class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2004?"</span>              <span class="text-slate-500"># Uncertain year (2004?)</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2004~"</span>              <span class="text-slate-500"># Approximate year (ca. 2004)</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2004%"</span>              <span class="text-slate-500"># Uncertain & approximate</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2004-06-11?"</span>        <span class="text-slate-500"># Uncertain day only</span></pre>
+                                class="font-mono text-xs"><span class="token-key">issued</span>: <span class="token-string">"2004?"</span>              <span class="token-comment"># Uncertain year (2004?)</span>
+<span class="token-key">issued</span>: <span class="token-string">"2004~"</span>              <span class="token-comment"># Approximate year (ca. 2004)</span>
+<span class="token-key">issued</span>: <span class="token-string">"2004%"</span>              <span class="token-comment"># Uncertain & approximate</span>
+<span class="token-key">issued</span>: <span class="token-string">"2004-06-11?"</span>        <span class="token-comment"># Uncertain day only</span></pre>
                         </div>
                     </div>
 
                     <!-- Seasons -->
-                    <div class="border border-indigo-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Seasons (Level 1)</div>
-                        <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Seasons (Level 1)</div>
+                        <div class="code-dark">
                             <pre
-                                class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2023-21"</span>           <span class="text-slate-500"># Spring 2023</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2023-22"</span>           <span class="text-slate-500"># Summer 2023</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2023-23"</span>           <span class="text-slate-500"># Autumn 2023</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2023-24"</span>           <span class="text-slate-500"># Winter 2023</span></pre>
+                                class="font-mono text-xs"><span class="token-key">issued</span>: <span class="token-string">"2023-21"</span>           <span class="token-comment"># Spring 2023</span>
+<span class="token-key">issued</span>: <span class="token-string">"2023-22"</span>           <span class="token-comment"># Summer 2023</span>
+<span class="token-key">issued</span>: <span class="token-string">"2023-23"</span>           <span class="token-comment"># Autumn 2023</span>
+<span class="token-key">issued</span>: <span class="token-string">"2023-24"</span>           <span class="token-comment"># Winter 2023</span></pre>
                         </div>
                     </div>
 
                     <!-- Unspecified Digits -->
-                    <div class="border border-rose-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Unspecified Digits (Level 1)
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Unspecified Digits (Level 1)
                         </div>
-                        <div class="bg-slate-900 rounded p-4 overflow-x-auto mt-1">
+                        <div class="code-dark">
                             <pre
-                                class="font-mono text-xs text-slate-300 leading-relaxed"><span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"199u"</span>              <span class="text-slate-500"># Some time in the 1990s</span>
-<span class="text-indigo-400">issued</span>: <span class="text-emerald-400">"2004-uu-uu"</span>        <span class="text-slate-500"># Some time in 2004 (month/day unknown)</span></pre>
+                                class="font-mono text-xs"><span class="token-key">issued</span>: <span class="token-string">"199u"</span>              <span class="token-comment"># Some time in the 1990s</span>
+<span class="token-key">issued</span>: <span class="token-string">"2004-uu-uu"</span>        <span class="token-comment"># Some time in 2004 (month/day unknown)</span></pre>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="bg-slate-50 p-6 border-t border-slate-200">
-                <div class="flex items-start gap-3">
+            <div class="bg-slate-50 border-t">
+                <div class="flex items-start">
                     <div
-                        class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center text-primary flex-shrink-0 mt-1">
-                        <span class="material-icons text-sm">history_edu</span>
-                    </div>
-                    <div class="text-sm text-slate-600 leading-relaxed">
+                        class="w-8-lg-shrink-0">
+                        </div>
+                    <div>
                         <strong class="text-slate-900">Fidelity First:</strong>
                         Unlike CSL 1.0's structured date objects, Citum uses EDTF strings as the primary exchange format,
                         ensuring that semantic nuances like "approximate" or "unspecified" are preserved and can be
@@ -1202,107 +1054,103 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
         </article>
 
         <!-- Options-Level Presets -->
-        <article id="options-presets" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">tune</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="options-presets" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Options Presets &amp; Style Inheritance
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Common configuration patterns for contributors, dates,
                     and titles can be expressed as a single preset name
                     instead of spelling out every field. At the style level,
-                    <code class="text-xs bg-slate-100 px-1 rounded">extends:</code>
+                    <code>extends:</code>
                     lets a thin wrapper inherit all templates from a named
                     base style, then tune shared behavior through the same
                     scoped configuration blocks as any other style:
-                    <code class="text-xs bg-slate-100 px-1 rounded">options.*</code>,
-                    <code class="text-xs bg-slate-100 px-1 rounded">citation.options.*</code>,
+                    <code>options.*</code>,
+                    <code>citation.options.*</code>,
                     and
-                    <code class="text-xs bg-slate-100 px-1 rounded">bibliography.options.*</code>.
+                    <code>bibliography.options.*</code>.
                 </p>
             </div>
-            <div class="bg-slate-900 p-6 overflow-x-auto">
-                <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-slate-500"># Named presets replace verbose config blocks</span>
-<span class="text-indigo-400">options</span>:
-  <span class="text-primary">contributors</span>:            <span class="text-slate-500"># Explicit config (verbose)</span>
-    <span class="text-primary">display-as-sort</span>: <span class="text-emerald-400">all</span>
-    <span class="text-primary">initialize-with</span>: <span class="text-emerald-400">". "</span>
-    <span class="text-primary">delimiter</span>: <span class="text-emerald-400">", "</span>
-    <span class="text-primary">and</span>: <span class="text-emerald-400">symbol</span>
-  <span class="text-primary">dates</span>: <span class="text-emerald-400">long</span>              <span class="text-slate-500"># Preset shorthand</span>
-  <span class="text-primary">titles</span>: <span class="text-emerald-400">apa</span>             <span class="text-slate-500"># Preset shorthand</span>
+            <div class="code-dark">
+                <pre>
+<span class="token-comment"># Named presets replace verbose config blocks</span>
+<span class="token-key">options</span>:
+  <span class="token-value">contributors</span>:            <span class="token-comment"># Explicit config (verbose)</span>
+    <span class="token-value">display-as-sort</span>: <span class="token-string">all</span>
+    <span class="token-value">initialize-with</span>: <span class="token-string">". "</span>
+    <span class="token-value">delimiter</span>: <span class="token-string">", "</span>
+    <span class="token-value">and</span>: <span class="token-string">symbol</span>
+  <span class="token-value">dates</span>: <span class="token-string">long</span>              <span class="token-comment"># Preset shorthand</span>
+  <span class="token-value">titles</span>: <span class="token-string">apa</span>             <span class="token-comment"># Preset shorthand</span>
 
-<span class="text-slate-500"># Available presets:</span>
-<span class="text-slate-500">#   contributors: apa | chicago | harvard | ieee | springer | vancouver | numeric-compact | numeric-medium</span>
-<span class="text-slate-500">#   dates:        long | short | numeric | iso</span>
-<span class="text-slate-500">#   titles:       apa | chicago | humanities | ieee | journal-emphasis | scientific</span>
-<span class="text-slate-500">#   substitute:   standard | editor-* | editor-translator-* | editor-title-* | editor-translator-title-*</span>
-<span class="text-slate-500">#   citation:     extends: numeric-citation</span></pre>
+<span class="token-comment"># Available presets:</span>
+<span class="token-comment">#   contributors: apa | chicago | harvard | ieee | springer | vancouver | numeric-compact | numeric-medium</span>
+<span class="token-comment">#   dates:        long | short | numeric | iso</span>
+<span class="token-comment">#   titles:       apa | chicago | humanities | ieee | journal-emphasis | scientific</span>
+<span class="token-comment">#   substitute:   standard | editor-* | editor-translator-* | editor-title-* | editor-translator-title-*</span>
+<span class="token-comment">#   citation:     extends: numeric-citation</span></pre>
             </div>
-            <div class="border-t border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="border-t">
+                <div>
+                    <h3>
                         Style Inheritance
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-slate-500"># Inherit all templates from a named base; add only metadata</span>
-<span class="text-indigo-400">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span></pre>
+                <div class="code-dark">
+                    <pre>
+<span class="token-comment"># Inherit all templates from a named base; add only metadata</span>
+<span class="token-key">extends</span>: <span class="token-string">springer-basic-author-date-core</span></pre>
                 </div>
             </div>
-            <div class="border-t border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="border-t">
+                <div>
+                    <h3>
                         Scoped Options
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-slate-500"># Style-wide option: choose a contributor preset without touching templates</span>
-<span class="text-indigo-400">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span>
-<span class="text-indigo-400">options</span>:
-  <span class="text-primary">contributors</span>: <span class="text-emerald-400">springer</span>
-<span class="text-indigo-400">bibliography</span>:
-  <span class="text-primary">options</span>:
-    <span class="text-primary">date-position</span>: <span class="text-emerald-400">after-author</span>
+                <div class="code-dark">
+                    <pre>
+<span class="token-comment"># Style-wide option: choose a contributor preset without touching templates</span>
+<span class="token-key">extends</span>: <span class="token-string">springer-basic-author-date-core</span>
+<span class="token-key">options</span>:
+  <span class="token-value">contributors</span>: <span class="token-string">springer</span>
+<span class="token-key">bibliography</span>:
+  <span class="token-value">options</span>:
+    <span class="token-value">date-position</span>: <span class="token-string">after-author</span>
 
-<span class="text-slate-500"># Citation-scoped and bibliography-scoped options</span>
-<span class="text-indigo-400">extends</span>: <span class="text-emerald-400">elsevier-vancouver-core</span>
-<span class="text-indigo-400">citation</span>:
-  <span class="text-primary">options</span>:
-    <span class="text-primary">label-wrap</span>: <span class="text-emerald-400">brackets</span>
-<span class="text-indigo-400">bibliography</span>:
-  <span class="text-primary">options</span>:
-    <span class="text-primary">label-mode</span>: <span class="text-emerald-400">numeric</span>
+<span class="token-comment"># Citation-scoped and bibliography-scoped options</span>
+<span class="token-key">extends</span>: <span class="token-string">elsevier-vancouver-core</span>
+<span class="token-key">citation</span>:
+  <span class="token-value">options</span>:
+    <span class="token-value">label-wrap</span>: <span class="token-string">brackets</span>
+<span class="token-key">bibliography</span>:
+  <span class="token-value">options</span>:
+    <span class="token-value">label-mode</span>: <span class="token-string">numeric</span>
 
-<span class="text-slate-500"># Use `options.*` for style-wide settings and nested `*.options.*` for scoped settings.</span>
-<span class="text-slate-500"># Supported fields here include: contributors | label-wrap | label-mode | date-position</span></pre>
+<span class="token-comment"># Use `options.*` for style-wide settings and nested `*.options.*` for scoped settings.</span>
+<span class="token-comment"># Supported fields here include: contributors | label-wrap | label-mode | date-position</span></pre>
                 </div>
             </div>
-            <div class="bg-[var(--citum-surface)] p-6 border-t border-slate-200">
-                <div class="grid gap-4">
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+            <div class="bg-[var(--citum-surface)] border-t">
+                <div>
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Author-Date Inheritance
                         </div>
-                        <div class="text-sm text-slate-700">
-                            <code class="text-xs bg-slate-100 px-1 rounded">styles/embedded/springer-basic-author-date.yaml</code>
+                        <div>
+                            <code>styles/embedded/springer-basic-author-date.yaml</code>
                             inherits Springer's author-date base and sets name and date axes.
                         </div>
                     </div>
-                    <div class="border border-primary/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Numeric Inheritance
                         </div>
-                        <div class="text-sm text-slate-700">
-                            <code class="text-xs bg-slate-100 px-1 rounded">styles/embedded/elsevier-vancouver.yaml</code>
+                        <div>
+                            <code>styles/embedded/elsevier-vancouver.yaml</code>
                             inherits Elsevier Vancouver and configures bracket + numeric labels.
                         </div>
                     </div>
@@ -1311,17 +1159,13 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
         </article>
 
         <!-- Title Formatting & Declarative Links -->
-        <article id="titles-links" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">title</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="titles-links" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Titles & Links
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Citum separates title content from its role (primary,
                     parent-monograph, parent-serial) and uses declarative
                     global formatting rules for consistency across item
@@ -1329,175 +1173,166 @@ Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of th
                 </p>
             </div>
 
-            <div class="grid md:grid-cols-2 border-b border-slate-200">
-                <div class="border-r border-slate-200">
-                    <div class="px-8 py-4 bg-slate-100">
-                        <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="grid border-b">
+                <div class="border-r">
+                    <div>
+                        <h3>
                             Global Formatting (options.titles)
                         </h3>
                     </div>
-                    <div class="bg-slate-900 p-6 h-full">
-                        <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">titles</span>:
-  <span class="text-primary">monograph</span>:
-    <span class="text-primary">emph</span>: <span class="text-emerald-400">true</span>      <span class="text-slate-500"># Italics for books</span>
-  <span class="text-primary">periodical</span>:
-    <span class="text-primary">emph</span>: <span class="text-emerald-400">true</span>      <span class="text-slate-500"># Italics for journals</span>
-  <span class="text-primary">component</span>:
-    <span class="text-primary">emph</span>: <span class="text-emerald-400">false</span>     <span class="text-slate-500"># Plain for articles</span></pre>
+                    <div class="code-dark">
+                        <pre>
+<span class="token-key">titles</span>:
+  <span class="token-value">monograph</span>:
+    <span class="token-value">emph</span>: <span class="token-string">true</span>      <span class="token-comment"># Italics for books</span>
+  <span class="token-value">periodical</span>:
+    <span class="token-value">emph</span>: <span class="token-string">true</span>      <span class="token-comment"># Italics for journals</span>
+  <span class="token-value">component</span>:
+    <span class="token-value">emph</span>: <span class="token-string">false</span>     <span class="token-comment"># Plain for articles</span></pre>
                     </div>
                 </div>
                 <div>
-                    <div class="px-8 py-4 bg-slate-100">
-                        <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+                    <div>
+                        <h3>
                             Template Usage & Links
                         </h3>
                     </div>
-                    <div class="bg-slate-900 p-6 h-full">
-                        <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">template</span>:
-  - <span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
-    <span class="text-primary">links</span>:
-      <span class="text-primary">target</span>: <span class="text-emerald-400">doi</span>
-      <span class="text-primary">anchor</span>: <span class="text-emerald-400">component</span>
-  - <span class="text-primary">title</span>: <span class="text-emerald-400">parent-serial</span>
-    <span class="text-primary">suffix</span>: <span class="text-emerald-400">","</span></pre>
+                    <div class="code-dark">
+                        <pre>
+<span class="token-key">template</span>:
+  - <span class="token-value">title</span>: <span class="token-string">primary</span>
+    <span class="token-value">links</span>:
+      <span class="token-value">target</span>: <span class="token-string">doi</span>
+      <span class="token-value">anchor</span>: <span class="token-string">component</span>
+  - <span class="token-value">title</span>: <span class="token-string">parent-serial</span>
+    <span class="token-value">suffix</span>: <span class="token-string">","</span></pre>
                     </div>
                 </div>
             </div>
         </article>
 
         <!-- Type Variants -->
-        <article id="overrides" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">settings_input_component</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="overrides" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Type Variants
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     When reference types need a completely different component layout,
-                    declare a <code class="font-mono bg-slate-100 px-1 rounded text-slate-900">type-variants</code>
+                    declare a <code class="font-mono">type-variants</code>
                     map. Each entry replaces the default template for matching types.
                     Use a comma-separated selector to share one template across multiple types.
                 </p>
             </div>
-            <div class="bg-slate-900 p-6 overflow-x-auto">
-                <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-indigo-400">bibliography</span>:
-  <span class="text-primary">template</span>:              <span class="text-slate-500"># default for all other types</span>
-    - <span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
-    - <span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
-    - <span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
-    - <span class="text-primary">variable</span>: <span class="text-emerald-400">publisher</span>
+            <div class="code-dark">
+                <pre>
+<span class="token-key">bibliography</span>:
+  <span class="token-value">template</span>:              <span class="token-comment"># default for all other types</span>
+    - <span class="token-value">contributor</span>: <span class="token-string">author</span>
+    - <span class="token-value">date</span>: <span class="token-string">issued</span>
+    - <span class="token-value">title</span>: <span class="token-string">primary</span>
+    - <span class="token-value">variable</span>: <span class="token-string">publisher</span>
 
-  <span class="text-primary">type-variants</span>:
-    <span class="text-emerald-400">article-journal</span>:      <span class="text-slate-500"># single type</span>
-      - <span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
-      - <span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
-      - <span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
-      - <span class="text-primary">title</span>: <span class="text-emerald-400">parent-serial</span>
-        <span class="text-primary">emph</span>: <span class="text-emerald-400">true</span>
+  <span class="token-value">type-variants</span>:
+    <span class="token-string">article-journal</span>:      <span class="token-comment"># single type</span>
+      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
+      - <span class="token-value">date</span>: <span class="token-string">issued</span>
+      - <span class="token-value">title</span>: <span class="token-string">primary</span>
+      - <span class="token-value">title</span>: <span class="token-string">parent-serial</span>
+        <span class="token-value">emph</span>: <span class="token-string">true</span>
 
-    <span class="text-emerald-400">book, report</span>:         <span class="text-slate-500"># comma-separated: share one template</span>
-      - <span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
-      - <span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
-      - <span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
-        <span class="text-primary">emph</span>: <span class="text-emerald-400">true</span>
-      - <span class="text-primary">variable</span>: <span class="text-emerald-400">publisher</span></pre>
+    <span class="token-string">book, report</span>:         <span class="token-comment"># comma-separated: share one template</span>
+      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
+      - <span class="token-value">date</span>: <span class="token-string">issued</span>
+      - <span class="token-value">title</span>: <span class="token-string">primary</span>
+        <span class="token-value">emph</span>: <span class="token-string">true</span>
+      - <span class="token-value">variable</span>: <span class="token-string">publisher</span></pre>
             </div>
         </article>
 
         <!-- Output Formats -->
-        <article id="output-formats" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">html</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="output-formats" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Pluggable Output Formats
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Citum supports multiple output formats with a pluggable
                     architecture. Generate semantic HTML, native LaTeX, flexible Djot for
                     static site generators, native Typst markup, or clean Plain Text.
                 </p>
             </div>
 
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="grid gap-6">
+            <div class="example-card-body">
+                <div>
                     <!-- Plain Text -->
-                    <div class="border border-slate-300/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div>
+                        <div class="example-io-label">
                             Plain Text (-f plain)
                         </div>
-                        <div class="font-mono text-sm text-slate-900">
+                        <div>
                             Smith, J. A. (2023). The Future of Citations.
                             Academic Press.
                         </div>
                     </div>
 
                     <!-- LaTeX -->
-                    <div class="border border-indigo-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Native LaTeX (-f latex)
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">
+                        <div class="code-dark">
+                            <pre>
 Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
                         </div>
                     </div>
 
                     <!-- HTML -->
-                    <div class="border border-primary/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Semantic HTML (-f html)
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">
-&lt;<span class="text-indigo-400">span</span> <span class="text-primary">class</span>=<span class="text-emerald-400">"citum-entry"</span>&gt;
-  &lt;<span class="text-indigo-400">span</span> <span class="text-primary">class</span>=<span class="text-emerald-400">"citum-author"</span>&gt;Smith, J. A.&lt;/<span class="text-indigo-400">span</span>&gt; (2023).
-  &lt;<span class="text-indigo-400">i</span> <span class="text-primary">class</span>=<span class="text-emerald-400">"citum-title"</span>&gt;The Future of Citations&lt;/<span class="text-indigo-400">i</span>&gt;. Academic Press.
-&lt;/<span class="text-indigo-400">span</span>&gt;</pre>
+                        <div class="code-dark">
+                            <pre>
+&lt;<span class="token-key">span</span> <span class="token-value">class</span>=<span class="token-string">"citum-entry"</span>&gt;
+  &lt;<span class="token-key">span</span> <span class="token-value">class</span>=<span class="token-string">"citum-author"</span>&gt;Smith, J. A.&lt;/<span class="token-key">span</span>&gt; (2023).
+  &lt;<span class="token-key">i</span> <span class="token-value">class</span>=<span class="token-string">"citum-title"</span>&gt;The Future of Citations&lt;/<span class="token-key">i</span>&gt;. Academic Press.
+&lt;/<span class="token-key">span</span>&gt;</pre>
                         </div>
                     </div>
 
                     <!-- Djot -->
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">
                             Djot (-f djot)
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">
-[Smith, J. A.]<span class="text-primary">{.citum-author}</span> (2023). _The Future of Citations_<span class="text-primary">{.citum-title}</span>. Academic Press.</pre>
+                        <div class="code-dark">
+                            <pre>
+[Smith, J. A.]<span class="token-value">{.citum-author}</span> (2023). _The Future of Citations_<span class="token-value">{.citum-title}</span>. Academic Press.</pre>
                         </div>
                     </div>
 
                     <!-- Typst -->
-                    <div class="border border-sky-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div class="border border-sky-500/30-lg">
+                        <div class="example-io-label">
                             Typst Markup (-f typst)
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">
+                        <div class="code-dark">
+                            <pre>
 Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith2023&gt;</pre>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="bg-slate-50 p-6 border-t border-slate-200">
-                <div class="flex items-start gap-3">
+            <div class="bg-slate-50 border-t">
+                <div class="flex items-start">
                     <div
-                        class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center text-primary flex-shrink-0 mt-1">
-                        <span class="material-icons text-sm">rocket_launch</span>
-                    </div>
-                    <div class="text-sm text-slate-600 leading-relaxed">
+                        class="w-8-lg-shrink-0">
+                        </div>
+                    <div>
                         <strong class="text-slate-900">Consistent Rendering:</strong>
                         The pluggable renderer system ensures that complex CSL rules (sorting, disambiguation, name
                         formatting) are applied identically regardless of the output target. LaTeX and Typst support include
@@ -1509,24 +1344,23 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
         </article>
 
         <!-- Typst PDF Publishing -->
-        <article id="typst-pdf-publishing" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-sky-100 flex items-center justify-center text-sky-700">
-                        <span class="material-icons">picture_as_pdf</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="typst-pdf-publishing" class="example-card">
+            <div class="example-card-header">
+                <div class="flex">
+                    <div class="w-10-lg bg-sky-100 text-sky-700">
+                        </div>
+                    <h2>
                         Typst PDF Publishing
-                        <span class="text-xs font-normal ml-2 bg-sky-100 text-sky-700 px-2 py-0.5 rounded-full align-middle">Native Rust path</span>
+                        <span class="text-xs font-normal bg-sky-100 text-sky-700.5-full align-middle">Native Rust path</span>
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Citum now supports a native Typst workflow for PDF publishing. The Rust engine renders citations,
                     notes, and bibliography entries to Typst markup, then the CLI can compile that markup to PDF in
-                    process with the optional <code class="text-xs bg-slate-200 px-1 rounded">typst-pdf</code> feature.
+                    process with the optional <code>typst-pdf</code> feature.
                     This keeps citation logic in Citum while giving you a modern PDF toolchain without a TeX or FFI step.
                 </p>
-                <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300 leading-relaxed">
+                <div class="code-dark">
                     <pre>.djot + refs.json + style.yaml
   └─► citum render doc -f typst
          └─► Typst markup (.typ)
@@ -1535,37 +1369,35 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                 </div>
             </div>
 
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         CLI Workflow
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-slate-500"># 1. Render Typst markup</span>
-<span class="text-primary">$</span> citum render doc examples/document.djot -b examples/document-refs.json -s mla -f typst
+                <div class="code-dark">
+                    <pre>
+<span class="token-comment"># 1. Render Typst markup</span>
+<span class="token-value">$</span> citum render doc examples/document.djot -b examples/document-refs.json -s mla -f typst
 
-<span class="text-slate-500"># 2. Compile directly to PDF</span>
-<span class="text-primary">$</span> cargo run -p citum --features typst-pdf -- render doc examples/document.djot -b examples/document-refs.json -s mla -f typst --pdf -o paper.pdf</pre>
+<span class="token-comment"># 2. Compile directly to PDF</span>
+<span class="token-value">$</span> cargo run -p citum --features typst-pdf -- render doc examples/document.djot -b examples/document-refs.json -s mla -f typst --pdf -o paper.pdf</pre>
                 </div>
             </div>
 
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         What This Gives You
                     </h3>
                 </div>
                 <div class="p-8 bg-[var(--citum-surface)]">
-                    <div class="grid md:grid-cols-2 gap-6 text-sm text-slate-600 leading-relaxed">
-                        <div class="rounded-lg border border-slate-200 bg-slate-50 p-5">
-                            <h4 class="font-bold text-slate-900 mb-2">Citum remains the citation formatter</h4>
+                    <div class="grid text-sm">
+                        <div class="rounded-lg border">
+                            <h4 class="font-bold">Citum remains the citation formatter</h4>
                             Citum still handles citation formatting, bibliography grouping, note behavior, and link
                             resolution. Typst is the markup and PDF backend, not the bibliography engine.
                         </div>
-                        <div class="rounded-lg border border-slate-200 bg-slate-50 p-5">
-                            <h4 class="font-bold text-slate-900 mb-2">Practical PDF interactivity</h4>
+                        <div class="rounded-lg border">
+                            <h4 class="font-bold">Practical PDF interactivity</h4>
                             Generated PDFs include internal citation-to-bibliography links and external DOI/URL links.
                             Advanced hover-only behaviors and custom metadata popups are not currently part of the Typst path.
                         </div>
@@ -1573,42 +1405,37 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
                 </div>
             </div>
 
-            <div class="bg-slate-50 p-6 border-t border-slate-200">
-                <div class="flex items-start gap-3">
+            <div class="bg-slate-50 border-t">
+                <div class="flex items-start">
                     <div
-                        class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center text-primary flex-shrink-0 mt-1">
-                        <span class="material-icons text-sm">compare</span>
-                    </div>
-                    <div class="text-sm text-slate-600 leading-relaxed">
+                        class="w-8-lg-shrink-0">
+                        </div>
+                    <div>
                         <strong class="text-slate-900">Positioning:</strong>
                         Use Typst when you want a pure Rust markup-to-PDF workflow driven by the CLI. The
                         LuaLaTeX example below remains useful for TeX-native documents and direct
-                        <code class="text-xs bg-slate-200 px-1 rounded">\cite{...}</code> integration.
+                        <code>\cite{...}</code> integration.
                     </div>
                 </div>
             </div>
         </article>
 
         <!-- LuaLaTeX Integration -->
-        <article id="lualatex-integration" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">integration_instructions</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="lualatex-integration" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         LuaLaTeX Integration
-                        <span class="text-xs font-normal ml-2 bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full align-middle">Proof-of-concept</span>
+                        <span class="text-xs font-normal bg-amber-100 text-amber-700.5-full align-middle">Proof-of-concept</span>
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     A single-pass LuaLaTeX citation workflow backed by the Citum Rust processor via C-FFI.
-                    No Biber, no <code class="text-xs bg-slate-200 px-1 rounded">.bbl</code> file, no
+                    No Biber, no <code>.bbl</code> file, no
                     external bibliography step. The processor runs inline during compilation via LuaJIT FFI,
                     and all Citum output rules (disambiguation, name formatting, et-al) apply identically.
                     If you want a pure Rust PDF path instead, see the Typst example above.
                 </p>
-                <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300 leading-relaxed">
+                <div class="code-dark">
                     <pre>.tex \cite{key}
   └─► \directlua ──► citum-cli.lua (LuaJIT FFI) ──► libcsln_processor (Rust)
                                                        │
@@ -1617,60 +1444,57 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
             </div>
 
             <!-- Usage -->
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Package Usage (citum-cli.sty)
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-slate-500">% Load with your YAML style and bibliography</span>
-\usepackage[style=<span class="text-emerald-400">styles/apa-7th.yaml</span>,bibfile=<span class="text-emerald-400">refs.yaml</span>]{citum-cli}
+                <div class="code-dark">
+                    <pre>
+<span class="token-comment">% Load with your YAML style and bibliography</span>
+\usepackage[style=<span class="token-string">styles/apa-7th.yaml</span>,bibfile=<span class="token-string">refs.yaml</span>]{citum-cli}
 
-<span class="text-slate-500">% Non-integral (parenthetical)</span>
-\cite[p.~10]{<span class="text-emerald-400">kuhn1962</span>}               <span class="text-slate-500">% → (Kuhn, 1962, p. 10)</span>
+<span class="token-comment">% Non-integral (parenthetical)</span>
+\cite[p.~10]{<span class="token-string">kuhn1962</span>}               <span class="token-comment">% → (Kuhn, 1962, p. 10)</span>
 
-<span class="text-slate-500">% Integral (narrative)</span>
-\textcite{<span class="text-emerald-400">weinberg1971</span>}              <span class="text-slate-500">% → Weinberg and Freedman (1971)</span>
+<span class="token-comment">% Integral (narrative)</span>
+\textcite{<span class="token-string">weinberg1971</span>}              <span class="token-comment">% → Weinberg and Freedman (1971)</span>
 
-<span class="text-slate-500">% Multi-key parenthetical</span>
-\cites{<span class="text-emerald-400">kuhn1962, watson1953</span>}          <span class="text-slate-500">% → (Kuhn, 1962; Watson &amp; Crick, 1953)</span>
+<span class="token-comment">% Multi-key parenthetical</span>
+\cites{<span class="token-string">kuhn1962, watson1953</span>}          <span class="token-comment">% → (Kuhn, 1962; Watson &amp; Crick, 1953)</span>
 
-<span class="text-slate-500">% Print bibliography</span>
+<span class="token-comment">% Print bibliography</span>
 \printbibliography</pre>
                 </div>
             </div>
 
             <!-- Build -->
-            <div class="border-b border-slate-200">
-                <div class="px-8 py-4 bg-slate-100">
-                    <h3 class="text-sm font-semibold text-slate-700 uppercase tracking-wide">
+            <div class="example-subsection"><div class="example-subsection-header">
+                    <h3>
                         Build Instructions
                     </h3>
                 </div>
-                <div class="bg-slate-900 p-6 overflow-x-auto">
-                    <pre class="font-mono text-sm text-slate-300 leading-relaxed">
-<span class="text-slate-500"># 1. Build the shared library</span>
-<span class="text-primary">$</span> cargo build -p citum_engine --release --features ffi
+                <div class="code-dark">
+                    <pre>
+<span class="token-comment"># 1. Build the shared library</span>
+<span class="token-value">$</span> cargo build -p citum_engine --release --features ffi
 
-<span class="text-slate-500"># 2. Compile your document</span>
-<span class="text-primary">$</span> CITUM_LIB=$(pwd)/target/release lualatex --shell-escape paper.tex</pre>
+<span class="token-comment"># 2. Compile your document</span>
+<span class="token-value">$</span> CITUM_LIB=$(pwd)/target/release lualatex --shell-escape paper.tex</pre>
                 </div>
             </div>
 
-            <div class="bg-slate-50 p-6 border-t border-slate-200">
-                <div class="flex items-start gap-3">
+            <div class="bg-slate-50 border-t">
+                <div class="flex items-start">
                     <div
-                        class="w-8 h-8 rounded-lg bg-amber-100 flex items-center justify-center text-amber-600 flex-shrink-0 mt-1">
-                        <span class="material-icons text-sm">science</span>
-                    </div>
-                    <div class="text-sm text-slate-600 leading-relaxed">
+                        class="w-8-lg bg-amber-100 text-amber-600-shrink-0">
+                        </div>
+                    <div>
                         <strong class="text-slate-900">Proof-of-concept status:</strong>
                         Currently targets macOS and Linux. A full working example document is available in
                         <a href="https://github.com/citum/citum-labs/tree/main/bindings/latex"
-                            class="text-primary hover:underline">bindings/latex/</a>.
-                        The <code class="text-xs bg-slate-200 px-1 rounded">&amp;</code> conjunction in
+                            class="text-primary">bindings/latex/</a>.
+                        The <code>&amp;</code> conjunction in
                         two-author citations is correctly escaped for LuaLaTeX output.
                     </div>
                 </div>
@@ -1678,46 +1502,42 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
         </article>
 
         <!-- Binary Performance -->
-        <article id="binary-performance" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">speed</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="binary-performance" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Binary Performance (CBOR)
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     For production environments, Citum styles and
                     bibliographies can be compiled into binary CBOR (Concise
                     Binary Object Representation) for near-instant loading.
                 </p>
             </div>
             <div class="p-8 bg-[var(--citum-surface)]">
-                <div class="grid md:grid-cols-2 gap-8">
+                <div class="grid">
                     <div>
-                        <h4 class="font-bold text-slate-900 mb-3 text-sm uppercase tracking-wider">
+                        <h4 class="font-bold text-sm">
                             Compilation
                         </h4>
-                        <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300">
-                            <span class="text-primary">$</span> citum convert style
+                        <div class="code-dark">
+                            <span class="token-value">$</span> citum convert style
                             styles/embedded/apa-7th.yaml -o /tmp/apa-7th.cbor
                         </div>
-                        <p class="text-xs text-slate-500 mt-2 italic">
+                        <p class="text-xs italic">
                             Binary formats can reduce parse overhead for
                             large styles and bibliographies.
                         </p>
                     </div>
                     <div>
-                        <h4 class="font-bold text-slate-900 mb-3 text-sm uppercase tracking-wider">
+                        <h4 class="font-bold text-sm">
                             Processing
                         </h4>
-                        <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300">
-                            <span class="text-primary">$</span> citum render refs
+                        <div class="code-dark">
+                            <span class="token-value">$</span> citum render refs
                             -b data.cbor -s style.cbor
                         </div>
-                        <p class="text-xs text-slate-500 mt-2 italic">
+                        <p class="text-xs italic">
                             Full binary pipeline for maximum throughput.
                         </p>
                     </div>
@@ -1726,31 +1546,30 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
         </article>
 
         <!-- Schema Generation -->
-        <article id="schema-generation" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-symbols-outlined">schema</span>
+        <article id="schema-generation" class="example-card">
+            <div class="example-card-header">
+                <div class="flex">
+                    <div class="w-10-lg">
                     </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+                    <h2>
                         Schema Generation
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Citum can generate JSON Schemas for its configuration formats, enabling
                     rich IDE support, validation, and auto-completion in editors like VS Code.
                 </p>
             </div>
             <div class="p-8 bg-[var(--citum-surface)]">
-                <div class="p-4 bg-slate-50 border border-slate-200 rounded-lg">
-                    <h4 class="font-bold text-slate-900 mb-2 text-sm uppercase tracking-wider">
+                <div class="p-4 border-lg">
+                    <h4 class="font-bold text-sm">
                         Generation Command (Optional Feature)
                     </h4>
-                    <div class="bg-slate-900 rounded-lg p-4 font-mono text-xs text-slate-300 overflow-x-auto">
-                        <span class="text-primary">$</span> cargo run --bin citum --features schema -- schema &gt;
+                    <div class="code-dark">
+                        <span class="token-value">$</span> cargo run --bin citum --features schema -- schema &gt;
                         citum.schema.json
                     </div>
-                    <p class="text-xs text-slate-500 mt-2 italic">
+                    <p class="text-xs italic">
                         Use this only when generating schemas locally; published schemas are already available on the
                         project website.
                     </p>
@@ -1759,129 +1578,118 @@ Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith202
         </article>
 
         <!-- Web Interactivity -->
-        <article id="web-interactivity" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">mouse</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="web-interactivity" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Web Interactivity
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-6">
+                <p>
                     Citum provides optional JS/CSS assets that enrich semantic HTML output with interactive behaviors.
                     They target data attributes injected by the processor, providing a <strong
                         class="text-slate-900">progressive enhancement</strong> layer for web-based citation views.
                 </p>
                 <a href="interactive-demo.html"
-                    class="inline-flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:brightness-105 transition-all text-sm font-semibold">
+                    class="inline-flex text-white-lg-105 text-sm">
                     Explore Enhancements
-                    <span class="material-icons text-sm">auto_fix_high</span>
-                </a>
+                    </a>
             </div>
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="grid md:grid-cols-2 gap-6">
-                    <div class="border border-indigo-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Bidirectional Navigation</div>
-                        <p class="text-sm text-slate-600">Click a citation to scroll to its bibliography entry. Hover an
+            <div class="example-card-body">
+                <div class="grid">
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Bidirectional Navigation</div>
+                        <p>Click a citation to scroll to its bibliography entry. Hover an
                             entry to highlight all its citations in the document.</p>
                     </div>
-                    <div class="border border-emerald-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Hover Tooltips</div>
-                        <p class="text-sm text-slate-600">Instant reference previews on citation hover, utilizing
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Hover Tooltips</div>
+                        <p>Instant reference previews on citation hover, utilizing
                             metadata attributes stored directly in the entry container.</p>
                     </div>
-                    <div class="border border-amber-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Sidebar Layouts</div>
-                        <p class="text-sm text-slate-600">Optimized for note-style documents. Bibliographies can be
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Sidebar Layouts</div>
+                        <p>Optimized for note-style documents. Bibliographies can be
                             pulled into a sticky sidebar on large screens.</p>
                     </div>
-                    <div class="border border-rose-500/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-2">Theming</div>
-                        <p class="text-sm text-slate-600">Fully customizable via CSS variables. Includes high-contrast
+                    <div class="example-io-panel">
+                        <div class="example-io-label">Theming</div>
+                        <p>Fully customizable via CSS variables. Includes high-contrast
                             support and clean print styles.</p>
                     </div>
                 </div>
             </div>
 
             <!-- Integration Guide -->
-            <div class="bg-slate-50 p-8 border-t border-slate-200">
-                <h3 class="text-lg font-bold text-slate-900 mb-4">Quick Start Integration</h3>
-                <p class="text-slate-600 text-sm mb-6">To add interactivity to your own site, simply include the
+            <div class="bg-slate-50 border-t">
+                <h3>Quick Start Integration</h3>
+                <p class="text-slate-600 text-sm">To add interactivity to your own site, simply include the
                     following tags in your HTML. These link to the latest assets via the JSDelivr CDN.</p>
 
                 <div class="space-y-4">
                     <div>
-                        <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1">1. CSS (Place
+                        <div class="text-[10px]">1. CSS (Place
                             in &lt;head&gt;)</div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto">
+                        <div class="code-dark">
                             <pre
-                                class="font-mono text-xs text-emerald-400">&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/citum/citum-core@main/docs/assets/citum-interactive.css"&gt;</pre>
+                                class="font-mono text-xs">&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/citum/citum-core@main/docs/assets/citum-interactive.css"&gt;</pre>
                         </div>
                     </div>
                     <div>
-                        <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1">2. JS (Place
+                        <div class="text-[10px]">2. JS (Place
                             before &lt;/body&gt;)</div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto">
+                        <div class="code-dark">
                             <pre
-                                class="font-mono text-xs text-emerald-400">&lt;script src="https://cdn.jsdelivr.net/gh/citum/citum-core@main/docs/assets/citum-interactive.js"&gt;&lt;/script&gt;</pre>
+                                class="font-mono text-xs">&lt;script src="https://cdn.jsdelivr.net/gh/citum/citum-core@main/docs/assets/citum-interactive.js"&gt;&lt;/script&gt;</pre>
                         </div>
                     </div>
                 </div>
 
-                <div class="mt-8 grid md:grid-cols-2 gap-6">
-                    <div class="bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
-                        <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
-                            <span class="material-icons text-primary text-base">auto_fix_high</span>
+                <div class="mt-8">
+                    <div class="bg-[var(--citum-surface)]-lg border">
+                        <h4 class="font-bold text-sm">
                             Requirements
                         </h4>
-                        <p class="text-xs text-slate-500">Requires HTML output generated by the Citum processor
+                        <p class="text-xs">Requires HTML output generated by the Citum processor
                             (including v0.6.0+), which includes the semantic classes and data attributes used by the
                             interactive layer.</p>
                     </div>
-                    <div class="bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
-                        <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
-                            <span class="material-icons text-primary text-base">view_sidebar</span>
+                    <div class="bg-[var(--citum-surface)]-lg border">
+                        <h4 class="font-bold text-sm">
                             Sidebar Layout
                         </h4>
-                        <p class="text-xs text-slate-500">To enable the sidebar mode on large screens, wrap your content
+                        <p class="text-xs">To enable the sidebar mode on large screens, wrap your content
                             and bibliography in a container with the class <code
-                                class="bg-slate-100 px-1 rounded">citum-with-sidebar</code>.</p>
+                                class="bg-slate-100">citum-with-sidebar</code>.</p>
                     </div>
                 </div>
             </div>
         </article>
 
         <!-- Annotated Bibliography -->
-        <article id="annotated-bibliography" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">comment</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="annotated-bibliography" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Annotated Bibliography
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed">
+                <p class="text-slate-600">
                     Attach reader-authored annotations to any bibliography without style variants. Annotations are passed as a separate
                     YAML or JSON file mapping reference IDs to annotation text. The processor appends annotations after each entry,
                     respecting formatting options for italic, indentation, and paragraph spacing.
                 </p>
             </div>
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">Render with Annotations</div>
-                <div class="bg-slate-900 rounded p-3 overflow-x-auto mb-6">
-                    <pre class="font-mono text-xs text-emerald-400">citum render refs \
+            <div class="example-card-body">
+                <div class="text-[10px]">Render with Annotations</div>
+                <div class="code-dark">
+                    <pre>citum render refs \
   -b examples/annotated-bibliography/references.yaml \
   -s apa-7th \
   --annotations examples/annotated-bibliography/annotations.yaml</pre>
                 </div>
 
-                <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">Sample Output</div>
-                <div class="bg-slate-50 border border-slate-200 rounded p-4 text-sm space-y-4 overflow-x-auto">
-                    <div class="font-mono text-slate-700 whitespace-pre-wrap">
+                <div class="text-[10px]">Sample Output</div>
+                <div class="bg-slate-50 border text-sm">
+                    <div class="font-mono-wrap">
 Smith, J. (2019). Foundations of knowledge. Oxford University Press.
 
     A landmark work that fundamentally reshaped our understanding of the field.
@@ -1896,16 +1704,16 @@ Hawking, S. (1988). A brief history of time. Bantam Books.
             </div>
 
             <!-- Configuration Guide -->
-            <div class="bg-slate-50 p-8 border-t border-slate-200">
-                <h3 class="text-lg font-bold text-slate-900 mb-4">Annotation Format</h3>
-                <p class="text-slate-600 text-sm mb-6">Annotations are stored in a simple flat map. YAML is recommended for hand-authoring;
+            <div class="bg-slate-50 border-t">
+                <h3>Annotation Format</h3>
+                <p class="text-slate-600 text-sm">Annotations are stored in a simple flat map. YAML is recommended for hand-authoring;
                 JSON is also supported.</p>
 
-                <div class="grid md:grid-cols-2 gap-6">
+                <div class="grid">
                     <div>
-                        <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">YAML Format</div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                            <pre class="font-mono text-xs text-emerald-400">smith2019: >
+                        <div class="text-[10px]">YAML Format</div>
+                        <div class="code-dark">
+                            <pre>smith2019: >
   A landmark work that fundamentally
   reshaped our understanding.
 
@@ -1917,10 +1725,10 @@ jones2021: >
                 </div>
 
                 <!-- Documentation of annotation styling -->
-                <div class="mt-4 p-4 bg-slate-50 rounded border border-slate-200">
-                    <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-2">Styling Annotations</div>
-                    <p class="text-xs text-slate-600 mb-3">Annotation presentation is handled via CSS or document-level show rules. To style HTML output:</p>
-                    <pre class="bg-slate-800 text-slate-200 p-3 rounded text-[10px] font-mono">
+                <div class="mt-4 border">
+                    <div class="text-[10px]">Styling Annotations</div>
+                    <p class="text-xs">Annotation presentation is handled via CSS or document-level show rules. To style HTML output:</p>
+                    <pre class="bg-slate-800 text-[10px]">
 .citum-annotation {
     font-style: italic;
     padding-left: 1.5rem;
@@ -1929,28 +1737,26 @@ jones2021: >
 }</pre>
                 </div>
 
-                <div class="mt-8 bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
-                    <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
-                        <span class="material-icons text-primary text-base">format_bold</span>
+                <div class="mt-8 bg-[var(--citum-surface)]-lg border">
+                    <h4 class="font-bold text-sm">
                         Djot Inline Markup
                     </h4>
-                    <p class="text-xs text-slate-500 mb-3">Annotation text is parsed as <a href="https://djot.net" class="text-primary hover:underline">djot</a> inline markup by default.
+                    <p class="text-xs">Annotation text is parsed as <a href="https://djot.net" class="text-primary">djot</a> inline markup by default.
                         Emphasis, strong, and verbatim code are rendered into the target output format automatically.
-                        Citum also recognises <code class="bg-slate-100 px-1 rounded">{.smallcaps}[…]</code> spans as a convention on top of djot's generic span attributes.</p>
-                    <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                        <pre class="font-mono text-xs text-emerald-400">smith2019: >
+                        Citum also recognises <code class="bg-slate-100">{.smallcaps}[…]</code> spans as a convention on top of djot's generic span attributes.</p>
+                    <div class="code-dark">
+                        <pre>smith2019: >
   A _landmark_ work. Particularly useful for its
   {.smallcaps}[comparative methodology].</pre>
                     </div>
-                    <p class="text-xs text-slate-400 mt-2">To opt out, set <code class="bg-slate-100 px-1 rounded">format: plain</code> in the annotation style options.</p>
+                    <p class="text-xs">To opt out, set <code class="bg-slate-100">format: plain</code> in the annotation style options.</p>
                 </div>
 
-                <div class="mt-4 bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
-                    <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
-                        <span class="material-icons text-primary text-base">description</span>
+                <div class="mt-4 bg-[var(--citum-surface)]-lg border">
+                    <h4 class="font-bold text-sm">
                         Why Separate from References?
                     </h4>
-                    <p class="text-xs text-slate-500">Annotations are document-scoped overlays. The same reference carries different
+                    <p class="text-xs">Annotations are document-scoped overlays. The same reference carries different
                         annotations in different contexts (a course syllabus vs. a grant proposal vs. a personal reading list).
                         This design avoids style proliferation and keeps concerns separated.</p>
                 </div>
@@ -1958,36 +1764,32 @@ jones2021: >
         </article>
 
         <!-- Abbreviation Maps -->
-        <article id="abbreviation-map" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">find_replace</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="abbreviation-map" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Abbreviation Maps
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed">
+                <p class="text-slate-600">
                     Substitute full rendered strings with abbreviations at document scope. Pass a YAML or JSON map at render time to replace
                     journal titles, institutional names, corporate authors, and other strings with their abbreviations. The substitution applies after rendering,
                     so any style renders the full title first, then the map replaces it with the abbreviation.
                 </p>
             </div>
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">CLI Example</div>
-                <div class="bg-slate-900 rounded p-3 overflow-x-auto mb-6">
-                    <pre class="font-mono text-xs text-emerald-400">citum render refs \
+            <div class="example-card-body">
+                <div class="text-[10px]">CLI Example</div>
+                <div class="code-dark">
+                    <pre>citum render refs \
   -b examples/references.json \
   -s ieee \
   --abbreviation-map examples/abbrevs.yaml</pre>
                 </div>
 
-                <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">YAML Format</div>
-                <div class="grid md:grid-cols-2 gap-6 mb-6">
+                <div class="text-[10px]">YAML Format</div>
+                <div class="grid">
                     <div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto">
-                            <pre class="font-mono text-xs text-emerald-400">Estates Gazette: EG
+                        <div class="code-dark">
+                            <pre>Estates Gazette: EG
 "Lloyd's Law Reports": "Lloyd's Rep"
 "World Health Organization": WHO
 Nature Reviews Neuroscience: Nat Rev Neurosci</pre>
@@ -1995,17 +1797,17 @@ Nature Reviews Neuroscience: Nat Rev Neurosci</pre>
                     </div>
                 </div>
 
-                <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">Sample Output (Before &amp; After)</div>
-                <div class="bg-slate-50 border border-slate-200 rounded p-4 space-y-4 overflow-x-auto">
+                <div class="text-[10px]">Sample Output (Before &amp; After)</div>
+                <div class="bg-slate-50 border">
                     <div>
-                        <div class="text-xs font-semibold text-slate-500 mb-2">Without abbreviation map:</div>
-                        <div class="font-mono text-sm text-slate-700">
+                        <div class="text-xs">Without abbreviation map:</div>
+                        <div class="font-mono text-sm">
                             Smith, J., et al. "Analysis of inheritance." <i>Nature Reviews Neuroscience</i>, vol. 24, no. 5, pp. 311–326, 2023.
                         </div>
                     </div>
                     <div>
-                        <div class="text-xs font-semibold text-slate-500 mb-2">With abbreviation map:</div>
-                        <div class="font-mono text-sm text-slate-700">
+                        <div class="text-xs">With abbreviation map:</div>
+                        <div class="font-mono text-sm">
                             Smith, J., et al. "Analysis of inheritance." <i>Nat Rev Neurosci</i>, vol. 24, no. 5, pp. 311–326, 2023.
                         </div>
                     </div>
@@ -2013,105 +1815,100 @@ Nature Reviews Neuroscience: Nat Rev Neurosci</pre>
             </div>
 
             <!-- Configuration Guide -->
-            <div class="bg-slate-50 p-8 border-t border-slate-200">
-                <h3 class="text-lg font-bold text-slate-900 mb-4">Abbreviation Map Format</h3>
-                <p class="text-slate-600 text-sm mb-6">Abbreviation maps are simple flat key-value maps. Keys are full rendered strings (exact, case-sensitive). Values are the replacement abbreviations.</p>
+            <div class="bg-slate-50 border-t">
+                <h3>Abbreviation Map Format</h3>
+                <p class="text-slate-600 text-sm">Abbreviation maps are simple flat key-value maps. Keys are full rendered strings (exact, case-sensitive). Values are the replacement abbreviations.</p>
 
-                <div class="mt-4 p-4 bg-white rounded border border-slate-200">
-                    <div class="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-3">What Gets Abbreviated?</div>
-                    <ul class="text-xs text-slate-600 space-y-2 list-disc list-inside">
+                <div class="mt-4 bg-white border">
+                    <div class="text-[10px]">What Gets Abbreviated?</div>
+                    <ul class="text-xs list-disc list-inside">
                         <li>Title fields: main title, container title, collection title</li>
                         <li>Variable fields: publisher, archive, series</li>
                         <li>Contributor literal names: corporate or institutional authors</li>
                     </ul>
                 </div>
 
-                <div class="mt-8 bg-[var(--citum-surface)] p-4 rounded-lg border border-slate-200">
-                    <h4 class="font-bold text-slate-900 text-sm mb-2 flex items-center gap-2">
-                        <span class="material-icons text-primary text-base">description</span>
+                <div class="mt-8 bg-[var(--citum-surface)]-lg border">
+                    <h4 class="font-bold text-sm">
                         Why Separate from the Style?
                     </h4>
-                    <p class="text-xs text-slate-500">Abbreviations are document-scoped overlays. Different contexts may abbreviate the same reference differently (a journal article in a biology manuscript vs. a history paper). Keeping abbreviations separate from the style avoids proliferation of variant styles and keeps concerns separated.</p>
+                    <p class="text-xs">Abbreviations are document-scoped overlays. Different contexts may abbreviate the same reference differently (a journal article in a biology manuscript vs. a history paper). Keeping abbreviations separate from the style avoids proliferation of variant styles and keeps concerns separated.</p>
                 </div>
             </div>
         </article>
 
         <!-- Distributed Registries -->
-        <article id="distributed-registries" class="example-card rounded-xl overflow-hidden shadow-sm scroll-mt-24">
-            <div class="p-8 bg-slate-50 border-b border-slate-200">
-                <div class="flex items-center gap-3 mb-4">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary">
-                        <span class="material-icons">lan</span>
-                    </div>
-                    <h2 class="text-2xl font-bold text-slate-900">
+        <article id="distributed-registries" class="example-card">
+            <div class="example-card-header">
+                <h2>
                         Distributed Registries
-                        <span class="ml-2 text-xs align-middle px-2 py-0.5 rounded-full bg-primary/10 text-primary font-mono uppercase tracking-wider">New</span>
+                        <span class="ml-2 text-xs align-middle.5-full">New</span>
                     </h2>
                 </div>
-                <p class="text-slate-600 leading-relaxed mb-2">
+                <p class="text-slate-600">
                     Citum ships with a tiny embedded registry of builtin styles. Everything else
                     lives in registries you opt into &mdash; the Citum Hub, an institutional
                     registry, or your own static-HTTP host. Styles can be referenced by name,
                     by URL, or by content-addressed
-                    <code class="text-xs bg-slate-200/60 px-1.5 py-0.5 rounded">cid:</code> URI,
+                    <code class="text-xs.5.5">cid:</code> URI,
                     and any
-                    <code class="text-xs bg-slate-200/60 px-1.5 py-0.5 rounded">extends:</code>
+                    <code class="text-xs.5.5">extends:</code>
                     edge can be locked to a specific parent version with
-                    <code class="text-xs bg-slate-200/60 px-1.5 py-0.5 rounded">extends-pin</code>.
+                    <code class="text-xs.5.5">extends-pin</code>.
                 </p>
-                <p class="text-slate-600 leading-relaxed">
+                <p class="text-slate-600">
                     Walk the full UX in the
-                    <a class="text-primary hover:underline" target="_blank"
+                    <a class="text-primary" target="_blank"
                        href="https://github.com/citum/citum-core/blob/main/docs/guides/DISTRIBUTED_REGISTRIES.md">distributed
                     registries guide</a>. Spec:
-                    <a class="text-primary hover:underline" target="_blank"
+                    <a class="text-primary" target="_blank"
                        href="https://github.com/citum/citum-core/blob/main/docs/specs/DISTRIBUTED_RESOLVER.md">DISTRIBUTED_RESOLVER.md</a>.
                 </p>
             </div>
 
-            <div class="p-6 bg-[var(--citum-surface)]">
-                <div class="grid gap-6">
-                    <div class="border border-slate-300/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+            <div class="example-card-body">
+                <div>
+                    <div>
+                        <div class="example-io-label">
                             Add a registry &amp; render against an HTTPS URL
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">citum registry add https://hub.citum.org/registry/default.yaml --name citum-hub
+                        <div class="code-dark">
+                            <pre>citum registry add https://hub.citum.org/registry/default.yaml --name citum-hub
 citum render refs -b refs.json -s https://hub.citum.org/styles/apa-7th.yaml</pre>
                         </div>
                     </div>
 
-                    <div class="border border-slate-300/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div>
+                        <div class="example-io-label">
                             Pin a parent for reproducibility
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">$ citum style pin apa-7th --uri https://hub.citum.org/styles/apa-7th.yaml
+                        <div class="code-dark">
+                            <pre>$ citum style pin apa-7th --uri https://hub.citum.org/styles/apa-7th.yaml
 extends: https://hub.citum.org/styles/apa-7th.yaml
 extends-pin: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44</pre>
                         </div>
-                        <p class="text-sm text-slate-500 leading-relaxed mt-3">
+                        <p>
                             Paste the snippet at the top of any child style YAML. The resolver
                             re-hashes the fetched parent and refuses to render if the bytes drift,
                             so style inheritance becomes deterministic across upgrades.
                         </p>
                     </div>
 
-                    <div class="border border-slate-300/30 rounded-lg p-4">
-                        <div class="text-xs font-semibold text-slate-500 uppercase mb-1">
+                    <div>
+                        <div class="example-io-label">
                             Validate before publishing
                         </div>
-                        <div class="bg-slate-900 rounded p-3 overflow-x-auto mt-1">
-                            <pre class="font-mono text-xs text-slate-300 leading-relaxed">$ citum style validate my-journal.yaml
+                        <div class="code-dark">
+                            <pre>$ citum style validate my-journal.yaml
 OK   my-journal.yaml
 CID  bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
 Citum &gt;=0.38.0</pre>
                         </div>
-                        <p class="text-sm text-slate-500 leading-relaxed mt-3">
-                            <code class="text-xs">style validate</code> resolves
-                            <code class="text-xs">extends</code> chains, verifies any
-                            <code class="text-xs">extends-pin</code>, and checks
-                            <code class="text-xs">info.citum-version</code> against the running
+                        <p>
+                            <code>style validate</code> resolves
+                            <code>extends</code> chains, verifies any
+                            <code>extends-pin</code>, and checks
+                            <code>info.citum-version</code> against the running
                             engine. Air-gapped? Configure no remotes and the resolver chain falls
                             through to your local store and the embedded builtins with zero
                             network calls.
@@ -2121,42 +1918,30 @@ Citum &gt;=0.38.0</pre>
             </div>
         </article>
 
-    </main>
-</div>
+        </div>
+    </div>
 
     <!-- Footer -->
-    <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="developer.html">Developer</a>
+                    <a href="schemas/">Schemas</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
             </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
 
-    <script>
-        const navToggle = document.querySelector("[data-nav-toggle]");
-        const mobileMenu = document.querySelector("[data-mobile-menu]");
-
-        if (navToggle && mobileMenu) {
-            navToggle.addEventListener("click", () => {
-                const expanded = navToggle.getAttribute("aria-expanded") === "true";
-                navToggle.setAttribute("aria-expanded", String(!expanded));
-                mobileMenu.classList.toggle("hidden", expanded);
-            });
-        }
-    </script>
+        <script src="assets/citum-interactive.js"></script>
 </body>
 
 </html>

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -76,46 +76,37 @@
     <body class="bg-background-light text-slate-700 selection:bg-primary/20">
         <!-- Navigation -->
         <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="../index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../index.html">Overview</a>
+                <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../developer.html">Developer</a>
+                <a class="site-nav-link " href="../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
-                    Source
+                    GitHub
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
-                <span class="material-icons text-[20px]">menu</span>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../index.html">Overview</a>
+            <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../developer.html">Developer</a>
+            <a class="site-nav-link " href="../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
 
         <!-- Header -->
@@ -1047,21 +1038,20 @@ Always pair opening prefix with closing suffix. For structural wrapping (e.g. pa
         <!-- Footer -->
         <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
             <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="../examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="../reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../developer.html">Developer</a>
+                    <a href="../schemas/">Schemas</a>
+                    <a href="../reports.html">Reports</a>
+                    <a href="../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
             </div>        <!-- LAYOUT_FOOTER_END -->
         </footer>
 

--- a/docs/guides/style-authoring/inheritance-and-registries.html
+++ b/docs/guides/style-authoring/inheritance-and-registries.html
@@ -1,0 +1,129 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Inheritance and Registries | Citum Docs</title>
+        <meta name="description" content="Reuse base styles, pin remote parents, and validate distributed style dependencies." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>Inheritance and Registries</h1>
+                <p>Reuse base styles, pin remote parents, and validate distributed style dependencies.</p>
+                <div class="version-badges"><span class="version-badge" data-feature="style-inheritance-pins" data-status="active">active</span><span class="version-badge" data-feature="style-inheritance-pins">schema 0.38.0+</span><span class="version-badge" data-feature="style-inheritance-pins">engine 0.38.0+</span><span class="version-badge" data-feature="distributed-registries" data-status="active">active</span><span class="version-badge" data-feature="distributed-registries">schema 0.38.0+</span><span class="version-badge" data-feature="distributed-registries">engine 0.38.0+</span></div>
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/start.html">Start</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/templates.html">Templates</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/options.html">Options</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
+<a class="doc-sidebar-link active" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+                </aside>
+                <article class="doc-prose">
+                    <h2 id="extending-a-style">Extending a style</h2><p>Use <code>extends</code> when a style is mainly a tuned wrapper around an existing base.
+The parent supplies templates. The wrapper supplies metadata and scoped options.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">Springer</span> - Basic (author-date)
+
+<span class="text-primary">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span>
+<span class="text-indigo-400">options</span>:
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">springer</span>
+<span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">date-position</span>: <span class="text-emerald-400">after-author</span></code></pre>
+            </div>
+        <h2 id="pinning-a-parent">Pinning a parent</h2><p>Remote parents should be pinned by content identifier so the wrapper stays
+deterministic across upgrades.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">extends</span>: https://hub.citum.org/styles/apa-7th.yaml
+<span class="text-indigo-400">extends-pin</span>: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44</code></pre>
+            </div>
+        <p>Generate a paste-ready pair with:</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-bash">citum style pin styles/apa-7th.yaml</code></pre>
+            </div>
+        <h2 id="distributed-registries">Distributed registries</h2><p>Resolver chains can fetch styles from embedded styles, local files, remote
+registries, and content identifiers. Validation walks the inheritance chain,
+checks pins, and applies <code>info.citum-version</code> requirements.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-bash">citum style validate path/to/my-journal.yaml</code></pre>
+            </div>
+        <p>For the full operational workflow, see
+<a href="../DISTRIBUTED_REGISTRIES.md"><code>DISTRIBUTED_REGISTRIES.md</code></a>.</p>
+
+                </article>
+            </div>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/guides/style-authoring/locales.html
+++ b/docs/guides/style-authoring/locales.html
@@ -1,0 +1,170 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Locales and Gender-Aware Terms | Citum Docs</title>
+        <meta name="description" content="Use locale terms for roles, labels, locators, and grammatical agreement." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>Locales and Gender-Aware Terms</h1>
+                <p>Use locale terms for roles, labels, locators, and grammatical agreement.</p>
+                <div class="version-badges"><span class="version-badge" data-feature="gender-aware-locale-terms" data-status="active">active</span><span class="version-badge" data-feature="gender-aware-locale-terms">schema 0.49.0+</span><span class="version-badge" data-feature="gender-aware-locale-terms">engine 0.49.0+</span></div>
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/start.html">Start</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/templates.html">Templates</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/options.html">Options</a>
+<a class="doc-sidebar-link active" href="../../guides/style-authoring/locales.html">Locales</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+                </aside>
+                <article class="doc-prose">
+                    <h2 id="locale-owned-text">Locale-owned text</h2><p>Use locale terms for text that varies by language: page labels, role labels,
+and other bibliographic terms. Style templates should express structure; locale
+files should own language.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">term</span>: <span class="text-emerald-400">volume</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+  <span class="text-primary">suffix</span>: <span class="text-emerald-400">" "</span>
+<span class="text-slate-400">- </span><span class="text-primary">number</span>: <span class="text-emerald-400">volume</span></code></pre>
+            </div>
+        <h2 id="contributor-gender-metadata">Contributor gender metadata</h2><p>Contributor-driven role labels can use contributor gender metadata where the
+locale provides gendered forms.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">contributors</span>:
+  <span class="text-slate-400">- </span><span class="text-primary">role</span>: <span class="text-emerald-400">editor</span>
+    <span class="text-primary">contributor</span>:
+      <span class="text-primary">family</span>: <span class="text-emerald-400">"Martinez"</span>
+      <span class="text-primary">given</span>: <span class="text-emerald-400">"Ana"</span>
+    <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span></code></pre>
+            </div>
+        <p>Mixed-gender contributor groups prefer a locale&#39;s neutral or common form when
+one exists. Citum does not silently choose a masculine-specific label for a
+mixed group when only gendered forms are available.</p>
+<h2 id="template-gender-overrides">Template gender overrides</h2><p>Use a template-level <code>gender</code> override when the style needs to request a
+specific agreement form directly.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">editor</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">long</span>
+  <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span>
+
+<span class="text-slate-400">- </span><span class="text-primary">term</span>: <span class="text-emerald-400">volume</span>
+  <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+  <span class="text-primary">gender</span>: <span class="text-emerald-400">masculine</span>
+
+<span class="text-slate-400">- </span><span class="text-primary">number</span>: <span class="text-emerald-400">volume</span>
+  <span class="text-primary">label-form</span>: <span class="text-emerald-400">short</span>
+  <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span></code></pre>
+            </div>
+        <h2 id="locale-yaml">Locale YAML</h2><p>Locale terms can be plain strings or gendered maps.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">roles</span>:
+  <span class="text-primary">editor</span>:
+    <span class="text-primary">long</span>:
+      <span class="text-primary">singular</span>:
+        <span class="text-primary">masculine</span>: <span class="text-emerald-400">editor</span>
+        <span class="text-primary">feminine</span>: <span class="text-emerald-400">editora</span>
+        <span class="text-primary">common</span>: <span class="text-emerald-400">persona</span> editora
+      <span class="text-primary">plural</span>:
+        <span class="text-primary">masculine</span>: <span class="text-emerald-400">editores</span>
+        <span class="text-primary">feminine</span>: <span class="text-emerald-400">editoras</span>
+        <span class="text-primary">common</span>: <span class="text-emerald-400">equipo</span> editorial</code></pre>
+            </div>
+        <p>Locator terms can also declare lexical gender metadata.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">locators</span>:
+  <span class="text-primary">page</span>:
+    <span class="text-primary">long</span>:
+      <span class="text-primary">singular</span>: página
+      <span class="text-primary">plural</span>: páginas
+    <span class="text-primary">short</span>:
+      <span class="text-primary">singular</span>: <span class="text-emerald-400">p.</span>
+      <span class="text-primary">plural</span>: <span class="text-emerald-400">pp.</span>
+    <span class="text-primary">gender</span>: <span class="text-emerald-400">feminine</span></code></pre>
+            </div>
+
+            <div class="callout tip">
+                <span aria-hidden="true">ℹ️</span>
+                <div><strong>Current scope</strong>
+Gender-aware rendering applies to locale term selection and contributor role
+labels. Verb-form role terms remain ungendered until the follow-up adds the
+required plumbing.</div>
+            </div>
+
+                </article>
+            </div>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/guides/style-authoring/options.html
+++ b/docs/guides/style-authoring/options.html
@@ -1,0 +1,165 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Options, Sorting, and Document Inputs | Citum Docs</title>
+        <meta name="description" content="Configure shared formatting behavior without duplicating templates." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>Options, Sorting, and Document Inputs</h1>
+                <p>Configure shared formatting behavior without duplicating templates.</p>
+                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span><span class="version-badge" data-feature="abbreviation-map" data-status="active">active</span><span class="version-badge" data-feature="abbreviation-map">schema 0.49.0+</span><span class="version-badge" data-feature="abbreviation-map">engine 0.49.0+</span></div>
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/start.html">Start</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/templates.html">Templates</a>
+<a class="doc-sidebar-link active" href="../../guides/style-authoring/options.html">Options</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+                </aside>
+                <article class="doc-prose">
+                    <h2 id="global-options">Global options</h2><p>Global options apply across citation and bibliography rendering unless a
+section or component overrides them.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">options</span>:
+  <span class="text-primary">processing</span>: <span class="text-emerald-400">author-date</span>
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">apa</span>
+  <span class="text-primary">dates</span>: <span class="text-emerald-400">long</span></code></pre>
+            </div>
+
+            <div class="doc-table-shell">
+                <table class="doc-table">
+                    <thead><tr><th>Option family</th><th>Controls</th></tr></thead>
+                    <tbody><tr><td><code>processing</code></td><td>author-date, numeric, note, or label behavior</td></tr><tr><td><code>contributors</code></td><td>name order, initials, conjunctions, shortening</td></tr><tr><td><code>dates</code></td><td>long, short, numeric, or ISO date rendering</td></tr><tr><td><code>titles</code></td><td>title casing and title form behavior</td></tr></tbody>
+                </table>
+            </div>
+        <h2 id="component-rendering-options">Component rendering options</h2><p>Use component options for punctuation, wrapping, and emphasis.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">parent-serial</span>
+  <span class="text-primary">prefix</span>: <span class="text-emerald-400">". "</span>
+  <span class="text-primary">emph</span>: <span class="text-emerald-400">true</span>
+
+<span class="text-slate-400">- </span><span class="text-primary">number</span>: <span class="text-emerald-400">pages</span>
+  <span class="text-primary">prefix</span>: <span class="text-emerald-400">", "</span>
+  <span class="text-primary">label-form</span>: <span class="text-emerald-400">short</span></code></pre>
+            </div>
+
+            <div class="callout warning">
+                <span aria-hidden="true">⚠️</span>
+                <div><strong>Do not hardcode localized labels</strong>
+Avoid <code>prefix: &quot;pp. &quot;</code> or <code>prefix: &quot;In: &quot;</code>. Use <code>term</code> components or
+label options so locale files own language-specific text.</div>
+            </div>
+        <h2 id="options-inheritance">Options inheritance</h2><p>More local options override broader options:</p>
+<ol>
+<li>component-level options</li>
+<li>citation or bibliography section options</li>
+<li>global options</li>
+</ol>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">options</span>:
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">apa</span>
+
+<span class="text-primary">citation</span>:
+  <span class="text-primary">options</span>:
+    <span class="text-primary">contributors</span>:
+      <span class="text-primary">shorten</span>: { min: 3, use-first: <span class="text-emerald-400">1</span> }</code></pre>
+            </div>
+        <h2 id="bibliography-sort-and-groups">Bibliography sort and groups</h2>
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">sort</span>: <span class="text-emerald-400">author-date-title</span>
+  <span class="text-primary">groups</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">id</span>: <span class="text-emerald-400">primary</span>
+      <span class="text-primary">heading</span>:
+        <span class="text-primary">localized</span>:
+          en-US: <span class="text-emerald-400">"Primary Sources"</span>
+      <span class="text-primary">selector</span>:
+        <span class="text-primary">type</span>: <span class="text-emerald-400">legal-case</span></code></pre>
+            </div>
+        <h2 id="document-level-abbreviation-maps">Document-level abbreviation maps</h2><p>Abbreviation maps belong to the document input, not the style. They replace
+full rendered strings after value extraction and before output assembly.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">abbreviation-map</span>:
+  Estates Gazette: <span class="text-emerald-400">EG</span>
+  "Lloyd's Law Reports": <span class="text-emerald-400">"Lloyd's Rep"</span>
+  "World Health Organization": <span class="text-emerald-400">WHO</span></code></pre>
+            </div>
+
+                </article>
+            </div>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/guides/style-authoring/start.html
+++ b/docs/guides/style-authoring/start.html
@@ -1,0 +1,151 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Start Writing Citum Styles | Citum Docs</title>
+        <meta name="description" content="Learn the mental model for Citum styles and why the YAML format is different from CSL 1.0." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>Start Writing Citum Styles</h1>
+                <p>Learn the mental model for Citum styles and why the YAML format is different from CSL 1.0.</p>
+                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span></div>
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link active" href="../../guides/style-authoring/start.html">Start</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/templates.html">Templates</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/options.html">Options</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+                </aside>
+                <article class="doc-prose">
+                    <h2 id="how-citum-differs">How Citum Differs</h2><p>Citum replaces procedural CSL XML with declarative YAML. A style describes the
+formatting contract directly: metadata, processing options, citation templates,
+bibliography templates, and explicit variants for types that need different
+structure.</p>
+
+            <div class="doc-table-shell">
+                <table class="doc-table">
+                    <thead><tr><th>Aspect</th><th>CSL 1.0</th><th>Citum</th></tr></thead>
+                    <tbody><tr><td>Format</td><td>Procedural XML markup</td><td>Declarative YAML</td></tr><tr><td>Logic</td><td><code>choose</code> / <code>if</code> / <code>else</code> trees</td><td>type variants and scoped options</td></tr><tr><td>Name formatting</td><td>Inline attributes</td><td>global presets and component options</td></tr><tr><td>Dates</td><td>structured year/month/day object</td><td>EDTF strings</td></tr><tr><td>Reuse</td><td>parent aliases</td><td>explicit <code>extends</code> plus scoped overrides</td></tr><tr><td>Validation</td><td>external conventions</td><td>schema-backed editor and CLI validation</td></tr></tbody>
+                </table>
+            </div>
+
+            <div class="callout tip">
+                <span aria-hidden="true">ℹ️</span>
+                <div><strong>Explicit over hidden processor behavior</strong>
+If journals, books, legal cases, or web pages need different output, put that
+distinction in the style. The engine should not silently guess style intent.</div>
+            </div>
+        <h2 id="first-workflow">First workflow</h2><ol>
+<li>Pick the closest existing style or preset-backed core style.</li>
+<li>Write <code>info</code>, especially <code>title</code>, <code>id</code>, and <code>default-locale</code>.</li>
+<li>Set <code>options.processing</code> to <code>author-date</code>, <code>numeric</code>, <code>note</code>, or <code>label</code>.</li>
+<li>Add the citation and bibliography templates.</li>
+<li>Run <code>citum style validate path/to/style.yaml</code>.</li>
+<li>Compare rendered output against CSL, biblatex, or publisher examples.</li>
+</ol>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-slate-500"># yaml-language-server: $schema=https://docs.citum.org/schemas/style.json</span>
+
+<span class="text-primary">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">"My Style"</span>
+  <span class="text-primary">id</span>: <span class="text-emerald-400">"my-style"</span>
+  <span class="text-primary">default-locale</span>: <span class="text-emerald-400">"en-US"</span>
+
+<span class="text-primary">options</span>:
+  <span class="text-primary">processing</span>: <span class="text-emerald-400">author-date</span>
+
+<span class="text-primary">citation</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+
+<span class="text-primary">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span></code></pre>
+            </div>
+        <h2 id="where-to-go-next">Where to go next</h2><ul>
+<li>Use <strong>Style Anatomy</strong> when starting a new file.</li>
+<li>Use <strong>Templates</strong> when deciding what a citation or bibliography renders.</li>
+<li>Use <strong>Options</strong> when changing punctuation, names, dates, sorting, or groups.</li>
+<li>Use <strong>Locales</strong> when terms, roles, locators, or grammatical gender matter.</li>
+<li>Use <strong>Inheritance and Registries</strong> when wrapping an existing style.</li>
+<li>Use <strong>Validation</strong> before publishing or comparing fidelity.</li>
+</ul>
+
+                </article>
+            </div>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/guides/style-authoring/style-anatomy.html
+++ b/docs/guides/style-authoring/style-anatomy.html
@@ -1,0 +1,146 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Style File Anatomy | Citum Docs</title>
+        <meta name="description" content="The required top-level pieces of a Citum style file." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>Style File Anatomy</h1>
+                <p>The required top-level pieces of a Citum style file.</p>
+                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span></div>
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/start.html">Start</a>
+<a class="doc-sidebar-link active" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/templates.html">Templates</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/options.html">Options</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+                </aside>
+                <article class="doc-prose">
+                    <h2 id="top-level-structure">Top-level structure</h2><p>Every Citum style has four practical layers:</p>
+<ul>
+<li><code>info</code>: human metadata and compatibility declarations</li>
+<li><code>options</code>: processing mode and shared defaults</li>
+<li><code>citation</code>: citation rendering rules</li>
+<li><code>bibliography</code>: bibliography rendering rules</li>
+</ul>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">"APA 7th Edition"</span>
+  <span class="text-primary">id</span>: <span class="text-emerald-400">"apa-7th"</span>
+  <span class="text-primary">default-locale</span>: <span class="text-emerald-400">"en-US"</span>
+
+<span class="text-primary">options</span>:
+  <span class="text-primary">processing</span>: <span class="text-emerald-400">author-date</span>
+  <span class="text-primary">contributors</span>: <span class="text-emerald-400">apa</span>
+
+<span class="text-primary">citation</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+      <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>
+
+<span class="text-primary">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span></code></pre>
+            </div>
+        <h2 id="info-fields">Info fields</h2><p>Use <code>info</code> for identity and compatibility, not formatting.</p>
+
+            <div class="doc-table-shell">
+                <table class="doc-table">
+                    <thead><tr><th>Field</th><th>Purpose</th></tr></thead>
+                    <tbody><tr><td><code>title</code></td><td>human-readable style name</td></tr><tr><td><code>id</code></td><td>stable kebab-case style identifier</td></tr><tr><td><code>description</code></td><td>short catalog or search description</td></tr><tr><td><code>default-locale</code></td><td>BCP 47 language tag</td></tr><tr><td><code>fields</code></td><td>discipline categories</td></tr><tr><td><code>citum-version</code></td><td>minimum Citum engine requirement</td></tr></tbody>
+                </table>
+            </div>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">"Hypothetical Journal Style"</span>
+  <span class="text-primary">id</span>: <span class="text-emerald-400">"hypothetical-journal"</span>
+  <span class="text-primary">default-locale</span>: <span class="text-emerald-400">"en-US"</span>
+  <span class="text-primary">citum-version</span>: <span class="text-emerald-400">"&gt;=0.49.0"</span></code></pre>
+            </div>
+        <h2 id="editor-validation">Editor validation</h2><p>Add the schema comment at the top of hand-authored styles. Editors that support
+YAML Language Server use it for autocomplete and inline validation.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-slate-500"># yaml-language-server: $schema=https://docs.citum.org/schemas/style.json</span></code></pre>
+            </div>
+
+                </article>
+            </div>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/guides/style-authoring/templates.html
+++ b/docs/guides/style-authoring/templates.html
@@ -1,0 +1,172 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Templates and Type Variants | Citum Docs</title>
+        <meta name="description" content="Build citation and bibliography output from explicit template components." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>Templates and Type Variants</h1>
+                <p>Build citation and bibliography output from explicit template components.</p>
+                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span></div>
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/start.html">Start</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+<a class="doc-sidebar-link active" href="../../guides/style-authoring/templates.html">Templates</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/options.html">Options</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+                </aside>
+                <article class="doc-prose">
+                    <h2 id="template-components">Template components</h2><p>Templates are ordered component lists. Each component names the data it renders
+and optional formatting around that data.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+      <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>
+      <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">" "</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">" "</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">parent-serial</span>
+      <span class="text-primary">emph</span>: <span class="text-emerald-400">true</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">". "</span></code></pre>
+            </div>
+
+            <div class="doc-table-shell">
+                <table class="doc-table">
+                    <thead><tr><th>Component</th><th>Common use</th></tr></thead>
+                    <tbody><tr><td><code>contributor</code></td><td>author, editor, translator, and other contributor roles</td></tr><tr><td><code>date</code></td><td>issued, accessed, original-date, and other date fields</td></tr><tr><td><code>title</code></td><td>primary title, parent title, collection title</td></tr><tr><td><code>number</code></td><td>volume, issue, pages, edition, citation number</td></tr><tr><td><code>term</code></td><td>localized labels such as page, volume, or editor</td></tr><tr><td><code>variable</code></td><td>direct field output such as publisher, DOI, URL</td></tr></tbody>
+                </table>
+            </div>
+        <h2 id="type-variants">Type variants</h2><p>Use <code>type-variants</code> when a reference type needs a different bibliography
+structure. Prefer small diff variants when the default template is mostly
+right.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">bibliography</span>:
+  <span class="text-primary">template</span>:
+    <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+    <span class="text-slate-400">- </span><span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+    <span class="text-slate-400">- </span><span class="text-primary">variable</span>: <span class="text-emerald-400">publisher</span>
+      <span class="text-primary">prefix</span>: <span class="text-emerald-400">". "</span>
+
+  <span class="text-primary">type-variants</span>:
+    <span class="text-primary">article-journal</span>:
+      <span class="text-primary">modify</span>:
+        <span class="text-slate-400">- </span><span class="text-primary">match</span>:
+            <span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+          <span class="text-primary">suffix</span>: <span class="text-emerald-400">". "</span>
+      <span class="text-primary">add</span>:
+        <span class="text-slate-400">- </span><span class="text-primary">after</span>:
+            <span class="text-primary">title</span>: <span class="text-emerald-400">primary</span>
+          <span class="text-primary">component</span>:
+            <span class="text-primary">title</span>: <span class="text-emerald-400">parent-serial</span>
+            <span class="text-primary">emph</span>: <span class="text-emerald-400">true</span>
+      <span class="text-primary">remove</span>:
+        <span class="text-slate-400">- </span><span class="text-primary">match</span>:
+            <span class="text-primary">variable</span>: <span class="text-emerald-400">publisher</span></code></pre>
+            </div>
+        <p>Selectors are partial component matches. <code>{ title: primary }</code> matches a primary
+title component even when that component also has affixes or emphasis.</p>
+<h2 id="citation-modes">Citation modes</h2><p>Use mode-specific citation blocks when narrative and parenthetical citations
+diverge.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">citation</span>:
+  <span class="text-primary">non-integral</span>:
+    <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span>
+    <span class="text-primary">template</span>:
+      <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+      <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>
+        <span class="text-primary">prefix</span>: <span class="text-emerald-400">", "</span>
+  <span class="text-primary">integral</span>:
+    <span class="text-primary">delimiter</span>: <span class="text-emerald-400">" "</span>
+    <span class="text-primary">template</span>:
+      <span class="text-slate-400">- </span><span class="text-primary">contributor</span>: <span class="text-emerald-400">author</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">short</span>
+      <span class="text-slate-400">- </span><span class="text-primary">date</span>: <span class="text-emerald-400">issued</span>
+        <span class="text-primary">form</span>: <span class="text-emerald-400">year</span>
+        <span class="text-primary">wrap</span>: <span class="text-emerald-400">parentheses</span></code></pre>
+            </div>
+        <p>Note styles can also define <code>subsequent</code> and <code>ibid</code> templates for repeated
+citations.</p>
+
+                </article>
+            </div>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/guides/style-authoring/validation.html
+++ b/docs/guides/style-authoring/validation.html
@@ -1,0 +1,131 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Validation and Compatibility | Citum Docs</title>
+        <meta name="description" content="Check styles before publishing and understand the existing version enforcement boundaries." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <span class="citum-kicker">Style authoring</span>
+                <h1>Validation and Compatibility</h1>
+                <p>Check styles before publishing and understand the existing version enforcement boundaries.</p>
+                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span><span class="version-badge" data-feature="style-inheritance-pins" data-status="active">active</span><span class="version-badge" data-feature="style-inheritance-pins">schema 0.38.0+</span><span class="version-badge" data-feature="style-inheritance-pins">engine 0.38.0+</span></div>
+            </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/start.html">Start</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/templates.html">Templates</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/options.html">Options</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+<a class="doc-sidebar-link active" href="../../guides/style-authoring/validation.html">Validation</a>
+                </aside>
+                <article class="doc-prose">
+                    <h2 id="validate-before-publishing">Validate before publishing</h2><p>Run the end-to-end style validator before publishing or comparing fidelity.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-bash">citum style validate path/to/my-journal.yaml</code></pre>
+            </div>
+        <p>The validator parses the style, runs schema validation, resolves <code>extends</code>,
+verifies any <code>extends-pin</code> values, and checks <code>info.citum-version</code> against the
+running engine.</p>
+<p>Machine-readable output is available for tools:</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-bash">citum style validate path/to/my-journal.yaml --format json</code></pre>
+            </div>
+        <h2 id="engine-compatibility">Engine compatibility</h2><p>Use <code>info.citum-version</code> when a style depends on an engine feature that older
+versions should not try to render.</p>
+
+            <div class="workshop-block">
+                <pre><code class="language-yaml"><span class="text-indigo-400">info</span>:
+  <span class="text-primary">title</span>: <span class="text-emerald-400">Hypothetical</span> Style With New Features
+  <span class="text-primary">citum-version</span>: <span class="text-emerald-400">"&gt;=0.49.0"</span></code></pre>
+            </div>
+        <p>An older engine returns a direct version mismatch instead of an opaque
+deserialization or rendering failure.</p>
+<h2 id="schema-compatibility">Schema compatibility</h2><p>Style schema versioning and engine versioning are related but separate:</p>
+<ul>
+<li>schema version describes the YAML wire format</li>
+<li>engine version describes the Rust processor release</li>
+<li>generated schemas in <code>docs/schemas/</code> remain the committed validation
+artifacts</li>
+</ul>
+<p>For policy details, see <a href="../../reference/SCHEMA_VERSIONING.md"><code>SCHEMA_VERSIONING.md</code></a>.</p>
+<h2 id="fidelity-reports">Fidelity reports</h2><p>Use the generated reports when checking whether a style is production-ready:</p>
+<ul>
+<li><a href="../../compat.html"><code>compat.html</code></a> for style-level fidelity and SQI status</li>
+<li><a href="../../reports.html"><code>reports.html</code></a> for generated report entrypoints</li>
+<li><a href="../../TIER_STATUS.md"><code>TIER_STATUS.md</code></a> for the current style status table</li>
+</ul>
+
+                </article>
+            </div>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/interactive-demo.html
+++ b/docs/interactive-demo.html
@@ -111,46 +111,37 @@
 
   <!-- Navigation -->
   <!-- LAYOUT_NAV_START -->
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="schemas/">Schemas</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
-                    Source
+                    GitHub
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
-                <span class="material-icons text-[20px]">menu</span>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="nav-link text-slate-600" href="index.html">Docs</a>
-                <a class="nav-link text-slate-600" href="news/index.html">News</a>
-                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="interactive-demo.html">Demo</a>
-                <a class="nav-link text-slate-600" href="examples.html">Examples</a>
-                <a class="nav-link text-slate-600" href="guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link text-slate-600" href="reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="schemas/">Schemas</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
 
   <div class="container-demo pt-24">
@@ -245,21 +236,20 @@
     <!-- Footer -->
     <footer class="py-12 px-6 border-t border-slate-200 bg-white/50">
         <!-- LAYOUT_FOOTER_START -->
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="developer.html">Developer</a>
+                    <a href="schemas/">Schemas</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
             </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
 

--- a/docs/operating.html
+++ b/docs/operating.html
@@ -1,11 +1,11 @@
-<!-- PAGE_ID: docs -->
+<!-- PAGE_ID: operating -->
 <!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Citum Docs</title>
-    <meta name="description" content="Documentation for Citum: a Rust citation engine and YAML style system for structured bibliographies, multilingual terms, reusable style families, and verifiable output." />
+    <title>Contributing | Citum Docs</title>
+    <meta name="description" content="Contributor workflows, migration practice, policies, and architecture entrypoints for people working on Citum." />
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="assets/citum-theme.css" />
 </head>
@@ -20,7 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
-                <a class="site-nav-link active" href="index.html">Overview</a>
+                <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
@@ -37,7 +37,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
-            <a class="site-nav-link active" href="index.html">Overview</a>
+            <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
@@ -45,87 +45,78 @@
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
-
     <main class="doc-shell">
-        <header class="doc-hero">
-            <div>
-                <h1>Citum docs</h1>
-                <p class="doc-lede">
-                    A Rust citation engine and YAML style system. Citum handles
-                    structured bibliographies, multilingual terms, reusable style
-                    families, and output that can be checked against real examples.
-                    CSL compatibility is a goal, not the ceiling.
-                </p>
-                <div class="doc-actions">
-                    <a class="citum-button-primary" href="guides/style-authoring/start.html">Write a style</a>
-                    <a class="citum-button-secondary" href="developer.html">Integrate Citum</a>
-                </div>
-            </div>
-            <aside class="workshop-block">
-                <div class="workshop-label">Djot input → rendered output</div>
-                <pre><code>[@kuhn1962, ch. 2; @watson1953]
-
-# style: chicago-author-date
-# locale: en-US
-
-(Kuhn 1962, chap. 2; Watson 1953)</code></pre>
-            </aside>
+        <header class="doc-section-header">
+            <span class="citum-kicker">Contributing</span>
+            <h1>Contributing to Citum</h1>
+            <p>Internal workflows, migration practice, policies, and architecture references for people working on the project.</p>
         </header>
-
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>What Citum does</h2>
-                <p>
-                    Most citation engines treat formatting as an afterthought. Citum
-                    makes the hard parts first-class — so the output you need is
-                    expressible, testable, and maintainable.
-                </p>
+                <h2>Status and quality</h2>
             </div>
             <div class="doc-grid">
-                <a class="doc-card" href="examples.html#bibliography-grouping">
-                    <h3>Bibliographies that organize themselves</h3>
-                    <p>Group references by type, language, or citation status. Legal hierarchies, multilingual sections, and primary/secondary divisions without custom renderer code.</p>
+                <a class="doc-card" href="TIER_STATUS.md">
+                    <h3>Tier status</h3>
+                    <p>Canonical style status, fidelity metrics, and current known gaps across the top parent styles.</p>
                 </a>
-                <a class="doc-card" href="guides/style-authoring/locales.html">
-                    <h3>Multilingual by default</h3>
-                    <p>Role labels, date formats, and locators adapt to the document locale automatically. Gendered terms, plural forms, and right-to-left scripts work without style modifications.</p>
-                </a>
-                <a class="doc-card" href="guides/style-authoring/inheritance-and-registries.html">
-                    <h3>Styles that extend, not fork</h3>
-                    <p>Build on existing styles with scoped overrides. Pin to a specific parent version for reproducibility, and distribute your styles without handing out a mystery clone.</p>
+                <a class="doc-card" href="compat.html">
+                    <h3>Compatibility report</h3>
+                    <p>Generated compatibility snapshot across the CSL oracle fixture suite.</p>
                 </a>
                 <a class="doc-card" href="reports.html">
-                    <h3>Bundled, validated styles</h3>
-                    <p>APA, Chicago, MLA, and more ship with Citum and are tested against real published examples. Use them as-is or as a base for your own.</p>
+                    <h3>Core quality reports</h3>
+                    <p>Portfolio baseline gate and per-style SQI scoring.</p>
                 </a>
             </div>
         </section>
-
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>Where to start</h2>
+                <h2>Workflows</h2>
             </div>
             <div class="doc-grid">
-                <a class="feature-link" href="guides/style-authoring/start.html">
-                    <h3>Style authoring</h3>
-                    <p>Write or adapt a YAML citation style. Start from the anatomy, add templates, type variants, and scoped options for the behavior your journal or workflow needs.</p>
+                <a class="doc-card" href="guides/STYLE_EVOLVE_WORKFLOW.md">
+                    <h3>Style evolve workflow</h3>
+                    <p>Process for migrating, upgrading, and refining Citum styles using the <code>/style-evolve</code> skill.</p>
                 </a>
-                <a class="feature-link" href="developer.html">
-                    <h3>Integration</h3>
-                    <p>Embed Citum in a web app, a LaTeX workflow, or an editor plugin. WASM, C FFI, CLI, and JSON-RPC server entry points with usage examples.</p>
+                <a class="doc-card" href="guides/RENDERING_WORKFLOW.md">
+                    <h3>Rendering workflow</h3>
+                    <p>Operational rendering and verification commands: oracle, batch impact, core quality gate.</p>
                 </a>
-                <a class="feature-link" href="reference.html">
-                    <h3>Reference</h3>
-                    <p>JSON schemas, canonical value tables, BibLaTeX field mappings, schema versioning rules, and feature status.</p>
+                <a class="doc-card" href="guides/CODING_STANDARDS.md">
+                    <h3>Coding standards</h3>
+                    <p>Rust verification table, benchmark workflow, Serde checklist, and test style expectations.</p>
                 </a>
-                <a class="feature-link" href="operating.html">
-                    <h3>Contributing</h3>
-                    <p>Migration practice, fidelity workflows, coding standards, and architectural policies for people moving the project forward.</p>
+                <a class="doc-card" href="guides/DOCUMENT_CLASSIFICATION.md">
+                    <h3>Document classification</h3>
+                    <p>Placement rules for specs, architecture notes, policies, guides, and reference docs.</p>
+                </a>
+            </div>
+        </section>
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Policies and architecture</h2>
+            </div>
+            <div class="doc-grid">
+                <a class="doc-card" href="policies/TYPE_ADDITION_POLICY.md">
+                    <h3>Type addition policy</h3>
+                    <p>Active policy governing when and how new data-model and style-discriminated types are added.</p>
+                </a>
+                <a class="doc-card" href="architecture/DESIGN_PRINCIPLES.md">
+                    <h3>Design principles</h3>
+                    <p>Explicit templates, typed data, processor boundaries, and the explicit-over-magic principle.</p>
+                </a>
+                <a class="doc-card" href="architecture/MIGRATION_STRATEGY_ANALYSIS.md">
+                    <h3>Migration strategy</h3>
+                    <p>Current strategy for migrating CSL 1.0 styles into Citum: hybrid XML pipeline and LLM-authored templates.</p>
+                </a>
+                <a class="doc-card" href="architecture/ROADMAP.md">
+                    <h3>Roadmap</h3>
+                    <p>Strategic direction and milestone priorities.</p>
                 </a>
             </div>
         </section>
     </main>
-
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
             <div class="site-footer-inner">

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1,11 +1,11 @@
-<!-- PAGE_ID: reports -->
+<!-- PAGE_ID: reference -->
 <!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Reports | Citum Docs</title>
-    <meta name="description" content="Generated compatibility, behavior coverage, and migration reports for Citum." />
+    <title>Reference | Citum Docs</title>
+    <meta name="description" content="JSON schemas, versioning rules, feature metadata, and domain reference tables for Citum." />
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="assets/citum-theme.css" />
 </head>
@@ -23,8 +23,8 @@
                 <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
-                <a class="site-nav-link " href="schemas/">Schemas</a>
-                <a class="site-nav-link active" href="reports.html">Reports</a>
+                <a class="site-nav-link active" href="schemas/">Schemas</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
                     <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
@@ -40,54 +40,54 @@
             <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>
-            <a class="site-nav-link " href="schemas/">Schemas</a>
-            <a class="site-nav-link active" href="reports.html">Reports</a>
+            <a class="site-nav-link active" href="schemas/">Schemas</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
-
     <main class="doc-shell">
         <header class="doc-section-header">
-            <span class="citum-kicker">Reports</span>
-            <h1>Reports</h1>
-            <p>
-                Generated reports for compatibility, behavior coverage, and migration.
-                These are published from CI and reflect the current state of the production branch.
-            </p>
+            <span class="citum-kicker">Schemas</span>
+            <h1>Reference</h1>
+            <p>Schemas, versioning rules, feature metadata, and domain reference tables.</p>
         </header>
         <section class="doc-section">
             <div class="doc-grid">
-                <a class="report-card" href="compat.html" style="display: block; padding: 1.5rem; text-decoration: none;">
-                    <h2 style="font-family: var(--citum-font-sans); font-size: 1.1rem; letter-spacing: 0; margin: 0 0 0.6rem;">Compatibility dashboard</h2>
-                    <p style="color: var(--citum-muted); font-size: 0.92rem; line-height: 1.55; margin: 0 0 0.75rem;">
-                        Style-level fidelity and SQI coverage for the current production style set.
-                    </p>
-                    <p style="color: var(--citum-faint); font-size: 0.75rem; font-family: var(--citum-font-mono); margin: 0;">
-                        Generated from scripts/report-core.js
-                    </p>
+                <a class="doc-card" href="schemas/">
+                    <h3>JSON Schemas</h3>
+                    <p>Generated schemas for styles, locales, bibliographies, citations, registries, and the server API. Use these to validate input files and power editor tooling.</p>
                 </a>
-                <a class="report-card" href="behavior-report.html" style="display: block; padding: 1.5rem; text-decoration: none;">
-                    <h2 style="font-family: var(--citum-font-sans); font-size: 1.1rem; letter-spacing: 0; margin: 0 0 0.6rem;">Engine behavior coverage</h2>
-                    <p style="color: var(--citum-muted); font-size: 0.92rem; line-height: 1.55; margin: 0 0 0.75rem;">
-                        Human-readable behavior coverage for selected engine suites, with source file and line references.
-                    </p>
-                    <p style="color: var(--citum-faint); font-size: 0.75rem; font-family: var(--citum-font-mono); margin: 0;">
-                        Generated from scripts/test-report.sh
-                    </p>
+                <a class="doc-card" href="reference/SCHEMA_VERSIONING.md">
+                    <h3>Schema versioning</h3>
+                    <p>How Citum tracks breaking and additive changes to the style format, and how tools can declare and check minimum version requirements.</p>
                 </a>
-                <a class="report-card" href="migration-behavior-report.html" style="display: block; padding: 1.5rem; text-decoration: none;">
-                    <h2 style="font-family: var(--citum-font-sans); font-size: 1.1rem; letter-spacing: 0; margin: 0 0 0.6rem;">Migration behavior coverage</h2>
-                    <p style="color: var(--citum-muted); font-size: 0.92rem; line-height: 1.55; margin: 0 0 0.75rem;">
-                        Migration scenarios for selected citum-migrate suites, with source file and line references.
-                    </p>
-                    <p style="color: var(--citum-faint); font-size: 0.75rem; font-family: var(--citum-font-mono); margin: 0;">
-                        Generated from scripts/migration-test-report.sh
-                    </p>
+                <a class="doc-card" href="reference/VERSION_BUMPING.md">
+                    <h3>Workspace versioning</h3>
+                    <p>How release impact is inferred from conventional commits and path changes. Relevant when contributing crate changes.</p>
+                </a>
+                <a class="doc-card" href="reference/BIBLATEX_MAPPING.md">
+                    <h3>BibLaTeX field mapping</h3>
+                    <p>Reference mapping between biblatex field names and the Citum input data model.</p>
+                </a>
+                <a class="doc-card" href="reference/GENRE_AND_MEDIUM_VALUES.md">
+                    <h3>Genre and medium values</h3>
+                    <p>Canonical value guidance for the <code>genre</code> and <code>medium</code> fields.</p>
+                </a>
+                <a class="doc-card" href="reference/DISAMBIGUATION.md">
+                    <h3>Disambiguation</h3>
+                    <p>Reference notes for author-date disambiguation behavior in styles that use it.</p>
+                </a>
+                <a class="doc-card" href="reference/SQI.md">
+                    <h3>Style Quality Index</h3>
+                    <p>Scoring model and reporting conventions for SQI, the style-level fidelity metric.</p>
+                </a>
+                <a class="doc-card" href="reference/FEATURES.md">
+                    <h3>Feature status</h3>
+                    <p>Docs-facing registry mapping features to their introduction version and maturity status.</p>
                 </a>
             </div>
         </section>
     </main>
-
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
             <div class="site-footer-inner">

--- a/docs/schemas/index.html
+++ b/docs/schemas/index.html
@@ -1,248 +1,186 @@
-<!-- PAGE_ID: schemas -->
-<!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
-
+<!-- PAGE_ID: reference -->
+<!doctype html>
+<html lang="en">
 <head>
     <meta charset="utf-8" />
-    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-    <title>Citum | JSON Schemas</title>
-    <meta name="description"
-        content="JSON schemas for Citum styles, bibliography input, locales, citations, the style registry, abbreviation maps, and the JSON-RPC server API.">
-
-    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
-        rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <link
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
-        rel="stylesheet" />
-
-    <script>
-        tailwind.config = {
-            darkMode: "class",
-            theme: {
-                extend: {
-                    colors: {
-                        "primary": "#2a94d6",
-                        "background-light": "#fdfbf7",
-                        "accent-cream": "#f5f2eb",
-                    },
-                    fontFamily: {
-                        "display": ["Libre Franklin", "sans-serif"],
-                        "mono": ["JetBrains Mono", "monospace"]
-                    },
-                    borderRadius: {
-                        "DEFAULT": "0.25rem",
-                        "lg": "0.5rem",
-                        "xl": "0.75rem",
-                        "full": "9999px"
-                    },
-                },
-            },
-        }
-    </script>
-    <style type="text/tailwindcss">
-        body {
-            font-family: 'Libre Franklin', sans-serif;
-            color: #374151;
-        }
-        .font-mono {
-            font-family: 'JetBrains Mono', monospace;
-        }
-        .glass-nav {
-            background: rgba(253, 251, 247, 0.85);
-            backdrop-filter: blur(12px);
-            border-bottom: 1px solid rgba(42, 148, 214, 0.1);
-        }
-        .citum-panel {
-            background: var(--citum-surface);
-            transition: all 0.3s ease;
-        }
-        .citum-panel:hover {
-            border-color: #2a94d6;
-            transform: translateY(-2px);
-            box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.05);
-        }
-    </style>
-    <link rel="stylesheet" href="../assets/citum-theme.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JSON Schemas | Citum Docs</title>
+    <meta name="description" content="JSON schemas for Citum styles, bibliography input, locales, citations, the style registry, abbreviation maps, and the JSON-RPC server API." />
+    <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../assets/citum-theme.css" />
 </head>
-
-<body class="bg-background-light text-slate-700 selection:bg-primary/20">
-
-    <!-- Navigation -->
-    <nav class="glass-nav sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="../index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+<body>
+    <nav class="site-nav">
+        <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="flex items-center gap-6 text-sm font-medium text-slate-600">
-                <a href="../index.html" class="hover:text-primary transition-colors">Docs</a>
-                <a href="https://github.com/bdarcus/citum-core" class="hover:text-primary transition-colors flex items-center gap-1" target="_blank">
-                    <span class="material-icons text-base">code</span> GitHub
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
                 </a>
             </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
         </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../index.html">Overview</a>
+            <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <!-- Header -->
-    <section class="py-16 px-6 border-b border-slate-200">
-        <div class="max-w-7xl mx-auto text-center">
-            <div class="inline-flex items-center gap-2 text-primary text-sm font-mono mb-4 bg-primary/10 px-3 py-1 rounded-full">
-                <span class="material-icons text-sm">schema</span>
-                JSON Schemas
-            </div>
-            <h1 class="text-4xl md:text-5xl font-bold text-slate-900 mb-4">Citum Schema Catalogue</h1>
-            <p class="text-slate-500 max-w-2xl mx-auto">
-                Machine-readable schemas for every Citum data format. Use them in your editor for autocomplete
-                and real-time validation, or in your tooling to validate inputs at build time.
+    <main class="doc-shell doc-sidebar-layout">
+        <aside class="doc-sidebar" aria-label="Schemas sections">
+            <div class="doc-sidebar-title">Schemas</div>
+            <a class="doc-sidebar-link active" href="../schemas/">JSON Schemas</a>
+            <a class="doc-sidebar-link" href="../reference.html">All reference</a>
+            <div class="doc-sidebar-title doc-sidebar-title--spaced">Reference</div>
+            <a class="doc-sidebar-link" href="../reference/SCHEMA_VERSIONING.md">Schema versioning</a>
+            <a class="doc-sidebar-link" href="../reference/BIBLATEX_MAPPING.md">BibLaTeX mapping</a>
+            <a class="doc-sidebar-link" href="../reference/GENRE_AND_MEDIUM_VALUES.md">Genre &amp; medium</a>
+            <a class="doc-sidebar-link" href="../reference/DISAMBIGUATION.md">Disambiguation</a>
+            <a class="doc-sidebar-link" href="../reference/SQI.md">Style Quality Index</a>
+            <a class="doc-sidebar-link" href="../reference/FEATURES.md">Feature status</a>
+        </aside>
+        <div class="doc-main">
+        <header class="doc-section-header">
+            <span class="citum-kicker">Schemas</span>
+            <h1>JSON Schemas</h1>
+            <p>
+                Machine-readable schemas for every Citum data format. Use them in your
+                editor for autocomplete and real-time validation, or in tooling to
+                validate inputs at build time.
             </p>
+            <p class="citum-note">
+                Schemas are published automatically by CI from
+                <code>cargo run --bin citum --features schema -- schema --out-dir docs/schemas</code>.
+            </p>
+        </header>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Style authoring</h2>
+            </div>
+            <div class="doc-grid">
+                <a class="doc-card" href="style.json">
+                    <h3>Style</h3>
+                    <p>Core Citum style definition: templates, options, citation modes, and bibliography configuration.</p>
+                    <code>style.json</code>
+                </a>
+                <a class="doc-card" href="locale.json">
+                    <h3>Locale</h3>
+                    <p>Terms, date patterns, role labels, and MessageFormat 2 messages for a given language tag.</p>
+                    <code>locale.json</code>
+                </a>
+            </div>
+        </section>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Configuration</h2>
+            </div>
+            <div class="doc-grid">
+                <a class="doc-card" href="registry.json">
+                    <h3>Registry</h3>
+                    <p>Style registry and alias map. Defines named style entries and their resolution rules.</p>
+                    <code>registry.json</code>
+                </a>
+                <a class="doc-card" href="abbrev-map.json">
+                    <h3>Abbreviation map</h3>
+                    <p>Flat key-value map for substituting journal titles, institutional names, and other strings.</p>
+                    <code>abbrev-map.json</code>
+                </a>
+            </div>
+        </section>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Reference and citation data</h2>
+            </div>
+            <div class="doc-grid">
+                <a class="doc-card" href="bib.json">
+                    <h3>Bibliography</h3>
+                    <p>Input reference format: typed fields, contributors, dates, identifiers, and archive data.</p>
+                    <code>bib.json</code>
+                </a>
+                <a class="doc-card" href="citation.json">
+                    <h3>Citations</h3>
+                    <p>Citation list format with locators, visibility modifiers, and infix text.</p>
+                    <code>citation.json</code>
+                </a>
+            </div>
+        </section>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Server API</h2>
+            </div>
+            <div class="doc-grid">
+                <a class="doc-card" href="server.json">
+                    <h3>Server RPC</h3>
+                    <p>JSON-RPC method parameter schemas: <code>render_citation</code>, <code>render_bibliography</code>, <code>validate_style</code>, <code>format_document</code>.</p>
+                    <code>server.json</code>
+                </a>
+            </div>
+        </section>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>Editor integration</h2>
+                <p>
+                    Add this comment as the first line of any YAML style file to get real-time
+                    validation and autocomplete in editors with
+                    <a href="https://github.com/redhat-developer/yaml-language-server#clients">YAML language server support</a>
+                    (VS Code, Helix, Zed, and others).
+                </p>
+            </div>
+            <div class="workshop-block">
+                <div class="workshop-label">yaml-language-server hint</div>
+                <pre><code># yaml-language-server: $schema=https://docs.citum.org/schemas/style.json</code></pre>
+                <button class="citum-copy-btn" onclick="navigator.clipboard.writeText('# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json')" title="Copy to clipboard">Copy</button>
+            </div>
+            <p class="citum-note" style="margin-top: 0.75rem;">
+                Replace <code>style.json</code> with the appropriate schema filename for your file type.
+            </p>
+        </section>
         </div>
-    </section>
+    </main>
 
-    <!-- Schema Cards -->
-    <section class="py-16 px-6">
-        <div class="max-w-7xl mx-auto">
-            <div class="max-w-3xl mx-auto mb-10 p-4 bg-amber-50 border border-amber-200 rounded-lg">
-                <p class="text-sm text-slate-700">
-                    Schema files are published automatically by CI from
-                    <code class="text-xs bg-amber-100 px-1 rounded">cargo run --bin citum --features schema -- schema --out-dir docs/schemas</code>.
-                    The <code class="text-xs bg-amber-100 px-1 rounded">schema</code> feature is gated to keep the default binary smaller.
-                </p>
-            </div>
-
-            <!-- Style Authoring row: style + locale -->
-            <h2 class="text-lg font-semibold text-slate-700 mb-4">Style Authoring</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-12 max-w-2xl">
-                <a href="style.json"
-                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons text-sm">architecture</span>
-                    </div>
-                    <h3 class="font-bold text-slate-900 mb-1">Style</h3>
-                    <p class="text-xs text-slate-500 mb-3">Core Citum style definition.</p>
-                    <code class="text-[10px] font-mono text-slate-400">style.json</code>
-                </a>
-                <a href="locale.json"
-                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons text-sm">language</span>
-                    </div>
-                    <h3 class="font-bold text-slate-900 mb-1">Locale</h3>
-                    <p class="text-xs text-slate-500 mb-3">Terms and date patterns.</p>
-                    <code class="text-[10px] font-mono text-slate-400">locale.json</code>
-                </a>
-            </div>
-
-            <!-- Configuration row: registry + abbrev-map -->
-            <h2 class="text-lg font-semibold text-slate-700 mb-4">Configuration</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-12 max-w-2xl">
-                <a href="registry.json"
-                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons text-sm">library_books</span>
-                    </div>
-                    <h3 class="font-bold text-slate-900 mb-1">Registry</h3>
-                    <p class="text-xs text-slate-500 mb-3">Style registry / alias map.</p>
-                    <code class="text-[10px] font-mono text-slate-400">registry.json</code>
-                </a>
-                <a href="abbrev-map.json"
-                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons text-sm">short_text</span>
-                    </div>
-                    <h3 class="font-bold text-slate-900 mb-1">Abbreviation Map</h3>
-                    <p class="text-xs text-slate-500 mb-3">Journal/publisher abbreviations.</p>
-                    <code class="text-[10px] font-mono text-slate-400">abbrev-map.json</code>
-                </a>
-            </div>
-
-            <!-- Reference / Citation data row -->
-            <h2 class="text-lg font-semibold text-slate-700 mb-4">Reference &amp; Citation Data</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-12 max-w-2xl">
-                <a href="bib.json"
-                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons text-sm">inventory_2</span>
-                    </div>
-                    <h3 class="font-bold text-slate-900 mb-1">Bibliography</h3>
-                    <p class="text-xs text-slate-500 mb-3">Input reference format.</p>
-                    <code class="text-[10px] font-mono text-slate-400">bib.json</code>
-                </a>
-                <a href="citation.json"
-                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons text-sm">format_quote</span>
-                    </div>
-                    <h3 class="font-bold text-slate-900 mb-1">Citations</h3>
-                    <p class="text-xs text-slate-500 mb-3">Citation list format.</p>
-                    <code class="text-[10px] font-mono text-slate-400">citation.json</code>
-                </a>
-            </div>
-
-            <!-- Server API row -->
-            <h2 class="text-lg font-semibold text-slate-700 mb-4">Server API</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-12 max-w-2xl">
-                <a href="server.json"
-                    class="citum-panel p-6 rounded-xl border border-slate-200 transition-all group block">
-                    <div class="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary mb-4 group-hover:bg-primary group-hover:text-white transition-colors">
-                        <span class="material-icons text-sm">dns</span>
-                    </div>
-                    <h3 class="font-bold text-slate-900 mb-1">Server RPC</h3>
-                    <p class="text-xs text-slate-500 mb-3">
-                        JSON-RPC method parameter schemas:
-                        <code class="text-[10px] font-mono">render_citation</code>,
-                        <code class="text-[10px] font-mono">render_bibliography</code>,
-                        <code class="text-[10px] font-mono">validate_style</code>,
-                        <code class="text-[10px] font-mono">format_document</code>.
-                    </p>
-                    <code class="text-[10px] font-mono text-slate-400">server.json</code>
-                </a>
-            </div>
-
-            <!-- IDE Integration Note -->
-            <div class="mt-4 p-6 bg-slate-50 rounded-xl border border-slate-200 max-w-3xl text-left">
-                <h3 class="font-bold text-slate-900 mb-3 flex items-center gap-2 text-sm">
-                    <span class="material-icons text-primary text-lg">tips_and_updates</span>
-                    Editor Integration
-                </h3>
-                <p class="text-sm text-slate-600 mb-4">
-                    To get real-time validation and autocomplete in editors with
-                    <a href="https://github.com/redhat-developer/yaml-language-server#clients"
-                        class="text-primary hover:underline" target="_blank">YAML language server support</a>
-                    (VS Code, Helix, Zed, and many others), add this comment as the first line of your YAML file:
-                </p>
-                <div class="bg-slate-900 rounded-lg p-4 flex items-center justify-between group border border-slate-700 shadow-md">
-                    <code class="font-mono text-xs text-slate-300">
-                        <span class="text-slate-500"># yaml-language-server: $schema=https://docs.citum.org/schemas/style.json</span>
-                    </code>
-                    <button class="text-slate-500 hover:text-white transition-colors"
-                        onclick="navigator.clipboard.writeText('# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json')"
-                        title="Copy to clipboard">
-                        <span class="material-icons text-base">content_copy</span>
-                    </button>
+    <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+        <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <p class="text-[10px] text-slate-400 mt-4 font-mono italic">
-                    Replace <code class="text-slate-600 px-0.5 rounded">style.json</code> with the appropriate schema filename for your file type.
-                </p>
-            </div>
-        </div>
-    </section>
-
-    <!-- Footer -->
-    <footer class="py-10 px-6 border-t border-slate-200 text-center text-xs text-slate-400">
-        <p>
-            <a href="../index.html" class="hover:text-primary transition-colors">← Back to Citum Docs</a>
-            &nbsp;·&nbsp;
-            Schemas published automatically by CI from
-            <a href="https://github.com/bdarcus/citum-core" class="hover:text-primary transition-colors" target="_blank">citum-core</a>.
-        </p>
+                <div class="site-footer-links">
+                    <a href="../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../developer.html">Developer</a>
+                    <a href="../schemas/">Schemas</a>
+                    <a href="../reports.html">Reports</a>
+                    <a href="../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
     </footer>
-
+    <script src="../assets/citum-interactive.js"></script>
 </body>
 </html>

--- a/scripts/build-layout.js
+++ b/scripts/build-layout.js
@@ -4,65 +4,57 @@ const path = require('path');
 const DOCS_DIR = path.join(__dirname, '../docs');
 
 const NAV_TEMPLATE = `
-        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-            <div class="flex items-center gap-2 shrink-0">
-                <a href="{{ROOT}}index.html" class="flex items-center gap-2 group">
-                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
-                        <span class="text-white font-mono font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="{{ROOT}}index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </a>
             </div>
-            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
-                <a class="nav-link" href="https://citum.org">Home</a>
-                <a class="nav-link" href="https://citum.org/news/index.html">News</a>
-                <a class="nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Docs</a>
-                <a class="nav-link {{ACTIVE_DEMO}}" href="{{ROOT}}interactive-demo.html">Demo</a>
-                <a class="nav-link {{ACTIVE_EXAMPLES}}" href="{{ROOT}}examples.html">Examples</a>
-                <a class="nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
-                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
-                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
-                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Overview</a>
+                <a class="site-nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link {{ACTIVE_DEVELOPER}}" href="{{ROOT}}developer.html">Developer</a>
+                <a class="site-nav-link {{ACTIVE_REFERENCE}}" href="{{ROOT}}schemas/">Schemas</a>
+                <a class="site-nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
-                    Source
+                    GitHub
                 </a>
             </div>
-            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
-                <span class="material-icons text-[20px]">menu</span>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
             </button>
         </div>
-        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
-            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
-                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
-                <a class="hover:text-primary transition-colors" href="https://citum.org/news/index.html">News</a>
-                <a class="nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Docs</a>
-                <a class="nav-link {{ACTIVE_DEMO}}" href="{{ROOT}}interactive-demo.html">Demo</a>
-                <a class="nav-link {{ACTIVE_EXAMPLES}}" href="{{ROOT}}examples.html">Examples</a>
-                <a class="nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-author-guide.html">Style Guide</a>
-                <a class="nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
-                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-            </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link {{ACTIVE_DOCS}}" href="{{ROOT}}index.html">Overview</a>
+            <a class="site-nav-link {{ACTIVE_STYLE}}" href="{{ROOT}}guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link {{ACTIVE_DEVELOPER}}" href="{{ROOT}}developer.html">Developer</a>
+            <a class="site-nav-link {{ACTIVE_REFERENCE}}" href="{{ROOT}}schemas/">Schemas</a>
+            <a class="site-nav-link {{ACTIVE_REPORTS}}" href="{{ROOT}}reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
         </div>`;
 
 const FOOTER_TEMPLATE = `
-            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
-                <div class="flex items-center gap-2">
-                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
-                        <span class="text-white font-mono text-xs font-bold">C</span>
-                    </div>
-                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
                 </div>
-                <div class="flex gap-8 text-sm font-medium text-slate-500">
-                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
-                    <a class="hover:text-primary transition-colors" href="{{ROOT}}examples.html">Examples</a>
-                    <a class="hover:text-primary transition-colors" href="{{ROOT}}reports.html">Reports</a>
+                <div class="site-footer-links">
+                    <a href="{{ROOT}}guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="{{ROOT}}developer.html">Developer</a>
+                    <a href="{{ROOT}}schemas/">Schemas</a>
+                    <a href="{{ROOT}}reports.html">Reports</a>
+                    <a href="{{ROOT}}operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
                 </div>
-                <div class="text-sm text-slate-400">
-                    © 2026 Citum Project.
-                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
             </div>`;
+
+const ACTIVE_CLASS = 'active';
 
 function getFiles(dir, fileList = []) {
     const files = fs.readdirSync(dir);
@@ -70,11 +62,15 @@ function getFiles(dir, fileList = []) {
         const filepath = path.join(dir, file);
         if (fs.statSync(filepath).isDirectory()) {
             getFiles(filepath, fileList);
-        } else if (filepath.endsWith('.html') && !filepath.includes('/news/posts/')) {
+        } else if (filepath.endsWith('.html') && !filepath.endsWith('.template.html') && !filepath.includes('/news/posts/')) {
             fileList.push(filepath);
         }
     }
     return fileList;
+}
+
+function activeFor(pageId, target) {
+    return pageId === target ? ACTIVE_CLASS : '';
 }
 
 function buildLayouts() {
@@ -85,45 +81,38 @@ function buildLayouts() {
         let content = fs.readFileSync(file, 'utf8');
         let modified = false;
 
-        // Determine active tab via <!-- PAGE_ID: xxx -->
         const idMatch = content.match(/<!-- PAGE_ID:\s*([a-zA-Z0-9-]+)\s*-->/);
         const pageId = idMatch ? idMatch[1] : '';
-
-        // Calculate root prefix
         const relative = path.relative(path.dirname(file), DOCS_DIR);
-        const rootPrefix = relative ? relative + '/' : '';
+        const rootPrefix = relative ? `${relative}/` : '';
 
-        const activeClass = 'active bg-primary/10 text-primary font-semibold';
-        
-        let navHtml = NAV_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix)
-            .replace(/{{ACTIVE_DOCS}}/g, pageId === 'docs' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_DEMO}}/g, pageId === 'demo' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_EXAMPLES}}/g, pageId === 'examples' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_STYLE}}/g, pageId === 'style' ? activeClass : 'text-slate-600')
-            .replace(/{{ACTIVE_REPORTS}}/g, pageId === 'reports' ? activeClass : 'text-slate-600');
-            
-        let footerHtml = FOOTER_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix);
+        const navHtml = NAV_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix)
+            .replace(/{{ACTIVE_DOCS}}/g, activeFor(pageId, 'docs'))
+            .replace(/{{ACTIVE_STYLE}}/g, activeFor(pageId, 'style'))
+            .replace(/{{ACTIVE_DEVELOPER}}/g, activeFor(pageId, 'developer'))
+            .replace(/{{ACTIVE_REFERENCE}}/g, activeFor(pageId, 'reference'))
+            .replace(/{{ACTIVE_REPORTS}}/g, activeFor(pageId, 'reports'));
 
-        // Inject Nav
+        const footerHtml = FOOTER_TEMPLATE.replace(/{{ROOT}}/g, rootPrefix);
+
         const navRegex = /(<!-- LAYOUT_NAV_START -->)([\s\S]*?)(<!-- LAYOUT_NAV_END -->)/;
         if (navRegex.test(content)) {
-            content = content.replace(navRegex, '$1' + navHtml + '        $3');
+            content = content.replace(navRegex, `$1${navHtml}        $3`);
             modified = true;
         }
 
-        // Inject Footer
         const footerRegex = /(<!-- LAYOUT_FOOTER_START -->)([\s\S]*?)(<!-- LAYOUT_FOOTER_END -->)/;
         if (footerRegex.test(content)) {
-            content = content.replace(footerRegex, '$1' + footerHtml + '        $3');
+            content = content.replace(footerRegex, `$1${footerHtml}        $3`);
             modified = true;
         }
 
         if (modified) {
             fs.writeFileSync(file, content);
-            console.log(`Updated layout in ${path.relative(DOCS_DIR, file)}`);
+            console.log(`  Updated: ${path.relative(DOCS_DIR, file)}`);
         }
     }
-    console.log('Done!');
+    console.log('Done.');
 }
 
 buildLayouts();


### PR DESCRIPTION
## Summary

- Remove Tailwind CDN and Material Icons from all pages; replace with single semantic `citum-theme.css` using `--citum-*` design tokens
- New pages: `developer.html`, `reference.html`, `operating.html` (Contributing), `schemas/index.html`, and full `guides/style-authoring/` section
- Primary nav: three audience tracks — Style Authoring, Developer, Reference; Contributing moves to footer-only
- `index.html` hero and "What Citum does" cards rewritten for non-technical readers
- Developer page: removes hallucinated Python bindings; Lua/LuaLaTeX links to citum-labs repo
- `build-layout.js` updated to inject semantic nav/footer via `LAYOUT_NAV_START/END` markers into all pages
- Mobile nav toggle wired in `citum-interactive.js`; `.hidden` utility rule added so dropdown closes correctly
- Bean `csl26-0y0z` defers version badge injection from `features.yaml` to a follow-up task

## Test plan

- [x] Hard-refresh each top-level page and verify nav links render at full laptop width
- [x] Verify mobile nav toggle opens and closes at narrow viewport
- [x] Check `schemas/index.html` renders with correct relative asset paths
- [x] Confirm `operating.html` (Contributing) is accessible via footer links
- [x] Confirm `developer.html` Lua binding links to citum-labs repo correctly
