### PR TITLE
docs(spec): forward-compat contract + tests

### DIFF
--- a/.beans/csl26-0ksu--capture-unknown-fields-wrapper-for-style-schemas.md
+++ b/.beans/csl26-0ksu--capture-unknown-fields-wrapper-for-style-schemas.md
@@ -1,0 +1,23 @@
+---
+# csl26-0ksu
+title: Capture-unknown-fields wrapper for style schemas
+status: todo
+type: feature
+priority: high
+created_at: 2026-05-15T14:48:07Z
+updated_at: 2026-05-15T14:48:07Z
+blocked_by:
+    - csl26-2a0b
+---
+
+Promote forward-compat rows 05 and 06 from observed=HardFail to observed=SoftDegrade.
+
+Replace deny_unknown_fields on style option / template / top-level Style structs with a wrapper that captures unknown keys into an opaque map and emits a CompatibilityWarning per skipped key. Strict mode (e.g. 'citum check --strict') preserves the current typo-catching behavior.
+
+Files affected (audit, not exhaustive):
+- crates/citum-schema-style/src/options/*.rs
+- crates/citum-schema-style/src/lib.rs (Style)
+- crates/citum-schema-style/src/template.rs
+
+Spec: docs/specs/FORWARD_COMPATIBILITY.md
+Snapshot rows: 05-new-option-key, 06-new-top-level-section

--- a/.beans/csl26-1bdr--inputreference-unknown-class-escape-hatch-design-i.md
+++ b/.beans/csl26-1bdr--inputreference-unknown-class-escape-hatch-design-i.md
@@ -1,0 +1,23 @@
+---
+# csl26-1bdr
+title: InputReference unknown-class escape hatch (design + impl)
+status: todo
+type: feature
+priority: normal
+created_at: 2026-05-15T14:48:20Z
+updated_at: 2026-05-15T14:48:20Z
+blocked_by:
+    - csl26-2a0b
+---
+
+Decide and implement how forward-compat row 02b is handled.
+
+InputReference uses #[serde(tag = "class")] at crates/citum-schema-data/src/reference/mod.rs:74. An unknown class has no struct shape to deserialize into, so the standard tolerant-enum trick does not apply. Two viable shapes (see docs/specs/FORWARD_COMPATIBILITY.md § InputReference discriminator):
+
+- **Option A — Catch-all variant**: add InputReference::Unknown(UnknownReference { class: String, fields: serde_json::Map<String, Value> }). Brand-new classes round-trip data, emit a SoftDegrade warning, and degrade to a generic rendering path. Recommended in the spec.
+- **Option B — Major-bump category**: declare new top-level classes as a second opt-out category alongside template grammar.
+
+Pick one, implement, and update the snapshot. Until decided, row 02b correctly observes HardFail.
+
+Spec: docs/specs/FORWARD_COMPATIBILITY.md
+Snapshot row: 02b-discriminator-class

--- a/.beans/csl26-1bdr--inputreference-unknown-class-escape-hatch-design-i.md
+++ b/.beans/csl26-1bdr--inputreference-unknown-class-escape-hatch-design-i.md
@@ -3,9 +3,9 @@
 title: InputReference unknown-class escape hatch (design + impl)
 status: todo
 type: feature
-priority: normal
+priority: deferred
 created_at: 2026-05-15T14:48:20Z
-updated_at: 2026-05-15T14:48:20Z
+updated_at: 2026-05-15T15:20:21Z
 blocked_by:
     - csl26-2a0b
 ---
@@ -21,3 +21,11 @@ Pick one, implement, and update the snapshot. Until decided, row 02b correctly o
 
 Spec: docs/specs/FORWARD_COMPATIBILITY.md
 Snapshot row: 02b-discriminator-class
+
+
+
+## Update 2026-05-15 — deferred per pre-1.0 stance
+
+Per author feedback on PR #715: pre-public-release, there is no concern for backward-compatibility breakage, so the headline forward-compat rule does not need to hold for top-level reference classes yet. The spec now declares new `InputReference` classes as a major-bump opt-out (alongside template grammar). No design work needed today.
+
+Revisit post-1.0 only if real-world evidence shows brand-new classes are common enough to justify the catch-all variant engineering. Snapshot row 02b stays `declared=HardFail observed=HardFail` (correct opt-out) until then.

--- a/.beans/csl26-2a0b--forward-compatibility-spec-scenario-test-corpus.md
+++ b/.beans/csl26-2a0b--forward-compatibility-spec-scenario-test-corpus.md
@@ -1,0 +1,23 @@
+---
+# csl26-2a0b
+title: Forward-compatibility spec + scenario test corpus
+status: in-progress
+type: task
+priority: high
+created_at: 2026-05-15T14:41:05Z
+updated_at: 2026-05-15T14:49:05Z
+---
+
+Audit + tests + spec to confirm and document the forward-compat strategy: older engines should soft-degrade with warnings on new attribute enums / option fields / locale terms, hard-fail only on template grammar changes and unknown InputReference class.
+
+Plan: /Users/brucedarcus/.claude/plans/can-you-confirm-ideally-wiggly-elephant.md
+Related: csl26-piea, csl26-fuw7
+
+## Tasks
+- [x] Write docs/specs/FORWARD_COMPATIBILITY.md (Draft)
+- [x] Add forward_compatibility integration test in crates/citum-engine/tests/
+- [x] Check in initial forward_compat_gaps.snap snapshot
+- [x] Cross-link from DESIGN_PRINCIPLES, SCHEMA_VERSIONING, ENUM_VOCABULARY_POLICY, EXTENSIBILITY_STRATEGY
+- [x] Update bean csl26-fuw7 body to point at the new spec
+- [x] File follow-up beans for each declared!=observed gap row (csl26-ld6e, csl26-0ksu, csl26-acfh, csl26-o1z5, csl26-1bdr)
+- [ ] PR with snapshot summary table

--- a/.beans/csl26-acfh--surface-silent-unknown-field-acceptance-on-referen.md
+++ b/.beans/csl26-acfh--surface-silent-unknown-field-acceptance-on-referen.md
@@ -1,0 +1,22 @@
+---
+# csl26-acfh
+title: Surface silent unknown-field acceptance on reference data
+status: todo
+type: feature
+priority: normal
+created_at: 2026-05-15T14:48:11Z
+updated_at: 2026-05-15T14:48:11Z
+blocked_by:
+    - csl26-2a0b
+---
+
+Promote forward-compat row 07 from observed=Pass (silent) to observed=SoftDegrade (warning).
+
+Reference data structs cannot use deny_unknown_fields due to serde's #[serde(tag)] limitation on InputReference, so unknown keys are silently discarded today. Add a Deserializer hook that records skipped keys during reference parsing and emits a CompatibilityWarning per dropped key. The render still proceeds without the extra data.
+
+Files affected:
+- crates/citum-schema-data/src/reference/types/{structural,specialized,legal,common}.rs
+- crates/citum-schema-data/src/reference/mod.rs (InputReference)
+
+Spec: docs/specs/FORWARD_COMPATIBILITY.md
+Snapshot row: 07-new-reference-field

--- a/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
+++ b/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
@@ -8,7 +8,7 @@ tags:
     - policy
     - dx
 created_at: 2026-02-24T17:28:17Z
-updated_at: 2026-04-25T20:20:08Z
+updated_at: 2026-05-15T14:47:53Z
 parent: csl26-li63
 blocked_by:
     - csl26-yipx
@@ -35,3 +35,26 @@ Operational release wiring now lives in `.github/workflows/release-plz.yml` and
 
 This bean remains the place for the deeper compatibility contract and durable
 schema-history docs. Blocked by version validation task `csl26-yipx`.
+
+
+
+## Update 2026-05-15 — forward-compat contract relocated
+
+The forward-compatibility portion of this bean's scope is now owned by
+**docs/specs/FORWARD_COMPATIBILITY.md** (Draft, shipped in bean csl26-2a0b).
+That spec defines the older-engine-reads-newer-data contract, the outcome
+classes, the scope table, and the producer/consumer obligations. It also
+records the InputReference discriminator escape-hatch design question.
+
+What still belongs in this bean (the deeper compatibility contract for the
+first public release):
+
+- the deprecation policy (2-version window) for renaming/removing fields
+- the citum-migrate command specification for upgrading older data
+- docs/architecture/SCHEMA_CHANGELOG.md (machine-readable schema-field
+  history)
+- promoting docs/specs/FORWARD_COMPATIBILITY.md to Active once the engine
+  matches its declared outcomes
+
+Snapshot of current gaps:
+crates/citum-engine/tests/snapshots/forward_compat_gaps.snap

--- a/.beans/csl26-ld6e--tolerant-deserializer-for-attribute-enums-forward.md
+++ b/.beans/csl26-ld6e--tolerant-deserializer-for-attribute-enums-forward.md
@@ -1,0 +1,25 @@
+---
+# csl26-ld6e
+title: Tolerant deserializer for attribute enums (forward compat)
+status: todo
+type: feature
+priority: high
+created_at: 2026-05-15T14:48:03Z
+updated_at: 2026-05-15T14:48:03Z
+blocked_by:
+    - csl26-2a0b
+---
+
+Promote forward-compat rows 01, 02, 03, 04 in crates/citum-engine/tests/snapshots/forward_compat_gaps.snap from observed=HardFail to observed=SoftDegrade.
+
+Wrap derived Deserialize on attribute enums with an Unknown(String) fallback that emits a CompatibilityWarning. Scope:
+- ContributorRole (crates/citum-schema-style/src/template.rs)
+- MonographType, SerialComponentType, CollectionType, MonographComponentType (crates/citum-schema-data/src/reference/types/structural.rs)
+- TermForm, GrammaticalGender (crates/citum-schema-style/src/locale/types.rs)
+- DateForm (crates/citum-schema-style/src/template.rs)
+- NumberingType (crates/citum-schema-data/src/reference/)
+
+Excludes InputReference::class — that one is a dispatch discriminator (see follow-up bean for that design).
+
+Spec: docs/specs/FORWARD_COMPATIBILITY.md
+Snapshot rows: 01-attr-enum-template, 02-attr-enum-data, 03-locale-form, 04-date-form

--- a/.beans/csl26-o1z5--tolerant-locale-term-key-lookup.md
+++ b/.beans/csl26-o1z5--tolerant-locale-term-key-lookup.md
@@ -1,0 +1,21 @@
+---
+# csl26-o1z5
+title: Tolerant locale term-key lookup
+status: todo
+type: feature
+priority: normal
+created_at: 2026-05-15T14:48:14Z
+updated_at: 2026-05-15T14:48:14Z
+blocked_by:
+    - csl26-2a0b
+---
+
+Promote forward-compat row 08 from observed=HardFail to observed=SoftDegrade.
+
+A locale term key not in the engine's current vocabulary should not abort parse. The lookup path should fall back to rendering the key itself (or empty + warning) and surface a CompatibilityWarning so users know the term wasn't honored.
+
+Files affected:
+- crates/citum-schema-style/src/locale/mod.rs (Locale::from_yaml_str and the term resolution path)
+
+Spec: docs/specs/FORWARD_COMPATIBILITY.md
+Snapshot row: 08-new-locale-term-key

--- a/crates/citum-engine/tests/forward_compatibility.rs
+++ b/crates/citum-engine/tests/forward_compatibility.rs
@@ -1,0 +1,376 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Forward-compatibility scenario corpus.
+//!
+//! Each scenario constructs a "future" style, reference, or locale that uses a
+//! feature beyond what the current engine knows, then runs it through the same
+//! load path real users hit. The actual outcome is captured as `Pass`,
+//! `SoftDegrade`, or `HardFail` and compared against a checked-in snapshot.
+//!
+//! See `docs/specs/FORWARD_COMPATIBILITY.md` for the contract these cases
+//! anchor and `crates/citum-engine/tests/snapshots/forward_compat_gaps.snap`
+//! for the truth-of-record outcomes.
+//!
+//! The test passes when the observed outcomes match the snapshot exactly. It
+//! fails only on drift in either direction — a gap that silently closed (good
+//! — update the snapshot) or a new gap that appeared (review and decide). The
+//! snapshot rows whose `declared != observed` are the punch list for the
+//! follow-up implementation beans listed in the spec.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+use citum_schema::Style;
+use citum_schema::locale::Locale;
+use citum_schema_data::InputBibliography;
+
+/// What a loader did when it met a "future" feature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Outcome {
+    /// Parse succeeded and the feature was silently accepted (no warning channel today).
+    Pass,
+    /// Parse succeeded with a documented warning emitted through the
+    /// compatibility channel. Not reachable today — there is no warning
+    /// channel yet, so this class only appears in the `declared` column.
+    SoftDegrade,
+    /// Parse returned an error and no artifact was produced.
+    HardFail,
+}
+
+impl Outcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Outcome::Pass => "Pass",
+            Outcome::SoftDegrade => "SoftDegrade",
+            Outcome::HardFail => "HardFail",
+        }
+    }
+}
+
+/// One row of the scope table in `docs/specs/FORWARD_COMPATIBILITY.md`.
+struct Scenario {
+    id: &'static str,
+    category: &'static str,
+    declared: Outcome,
+    observed: fn() -> Outcome,
+    follow_up: &'static str,
+}
+
+fn parse_style(yaml: &str) -> Outcome {
+    match Style::from_yaml_str(yaml) {
+        Ok(_) => Outcome::Pass,
+        Err(_) => Outcome::HardFail,
+    }
+}
+
+fn parse_bibliography(yaml: &str) -> Outcome {
+    match serde_yaml::from_str::<InputBibliography>(yaml) {
+        Ok(_) => Outcome::Pass,
+        Err(_) => Outcome::HardFail,
+    }
+}
+
+fn parse_locale(yaml: &str) -> Outcome {
+    match Locale::from_yaml_str(yaml) {
+        Ok(_) => Outcome::Pass,
+        Err(_) => Outcome::HardFail,
+    }
+}
+
+// ------------ Case fixtures ------------
+//
+// Every fixture is a self-contained YAML literal. The only "future" feature
+// in each fixture is the one named by the case; everything else is valid
+// against the current schema.
+
+const STYLE_HEAD: &str =
+    "version: \"0.51\"\ninfo:\n  id: forward-compat-fixture\n  title: Forward compat fixture\n";
+
+fn case_attribute_enum_in_template() -> Outcome {
+    // ContributorRole gains hypothetical `producer`.
+    let yaml = format!(
+        "{STYLE_HEAD}bibliography:\n  template:\n    - contributor: producer\n      form: long\n"
+    );
+    parse_style(&yaml)
+}
+
+fn case_attribute_enum_in_data() -> Outcome {
+    // MonographType gains hypothetical `dance-performance`.
+    let yaml = "references:\n  - id: perf2026\n    class: monograph\n    type: dance-performance\n    title: A Performance\n";
+    parse_bibliography(yaml)
+}
+
+fn case_discriminator_class() -> Outcome {
+    // InputReference gains a brand-new `class`.
+    let yaml =
+        "references:\n  - id: perf2026\n    class: dance-performance\n    title: A Performance\n";
+    parse_bibliography(yaml)
+}
+
+fn case_locale_form() -> Outcome {
+    // TermForm gains hypothetical `vocative`.
+    let yaml = "language: en\nterms:\n  page:\n    vocative: pp\n";
+    parse_locale(yaml)
+}
+
+fn case_date_form() -> Outcome {
+    // DateForm gains hypothetical `month-and-day`.
+    let yaml = format!(
+        "{STYLE_HEAD}bibliography:\n  template:\n    - date: issued\n      form: month-and-day\n"
+    );
+    parse_style(&yaml)
+}
+
+fn case_new_style_option_key() -> Outcome {
+    // A new key inside a `deny_unknown_fields` option struct.
+    let yaml = format!(
+        "{STYLE_HEAD}options:\n  contributors:\n    future-key: true\nbibliography:\n  template:\n    - contributor: author\n      form: long\n"
+    );
+    parse_style(&yaml)
+}
+
+fn case_new_top_level_section() -> Outcome {
+    // A brand-new top-level block on Style.
+    let yaml = format!(
+        "{STYLE_HEAD}experiments:\n  inline-author-disambiguation: true\nbibliography:\n  template:\n    - contributor: author\n      form: long\n"
+    );
+    parse_style(&yaml)
+}
+
+fn case_new_reference_field() -> Outcome {
+    // A field that does not exist on Monograph. Everything else is a valid
+    // Monograph so the only "future" element is `audience: scholarly`.
+    let yaml = "references:\n  - id: smith2026\n    class: monograph\n    type: book\n    audience: scholarly\n";
+    parse_bibliography(yaml)
+}
+
+fn case_new_locale_term_key() -> Outcome {
+    // A locale term that's not in the current vocabulary.
+    let yaml = "language: en\nterms:\n  preprint-server:\n    long: preprint server\n";
+    parse_locale(yaml)
+}
+
+fn case_custom_namespace() -> Outcome {
+    // Namespaced custom metadata — must Pass per the spec.
+    let yaml = format!(
+        "{STYLE_HEAD}bibliography:\n  template:\n    - contributor: author\n      form: long\n      custom:\n        publisher-x.house-format: true\n"
+    );
+    parse_style(&yaml)
+}
+
+fn case_version_only_signal() -> Outcome {
+    // version: "99.0" on an otherwise-valid style. citum check is the warning
+    // channel for this case; parsing alone succeeds (Pass). The SoftDegrade
+    // is delivered later by `citum check`, not by the loader.
+    let yaml = "version: \"99.0\"\ninfo:\n  id: forward-compat-fixture\n  title: Forward compat fixture\nbibliography:\n  template:\n    - contributor: author\n      form: long\n";
+    parse_style(yaml)
+}
+
+fn case_template_grammar() -> Outcome {
+    // Hypothetical new TemplateComponent variant (must HardFail; opt-out).
+    let yaml = format!(
+        "{STYLE_HEAD}bibliography:\n  template:\n    - loop: authors\n      body:\n        - contributor: author\n          form: long\n"
+    );
+    parse_style(&yaml)
+}
+
+fn case_template_required_field() -> Outcome {
+    // We can't actually introduce a hypothetical required field from a test;
+    // we exercise the dual — a known-good template with a typoed required
+    // shape — to confirm the loader still rejects malformed templates
+    // (the contract for this row is HardFail).
+    let yaml = format!(
+        "{STYLE_HEAD}bibliography:\n  template:\n    - variable:\n        not-a-real-shape: true\n"
+    );
+    parse_style(&yaml)
+}
+
+// ------------ Snapshot harness ------------
+
+fn scenarios() -> Vec<Scenario> {
+    vec![
+        Scenario {
+            id: "01-attr-enum-template",
+            category: "Attribute enum in template",
+            declared: Outcome::SoftDegrade,
+            observed: case_attribute_enum_in_template,
+            follow_up: "csl26-ld6e tolerant-enum-deserializer",
+        },
+        Scenario {
+            id: "02-attr-enum-data",
+            category: "Attribute enum in reference data",
+            declared: Outcome::SoftDegrade,
+            observed: case_attribute_enum_in_data,
+            follow_up: "csl26-ld6e tolerant-enum-deserializer",
+        },
+        Scenario {
+            id: "02b-discriminator-class",
+            category: "Unknown InputReference class",
+            declared: Outcome::HardFail,
+            observed: case_discriminator_class,
+            follow_up: "csl26-1bdr inputreference-discriminator-design",
+        },
+        Scenario {
+            id: "03-locale-form",
+            category: "Locale TermForm value",
+            declared: Outcome::SoftDegrade,
+            observed: case_locale_form,
+            follow_up: "csl26-ld6e tolerant-enum-deserializer",
+        },
+        Scenario {
+            id: "04-date-form",
+            category: "DateForm value in template",
+            declared: Outcome::SoftDegrade,
+            observed: case_date_form,
+            follow_up: "csl26-ld6e tolerant-enum-deserializer",
+        },
+        Scenario {
+            id: "05-new-option-key",
+            category: "New key inside style option struct",
+            declared: Outcome::SoftDegrade,
+            observed: case_new_style_option_key,
+            follow_up: "csl26-0ksu capture-unknown-fields-wrapper",
+        },
+        Scenario {
+            id: "06-new-top-level-section",
+            category: "New top-level Style section",
+            declared: Outcome::SoftDegrade,
+            observed: case_new_top_level_section,
+            follow_up: "csl26-0ksu capture-unknown-fields-wrapper",
+        },
+        Scenario {
+            id: "07-new-reference-field",
+            category: "New optional field on reference type",
+            declared: Outcome::SoftDegrade,
+            observed: case_new_reference_field,
+            follow_up: "csl26-acfh reference-data-silent-acceptance",
+        },
+        Scenario {
+            id: "08-new-locale-term-key",
+            category: "New locale term key",
+            declared: Outcome::SoftDegrade,
+            observed: case_new_locale_term_key,
+            follow_up: "csl26-o1z5 tolerant-locale-lookup",
+        },
+        Scenario {
+            id: "09-custom-namespace",
+            category: "Namespaced custom.* metadata (control)",
+            declared: Outcome::Pass,
+            observed: case_custom_namespace,
+            follow_up: "—",
+        },
+        Scenario {
+            id: "10-version-only-signal",
+            category: "Style version bumped without other changes (control)",
+            declared: Outcome::Pass,
+            observed: case_version_only_signal,
+            follow_up: "—",
+        },
+        Scenario {
+            id: "11-template-grammar",
+            category: "New TemplateComponent variant (opt-out)",
+            declared: Outcome::HardFail,
+            observed: case_template_grammar,
+            follow_up: "—",
+        },
+        Scenario {
+            id: "12-template-required-field",
+            category: "Malformed template shape (opt-out)",
+            declared: Outcome::HardFail,
+            observed: case_template_required_field,
+            follow_up: "—",
+        },
+    ]
+}
+
+fn render_report(rows: &[(String, Outcome, Outcome, String, String)]) -> String {
+    let mut out = String::new();
+    out.push_str("# Forward-compat gap snapshot\n");
+    out.push_str("#\n");
+    out.push_str("# Source: crates/citum-engine/tests/forward_compatibility.rs\n");
+    out.push_str("# Spec:   docs/specs/FORWARD_COMPATIBILITY.md\n");
+    out.push_str("#\n");
+    out.push_str("# Format: id | category | declared | observed | gap? | follow-up\n");
+    out.push_str(
+        "# A row is a GAP when declared != observed. GAP rows roll up to follow-up beans.\n",
+    );
+    out.push_str("#\n\n");
+    for (id, declared, observed, category, follow_up) in rows {
+        let gap = if declared == observed { "ok " } else { "GAP" };
+        writeln!(
+            out,
+            "{:<28} | {:<55} | declared={:<11} observed={:<11} {} | {}",
+            id,
+            category,
+            declared.as_str(),
+            observed.as_str(),
+            gap,
+            follow_up,
+        )
+        .unwrap();
+    }
+    out
+}
+
+#[test]
+fn forward_compat_snapshot_matches() {
+    let rows: Vec<_> = scenarios()
+        .into_iter()
+        .map(|s| {
+            let observed = (s.observed)();
+            (
+                s.id.to_string(),
+                s.declared,
+                observed,
+                s.category.to_string(),
+                s.follow_up.to_string(),
+            )
+        })
+        .collect();
+
+    let actual = render_report(&rows);
+
+    let snapshot_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("snapshots")
+        .join("forward_compat_gaps.snap");
+
+    // Update-on-demand path: setting INSTA_UPDATE=1 (or the project's
+    // standard env var) rewrites the snapshot. Otherwise we assert equality.
+    if std::env::var_os("UPDATE_FORWARD_COMPAT_SNAPSHOT").is_some() {
+        fs::create_dir_all(snapshot_path.parent().unwrap()).unwrap();
+        fs::write(&snapshot_path, &actual).expect("write snapshot");
+        return;
+    }
+
+    let expected = fs::read_to_string(&snapshot_path).unwrap_or_else(|_| {
+        panic!(
+            "snapshot missing at {}. Run with UPDATE_FORWARD_COMPAT_SNAPSHOT=1 to create it.",
+            snapshot_path.display()
+        )
+    });
+
+    if expected != actual {
+        // Show full diff via assert_eq! so reviewers can see exactly which
+        // (declared, observed) tuple changed.
+        assert_eq!(
+            expected.trim_end(),
+            actual.trim_end(),
+            "Forward-compat snapshot drift detected. \
+             If this drift is intentional (an engine change closed or moved a gap), \
+             rerun with UPDATE_FORWARD_COMPAT_SNAPSHOT=1 and review the diff.",
+        );
+    }
+}

--- a/crates/citum-engine/tests/forward_compatibility.rs
+++ b/crates/citum-engine/tests/forward_compatibility.rs
@@ -33,7 +33,6 @@ use std::fs;
 use std::path::Path;
 
 use citum_schema::Style;
-use citum_schema::locale::Locale;
 use citum_schema_data::InputBibliography;
 
 /// What a loader did when it met a "future" feature.
@@ -82,13 +81,6 @@ fn parse_bibliography(yaml: &str) -> Outcome {
     }
 }
 
-fn parse_locale(yaml: &str) -> Outcome {
-    match Locale::from_yaml_str(yaml) {
-        Ok(_) => Outcome::Pass,
-        Err(_) => Outcome::HardFail,
-    }
-}
-
 // ------------ Case fixtures ------------
 //
 // Every fixture is a self-contained YAML literal. The only "future" feature
@@ -120,9 +112,13 @@ fn case_discriminator_class() -> Outcome {
 }
 
 fn case_locale_form() -> Outcome {
-    // TermForm gains hypothetical `vocative`.
-    let yaml = "language: en\nterms:\n  page:\n    vocative: pp\n";
-    parse_locale(yaml)
+    // TermForm gains hypothetical `vocative`. Drives the typed enum via
+    // TemplateTerm.form: Option<TermForm> on the style side — the raw
+    // locale YAML uses string-keyed maps and does not exercise TermForm
+    // deserialization.
+    let yaml =
+        format!("{STYLE_HEAD}bibliography:\n  template:\n    - term: page\n      form: vocative\n");
+    parse_style(&yaml)
 }
 
 fn case_date_form() -> Outcome {
@@ -157,9 +153,14 @@ fn case_new_reference_field() -> Outcome {
 }
 
 fn case_new_locale_term_key() -> Outcome {
-    // A locale term that's not in the current vocabulary.
-    let yaml = "language: en\nterms:\n  preprint-server:\n    long: preprint server\n";
-    parse_locale(yaml)
+    // A style references a GeneralTerm key that the engine vocabulary
+    // does not enumerate. Drives the typed enum via TemplateTerm.term:
+    // GeneralTerm — the style-side lookup path the spec actually targets,
+    // not the raw locale map.
+    let yaml = format!(
+        "{STYLE_HEAD}bibliography:\n  template:\n    - term: preprint-server\n      form: long\n"
+    );
+    parse_style(&yaml)
 }
 
 fn case_custom_namespace() -> Outcome {
@@ -347,8 +348,8 @@ fn forward_compat_snapshot_matches() {
         .join("snapshots")
         .join("forward_compat_gaps.snap");
 
-    // Update-on-demand path: setting INSTA_UPDATE=1 (or the project's
-    // standard env var) rewrites the snapshot. Otherwise we assert equality.
+    // Update-on-demand path: setting UPDATE_FORWARD_COMPAT_SNAPSHOT=1
+    // rewrites the snapshot. Otherwise we assert equality.
     if std::env::var_os("UPDATE_FORWARD_COMPAT_SNAPSHOT").is_some() {
         fs::create_dir_all(snapshot_path.parent().unwrap()).unwrap();
         fs::write(&snapshot_path, &actual).expect("write snapshot");

--- a/crates/citum-engine/tests/snapshots/forward_compat_gaps.snap
+++ b/crates/citum-engine/tests/snapshots/forward_compat_gaps.snap
@@ -1,0 +1,22 @@
+# Forward-compat gap snapshot
+#
+# Source: crates/citum-engine/tests/forward_compatibility.rs
+# Spec:   docs/specs/FORWARD_COMPATIBILITY.md
+#
+# Format: id | category | declared | observed | gap? | follow-up
+# A row is a GAP when declared != observed. GAP rows roll up to follow-up beans.
+#
+
+01-attr-enum-template        | Attribute enum in template                              | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
+02-attr-enum-data            | Attribute enum in reference data                        | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
+02b-discriminator-class      | Unknown InputReference class                            | declared=HardFail    observed=HardFail    ok  | csl26-1bdr inputreference-discriminator-design
+03-locale-form               | Locale TermForm value                                   | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
+04-date-form                 | DateForm value in template                              | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
+05-new-option-key            | New key inside style option struct                      | declared=SoftDegrade observed=HardFail    GAP | csl26-0ksu capture-unknown-fields-wrapper
+06-new-top-level-section     | New top-level Style section                             | declared=SoftDegrade observed=HardFail    GAP | csl26-0ksu capture-unknown-fields-wrapper
+07-new-reference-field       | New optional field on reference type                    | declared=SoftDegrade observed=Pass        GAP | csl26-acfh reference-data-silent-acceptance
+08-new-locale-term-key       | New locale term key                                     | declared=SoftDegrade observed=HardFail    GAP | csl26-o1z5 tolerant-locale-lookup
+09-custom-namespace          | Namespaced custom.* metadata (control)                  | declared=Pass        observed=Pass        ok  | —
+10-version-only-signal       | Style version bumped without other changes (control)    | declared=Pass        observed=Pass        ok  | —
+11-template-grammar          | New TemplateComponent variant (opt-out)                 | declared=HardFail    observed=HardFail    ok  | —
+12-template-required-field   | Malformed template shape (opt-out)                      | declared=HardFail    observed=HardFail    ok  | —

--- a/docs/architecture/DESIGN_PRINCIPLES.md
+++ b/docs/architecture/DESIGN_PRINCIPLES.md
@@ -25,6 +25,8 @@ See CLAUDE.md for active behavioral policy. This document captures the full desi
 3. **Explicit Extension Points**: Styles use explicit `custom: Option<HashMap<String, serde_json::Value>>` fields for user-defined metadata and extensions. See [EXTENSIBILITY_STRATEGY_2026-03-14.md](./EXTENSIBILITY_STRATEGY_2026-03-14.md) for the portability-first extension ladder and limits on executable extensions.
 4. **Extension via Defaults**: All new features must be `Option<T>` with `#[serde(default)]`.
 
+The end-to-end contract — what an older engine must do when it meets a newer feature, and which categories may or may not hard-fail — is defined in [`../specs/FORWARD_COMPATIBILITY.md`](../specs/FORWARD_COMPATIBILITY.md).
+
 **Graceful Degradation for Multilingual Data**
 - **Fallback Chain**: Multilingual fields must always implement a `Display` fallback (e.g., `Complex.original` -> `Simple string`).
 - **Mode Fallback**: If a style requests a `translated` view but the data only provides `original`, the processor must return `original` rather than failing.

--- a/docs/architecture/EXTENSIBILITY_STRATEGY_2026-03-14.md
+++ b/docs/architecture/EXTENSIBILITY_STRATEGY_2026-03-14.md
@@ -200,6 +200,11 @@ Interpretation:
 When a new need appears, use this sequence:
 
 1. If several important styles need it, promote it into the core schema.
+   How that promoted feature behaves in older engines is governed by
+   [`../specs/FORWARD_COMPATIBILITY.md`](../specs/FORWARD_COMPATIBILITY.md):
+   most additive promotions ship as a `minor` bump and older engines
+   degrade gracefully; only template-grammar changes and brand-new
+   `InputReference` classes are allowed to hard-fail.
 2. If it is still exploratory or domain-specific, model it as namespaced
    data-only metadata first.
 3. If data-only metadata is insufficient, ask whether a tiny declarative rule

--- a/docs/policies/ENUM_VOCABULARY_POLICY.md
+++ b/docs/policies/ENUM_VOCABULARY_POLICY.md
@@ -98,7 +98,7 @@ Enums marked `#[non_exhaustive]` signal that new variants may be added. For
 deserialization of unknown values:
 
 1. **Strict mode** (current, default): reject unknown variants with a descriptive error naming the field and listing valid values. This is what derived `serde::Deserialize` provides.
-2. **Proposed tolerant mode** (not yet implemented): in future, applications MAY implement a custom deserializer that maps unknown variants to a catch-all (e.g., `Other(String)`) and emits a warning, for forward compatibility when reading data from a newer schema version. This requires an explicit implementation — no built-in `Other(String)` variant exists today.
+2. **Tolerant mode** (specified, not yet implemented): the forward-compatibility contract in [`../specs/FORWARD_COMPATIBILITY.md`](../specs/FORWARD_COMPATIBILITY.md) calls for a custom deserializer that maps unknown variants of *attribute* enums (not the `InputReference::class` discriminator) to a catch-all and emits a warning. That spec is the source of truth for which enums must be tolerant and which categories may hard-fail; the current observed behavior per category is recorded in `crates/citum-engine/tests/snapshots/forward_compat_gaps.snap`.
 
 ## Controlled Vocabulary Strings
 

--- a/docs/reference/SCHEMA_VERSIONING.md
+++ b/docs/reference/SCHEMA_VERSIONING.md
@@ -58,6 +58,13 @@ Do not use `scripts/bump.sh` for code versions or `v*` tags.
 
 ## Bump Contract
 
+What `minor` *promises* end-to-end — which categories of additive change
+older engines must keep loading, and which warning behavior they should
+emit — is defined in
+[`../specs/FORWARD_COMPATIBILITY.md`](../specs/FORWARD_COMPATIBILITY.md).
+A schema change that violates that contract is not a valid `minor` bump
+regardless of what the conventional-commit prefix says.
+
 Release impact comes from conventional commits:
 
 | Commit signal | Release impact |

--- a/docs/specs/FORWARD_COMPATIBILITY.md
+++ b/docs/specs/FORWARD_COMPATIBILITY.md
@@ -97,31 +97,36 @@ follow-up implementation beans; this spec only fixes the contract.
 ## Scope table
 
 Each row is anchored to one or more cases in
-`crates/citum-engine/tests/forward_compatibility.rs`. The "Currently
-observed" column reflects what the engine does **today**, not what the
-contract demands.
+`crates/citum-engine/tests/forward_compatibility.rs`. The columns below
+measure **loader behavior** and align row-for-row with
+`crates/citum-engine/tests/snapshots/forward_compat_gaps.snap` — the
+truth-of-record. End-to-end user-visible outcomes may add a warning via
+`citum check` on top of a loader `Pass`; see row 10.
 
-| # | Category | Example | Desired | Currently observed | Follow-up |
+| # | Category | Example | Declared | Observed | Follow-up |
 |---|---|---|---|---|---|
-| 1 | Attribute enum in template | `contributor: producer` (new `ContributorRole`) | `SoftDegrade` | `HardFail` (raw serde error) | Tolerant enum deserializer |
-| 2 | Attribute enum in data | `class: monograph, type: dance-performance` | `SoftDegrade` | `HardFail` | Tolerant enum deserializer |
-| 2b | Top-level `class` value | `class: dance-performance` | `HardFail` (opt-out, major bump) **or** `SoftDegrade` via catch-all variant | `HardFail` | InputReference discriminator design |
-| 3 | Locale form | `form: vocative` | `SoftDegrade` (fall back to `Long`) | `HardFail` | Tolerant enum deserializer |
-| 4 | Date form | `form: month-and-day` (new `DateForm`) | `SoftDegrade` | `HardFail` | Tolerant enum deserializer |
-| 5 | New style option key | `options.contributors.future-key: true` | `SoftDegrade` (ignore field, warn) | `HardFail` (`deny_unknown_fields`) | Capture-unknown-fields wrapper |
-| 6 | New top-level style section | `experiments: { ... }` | `SoftDegrade` | `HardFail` (`deny_unknown_fields` on `Style`) | Capture-unknown-fields wrapper |
-| 7 | New reference field | `audience: scholarly` on `Monograph` | `Pass` (silent ignore) **or** `SoftDegrade` (warn) | `Pass` (silent — known gap) | Reference-data silent-acceptance fix |
-| 8 | New locale term key | term key not in current vocabulary | `SoftDegrade` at lookup, render the key as fallback | depends on lookup path — to be measured | Tolerant locale lookup |
-| 9 | Custom namespace | `custom.publisher-x.foo: true` | `Pass` | `Pass` (control case) | none |
-| 10 | Version-only signal | `version: "99.0"` on otherwise valid style | `SoftDegrade` via `citum check` | `SoftDegrade` (control case) | none |
-| 11 | Template grammar add | hypothetical `loop:` variant | `HardFail` (opt-out, major) | `HardFail` (control case) | none |
-| 12 | Required template field add | new required field on `TemplateVariable` | `HardFail` (opt-out, major) | `HardFail` (control case) | none |
+| 1 | Attribute enum in template | `contributor: producer` (new `ContributorRole`) | `SoftDegrade` | `HardFail` | `csl26-ld6e` tolerant enum deserializer |
+| 2 | Attribute enum in data | `class: monograph, type: dance-performance` | `SoftDegrade` | `HardFail` | `csl26-ld6e` |
+| 2b | Top-level `class` value | `class: dance-performance` | `HardFail` | `HardFail` | `csl26-1bdr` (post-1.0 design) |
+| 3 | TermForm in template | `term: page, form: vocative` (new `TermForm`) | `SoftDegrade` | `HardFail` | `csl26-ld6e` |
+| 4 | DateForm in template | `date: issued, form: month-and-day` (new `DateForm`) | `SoftDegrade` | `HardFail` | `csl26-ld6e` |
+| 5 | New style option key | `options.contributors.future-key: true` | `SoftDegrade` | `HardFail` | `csl26-0ksu` capture-unknown-fields wrapper |
+| 6 | New top-level style section | `experiments: { ... }` | `SoftDegrade` | `HardFail` | `csl26-0ksu` |
+| 7 | New reference field | `audience: scholarly` on `Monograph` | `SoftDegrade` | `Pass` (silent — known gap) | `csl26-acfh` reference-data silent-acceptance |
+| 8 | New `GeneralTerm` in template | `term: preprint-server` (unknown `GeneralTerm`) | `SoftDegrade` | `HardFail` | `csl26-o1z5` tolerant locale lookup |
+| 9 | Custom namespace | `custom.publisher-x.foo: true` | `Pass` | `Pass` | — |
+| 10 | Style version bumped | `version: "99.0"` on otherwise valid style | `Pass` | `Pass` | — (see footnote) |
+| 11 | Template grammar add | hypothetical `loop:` variant | `HardFail` | `HardFail` | — (opt-out by design) |
+| 12 | Malformed template shape | typoed `variable` body | `HardFail` | `HardFail` | — (opt-out by design) |
 
-The truth-of-record for these outcomes is
-`crates/citum-engine/tests/snapshots/forward_compat_gaps.snap`. The
-test corpus runs every row, captures `(declared, observed)` pairs, and
-asserts the snapshot. Documentation rows that drift from the snapshot
-must be updated in the same PR that changes engine behavior.
+**Row 10 footnote.** The loader correctly accepts a style whose `version`
+declares a newer minor than the engine knows. The user-visible
+`SoftDegrade` is delivered by `citum check`
+(`crates/citum-cli/src/commands.rs:1716`), which compares
+`style.version` against `SchemaVersion::default()` and emits a clean
+warning when minor > supported minor. The snapshot measures the loader
+only; end-to-end the composition is `loader Pass + citum check warning =
+SoftDegrade`.
 
 ## InputReference discriminator
 
@@ -132,24 +137,23 @@ determines which concrete struct (`Monograph`, `SerialComponent`,
 `class` value has no struct shape to fall into; serde cannot type the
 payload at all.
 
-Two viable shapes (one must be picked before this spec graduates to
-`Active`):
+**Pre-1.0 stance (current).** New top-level reference classes are the
+second opt-out category alongside template grammar. Producers must
+introduce them as a `major` bump; older engines hard-fail. Pre-1.0 the
+engine has no published older-engine population to honor, so the cost
+of a hard-break on `class` rebases the design question to "do we ever
+need anything else?" — and the answer today is no.
 
-**Option A — Catch-all variant.** Add
+**Post-1.0 future work.** Once crates have a real wild-engine
+population, we may want to keep the headline rule ("new features warn,
+not break") even for new classes. The shape that delivers that is a
+catch-all variant —
 `InputReference::Unknown(UnknownReference { class: String, fields:
-serde_json::Map<String, Value> })`. A brand-new class round-trips its
-data, emits a `SoftDegrade` warning, and degrades to a generic
-rendering path (likely "render title + author + year, drop everything
-else"). Preserves the spec's headline rule that new features warn
-rather than break.
-
-**Option B — Major-bump category.** Declare new top-level classes as a
-second opt-out category alongside template grammar. Producers must bump
-major and accept that older engines hard-fail. Simpler to implement;
-worse user experience.
-
-This spec recommends Option A and tracks the design in a follow-up
-bean. Until then row 2b stays `HardFail` in the snapshot.
+serde_json::Map<String, Value> })` — which round-trips the data, emits
+a `SoftDegrade` warning, and degrades to a generic rendering path. We
+defer this design until there is real-world evidence that brand-new
+classes are common enough to warrant the engineering cost. Tracked in
+bean `csl26-1bdr`.
 
 ## Producer obligations
 
@@ -263,10 +267,10 @@ otherwise unchanged.
   title: ...
 ```
 
-Today: parse fails. Under Option A (recommended): the reference lands
-in `InputReference::Unknown { class: "dance-performance", fields: ... }`
-and degrades to a generic render. Under Option B: hard fail; the
-producer must bump major and accept the break.
+Today: parse fails. Pre-1.0 stance: the producer must introduce
+`dance-performance` as a `major` bump; older engines may hard-fail.
+Post-1.0 we may revisit this with a catch-all variant — see
+[§ InputReference discriminator](#inputreference-discriminator).
 
 ## Non-goals
 

--- a/docs/specs/FORWARD_COMPATIBILITY.md
+++ b/docs/specs/FORWARD_COMPATIBILITY.md
@@ -1,0 +1,278 @@
+# Forward-Compatibility Specification
+
+**Status:** Draft
+**Version:** 0.1
+**Date:** 2026-05-15
+**Related:** bean `csl26-2a0b`, bean `csl26-fuw7`, `docs/architecture/DESIGN_PRINCIPLES.md`, `docs/reference/SCHEMA_VERSIONING.md`, `docs/policies/ENUM_VOCABULARY_POLICY.md`, `docs/architecture/EXTENSIBILITY_STRATEGY_2026-03-14.md`
+
+## Purpose
+
+Define the contract that an older Citum engine must honor when it parses a
+newer style, reference, or locale that uses features it does not yet
+understand. The goal is to make most non-template feature additions safe to
+ship as a `minor` schema bump: producers can ship styles or data using new
+options, attribute enum values, or locale terms without breaking older
+engines. Older engines surface a single, consistent warning channel instead
+of raw serde errors.
+
+Template grammar changes and brand-new top-level reference classes are
+explicitly out of scope: those remain `major`-level changes that older
+engines may reject.
+
+## Scope
+
+**In scope** (must soft-degrade with a warning):
+
+- Additive variants on attribute enums referenced inside templates or
+  inside already-dispatched reference structs:
+  `ContributorRole`, `MonographType`, `SerialComponentType`,
+  `CollectionType`, `MonographComponentType`, `TermForm`, `DateForm`,
+  `NumberingType`, `GrammaticalGender`.
+- New optional fields on style option structs (anywhere
+  `deny_unknown_fields` is currently applied in
+  `crates/citum-schema-style/`).
+- New optional fields on reference data types
+  (`crates/citum-schema-data/src/reference/types/`).
+- New optional top-level sections in a `Style` document.
+- New locale term keys that a style references but the engine's vocabulary
+  does not yet enumerate.
+- New `custom.<namespace>.*` keys (the existing inert-metadata escape
+  hatch from [`EXTENSIBILITY_STRATEGY_2026-03-14.md`](../architecture/EXTENSIBILITY_STRATEGY_2026-03-14.md)).
+
+**Out of scope** (older engines may hard-fail; producers must bump major):
+
+- Changes to template grammar — new required variants of
+  `TemplateComponent`, new required fields on an existing template
+  component, changed semantics of an existing variant.
+- Unknown values of the top-level `InputReference::class` discriminator.
+  See [§ InputReference discriminator](#inputreference-discriminator).
+- Renames or removals of any field, variant, or term key. See
+  [`ENUM_VOCABULARY_POLICY.md` §Backward Compatibility](../policies/ENUM_VOCABULARY_POLICY.md).
+
+This spec governs **forward** compatibility (old engine reads new data).
+**Backward** compatibility (new engine reads old data) is delivered by
+`#[serde(default)]` + `Option<T>` on every additive field; that part of
+the contract is already enforced by code review and is not restated here.
+
+## Outcome classes
+
+Every loadable artifact (style, reference, locale) lands in exactly one
+outcome class when an older engine reads it:
+
+| Class | Meaning |
+|---|---|
+| `Pass` | The new feature was silently accepted and the artifact behaves as if the feature were absent. No warning emitted. Used for inert metadata (`custom.*`) and for new fields the older engine simply ignores. |
+| `SoftDegrade` | The new feature was acknowledged but its effect was dropped or replaced with a documented fallback. A warning is emitted through the documented channel. The render still produces output. |
+| `HardFail` | Parse or load returned an error. No render. Used only for grammar-level changes the engine cannot reason about and for unknown top-level reference classes. |
+
+`SoftDegrade` is the dominant target. `Pass` is acceptable only when the
+older engine genuinely cannot infer the producer's intent (e.g.
+namespaced custom keys). `HardFail` is reserved for the out-of-scope
+categories above.
+
+## Warning channel
+
+All `SoftDegrade` outcomes surface through one channel so consumers — the
+CLI, `citum-hub`, the language bindings — present them uniformly. The
+channel already exists in skeletal form at
+`crates/citum-cli/src/commands.rs:1716`, where `citum check` compares
+`style.version` against `SchemaVersion::default()` and emits a warning
+when minor > supported minor.
+
+The channel must be extended so that:
+
+1. Engine load APIs (`Style::from_yaml_str`, `Locale::from_yaml_str`,
+   reference loaders in `citum-io`) accumulate `CompatibilityWarning`
+   records during parse instead of returning early with a serde error
+   for additive cases.
+2. `citum check` reports each warning with the field path, the offending
+   value, the fallback applied, and the schema version that introduced
+   the feature (when known).
+3. Bindings expose the warning list on the returned style / reference /
+   locale handle.
+
+The shape of `CompatibilityWarning` is intentionally left to the
+follow-up implementation beans; this spec only fixes the contract.
+
+## Scope table
+
+Each row is anchored to one or more cases in
+`crates/citum-engine/tests/forward_compatibility.rs`. The "Currently
+observed" column reflects what the engine does **today**, not what the
+contract demands.
+
+| # | Category | Example | Desired | Currently observed | Follow-up |
+|---|---|---|---|---|---|
+| 1 | Attribute enum in template | `contributor: producer` (new `ContributorRole`) | `SoftDegrade` | `HardFail` (raw serde error) | Tolerant enum deserializer |
+| 2 | Attribute enum in data | `class: monograph, type: dance-performance` | `SoftDegrade` | `HardFail` | Tolerant enum deserializer |
+| 2b | Top-level `class` value | `class: dance-performance` | `HardFail` (opt-out, major bump) **or** `SoftDegrade` via catch-all variant | `HardFail` | InputReference discriminator design |
+| 3 | Locale form | `form: vocative` | `SoftDegrade` (fall back to `Long`) | `HardFail` | Tolerant enum deserializer |
+| 4 | Date form | `form: month-and-day` (new `DateForm`) | `SoftDegrade` | `HardFail` | Tolerant enum deserializer |
+| 5 | New style option key | `options.contributors.future-key: true` | `SoftDegrade` (ignore field, warn) | `HardFail` (`deny_unknown_fields`) | Capture-unknown-fields wrapper |
+| 6 | New top-level style section | `experiments: { ... }` | `SoftDegrade` | `HardFail` (`deny_unknown_fields` on `Style`) | Capture-unknown-fields wrapper |
+| 7 | New reference field | `audience: scholarly` on `Monograph` | `Pass` (silent ignore) **or** `SoftDegrade` (warn) | `Pass` (silent — known gap) | Reference-data silent-acceptance fix |
+| 8 | New locale term key | term key not in current vocabulary | `SoftDegrade` at lookup, render the key as fallback | depends on lookup path — to be measured | Tolerant locale lookup |
+| 9 | Custom namespace | `custom.publisher-x.foo: true` | `Pass` | `Pass` (control case) | none |
+| 10 | Version-only signal | `version: "99.0"` on otherwise valid style | `SoftDegrade` via `citum check` | `SoftDegrade` (control case) | none |
+| 11 | Template grammar add | hypothetical `loop:` variant | `HardFail` (opt-out, major) | `HardFail` (control case) | none |
+| 12 | Required template field add | new required field on `TemplateVariable` | `HardFail` (opt-out, major) | `HardFail` (control case) | none |
+
+The truth-of-record for these outcomes is
+`crates/citum-engine/tests/snapshots/forward_compat_gaps.snap`. The
+test corpus runs every row, captures `(declared, observed)` pairs, and
+asserts the snapshot. Documentation rows that drift from the snapshot
+must be updated in the same PR that changes engine behavior.
+
+## InputReference discriminator
+
+`InputReference` uses `#[serde(tag = "class")]` at
+`crates/citum-schema-data/src/reference/mod.rs:74`. The tag value
+determines which concrete struct (`Monograph`, `SerialComponent`,
+`LegalCase`, …) the rest of the payload deserializes into. An unknown
+`class` value has no struct shape to fall into; serde cannot type the
+payload at all.
+
+Two viable shapes (one must be picked before this spec graduates to
+`Active`):
+
+**Option A — Catch-all variant.** Add
+`InputReference::Unknown(UnknownReference { class: String, fields:
+serde_json::Map<String, Value> })`. A brand-new class round-trips its
+data, emits a `SoftDegrade` warning, and degrades to a generic
+rendering path (likely "render title + author + year, drop everything
+else"). Preserves the spec's headline rule that new features warn
+rather than break.
+
+**Option B — Major-bump category.** Declare new top-level classes as a
+second opt-out category alongside template grammar. Producers must bump
+major and accept that older engines hard-fail. Simpler to implement;
+worse user experience.
+
+This spec recommends Option A and tracks the design in a follow-up
+bean. Until then row 2b stays `HardFail` in the snapshot.
+
+## Producer obligations
+
+Style and tool authors:
+
+1. **Bump `style.version`** whenever the style uses a feature added in a
+   newer schema minor. The `version` is the primary signal `citum check`
+   uses to emit the global "this style targets a newer engine" warning.
+2. **Prefer `custom.<namespace>.*`** for genuinely experimental or
+   institution-specific metadata. The portable schema is not the right
+   incubation surface; see
+   [`EXTENSIBILITY_STRATEGY_2026-03-14.md`](../architecture/EXTENSIBILITY_STRATEGY_2026-03-14.md).
+3. **Treat template grammar changes as `major`-only.** New
+   `TemplateComponent` variants and changes to existing-component
+   shapes are not forward-compatible and must not ship as `minor`.
+
+## Consumer obligations
+
+Engine and binding authors:
+
+1. **Never lose data silently.** Any feature that the older engine
+   cannot honor must produce a `CompatibilityWarning`. Silent `Pass` is
+   reserved for namespaced `custom.*` and for cases where the data
+   simply has no effect on rendering.
+2. **Render must still produce output** in every `SoftDegrade` case.
+   The user should see what the older engine *could* do, plus a
+   warning.
+3. **Surface warnings through the documented channel** rather than
+   inventing a new one.
+
+## Promotion path
+
+Borrowed from
+[`EXTENSIBILITY_STRATEGY_2026-03-14.md`](../architecture/EXTENSIBILITY_STRATEGY_2026-03-14.md)
+and applied here:
+
+1. New behavior starts as `custom.<namespace>.*` if it is exploratory or
+   non-portable.
+2. If multiple styles need it, it graduates to a typed schema addition
+   (`Option<T>` field, new attribute-enum variant).
+3. The schema addition lands as a `minor` bump. Older engines see it as
+   `SoftDegrade`. Newer engines honor it.
+4. Stable promoted features may eventually become required — that
+   transition is the `major` bump and is governed by the deprecation
+   policy in [`ENUM_VOCABULARY_POLICY.md`](../policies/ENUM_VOCABULARY_POLICY.md).
+
+## Acceptance checks
+
+This spec is `Active` once the snapshot in
+`crates/citum-engine/tests/snapshots/forward_compat_gaps.snap` shows
+`declared == observed` for every row whose desired class is `Pass` or
+`SoftDegrade`. Rows whose desired class is `HardFail` are already
+aligned and do not block promotion.
+
+## Worked scenarios
+
+### A new contributor role ships in v0.52
+
+A style needs `producer` for a film-credits template:
+
+```yaml
+bibliography:
+  template:
+    - contributor: producer
+      form: long
+```
+
+Engine 0.51 reads this style. Today: serde rejects the unknown variant
+with a parse error, the user sees "unknown variant `producer`". Under
+this spec: `SoftDegrade` — the template component renders as empty
+(no producer field on the data), and a `CompatibilityWarning` is
+emitted naming `contributor: producer` and the schema version that
+introduced it.
+
+### A style adds a new top-level section
+
+A style ships an `experiments` block:
+
+```yaml
+version: "0.52"
+experiments:
+  inline-author-disambiguation: true
+bibliography: ...
+```
+
+Engine 0.51 reads this. Today: `Style` has `deny_unknown_fields`,
+parse fails. Under this spec: `SoftDegrade` — the `experiments` block
+is captured into an opaque `unknown_sections` map (or similar), a
+warning is emitted, and the rest of the style renders normally.
+
+### A reference adds a new field
+
+```yaml
+- id: smith2026
+  class: monograph
+  title: ...
+  audience: scholarly
+```
+
+Engine 0.51 reads this. Today: `Monograph` cannot deny unknown fields
+(serde+`#[serde(tag)]` limitation), so the `audience` key is silently
+discarded with no warning. Under this spec: the silent drop becomes a
+`SoftDegrade` warning so users know data was not honored. Rendering is
+otherwise unchanged.
+
+### A reference uses a brand-new class
+
+```yaml
+- id: perf2026
+  class: dance-performance
+  title: ...
+```
+
+Today: parse fails. Under Option A (recommended): the reference lands
+in `InputReference::Unknown { class: "dance-performance", fields: ... }`
+and degrades to a generic render. Under Option B: hard fail; the
+producer must bump major and accept the break.
+
+## Non-goals
+
+- Defining the exact Rust shape of `CompatibilityWarning`.
+- Specifying which `style.version` value corresponds to which feature
+  (the schema changelog already records that).
+- Adding any tolerant deserializer code in this spec's PR.
+- Changing the contract for `backward` compatibility (new engine, old
+  data) — that path is already handled by `Option<T>` + `#[serde(default)]`.

--- a/docs/specs/FORWARD_COMPATIBILITY.md
+++ b/docs/specs/FORWARD_COMPATIBILITY.md
@@ -7,17 +7,24 @@
 
 ## Purpose
 
-Define the contract that an older Citum engine must honor when it parses a
-newer style, reference, or locale that uses features it does not yet
-understand. The goal is to make most non-template feature additions safe to
-ship as a `minor` schema bump: producers can ship styles or data using new
-options, attribute enum values, or locale terms without breaking older
-engines. Older engines surface a single, consistent warning channel instead
-of raw serde errors.
+Define the contract that an older build of the Citum engine must honor
+when it parses a newer style, reference, or locale that uses features it
+does not yet understand. The goal is to make most non-template feature
+additions safe to ship as a `minor` schema bump: producers can ship
+styles or data using new options, attribute enum values, or locale
+terms without breaking older engine builds. Older builds surface a
+single, consistent warning channel instead of raw serde errors.
 
 Template grammar changes and brand-new top-level reference classes are
 explicitly out of scope: those remain `major`-level changes that older
-engines may reject.
+builds may reject.
+
+**Scope of "implementations."** This spec governs the behavior of the
+Citum engine as we ship it. It does not assume — or attempt to bind —
+any alternative implementation of the Citum data model. There is one
+engine; this spec is our internal forward-compatibility contract with
+ourselves and with style/data producers whose output may reach older
+engine builds (e.g. via an editor that ships a pinned engine version).
 
 ## Scope
 
@@ -92,7 +99,7 @@ The channel must be extended so that:
    locale handle.
 
 The shape of `CompatibilityWarning` is intentionally left to the
-follow-up implementation beans; this spec only fixes the contract.
+follow-up engine beans; this spec only fixes the contract.
 
 ## Scope table
 
@@ -107,7 +114,7 @@ truth-of-record. End-to-end user-visible outcomes may add a warning via
 |---|---|---|---|---|---|
 | 1 | Attribute enum in template | `contributor: producer` (new `ContributorRole`) | `SoftDegrade` | `HardFail` | `csl26-ld6e` tolerant enum deserializer |
 | 2 | Attribute enum in data | `class: monograph, type: dance-performance` | `SoftDegrade` | `HardFail` | `csl26-ld6e` |
-| 2b | Top-level `class` value | `class: dance-performance` | `HardFail` | `HardFail` | `csl26-1bdr` (post-1.0 design) |
+| 2b | Top-level `class` value | `class: dance-performance` | `HardFail` | `HardFail` | `csl26-1bdr` (deferred future option) |
 | 3 | TermForm in template | `term: page, form: vocative` (new `TermForm`) | `SoftDegrade` | `HardFail` | `csl26-ld6e` |
 | 4 | DateForm in template | `date: issued, form: month-and-day` (new `DateForm`) | `SoftDegrade` | `HardFail` | `csl26-ld6e` |
 | 5 | New style option key | `options.contributors.future-key: true` | `SoftDegrade` | `HardFail` | `csl26-0ksu` capture-unknown-fields wrapper |
@@ -137,23 +144,21 @@ determines which concrete struct (`Monograph`, `SerialComponent`,
 `class` value has no struct shape to fall into; serde cannot type the
 payload at all.
 
-**Pre-1.0 stance (current).** New top-level reference classes are the
-second opt-out category alongside template grammar. Producers must
-introduce them as a `major` bump; older engines hard-fail. Pre-1.0 the
-engine has no published older-engine population to honor, so the cost
-of a hard-break on `class` rebases the design question to "do we ever
-need anything else?" — and the answer today is no.
+**Current stance.** New top-level reference classes are the second
+opt-out category alongside template grammar. Style/data producers must
+introduce them as a `major` bump; older engine builds hard-fail. The
+soft-degrade rule does not apply at the `class` boundary.
 
-**Post-1.0 future work.** Once crates have a real wild-engine
-population, we may want to keep the headline rule ("new features warn,
-not break") even for new classes. The shape that delivers that is a
-catch-all variant —
+**Future option (deferred).** If downstream environments end up pinning
+older engine builds (e.g. an editor ships citum-engine 0.51 and users
+encounter styles authored against 0.52 in the wild) and brand-new
+classes become a common reason for hard-fails, we can add a catch-all
+variant —
 `InputReference::Unknown(UnknownReference { class: String, fields:
-serde_json::Map<String, Value> })` — which round-trips the data, emits
-a `SoftDegrade` warning, and degrades to a generic rendering path. We
-defer this design until there is real-world evidence that brand-new
-classes are common enough to warrant the engineering cost. Tracked in
-bean `csl26-1bdr`.
+serde_json::Map<String, Value> })` — that round-trips the data, emits a
+`SoftDegrade` warning, and degrades to a generic rendering path. This
+is an engine-side change, not an ecosystem-wide contract, and is
+deferred until the evidence justifies it. Tracked in bean `csl26-1bdr`.
 
 ## Producer obligations
 
@@ -267,10 +272,11 @@ otherwise unchanged.
   title: ...
 ```
 
-Today: parse fails. Pre-1.0 stance: the producer must introduce
-`dance-performance` as a `major` bump; older engines may hard-fail.
-Post-1.0 we may revisit this with a catch-all variant — see
-[§ InputReference discriminator](#inputreference-discriminator).
+Today: parse fails. The producer must introduce `dance-performance` as
+a `major` bump — new top-level classes are an explicit opt-out from the
+soft-degrade rule. See
+[§ InputReference discriminator](#inputreference-discriminator) for the
+deferred future option.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Confirms (with a measurement, not a claim) what an older Citum engine actually does today when it reads a newer style/reference/locale, lands the canonical forward-compatibility contract in `docs/specs/FORWARD_COMPATIBILITY.md`, and files five follow-up beans — one per snapshot gap.

No engine behavior changes here. The test passes against the snapshot of current state. Follow-up PRs close gaps by editing the snapshot, which is the handoff artifact.

## Why now

Crates are about to be published and will continue rapid iteration. The desired contract — "new features should warn rather than break; only template grammar changes may hard-fail" — was claimed across DESIGN_PRINCIPLES, SCHEMA_VERSIONING, ENUM_VOCABULARY_POLICY, and EXTENSIBILITY_STRATEGY, but the implementation contradicts it in several places. This PR makes the contract single-sourced, the behavior measurable, and the gaps trackable.

## Snapshot at a glance

`crates/citum-engine/tests/snapshots/forward_compat_gaps.snap` — 13 rows, 7 gaps, 6 controls aligned.

| Class of row | Count | Notes |
|---|---|---|
| `declared=SoftDegrade observed=HardFail` | 6 | Attribute enums (1, 2, 3, 4), new option key (5), new top-level section (6), new locale term key (8). Fix path: tolerant deserializer + capture-unknown-fields wrapper. |
| `declared=SoftDegrade observed=Pass` (silent drop) | 1 | New reference field (7). serde+`#[serde(tag)]` swallows unknown keys with no warning. |
| `declared=HardFail observed=HardFail` (correct opt-out) | 3 | Unknown `InputReference::class` (2b), new TemplateComponent variant (11), malformed template shape (12). |
| `declared=Pass observed=Pass` (correct control) | 2 | Namespaced `custom.*` (9), `version: "99.0"` on otherwise-valid style (10). |

## Type-system constraint worth flagging

`InputReference` uses `#[serde(tag = "class")]` at one place. The discriminator cannot soft-degrade by ordinary tolerant-enum tricks because there is no struct shape to deserialize into for an unknown class. The spec calls this out explicitly and presents two options (catch-all `Unknown` variant, recommended; or major-bump category). Tracked separately in **csl26-1bdr**.

Every other enum the prior reviews tightened (`MonographType`, `SerialComponentType`, `ContributorRole`, `TermForm`, …) is an *attribute* inside an already-dispatched struct and is **not** a dispatch constraint — those can carry an `Unknown(String)` fallback safely.

## Follow-up beans

| Bean | Snapshot rows owned | Description |
|---|---|---|
| `csl26-ld6e` | 01, 02, 03, 04 | Tolerant deserializer for attribute enums |
| `csl26-0ksu` | 05, 06 | Capture-unknown-fields wrapper for style schemas |
| `csl26-acfh` | 07 | Surface silent unknown-field acceptance on reference data |
| `csl26-o1z5` | 08 | Tolerant locale term-key lookup |
| `csl26-1bdr` | 02b | `InputReference` unknown-class escape hatch (design + impl) |

Each bean is `blocked_by: csl26-2a0b`. When an impl PR lands, it deletes the row from the snapshot — the diff is the proof.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run` — 1270 / 1270 pass
- [x] `cargo nextest run -p citum-engine --test forward_compatibility` — 1 / 1 pass
- [ ] Reviewer reads `docs/specs/FORWARD_COMPATIBILITY.md` and confirms the contract matches intent
- [ ] Reviewer scans the snapshot and confirms each `GAP` row has a sensible follow-up bean
- [ ] Reviewer confirms the four cross-link edits read cleanly in context

## Snapshot update workflow (for future PRs)

If an impl PR intentionally changes a row's `observed` outcome:

```bash
UPDATE_FORWARD_COMPAT_SNAPSHOT=1 cargo nextest run -p citum-engine --test forward_compatibility
git add crates/citum-engine/tests/snapshots/forward_compat_gaps.snap
```

Drift without explicit update fails CI.
