### PR TITLE
ci(tooling): update commit linting and hygiene

### DIFF
--- a/.alint.yml
+++ b/.alint.yml
@@ -107,7 +107,7 @@ rules:
 
   - id: conventional-commits
     kind: git_commit_message
-    pattern: '^(Revert ".+"|fixup! .+|squash! .+|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?(!)?: [a-z].+)'
+    pattern: '^(Revert ".+"|fixup! .+|squash! .+|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((engine|schema|migrate|store|cli|server|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security)\))?(!)?: [a-z].+)'
     subject_max_length: 50
     requires_body: true
     since: ${ALINT_BASE_SHA:-origin/main}

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -10,7 +10,7 @@ if [[ "$header" =~ ^(Merge|Revert|fixup!|squash!) ]]; then
   exit 0
 fi
 
-header_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9._/-]+\))?(!)?: [a-z].+$'
+header_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((engine|schema|migrate|store|cli|server|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security)\))?(!)?: [a-z].+$'
 
 if [[ ! "$header" =~ $header_regex ]]; then
   cat <<'EOF' >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run repository hygiene (alint)
-        uses: asamarts/alint@v0.9.21
+        uses: asamarts/alint@v0.9.22
 
   hygiene-beans:
     name: Hygiene Checks — Beans

--- a/examples/document-citations.json
+++ b/examples/document-citations.json
@@ -6,9 +6,9 @@
   },
   {
     "id": "cite-2",
-    "items": [{ 
-      "id": "watson1953", 
-      "locator": { "label": "page", "value": "737" } 
+    "items": [{
+      "id": "watson1953",
+      "locator": { "label": "page", "value": "737" }
     }],
     "mode": "integral"
   }


### PR DESCRIPTION
Consolidates commit linting fixes, upgrades alint to v0.9.22, and fixes a trailing whitespace issue.