### PR TITLE
feat: contributor short-name + abbrev-map fix

### DIFF
--- a/.beans/archive/csl26-9faf--spec-contributor-short-name.md
+++ b/.beans/archive/csl26-9faf--spec-contributor-short-name.md
@@ -1,0 +1,14 @@
+---
+# csl26-9faf
+title: 'Spec: contributor short-name'
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-15T11:09:23Z
+updated_at: 2026-05-15T11:19:23Z
+parent: csl26-ycyp
+---
+
+Write docs/specs/SHORT_NAME.md (status: Active). Cover: short-name field on SimpleName, first-mention parenthetical rendering (full-then-parenthetical default), short-then-bracketed option, integral name state wiring, non-goals.
+
+## Summary of Changes\n\nWrote docs/specs/SHORT_NAME.md covering: short-name field semantics, rendering table (First/Subsequent × short-name present/absent), short-name-display style option (full-then-parenthetical default, short-then-bracketed), relationship to abbreviation-map, non-goals.

--- a/.beans/archive/csl26-hnpf--engine-treat-suppress-author-as-seen-for-integral.md
+++ b/.beans/archive/csl26-hnpf--engine-treat-suppress-author-as-seen-for-integral.md
@@ -1,0 +1,14 @@
+---
+# csl26-hnpf
+title: 'Engine: treat suppress-author as seen for integral name memory'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-05-15T11:09:23Z
+updated_at: 2026-05-15T11:19:23Z
+parent: csl26-ycyp
+---
+
+In annotate_integral_name_states, citations with suppress_author:true should update the seen-map (same as integral mode). Currently only CitationMode::Integral is tracked. File: crates/citum-engine/src/processor/document/integral_names.rs
+
+## Summary of Changes\n\nIn annotate_integral_name_states, changed guard from CitationMode::Integral-only to also fire when suppress_author:true, so suppress-author citations mark the work as seen for subsequent integral name-memory lookups.

--- a/.beans/archive/csl26-iaou--fix-abbreviation-map-schema-restore-flat-map.md
+++ b/.beans/archive/csl26-iaou--fix-abbreviation-map-schema-restore-flat-map.md
@@ -1,0 +1,14 @@
+---
+# csl26-iaou
+title: 'Fix abbreviation-map schema: restore flat map shape'
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-15T11:09:22Z
+updated_at: 2026-05-15T11:19:23Z
+parent: csl26-ycyp
+---
+
+AbbreviationMap should remain a transparent HashMap<String, String>. Regenerate abbrev-map.json so the schema matches the flat map model. File: crates/citum-schema-data/src/abbreviation.rs
+
+## Summary of Changes\n\nKept AbbreviationMap as a transparent HashMap newtype, regenerated the schema for the flat map shape, and added serde coverage proving reserved-looking keys are ordinary entries.

--- a/.beans/archive/csl26-n3qp--schema-add-short-name-to-simplename-flatname.md
+++ b/.beans/archive/csl26-n3qp--schema-add-short-name-to-simplename-flatname.md
@@ -1,0 +1,14 @@
+---
+# csl26-n3qp
+title: 'Schema: add short-name to SimpleName + FlatName'
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-15T11:09:23Z
+updated_at: 2026-05-15T11:19:23Z
+parent: csl26-ycyp
+---
+
+Add short_name: Option<MultilingualString> to SimpleName, short_name: Option<String> to FlatName, propagate in to_names_vec(). File: crates/citum-schema-data/src/reference/contributor.rs
+
+## Summary of Changes\n\nAdded short_name: Option<MultilingualString> to SimpleName, short_name: Option<String> to FlatName, propagated in to_names_vec() SimpleName arm.

--- a/.beans/archive/csl26-vklv--engine-render-contributor-short-name-first-mention.md
+++ b/.beans/archive/csl26-vklv--engine-render-contributor-short-name-first-mention.md
@@ -1,0 +1,14 @@
+---
+# csl26-vklv
+title: 'Engine: render contributor short-name (first-mention parenthetical + subsequent short)'
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-15T11:09:23Z
+updated_at: 2026-05-15T11:19:23Z
+parent: csl26-ycyp
+---
+
+Add integral_name_state to NameFormatContext. In format_single_name literal-name path: First+short_name -> 'Full (Short)', Subsequent+short_name -> 'Short'. Add ShortNameDisplay option to IntegralNameConfig (full-then-parenthetical, short-then-bracketed). Files: names.rs, options/integral_names.rs
+
+## Summary of Changes\n\nAdded integral_name_state and short_name_display to NameFormatContext; plumbed from format_names via hints + options.config. Literal-name path in format_single_name now dispatches: First+short_name -> full-then-parenthetical or short-then-bracketed; Subsequent+short_name -> short name only.

--- a/.beans/archive/csl26-ycyp--short-name-for-organizational-contributors-suppres.md
+++ b/.beans/archive/csl26-ycyp--short-name-for-organizational-contributors-suppres.md
@@ -1,0 +1,13 @@
+---
+# csl26-ycyp
+title: Short-name for organizational contributors + suppress-author memory fix
+status: completed
+type: epic
+priority: normal
+created_at: 2026-05-15T11:09:11Z
+updated_at: 2026-05-15T11:19:28Z
+---
+
+Three related items in one PR: (1) keep abbreviation-map as a flat string map and align the JSON schema, (2) add short-name field to SimpleName for organizational acronyms (WHO, etc.) with first-mention parenthetical rendering, (3) treat suppress-author citations as integral for name-memory purposes. Spec: docs/specs/SHORT_NAME.md
+
+## Summary of Changes\n\nAll five child tasks completed in one PR:\n1. AbbreviationMap: flat transparent map schema regenerated with serde compatibility coverage\n2. Spec: docs/specs/SHORT_NAME.md\n3. SimpleName.short_name + FlatName.short_name schema fields\n4. Engine: integral name state + short_name_display wired into NameFormatContext; first-mention parenthetical and subsequent short-only rendering for literal names\n5. suppress-author treated as integral for name-memory tracking

--- a/crates/citum-engine/src/processor/document/integral_names.rs
+++ b/crates/citum-engine/src/processor/document/integral_names.rs
@@ -115,10 +115,14 @@ impl Processor {
 
         let mut seen: HashMap<(String, String), SeenIntegralNameState> = HashMap::new();
         for (citation, context) in citations.iter_mut().zip(contexts.iter()) {
-            if !matches!(
+            // suppress-author on a non-integral citation is semantically
+            // equivalent to integral mode — both suppress the author in the
+            // rendered output, so both should count as "seen" for name memory.
+            let counts_as_integral = matches!(
                 citation.mode,
                 citum_schema::citation::CitationMode::Integral
-            ) {
+            ) || citation.suppress_author;
+            if !counts_as_integral {
                 continue;
             }
 

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -173,6 +173,7 @@ fn make_integral_name_style(scope: IntegralNameScope, contexts: IntegralNameCont
                 scope: Some(scope),
                 contexts: Some(contexts),
                 subsequent_form: Some(IntegralNameForm::Short),
+                short_name_display: None,
             }),
             ..Default::default()
         }),

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -699,6 +699,28 @@ fn test_integral_name_memory_full_then_short_in_one_document() {
 }
 
 #[test]
+fn test_suppress_author_counts_as_seen_for_later_integral_name_memory() {
+    let bib = make_test_bib();
+    let processor = Processor::new(
+        make_integral_name_style(
+            IntegralNameScope::Document,
+            IntegralNameContexts::BodyAndNotes,
+        ),
+        bib,
+    );
+    let parser = DjotParser;
+
+    let content = "Hidden [-@item1]. Later [+@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert_eq!(
+        result,
+        "Hidden (2020). Later Doe.\n\n# Bibliography\n\nJohn Doe (2020)"
+    );
+}
+
+#[test]
 fn test_integral_name_memory_chapter_reset_uses_full_name_again() {
     let bib = make_test_bib();
     let processor = Processor::new(

--- a/crates/citum-engine/src/processor/document/types.rs
+++ b/crates/citum-engine/src/processor/document/types.rs
@@ -55,6 +55,9 @@ pub struct DocumentIntegralNameOverride {
     /// The contributor form used after the first mention.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subsequent_form: Option<citum_schema::options::IntegralNameForm>,
+    /// How to display a short name on the first integral mention.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short_name_display: Option<citum_schema::options::ShortNameDisplay>,
 }
 
 impl DocumentIntegralNameOverride {
@@ -76,7 +79,51 @@ impl DocumentIntegralNameOverride {
         if self.subsequent_form.is_some() {
             result.subsequent_form = self.subsequent_form;
         }
+        if self.short_name_display.is_some() {
+            result.short_name_display = self.short_name_display;
+        }
         Some(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DocumentIntegralNameOverride;
+    use citum_schema::options::{IntegralNameConfig, IntegralNameRule, ShortNameDisplay};
+
+    #[test]
+    fn test_document_integral_name_override_deserializes_short_name_display() {
+        assert_eq!(
+            serde_yaml::from_str::<DocumentIntegralNameOverride>(
+                "short-name-display: short-then-bracketed"
+            )
+            .ok()
+            .map(|config| config.short_name_display),
+            Some(Some(ShortNameDisplay::ShortThenBracketed))
+        );
+    }
+
+    #[test]
+    fn test_document_integral_name_override_applies_short_name_display() {
+        let base = IntegralNameConfig {
+            rule: Some(IntegralNameRule::FullThenShort),
+            short_name_display: Some(ShortNameDisplay::FullThenParenthetical),
+            ..Default::default()
+        };
+        let override_config = DocumentIntegralNameOverride {
+            short_name_display: Some(ShortNameDisplay::ShortThenBracketed),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            override_config
+                .apply_to(Some(&base))
+                .map(|config| (config.short_name_display, config.rule)),
+            Some((
+                Some(ShortNameDisplay::ShortThenBracketed),
+                Some(IntegralNameRule::FullThenShort)
+            ))
+        );
     }
 }
 

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -84,6 +84,7 @@ fn integral_name_style() -> Style {
                 scope: Some(IntegralNameScope::Document),
                 contexts: Some(IntegralNameContexts::BodyAndNotes),
                 subsequent_form: Some(IntegralNameForm::Short),
+                short_name_display: None,
             }),
             ..Default::default()
         }),

--- a/crates/citum-engine/src/values/contributor/names.rs
+++ b/crates/citum-engine/src/values/contributor/names.rs
@@ -21,6 +21,9 @@ pub(crate) struct NameFormatContext<'a> {
     pub(crate) name_form: Option<NameForm>,
     pub(crate) demote_ndp: Option<&'a DemoteNonDroppingParticle>,
     pub(crate) sort_separator: Option<&'a String>,
+    pub(crate) integral_name_state: Option<citum_schema::citation::IntegralNameState>,
+    pub(crate) use_integral_short_name: bool,
+    pub(crate) short_name_display: Option<citum_schema::options::ShortNameDisplay>,
 }
 
 /// Per-call template overrides passed to [`format_names`].
@@ -293,6 +296,16 @@ pub fn format_names(
         sort_separator: overrides
             .sort_separator
             .or_else(|| config.and_then(|c| c.sort_separator.as_ref())),
+        integral_name_state: hints.integral_name_state,
+        use_integral_short_name: matches!(
+            options.mode,
+            citum_schema::citation::CitationMode::Integral
+        ),
+        short_name_display: options
+            .config
+            .integral_names
+            .as_ref()
+            .map(|c| c.resolve().short_name_display),
     };
 
     let delimiter = config.and_then(|c| c.delimiter.as_deref()).unwrap_or(", ");
@@ -483,6 +496,28 @@ fn assemble_long_name(
     }
 }
 
+fn format_literal_name(literal: &str, short: Option<&str>, ctx: &NameFormatContext) -> String {
+    if ctx.use_integral_short_name
+        && let Some(short) = short
+    {
+        match ctx.integral_name_state {
+            Some(citum_schema::citation::IntegralNameState::First) => {
+                return match ctx.short_name_display {
+                    Some(citum_schema::options::ShortNameDisplay::ShortThenBracketed) => {
+                        format!("{short} [{literal}]")
+                    }
+                    _ => format!("{literal} ({short})"),
+                };
+            }
+            Some(citum_schema::citation::IntegralNameState::Subsequent) => {
+                return short.to_string();
+            }
+            _ => {}
+        }
+    }
+    literal.to_string()
+}
+
 /// Format a single name.
 pub(crate) fn format_single_name(
     name: &crate::reference::FlatName,
@@ -501,7 +536,7 @@ pub(crate) fn format_single_name(
 
     // Handle literal names (e.g., corporate authors)
     if let Some(literal) = &name.literal {
-        return literal.clone();
+        return format_literal_name(literal, name.short_name.as_deref(), ctx);
     }
 
     let family = name.family.as_deref().unwrap_or("");

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -328,6 +328,7 @@ pub fn resolve_multilingual_name(
                 dropping_particle: selected_name.dropping_particle.clone(),
                 non_dropping_particle: selected_name.non_dropping_particle.clone(),
                 literal: None,
+                short_name: None,
             }]
         }
 

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -154,7 +154,87 @@ fn make_name_format_context<'a>(
         name_form,
         demote_ndp,
         sort_separator,
+        integral_name_state: None,
+        use_integral_short_name: true,
+        short_name_display: None,
     }
+}
+
+fn make_literal_name_with_short_name() -> FlatName {
+    FlatName {
+        literal: Some("World Health Organization".to_string()),
+        short_name: Some("WHO".to_string()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn given_literal_short_name_when_first_integral_mention_then_parenthetical_form_renders() {
+    let mut ctx = make_name_format_context(None, None, None, None, None, None, None);
+    ctx.integral_name_state = Some(citum_schema::citation::IntegralNameState::First);
+    ctx.short_name_display = Some(ShortNameDisplay::FullThenParenthetical);
+
+    let result = super::contributor::format_single_name(
+        &make_literal_name_with_short_name(),
+        &ContributorForm::Long,
+        0,
+        &ctx,
+        false,
+    );
+
+    assert_eq!(result, "World Health Organization (WHO)");
+}
+
+#[test]
+fn given_literal_short_name_when_subsequent_integral_mention_then_short_form_renders() {
+    let mut ctx = make_name_format_context(None, None, None, None, None, None, None);
+    ctx.integral_name_state = Some(citum_schema::citation::IntegralNameState::Subsequent);
+    ctx.short_name_display = Some(ShortNameDisplay::FullThenParenthetical);
+
+    let result = super::contributor::format_single_name(
+        &make_literal_name_with_short_name(),
+        &ContributorForm::Long,
+        0,
+        &ctx,
+        false,
+    );
+
+    assert_eq!(result, "WHO");
+}
+
+#[test]
+fn given_short_then_bracketed_option_when_first_integral_mention_then_bracketed_form_renders() {
+    let mut ctx = make_name_format_context(None, None, None, None, None, None, None);
+    ctx.integral_name_state = Some(citum_schema::citation::IntegralNameState::First);
+    ctx.short_name_display = Some(ShortNameDisplay::ShortThenBracketed);
+
+    let result = super::contributor::format_single_name(
+        &make_literal_name_with_short_name(),
+        &ContributorForm::Long,
+        0,
+        &ctx,
+        false,
+    );
+
+    assert_eq!(result, "WHO [World Health Organization]");
+}
+
+#[test]
+fn given_non_integral_context_when_integral_name_state_is_set_then_literal_short_name_is_ignored() {
+    let mut ctx = make_name_format_context(None, None, None, None, None, None, None);
+    ctx.integral_name_state = Some(citum_schema::citation::IntegralNameState::Subsequent);
+    ctx.use_integral_short_name = false;
+    ctx.short_name_display = Some(ShortNameDisplay::FullThenParenthetical);
+
+    let result = super::contributor::format_single_name(
+        &make_literal_name_with_short_name(),
+        &ContributorForm::Long,
+        0,
+        &ctx,
+        false,
+    );
+
+    assert_eq!(result, "World Health Organization");
 }
 
 /// Tests the behavior of `test_contributor_values`.

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -98,6 +98,7 @@ fn build_integral_name_style() -> Style {
                 scope: Some(IntegralNameScope::Document),
                 contexts: Some(IntegralNameContexts::BodyAndNotes),
                 subsequent_form: Some(IntegralNameForm::Short),
+                short_name_display: None,
             }),
             ..Default::default()
         }),

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -216,6 +216,7 @@ fn test_name_rendering_corporate() {
                     "World Health Organization".to_string(),
                 ),
                 location: None,
+                short_name: None,
             },
         ));
     }

--- a/crates/citum-schema-data/src/abbreviation.rs
+++ b/crates/citum-schema-data/src/abbreviation.rs
@@ -15,8 +15,65 @@ use serde::{Deserialize, Serialize};
 ///
 /// Keys are the full rendered string (exact, case-sensitive). Values are the
 /// replacement abbreviation. Applied after value extraction, before output.
+///
 /// Accepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(transparent)]
 pub struct AbbreviationMap(pub HashMap<String, String>);
+
+#[cfg(test)]
+mod tests {
+    use super::AbbreviationMap;
+
+    #[test]
+    fn given_flat_map_when_deserialized_then_entries_are_preserved() {
+        let json = r#"{
+            "Estates Gazette": "EG",
+            "Lloyd's Law Reports": "Lloyd's Rep"
+        }"#;
+
+        let map: AbbreviationMap = serde_json::from_str(json).unwrap_or_default();
+
+        assert_eq!(map.0.get("Estates Gazette"), Some(&"EG".to_string()));
+        assert_eq!(
+            map.0.get("Lloyd's Law Reports"),
+            Some(&"Lloyd's Rep".to_string())
+        );
+    }
+
+    #[test]
+    fn given_reserved_looking_keys_when_deserialized_then_keys_are_entries() {
+        let json = r#"{
+            "title": "ttl.",
+            "description": "desc.",
+            "metadata": "meta.",
+            "entries": "ent."
+        }"#;
+
+        let map: AbbreviationMap = serde_json::from_str(json).unwrap_or_default();
+
+        assert_eq!(map.0.get("title"), Some(&"ttl.".to_string()));
+        assert_eq!(map.0.get("description"), Some(&"desc.".to_string()));
+        assert_eq!(map.0.get("metadata"), Some(&"meta.".to_string()));
+        assert_eq!(map.0.get("entries"), Some(&"ent.".to_string()));
+    }
+
+    #[test]
+    fn given_flat_map_when_serialized_then_output_has_only_entries() {
+        let json = r#"{
+            "title": "ttl.",
+            "World Health Organization": "WHO"
+        }"#;
+        let map: AbbreviationMap = serde_json::from_str(json).unwrap_or_default();
+
+        let serialized = serde_json::to_value(&map).unwrap_or(serde_json::Value::Null);
+
+        assert_eq!(serialized.get("title"), Some(&serde_json::json!("ttl.")));
+        assert_eq!(
+            serialized.get("World Health Organization"),
+            Some(&serde_json::json!("WHO"))
+        );
+        assert!(serialized.get("metadata").is_none());
+    }
+}

--- a/crates/citum-schema-data/src/reference/contributor.rs
+++ b/crates/citum-schema-data/src/reference/contributor.rs
@@ -68,6 +68,9 @@ pub struct SimpleName {
     /// Geographic place associated with the name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Place>,
+    /// Short form of the name (e.g., abbreviation or shortened form).
+    #[serde(rename = "short-name", skip_serializing_if = "Option::is_none")]
+    pub short_name: Option<String>,
 }
 
 /// A structured name is a name broken down into its constituent parts.
@@ -97,6 +100,7 @@ impl Contributor {
         match self {
             Contributor::SimpleName(n) => vec![FlatName {
                 literal: Some(n.name.to_string()),
+                short_name: n.short_name.clone(),
                 ..Default::default()
             }],
             Contributor::StructuredName(n) => vec![FlatName {
@@ -146,6 +150,7 @@ pub struct FlatName {
     pub dropping_particle: Option<String>,
     pub non_dropping_particle: Option<String>,
     pub literal: Option<String>,
+    pub short_name: Option<String>,
 }
 
 impl FlatName {

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -1566,6 +1566,7 @@ fn from_event_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> I
             contributor: Contributor::SimpleName(SimpleName {
                 name: organizer_name.into(),
                 location: None,
+                short_name: None,
             }),
             gender: None,
         });
@@ -1720,6 +1721,7 @@ impl From<Vec<csl_legacy::csl_json::Name>> for Contributor {
                     Contributor::SimpleName(SimpleName {
                         name: literal.into(),
                         location: None,
+                        short_name: None,
                     })
                 } else {
                     let given_str = n.given.as_deref().map(str::trim).unwrap_or("");
@@ -1731,6 +1733,7 @@ impl From<Vec<csl_legacy::csl_json::Name>> for Contributor {
                         Contributor::SimpleName(SimpleName {
                             name: n.family.unwrap_or_default().into(),
                             location: None,
+                            short_name: None,
                         })
                     } else {
                         Contributor::StructuredName(StructuredName {

--- a/crates/citum-schema-style/src/options/integral_names.rs
+++ b/crates/citum-schema-style/src/options/integral_names.rs
@@ -24,6 +24,9 @@ pub struct IntegralNameConfig {
     /// The contributor form to use after the first mention in scope.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subsequent_form: Option<IntegralNameForm>,
+    /// How to display the short name on the first mention.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short_name_display: Option<ShortNameDisplay>,
 }
 
 impl IntegralNameConfig {
@@ -41,6 +44,9 @@ impl IntegralNameConfig {
         if other.subsequent_form.is_some() {
             self.subsequent_form = other.subsequent_form;
         }
+        if other.short_name_display.is_some() {
+            self.short_name_display = other.short_name_display;
+        }
     }
 
     /// Resolve the effective integral-name config with defaults filled in.
@@ -50,6 +56,7 @@ impl IntegralNameConfig {
             scope: self.scope.unwrap_or_default(),
             contexts: self.contexts.unwrap_or_default(),
             subsequent_form: self.subsequent_form.unwrap_or_default(),
+            short_name_display: self.short_name_display.unwrap_or_default(),
         }
     }
 }
@@ -102,6 +109,18 @@ pub enum IntegralNameForm {
     FamilyOnly,
 }
 
+/// How to display a contributor's short name on the first integral mention.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum ShortNameDisplay {
+    /// Render "Full Name (Short)" on first mention (default).
+    #[default]
+    FullThenParenthetical,
+    /// Render "Short [Full Name]" on first mention.
+    ShortThenBracketed,
+}
+
 /// Integral-name configuration with defaults resolved.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct ResolvedIntegralNameConfig {
@@ -113,4 +132,6 @@ pub struct ResolvedIntegralNameConfig {
     pub contexts: IntegralNameContexts,
     /// The contributor form used after the first mention.
     pub subsequent_form: IntegralNameForm,
+    /// How to display short names on first mention.
+    pub short_name_display: ShortNameDisplay,
 }

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -29,7 +29,7 @@ pub use contributors::{
 pub use dates::{DateConfig, DateConfigEntry};
 pub use integral_names::{
     IntegralNameConfig, IntegralNameContexts, IntegralNameForm, IntegralNameRule,
-    IntegralNameScope, ResolvedIntegralNameConfig,
+    IntegralNameScope, ResolvedIntegralNameConfig, ShortNameDisplay,
 };
 pub use localization::{Localize, MonthFormat, Scope};
 pub use locators::{

--- a/docs/schemas/abbrev-map.json
+++ b/docs/schemas/abbrev-map.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AbbreviationMap",
-  "description": "Document-level map from full rendered strings to their abbreviations.\n\nKeys are the full rendered string (exact, case-sensitive). Values are the\nreplacement abbreviation. Applied after value extraction, before output.\nAccepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.",
+  "description": "Document-level map from full rendered strings to their abbreviations.\n\nKeys are the full rendered string (exact, case-sensitive). Values are the\nreplacement abbreviation. Applied after value extraction, before output.\n\nAccepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.",
   "type": "object",
   "additionalProperties": {
     "type": "string"

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -585,6 +585,13 @@
               "type": "null"
             }
           ]
+        },
+        "short-name": {
+          "description": "Short form of the name (e.g., abbreviation or shortened form).",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2832,7 +2832,7 @@
       ]
     },
     "AbbreviationMap": {
-      "description": "Document-level map from full rendered strings to their abbreviations.\n\nKeys are the full rendered string (exact, case-sensitive). Values are the\nreplacement abbreviation. Applied after value extraction, before output.\nAccepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.",
+      "description": "Document-level map from full rendered strings to their abbreviations.\n\nKeys are the full rendered string (exact, case-sensitive). Values are the\nreplacement abbreviation. Applied after value extraction, before output.\n\nAccepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.",
       "type": "object",
       "additionalProperties": {
         "type": "string"

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2747,6 +2747,17 @@
               "type": "null"
             }
           ]
+        },
+        "short-name-display": {
+          "description": "How to display a short name on the first integral mention.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShortNameDisplay"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -2808,6 +2819,21 @@
           "description": "Use family name only for subsequent mentions.",
           "type": "string",
           "const": "family-only"
+        }
+      ]
+    },
+    "ShortNameDisplay": {
+      "description": "How to display a contributor's short name on the first integral mention.",
+      "oneOf": [
+        {
+          "description": "Render \"Full Name (Short)\" on first mention (default).",
+          "type": "string",
+          "const": "full-then-parenthetical"
+        },
+        {
+          "description": "Render \"Short [Full Name]\" on first mention.",
+          "type": "string",
+          "const": "short-then-bracketed"
         }
       ]
     },

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -4270,6 +4270,17 @@
               "type": "null"
             }
           ]
+        },
+        "short-name-display": {
+          "description": "How to display the short name on the first mention.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShortNameDisplay"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -4331,6 +4342,21 @@
           "description": "Use family name only for subsequent mentions.",
           "type": "string",
           "const": "family-only"
+        }
+      ]
+    },
+    "ShortNameDisplay": {
+      "description": "How to display a contributor's short name on the first integral mention.",
+      "oneOf": [
+        {
+          "description": "Render \"Full Name (Short)\" on first mention (default).",
+          "type": "string",
+          "const": "full-then-parenthetical"
+        },
+        {
+          "description": "Render \"Short [Full Name]\" on first mention.",
+          "type": "string",
+          "const": "short-then-bracketed"
         }
       ]
     },

--- a/docs/specs/SHORT_NAME.md
+++ b/docs/specs/SHORT_NAME.md
@@ -1,0 +1,70 @@
+# Contributor Short-Name
+
+Status: Active
+Bean: csl26-ycyp
+
+## Overview
+
+`short-name` is an optional field on organizational/literal contributor names that provides
+an acronym or abbreviated form (e.g. `WHO` for `World Health Organization`). When set and
+integral citation name-memory is active, the engine renders the full name with the short name
+on the first mention, then the short name alone on subsequent mentions.
+
+## Input Schema
+
+```yaml
+author:
+  name: World Health Organization
+  short-name: WHO
+```
+
+`short-name` is valid only on `SimpleName` (organizational, institutional, or literal names).
+It has no meaning on `StructuredName` — personal name abbreviation is handled by name
+formatting options (`initialize-with`, `ContributorForm::Short`).
+
+## Rendering Semantics
+
+Short-name rendering is gated on the integral citation name-memory system
+(`integral-names` style option, `rule: full-then-short`). When the rule is active:
+
+| Integral name state | `short-name` present | Output |
+|---------------------|----------------------|--------|
+| `First`             | yes                  | see `short-name-display` option |
+| `First`             | no                   | full name (unchanged) |
+| `Subsequent`        | yes                  | short name only |
+| `Subsequent`        | no                   | existing `subsequent-form` logic |
+| non-integral        | any                  | full name always |
+
+In bibliography output, the full name is always used regardless of `short-name`.
+
+## Style Option: `short-name-display`
+
+Placed under `integral-names` in the style options block:
+
+```yaml
+options:
+  integral-names:
+    rule: full-then-short
+    short-name-display: full-then-parenthetical  # default
+```
+
+| Value | Output for first integral mention |
+|-------|-----------------------------------|
+| `full-then-parenthetical` (default) | `World Health Organization (WHO)` |
+| `short-then-bracketed` | `WHO [World Health Organization]` |
+
+## Relationship to Abbreviation Map
+
+The abbreviation-map is a document-level post-render substitution applied to rendered
+strings. `short-name` is an input-level field on the reference data. They are independent:
+
+- Use `short-name` when the abbreviation is a stable property of the organization and
+  should trigger first-mention parenthetical rendering.
+- Use `abbreviation-map` for ad-hoc post-render substitutions (e.g. journal title
+  abbreviations).
+
+## Non-Goals
+
+- `short-name` on `StructuredName` (personal names): not in scope; use `initialize-with`.
+- Per-language `short-name` variants: not in scope; `short-name` is a plain string.
+- Fuzzy or partial matching: the engine uses the short name verbatim.


### PR DESCRIPTION
## Summary

- **fix(data): restore flat abbreviation-map schema** — Keep `abbreviation-map` as a flat string-to-string map, with reserved-looking keys such as `title`, `description`, `metadata`, and `entries` treated as ordinary abbreviation keys.
- **docs(specs): contributor short-name** — Add `docs/specs/SHORT_NAME.md` covering `SimpleName.short-name`, rendering behavior, `short-name-display`, and the explicit non-goal for per-language short-name variants.
- **feat(data): short-name on simplename** — Add plain `short_name: Option<String>` support for organizational/simple names and propagate it into `FlatName`.
- **feat(engine): short-name first-mention** — Wire `ShortNameDisplay` through integral-name rendering, including document frontmatter overrides and guards so short names only apply in integral citation mode.
- **fix(engine): suppress-author name memory** — Treat `suppress_author: true` citations as seen by integral name memory, so later explicit integral citations use the correct subsequent form.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run` — 1269/1269 passed
- [x] `cargo run --bin citum --all-features -- schema --out-dir "$tmp_dir"` + `diff -ru --exclude='*.html' "$tmp_dir" docs/schemas`
