### PR TITLE
docs(server): expand README and update schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "jotdown",
  "orgize",
  "rstest",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -27,11 +27,13 @@ orgize = "0.9"
 icu_collator = { version = "2.2.0", features = ["compiled_data"], optional = true }
 icu_locale = { version = "2.2.0", optional = true }
 unicode-script = "0.5.8"
+schemars = { version = "1.2.1", features = ["derive"], optional = true }
 
 [features]
 default = ["icu"]
 icu = ["dep:icu_collator", "dep:icu_locale"]
 ffi = []
+schema = ["dep:schemars", "citum_schema/schema", "citum_schema_data/schema"]
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/citum-engine/src/api/style_input.rs
+++ b/crates/citum-engine/src/api/style_input.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 /// or as an identifier that requires a remote resolver. Only `Path` and `Yaml`
 /// can be resolved locally; `Id` and `Uri` require the citum-server resolver chain.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "kind", content = "value", rename_all = "lowercase")]
 pub enum StyleInput {
     /// A style identifier to be resolved from registries (builtin, store, remote).

--- a/crates/citum-engine/src/api/types.rs
+++ b/crates/citum-engine/src/api/types.rs
@@ -70,6 +70,7 @@ impl Default for AnnotationStyle {
 
 /// Markup format for annotation text.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum AnnotationFormat {
     /// Parse annotation as djot inline markup (default).
@@ -163,6 +164,7 @@ impl From<CitationOccurrence> for citum_schema::data::citation::Citation {
 ///
 /// Controls rendering behavior that belongs to the document rather than the style.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct DocumentOptions {
     /// Override or replace style-defined bibliography grouping.

--- a/crates/citum-engine/src/processor/document/types.rs
+++ b/crates/citum-engine/src/processor/document/types.rs
@@ -37,6 +37,7 @@ pub struct CitationStructure {
 
 /// Document-level integral-name override parsed from frontmatter.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct DocumentIntegralNameOverride {
     /// Whether the integral-name policy is enabled for this document.

--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -38,7 +38,7 @@ tower = { version = "0.5", features = ["util"] }
 default = []
 async = ["tokio"]
 http = ["async", "axum"]
-schema-types = ["dep:schemars"]
+schema-types = ["dep:schemars", "citum-engine/schema"]
 schema = ["http", "schema-types"]
 
 [lints]

--- a/crates/citum-server/README.md
+++ b/crates/citum-server/README.md
@@ -25,11 +25,11 @@ Build with `--features http` to expose the same three methods over HTTP via
 `axum`. Useful for the citum-hub live preview panel.
 
 ```sh
-cargo run -p citum-server --features http -- --http --port 8080
+cargo run -p citum-server --features http -- --http --port 9000
 ```
 
 ```sh
-curl -s http://localhost:8080/rpc \
+curl -s http://localhost:9000/rpc \
   -H 'Content-Type: application/json' \
   -d '{
     "id": 1,
@@ -74,7 +74,7 @@ node scripts/benchmark-rpc-workflow.js
 | `render_citation` | `style_path`, `refs`, `citation`, `output_format?`, `inject_ast_indices?` | `String` |
 | `render_bibliography` | `style_path`, `refs`, `output_format?`, `inject_ast_indices?` | `{format, content, entries?}` |
 | `validate_style` | `style_path` | `{valid, warnings}` |
-| `format_document` | `style`, `refs`, `citations`, `output_format?` | `{citations, bibliography}` |
+| `format_document` | `style`, `refs`, `citations`, `document_options?`, `output_format?`, `locale?` | `{formatted_citations, bibliography, warnings}` |
 
 Supported `output_format` values:
 
@@ -101,21 +101,53 @@ When running in HTTP mode, two read-only discovery endpoints are available:
 
 ```sh
 # List all supported methods
-curl http://localhost:8080/rpc/methods
+curl http://localhost:9000/rpc/methods
 
 # JSON Schema for method parameters (requires --features schema build)
-curl http://localhost:8080/rpc/schema
+curl http://localhost:9000/rpc/schema
 ```
 
 Sending a `GET` request to `/rpc` returns a `405 Method Not Allowed` response with a JSON hint explaining POST usage.
+
+## Batch Document Formatting
+
+The `format_document` method is designed for processing a full document in one request. For practical workflows where data is stored in local files, you can use `jq` to assemble the JSON-RPC payload.
+
+```sh
+# Assemble and send a document formatting request using local JSON files
+jq -n \
+  --arg style_path "styles/embedded/apa-7th.yaml" \
+  --slurpfile refs examples/document-refs-native.json \
+  --slurpfile citations examples/document-citations.json \
+  --slurpfile options examples/document-options.json \
+  '{
+    id: 1,
+    method: "format_document",
+    params: {
+      style: { kind: "path", value: $style_path },
+      refs: $refs[0],
+      citations: $citations[0],
+      document_options: $options[0],
+      output_format: "html"
+    }
+  }' | curl -s http://localhost:9000/rpc \
+    -H 'Content-Type: application/json' \
+    -d @-
+```
+
+## Working with Local Files
+
+When running `citum-server` locally, the `style_path` (or `style`) parameter accepts relative or absolute paths to Citum YAML files.
+
+However, the `refs` and `citations` parameters always expect data objects, not paths. This allows the server to remain transport-agnostic and simplifies its security model (preventing arbitrary file reads by the server process). To use local files for these parameters, load them into the request payload on the client side as shown in the example above.
 
 ## Features
 
 | Feature | Default | Description |
 |---|---|---|
-| `async` | off | Wraps `Processor` in `tokio::task::spawn_blocking` |
-| `http` | off | Enables axum HTTP server; implies `async` |
-| `schema` | off | Enables GET /rpc/schema endpoint with schemars-generated JSON Schema; implies `http` |
+| `async` | off | Required for non-blocking I/O. Wraps `Processor` in `tokio::task::spawn_blocking` |
+| `http` | off | Enables axum HTTP server; **requires and automatically enables `async`** |
+| `schema` | off | Enables `/rpc/schema` endpoint; **requires and automatically enables `http` and `async`** |
 
 ## Usage
 

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use crate::error::ServerError;
 use citum_engine::{
-    Bibliography, Citation, Processor,
+    Bibliography, Citation, DocumentOptions, Processor, StyleInput,
     render::{djot::Djot, html::Html, latex::Latex, plain::PlainText, typst::Typst},
 };
 use citum_schema::Style;
@@ -104,7 +104,7 @@ pub struct ValidateStyleParams {
 )]
 pub struct FormatDocumentParams {
     /// Style identifier, path, URI, or inline YAML.
-    pub style: String,
+    pub style: StyleInput,
     /// Optional BCP 47 locale override.
     pub locale: Option<String>,
     /// Output format (plain, html, djot, latex, typst). Defaults to plain.
@@ -113,6 +113,8 @@ pub struct FormatDocumentParams {
     pub refs: serde_json::Value,
     /// Ordered citations as they appear in the document.
     pub citations: serde_json::Value,
+    /// Optional document-level configuration.
+    pub document_options: Option<DocumentOptions>,
 }
 
 #[derive(Debug, Serialize)]

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -32,6 +32,2811 @@
           "const": "typst"
         }
       ]
+    },
+    "StyleInput": {
+      "description": "A style reference that can be resolved locally or by an external resolver.\n\nThis union type allows callers to supply a style by local path, inline YAML,\nor as an identifier that requires a remote resolver. Only `Path` and `Yaml`\ncan be resolved locally; `Id` and `Uri` require the citum-server resolver chain.",
+      "oneOf": [
+        {
+          "description": "A style identifier to be resolved from registries (builtin, store, remote).\nRequires external resolver chain — local resolution returns UnresolvedInput error.",
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "id"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ]
+        },
+        {
+          "description": "A remote URI to be resolved (requires HTTP access).\nRequires external resolver chain — local resolution returns UnresolvedInput error.",
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "uri"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ]
+        },
+        {
+          "description": "A local filesystem path to a YAML style file.",
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "path"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ]
+        },
+        {
+          "description": "Inline YAML style definition.",
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "yaml"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ]
+        }
+      ]
+    },
+    "DocumentOptions": {
+      "description": "Document-level configuration for rendering.\n\nControls rendering behavior that belongs to the document rather than the style.",
+      "type": "object",
+      "properties": {
+        "bibliography_groups": {
+          "description": "Override or replace style-defined bibliography grouping.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/BibliographyGroup"
+          }
+        },
+        "sort_partitioning": {
+          "description": "Automatic bibliography partitioning by script or language.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BibliographySortPartitioning"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "integral_names": {
+          "description": "Document-level narrative citation rules.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DocumentIntegralNameOverride"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "show_semantics": {
+          "description": "Whether to output semantic markup (HTML spans, Djot attributes).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "inject_ast_indices": {
+          "description": "Whether to annotate semantic wrappers with source template indices.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "annotations": {
+          "description": "Reference ID to annotation text mapping.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "annotation_format": {
+          "description": "Format for annotation text (djot, plain, org).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnnotationFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "abbreviation_map": {
+          "description": "Map from full rendered strings to their abbreviations.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbbreviationMap"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "BibliographyGroup": {
+      "description": "A bibliography group with selector, optional heading, and per-group sorting.\n\nGroups allow styles to divide bibliographies into labeled sections with\ndistinct sorting rules. Items match the first group whose selector evaluates\nto true (first-match semantics).\n\n# Examples\n\n```yaml\ngroups:\n  - id: vietnamese\n    heading:\n      localized:\n        vi: \"Tài liệu tiếng Việt\"\n        en-US: \"Vietnamese Sources\"\n    selector:\n      field:\n        language: vi\n    sort:\n      template:\n        - key: author\n          sort-order: given-family\n```",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique identifier for this group.",
+          "type": "string"
+        },
+        "heading": {
+          "description": "Optional heading to display above this group.\nOmit for no heading (e.g., fallback group).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupHeading"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "selector": {
+          "description": "Selector predicate to match references.",
+          "$ref": "#/$defs/GroupSelector"
+        },
+        "sort": {
+          "description": "Optional per-group sorting specification.\nFalls back to global bibliography sort if omitted.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSortEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "template": {
+          "description": "Optional per-group template override.\nFalls back to global bibliography template if omitted.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "disambiguate": {
+          "description": "Optional disambiguation scope.\n- `globally` (default): Year suffixes are assigned across the whole bibliography.\n- `locally`: Year suffixes are assigned independently within this group.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DisambiguationScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "selector"
+      ]
+    },
+    "GroupHeading": {
+      "description": "Localizable heading source for bibliography groups.",
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "type": "object",
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ]
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "type": "object",
+          "properties": {
+            "term": {
+              "description": "Locale general term key.",
+              "$ref": "#/$defs/GeneralTerm"
+            },
+            "form": {
+              "description": "Optional term form (defaults to long).",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "term"
+          ]
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "type": "object",
+          "properties": {
+            "localized": {
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "localized"
+          ]
+        }
+      ]
+    },
+    "GeneralTerm": {
+      "description": "A list of general terms for citation formatting.\n\nThese are the standard terms that appear in bibliographies and citations,\nincluding prepositions (in, at, from, by), punctuation terms (and, et al),\ndate-related terms (accessed, no-date, circa), locator terms (page, chapter, volume),\nand special phrases (ibid, forthcoming, available-at).",
+      "oneOf": [
+        {
+          "description": "The preposition \"in\" (e.g., \"in Smith, 2020\").",
+          "type": "string",
+          "const": "in"
+        },
+        {
+          "description": "The term used for access dates (e.g., \"accessed May 1\").",
+          "type": "string",
+          "const": "accessed"
+        },
+        {
+          "description": "The term used for retrieval statements (e.g., \"retrieved from URL\").",
+          "type": "string",
+          "const": "retrieved"
+        },
+        {
+          "description": "The preposition \"at\" (e.g., \"at the conference\").",
+          "type": "string",
+          "const": "at"
+        },
+        {
+          "description": "The preposition \"from\" (e.g., \"from the publisher\").",
+          "type": "string",
+          "const": "from"
+        },
+        {
+          "description": "The preposition \"of\" (e.g., \"special issue of\").",
+          "type": "string",
+          "const": "of"
+        },
+        {
+          "description": "The preposition \"to\" (e.g., \"from x to y\").",
+          "type": "string",
+          "const": "to"
+        },
+        {
+          "description": "The preposition \"by\" (e.g., \"by John Smith\").",
+          "type": "string",
+          "const": "by"
+        },
+        {
+          "description": "The term used when no date is available (e.g., \"n.d.\").",
+          "type": "string",
+          "const": "no-date"
+        },
+        {
+          "description": "The term used for anonymous authorship (e.g., \"anonymous\").",
+          "type": "string",
+          "const": "anonymous"
+        },
+        {
+          "description": "The term used for approximate dates (e.g., \"circa\").",
+          "type": "string",
+          "const": "circa"
+        },
+        {
+          "description": "The phrase used for availability statements (e.g., \"available at URL\").",
+          "type": "string",
+          "const": "available-at"
+        },
+        {
+          "description": "The term used for immediately repeated citations (e.g., \"ibid.\").",
+          "type": "string",
+          "const": "ibid"
+        },
+        {
+          "description": "The conjunction \"and\" (e.g., \"Smith and Jones\").",
+          "type": "string",
+          "const": "and"
+        },
+        {
+          "description": "The abbreviation for omitted additional names (e.g., \"et al.\").",
+          "type": "string",
+          "const": "et-al"
+        },
+        {
+          "description": "The phrase \"and others\" (generic use).",
+          "type": "string",
+          "const": "and-others"
+        },
+        {
+          "description": "The term used for forthcoming works (e.g., \"forthcoming\").",
+          "type": "string",
+          "const": "forthcoming"
+        },
+        {
+          "description": "The term used for online resources (e.g., \"online\").",
+          "type": "string",
+          "const": "online"
+        },
+        {
+          "description": "The adverb \"here\".",
+          "type": "string",
+          "const": "here"
+        },
+        {
+          "description": "The term used for deposited materials.",
+          "type": "string",
+          "const": "deposited"
+        },
+        {
+          "description": "The phrase used to introduce reviewed works (e.g., \"review of\").",
+          "type": "string",
+          "const": "review-of"
+        },
+        {
+          "description": "The phrase used for original publication references (e.g., \"originally published\").",
+          "type": "string",
+          "const": "original-work-published"
+        },
+        {
+          "description": "The term used for patents (e.g., \"patent\").",
+          "type": "string",
+          "const": "patent"
+        },
+        {
+          "description": "The general term for volume locators (e.g., \"volume\", \"vol.\").",
+          "type": "string",
+          "const": "volume"
+        },
+        {
+          "description": "The general term for issue locators (e.g., \"issue\", \"no.\").",
+          "type": "string",
+          "const": "issue"
+        },
+        {
+          "description": "The general term for page locators (e.g., \"page\", \"p.\", \"pp.\").",
+          "type": "string",
+          "const": "page"
+        },
+        {
+          "description": "The general term for chapter locators (e.g., \"chapter\", \"ch.\").",
+          "type": "string",
+          "const": "chapter"
+        },
+        {
+          "description": "The general term for editions (e.g., \"edition\", \"ed.\").",
+          "type": "string",
+          "const": "edition"
+        },
+        {
+          "description": "The general term for section locators (e.g., \"section\", \"§\").",
+          "type": "string",
+          "const": "section"
+        },
+        {
+          "description": "The label for personal communications (e.g., \"personal communication\").",
+          "type": "string",
+          "const": "personal-communication"
+        }
+      ]
+    },
+    "TermForm": {
+      "description": "Form for term lookup.\n\nSpecifies which form variant of a term should be used in citation output.",
+      "oneOf": [
+        {
+          "description": "Long form of a term (e.g., \"page\" vs \"p.\").",
+          "type": "string",
+          "const": "long"
+        },
+        {
+          "description": "Short form of a term (e.g., \"p.\" vs \"page\").",
+          "type": "string",
+          "const": "short"
+        },
+        {
+          "description": "Verb form of a term (e.g., \"edited by\").",
+          "type": "string",
+          "const": "verb"
+        },
+        {
+          "description": "Short verb form of a term (e.g., \"ed.\" vs \"edited by\").",
+          "type": "string",
+          "const": "verb-short"
+        },
+        {
+          "description": "Symbol form of a term (e.g., \"§\" for section).",
+          "type": "string",
+          "const": "symbol"
+        }
+      ]
+    },
+    "GroupSelector": {
+      "description": "Selector predicate for matching references to groups.\n\nAll specified conditions must match (AND logic).\nUse the `not` field for negation-based fallback groups.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Match references by type.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cited": {
+          "description": "Match references by citation status.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitedStatus"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "field": {
+          "description": "Match references by field values (e.g., language, keywords).",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/FieldMatcher"
+          }
+        },
+        "not": {
+          "description": "Negation for fallback groups.\nMatches references that do NOT match the nested selector.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSelector"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "TypeSelector": {
+      "description": "Selector for reference types in overrides.\nCan be a single type string or a list of types.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "Single": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Single"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Multiple": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "Multiple"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CitedStatus": {
+      "description": "Citation status filter.",
+      "oneOf": [
+        {
+          "description": "Match only references cited in the document.",
+          "type": "string",
+          "const": "visible"
+        },
+        {
+          "description": "Match all references regardless of citation status.",
+          "type": "string",
+          "const": "any"
+        }
+      ]
+    },
+    "FieldMatcher": {
+      "description": "Field value matcher.",
+      "anyOf": [
+        {
+          "description": "Match exact field value.",
+          "type": "string"
+        },
+        {
+          "description": "Match any of multiple values.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "GroupSortEntry": {
+      "description": "Citation sort configuration: either a preset name or explicit configuration.",
+      "anyOf": [
+        {
+          "description": "A named sort preset (e.g., \"author-date-title\").",
+          "$ref": "#/$defs/SortPreset"
+        },
+        {
+          "description": "Explicit sort configuration.",
+          "$ref": "#/$defs/GroupSort"
+        }
+      ]
+    },
+    "SortPreset": {
+      "description": "Sort order presets for bibliography entries.\n\nEach preset encodes the sort key sequence for a citation style family.\nUse for the `bibliography.sort` field to avoid repeating boilerplate key lists.",
+      "oneOf": [
+        {
+          "description": "Author → year → title. Standard for author-date styles (APA, Chicago, Harvard).",
+          "type": "string",
+          "const": "author-date-title"
+        },
+        {
+          "description": "Author → title → year. Used in some footnote and note styles.",
+          "type": "string",
+          "const": "author-title-date"
+        },
+        {
+          "description": "Citation number only. Used in numeric styles (Vancouver, IEEE).",
+          "type": "string",
+          "const": "citation-number"
+        }
+      ]
+    },
+    "GroupSort": {
+      "description": "Per-group sorting specification.\n\nSorting follows a template of sort keys, applied in order.\nThe first key is the primary sort, second is the tiebreaker, etc.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "description": "Ordered list of sort keys to apply.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/GroupSortKey"
+          }
+        }
+      },
+      "required": [
+        "template"
+      ]
+    },
+    "GroupSortKey": {
+      "description": "A single sort key in a group sorting template.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The field or variable to sort by.",
+          "$ref": "#/$defs/SortKey"
+        },
+        "ascending": {
+          "description": "Sort order direction.",
+          "type": "boolean",
+          "default": true
+        },
+        "order": {
+          "description": "For type-based ordering: explicit type sequence.\n\nExample: `[\"legal-case\", \"statute\", \"treaty\"]` for Bluebook hierarchy.\nItems appear in this order regardless of alphabetical content.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "sort-order": {
+          "description": "For name-based sorting: culturally appropriate name order.\n\nExample: `given-family` for Vietnamese, `family-given` for Western.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameSortOrder"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "key"
+      ]
+    },
+    "SortKey": {
+      "description": "Sort key selector.",
+      "oneOf": [
+        {
+          "description": "Sort by reference type.",
+          "type": "string",
+          "const": "type"
+        },
+        {
+          "description": "Sort by author/contributor.",
+          "type": "string",
+          "const": "author"
+        },
+        {
+          "description": "Sort by title.",
+          "type": "string",
+          "const": "title"
+        },
+        {
+          "description": "Sort by issued date.",
+          "type": "string",
+          "const": "issued"
+        },
+        {
+          "description": "Sort by custom field.",
+          "type": "object",
+          "properties": {
+            "field": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "field"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "NameSortOrder": {
+      "description": "Name sorting order for culturally appropriate collation.",
+      "oneOf": [
+        {
+          "description": "Family name first (Western convention).\nExample: \"Smith, John\" → \"S\" sorts before \"T\"",
+          "type": "string",
+          "const": "family-given"
+        },
+        {
+          "description": "Given name first (Vietnamese convention).\nExample: \"Nguyễn Văn A\" → \"Nguyễn\" sorts before \"Trần\"",
+          "type": "string",
+          "const": "given-family"
+        }
+      ]
+    },
+    "TemplateComponent": {
+      "description": "A template component - the building blocks of citation/bibliography templates.\n\nEach variant handles a specific data type with appropriate formatting options.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TemplateContributor"
+        },
+        {
+          "$ref": "#/$defs/TemplateDate"
+        },
+        {
+          "$ref": "#/$defs/TemplateTitle"
+        },
+        {
+          "$ref": "#/$defs/TemplateNumber"
+        },
+        {
+          "$ref": "#/$defs/TemplateVariable"
+        },
+        {
+          "$ref": "#/$defs/TemplateGroup"
+        },
+        {
+          "$ref": "#/$defs/TemplateTerm"
+        }
+      ]
+    },
+    "TemplateContributor": {
+      "description": "A contributor component for rendering names.",
+      "type": "object",
+      "properties": {
+        "contributor": {
+          "description": "Which contributor role to render (author, editor, etc.).",
+          "$ref": "#/$defs/ContributorRole"
+        },
+        "form": {
+          "description": "How to display the contributor (long names, short, with label, etc.).",
+          "$ref": "#/$defs/ContributorForm"
+        },
+        "label": {
+          "description": "Optional role label configuration (e.g., \"eds.\" for editors).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name-order": {
+          "description": "Override the global name order for this specific component.\nUse to show editors as \"Given Family\" even when global setting is \"Family, Given\".",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameOrder"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "delimiter": {
+          "description": "Custom delimiter between names (overrides global setting).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sort-separator": {
+          "description": "Delimiter between family and given name when inverted (overrides global setting).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shorten": {
+          "description": "Shorten the list of names (et al. configuration).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShortenListOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "and": {
+          "description": "Override the conjunction between the last two names.\nUse `none` for bibliography when citation uses `text` or `symbol`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AndOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "links": {
+          "description": "Structured link options (DOI, URL).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gender": {
+          "description": "Explicit grammatical gender override for role-label agreement.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "contributor",
+        "form"
+      ]
+    },
+    "ContributorRole": {
+      "description": "Contributor roles.",
+      "oneOf": [
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "author"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "chair"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "editor"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "translator"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "director"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "publisher"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "recipient"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "interviewer"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "interviewee"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "guest"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "inventor"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "counsel"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "composer"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "collection-editor"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "container-author"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "editorial-director"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "textual-editor"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "illustrator"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "original-author"
+        },
+        {
+          "description": "String-backed enum variant.",
+          "type": "string",
+          "const": "reviewed-author"
+        }
+      ]
+    },
+    "ContributorForm": {
+      "description": "How to render contributor names.",
+      "type": "string",
+      "enum": [
+        "long",
+        "short",
+        "family-only",
+        "verb",
+        "verb-short"
+      ]
+    },
+    "RoleLabel": {
+      "description": "Configuration for role labels (e.g., \"eds.\", \"trans.\").",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "Locale term key for the role (e.g., \"editor\", \"translator\").",
+          "type": "string"
+        },
+        "form": {
+          "description": "Term form: short (\"eds.\") or long (\"editors\").",
+          "$ref": "#/$defs/RoleLabelForm",
+          "default": "short"
+        },
+        "placement": {
+          "description": "Where to place the label relative to names.",
+          "$ref": "#/$defs/LabelPlacement",
+          "default": "suffix"
+        }
+      },
+      "required": [
+        "term"
+      ]
+    },
+    "RoleLabelForm": {
+      "description": "Term form for role labels.",
+      "type": "string",
+      "enum": [
+        "short",
+        "long"
+      ]
+    },
+    "LabelPlacement": {
+      "description": "Label placement relative to contributor names.",
+      "type": "string",
+      "enum": [
+        "prefix",
+        "suffix"
+      ]
+    },
+    "NameOrder": {
+      "description": "Name display order.",
+      "oneOf": [
+        {
+          "description": "Display as \"Given Family\" (e.g., \"John Smith\").",
+          "type": "string",
+          "const": "given-first"
+        },
+        {
+          "description": "Display as \"Family, Given\" (e.g., \"Smith, John\").",
+          "type": "string",
+          "const": "family-first"
+        },
+        {
+          "description": "First contributor inverted (\"Family, Given\"); subsequent contributors given-first.",
+          "type": "string",
+          "const": "family-first-only"
+        }
+      ]
+    },
+    "NameForm": {
+      "description": "How to render the given-name component of a contributor name.\n\nControls whether full given names, family name only, or initialized\ngiven names are rendered. Used to express first/subsequent mention\ndifferences (Chicago) and integral/non-integral differences.\n\nInitialization formatting details (`initialize_with`, `initialize_with_hyphen`)\nare separate fields and only take effect when `NameForm::Initials` is active.",
+      "oneOf": [
+        {
+          "description": "Render full given names: \"John D. Smith\".",
+          "type": "string",
+          "const": "full"
+        },
+        {
+          "description": "Render family name only, suppressing given names: \"Smith\".\nUsed for subsequent mentions in Chicago/Turabian note styles.",
+          "type": "string",
+          "const": "family-only"
+        },
+        {
+          "description": "Render initialized given names using `initialize_with` separator.\nIf `initialize_with` is None, defaults to \". \" (e.g., \"J. Smith\").\nEmpty string gives compact initials: \"JD Smith\".",
+          "type": "string",
+          "const": "initials"
+        }
+      ]
+    },
+    "ShortenListOptions": {
+      "description": "Et al. / list shortening options.",
+      "type": "object",
+      "properties": {
+        "min": {
+          "description": "Minimum number of names to trigger shortening.",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "use-first": {
+          "description": "Number of names to show when shortened.",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "use-last": {
+          "description": "Number of names to show after the ellipsis (et-al-use-last).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "and-others": {
+          "description": "How to render \"and others\".",
+          "$ref": "#/$defs/AndOtherOptions",
+          "default": "et-al"
+        },
+        "delimiter-precedes-last": {
+          "description": "When to use delimiter before last name.",
+          "$ref": "#/$defs/DelimiterPrecedesLast",
+          "default": "contextual"
+        },
+        "subsequent-min": {
+          "description": "Minimum number of names to trigger shortening on subsequent cites.\nDefaults to `min` if not set.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "subsequent-use-first": {
+          "description": "Number of names to show when shortened on subsequent cites.\nDefaults to `use_first` if not set.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
+        }
+      },
+      "required": [
+        "min",
+        "use-first"
+      ]
+    },
+    "AndOtherOptions": {
+      "description": "How to render \"and others\" / et al.",
+      "type": "string",
+      "enum": [
+        "et-al",
+        "text"
+      ]
+    },
+    "DelimiterPrecedesLast": {
+      "description": "When to use delimiter before last contributor.",
+      "type": "string",
+      "enum": [
+        "after-inverted-name",
+        "always",
+        "never",
+        "contextual"
+      ]
+    },
+    "AndOptions": {
+      "description": "Conjunction options between contributors.",
+      "oneOf": [
+        {
+          "description": "Use the localized term for \"and\" (e.g., \"and\" in English).",
+          "type": "string",
+          "const": "text"
+        },
+        {
+          "description": "Use the localized symbol for \"and\" (e.g., \"&\" in English).",
+          "type": "string",
+          "const": "symbol"
+        },
+        {
+          "description": "No conjunction (e.g., \"Smith, Jones\").",
+          "type": "string",
+          "const": "none"
+        }
+      ]
+    },
+    "TextCase": {
+      "description": "Text-case transform applied to title-like fields.\n\nStyles select which transform applies to which field category.\nThe engine provides the generic primitives; styles own the selection.",
+      "oneOf": [
+        {
+          "description": "English headline-style title case (capitalize principal words).",
+          "type": "string",
+          "const": "title"
+        },
+        {
+          "description": "Generic sentence case (capitalize first word only).",
+          "type": "string",
+          "const": "sentence"
+        },
+        {
+          "description": "APA-style sentence case: capitalize first word of main title\nand first word after each subtitle boundary.",
+          "type": "string",
+          "const": "sentence-apa"
+        },
+        {
+          "description": "NLM-style sentence case: capitalize first word of main title only;\nsubtitles preserve only explicit/protected capitals.",
+          "type": "string",
+          "const": "sentence-nlm"
+        },
+        {
+          "description": "Capitalize the first letter of the value.",
+          "type": "string",
+          "const": "capitalize-first"
+        },
+        {
+          "description": "Transform the entire value to lowercase.",
+          "type": "string",
+          "const": "lowercase"
+        },
+        {
+          "description": "Transform the entire value to uppercase.",
+          "type": "string",
+          "const": "uppercase"
+        },
+        {
+          "description": "No transformation; render the value exactly as stored.",
+          "type": "string",
+          "const": "as-is"
+        }
+      ]
+    },
+    "VerticalAlign": {
+      "description": "Vertical text alignment relative to the baseline.",
+      "oneOf": [
+        {
+          "description": "Render at the baseline (default).",
+          "type": "string",
+          "const": "baseline"
+        },
+        {
+          "description": "Render as superscript.",
+          "type": "string",
+          "const": "superscript"
+        },
+        {
+          "description": "Render as subscript.",
+          "type": "string",
+          "const": "subscript"
+        }
+      ]
+    },
+    "WrapConfig": {
+      "description": "Wrapping punctuation and optional inner affixes applied around a rendered value.\n\nCombines the wrap punctuation with optional text that appears inside the wrap\n(between the wrap character and the rendered content).",
+      "type": "object",
+      "properties": {
+        "punctuation": {
+          "description": "The wrapping punctuation style.",
+          "$ref": "#/$defs/WrapPunctuation"
+        },
+        "inner-prefix": {
+          "description": "Text inserted after the opening wrap character but before the content.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inner-suffix": {
+          "description": "Text inserted after the content but before the closing wrap character.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "punctuation"
+      ]
+    },
+    "WrapPunctuation": {
+      "description": "Punctuation to wrap a component in.",
+      "type": "string",
+      "enum": [
+        "parentheses",
+        "brackets",
+        "quotes"
+      ]
+    },
+    "LinksConfig": {
+      "description": "Structured link options.",
+      "type": "object",
+      "properties": {
+        "doi": {
+          "description": "Link value to the item's DOI.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "url": {
+          "description": "Link value to the item's URL.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "target": {
+          "description": "The target for the link (url, doi, etc.).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinkTarget"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "anchor": {
+          "description": "What text should be hyperlinked (title, url, etc.).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinkAnchor"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "LinkTarget": {
+      "description": "Link target options.",
+      "type": "string",
+      "enum": [
+        "url",
+        "doi",
+        "url-or-doi",
+        "pubmed",
+        "pmcid"
+      ]
+    },
+    "LinkAnchor": {
+      "description": "Link anchor options.",
+      "oneOf": [
+        {
+          "description": "Link the title component.",
+          "type": "string",
+          "const": "title"
+        },
+        {
+          "description": "Link the URL component itself.",
+          "type": "string",
+          "const": "url"
+        },
+        {
+          "description": "Link the DOI component itself.",
+          "type": "string",
+          "const": "doi"
+        },
+        {
+          "description": "Link the specific component this config is attached to.",
+          "type": "string",
+          "const": "component"
+        },
+        {
+          "description": "Link the entire bibliography entry.",
+          "type": "string",
+          "const": "entry"
+        }
+      ]
+    },
+    "GrammaticalGender": {
+      "description": "Grammatical gender used for locale agreement and term selection.",
+      "oneOf": [
+        {
+          "description": "Masculine grammatical gender.",
+          "type": "string",
+          "const": "masculine"
+        },
+        {
+          "description": "Feminine grammatical gender.",
+          "type": "string",
+          "const": "feminine"
+        },
+        {
+          "description": "Neuter grammatical gender.",
+          "type": "string",
+          "const": "neuter"
+        },
+        {
+          "description": "Common or shared grammatical gender.",
+          "type": "string",
+          "const": "common"
+        }
+      ]
+    },
+    "TemplateDate": {
+      "description": "A date component for rendering dates.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "$ref": "#/$defs/DateVariable"
+        },
+        "form": {
+          "$ref": "#/$defs/DateForm"
+        },
+        "fallback": {
+          "description": "Fallback components if the primary date is missing.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "links": {
+          "description": "Structured link options (DOI, URL).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "date",
+        "form"
+      ]
+    },
+    "DateVariable": {
+      "description": "Date variables.",
+      "type": "string",
+      "enum": [
+        "issued",
+        "accessed",
+        "original-published",
+        "submitted",
+        "event-date"
+      ]
+    },
+    "DateForm": {
+      "description": "Date rendering forms.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "year",
+            "year-month",
+            "full",
+            "month-day",
+            "year-month-day",
+            "day-month-abbr-year"
+          ]
+        },
+        {
+          "description": "Abbreviated month + day + year in US order: \"Jan 15, 2024\".",
+          "type": "string",
+          "const": "month-abbr-day-year"
+        }
+      ]
+    },
+    "TemplateTitle": {
+      "description": "A title component.",
+      "type": "object",
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/TitleType"
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disambiguate-only": {
+          "description": "When true, suppress this title component unless the reference needs\ndisambiguation (i.e. multiple works by the same author appear in the\ndocument). Used by author-class styles (e.g. MLA) where the title\nappears in citations only to resolve same-author ambiguity.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "links": {
+          "description": "Structured link options (DOI, URL).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "title"
+      ]
+    },
+    "TitleType": {
+      "description": "Types of titles.",
+      "oneOf": [
+        {
+          "description": "The primary title of the cited work.",
+          "type": "string",
+          "const": "primary"
+        },
+        {
+          "description": "Title of a book/monograph containing the cited work.",
+          "type": "string",
+          "const": "parent-monograph"
+        },
+        {
+          "description": "Title of a periodical/serial containing the cited work.",
+          "type": "string",
+          "const": "parent-serial"
+        }
+      ]
+    },
+    "TitleForm": {
+      "description": "Title rendering forms.",
+      "type": "string",
+      "enum": [
+        "short",
+        "long"
+      ]
+    },
+    "TemplateNumber": {
+      "description": "A number component (volume, issue, pages, etc.).",
+      "type": "object",
+      "properties": {
+        "number": {
+          "$ref": "#/$defs/NumberVariable"
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NumberForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LabelForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "show-with-locator": {
+          "description": "When `true`, show this pages component even when a locator is present in a note-style citation.\nBy default, pages are suppressed in note-style citations when a locator is present.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "links": {
+          "description": "Structured link options (DOI, URL).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gender": {
+          "description": "Explicit grammatical gender override for number/ordinal agreement.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "number"
+      ]
+    },
+    "NumberVariable": {
+      "description": "Known number variable keyword or custom kebab-case identifier.",
+      "type": "string"
+    },
+    "NumberForm": {
+      "description": "Number rendering forms.",
+      "type": "string",
+      "enum": [
+        "numeric",
+        "ordinal",
+        "roman"
+      ]
+    },
+    "LabelForm": {
+      "description": "Label rendering forms.",
+      "type": "string",
+      "enum": [
+        "long",
+        "short",
+        "symbol"
+      ]
+    },
+    "TemplateVariable": {
+      "description": "A simple variable component (DOI, ISBN, URL, etc.).",
+      "type": "object",
+      "properties": {
+        "variable": {
+          "$ref": "#/$defs/SimpleVariable"
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "links": {
+          "description": "Structured link options (DOI, URL).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "variable"
+      ]
+    },
+    "SimpleVariable": {
+      "description": "Simple string variables.\n\nUse `variable:` for string passthrough fields, even when the field name is\nalso present in [`NumberVariable`]. For example, `variable: volume` keeps the\nsource value as plain text, while `number: volume` opts into numeric\nformatting behavior.",
+      "type": "string",
+      "enum": [
+        "doi",
+        "isbn",
+        "issn",
+        "url",
+        "pmid",
+        "pmcid",
+        "abstract",
+        "note",
+        "annote",
+        "keyword",
+        "genre",
+        "medium",
+        "source",
+        "status",
+        "archive",
+        "archive-location",
+        "archive-name",
+        "archive-place",
+        "archive-collection",
+        "archive-collection-id",
+        "archive-series",
+        "archive-box",
+        "archive-folder",
+        "archive-item",
+        "archive-url",
+        "eprint-id",
+        "eprint-server",
+        "eprint-class",
+        "publisher",
+        "publisher-place",
+        "original-publisher",
+        "original-publisher-place",
+        "event-place",
+        "dimensions",
+        "scale",
+        "version",
+        "locator",
+        "container-title-short",
+        "authority",
+        "code",
+        "reporter",
+        "page",
+        "section",
+        "volume",
+        "number",
+        "docket-number",
+        "patent-number",
+        "standard-number",
+        "report-number",
+        "ads-bibcode"
+      ]
+    },
+    "TemplateGroup": {
+      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+      "type": "object",
+      "properties": {
+        "group": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "group"
+      ]
+    },
+    "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
+      "type": "string"
+    },
+    "TemplateTerm": {
+      "description": "A term component for rendering locale-specific text.",
+      "type": "object",
+      "properties": {
+        "term": {
+          "description": "Which term to render.",
+          "$ref": "#/$defs/GeneralTerm"
+        },
+        "form": {
+          "description": "Form: long (default), short, or symbol.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TermForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gender": {
+          "description": "Explicit grammatical gender override for term selection.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "term"
+      ]
+    },
+    "DisambiguationScope": {
+      "description": "Scope for disambiguation (e.g., year suffix assignment).",
+      "oneOf": [
+        {
+          "description": "Disambiguate across all items in the bibliography.",
+          "type": "string",
+          "const": "globally"
+        },
+        {
+          "description": "Disambiguate only within the current group.",
+          "type": "string",
+          "const": "locally"
+        }
+      ]
+    },
+    "BibliographySortPartitioning": {
+      "description": "Bibliography partitioning policy for multilingual sort order and sections.",
+      "type": "object",
+      "properties": {
+        "by": {
+          "description": "Source used to derive each reference's partition key.",
+          "$ref": "#/$defs/BibliographyPartitionKind"
+        },
+        "mode": {
+          "description": "Whether partitioning affects flat sorting, visible sections, or both.",
+          "$ref": "#/$defs/BibliographyPartitionMode",
+          "default": "sort-only"
+        },
+        "order": {
+          "description": "Preferred partition order. Unlisted partitions sort after listed ones.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "headings": {
+          "description": "Optional headings for visible partition sections.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/BibliographyPartitionHeading"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "by"
+      ]
+    },
+    "BibliographyPartitionKind": {
+      "description": "Partition key source for bibliography partitioning.",
+      "oneOf": [
+        {
+          "description": "Partition by Unicode script detected from author/editor/title sort text.",
+          "type": "string",
+          "const": "script"
+        },
+        {
+          "description": "Partition by the reference's effective item language.",
+          "type": "string",
+          "const": "language"
+        }
+      ]
+    },
+    "BibliographyPartitionMode": {
+      "description": "Rendering mode for bibliography partitioning.",
+      "oneOf": [
+        {
+          "description": "Sort a flat bibliography by partition before normal sort keys.",
+          "type": "string",
+          "const": "sort-only"
+        },
+        {
+          "description": "Render visible sections for grouped bibliography output only.",
+          "type": "string",
+          "const": "sections"
+        },
+        {
+          "description": "Sort flat output by partition and render visible sections for grouped output.",
+          "type": "string",
+          "const": "sort-and-sections"
+        }
+      ]
+    },
+    "BibliographyPartitionHeading": {
+      "description": "Localizable heading source for automatic bibliography partition sections.",
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "type": "object",
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ]
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "type": "object",
+          "properties": {
+            "term": {
+              "description": "Locale general term key.",
+              "$ref": "#/$defs/GeneralTerm"
+            },
+            "form": {
+              "description": "Optional term form (defaults to long).",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "term"
+          ]
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "type": "object",
+          "properties": {
+            "localized": {
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "localized"
+          ]
+        }
+      ]
+    },
+    "DocumentIntegralNameOverride": {
+      "description": "Document-level integral-name override parsed from frontmatter.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether the integral-name policy is enabled for this document.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "rule": {
+          "description": "The name-memory rule to apply.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameRule"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Where name-memory resets.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "contexts": {
+          "description": "Which document contexts participate in the policy.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameContexts"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subsequent-form": {
+          "description": "The contributor form used after the first mention.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "IntegralNameRule": {
+      "description": "The supported integral citation name-memory rule.",
+      "oneOf": [
+        {
+          "description": "Render the first integral mention in scope in full, then shorten later mentions.",
+          "type": "string",
+          "const": "full-then-short"
+        }
+      ]
+    },
+    "IntegralNameScope": {
+      "description": "The scope where integral citation name-memory resets.",
+      "oneOf": [
+        {
+          "description": "Keep one name-memory scope for the whole document.",
+          "type": "string",
+          "const": "document"
+        },
+        {
+          "description": "Reset name memory at chapter boundaries.",
+          "type": "string",
+          "const": "chapter"
+        },
+        {
+          "description": "Reset name memory at section boundaries.",
+          "type": "string",
+          "const": "section"
+        }
+      ]
+    },
+    "IntegralNameContexts": {
+      "description": "Which document contexts participate in integral citation name memory.",
+      "oneOf": [
+        {
+          "description": "Only body-text integral citations participate.",
+          "type": "string",
+          "const": "body-only"
+        },
+        {
+          "description": "Body text and note citations both participate.",
+          "type": "string",
+          "const": "body-and-notes"
+        }
+      ]
+    },
+    "IntegralNameForm": {
+      "description": "The contributor form used after the first integral mention in scope.",
+      "oneOf": [
+        {
+          "description": "Use the short contributor form for subsequent mentions.",
+          "type": "string",
+          "const": "short"
+        },
+        {
+          "description": "Use family name only for subsequent mentions.",
+          "type": "string",
+          "const": "family-only"
+        }
+      ]
+    },
+    "AnnotationFormat": {
+      "description": "Markup format for annotation text.",
+      "oneOf": [
+        {
+          "description": "Parse annotation as djot inline markup (default).",
+          "type": "string",
+          "const": "djot"
+        },
+        {
+          "description": "Treat annotation as plain text with no markup interpretation.",
+          "type": "string",
+          "const": "plain"
+        },
+        {
+          "description": "Parse annotation as org-mode markup.",
+          "type": "string",
+          "const": "org"
+        }
+      ]
+    },
+    "AbbreviationMap": {
+      "description": "Document-level map from full rendered strings to their abbreviations.\n\nKeys are the full rendered string (exact, case-sensitive). Values are the\nreplacement abbreviation. Applied after value extraction, before output.\nAccepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "render_citation": {
@@ -136,7 +2941,7 @@
     "properties": {
       "style": {
         "description": "Style identifier, path, URI, or inline YAML.",
-        "type": "string"
+        "$ref": "#/$defs/StyleInput"
       },
       "locale": {
         "description": "Optional BCP 47 locale override.",
@@ -161,6 +2966,17 @@
       },
       "citations": {
         "description": "Ordered citations as they appear in the document."
+      },
+      "document_options": {
+        "description": "Optional document-level configuration.",
+        "anyOf": [
+          {
+            "$ref": "#/$defs/DocumentOptions"
+          },
+          {
+            "type": "null"
+          }
+        ]
       }
     }
   }

--- a/examples/document-citations.json
+++ b/examples/document-citations.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "cite-1",
+    "items": [{ "id": "kuhn1962" }],
+    "mode": "non-integral"
+  },
+  {
+    "id": "cite-2",
+    "items": [{ 
+      "id": "watson1953", 
+      "locator": { "label": "page", "value": "737" } 
+    }],
+    "mode": "integral"
+  }
+]

--- a/examples/document-options.json
+++ b/examples/document-options.json
@@ -1,0 +1,5 @@
+{
+  "show_semantics": true,
+  "inject_ast_indices": false,
+  "annotation_format": "djot"
+}

--- a/examples/document-refs-native.json
+++ b/examples/document-refs-native.json
@@ -1,0 +1,39 @@
+{
+  "kuhn1962": {
+    "id": "kuhn1962",
+    "class": "monograph",
+    "type": "book",
+    "title": "The Structure of Scientific Revolutions",
+    "author": [{ "family": "Kuhn", "given": "Thomas S." }],
+    "issued": "1962",
+    "publisher": { "name": "University of Chicago Press" }
+  },
+  "watson1953": {
+    "id": "watson1953",
+    "class": "serial-component",
+    "type": "article",
+    "title": "Molecular Structure of Nucleic Acids",
+    "author": [
+      { "family": "Watson", "given": "J. D." },
+      { "family": "Crick", "given": "F. H. C." }
+    ],
+    "issued": "1953-04-25",
+    "container": {
+      "class": "serial",
+      "type": "academic-journal",
+      "title": "Nature"
+    },
+    "volume": "171",
+    "issue": "4356",
+    "pages": "737-738"
+  },
+  "smith2010": {
+    "id": "smith2010",
+    "class": "monograph",
+    "type": "book",
+    "title": "Nationalism: Theory, Ideology, History",
+    "author": [{ "family": "Smith", "given": "Anthony D." }],
+    "issued": "2010",
+    "publisher": { "name": "Polity" }
+  }
+}


### PR DESCRIPTION
- Added practical jq examples for document formatting.
- Clarified feature dependencies (http, async, schema).
- Updated RPC schema to include document_options.
- Switched format_document style param to StyleInput.
- Added supporting JSON examples in examples/.
