### PR TITLE
docs: link back to citum.org from all nav bars

### DIFF
--- a/docs/developer.html
+++ b/docs/developer.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="developer.html">Developer</a>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -27,6 +27,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
@@ -44,6 +45,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -84,6 +84,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../index.html">Overview</a>
                 <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Developer</a>
@@ -101,6 +102,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../index.html">Overview</a>
             <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Developer</a>

--- a/docs/guides/style-authoring/inheritance-and-registries.html
+++ b/docs/guides/style-authoring/inheritance-and-registries.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../../index.html">Overview</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../../index.html">Overview</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Developer</a>

--- a/docs/guides/style-authoring/locales.html
+++ b/docs/guides/style-authoring/locales.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../../index.html">Overview</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../../index.html">Overview</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Developer</a>

--- a/docs/guides/style-authoring/options.html
+++ b/docs/guides/style-authoring/options.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../../index.html">Overview</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../../index.html">Overview</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Developer</a>

--- a/docs/guides/style-authoring/start.html
+++ b/docs/guides/style-authoring/start.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../../index.html">Overview</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../../index.html">Overview</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Developer</a>

--- a/docs/guides/style-authoring/style-anatomy.html
+++ b/docs/guides/style-authoring/style-anatomy.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../../index.html">Overview</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../../index.html">Overview</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Developer</a>

--- a/docs/guides/style-authoring/validation.html
+++ b/docs/guides/style-authoring/validation.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../../index.html">Overview</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../../index.html">Overview</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Developer</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link active" href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link active" href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>

--- a/docs/interactive-demo.html
+++ b/docs/interactive-demo.html
@@ -119,6 +119,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
@@ -136,6 +137,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>

--- a/docs/operating.html
+++ b/docs/operating.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>

--- a/docs/reports.html
+++ b/docs/reports.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="index.html">Overview</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="index.html">Overview</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Developer</a>

--- a/docs/schemas/index.html
+++ b/docs/schemas/index.html
@@ -20,6 +20,7 @@
                 </a>
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
                 <a class="site-nav-link " href="../index.html">Overview</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Developer</a>
@@ -37,6 +38,7 @@
             </button>
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link" href="https://citum.org">&#8592; citum.org</a>
             <a class="site-nav-link " href="../index.html">Overview</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Developer</a>


### PR DESCRIPTION
## Summary

Add a home link to citum.org in both desktop and mobile navigation bars across all 15 documentation HTML files. This enables users to navigate from the docs site back to the landing page.

## Changes

- Added `← citum.org` back-link as the first item in both desktop and mobile navigation bars
- Updated 15 HTML files in `/docs/` and subdirectories
- Link targets https://citum.org with arrow indicator