### PR TITLE
chore: centralize unsafe_code lint

### DIFF
--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -6,7 +6,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Analyzes CSL 1.0 styles in a directory to collect statistics
 //! and identify patterns for guiding migration development.
 
-#![forbid(unsafe_code)]
 #![allow(missing_docs, reason = "bin/main")]
 
 mod analyzer;

--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -25,8 +25,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! - [`render_bibliography`] — render a full bibliography
 //! - [`validate_style`] — check a style for parse/schema errors
 
-#![forbid(unsafe_code)]
-
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -3,7 +3,6 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-#![forbid(unsafe_code)]
 #![allow(missing_docs, reason = "bin")]
 
 mod args;

--- a/crates/citum-edtf/src/lib.rs
+++ b/crates/citum-edtf/src/lib.rs
@@ -7,8 +7,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //!
 //! This crate implements ISO 8601-2:2019 (EDTF) Level 0 and Level 1.
 
-#![forbid(unsafe_code)]
-
 use winnow::ascii::dec_int;
 use winnow::combinator::{alt, opt};
 use winnow::error::{ContextError, ErrMode};

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -12,8 +12,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! The processor is designed to be pluggable with different renderers and supports
 //! advanced features like disambiguation, sorting, and localization.
 
-#![deny(unsafe_code)]
-
 //! # Example
 //!
 //! ```rust

--- a/crates/citum-io/src/lib.rs
+++ b/crates/citum-io/src/lib.rs
@@ -8,8 +8,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Provides functions to load bibliographies and citations from various formats
 //! (Citum YAML/JSON/CBOR, CSL-JSON, BibLaTeX, RIS) into Citum's internal types.
 
-#![forbid(unsafe_code)]
-
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::fs;

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -5,7 +5,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! citum-migrate
 
-#![forbid(unsafe_code)]
 #![allow(missing_docs, reason = "lib/crate")]
 
 use csl_legacy::model::{CslNode, Style};

--- a/crates/citum-pdf/src/lib.rs
+++ b/crates/citum-pdf/src/lib.rs
@@ -5,8 +5,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Typst PDF compilation for Citum.
 
-#![forbid(unsafe_code)]
-
 use std::error::Error;
 use std::fs;
 use std::path::Path;

--- a/crates/citum-resolver-api/src/lib.rs
+++ b/crates/citum-resolver-api/src/lib.rs
@@ -11,8 +11,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! to facilitate integration by third-party tool authors who don't
 //! need the full store logic.
 
-#![forbid(unsafe_code)]
-
 /// Error types and conversion helpers.
 pub mod error;
 pub use error::{ResolutionError, ResolverError};

--- a/crates/citum-schema-data/src/lib.rs
+++ b/crates/citum-schema-data/src/lib.rs
@@ -5,8 +5,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Data input models for Citum references, citations, and bibliographies.
 
-#![deny(unsafe_code)]
-
 use indexmap::IndexMap;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -5,8 +5,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Public schema types for Citum styles, citations, references, and locales.
 
-#![forbid(unsafe_code)]
-
 use indexmap::IndexMap;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;

--- a/crates/citum-schema/src/lib.rs
+++ b/crates/citum-schema/src/lib.rs
@@ -8,8 +8,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! This crate re-exports style-focused types from `citum-schema-style`
 //! and data-focused accessors through `citum-schema-data`.
 
-#![forbid(unsafe_code)]
-
 pub use citum_schema_style::*;
 
 /// Canonical Citum style schema version for external consumers.

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -28,8 +28,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! - `async`: Enable tokio runtime (required for HTTP)
 //! - `http`: Enable HTTP server (implies async)
 
-#![forbid(unsafe_code)]
-
 /// Server error types and conversions.
 pub mod error;
 /// JSON-RPC request handling and stdio transport.

--- a/crates/citum-server/src/main.rs
+++ b/crates/citum-server/src/main.rs
@@ -3,7 +3,6 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-#![forbid(unsafe_code)]
 #![allow(missing_docs, reason = "bin")]
 
 #[cfg(feature = "http")]

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -8,7 +8,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Provides a `StoreResolver` that searches user data directories for custom styles
 //! and locales, with fallback to embedded builtins. Supports YAML, JSON, and CBOR formats.
 
-#![forbid(unsafe_code)]
 #![allow(missing_docs, reason = "lib/crate")]
 
 #[cfg(feature = "http")]

--- a/crates/csl-legacy/src/lib.rs
+++ b/crates/csl-legacy/src/lib.rs
@@ -14,8 +14,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! - [`parser`] – XML → model parser built on top of [`roxmltree`].
 //! - [`csl_json`] – companion CSL-JSON reference model (legacy input format).
 
-#![forbid(unsafe_code)]
-
 /// CSL-JSON reference types used alongside legacy CSL style processing.
 pub mod csl_json;
 /// Rust data structures that mirror the CSL 1.0 XML schema.


### PR DESCRIPTION
## Summary
- keep workspace `unsafe_code = "deny"` as the source of truth
- remove redundant crate-level unsafe_code lint attributes
- preserve intentional unsafe code behind documented local allowances

## Rationale
The previous PR used workspace `unsafe_code = "forbid"`, but `forbid` cannot be locally relaxed. That breaks deliberate unsafe boundaries such as the citum-engine FFI module and bindings-related derives.

## Test Plan
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`