### PR TITLE
docs: simplify index page to navigation-only

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,10 +53,9 @@
             <div>
                 <h1>Citum docs</h1>
                 <p class="doc-lede">
-                    A Rust citation engine and YAML style system. Citum handles
-                    structured bibliographies, multilingual terms, reusable style
-                    families, and output that can be checked against real examples.
-                    CSL compatibility is a goal, not the ceiling.
+                    Documentation for the Citum citation engine and YAML style system.
+                    Pick a path below — or head back to
+                    <a href="https://citum.org">citum.org</a> if you want the overview first.
                 </p>
                 <div class="doc-actions">
                     <a class="citum-button-primary" href="guides/style-authoring/start.html">Write a style</a>
@@ -73,35 +72,6 @@
 (Kuhn 1962, chap. 2; Watson 1953)</code></pre>
             </aside>
         </header>
-
-        <section class="doc-section">
-            <div class="doc-section-header">
-                <h2>What Citum does</h2>
-                <p>
-                    Most citation engines treat formatting as an afterthought. Citum
-                    makes the hard parts first-class — so the output you need is
-                    expressible, testable, and maintainable.
-                </p>
-            </div>
-            <div class="doc-grid">
-                <a class="doc-card" href="examples.html#bibliography-grouping">
-                    <h3>Bibliographies that organize themselves</h3>
-                    <p>Group references by type, language, or citation status. Legal hierarchies, multilingual sections, and primary/secondary divisions without custom renderer code.</p>
-                </a>
-                <a class="doc-card" href="guides/style-authoring/locales.html">
-                    <h3>Multilingual by default</h3>
-                    <p>Role labels, date formats, and locators adapt to the document locale automatically. Gendered terms, plural forms, and right-to-left scripts work without style modifications.</p>
-                </a>
-                <a class="doc-card" href="guides/style-authoring/inheritance-and-registries.html">
-                    <h3>Styles that extend, not fork</h3>
-                    <p>Build on existing styles with scoped overrides. Pin to a specific parent version for reproducibility, and distribute your styles without handing out a mystery clone.</p>
-                </a>
-                <a class="doc-card" href="reports.html">
-                    <h3>Bundled, validated styles</h3>
-                    <p>APA, Chicago, MLA, and more ship with Citum and are tested against real published examples. Use them as-is or as a base for your own.</p>
-                </a>
-            </div>
-        </section>
 
         <section class="doc-section">
             <div class="doc-section-header">


### PR DESCRIPTION
## Summary

- Removes the "What Citum does" feature cards (Bibliographies that organize themselves, Multilingual by default, Styles that extend not fork, Bundled validated styles) — this content now lives on the landing page at citum.org
- Updates the hero lede to assume the reader has already decided to use Citum, with a back-link for anyone who landed here first
- The "Where to start" navigation grid is unchanged

## Context

Follows the landing page rewrite (citum-org#4). The docs index was doing pitch work that belongs on citum.org. Now it's a clean entry point.