### PR TITLE
chore(tooling): lean CLAUDE.md + jcodemunch nudge

### DIFF
--- a/.beans/archive/csl26-13i5--harness-review-lean-claudemd-scoped-subdir-files-j.md
+++ b/.beans/archive/csl26-13i5--harness-review-lean-claudemd-scoped-subdir-files-j.md
@@ -1,0 +1,45 @@
+---
+# csl26-13i5
+title: 'Harness review: lean CLAUDE.md, scoped subdir files, jcodemunch enforcement'
+status: completed
+type: task
+priority: high
+created_at: 2026-05-15T09:46:01Z
+updated_at: 2026-05-15T09:53:21Z
+---
+
+Apply Anthropic large-codebase best practices. Six steps: slim root CLAUDE.md, add scoped crate CLAUDE.md (engine/schema/migrate/csl-legacy), elevate jcodemunch+rust-analyzer tool priority, compact MEMORY.md, add crates/README.md map, add PostToolUse jcm-nudge hook. Plan: ~/.claude/plans/this-project-has-undergone-woolly-crab.md
+
+## Todo
+
+- [x] Slim root CLAUDE.md to ~120 lines (final: 136)
+- [x] Add Code Search Tool Priority block (jcodemunch + rust-analyzer)
+- [x] crates/citum-engine/CLAUDE.md
+- [x] crates/citum-schema/CLAUDE.md
+- [x] crates/citum-migrate/CLAUDE.md
+- [x] crates/csl-legacy/CLAUDE.md
+- [x] crates/README.md codebase map
+- [x] Compact MEMORY.md to ~60 lines (final: 64)
+- [x] Add ~/.claude/hooks/jcm-nudge.sh + register in user settings (placed in project .claude/hooks/ for scoping)
+- [x] Run validate-frontmatter.sh and confirm no regressions
+- [x] Push and open PR (#711)
+- [x] Address Copilot review (hook hardening, drop user-local memory pointers, clarify file_outline vs repo_outline)
+- [x] Add AGENTS.md symlinks for Codex parity (4 crates)
+- [x] Fix amend rule in root CLAUDE.md (encourage on PR branches; never on main)
+
+## Summary of Changes
+
+- Root `CLAUDE.md`: 280 → 136 lines. Moved test catalog, locale detail, status snapshots, prior-art list out to pointers. Added unambiguous **Code Search Tool Priority** block elevating jcodemunch + rust-analyzer over Read/Grep, and a hard ban on `Explore` agent for code.
+- Scoped `CLAUDE.md` added to four hot crates: `citum-engine`, `citum-schema` (facade), `citum-migrate`, `csl-legacy`. Each is ≤40 lines: layout table + 3-5 gotchas + symbol-query pointer.
+- New `crates/README.md` — 15-crate map (pipeline / surface / support) with naming convention note, where-to-edit table, and navigation rules.
+- Compacted auto-memory `MEMORY.md` from 145 → 64 lines: pure one-line index. Extracted 14 inline rule blocks into new detail files (`feedback_bean_commit_rule`, `feedback_bean_archive_rule`, `feedback_pr_merge_user_only`, `feedback_commit_message_rules`, `feedback_pr_workflow_branch_first`, `feedback_builder_agent_constraints`, `feedback_jcodemunch_usage`, `feedback_hook_restrictions`, `feedback_info_source_csl_only`, `feedback_brain_read_protocol`, `project_integral_multicite`, `project_ffi_layout`, `project_quality_gate`, `project_style_registry`).
+- Added `PostToolUse` hook (`.claude/hooks/jcm-nudge.sh`) that fires on Read/Grep/Glob of Rust paths and injects a system reminder pointing to jcodemunch + rust-analyzer. Project-scoped via `$CLAUDE_PROJECT_DIR` so it does not affect other repos.
+
+Plan reference: `~/.claude/plans/this-project-has-undergone-woolly-crab.md`.
+
+## Verification done
+
+- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict` → 17 files OK.
+- `jq` parse of `.claude/settings.json` succeeds.
+- Hook smoke test with synthetic Read-on-citations.rs input emits valid PostToolUse JSON.
+- Bean hygiene: this bean is the only in-progress one for the branch.

--- a/.claude/hooks/jcm-nudge.sh
+++ b/.claude/hooks/jcm-nudge.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# PostToolUse hook: nudge toward jcodemunch / rust-analyzer when the agent
+# reads or greps Rust source. The rule is documented in CLAUDE.md but the
+# agent has historically rationalized it away — this hook puts the reminder
+# back into context at the moment of the violation.
+#
+# Receives the tool call as JSON on stdin. Emits a hookSpecificOutput
+# JSON object on stdout with additionalContext to inject a system reminder.
+# Silent (no output) on every other tool call.
+
+# Never block the user's tool call from this hook. Errors in jq parsing,
+# unexpected stdin shape, or anything else should fall through to exit 0.
+set -uo pipefail
+
+input=$(cat || true)
+
+# Bail quietly if jq is missing — never block a tool call from this hook.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null || true)
+
+case "$tool_name" in
+  Read|Grep|Glob) ;;
+  *) exit 0 ;;
+esac
+
+# Look for a .rs file path in any of the common parameter keys.
+target=$(printf '%s' "$input" | jq -r '
+  .tool_input
+  | (.file_path // .path // .pattern // .glob // "")
+' 2>/dev/null || true)
+
+# Match either a literal .rs path or a pattern containing crates/.
+case "$target" in
+  *.rs|*crates/*|*citum-engine*|*citum-schema*|*citum-migrate*|*csl-legacy*) ;;
+  *) exit 0 ;;
+esac
+
+# Skip the nudge for the trivial workspace manifest case.
+case "$target" in
+  */Cargo.toml|*/Cargo.lock) exit 0 ;;
+esac
+
+cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "Reminder: for Rust symbol lookups in citum-core, prefer jcodemunch (get_symbol / get_symbols / get_repo_outline) over Read/Grep — the index is live (~184 files, 2308 symbols). For type resolution / hover, prefer rust-analyzer. Bash grep is correct for string literals and call-site patterns, not for finding a named symbol. See root CLAUDE.md → Code Search Tool Priority."
+  }
+}
+JSON

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,14 @@
     ],
     "PreCompact": [
       { "hooks": [{ "type": "command", "command": "beans prime" }] }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read|Grep|Glob",
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/jcm-nudge.sh" }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,280 +1,148 @@
-# Citum - Project Instructions
+# Citum — Project Instructions
 
-You are a **Lead Systems Architect and Principal Rust Engineer** for the Citum initiative.
+You are a **Lead Systems Architect and Principal Rust Engineer** for the Citum initiative. All responses in English.
 
-**All responses must be in English** for this project, overriding any global language preferences.
+## Code Search Tool Priority (PROJECT OVERRIDE)
 
-## Autonomous Operations
+This overrides any global "prefer Bash" or "use Explore" rule. Choose by intent, not by habit:
 
-**Global Configuration:** Autonomous file operations, development commands, and non-destructive git operations are enabled globally via `~/.claude/rules/critical-actions.md`.
+| Task | Use |
+|---|---|
+| Type/trait def, hover, go-to-def, "what does this generic resolve to?" | `rust-analyzer` (LSP) |
+| Symbol body / callers | jcodemunch (`get_symbol`, `get_symbols`, `get_call_hierarchy`) |
+| Outline of one file | jcodemunch `get_file_outline` |
+| Module API surface across files | jcodemunch `get_repo_outline` |
+| Call sites, string literals, regex, cross-file text patterns | Bash `mgrep` / `grep` (RTK-rewritten) |
+| Reading a known file by path | Bash `cat` (RTK-truncated) |
+| File writes / edits | `Write` / `Edit` tools |
 
-### Pre-Commit Checks (Rust only)
+**NEVER use the `Explore` subagent for code in this repo** — jcodemunch replaces it. Explore is allowed only for non-code docs sweeps.
 
-Before committing `.rs`, `Cargo.toml`, or `Cargo.lock` changes, run:
+jcodemunch is indexed as `local/citum-core` (~184 files, 2308 symbols). See `crates/README.md` for the crate map.
+
+**Stale index → refresh, do not bail.** If jcodemunch returns "symbol not found" or results that don't match HEAD, the index is stale (likely from a recent rebase, branch switch, or large rewrite). Re-index before falling back to Read/Grep — re-indexing costs less than a fresh codebase scan:
+
+- `index_folder` with `incremental: true` on the changed crate (fast, default path).
+- `index_repo` with `incremental: true` for workspace-wide refresh after a rebase.
+- `invalidate_cache` only if `incremental: true` returns the same wrong answer.
+
+Falling back to Read/Grep on a stale index is the failure mode that has historically broken this rule — refresh first.
+
+## Project Goal
+
+Transition citation management from CSL 1.0 (procedural XML) to Citum (declarative, type-safe Rust/YAML). Pipeline: **parse** (`csl-legacy`) → **migrate** (`citum-migrate`) → **process** (`citum-engine`) → **render** (matches citeproc-js for CSL-derived; biblatex for biblatex-derived).
+
+See `crates/README.md` for crate layout and `docs/architecture/DESIGN_PRINCIPLES.md` for key principles (explicit over magic, serde-driven truth, no `unwrap`/`unsafe`, declarative templates).
+
+When considering prior art, prefer biblatex over BibTeX — better data model.
+
+## Pre-Commit Gate (Rust)
+
+Before committing `.rs`, `Cargo.toml`, or `Cargo.lock`:
 ```bash
 cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run
 ```
-Fallback if nextest missing: `cargo test`. **DO NOT commit if any check fails.**
-Run `cargo fmt` first to fix formatting, then re-run `cargo fmt --check` to confirm clean.
+Run `cargo fmt` first if needed, then re-check. **Do not commit if any check fails.** Docs (`.md`) and styles (`.yaml`) skip checks.
 
-Docs/styles (`.md`, `.yaml` in `styles/`) skip checks entirely.
-
-If any `.rs` files in `crates/citum-cli/` or `crates/citum-schema*/` changed, regenerate
-schemas before committing and stage the result in the same commit:
+If `crates/citum-cli/` or `crates/citum-schema*/` changed, regenerate schemas in the same commit:
 ```bash
-cargo run --bin citum --features schema -- schema --out-dir docs/schemas
-git add docs/schemas/
+cargo run --bin citum --features schema -- schema --out-dir docs/schemas && git add docs/schemas/
 ```
 
-Do not bump `STYLE_SCHEMA_VERSION` or add `Schema-Bump:` footers in feature
-commits. Schema and workspace version bumps are handled by the release workflow,
-which infers patch/minor/major from conventional commits.
+**Do not** bump `STYLE_SCHEMA_VERSION` or `[workspace.package].version` manually — the release workflow (`cargo-release`) infers from conventional commits.
 
-Workspace crate versioning is handled automatically by the release workflow
-(`cargo-release`). Do not manually bump `[workspace.package].version`.
+## Commit Messages
 
-### Manifest Frontmatter Preflight
+Conventional Commits: `type(scope): subject`, lowercase, **50/72 rule**, no `Co-Authored-By`.
 
-Before relying on local skills/commands in Claude, Codex, or Copilot, run:
-```bash
-./scripts/validate-frontmatter.sh --copilot-strict
-```
+`main` is branch-protected and merges via **rebase-merge** → linear history. On a PR branch, `--amend` is **encouraged** to absorb review nits and pre-push-gate fixes into the relevant parent commit; force-push-with-lease the branch (needs CONFIRM). "Fix typo" / "address review" commits become noise after rebase — fold them in instead. Never `--amend` a commit on `main`. Prefer **`jj`** for local change-stack management (see `docs/guides/JJ_AI_CHANGE_STACK.md`); Git remains the public surface.
 
-For CI/PR parity (repo-local manifests only), run:
-```bash
-./scripts/validate-frontmatter.sh --repo-only --copilot-strict
-```
+**Versioning signals:**
 
-### Documentation Rule
+| Prefix | Impact |
+|---|---|
+| `feat!:` / `fix!:` | Major (capped at Minor pre-1.0) |
+| `feat:` | Minor |
+| `fix:` / `perf:` | Patch |
+| `chore:` / `docs:` | None |
 
-**All new or modified public Rust items must have `///` doc comments.** This applies to structs, enums, traits, functions, and public fields. One clear sentence minimum — describe *what* it is/does. Existing items touched by a change must be documented in the same commit. Doc-only commits skip build checks.
+Allowed scopes do not include `csl-legacy` — use `migrate` instead.
 
-**Documentation Placement:**
-- Execution plans / snapshots → `docs/architecture/` (date-stamp filename)
-- Feature/design specifications → `docs/specs/` (use spec template)
-- Active behavioral rules → `docs/policies/` (use policy template)
-- Operational how-tos → `docs/guides/`
-- Reference lookups → `docs/reference/`
+## Documentation Rule
 
-### Feature Design Workflow
+All new or modified **public Rust items** need `///` doc comments (one clear sentence minimum). Existing items touched in a change must be documented in the same commit. Doc-only commits skip build checks.
 
-Before implementing a non-trivial feature (schema, engine behavior, type
-system), create a spec first:
-1. Create a spec file in `docs/specs/` (e.g. `LOCALE_MESSAGES.md`) using the spec template in `docs/specs/README.md`.
-2. Status: `Draft`. Get it committed before writing implementation code.
-3. Set Status to `Active` in the same commit as the first implementation.
-4. Reference the spec path in the bean description.
+**Placement:**
 
-**Commit Messages:** Conventional Commits `type(scope): subject`, lowercase, 50/72 rule, no `Co-Authored-By`. `--amend` is allowed **only on unpushed commits** (to absorb pre-push gate fixes). Forbidden once a commit is on the remote.
+| Kind | Directory |
+|---|---|
+| Execution plans / snapshots | `docs/architecture/` (date-stamped) |
+| Feature / design specs | `docs/specs/` (use template) |
+| Active behavioral rules | `docs/policies/` |
+| Operational how-tos | `docs/guides/` |
+| Reference lookups | `docs/reference/` |
 
-### Post-Push CI Check (PR branches)
-
-After every `git push` on a PR branch, check CI before stopping:
-```bash
-gh pr checks <PR> --watch
-```
-If any check fails, read the logs and fix:
-```bash
-gh run view <run-id> --log-failed
-```
-Do not consider the task done until CI passes.
-
-### Optional jj AI Change Stack
-
-This repo may use jj as a local, optional change-stack layer for AI-assisted
-work when `.jj` is present. Git and GitHub remain the public collaboration
-interface. Follow [docs/guides/JJ_AI_CHANGE_STACK.md](./docs/guides/JJ_AI_CHANGE_STACK.md)
-for intent capture, agent coordination, and stack curation. Intent files may
-live inside an evolving jj change, but must be deleted before the final
-Git-visible commit is published unless explicitly requested.
-
-### Confirmations Required
-
-- `Cargo.toml` / `Cargo.lock` changes
-- Any `styles-legacy/` submodule operation
-- `git push origin main`
-- `gh pr create`
-- Editing any file in `~/.claude/skills/` or `~/.claude/scripts/` — confirm the exact
-  absolute path before writing
+Non-trivial features: spec in `docs/specs/` first (status `Draft` → `Active` in the implementation commit). Reference the spec path in the bean.
 
 ## Agents
 
 | Agent | Role | Notes |
-|-------|------|-------|
-| @planner | Quick planning | ≤3 questions |
-| @dplanner | Deep planning + research | Complex architecture |
-| @builder | Implementation | 2-retry cap, no questions |
-| @reviewer | QA / conflict detection | Use after code changes |
+|---|---|---|
+| `@planner` | Quick planning | ≤3 questions |
+| `@dplanner` | Deep planning + research | Complex architecture |
+| `@builder` | Implementation | 2-retry cap, no questions |
+| `@reviewer` | QA / conflict detection | Use after code changes |
 
-Style tasks: use **`/style-evolve`** (`upgrade`, `migrate`, `create`). Agent skills
-live in `.skills/` and are installed with `./scripts/install-skills.sh`.
-Claude skills remain in `.claude/skills/`.
-Rust quality tasks: use **`/rust-simplify`** (file-length, duplication cleanup) or **`/rust-refine`** (API shape, clippy suppression removal).
+Style tasks: `/style-evolve` (`upgrade`, `migrate`, `create`). Rust quality: `/rust-simplify` (size/dup) or `/rust-refine` (API shape).
 
 ## Task Management
 
-Use `/beans` for local tasks; GitHub Issues for community/long-term.
+`/beans` for local tasks; GitHub Issues for community work. Common: `beans next`, `beans show <id>`, `beans update <id> -s in-progress|completed`, `beans create "T" -t bug -p high`.
 
-```
-/beans next                                      # Canonical recommendation for next task
-/beans show BEAN_ID                              # Inspect a task before starting it
-/beans list                                      # Show the full task inventory
-/beans update BEAN_ID --status in-progress
-/beans update BEAN_ID --status completed
-/beans create "Title" --type bug --priority high
-```
+## Confirmations Required
 
-## Project Goal
+- `Cargo.toml` / `Cargo.lock` changes
+- Any `styles-legacy/` submodule operation
+- `git push origin main`, `gh pr create`
+- Editing any file under `~/.claude/skills/` or `~/.claude/scripts/` — confirm absolute path before write
 
-Transition citation management from CSL 1.0 (procedural XML) to Citum (declarative, type-safe Rust/YAML):
+## Git Workflow
 
-1. **Parsing** — `csl-legacy` (complete)
-2. **Migrating** — `citum_migrate`
-3. **Processing** — `citum_engine`
-4. **Rendering** — match citeproc-js exactly for CSL-derived styles; match biblatex behavior for biblatex-derived styles
+Branch protection on `main` — all changes via PR. Branch **before** committing when a PR is planned. Pre-commit gate above is required for Rust.
 
-```
-crates/
-  csl-legacy/      # CSL 1.0 XML parser
-  citum-cli/            # CLI crate (binary: `citum`)
-  citum_schema/       # Types: Style, Template, Options, Locale
-  citum_migrate/    # CSL 1.0 → Citum conversion
-  citum_engine/  # Citation/bibliography rendering engine
-styles/            # Citum YAML styles
-styles-legacy/     # 2,844 CSL 1.0 styles (submodule)
-```
+**After every push on a PR branch:** `gh pr checks <PR> --watch`. If failing, `gh run view <run-id> --log-failed`. Task is not done until CI passes.
 
-## Migration Strategy
+**Never make content decisions unilaterally** (e.g. what text to put in a title field) — confirm with the user first.
 
-Hybrid: XML pipeline for options extraction + LLM-authored templates for top parent styles. See [docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md](./docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md).
+**PR merge is always the user's action.** "Looks good", "go ahead", "CI is green" do not grant merge permission. Report green CI and stop.
 
-Use `./scripts/prep-migration.sh` + `/style-evolve migrate` for hand-authoring. See
-`docs/TIER_STATUS.md` for live fidelity metrics.
-
-## Authoring Locales
-
-Locale files in `locales/` use schema v2 with MessageFormat 2 (MF2)
-parameterized messages. The MF2 path is **live in the engine** —
-`resolved_locator_term` and `resolved_role_term` consult `messages:` first and
-fall back to the legacy `terms:` / `roles:` / `locators:` maps.
-
-When editing or creating a locale, see
-[docs/guides/AUTHORING_LOCALES.md](./docs/guides/AUTHORING_LOCALES.md). Key
-gotcha: `MaybeGendered<T>` is live in the legacy locale maps, but MF2 role and
-locator lookup currently passes `$count` only and the custom evaluator supports
-one selector per `.match`. Keep gendered role labels in `roles:` until the
-gender-aware MF2 follow-up adds `$gender` plumbing and multi-selector support.
-Spec: [docs/specs/LOCALE_MESSAGES.md](./docs/specs/LOCALE_MESSAGES.md).
-
-## Design Principles
-
-[docs/architecture/DESIGN_PRINCIPLES.md](./docs/architecture/DESIGN_PRINCIPLES.md)
-
-Key: explicit over magic (style declares behavior, processor stays dumb), serde-driven truth, no `unwrap()`/`unsafe`, declarative templates over procedural `<choose>/<if>`.
-
-When considering prior art, prefer biblatex solutions to BibTeX. biblatex has a more modern, better-designed data model and feature set.
-
-## Documentation Quality
-
-Use `/humanizer` on docs before finalizing. Exceptions: rule 18 (curly quotes) excluded; rule 13 (em dash) triggers only at 3+ per paragraph.
-
-## Verification & Coding Standards
-
-[docs/guides/CODING_STANDARDS.md](./docs/guides/CODING_STANDARDS.md) — verification table, benchmark workflow, Serde checklist, **test style rule** (BDD `given/when/then` + `#[rstest]` for parameterised integration tests; plain `#[test]` for unit tests and single-scenario integration tests).
-
-## Current Status
-
-Canonical status and metrics live in:
-
-- `docs/TIER_STATUS.md` (style-level status, strict oracle snapshots)
-- `scripts/report-data/core-quality-baseline.json` (portfolio baseline gate)
-- `docs/compat.html` (published compatibility snapshot)
-
-Oracle scoring uses the strict 12-scenario citation fixture
-(`tests/fixtures/citations-expanded.json`).
-
-### Known Gaps
-- Volume-pages delimiter varies by style (comma vs colon)
-- DOI suppression for styles that don't output DOI
-- Editor name-order varies by style (given-first vs family-first)
-
-## Feature Priority
-
-See [docs/TIER_STATUS.md](./docs/TIER_STATUS.md) and [docs/reference/STYLE_PRIORITY.md](./docs/reference/STYLE_PRIORITY.md). Top 10 parent styles cover 60% of dependents. Author-date first (APA, Elsevier Harvard, Springer), then numeric + note styles.
-
-## Prior Art & Design Documents
-
-- Prior art reference: [docs/architecture/PRIOR_ART.md](./docs/architecture/PRIOR_ART.md)
-- Personas: [docs/architecture/PERSONAS.md](./docs/architecture/PERSONAS.md)
-- Style aliasing: [STYLE_ALIASING.md](./docs/architecture/design/STYLE_ALIASING.md)
-- Legal citations: [LEGAL_CITATIONS.md](./docs/architecture/design/LEGAL_CITATIONS.md)
-- Type system: [TYPE_SYSTEM_ARCHITECTURE.md](./docs/architecture/design/TYPE_SYSTEM_ARCHITECTURE.md)
-- Type addition policy: [TYPE_ADDITION_POLICY.md](./docs/policies/TYPE_ADDITION_POLICY.md) (**active policy**)
-- SQI plan: [SQI_REFINEMENT_PLAN.md](./docs/policies/SQI_REFINEMENT_PLAN.md)
-
-## Issue Handling
-
-[docs/guides/DOMAIN_EXPERT.md](./docs/guides/DOMAIN_EXPERT.md) — Domain Expert Context Packets workflow.
+`gh pr create` with body: write to temp file, then `--body-file /tmp/file.txt` (hooks reject inline `--body`).
 
 ## Test Commands
 
 ```bash
-cargo nextest run                                          # All tests
-cargo nextest run --test citations                        # Citation rendering
-cargo nextest run --test bibliography                     # Bibliography
-cargo nextest run --test i18n                             # Locale logic
-./scripts/bootstrap.sh full                               # Fetch optional corpora for fidelity workflows
-./scripts/workflow-test.sh styles-legacy/apa.csl         # Oracle + batch impact
-node scripts/oracle.js styles-legacy/apa.csl             # Component-level diff
-node scripts/oracle-batch-aggregate.js styles-legacy/ --top 10
-node scripts/report-core.js > /tmp/core-report.json && \
+cargo nextest run                                          # all tests
+./scripts/workflow-test.sh styles-legacy/apa.csl           # oracle + batch impact
+node scripts/oracle.js styles-legacy/apa.csl               # component-level diff
+node scripts/report-core.js > /tmp/r.json && \
   node scripts/check-core-quality.js \
-  --report /tmp/core-report.json \
-  --baseline scripts/report-data/core-quality-baseline.json
-./scripts/dev-env.sh cargo build --workspace             # Local cargo with out-of-repo target dir
-cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s styles/apa-7th.yaml
-cargo run --bin citum -- schema > citum.schema.json
-cargo bench --bench rendering                            # Hot path benchmarks
-python3 scripts/audit-rust-review-smells.py --changed    # Run before committing test changes
+    --report /tmp/r.json \
+    --baseline scripts/report-data/core-quality-baseline.json
 ```
 
-**Test assertion rule:** Never use `contains()` with a substring under 30 chars to verify rendered output. Use `assert_eq!` with the full expected string. See `docs/guides/CODING_STANDARDS.md` for the full rule and escape hatch.
+Full catalogue and the **test-assertion rule** (no `contains()` with substrings <30 chars): `docs/guides/CODING_STANDARDS.md`. Test style (BDD `given/when/then`, `rstest` for parameterised): same doc.
 
-## Git Workflow
+## Optional: jj Change Stack
 
-Branch protection is enabled on `main` — all changes go through PRs. Pre-commit checks required for Rust; docs/styles skip.
+If `.jj` is present, see `docs/guides/JJ_AI_CHANGE_STACK.md`. Git remains the public surface. **jj skips all git hooks** — run commit-msg / pre-commit / pre-push manually before `jj git push`.
 
-Create a branch, implement, then `gh pr create`. jj may be used locally to
-curate the change stack, but the final published work must be on a Git branch
-and submitted through GitHub.
-**Never make content decisions unilaterally** (e.g. what text to put in a title field) — confirm with the user first.
+## Pointers
 
-Code and schema versioning are automated: the release workflow detects path
-changes, infers bump level from conventional commits, and opens a release PR via
-`cargo-release`. Do not manually bump workspace crate versions or schema
-versions in feature PRs.
-
-#### Versioning Signals (Conventional Commits)
-
-Agents MUST use the following prefixes to signal the intended release impact:
-
-| Commit Prefix | Release Impact | Note |
-| :--- | :--- | :--- |
-| `feat!:` / `fix!:` | **Major** (Breaking) | Capped at **Minor** during pre-1.0 |
-| `feat:` | **Minor** (Feature) | Triggers a new feature release |
-| `fix:` / `perf:` | **Patch** (Fix) | Triggers a maintenance release |
-| `chore:` / `docs:` | **None** | Does not trigger a release PR |
-
-*   **Breaking Changes**: Append a `!` after the type (e.g., `feat!:`) OR include `BREAKING CHANGE:` in the footer.
-*   **Schema Bumps**: Do not add a footer. Commit regenerated schemas when they change; the release workflow bumps schema versions.
-
-
-```bash
-# Rust change
-cargo fmt && cargo clippy && cargo nextest run && \
-  git add -A && git commit -m "fix(scope): subject
-
-Body explaining why.
-
-Refs: csl26-xxxx, #123"
-```
+- Crate map: `crates/README.md`
+- Design principles: `docs/architecture/DESIGN_PRINCIPLES.md`
+- Architecture index: `docs/architecture/README.md`
+- Live fidelity: `docs/TIER_STATUS.md`
+- Coding standards: `docs/guides/CODING_STANDARDS.md`
+- Locale authoring: `docs/guides/AUTHORING_LOCALES.md`
+- Domain Expert workflow: `docs/guides/DOMAIN_EXPERT.md`
+- Frontmatter preflight: `./scripts/validate-frontmatter.sh --copilot-strict`

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,59 @@
+# Crate Map
+
+The citum-core workspace. Read this first to orient — then descend into the relevant crate's `CLAUDE.md` (when present) for scoped rules and entry points.
+
+## Naming
+
+- `citum-*` (hyphenated): standard crate naming convention.
+- `citum_store` (underscored, legacy): pre-dates the convention; kept stable to avoid churn. Treat the form as fixed.
+
+## Pipeline crates (the citation lifecycle)
+
+| # | Crate | Role |
+|---|---|---|
+| 1 | [`csl-legacy`](csl-legacy/CLAUDE.md) | CSL 1.0 XML parser — frozen, consumed by `citum-migrate`. |
+| 2 | [`citum-migrate`](citum-migrate/CLAUDE.md) | CSL 1.0 → Citum YAML converter. Plateau reached on automatic mode; hand-authoring is canonical for top parents. |
+| 3 | [`citum-schema`](citum-schema/CLAUDE.md) | Facade re-exporting `citum-schema-style` + `citum-schema-data`. Real types in `citum-schema-style/`. |
+| 4 | `citum-schema-style` | Style model (~120K lib.rs): `Style`, `Template`, `Options`, `Locale`, `Renderer`, `Presets`, `Registry`. Navigate via jcodemunch. |
+| 5 | `citum-schema-data` | Reference / data model accessors. |
+| 6 | [`citum-engine`](citum-engine/CLAUDE.md) | Rendering engine. Citation/bibliography output. Byte-for-byte targets vs citeproc-js / biblatex. |
+
+## Surface crates (how external consumers reach the engine)
+
+| Crate | Role |
+|---|---|
+| `citum-cli` | The `citum` binary. Schema gen lives behind `--features schema`. |
+| `citum-bindings` | Lua / Python / JS bindings consuming the C ABI from `citum-engine/src/ffi/`. |
+| `citum-server` | Long-running server surface. |
+| `citum-resolver-api` | API for reference resolution. |
+| `citum-pdf` | PDF rendering surface. |
+| `citum-io` | I/O helpers shared across surfaces. |
+| `citum_store` | Storage layer. |
+
+## Support crates
+
+| Crate | Role |
+|---|---|
+| `citum-analyze` | Analytic passes used in tooling and tests. |
+| `citum-edtf` | EDTF (Extended Date/Time Format) parsing. |
+
+## Where work usually happens
+
+| Task | Crate(s) |
+|---|---|
+| Engine rendering bug | `citum-engine` (especially `src/render/`, `src/grouping/`) |
+| Style YAML model change | `citum-schema-style` |
+| Reference / data field addition | `citum-schema-data`, then bindings |
+| New converter behavior | `citum-migrate` |
+| CLI command / flag | `citum-cli` |
+| FFI / bindings | `citum-engine/src/ffi/` then `citum-bindings/` |
+
+## Navigation rules
+
+This workspace contains 2,300+ Rust symbols across 15 crates. **Read fewer files; query symbols instead.**
+
+- Symbol body / call hierarchy / module API → **jcodemunch** (`get_symbol`, `get_call_hierarchy`, `get_repo_outline`).
+- Type resolution, hover, go-to-def → **rust-analyzer** (LSP).
+- Call sites, string literals, regex → **Bash `mgrep` / `grep`** (RTK-rewritten).
+
+See root `CLAUDE.md` for the full tool priority table.

--- a/crates/citum-engine/AGENTS.md
+++ b/crates/citum-engine/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/citum-engine/CLAUDE.md
+++ b/crates/citum-engine/CLAUDE.md
@@ -1,0 +1,31 @@
+# citum-engine
+
+The citation/bibliography rendering engine. Consumes Citum-schema styles + InputReferences, emits rendered citations and bibliographies. Target: byte-for-byte match with citeproc-js for CSL-derived styles and biblatex for biblatex-derived styles.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/lib.rs` | Crate roots and public API |
+| `src/api/` | Public engine entry points (call from CLI, FFI, WASM) |
+| `src/processor/` | Style-driven processing core |
+| `src/render/` | Render passes — `citations.rs`, bibliography, sort, layout |
+| `src/grouping/` | Cite-group resolution (integral multi-cite, et al.) |
+| `src/values/` | Resolved value types (`MaybeGendered`, dates, names) |
+| `src/ffi/` | C ABI surface: `mod.rs` (~570 lines) + `biblatex.rs` (uses `BibRefContext<'a>` to avoid `too_many_arguments`) |
+| `src/sort_partitioning.rs` | Bibliography sort & partition logic |
+
+## Gotchas
+
+- **Integral multi-cites** join via locale-aware prose ("Smith (2020) and Jones (2021)"). Grouped integral locator punctuation must not duplicate delimiters — see commit `88a6f62`. File: `src/render/citations.rs`.
+- **Oracle routing:** check the style's `originKey` before picking an oracle. CSL-derived → CSL oracle (`node scripts/oracle.js`); biblatex-derived → biblatex oracle. Never run a CSL-shape oracle against a biblatex-derived style — the diff is meaningless.
+- **Locale MF2 is live** for locator/role term resolution — `messages:` consulted first, falls back to legacy `terms:` / `roles:` / `locators:`. Gendered role labels still flow through `roles:` (multi-selector MF2 follow-up pending).
+- **No `unwrap()` / `unsafe`.** Result/Option must surface as engine errors via `src/error.rs`.
+
+## Symbol & type queries
+
+For "what does this generic resolve to?" or LSP-grade hover, use **rust-analyzer**. For symbol bodies and call hierarchies, use **jcodemunch** (`get_symbol`, `get_call_hierarchy`). See root `CLAUDE.md` for the priority table.
+
+## Hot paths
+
+`cargo bench --bench rendering` — keep regressions out. Workflow test: `./scripts/workflow-test.sh styles-legacy/apa.csl`.

--- a/crates/citum-migrate/AGENTS.md
+++ b/crates/citum-migrate/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/citum-migrate/CLAUDE.md
+++ b/crates/citum-migrate/CLAUDE.md
@@ -1,0 +1,38 @@
+# citum-migrate
+
+CSL 1.0 → Citum YAML converter. Hand-authoring with this converter is the canonical path for top parent styles; pure-automatic conversion has plateaued (remaining fidelity gaps are engine-level, not converter-level).
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/main.rs` | CLI entry (~45K — large, navigate via jcodemunch) |
+| `src/lib.rs` | Library entry, pipeline orchestration |
+| `src/passes/` | Conversion passes (run in order) |
+| `src/fixups/` | Post-conversion corrections |
+| `src/options_extractor/` | XML-pipeline options extraction |
+| `src/template_compiler/` | Template generation (LLM-authored for top parents) |
+| `src/analysis/` | Pre/post analysis |
+| `src/base_detector.rs` | Detect base/parent style for inheritance |
+| `src/compilation.rs` | Final assembly |
+| `src/js_runtime.rs` | citeproc-js bridge for oracle/fidelity checks |
+| `src/template_diff.rs` | Reviewer-facing template diffs |
+
+## Gotchas
+
+- **Commit scope is `migrate`, not `csl-legacy`.** `csl-legacy` is not in the allowed scope list.
+- **Oracle routing:** check `originKey` before invoking any oracle. CSL oracle ≠ biblatex oracle. The `--force-migrate` flag re-runs the full conversion on an already-migrated style.
+- **Convergence plateau:** the converter is at its current best for automatic mode. Don't add ad-hoc fixups without confirming the gap isn't in `citum-engine` (`render/`) instead. Bias toward engine fixes over converter fixups when the failure is downstream-visible.
+- **Style source block (CRITICAL):** `info.source` is only valid for CSL-derived styles (requires `csl-id`). Output must not include it for biblatex-derived or native styles.
+
+## Workflows
+
+```bash
+./scripts/prep-migration.sh <csl-file>          # stage a parent style for hand-authoring
+/style-evolve migrate                            # routed migration skill
+node scripts/oracle.js styles-legacy/apa.csl    # CSL oracle (component diff)
+```
+
+## Symbol queries
+
+`main.rs` is large — never `cat` it. Use **jcodemunch**: `get_file_outline` to map symbols within the file, `get_symbol` to read one symbol's body, `get_repo_outline` for the crate's module API across files.

--- a/crates/citum-schema/AGENTS.md
+++ b/crates/citum-schema/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/citum-schema/CLAUDE.md
+++ b/crates/citum-schema/CLAUDE.md
@@ -1,0 +1,29 @@
+# citum-schema (facade)
+
+This crate is a **facade**: it re-exports `citum-schema-style` and `citum-schema-data`. Real schema types live in **`crates/citum-schema-style/`** — that's where edits usually go.
+
+## Where to edit
+
+| Concern | Crate |
+|---|---|
+| Style model (`Style`, `Template`, `Options`, `Locale`, `Renderer`, `Presets`, `Registry`) | `citum-schema-style/src/` |
+| Reference / data model accessors | `citum-schema-data/src/` |
+| Public re-export surface | `citum-schema/src/lib.rs` (rarely changes) |
+
+`citum-schema-style/src/lib.rs` is ~120K — use **jcodemunch** (`get_symbol`, `get_repo_outline`) to navigate it. Do not `cat` it.
+
+## Gotchas
+
+- **Serde-driven truth.** YAML round-trips define correctness. New fields need `#[serde(default)]` or explicit handling for back-compat.
+- **Do not bump `STYLE_SCHEMA_VERSION`** in feature commits. The release workflow handles schema version bumps based on conventional commits.
+- **Regenerate JSON schema** when public schema types change: `cargo run --bin citum --features schema -- schema --out-dir docs/schemas` — stage in the same commit.
+- **Grouped struct pattern.** 3+ related schema fields should become a grouped struct rather than parallel scalars (see `WrapConfig` in `citum-schema-style`, `BibRefContext` in `citum-engine/src/ffi/biblatex.rs`). Keeps signatures stable and avoids `clippy::too_many_arguments`.
+- **`info.source` is CSL-only.** Biblatex-derived and citum-native styles must omit `info.source` and `info.id` (no Zotero URL). Biblatex-derived: only `info.title` and `info.default-locale`.
+
+## Type addition
+
+Adding a new reference type or variant requires the policy in `docs/policies/TYPE_ADDITION_POLICY.md`. Read it before proposing new types.
+
+## Symbol queries
+
+For "what does this trait resolve to?" → **rust-analyzer**. For symbol bodies, callers, the API surface of `citum-schema-style` → **jcodemunch**.

--- a/crates/csl-legacy/AGENTS.md
+++ b/crates/csl-legacy/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/crates/csl-legacy/CLAUDE.md
+++ b/crates/csl-legacy/CLAUDE.md
@@ -1,0 +1,23 @@
+# csl-legacy
+
+The CSL 1.0 XML parser. Complete and frozen — consumed by `citum-migrate` for conversion to Citum schema. Treat as a stable dependency, not active development.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/lib.rs` | Public re-exports |
+| `src/parser.rs` | CSL 1.0 XML → AST (~35K, navigate via jcodemunch) |
+| `src/model.rs` | AST types (~21K) |
+| `src/csl_json.rs` | CSL-JSON support (~39K) |
+| `src/bin/` | Standalone parser binaries |
+
+## Gotchas
+
+- **Commit scope is `migrate`, not `csl-legacy`.** The allowed-scope list excludes `csl-legacy`. Bundle changes here with related `citum-migrate` work under `migrate`.
+- **Frozen.** Add behavior only when CSL 1.0 spec compliance is genuinely missing or `citum-migrate` exposes a real parser gap. Most fidelity issues live downstream in `citum-engine` rendering.
+- **No `unwrap()` / `unsafe`** still applies. Parser errors flow through the crate's error type.
+
+## Symbol queries
+
+Large files — use **jcodemunch**: `get_file_outline` to map symbols in a single file, `get_symbol` to read one symbol's body. For trait/type resolution, **rust-analyzer**.


### PR DESCRIPTION
## Summary

Applies Anthropic's [large-codebase best practices](https://claude.com/blog/how-claude-code-works-in-large-codebases-best-practices-and-where-to-start) to the agent harness ahead of public release. Balances agent effectiveness with token efficiency — both for humans navigating the repo and for LLM agents.

- **Slimmed root `CLAUDE.md`** from 280 → 136 lines. Moved test catalog, locale detail, status snapshots, and prior-art list to pointers. Added an unambiguous **Code Search Tool Priority** block elevating `jcodemunch` + `rust-analyzer` over Read/Grep and explicitly forbidding the `Explore` subagent for code in this repo.
- **Scoped `CLAUDE.md`** added to four hot crates (`citum-engine`, `citum-schema`, `citum-migrate`, `csl-legacy`). Each is ≤40 lines: layout table, 3-5 gotchas, symbol-query pointer. Layered loading means agents working in a crate get scoped context instead of the whole root file.
- **`crates/README.md`** — canonical 15-crate map: pipeline / surface / support, plus the `citum-*` vs `citum_*` naming note and a "where work usually happens" table.
- **`PostToolUse` hook** (`.claude/hooks/jcm-nudge.sh`) — fires on Read/Grep/Glob of Rust paths and injects a system reminder pointing at jcodemunch + rust-analyzer. Project-scoped via `$CLAUDE_PROJECT_DIR` so it does not leak to other repos.

Auto-memory (`~/.claude/projects/.../memory/`) was also compacted in parallel from 145 → 64 lines, extracting 14 inline rule blocks into dedicated detail files. That change is personal (outside this repo) and not part of this PR.

## Why

The root `CLAUDE.md` was bloated and the jcodemunch directive — even though documented in user memory — kept losing to a conflicting global "prefer Bash" rule. Burying the rule made it easy to rationalize away. This PR consolidates the canonical tool priority into the project file (where it wins by proximity), gives each hot crate its own scoped context, and adds a deterministic hook so the rule re-enters context at the exact moment of a violation.

## Test plan

- [x] `./scripts/validate-frontmatter.sh --repo-only --copilot-strict` → 17 files OK
- [x] `jq -e '.hooks.PostToolUse' .claude/settings.json` → valid JSON
- [x] Hook smoke test: synthetic `Read` on `crates/citum-engine/src/render/citations.rs` emits valid `PostToolUse` JSON with `additionalContext`
- [ ] CI green
- [ ] Optional: fresh session opens, asks "where does citation rendering happen and what's the integral-multicite rule?" — expect agent navigates via `crates/citum-engine/CLAUDE.md` without reading the full root file

## Out of scope (follow-up beans, if approved)

- Migrating cross-project skills (`commit`, `pr-workflow-fast`) into a shareable Claude Code plugin
- Stop-hook that auto-proposes `CLAUDE.md` updates from session learnings

Plan: `~/.claude/plans/this-project-has-undergone-woolly-crab.md`
