### PR TITLE
chore(tooling): remove unused dependencies

### DIFF
--- a/.beans/archive/csl26-gonm--remove-unused-dependencies-via-cargo-shear.md
+++ b/.beans/archive/csl26-gonm--remove-unused-dependencies-via-cargo-shear.md
@@ -1,0 +1,11 @@
+---
+# csl26-gonm
+title: Remove unused dependencies via cargo shear
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-14T15:25:42Z
+updated_at: 2026-05-14T15:25:50Z
+---
+
+Apply cargo shear --expand --fix to remove genuinely unused deps; suppress optional false positives; fix doctest/test advisory warnings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,6 @@ dependencies = [
 name = "citum"
 version = "0.43.0"
 dependencies = [
- "biblatex",
  "ciborium",
  "citum-bindings",
  "citum-engine",
@@ -608,17 +607,13 @@ dependencies = [
  "clap_complete",
  "comfy-table",
  "crossterm",
- "csl-legacy",
- "indexmap 2.14.0",
  "ratatui",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "strsim",
- "tracing",
  "url",
- "walkdir",
 ]
 
 [[package]]
@@ -644,12 +639,10 @@ dependencies = [
  "citum-schema",
  "csl-legacy",
  "indexmap 2.14.0",
- "serde",
  "serde_json",
  "serde_yaml_ng",
  "specta",
  "specta-typescript",
- "tracing",
  "wasm-bindgen",
 ]
 
@@ -658,7 +651,6 @@ name = "citum-edtf"
 version = "0.43.0"
 dependencies = [
  "serde",
- "tracing",
  "winnow 1.0.2",
 ]
 
@@ -668,7 +660,6 @@ version = "0.43.0"
 dependencies = [
  "citum-edtf",
  "citum-io",
- "citum-migrate",
  "citum-schema",
  "citum-schema-data",
  "criterion",
@@ -678,7 +669,6 @@ dependencies = [
  "indexmap 2.14.0",
  "jotdown",
  "orgize",
- "roxmltree 0.21.1",
  "rstest",
  "serde",
  "serde_json",
@@ -704,8 +694,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "thiserror",
- "tracing",
  "url",
 ]
 
@@ -728,7 +716,6 @@ dependencies = [
 name = "citum-pdf"
 version = "0.43.0"
 dependencies = [
- "tracing",
  "typst",
  "typst-kit",
  "typst-pdf",
@@ -740,7 +727,6 @@ version = "0.43.0"
 dependencies = [
  "serde_json",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -768,7 +754,6 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "specta",
- "tracing",
  "url",
 ]
 
@@ -778,7 +763,6 @@ version = "0.43.0"
 dependencies = [
  "ciborium",
  "cid",
- "citum-edtf",
  "citum-resolver-api",
  "citum-schema-data",
  "criterion",
@@ -793,8 +777,6 @@ dependencies = [
  "serde_yaml_ng",
  "sha2",
  "specta",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -813,7 +795,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tower",
- "tracing",
 ]
 
 [[package]]
@@ -836,7 +817,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml 1.1.2+spec-1.1.0",
- "tracing",
 ]
 
 [[package]]
@@ -1202,7 +1182,6 @@ dependencies = [
  "roxmltree 0.21.1",
  "serde",
  "serde_json",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,9 @@ four_forward_slashes = "deny"      # Enforce comment syntax correctness
 missing_safety_doc = "deny"        # Safety-critical items must be documented
 tabs_in_doc_comments = "deny"      # Enforce consistent formatting
 
+[workspace.metadata.cargo-shear]
+ignored = ["csl_legacy", "specta", "multibase"]
+
 [workspace.dependencies]
 tracing = "0.1"
 

--- a/crates/citum-bindings/Cargo.toml
+++ b/crates/citum-bindings/Cargo.toml
@@ -14,13 +14,13 @@ wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-simd", "--strip-debug", "--
 [lib]
 name = "citum_bindings"
 crate-type = ["cdylib", "rlib"]
+test = false
+doctest = false
 
 [dependencies]
-tracing.workspace = true
 citum-engine = { path = "../citum-engine", default-features = false }
 citum-schema = { package = "citum-schema", path = "../citum-schema", default-features = false }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy", optional = true }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -11,7 +11,6 @@ name = "citum"
 path = "src/main.rs"
 
 [dependencies]
-tracing.workspace = true
 clap = { version = "4.4", features = ["derive", "color"] }
 clap_complete = "4.4"
 comfy-table = "7.1"
@@ -21,16 +20,12 @@ serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 strsim = "0.11"
-walkdir = "2.4"
 schemars = { version = "1.2.1", features = ["indexmap2"], optional = true }
-indexmap = "2.2.3"
 ratatui = { version = "0.30.0", default-features = false, features = ["crossterm_0_29"] }
 citum_schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
 citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
 citum_engine = { package = "citum-engine", path = "../citum-engine" }
 citum_io = { package = "citum-io", path = "../citum-io" }
-csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
-biblatex = "0.11"
 citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }
 citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
 citum-pdf = { path = "../citum-pdf", optional = true }

--- a/crates/citum-edtf/Cargo.toml
+++ b/crates/citum-edtf/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-tracing.workspace = true
 winnow = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
@@ -17,3 +16,6 @@ serde = ["dep:serde"]
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -12,7 +12,6 @@ name = "citum_engine"
 crate-type = ["rlib"]
 
 [dependencies]
-tracing.workspace = true
 citum_schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
 citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
@@ -21,7 +20,6 @@ serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 thiserror = "2.0"
 citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }
-url = { version = "2.5", features = ["serde"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 winnow = "1.0"
 jotdown = "0.10"
@@ -37,11 +35,11 @@ ffi = []
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-citum_migrate = { package = "citum-migrate", path = "../citum-migrate" }
 citum_io = { package = "citum-io", path = "../citum-io" }
-roxmltree = "0.21"
 rstest = "0.26"
 tempfile = "3.8"
+tracing.workspace = true
+url = { version = "2.5", features = ["serde"] }
 
 [[bench]]
 name = "rendering"

--- a/crates/citum-io/Cargo.toml
+++ b/crates/citum-io/Cargo.toml
@@ -7,7 +7,6 @@ description = "Citum I/O and format conversion library"
 repository.workspace = true
 
 [dependencies]
-tracing.workspace = true
 citum-schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
 citum-engine = { package = "citum-engine", path = "../citum-engine" }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
@@ -18,7 +17,9 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 indexmap = { version = "2.2.6", features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
-thiserror = "2.0"
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/crates/citum-migrate/Cargo.toml
+++ b/crates/citum-migrate/Cargo.toml
@@ -23,3 +23,6 @@ serde = { version = "1.0", features = ["derive"] }
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/crates/citum-pdf/Cargo.toml
+++ b/crates/citum-pdf/Cargo.toml
@@ -8,9 +8,10 @@ repository.workspace = true
 
 [lib]
 name = "citum_pdf"
+test = false
+doctest = false
 
 [dependencies]
-tracing.workspace = true
 typst = "0.14.2"
 typst-pdf = "0.14.2"
 typst-kit = { version = "0.14.2", default-features = false, features = ["fonts", "embed-fonts"] }

--- a/crates/citum-resolver-api/Cargo.toml
+++ b/crates/citum-resolver-api/Cargo.toml
@@ -7,7 +7,6 @@ description = "Citum style resolution interfaces and error types"
 repository.workspace = true
 
 [dependencies]
-tracing.workspace = true
 thiserror = "2.0"
 serde_json = { version = "1.0", optional = true }
 
@@ -17,3 +16,7 @@ http = []
 
 [lints]
 workspace = true
+
+[lib]
+test = false
+doctest = false

--- a/crates/citum-schema-data/Cargo.toml
+++ b/crates/citum-schema-data/Cargo.toml
@@ -7,7 +7,6 @@ description = "Citum bibliographic data schema types"
 repository.workspace = true
 
 [dependencies]
-tracing.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = { version = "1.2.1", features = ["derive", "url2", "indexmap2"], optional = true }
@@ -29,3 +28,6 @@ workspace = true
 [dev-dependencies]
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10.0" }
+
+[lib]
+doctest = false

--- a/crates/citum-schema-style/Cargo.toml
+++ b/crates/citum-schema-style/Cargo.toml
@@ -7,15 +7,12 @@ description = "Citum style schema types and styling engine"
 repository.workspace = true
 
 [dependencies]
-tracing.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 schemars = { version = "1.2.1", features = ["derive", "url2", "indexmap2"], optional = true }
 specta = { version = "2.0.0-rc.23", features = ["derive"], optional = true }
-citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }
-url = { version = "2.5", features = ["serde"] }
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy", optional = true }
 indexmap = { version = "2", features = ["serde"] }
 citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
@@ -42,3 +39,6 @@ harness = false
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/crates/citum-schema/Cargo.toml
+++ b/crates/citum-schema/Cargo.toml
@@ -26,3 +26,7 @@ ciborium = "0.2"
 
 [lints]
 workspace = true
+
+[lib]
+test = false
+doctest = false

--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -13,7 +13,6 @@ name = "citum-server"
 path = "src/main.rs"
 
 [dependencies]
-tracing.workspace = true
 citum-engine = { package = "citum-engine", path = "../citum-engine" }
 citum-schema = { package = "citum-schema", path = "../citum-schema" }
 citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }
@@ -44,3 +43,6 @@ schema = ["http", "schema-types"]
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 repository.workspace = true
 
 [dependencies]
-tracing.workspace = true
 citum-schema = { package = "citum-schema", path = "../citum-schema" }
 dirs = "6.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -35,3 +34,6 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false

--- a/crates/csl-legacy/Cargo.toml
+++ b/crates/csl-legacy/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 repository.workspace = true
 
 [dependencies]
-tracing.workspace = true
 indexmap = "2.13.0"
 roxmltree = "0.21"
 serde = { version = "1.0", features = ["derive"] }
@@ -15,3 +14,6 @@ serde_json = "1.0"
 
 [lints]
 workspace = true
+
+[lib]
+doctest = false


### PR DESCRIPTION
## Summary

Apply `cargo shear --expand` (macro-aware via nightly) to remove genuinely
unused dependencies across the workspace.

**Removed: 19 direct dependencies across 12 crates**

| Crate | Removed |
|-------|---------|
| `citum-cli` | `tracing`, `walkdir`, `indexmap`, `csl_legacy`, `biblatex` |
| `citum-bindings` | `tracing`, `serde` |
| `citum-edtf` | `tracing` |
| `citum-engine` | `tracing` → dev-deps, `url` → dev-deps |
| `citum-engine` (dev) | `citum_migrate`, `roxmltree` |
| `citum-io` | `tracing`, `thiserror` |
| `citum-pdf` | `tracing` |
| `citum-resolver-api` | `tracing` |
| `citum-schema-data` | `tracing` |
| `citum-schema-style` | `tracing`, `citum_edtf`, `url` |
| `citum-server` | `tracing` |
| `citum_store` | `tracing` |
| `csl-legacy` | `tracing` |

**21 entries removed from `Cargo.lock`**

Also:
- Adds `[workspace.metadata.cargo-shear] ignored` for 3 optional deps that are
  feature-gated (`csl_legacy`, `specta`, `multibase`) — shear flags these as
  warnings but they are correctly used via feature flags
- Sets `doctest = false` / `test = false` on lib targets that have no doc tests
  or unit tests, eliminating spurious test-harness compilation

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo nextest run` — 1259/1259 tests pass
- [x] `cargo shear --expand` reports 0 errors after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
