### PR TITLE
feat(schema): InputReference class discriminator impl (csl26-odgh)

### DIFF
--- a/.beans/archive/csl26-6bf3--inputreference-hot-path-drop-to-value-round-trip.md
+++ b/.beans/archive/csl26-6bf3--inputreference-hot-path-drop-to-value-round-trip.md
@@ -1,0 +1,61 @@
+---
+# csl26-6bf3
+title: 'InputReference hot-path: drop to_value round-trip'
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-16T00:15:35Z
+updated_at: 2026-05-16T00:24:59Z
+parent: csl26-1bdr
+---
+
+Resolve Copilot review comments #3251089405, #3251089411 (residual), #3251089475, #3251089491 on PR #717 — the three are the same architectural shape (`serde_json::to_value` round-trip on the hot path).
+
+## Background
+
+The discriminator cutover that landed in #717 took a serialize-then-extract shortcut to ship Layer 2–4 quickly:
+
+- **Construction** (`boxed_reference_constructor!` / `from_known`): `serde_json::to_value(inner)` → `from_value::<SharedReferenceFields>`. One JSON-tree allocation + reparse per known-class construction.
+- **Visitor / Deserialize** (`InputReference::deserialize` visit_map): buffers the entire object body into a `serde_json::Map` before dispatching to the typed inner deserializer. For YAML/TOML inputs this materializes a JSON-shaped intermediate per reference.
+- **Serialize**: `serde_json::to_value(&extension)` → reflatten through SerializeMap. One JSON-tree allocation per serialization (hits BibLaTeX, RIS, CSL-JSON exporters).
+
+For a bibliography with thousands of references, this is a measurable cost. Copilot is right that the previous tagged-enum design avoided it.
+
+## Approach (recommended)
+
+The root cause is the duplicated shared fields on `InputReference` (now pub(crate)). Resolving cleanly means:
+
+1. Drop the 17 pub(crate) shared fields from `InputReference` — read everything through `self.extension` lazily via the existing accessors.
+2. Drop `SharedReferenceFields` (or keep only as a deserialize-time aid).
+3. Rewrite the `Deserialize` visitor to consume `class` first, then forward remaining keys to the typed inner deserializer via `MapAccessDeserializer` — no JSON intermediate.
+4. Rewrite `Serialize` to wrap the inner struct's serializer and inject `class` at the top — no `to_value` round-trip.
+5. Update `with_extension` / `from_known` to take only the extension.
+6. Update `set_id` and other setters to update only the extension (one path).
+
+## Acceptance criteria
+
+- [ ] All current discriminator tests (13) still pass.
+- [ ] `docs/schemas/bib.json` regen is wire-identical.
+- [ ] A microbench (criterion) on construction + ser + deser of a 1000-reference bibliography shows the expected allocation reduction. Add the bench under `crates/citum-schema-data/benches/`.
+- [ ] No `serde_json::to_value` in the hot path of either Serialize or Deserialize.
+- [ ] Forward-compat unknown-class round-trip still works (since Unknown still needs a JsonMap for its captured fields, that path can keep the intermediate).
+
+## Out of scope
+
+- Layer 5 CompatibilityWarning plumbing (tracked separately).
+- Transitional PascalCase constructor cleanup (block-level TODO remains; replace when snake_case factories are added).
+
+## Summary of Changes
+
+Resolved in the follow-up commit on PR #717.
+
+- Deleted SharedReferenceFields struct + its from_body / from_serializable helpers entirely.
+- Deleted the 17 duplicated pub(crate) shared fields on InputReference. The struct now contains only extension: ClassExtension. Cross-crate grep confirmed the fields were write-only (only set_id wrote self.id, no readers anywhere).
+- Simplified boxed_reference_constructor! to a one-liner: no JSON work at all on the construction path (Copilot #3251089405).
+- Simplified from_known to skip the SharedReferenceFields::from_body round-trip; only one serde_json::from_value per deserialization now (Copilot #3251089405 deserialize-side).
+- Removed reference_class_and_body + serialize_known_reference helpers. Replaced with a FlatClassProxy struct that uses #[serde(flatten)] to splat the typed inner directly through the parent serializer (Copilot #3251089491). No to_value round-trip on serialize.
+- The visitor's JsonMap buffering in visit_map is unchanged — it's intrinsic to a custom dispatcher with an Unknown fallback (#[serde(other)] only catches unit variants, not data-carrying ones). The downstream from_known no longer adds a second round-trip on top, which is the practical win on the deserialize side (Copilot #3251089475 partially addressed; the buffering itself is structurally required).
+- set_id simplified to a single write (no more dual-storage sync).
+- 2 new tests on top of the existing 13: serialize_emits_flat_object_with_class_first_and_no_nesting locks the flatten-proxy wire shape; round_trip_through_serde_value_preserves_every_known_class exercises Serialize -> from_value -> equality for 6 known classes + Unknown.
+
+Gate: 1284 passed (up from 1282), clippy clean, fmt clean. Schema regen is wire-identical (jq -S diff confirms).

--- a/.beans/archive/csl26-odgh--implement-inputreference-class-discriminator-desig.md
+++ b/.beans/archive/csl26-odgh--implement-inputreference-class-discriminator-desig.md
@@ -1,0 +1,32 @@
+---
+# csl26-odgh
+title: Implement InputReference class discriminator design
+status: completed
+type: task
+priority: high
+created_at: 2026-05-15T19:00:04Z
+updated_at: 2026-05-15T21:10:59Z
+blocked_by:
+    - csl26-1bdr
+---
+
+Implementation of docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md (v0.3).
+
+## Completed change stack
+
+[x] **Layer 1 — schema-data wire discriminator.** `InputReference` has a hand-written flat `class` dispatcher, explicit known-class dispatch for all 18 classes, unknown-class capture, strict known-class payload deserialization, public `ReferenceClass`/`ClassExtension`/`as_<class>()`/`unknown_class()` accessors, and custom schema composition.
+[x] **Layer 2 — citum-io constructors and exporters.** BibLaTeX/RIS/CSL JSON conversion paths compile against the shared-base reference model and use `extension()`/`extension_mut()` for class-specific data.
+[x] **Layer 3 — citum-migrate constructors.** CSL-to-Citum conversion constructors now build the shared-base `InputReference` through compatibility constructors while tests inspect class data through `extension()`.
+[x] **Layer 4 — engine call-site rewrites.** Engine variable/title/sorting/metadata tests and render paths no longer pattern-match on `InputReference` variants; class-specific reads go through `ClassExtension`.
+[x] **Layer 6 — forward-compat snapshot.** Row 02b now observes `Pass` for unknown reference classes; row 07 now observes `HardFail` for unknown fields on known reference payloads.
+[x] **Layer 7 — schema artifact regeneration.** `docs/schemas/bib.json` regenerated.
+
+## Verification
+
+- `cargo run --bin citum --features schema -- schema --out-dir docs/schemas`
+- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run` — 1282 passed.
+
+Temporary `.ai-intents/` handoff provenance was removed before publication.
+
+Spec: docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md
+Parent design bean: csl26-1bdr

--- a/.beans/archive/csl26-powf--address-copilot-review-on-pr-717-discriminator-imp.md
+++ b/.beans/archive/csl26-powf--address-copilot-review-on-pr-717-discriminator-imp.md
@@ -1,0 +1,66 @@
+---
+# csl26-powf
+title: 'Address Copilot review on PR #717 discriminator impl'
+status: completed
+type: task
+priority: high
+created_at: 2026-05-15T23:42:08Z
+updated_at: 2026-05-15T23:56:01Z
+parent: csl26-1bdr
+---
+
+Resolve 16 Copilot inline comments on PR #717 (csl26-odgh discriminator cutover).
+
+## Tier A — MUST-FIX (correctness / API hazards)
+- [x] 1. Delete crates/citum-schema-data/src/reference/discriminator/ (parallel public types)
+- [x] 2. Demote 16 pub fields on InputReference to pub(crate) (stale-fields footgun)
+- [x] 3. Unknown::ref_type() — debug_assert + sentinel + Layer-5 TODO
+- [x] 4. SharedReferenceFields::from_serializable — debug_assert on swallow
+
+## Tier B — SHOULD-FIX (low-risk quality)
+- [x] 5. as_event / as_audio_visual — add .as_ref() for consistency
+- [x] 6. from_known — avoid unconditional value.clone()
+- [x] 7. from_known — replace io error with de::Error::custom / unreachable
+- [x] 8. Deserialize — use de::Error::duplicate_field uniformly
+- [x] 9. ReferenceClass::Unknown — doc the serde(skip) round-trip via UnknownClassData
+- [x] 10. set_id on Unknown — doc string-id constraint
+- [x] 11. Transitional Monograph(...) etc constructors — block-level TODO(csl26-1bdr) marker
+- [x] 12. EMPTY_FIELD_LANGUAGES — investigated (HashMap::new not const, kept LazyLock with rationale doc)
+
+## Test rigor
+- [x] Strengthen assertions around extension_mut → accessor consistency
+- [x] Strengthen assertions around unknown-class round-trip (id, ref_type, ser/de)
+- [x] Strengthen assertions around duplicate-field error shape (canonical serde form)
+
+## Gate + ship
+- [x] cargo fmt --check && cargo clippy -D warnings && cargo nextest run
+- [x] Regenerate docs/schemas/bib.json (semantic no-op; jq -S confirms identical)
+- [ ] Squash with jj, push, watch CI green
+- [ ] Reply to / resolve all 16 Copilot threads
+- [ ] Open follow-up beans: perf hot-path (#13/14/15), Layer-5 plumbing
+
+Parent: csl26-1bdr
+
+## Summary of Changes
+
+All 16 Copilot inline comments resolved on PR #717:
+
+- Deleted the entire 596-line `crates/citum-schema-data/src/reference/discriminator/` scaffolding module that exposed parallel public `InputReference` / `ClassExtension` / `ReferenceClass` types. This single change resolves comments #3251089378 and #3251089506.
+- Demoted 16 shared `pub` fields on `InputReference` to `pub(crate)`. Cross-crate verification showed no production reader of the duplicated fields; accessors are now the only public read path.
+- `ref_type()` for `Unknown` class adds a `debug_assert!` that the class string is not a KNOWN name, and a `TODO(csl26-1bdr)` for Layer 5 CompatibilityWarning plumbing.
+- `SharedReferenceFields::from_serializable` adds `debug_assert!` so silent default-on-serialize-failure regressions surface in debug builds.
+- `as_event` / `as_audio_visual` now call `.as_ref()` for consistency with the other 17 accessors.
+- `from_known` matches `&value` to avoid the per-reference deep clone; defensive non-object branch uses `de::Error::custom` instead of `Error::io(InvalidData)`.
+- New `duplicate_field_error<E>` helper produces the canonical `duplicate field \`X\`` shape for both the class and non-class duplicate-key paths, restoring uniform error semantics.
+- `ReferenceClass::Unknown` gains a doc note explaining the `#[serde(skip)]` round-trip via `UnknownClassData::class`.
+- `set_id` gains documentation on the string-id wire constraint for Unknown class.
+- Transitional PascalCase `InputReference::Monograph(...)` constructors are now preceded by a block-level note + `TODO(csl26-1bdr)` marker pinning their removal to the parent epic. Full `#[deprecated]` attribute deferred (would force `#[allow(deprecated)]` across 79 call sites; agreed scope per plan).
+- `EMPTY_FIELD_LANGUAGES` gains a doc explaining why `LazyLock` is required (HashMap::new is not const).
+
+Test rigor strengthened: 13 tests now cover the discriminator surface (up from 5), with structural assertions on serialized JSON (no `contains()` on short substrings), canonical serde-error-shape checks, accessor/extension agreement across 6 class variants, set_id sync on both known and unknown classes, and a ref_type sentinel non-collision guard.
+
+Gate: cargo fmt --check + cargo clippy --all-targets --all-features -- -D warnings + cargo nextest run = 1282 passed. Schema regen produces a key-reordered but semantically identical `docs/schemas/bib.json` (verified via `jq -S` diff).
+
+Deferred follow-ups (will be tracked in separate beans):
+- Perf hot-path (Copilot #405, #475, #491) — drop the `to_value` round-trip in construction/serialize/visit paths; needs benchmark data before investment.
+- Layer 5 `CompatibilityWarning` plumbing for unknown-class soft-degrade UX (out of scope per original PR body, now explicitly marked in code with TODO).

--- a/.beans/csl26-odgh--implement-inputreference-class-discriminator-desig.md
+++ b/.beans/csl26-odgh--implement-inputreference-class-discriminator-desig.md
@@ -1,0 +1,36 @@
+---
+# csl26-odgh
+title: Implement InputReference class discriminator design
+status: in-progress
+type: task
+priority: high
+created_at: 2026-05-15T19:00:04Z
+updated_at: 2026-05-15T20:30:21Z
+blocked_by:
+    - csl26-1bdr
+---
+
+Implementation of `docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md` (v0.3).
+
+Pre-1.0 hard cut originally targeted replacing the closed `#[serde(tag = "class")]` enum with a shared-base struct + class-specific overlay. Current Layer 1 keeps the existing enum storage/API inside `citum-schema-data` so Layers 2-4 do not get pulled into this session, but replaces the public wire/schema boundary with a hand-written flat discriminator dispatcher and restores strict class payload deserialization.
+
+## Layered change stack
+
+- [x] **Layer 1 — schema-data refactor.** Complete for the scoped single-session cut: live `InputReference` now has custom flat-map `Deserialize`/`Serialize`, all 18 known classes dispatch through explicit `class` values, unknown classes capture into `UnknownClassData`, `ReferenceClass`/`ClassExtension`/`as_<class>()`/`unknown_class()` accessors are present, `deny_unknown_fields` is restored across reference payloads/helpers, and `InputReference` has a custom schema composition with per-class `class` const branches plus `unevaluatedProperties: false`. Verification: `cargo fmt --check`; `cargo clippy -p citum-schema-data --all-features --all-targets -- -D warnings`; `cargo nextest run -p citum-schema-data --all-features` (108 passed). See `.ai-intents/INTENT-2026-05-15-1500-layer1-schema-data.md` for handoff state.
+- [ ] **Layer 2 — citum-io biblatex constructors.** Deferred.
+- [ ] **Layer 3 — citum-migrate constructors.** Deferred.
+- [ ] **Layer 4 — engine call-site rewrites.** Deferred.
+- [ ] **Layer 5 — `CompatibilityWarning` plumbing.**
+- [ ] **Layer 6 — forward-compat tests + snapshot.** Flip row 02b; close row 07.
+- [ ] **Layer 7 — schema artifact regeneration.**
+- [ ] **Layer 8 — schema-alignment tests.** Expand beyond the Layer 1 schema smoke test.
+
+## Workflow
+
+- Single PR; multi-session.
+- jj change stack per `docs/guides/JJ_AI_CHANGE_STACK.md`.
+- `.ai-intents/` tracks session handoff state and must be removed before merge-ready publication.
+- Pre-commit gate run manually before every push (jj skips git hooks).
+
+Spec: `docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`
+Parent design bean (related): `csl26-1bdr`

--- a/.beans/csl26-s4io--inputreference-layer-5-compatibilitywarning-for-un.md
+++ b/.beans/csl26-s4io--inputreference-layer-5-compatibilitywarning-for-un.md
@@ -1,0 +1,31 @@
+---
+# csl26-s4io
+title: 'InputReference Layer 5: CompatibilityWarning for unknown class'
+status: todo
+type: task
+priority: normal
+created_at: 2026-05-16T00:15:48Z
+updated_at: 2026-05-16T00:15:48Z
+parent: csl26-1bdr
+---
+
+Surface unknown-class references through a `CompatibilityWarning` channel so the engine emits soft-degrade messaging instead of silently falling through to an empty render.
+
+## Background
+
+PR #717 landed the discriminator cutover (Layers 1–4) and explicitly deferred Layer 5. Today, `InputReference::ref_type()` for an `Unknown` class returns the raw kebab-case class string — which the engine has no template branch for — so renders silently produce empty output. The current code has a `debug_assert!` + `TODO(csl26-1bdr)` marker pinning this gap.
+
+## Approach
+
+- Add a `CompatibilityWarning` enum / channel that the engine pipeline can emit during processing.
+- When an unknown-class reference is processed, emit a `UnknownReferenceClass { class, ref_id }` warning.
+- Hub / CLI surface: render the warnings alongside output (CLI: stderr; WASM: structured result).
+- Replace the `debug_assert!` in `ref_type()` for Unknown with a proper warning emission path.
+
+## Acceptance criteria
+
+- [ ] Unknown-class references emit a structured warning during render.
+- [ ] CLI prints warnings on stderr without breaking output.
+- [ ] WASM bridge exposes warnings in the structured result.
+- [ ] Round-trip preservation of unknown-class data is unchanged.
+- [ ] Tests cover: unknown class in citation list, unknown class in bibliography, unknown class in both.

--- a/crates/citum-engine/src/grouping/sorting.rs
+++ b/crates/citum-engine/src/grouping/sorting.rs
@@ -14,6 +14,8 @@ use std::collections::HashMap;
 
 use citum_schema::grouping::{GroupSort, GroupSortKey, NameSortOrder, SortKey as GroupSortKeyType};
 use citum_schema::locale::Locale;
+#[cfg(test)]
+use citum_schema::reference::ClassExtension;
 
 use crate::reference::Reference;
 use crate::sort_support::{TextCollator, author_sort_key_opt, normalize_sort_text, title_sort_key};
@@ -582,7 +584,7 @@ mod tests {
         let dated_early = make_reference("r1", "book", "Smith", "Book D", 1999);
         let dated_late = make_reference("r2", "book", "Jones", "Book B", 2000);
         let mut undated = make_reference("r3", "book", "Brown", "Book A", 2000);
-        if let Reference::Monograph(monograph) = &mut undated {
+        if let ClassExtension::Monograph(monograph) = undated.extension_mut() {
             monograph.issued = citum_schema::reference::EdtfString(String::new());
         }
 
@@ -611,7 +613,7 @@ mod tests {
 
         let dated = make_reference("r1", "book", "Smith", "Book D", 1999);
         let mut created_only = make_reference("r2", "book", "Jones", "Book C", 2000);
-        if let Reference::Monograph(monograph) = &mut created_only {
+        if let ClassExtension::Monograph(monograph) = created_only.extension_mut() {
             monograph.created = citum_schema::reference::EdtfString("1985".to_string());
             monograph.issued = citum_schema::reference::EdtfString(String::new());
         }

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -11,6 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use crate::reference::Reference;
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
 use citum_schema::locale::{GrammaticalGender, TermForm};
+use citum_schema::reference::ClassExtension;
 use citum_schema::template::{NumberVariable, TemplateNumber};
 
 /// Resolve the raw value string for a number variable from a reference.
@@ -40,8 +41,8 @@ fn resolve_number_value(
                 })
             }
         }
-        NumberVariable::ChapterNumber => match reference {
-            Reference::Statute(r) => r.chapter_number.clone(),
+        NumberVariable::ChapterNumber => match reference.extension() {
+            ClassExtension::Statute(r) => r.chapter_number.clone(),
             _ => reference.numbering_value(&citum_schema::reference::NumberingType::Chapter),
         },
         NumberVariable::Edition => reference.edition(),
@@ -50,16 +51,16 @@ fn resolve_number_value(
         NumberVariable::Custom(kind) => reference.numbering_value(
             &citum_schema::reference::NumberingType::Custom(kind.clone()),
         ),
-        NumberVariable::DocketNumber => match reference {
-            Reference::Brief(r) => r.docket_number.clone(),
+        NumberVariable::DocketNumber => match reference.extension() {
+            ClassExtension::Brief(r) => r.docket_number.clone(),
             _ => None,
         },
-        NumberVariable::PatentNumber => match reference {
-            Reference::Patent(r) => Some(r.patent_number.clone()),
+        NumberVariable::PatentNumber => match reference.extension() {
+            ClassExtension::Patent(r) => Some(r.patent_number.clone()),
             _ => None,
         },
-        NumberVariable::StandardNumber => match reference {
-            Reference::Standard(r) => Some(r.standard_number.clone()),
+        NumberVariable::StandardNumber => match reference.extension() {
+            ClassExtension::Standard(r) => Some(r.standard_number.clone()),
             _ => None,
         },
         NumberVariable::ReportNumber => reference.report_number(),

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -10,8 +10,8 @@ use citum_schema::locale::{GeneralTerm, GrammaticalGender, Locale, TermForm};
 use citum_schema::options::contributors::NameForm;
 use citum_schema::options::*;
 use citum_schema::reference::{
-    Contributor, ContributorEntry, ContributorGender, EdtfString, FlatName, InputReference,
-    Monograph, MonographType, StructuredName,
+    ClassExtension, Contributor, ContributorEntry, ContributorGender, EdtfString, FlatName,
+    InputReference, Monograph, MonographType, StructuredName,
 };
 use citum_schema::template::DateVariable as TemplateDateVar;
 use citum_schema::template::*;
@@ -3313,7 +3313,7 @@ fn test_text_case_structured_title_sentence_apa() {
         ..Default::default()
     });
     // Replace with structured title
-    if let Reference::Monograph(ref mut m) = reference {
+    if let ClassExtension::Monograph(m) = reference.extension_mut() {
         m.title = Some(Title::Structured(StructuredTitle {
             full: None,
             main: "Understanding Citation Systems".to_string(),
@@ -3372,7 +3372,7 @@ fn test_text_case_structured_title_sentence_nlm() {
         title: Some("placeholder".to_string()),
         ..Default::default()
     });
-    if let Reference::Monograph(ref mut m) = reference {
+    if let ClassExtension::Monograph(m) = reference.extension_mut() {
         m.title = Some(Title::Structured(StructuredTitle {
             full: None,
             main: "Understanding Citation Systems".to_string(),
@@ -3524,7 +3524,7 @@ fn test_structured_title_form_short_returns_main_only() {
         title: Some("placeholder".to_string()),
         ..Default::default()
     });
-    if let Reference::Treaty(ref mut m) = reference {
+    if let ClassExtension::Treaty(m) = reference.extension_mut() {
         m.title = Some(Title::Structured(StructuredTitle {
             full: None,
             main: "Homeland Security Act of 2002".to_string(),

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -11,6 +11,7 @@ use crate::render::rich_text::render_djot_inline_with_transform;
 use crate::values::text_case::{self, apply_text_case, capitalize_first_word};
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
 use citum_schema::options::titles::TextCase;
+use citum_schema::reference::ClassExtension;
 use citum_schema::reference::types::{StructuredTitle, Subtitle, Title};
 use citum_schema::template::{TemplateTitle, TitleForm, TitleType};
 
@@ -317,17 +318,17 @@ impl ComponentValues for TemplateTitle {
 fn resolve_primary_title(reference: &Reference, title_type: &TitleType) -> Option<Title> {
     match title_type {
         TitleType::Primary => reference.title(),
-        TitleType::ParentMonograph => match reference {
-            Reference::Monograph(_)
-            | Reference::CollectionComponent(_)
-            | Reference::Event(_)
-            | Reference::AudioVisual(_) => reference.container_title(),
+        TitleType::ParentMonograph => match reference.extension() {
+            ClassExtension::Monograph(_)
+            | ClassExtension::CollectionComponent(_)
+            | ClassExtension::Event(_)
+            | ClassExtension::AudioVisual(_) => reference.container_title(),
             _ => None,
         },
-        TitleType::ParentSerial => match reference {
-            Reference::SerialComponent(_) | Reference::LegalCase(_) | Reference::Treaty(_) => {
-                reference.container_title()
-            }
+        TitleType::ParentSerial => match reference.extension() {
+            ClassExtension::SerialComponent(_)
+            | ClassExtension::LegalCase(_)
+            | ClassExtension::Treaty(_) => reference.container_title(),
             _ => None,
         },
         _ => None,

--- a/crates/citum-engine/src/values/variable.rs
+++ b/crates/citum-engine/src/values/variable.rs
@@ -12,7 +12,7 @@ use crate::reference::Reference;
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
 use citum_schema::locale::ArchiveHierarchyField;
 use citum_schema::options::titles::TextCase;
-use citum_schema::reference::RichText;
+use citum_schema::reference::{ClassExtension, RichText};
 use citum_schema::template::{SimpleVariable, TemplateVariable};
 
 /// Extracts the short title from a parent reference if available.
@@ -169,16 +169,16 @@ fn resolve_variable_value(
         SimpleVariable::Section => reference.section(),
         SimpleVariable::Volume => reference.volume().map(|v| v.to_string()),
         SimpleVariable::Number => reference.number(),
-        SimpleVariable::DocketNumber => match reference {
-            Reference::Brief(r) => r.docket_number.clone(),
+        SimpleVariable::DocketNumber => match reference.extension() {
+            ClassExtension::Brief(r) => r.docket_number.clone(),
             _ => None,
         },
-        SimpleVariable::PatentNumber => match reference {
-            Reference::Patent(r) => Some(r.patent_number.clone()),
+        SimpleVariable::PatentNumber => match reference.extension() {
+            ClassExtension::Patent(r) => Some(r.patent_number.clone()),
             _ => None,
         },
-        SimpleVariable::StandardNumber => match reference {
-            Reference::Standard(r) => Some(r.standard_number.clone()),
+        SimpleVariable::StandardNumber => match reference.extension() {
+            ClassExtension::Standard(r) => Some(r.standard_number.clone()),
             _ => None,
         },
         SimpleVariable::AdsBibcode => reference.ads_bibcode(),

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -17,6 +17,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 )]
 
 mod common;
+use citum_schema::reference::ClassExtension;
 use common::*;
 
 use citum_engine::{Processor, render::html::Html, render::plain::PlainText};
@@ -1631,7 +1632,7 @@ fn sorting_empty_dates_pushes_undated_items_after_dated_ones() {
 
     fn make_undated_book(id: &str, title: &str) -> InputReference {
         let mut reference = make_book(id, "Smith", "Jane", 2000, title);
-        if let InputReference::Monograph(monograph) = &mut reference {
+        if let ClassExtension::Monograph(monograph) = reference.extension_mut() {
             monograph.issued = citum_schema::reference::EdtfString(String::new());
         }
         reference
@@ -1761,7 +1762,7 @@ fn legal_case_parent_serial_uses_reporter_as_container_title() {
 fn suppressed_group_children_do_not_leave_stray_delimiters() {
     let style = build_group_with_suppressed_child_style();
     let mut reference = make_book("grouped", "Smith", "Jane", 2024, "Grouped Title");
-    if let InputReference::Monograph(book) = &mut reference {
+    if let ClassExtension::Monograph(book) = reference.extension_mut() {
         book.url = Some(Url::parse("https://example.com/grouped").expect("url should parse"));
     }
 
@@ -1781,7 +1782,7 @@ fn status_variables_render_in_bibliography_templates() {
         2025,
         "Oxford English Dictionary",
     );
-    if let InputReference::Monograph(book) = &mut reference {
+    if let ClassExtension::Monograph(book) = reference.extension_mut() {
         book.status = Some("last modified".to_string());
     }
 
@@ -2948,7 +2949,7 @@ fn given_archive_location_override_when_rendering_bibliography_then_legacy_fallb
     let mut bib = indexmap::IndexMap::new();
     let mut reference = make_archive_eprint_reference();
 
-    let InputReference::Monograph(monograph) = &mut reference else {
+    let ClassExtension::Monograph(monograph) = reference.extension_mut() else {
         panic!("archive test fixture should be a monograph");
     };
     monograph.id = Some("archive-eprint-location-ref".into());
@@ -2999,14 +3000,17 @@ fn given_legacy_archive_fields_when_converting_then_archive_info_is_hydrated() {
     .expect("legacy reference should parse");
 
     let reference: InputReference = legacy.into();
-    if let InputReference::Monograph(m) = reference {
+    if let ClassExtension::Monograph(m) = reference.extension() {
         assert_eq!(m.archive, Some("Bodleian Library".to_string()));
         assert_eq!(
             m.archive_location,
             Some("MS Bodl. Or. 579, fol. 23r".to_string())
         );
 
-        let archive_info = m.archive_info.expect("archive info should be hydrated");
+        let archive_info = m
+            .archive_info
+            .clone()
+            .expect("archive info should be hydrated");
         assert_eq!(
             archive_info
                 .name

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -22,6 +22,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
 mod common;
+use citum_schema::reference::ClassExtension;
 use common::*;
 
 use citum_engine::{Processor, render::html::Html};
@@ -787,7 +788,7 @@ fn sorting_empty_dates_pushes_undated_items_to_the_end() {
     // Upstream provenance: CSL fixture `date_SortEmptyDatesCitation`.
     fn make_undated_book(id: &str, title: &str) -> InputReference {
         let mut reference = make_book(id, "Smith", "Jane", 2000, title);
-        if let InputReference::Monograph(monograph) = &mut reference {
+        if let ClassExtension::Monograph(monograph) = reference.extension_mut() {
             monograph.issued = citum_schema::reference::EdtfString(String::new());
         }
         reference

--- a/crates/citum-engine/tests/domain_fixtures.rs
+++ b/crates/citum-engine/tests/domain_fixtures.rs
@@ -25,7 +25,7 @@ use citum_engine::Processor;
 use citum_io::load_bibliography;
 use citum_schema::Style;
 use citum_schema::citation::{Citation, CitationItem, CitationLocator, LocatorType};
-use citum_schema::reference::{InputReference, MultilingualString};
+use citum_schema::reference::{ClassExtension, MultilingualString};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -227,7 +227,7 @@ fn test_humanities_note_fixture_preserves_archive_and_interview_fields() {
         .process_citation(&single_item_citation("derrida-letter"))
         .expect("personal communication citation should render");
 
-    let InputReference::Monograph(manuscript_record) = manuscript_ref else {
+    let ClassExtension::Monograph(manuscript_record) = manuscript_ref.extension() else {
         panic!("dead-sea-scrolls should deserialize as a monograph");
     };
     let archive_info = manuscript_record

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -22,6 +22,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
 mod common;
+use citum_schema::reference::ClassExtension;
 use common::*;
 
 use citum_engine::Processor;
@@ -131,7 +132,7 @@ fn test_name_rendering_family_only() {
 
     let mut bib = indexmap::IndexMap::new();
     let mut item = make_book("item1", "Gogh", "Vincent", 1888, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item
+    if let ClassExtension::Monograph(m) = item.extension_mut()
         && let Some(citum_schema::reference::Contributor::StructuredName(n)) = &mut m.author
     {
         n.non_dropping_particle = Some("van".to_string());
@@ -186,7 +187,7 @@ fn test_name_rendering_particles() {
 
     let mut bib = indexmap::IndexMap::new();
     let mut item = make_book("item1", "Gogh", "Vincent", 1888, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item
+    if let ClassExtension::Monograph(m) = item.extension_mut()
         && let Some(citum_schema::reference::Contributor::StructuredName(n)) = &mut m.author
     {
         n.non_dropping_particle = Some("van".to_string());
@@ -209,7 +210,7 @@ fn test_name_rendering_corporate() {
 
     let mut bib = indexmap::IndexMap::new();
     let mut item = make_book("item1", "", "", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.author = Some(citum_schema::reference::Contributor::SimpleName(
             citum_schema::reference::SimpleName {
                 name: citum_schema::reference::MultilingualString::Simple(
@@ -254,7 +255,7 @@ fn test_date_rendering_full() {
     let mut bib = indexmap::IndexMap::new();
     // EDTF: 2020-05-15
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString("2020-05-15".to_string());
     }
     bib.insert("item1".to_string(), item);
@@ -277,7 +278,7 @@ fn test_date_rendering_day_month_abbr_year() {
     let mut bib = indexmap::IndexMap::new();
     // EDTF: 2020-05-15
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString("2020-05-15".to_string());
     }
     bib.insert("item1".to_string(), item);
@@ -301,7 +302,7 @@ fn test_date_rendering_range() {
     let mut bib = indexmap::IndexMap::new();
     // EDTF range: 2020/2022
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString("2020/2022".to_string());
     }
     bib.insert("item1".to_string(), item);
@@ -323,7 +324,7 @@ fn test_date_rendering_negative_year() {
 
     let mut bib = indexmap::IndexMap::new();
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString("-0099".to_string());
     }
     bib.insert("item1".to_string(), item);
@@ -344,7 +345,7 @@ fn test_date_rendering_negative_full_date() {
 
     let mut bib = indexmap::IndexMap::new();
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString("-0043-03-15".to_string());
     }
     bib.insert("item1".to_string(), item);
@@ -365,7 +366,7 @@ fn test_date_rendering_negative_range() {
 
     let mut bib = indexmap::IndexMap::new();
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString("-0099/-0043".to_string());
     }
     bib.insert("item1".to_string(), item);
@@ -389,7 +390,7 @@ fn test_date_rendering_open_range() {
     let mut bib = indexmap::IndexMap::new();
     // EDTF open range: 2020/..
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString("2020/..".to_string());
     }
     bib.insert("item1".to_string(), item);
@@ -412,7 +413,7 @@ fn test_date_rendering_fallback() {
     let mut bib = indexmap::IndexMap::new();
     // Missing date
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.issued = citum_schema::reference::EdtfString(String::new());
     }
     bib.insert("item1".to_string(), item);
@@ -433,7 +434,7 @@ fn test_date_rendering_uses_created_when_issued_is_missing() {
 
     let mut bib = indexmap::IndexMap::new();
     let mut item = make_book("item1", "Smith", "J", 2020, "Title");
-    if let citum_schema::reference::InputReference::Monograph(m) = &mut item {
+    if let ClassExtension::Monograph(m) = item.extension_mut() {
         m.created = citum_schema::reference::EdtfString("1954-05-17".to_string());
         m.issued = citum_schema::reference::EdtfString(String::new());
     }

--- a/crates/citum-engine/tests/snapshots/forward_compat_gaps.snap
+++ b/crates/citum-engine/tests/snapshots/forward_compat_gaps.snap
@@ -9,12 +9,12 @@
 
 01-attr-enum-template        | Attribute enum in template                              | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
 02-attr-enum-data            | Attribute enum in reference data                        | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
-02b-discriminator-class      | Unknown InputReference class                            | declared=HardFail    observed=HardFail    ok  | csl26-1bdr inputreference-discriminator-design
+02b-discriminator-class      | Unknown InputReference class                            | declared=HardFail    observed=Pass        GAP | csl26-1bdr inputreference-discriminator-design
 03-locale-form               | Locale TermForm value                                   | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
 04-date-form                 | DateForm value in template                              | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
 05-new-option-key            | New key inside style option struct                      | declared=SoftDegrade observed=HardFail    GAP | csl26-0ksu capture-unknown-fields-wrapper
 06-new-top-level-section     | New top-level Style section                             | declared=SoftDegrade observed=HardFail    GAP | csl26-0ksu capture-unknown-fields-wrapper
-07-new-reference-field       | New optional field on reference type                    | declared=SoftDegrade observed=Pass        GAP | csl26-acfh reference-data-silent-acceptance
+07-new-reference-field       | New optional field on reference type                    | declared=SoftDegrade observed=HardFail    GAP | csl26-acfh reference-data-silent-acceptance
 08-new-locale-term-key       | New locale term key                                     | declared=SoftDegrade observed=HardFail    GAP | csl26-o1z5 tolerant-locale-lookup
 09-custom-namespace          | Namespaced custom.* metadata (control)                  | declared=Pass        observed=Pass        ok  | —
 10-version-only-signal       | Style version bumped without other changes (control)    | declared=Pass        observed=Pass        ok  | —

--- a/crates/citum-io/src/lib.rs
+++ b/crates/citum-io/src/lib.rs
@@ -14,9 +14,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use citum_schema::InputBibliography;
-use citum_schema::reference::InputReference;
 use citum_schema::reference::conversion::input_reference_from_legacy_edited_book;
 use citum_schema::reference::types::{ArchiveInfo, EprintInfo};
+use citum_schema::reference::{ClassExtension, InputReference};
 use csl_legacy::csl_json::Reference as LegacyReference;
 use indexmap::IndexMap;
 
@@ -200,29 +200,29 @@ fn apply_hybrid_json_extensions(
         .transpose()
         .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
 
-    match &mut reference {
-        InputReference::Monograph(record) => {
-            if archive_info.is_some() {
-                record.archive_info = archive_info;
+    match reference.extension_mut() {
+        ClassExtension::Monograph(record) => {
+            if let Some(info) = archive_info.clone() {
+                record.archive_info = Some(info);
             }
-            if eprint.is_some() {
-                record.eprint = eprint;
-            }
-        }
-        InputReference::CollectionComponent(record) => {
-            if archive_info.is_some() {
-                record.archive_info = archive_info;
-            }
-            if eprint.is_some() {
-                record.eprint = eprint;
+            if let Some(info) = eprint.clone() {
+                record.eprint = Some(info);
             }
         }
-        InputReference::SerialComponent(record) => {
-            if archive_info.is_some() {
-                record.archive_info = archive_info;
+        ClassExtension::CollectionComponent(record) => {
+            if let Some(info) = archive_info.clone() {
+                record.archive_info = Some(info);
             }
-            if eprint.is_some() {
-                record.eprint = eprint;
+            if let Some(info) = eprint.clone() {
+                record.eprint = Some(info);
+            }
+        }
+        ClassExtension::SerialComponent(record) => {
+            if let Some(info) = archive_info {
+                record.archive_info = Some(info);
+            }
+            if let Some(info) = eprint {
+                record.eprint = Some(info);
             }
         }
         _ => {}
@@ -812,14 +812,14 @@ fn input_reference_to_csl_json(reference: &InputReference) -> LegacyReference {
     r.translator = reference.translator().map(contributor_to_csl_names);
     r.publisher = reference.publisher().map(|p| p.name.to_string());
 
-    match reference {
-        InputReference::Monograph(m) => {
+    match reference.extension() {
+        ClassExtension::Monograph(m) => {
             r.ref_type = "book".to_string();
             r.isbn.clone_from(&m.isbn);
             r.url = m.url.as_ref().map(std::string::ToString::to_string);
             r.edition = reference.edition().map(StringOrNumber::String);
         }
-        InputReference::SerialComponent(s) => {
+        ClassExtension::SerialComponent(s) => {
             r.ref_type = "article-journal".to_string();
             r.container_title = reference.container_title().map(|t| t.to_string());
             r.page.clone_from(&s.pages);
@@ -831,7 +831,7 @@ fn input_reference_to_csl_json(reference: &InputReference) -> LegacyReference {
                 .map(|v| StringOrNumber::String(v.to_string()));
             r.url = s.url.as_ref().map(std::string::ToString::to_string);
         }
-        InputReference::CollectionComponent(c) => {
+        ClassExtension::CollectionComponent(c) => {
             r.ref_type = "chapter".to_string();
             r.container_title = reference.container_title().map(|t| t.to_string());
             r.page = c.pages.as_ref().map(std::string::ToString::to_string);
@@ -885,9 +885,9 @@ fn render_biblatex(input: &InputBibliography) -> String {
     let mut out = String::new();
     for reference in &input.references {
         let id = reference.id().unwrap_or_else(|| "item".into());
-        let entry_type = match reference {
-            InputReference::SerialComponent(_) => "article",
-            InputReference::CollectionComponent(_) => "incollection",
+        let entry_type = match reference.extension() {
+            ClassExtension::SerialComponent(_) => "article",
+            ClassExtension::CollectionComponent(_) => "incollection",
             _ => "book",
         };
         let _ = writeln!(&mut out, "@{entry_type}{{{id},");
@@ -1045,9 +1045,9 @@ fn ris_record_to_reference(fields: &[(String, String)]) -> LegacyReference {
 fn render_ris(input: &InputBibliography) -> String {
     let mut out = String::new();
     for reference in &input.references {
-        let ty = match reference {
-            InputReference::SerialComponent(_) => "JOUR",
-            InputReference::CollectionComponent(_) => "CHAP",
+        let ty = match reference.extension() {
+            ClassExtension::SerialComponent(_) => "JOUR",
+            ClassExtension::CollectionComponent(_) => "CHAP",
             _ => "BOOK",
         };
         let _ = writeln!(&mut out, "TY  - {ty}");
@@ -1409,7 +1409,10 @@ issued: "2020"
             .get("edited-book-1")
             .expect("reference should be preserved");
         assert_eq!(reference.ref_type(), "book");
-        assert!(matches!(reference, Reference::Collection(_)));
+        assert!(matches!(
+            reference.extension(),
+            ClassExtension::Collection(_)
+        ));
         assert!(result.sets.is_none());
     }
 
@@ -1435,7 +1438,10 @@ issued: "2020"
             .get("edited-book-1")
             .expect("reference should be preserved");
         assert_eq!(reference.ref_type(), "book");
-        assert!(matches!(reference, Reference::Collection(_)));
+        assert!(matches!(
+            reference.extension(),
+            ClassExtension::Collection(_)
+        ));
     }
 
     #[test]

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -1764,6 +1764,8 @@ impl From<Vec<csl_legacy::csl_json::Name>> for Contributor {
     reason = "Panicking is acceptable and often desired in tests."
 )]
 mod tests {
+    use crate::reference::ClassExtension;
+
     use super::*;
     use serde_json::json;
 
@@ -1828,13 +1830,13 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::Monograph(monograph) = converted else {
+        let ClassExtension::Monograph(monograph) = converted.extension() else {
             panic!("expected monograph");
         };
-        let Some(WorkRelation::Embedded(original)) = monograph.original else {
+        let Some(WorkRelation::Embedded(original)) = monograph.original.as_ref() else {
             panic!("expected embedded original relation");
         };
-        let InputReference::Monograph(original_monograph) = *original else {
+        let ClassExtension::Monograph(original_monograph) = original.extension() else {
             panic!("expected original monograph relation");
         };
 
@@ -1867,7 +1869,7 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::SerialComponent(component) = converted else {
+        let ClassExtension::SerialComponent(component) = converted.extension() else {
             panic!("expected serial component");
         };
         assert!(
@@ -1876,10 +1878,10 @@ mod tests {
                 .iter()
                 .any(|entry| entry.r#type == NumberingType::Supplement && entry.value == "S1")
         );
-        let Some(WorkRelation::Embedded(reviewed)) = component.reviewed else {
+        let Some(WorkRelation::Embedded(reviewed)) = component.reviewed.as_ref() else {
             panic!("expected reviewed relation");
         };
-        let InputReference::Monograph(reviewed_work) = *reviewed else {
+        let ClassExtension::Monograph(reviewed_work) = reviewed.extension() else {
             panic!("expected reviewed monograph relation");
         };
         assert_eq!(
@@ -1909,7 +1911,7 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::Event(event) = converted else {
+        let ClassExtension::Event(event) = converted.extension() else {
             panic!("expected event");
         };
         assert_eq!(
@@ -1938,7 +1940,7 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::Event(event) = converted else {
+        let ClassExtension::Event(event) = converted.extension() else {
             panic!("expected event");
         };
         assert_eq!(event.date, None);
@@ -1960,7 +1962,7 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::SerialComponent(work) = converted else {
+        let ClassExtension::SerialComponent(work) = converted.extension() else {
             panic!("expected serial component");
         };
         assert!(
@@ -1996,7 +1998,7 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::Monograph(monograph) = converted else {
+        let ClassExtension::Monograph(monograph) = converted.extension() else {
             panic!("expected monograph");
         };
 
@@ -2033,7 +2035,7 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::Monograph(monograph) = converted else {
+        let ClassExtension::Monograph(monograph) = converted.extension() else {
             panic!("expected monograph");
         };
         assert_eq!(
@@ -2054,7 +2056,7 @@ mod tests {
 
         let converted = InputReference::from(legacy);
 
-        let InputReference::CollectionComponent(component) = converted else {
+        let ClassExtension::CollectionComponent(component) = converted.extension() else {
             panic!("expected collection component");
         };
         assert_eq!(

--- a/crates/citum-schema-data/src/reference/discriminator/mod.rs
+++ b/crates/citum-schema-data/src/reference/discriminator/mod.rs
@@ -1,0 +1,596 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+//! Layer-1 scaffolding for `csl26-1bdr` / `csl26-odgh`.
+//!
+//! Implements the design from `docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`
+//! (v0.3) on a representative subset of classes — Monograph, LegalCase,
+//! AudioVisual — so the serde mechanics, schemars wiring, and error UX are
+//! locked in at production scale before the cutover.
+//!
+//! Once the remaining 15 classes are added, this module replaces the legacy
+//! `pub enum InputReference` in `super::mod.rs`. The legacy types stay alive
+//! in parallel during the refactor; nothing in this module depends on them
+//! and nothing else in the crate depends on this module yet.
+
+#![allow(
+    clippy::too_many_lines,
+    reason = "scaffolding will be split when expanded to all 18 classes"
+)]
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::de::{self, MapAccess, Visitor};
+use serde::ser::SerializeMap as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+
+use super::EdtfString;
+use super::contributor::ContributorList;
+use super::types::common::{RefID, Title};
+
+// ---------------- Public surface ----------------
+
+/// Top-level bibliographic-data type with shared base + class-specific overlay.
+///
+/// See `docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md` §Wire format for
+/// the YAML/JSON contract and §Rust API for the accessor surface.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InputReference {
+    /// Reference identifier.
+    pub id: RefID,
+    /// Title of the work.
+    pub title: Option<Title>,
+    /// Unified contributor list.
+    pub contributors: Option<ContributorList>,
+    /// Publication date.
+    pub issued: Option<EdtfString>,
+    /// Creation or origination date.
+    pub created: Option<EdtfString>,
+    /// Note field.
+    pub note: Option<String>,
+    /// Class-specific overlay. Internal; consumers go through accessors.
+    pub(crate) extension: ClassExtension,
+}
+
+impl InputReference {
+    /// Return the typed class discriminator.
+    #[must_use]
+    pub fn class(&self) -> ReferenceClass {
+        match &self.extension {
+            ClassExtension::Monograph(_) => ReferenceClass::Monograph,
+            ClassExtension::LegalCase(_) => ReferenceClass::LegalCase,
+            ClassExtension::AudioVisual(_) => ReferenceClass::AudioVisual,
+            ClassExtension::Unknown(u) => ReferenceClass::Unknown(u.class.clone()),
+        }
+    }
+
+    /// Return the class-specific overlay for pattern-matching.
+    #[must_use]
+    pub fn extension(&self) -> &ClassExtension {
+        &self.extension
+    }
+
+    /// Return monograph-specific fields when the class is `monograph`.
+    #[must_use]
+    pub fn as_monograph(&self) -> Option<&MonographFields> {
+        match &self.extension {
+            ClassExtension::Monograph(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    /// Return legal-case-specific fields when the class is `legal-case`.
+    #[must_use]
+    pub fn as_legal_case(&self) -> Option<&LegalCaseFields> {
+        match &self.extension {
+            ClassExtension::LegalCase(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Return audio-visual-specific fields when the class is `audio-visual`.
+    #[must_use]
+    pub fn as_audio_visual(&self) -> Option<&AudioVisualFields> {
+        match &self.extension {
+            ClassExtension::AudioVisual(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Return unknown-class data when the class is not in the known vocabulary.
+    #[must_use]
+    pub fn unknown_class(&self) -> Option<&UnknownClassData> {
+        match &self.extension {
+            ClassExtension::Unknown(u) => Some(u),
+            _ => None,
+        }
+    }
+}
+
+/// Typed class discriminator returned by [`InputReference::class`].
+///
+/// The wire form for `class:` is always the raw kebab-case string. The
+/// `Unknown` variant is `#[serde(skip)]` so it never appears literally on
+/// the wire — the underlying string round-trips through
+/// [`UnknownClassData::class`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum ReferenceClass {
+    /// A monograph (book, report, thesis, etc.).
+    Monograph,
+    /// A legal case.
+    LegalCase,
+    /// An audio-visual work (film, recording, broadcast).
+    AudioVisual,
+    /// Forward-compat: a class string the engine does not recognize.
+    #[serde(skip)]
+    Unknown(String),
+}
+
+impl ReferenceClass {
+    /// Names of all variants in the **known** vocabulary, kebab-case as on
+    /// the wire. Used by the dispatcher and by the JSON-Schema generator.
+    pub const KNOWN: &'static [&'static str] = &["monograph", "legal-case", "audio-visual"];
+}
+
+/// Class-specific overlay; one variant per known class plus an `Unknown`
+/// arm for the forward-compat path.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClassExtension {
+    /// Monograph-specific fields.
+    Monograph(MonographFields),
+    /// Legal-case-specific fields.
+    LegalCase(LegalCaseFields),
+    /// Audio-visual-specific fields.
+    AudioVisual(AudioVisualFields),
+    /// Class not in the known vocabulary. Round-trips via the dispatcher
+    /// and the custom Serialize impl on [`InputReference`].
+    Unknown(UnknownClassData),
+}
+
+/// Monograph-specific fields.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct MonographFields {
+    /// Monograph subtype (book, report, thesis, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub monograph_type: Option<String>,
+    /// Edition designation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub edition: Option<String>,
+    /// Volume number.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume: Option<String>,
+    /// ISBN identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isbn: Option<String>,
+}
+
+/// Legal-case-specific fields.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct LegalCaseFields {
+    /// Court name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub court: Option<String>,
+    /// Docket or case number.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docket_number: Option<String>,
+    /// Legal reporter series.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reporter: Option<String>,
+}
+
+/// Audio-visual-specific fields.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct AudioVisualFields {
+    /// Runtime in minutes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_minutes: Option<u32>,
+    /// Medium descriptor (film, television, recording, …).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub medium: Option<String>,
+}
+
+/// Unknown-class payload captured by the dispatcher.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnknownClassData {
+    /// Raw class string from the input.
+    pub class: String,
+    /// Class-specific fields captured verbatim.
+    pub fields: JsonMap<String, JsonValue>,
+}
+
+// ---------------- Static field tables ----------------
+//
+// The dispatcher uses these to split the incoming map into shared vs
+// class-specific buckets and to produce scope-correct error messages.
+// Must stay in sync with the struct definitions above; a future macro can
+// derive them.
+
+const SHARED_KEYS: &[&str] = &["id", "title", "contributors", "issued", "created", "note"];
+
+const MONOGRAPH_KEYS: &[&str] = &["monograph-type", "edition", "volume", "isbn"];
+const LEGAL_CASE_KEYS: &[&str] = &["court", "docket-number", "reporter"];
+const AUDIO_VISUAL_KEYS: &[&str] = &["runtime-minutes", "medium"];
+
+fn class_keys(class: &str) -> Option<&'static [&'static str]> {
+    match class {
+        "monograph" => Some(MONOGRAPH_KEYS),
+        "legal-case" => Some(LEGAL_CASE_KEYS),
+        "audio-visual" => Some(AUDIO_VISUAL_KEYS),
+        _ => None,
+    }
+}
+
+// ---------------- Shared-fields helper ----------------
+//
+// Strict deserializer for the shared bucket. Separate from `InputReference`
+// itself because the outer type needs a hand-written impl for the dispatch
+// logic.
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+struct SharedFields {
+    id: RefID,
+    #[serde(default)]
+    title: Option<Title>,
+    #[serde(default)]
+    contributors: Option<ContributorList>,
+    #[serde(default)]
+    issued: Option<EdtfString>,
+    #[serde(default)]
+    created: Option<EdtfString>,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+// ---------------- Hand-written Deserialize ----------------
+
+impl<'de> Deserialize<'de> for InputReference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RefVisitor;
+
+        impl<'de> Visitor<'de> for RefVisitor {
+            type Value = InputReference;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a reference object with a `class` discriminator")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<InputReference, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut entries: Vec<(String, JsonValue)> = Vec::new();
+                let mut class: Option<String> = None;
+                let mut seen: BTreeSet<String> = BTreeSet::new();
+
+                while let Some(key) = map.next_key::<String>()? {
+                    if !seen.insert(key.clone()) {
+                        return Err(de::Error::custom(format!("duplicate field `{key}`")));
+                    }
+                    if key == "class" {
+                        class = Some(map.next_value()?);
+                    } else {
+                        let v: JsonValue = map.next_value()?;
+                        entries.push((key, v));
+                    }
+                }
+
+                let class = class.ok_or_else(|| de::Error::missing_field("class"))?;
+                let known = class_keys(&class);
+
+                let mut shared_map: JsonMap<String, JsonValue> = JsonMap::new();
+                let mut class_map: JsonMap<String, JsonValue> = JsonMap::new();
+
+                for (k, v) in entries {
+                    if SHARED_KEYS.contains(&k.as_str()) {
+                        shared_map.insert(k, v);
+                    } else if let Some(keys) = known {
+                        if keys.contains(&k.as_str()) {
+                            class_map.insert(k, v);
+                        } else {
+                            return Err(de::Error::custom(format!(
+                                "unknown field `{k}` for class `{class}`; \
+                                 known shared fields: {SHARED_KEYS:?}, \
+                                 known fields for this class: {keys:?}"
+                            )));
+                        }
+                    } else {
+                        // Unknown class — capture verbatim.
+                        class_map.insert(k, v);
+                    }
+                }
+
+                let shared: SharedFields = serde_json::from_value(JsonValue::Object(shared_map))
+                    .map_err(de::Error::custom)?;
+
+                let extension = match class.as_str() {
+                    "monograph" => {
+                        let f: MonographFields =
+                            serde_json::from_value(JsonValue::Object(class_map)).map_err(|e| {
+                                de::Error::custom(format!("class `monograph`: {e}"))
+                            })?;
+                        ClassExtension::Monograph(f)
+                    }
+                    "legal-case" => {
+                        let f: LegalCaseFields =
+                            serde_json::from_value(JsonValue::Object(class_map)).map_err(|e| {
+                                de::Error::custom(format!("class `legal-case`: {e}"))
+                            })?;
+                        ClassExtension::LegalCase(f)
+                    }
+                    "audio-visual" => {
+                        let f: AudioVisualFields =
+                            serde_json::from_value(JsonValue::Object(class_map)).map_err(|e| {
+                                de::Error::custom(format!("class `audio-visual`: {e}"))
+                            })?;
+                        ClassExtension::AudioVisual(f)
+                    }
+                    other => ClassExtension::Unknown(UnknownClassData {
+                        class: other.to_string(),
+                        fields: class_map,
+                    }),
+                };
+
+                Ok(InputReference {
+                    id: shared.id,
+                    title: shared.title,
+                    contributors: shared.contributors,
+                    issued: shared.issued,
+                    created: shared.created,
+                    note: shared.note,
+                    extension,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(RefVisitor)
+    }
+}
+
+// ---------------- Hand-written Serialize ----------------
+
+impl Serialize for InputReference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let class_str = match &self.extension {
+            ClassExtension::Monograph(_) => "monograph",
+            ClassExtension::LegalCase(_) => "legal-case",
+            ClassExtension::AudioVisual(_) => "audio-visual",
+            ClassExtension::Unknown(u) => &u.class,
+        };
+
+        // Materialize the class-specific fields as a JSON object so we can
+        // iterate without committing to an entry count up front.
+        let class_value = match &self.extension {
+            ClassExtension::Monograph(f) => serde_json::to_value(f),
+            ClassExtension::LegalCase(f) => serde_json::to_value(f),
+            ClassExtension::AudioVisual(f) => serde_json::to_value(f),
+            ClassExtension::Unknown(u) => Ok(JsonValue::Object(u.fields.clone())),
+        }
+        .map_err(serde::ser::Error::custom)?;
+        let class_map = match class_value {
+            JsonValue::Object(m) => m,
+            JsonValue::Null => JsonMap::new(),
+            _ => {
+                return Err(serde::ser::Error::custom(
+                    "class-specific fields did not serialize as an object",
+                ));
+            }
+        };
+
+        let mut total = 2 + class_map.len();
+        if self.title.is_some() {
+            total += 1;
+        }
+        if self.contributors.is_some() {
+            total += 1;
+        }
+        if self.issued.is_some() {
+            total += 1;
+        }
+        if self.created.is_some() {
+            total += 1;
+        }
+        if self.note.is_some() {
+            total += 1;
+        }
+
+        let mut out = serializer.serialize_map(Some(total))?;
+        out.serialize_entry("id", &self.id)?;
+        out.serialize_entry("class", class_str)?;
+        if let Some(t) = &self.title {
+            out.serialize_entry("title", t)?;
+        }
+        if let Some(c) = &self.contributors {
+            out.serialize_entry("contributors", c)?;
+        }
+        if let Some(i) = &self.issued {
+            out.serialize_entry("issued", i)?;
+        }
+        if let Some(c) = &self.created {
+            out.serialize_entry("created", c)?;
+        }
+        if let Some(n) = &self.note {
+            out.serialize_entry("note", n)?;
+        }
+        for (k, v) in &class_map {
+            out.serialize_entry(k, v)?;
+        }
+        out.end()
+    }
+}
+
+// ---------------- Tests ----------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable in tests."
+)]
+mod tests {
+    use super::*;
+
+    fn parse(yaml: &str) -> Result<InputReference, serde_yaml::Error> {
+        serde_yaml::from_str(yaml)
+    }
+
+    #[test]
+    fn valid_monograph_parses() {
+        let yaml = r#"
+id: smith2026
+class: monograph
+title: A Book
+issued: "2026"
+monograph-type: book
+volume: "2"
+"#;
+        let r = parse(yaml).unwrap();
+        assert_eq!(r.id.as_str(), "smith2026");
+        assert!(matches!(r.class(), ReferenceClass::Monograph));
+        let m = r.as_monograph().unwrap();
+        assert_eq!(m.monograph_type.as_deref(), Some("book"));
+        assert_eq!(m.volume.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn known_class_with_no_class_specific_fields() {
+        let yaml = r#"
+id: smith2026
+class: legal-case
+title: Smith v. Jones
+"#;
+        let r = parse(yaml).unwrap();
+        assert!(matches!(r.class(), ReferenceClass::LegalCase));
+        let c = r.as_legal_case().unwrap();
+        assert!(c.court.is_none());
+        assert!(c.docket_number.is_none());
+    }
+
+    #[test]
+    fn typo_in_shared_field_rejected() {
+        let yaml = r#"
+id: smith2026
+class: monograph
+titel: A Book
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("titel"),
+            "expected unknown-field error mentioning `titel`, got: {err}"
+        );
+    }
+
+    #[test]
+    fn typo_in_class_specific_field_rejected() {
+        let yaml = r#"
+id: smith2026
+class: monograph
+title: A Book
+monogarph-type: book
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("monogarph") && err.contains("monograph"),
+            "expected scope-correct unknown-field error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn class_specific_field_under_wrong_class_rejected() {
+        let yaml = r#"
+id: smith2026
+class: legal-case
+title: Smith v. Jones
+monograph-type: book
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("monograph-type") && err.contains("legal-case"),
+            "expected wrong-class error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_class_round_trips() {
+        let yaml = r#"
+id: perf2026
+class: dance-performance
+title: Pina
+issued: "2011"
+venue: Berlin
+duration-minutes: 103
+"#;
+        let r = parse(yaml).unwrap();
+        let u = r.unknown_class().unwrap();
+        assert_eq!(u.class, "dance-performance");
+        assert_eq!(u.fields.len(), 2);
+        assert!(u.fields.contains_key("venue"));
+
+        let reserialized = serde_yaml::to_string(&r).unwrap();
+        let r2 = parse(&reserialized).unwrap();
+        assert_eq!(r, r2);
+    }
+
+    #[test]
+    fn typo_in_class_value_captured_as_unknown() {
+        let yaml = r#"
+id: smith2026
+class: monogarph
+title: A Book
+monograph-type: book
+"#;
+        let r = parse(yaml).unwrap();
+        let u = r.unknown_class().unwrap();
+        assert_eq!(u.class, "monogarph");
+    }
+
+    #[test]
+    fn known_class_round_trip() {
+        let original = InputReference {
+            id: RefID("av2026".to_string()),
+            title: Some(Title::Single("Pina".to_string())),
+            contributors: None,
+            issued: Some(EdtfString("2011".to_string())),
+            created: None,
+            note: None,
+            extension: ClassExtension::AudioVisual(AudioVisualFields {
+                runtime_minutes: Some(103),
+                medium: Some("film".into()),
+            }),
+        };
+        let yaml = serde_yaml::to_string(&original).unwrap();
+        assert!(
+            !yaml.contains("class_data"),
+            "wire shape must be flat: {yaml}"
+        );
+        assert!(
+            !yaml.contains("extension:"),
+            "wire shape must be flat: {yaml}"
+        );
+        let round = parse(&yaml).unwrap();
+        assert_eq!(original, round);
+    }
+}

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -12,6 +12,8 @@ pub mod conversion;
 pub mod date;
 pub mod types;
 
+use std::sync::LazyLock;
+
 #[cfg(all(test, feature = "legacy-convert"))]
 #[allow(
     clippy::unwrap_used,
@@ -47,10 +49,20 @@ pub use self::types::structural::{
 
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::de::{self, MapAccess, Visitor};
+use serde::ser::SerializeMap as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 #[cfg(feature = "bindings")]
 use specta::Type;
 use url::Url;
+
+/// Empty field-language map returned by accessors on unknown-class references.
+///
+/// `FieldLanguageMap` is a `HashMap`, whose `::new()` is not `const`, so a
+/// `LazyLock` is required. The map is constructed once for the process and
+/// reused by every unknown-class reference.
+static EMPTY_FIELD_LANGUAGES: LazyLock<FieldLanguageMap> = LazyLock::new(FieldLanguageMap::new);
 
 /// A relation to another bibliographic entity.
 ///
@@ -67,61 +79,870 @@ pub enum WorkRelation {
     Embedded(Box<InputReference>),
 }
 
-/// The Reference model.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+/// The Reference model: a class-specific overlay reachable through accessor methods.
+///
+/// All shared bibliographic data (id, title, contributors, dates, publisher, ...)
+/// lives inside the class-specific payload in `extension`. The accessor methods
+/// (`id()`, `title()`, etc.) dispatch through the extension and are the public
+/// read path; the typed setters (`set_id`, ...) are the public mutation path.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "bindings", derive(Type))]
+pub struct InputReference {
+    pub(crate) extension: ClassExtension,
+}
+
+/// Unknown reference-class payload captured by the discriminator dispatcher.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(tag = "class", rename_all = "kebab-case")]
-pub enum InputReference {
-    /// A monograph, such as a book or a report, is a monolithic work published or produced as a complete entity.
-    Monograph(Box<Monograph>),
-    /// A component of a larger Monograph, such as a chapter in a book.
-    /// The parent monograph is referenced by its ID.
-    CollectionComponent(Box<CollectionComponent>),
-    /// A component of a larger serial publication; for example a journal or newspaper article.
-    /// The parent serial is referenced by its ID.
-    SerialComponent(Box<SerialComponent>),
+pub struct UnknownClassData {
+    /// Raw `class:` string from the input object.
+    pub class: String,
+    /// Non-shared fields captured verbatim for round-trip preservation.
+    #[cfg_attr(feature = "bindings", specta(type = serde_json::Value))]
+    pub fields: JsonMap<String, JsonValue>,
+}
+
+/// Typed class discriminator returned by [`InputReference::class`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "bindings", derive(Type))]
+#[serde(rename_all = "kebab-case")]
+pub enum ReferenceClass {
+    /// A monograph, such as a book or report.
+    Monograph,
+    /// A component of a larger monographic collection.
+    CollectionComponent,
+    /// A component of a larger serial publication.
+    SerialComponent,
     /// A collection of works, such as an anthology or proceedings.
-    Collection(Box<Collection>),
-    /// A serial publication (journal, magazine, etc.).
-    Serial(Box<Serial>),
-    /// A legal case (court decision).
-    LegalCase(Box<LegalCase>),
+    Collection,
+    /// A serial publication, such as a journal or newspaper.
+    Serial,
+    /// A legal case.
+    LegalCase,
     /// A statute or legislative act.
-    Statute(Box<Statute>),
+    Statute,
     /// An international treaty or agreement.
-    Treaty(Box<Treaty>),
+    Treaty,
     /// A legislative or administrative hearing.
-    Hearing(Box<Hearing>),
+    Hearing,
     /// An administrative regulation.
-    Regulation(Box<Regulation>),
+    Regulation,
     /// A legal brief or filing.
-    Brief(Box<Brief>),
+    Brief,
     /// A classic work with standard citation forms.
-    Classic(Box<Classic>),
+    Classic,
     /// A patent.
-    Patent(Box<Patent>),
+    Patent,
     /// A research dataset.
-    Dataset(Box<Dataset>),
+    Dataset,
     /// A technical standard or specification.
-    Standard(Box<Standard>),
+    Standard,
     /// Software or source code.
-    Software(Box<Software>),
+    Software,
     /// An event such as a conference, performance, or broadcast.
+    Event,
+    /// An audio-visual work.
+    AudioVisual,
+    /// A class string not known by this version.
+    ///
+    /// `#[serde(skip)]`: an `Unknown(...)` variant cannot serialize directly
+    /// through the derived `Serialize` impl on `ReferenceClass`. The class
+    /// string is preserved on the wire via [`UnknownClassData::class`] inside
+    /// the surrounding `InputReference`, not via this enum standalone.
+    #[serde(skip)]
+    Unknown(String),
+}
+
+impl ReferenceClass {
+    /// Known class names in their wire-format spelling.
+    pub const KNOWN: &'static [&'static str] = &[
+        "monograph",
+        "collection-component",
+        "serial-component",
+        "collection",
+        "serial",
+        "legal-case",
+        "statute",
+        "treaty",
+        "hearing",
+        "regulation",
+        "brief",
+        "classic",
+        "patent",
+        "dataset",
+        "standard",
+        "software",
+        "event",
+        "audio-visual",
+    ];
+}
+
+/// Class-specific overlay stored inside [`InputReference`].
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "bindings", derive(Type))]
+pub enum ClassExtension {
+    /// Monograph-specific payload.
+    Monograph(Box<Monograph>),
+    /// Collection-component-specific payload.
+    CollectionComponent(Box<CollectionComponent>),
+    /// Serial-component-specific payload.
+    SerialComponent(Box<SerialComponent>),
+    /// Collection-specific payload.
+    Collection(Box<Collection>),
+    /// Serial-specific payload.
+    Serial(Box<Serial>),
+    /// Legal-case-specific payload.
+    LegalCase(Box<LegalCase>),
+    /// Statute-specific payload.
+    Statute(Box<Statute>),
+    /// Treaty-specific payload.
+    Treaty(Box<Treaty>),
+    /// Hearing-specific payload.
+    Hearing(Box<Hearing>),
+    /// Regulation-specific payload.
+    Regulation(Box<Regulation>),
+    /// Brief-specific payload.
+    Brief(Box<Brief>),
+    /// Classic-work-specific payload.
+    Classic(Box<Classic>),
+    /// Patent-specific payload.
+    Patent(Box<Patent>),
+    /// Dataset-specific payload.
+    Dataset(Box<Dataset>),
+    /// Standard-specific payload.
+    Standard(Box<Standard>),
+    /// Software-specific payload.
+    Software(Box<Software>),
+    /// Event-specific payload.
     Event(Box<Event>),
-    /// An audio-visual work: film, TV episode, recording, or broadcast.
+    /// Audio-visual-specific payload.
     AudioVisual(Box<AudioVisualWork>),
+    /// Unknown-class payload.
+    Unknown(Box<UnknownClassData>),
+}
+
+macro_rules! boxed_reference_constructor {
+    ($fn_name:ident, $ty:ty, $variant:ident) => {
+        fn $fn_name(reference: Box<$ty>) -> Self {
+            Self {
+                extension: ClassExtension::$variant(reference),
+            }
+        }
+    };
 }
 
 impl InputReference {
+    fn from_known<T>(
+        class_extension: impl FnOnce(Box<T>) -> ClassExtension,
+        value: JsonValue,
+    ) -> Result<Self, serde_json::Error>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        // Defensive: the dispatcher in `deserialize_reference_body` only ever
+        // hands us a `JsonValue::Object`; reject anything else with a schema
+        // error rather than letting `from_value` produce an opaque type error.
+        if !matches!(&value, JsonValue::Object(_)) {
+            return Err(<serde_json::Error as serde::de::Error>::custom(
+                "reference body must be a JSON object",
+            ));
+        }
+        let inner = serde_json::from_value(value)?;
+        Ok(Self {
+            extension: class_extension(Box::new(inner)),
+        })
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Transitional PascalCase constructors.
+    //
+    // These exist to keep call sites that used to construct an `InputReference`
+    // enum variant working unchanged through the discriminator cutover
+    // (bean: csl26-1bdr). They are NOT the long-term public surface and
+    // SHOULD NOT be relied upon by new code — use a `Box::new(<Class> { … })`
+    // value plus a future snake_case factory once one is exposed.
+    //
+    // TODO(csl26-1bdr): replace these 19 functions with idiomatic snake_case
+    // constructors and drop the transitional set. Tracked by parent epic.
+    // ────────────────────────────────────────────────────────────────────
+
+    /// Construct a monograph reference (transitional; see block note above).
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Monograph(reference: Box<Monograph>) -> Self {
+        Self::from_boxed_monograph(reference)
+    }
+
+    /// Construct a collection-component reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn CollectionComponent(reference: Box<CollectionComponent>) -> Self {
+        Self::from_boxed_collection_component(reference)
+    }
+
+    /// Construct a serial-component reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn SerialComponent(reference: Box<SerialComponent>) -> Self {
+        Self::from_boxed_serial_component(reference)
+    }
+
+    /// Construct a collection reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Collection(reference: Box<Collection>) -> Self {
+        Self::from_boxed_collection(reference)
+    }
+
+    /// Construct a serial reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Serial(reference: Box<Serial>) -> Self {
+        Self::from_boxed_serial(reference)
+    }
+
+    /// Construct a legal-case reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn LegalCase(reference: Box<LegalCase>) -> Self {
+        Self::from_boxed_legal_case(reference)
+    }
+
+    /// Construct a statute reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Statute(reference: Box<Statute>) -> Self {
+        Self::from_boxed_statute(reference)
+    }
+
+    /// Construct a treaty reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Treaty(reference: Box<Treaty>) -> Self {
+        Self::from_boxed_treaty(reference)
+    }
+
+    /// Construct a hearing reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Hearing(reference: Box<Hearing>) -> Self {
+        Self::from_boxed_hearing(reference)
+    }
+
+    /// Construct a regulation reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Regulation(reference: Box<Regulation>) -> Self {
+        Self::from_boxed_regulation(reference)
+    }
+
+    /// Construct a brief reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Brief(reference: Box<Brief>) -> Self {
+        Self::from_boxed_brief(reference)
+    }
+
+    /// Construct a classic reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Classic(reference: Box<Classic>) -> Self {
+        Self::from_boxed_classic(reference)
+    }
+
+    /// Construct a patent reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Patent(reference: Box<Patent>) -> Self {
+        Self::from_boxed_patent(reference)
+    }
+
+    /// Construct a dataset reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Dataset(reference: Box<Dataset>) -> Self {
+        Self::from_boxed_dataset(reference)
+    }
+
+    /// Construct a standard reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Standard(reference: Box<Standard>) -> Self {
+        Self::from_boxed_standard(reference)
+    }
+
+    /// Construct a software reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Software(reference: Box<Software>) -> Self {
+        Self::from_boxed_software(reference)
+    }
+
+    /// Construct an event reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Event(reference: Box<Event>) -> Self {
+        Self::from_boxed_event(reference)
+    }
+
+    /// Construct an audio-visual reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn AudioVisual(reference: Box<AudioVisualWork>) -> Self {
+        Self::from_boxed_audio_visual(reference)
+    }
+
+    /// Construct an unknown-class reference.
+    #[allow(non_snake_case, reason = "Transitional compatibility constructor")]
+    #[must_use]
+    pub fn Unknown(reference: Box<UnknownClassData>) -> Self {
+        Self {
+            extension: ClassExtension::Unknown(reference),
+        }
+    }
+
+    boxed_reference_constructor!(from_boxed_monograph, Monograph, Monograph);
+    boxed_reference_constructor!(
+        from_boxed_collection_component,
+        CollectionComponent,
+        CollectionComponent
+    );
+    boxed_reference_constructor!(
+        from_boxed_serial_component,
+        SerialComponent,
+        SerialComponent
+    );
+    boxed_reference_constructor!(from_boxed_collection, Collection, Collection);
+    boxed_reference_constructor!(from_boxed_serial, Serial, Serial);
+    boxed_reference_constructor!(from_boxed_legal_case, LegalCase, LegalCase);
+    boxed_reference_constructor!(from_boxed_statute, Statute, Statute);
+    boxed_reference_constructor!(from_boxed_treaty, Treaty, Treaty);
+    boxed_reference_constructor!(from_boxed_hearing, Hearing, Hearing);
+    boxed_reference_constructor!(from_boxed_regulation, Regulation, Regulation);
+    boxed_reference_constructor!(from_boxed_brief, Brief, Brief);
+    boxed_reference_constructor!(from_boxed_classic, Classic, Classic);
+    boxed_reference_constructor!(from_boxed_patent, Patent, Patent);
+    boxed_reference_constructor!(from_boxed_dataset, Dataset, Dataset);
+    boxed_reference_constructor!(from_boxed_standard, Standard, Standard);
+    boxed_reference_constructor!(from_boxed_software, Software, Software);
+    boxed_reference_constructor!(from_boxed_event, Event, Event);
+    boxed_reference_constructor!(from_boxed_audio_visual, AudioVisualWork, AudioVisual);
+}
+
+/// Produce a serde duplicate-field error with the canonical
+/// `duplicate field \`<name>\`` shape.
+///
+/// `serde::de::Error::duplicate_field` requires `&'static str`; our keys are
+/// dynamic, so we route through `custom` while preserving the exact message
+/// format that `duplicate_field` would emit. Downstream consumers matching
+/// on the `Display` output see identical text.
+fn duplicate_field_error<E: de::Error>(field: &str) -> E {
+    de::Error::custom(format_args!("duplicate field `{field}`"))
+}
+
+impl<'de> Deserialize<'de> for InputReference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ReferenceVisitor;
+
+        impl<'de> Visitor<'de> for ReferenceVisitor {
+            type Value = InputReference;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a flat reference object with a `class` discriminator")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut class = None;
+                let mut body = JsonMap::new();
+
+                while let Some(key) = map.next_key::<String>()? {
+                    if key == "class" {
+                        if class.is_some() {
+                            // Canonical serde duplicate-field error; matches the
+                            // shape that `de::Error::duplicate_field` would emit
+                            // for the dynamic-name path below.
+                            return Err(duplicate_field_error::<M::Error>("class"));
+                        }
+                        class = Some(map.next_value::<String>()?);
+                    } else {
+                        let value = map.next_value::<JsonValue>()?;
+                        if body.insert(key.clone(), value).is_some() {
+                            return Err(duplicate_field_error::<M::Error>(&key));
+                        }
+                    }
+                }
+
+                let class = class.ok_or_else(|| de::Error::missing_field("class"))?;
+                deserialize_reference_body(&class, body).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_map(ReferenceVisitor)
+    }
+}
+
+/// Flat-with-class serialization proxy: prepends a `class` field and flattens
+/// the typed payload directly through the serializer. Avoids the
+/// `serde_json::to_value` round-trip that the previous implementation used
+/// to compute the body map.
+#[derive(Serialize)]
+struct FlatClassProxy<'a, T: Serialize + ?Sized> {
+    class: &'a str,
+    #[serde(flatten)]
+    inner: &'a T,
+}
+
+impl Serialize for InputReference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // For known classes we let serde's `flatten` machinery splat the
+        // typed inner struct directly into the parent serializer — no
+        // intermediate `serde_json::Value` allocation per reference. For
+        // `Unknown`, the payload is already a `JsonMap`, so we walk it
+        // directly.
+        match &self.extension {
+            ClassExtension::Monograph(inner) => FlatClassProxy {
+                class: "monograph",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::CollectionComponent(inner) => FlatClassProxy {
+                class: "collection-component",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::SerialComponent(inner) => FlatClassProxy {
+                class: "serial-component",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Collection(inner) => FlatClassProxy {
+                class: "collection",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Serial(inner) => FlatClassProxy {
+                class: "serial",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::LegalCase(inner) => FlatClassProxy {
+                class: "legal-case",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Statute(inner) => FlatClassProxy {
+                class: "statute",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Treaty(inner) => FlatClassProxy {
+                class: "treaty",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Hearing(inner) => FlatClassProxy {
+                class: "hearing",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Regulation(inner) => FlatClassProxy {
+                class: "regulation",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Brief(inner) => FlatClassProxy {
+                class: "brief",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Classic(inner) => FlatClassProxy {
+                class: "classic",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Patent(inner) => FlatClassProxy {
+                class: "patent",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Dataset(inner) => FlatClassProxy {
+                class: "dataset",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Standard(inner) => FlatClassProxy {
+                class: "standard",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Software(inner) => FlatClassProxy {
+                class: "software",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Event(inner) => FlatClassProxy {
+                class: "event",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::AudioVisual(inner) => FlatClassProxy {
+                class: "audio-visual",
+                inner: inner.as_ref(),
+            }
+            .serialize(serializer),
+            ClassExtension::Unknown(data) => {
+                let mut out = serializer.serialize_map(Some(data.fields.len() + 1))?;
+                out.serialize_entry("class", &data.class)?;
+                for (key, value) in &data.fields {
+                    out.serialize_entry(key, value)?;
+                }
+                out.end()
+            }
+        }
+    }
+}
+
+#[cfg(feature = "schema")]
+impl JsonSchema for InputReference {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "InputReference".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let variants = [
+            reference_schema_branch::<Monograph>(generator, "monograph"),
+            reference_schema_branch::<CollectionComponent>(generator, "collection-component"),
+            reference_schema_branch::<SerialComponent>(generator, "serial-component"),
+            reference_schema_branch::<Collection>(generator, "collection"),
+            reference_schema_branch::<Serial>(generator, "serial"),
+            reference_schema_branch::<LegalCase>(generator, "legal-case"),
+            reference_schema_branch::<Statute>(generator, "statute"),
+            reference_schema_branch::<Treaty>(generator, "treaty"),
+            reference_schema_branch::<Hearing>(generator, "hearing"),
+            reference_schema_branch::<Regulation>(generator, "regulation"),
+            reference_schema_branch::<Brief>(generator, "brief"),
+            reference_schema_branch::<Classic>(generator, "classic"),
+            reference_schema_branch::<Patent>(generator, "patent"),
+            reference_schema_branch::<Dataset>(generator, "dataset"),
+            reference_schema_branch::<Standard>(generator, "standard"),
+            reference_schema_branch::<Software>(generator, "software"),
+            reference_schema_branch::<Event>(generator, "event"),
+            reference_schema_branch::<AudioVisualWork>(generator, "audio-visual"),
+        ];
+
+        schemars::json_schema!({
+            "oneOf": variants,
+            "unevaluatedProperties": false
+        })
+    }
+}
+
+#[cfg(feature = "schema")]
+fn reference_schema_branch<T: JsonSchema>(
+    generator: &mut schemars::SchemaGenerator,
+    class: &'static str,
+) -> JsonValue {
+    let mut schema = T::json_schema(generator);
+    let object = schema.ensure_object();
+    if !object.get("properties").is_some_and(JsonValue::is_object) {
+        object.insert("properties".to_string(), JsonValue::Object(JsonMap::new()));
+    }
+    let Some(properties) = object
+        .get_mut("properties")
+        .and_then(JsonValue::as_object_mut)
+    else {
+        return schema.to_value();
+    };
+    properties.insert(
+        "class".to_string(),
+        serde_json::json!({
+            "type": "string",
+            "const": class
+        }),
+    );
+
+    if !object.get("required").is_some_and(JsonValue::is_array) {
+        object.insert("required".to_string(), JsonValue::Array(Vec::new()));
+    }
+    let Some(required) = object.get_mut("required").and_then(JsonValue::as_array_mut) else {
+        return schema.to_value();
+    };
+    if !required.iter().any(|value| value.as_str() == Some("class")) {
+        required.push(JsonValue::String("class".to_string()));
+    }
+
+    schema.to_value()
+}
+
+fn deserialize_reference_body(
+    class: &str,
+    body: JsonMap<String, JsonValue>,
+) -> Result<InputReference, serde_json::Error> {
+    let value = JsonValue::Object(body);
+    match class {
+        "monograph" => InputReference::from_known(ClassExtension::Monograph, value),
+        "collection-component" => {
+            InputReference::from_known(ClassExtension::CollectionComponent, value)
+        }
+        "serial-component" => InputReference::from_known(ClassExtension::SerialComponent, value),
+        "collection" => InputReference::from_known(ClassExtension::Collection, value),
+        "serial" => InputReference::from_known(ClassExtension::Serial, value),
+        "legal-case" => InputReference::from_known(ClassExtension::LegalCase, value),
+        "statute" => InputReference::from_known(ClassExtension::Statute, value),
+        "treaty" => InputReference::from_known(ClassExtension::Treaty, value),
+        "hearing" => InputReference::from_known(ClassExtension::Hearing, value),
+        "regulation" => InputReference::from_known(ClassExtension::Regulation, value),
+        "brief" => InputReference::from_known(ClassExtension::Brief, value),
+        "classic" => InputReference::from_known(ClassExtension::Classic, value),
+        "patent" => InputReference::from_known(ClassExtension::Patent, value),
+        "dataset" => InputReference::from_known(ClassExtension::Dataset, value),
+        "standard" => InputReference::from_known(ClassExtension::Standard, value),
+        "software" => InputReference::from_known(ClassExtension::Software, value),
+        "event" => InputReference::from_known(ClassExtension::Event, value),
+        "audio-visual" => InputReference::from_known(ClassExtension::AudioVisual, value),
+        other => {
+            let fields = if let JsonValue::Object(fields) = value {
+                fields
+            } else {
+                JsonMap::new()
+            };
+            Ok(InputReference::Unknown(Box::new(UnknownClassData {
+                class: other.to_string(),
+                fields,
+            })))
+        }
+    }
+}
+
+impl InputReference {
+    /// Return the typed class discriminator.
+    #[must_use]
+    pub fn class(&self) -> ReferenceClass {
+        match &self.extension {
+            ClassExtension::Monograph(_) => ReferenceClass::Monograph,
+            ClassExtension::CollectionComponent(_) => ReferenceClass::CollectionComponent,
+            ClassExtension::SerialComponent(_) => ReferenceClass::SerialComponent,
+            ClassExtension::Collection(_) => ReferenceClass::Collection,
+            ClassExtension::Serial(_) => ReferenceClass::Serial,
+            ClassExtension::LegalCase(_) => ReferenceClass::LegalCase,
+            ClassExtension::Statute(_) => ReferenceClass::Statute,
+            ClassExtension::Treaty(_) => ReferenceClass::Treaty,
+            ClassExtension::Hearing(_) => ReferenceClass::Hearing,
+            ClassExtension::Regulation(_) => ReferenceClass::Regulation,
+            ClassExtension::Brief(_) => ReferenceClass::Brief,
+            ClassExtension::Classic(_) => ReferenceClass::Classic,
+            ClassExtension::Patent(_) => ReferenceClass::Patent,
+            ClassExtension::Dataset(_) => ReferenceClass::Dataset,
+            ClassExtension::Standard(_) => ReferenceClass::Standard,
+            ClassExtension::Software(_) => ReferenceClass::Software,
+            ClassExtension::Event(_) => ReferenceClass::Event,
+            ClassExtension::AudioVisual(_) => ReferenceClass::AudioVisual,
+            ClassExtension::Unknown(data) => ReferenceClass::Unknown(data.class.clone()),
+        }
+    }
+
+    /// Return the active class-specific overlay.
+    #[must_use]
+    pub fn extension(&self) -> &ClassExtension {
+        &self.extension
+    }
+
+    /// Return the mutable active class-specific overlay.
+    #[must_use]
+    pub fn extension_mut(&mut self) -> &mut ClassExtension {
+        &mut self.extension
+    }
+
+    /// Return monograph data when this reference is a monograph.
+    #[must_use]
+    pub fn as_monograph(&self) -> Option<&Monograph> {
+        match &self.extension {
+            ClassExtension::Monograph(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return collection-component data when this reference is a collection component.
+    #[must_use]
+    pub fn as_collection_component(&self) -> Option<&CollectionComponent> {
+        match &self.extension {
+            ClassExtension::CollectionComponent(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return serial-component data when this reference is a serial component.
+    #[must_use]
+    pub fn as_serial_component(&self) -> Option<&SerialComponent> {
+        match &self.extension {
+            ClassExtension::SerialComponent(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return collection data when this reference is a collection.
+    #[must_use]
+    pub fn as_collection(&self) -> Option<&Collection> {
+        match &self.extension {
+            ClassExtension::Collection(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return serial data when this reference is a serial.
+    #[must_use]
+    pub fn as_serial(&self) -> Option<&Serial> {
+        match &self.extension {
+            ClassExtension::Serial(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return legal-case data when this reference is a legal case.
+    #[must_use]
+    pub fn as_legal_case(&self) -> Option<&LegalCase> {
+        match &self.extension {
+            ClassExtension::LegalCase(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return statute data when this reference is a statute.
+    #[must_use]
+    pub fn as_statute(&self) -> Option<&Statute> {
+        match &self.extension {
+            ClassExtension::Statute(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return treaty data when this reference is a treaty.
+    #[must_use]
+    pub fn as_treaty(&self) -> Option<&Treaty> {
+        match &self.extension {
+            ClassExtension::Treaty(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return hearing data when this reference is a hearing.
+    #[must_use]
+    pub fn as_hearing(&self) -> Option<&Hearing> {
+        match &self.extension {
+            ClassExtension::Hearing(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return regulation data when this reference is a regulation.
+    #[must_use]
+    pub fn as_regulation(&self) -> Option<&Regulation> {
+        match &self.extension {
+            ClassExtension::Regulation(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return brief data when this reference is a brief.
+    #[must_use]
+    pub fn as_brief(&self) -> Option<&Brief> {
+        match &self.extension {
+            ClassExtension::Brief(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return classic-work data when this reference is a classic.
+    #[must_use]
+    pub fn as_classic(&self) -> Option<&Classic> {
+        match &self.extension {
+            ClassExtension::Classic(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return patent data when this reference is a patent.
+    #[must_use]
+    pub fn as_patent(&self) -> Option<&Patent> {
+        match &self.extension {
+            ClassExtension::Patent(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return dataset data when this reference is a dataset.
+    #[must_use]
+    pub fn as_dataset(&self) -> Option<&Dataset> {
+        match &self.extension {
+            ClassExtension::Dataset(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return standard data when this reference is a standard.
+    #[must_use]
+    pub fn as_standard(&self) -> Option<&Standard> {
+        match &self.extension {
+            ClassExtension::Standard(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return software data when this reference is software.
+    #[must_use]
+    pub fn as_software(&self) -> Option<&Software> {
+        match &self.extension {
+            ClassExtension::Software(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return event data when this reference is an event.
+    #[must_use]
+    pub fn as_event(&self) -> Option<&Event> {
+        match &self.extension {
+            ClassExtension::Event(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return audio-visual data when this reference is audio-visual.
+    #[must_use]
+    pub fn as_audio_visual(&self) -> Option<&AudioVisualWork> {
+        match &self.extension {
+            ClassExtension::AudioVisual(reference) => Some(reference.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Return unknown-class data when this reference names an unknown class.
+    #[must_use]
+    pub fn unknown_class(&self) -> Option<&UnknownClassData> {
+        match &self.extension {
+            ClassExtension::Unknown(data) => Some(data),
+            _ => None,
+        }
+    }
+
     fn numbered(&self) -> Option<&dyn HasNumbering> {
-        match self {
-            InputReference::Monograph(reference) => Some(reference.as_ref()),
-            InputReference::Collection(reference) => Some(reference.as_ref()),
-            InputReference::CollectionComponent(reference) => Some(reference.as_ref()),
-            InputReference::SerialComponent(reference) => Some(reference.as_ref()),
-            InputReference::Classic(reference) => Some(reference.as_ref()),
-            InputReference::AudioVisual(reference) => Some(reference.as_ref()),
+        match &self.extension {
+            ClassExtension::Monograph(reference) => Some(reference.as_ref()),
+            ClassExtension::Collection(reference) => Some(reference.as_ref()),
+            ClassExtension::CollectionComponent(reference) => Some(reference.as_ref()),
+            ClassExtension::SerialComponent(reference) => Some(reference.as_ref()),
+            ClassExtension::Classic(reference) => Some(reference.as_ref()),
+            ClassExtension::AudioVisual(reference) => Some(reference.as_ref()),
             _ => None,
         }
     }
@@ -139,25 +960,30 @@ impl InputReference {
 
     /// Return the reference ID.
     pub fn id(&self) -> Option<RefID> {
-        match self {
-            InputReference::Monograph(r) => r.id.clone(),
-            InputReference::CollectionComponent(r) => r.id.clone(),
-            InputReference::SerialComponent(r) => r.id.clone(),
-            InputReference::Collection(r) => r.id.clone(),
-            InputReference::Serial(r) => r.id.clone(),
-            InputReference::LegalCase(r) => r.id.clone(),
-            InputReference::Statute(r) => r.id.clone(),
-            InputReference::Treaty(r) => r.id.clone(),
-            InputReference::Hearing(r) => r.id.clone(),
-            InputReference::Regulation(r) => r.id.clone(),
-            InputReference::Brief(r) => r.id.clone(),
-            InputReference::Classic(r) => r.id.clone(),
-            InputReference::Patent(r) => r.id.clone(),
-            InputReference::Dataset(r) => r.id.clone(),
-            InputReference::Standard(r) => r.id.clone(),
-            InputReference::Software(r) => r.id.clone(),
-            InputReference::Event(r) => r.id.clone(),
-            InputReference::AudioVisual(r) => r.id.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.id.clone(),
+            ClassExtension::CollectionComponent(r) => r.id.clone(),
+            ClassExtension::SerialComponent(r) => r.id.clone(),
+            ClassExtension::Collection(r) => r.id.clone(),
+            ClassExtension::Serial(r) => r.id.clone(),
+            ClassExtension::LegalCase(r) => r.id.clone(),
+            ClassExtension::Statute(r) => r.id.clone(),
+            ClassExtension::Treaty(r) => r.id.clone(),
+            ClassExtension::Hearing(r) => r.id.clone(),
+            ClassExtension::Regulation(r) => r.id.clone(),
+            ClassExtension::Brief(r) => r.id.clone(),
+            ClassExtension::Classic(r) => r.id.clone(),
+            ClassExtension::Patent(r) => r.id.clone(),
+            ClassExtension::Dataset(r) => r.id.clone(),
+            ClassExtension::Standard(r) => r.id.clone(),
+            ClassExtension::Software(r) => r.id.clone(),
+            ClassExtension::Event(r) => r.id.clone(),
+            ClassExtension::AudioVisual(r) => r.id.clone(),
+            ClassExtension::Unknown(data) => data
+                .fields
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .map(|id| RefID(id.to_string())),
         }
     }
 
@@ -165,16 +991,16 @@ impl InputReference {
     pub fn author(&self) -> Option<Contributor> {
         use crate::reference::contributor::ContributorRole as DataRole;
 
-        match self {
-            InputReference::Monograph(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => {
                 collect_contributors_by_role(&r.contributors, &DataRole::Author)
                     .or_else(|| r.author.clone())
             }
-            InputReference::CollectionComponent(r) => {
+            ClassExtension::CollectionComponent(r) => {
                 collect_contributors_by_role(&r.contributors, &DataRole::Author)
                     .or_else(|| r.author.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 let explicit_author =
                     collect_contributors_by_role(&r.contributors, &DataRole::Author)
                         .or_else(|| r.author.clone());
@@ -208,13 +1034,13 @@ impl InputReference {
                     }
                 })
             }
-            InputReference::Treaty(r) => r.author.clone(),
-            InputReference::Brief(r) => r.author.clone(),
-            InputReference::Classic(r) => r.author.clone(),
-            InputReference::Patent(r) => r.author.clone(),
-            InputReference::Dataset(r) => r.author.clone(),
-            InputReference::Software(r) => r.author.clone(),
-            InputReference::Event(r) => {
+            ClassExtension::Treaty(r) => r.author.clone(),
+            ClassExtension::Brief(r) => r.author.clone(),
+            ClassExtension::Classic(r) => r.author.clone(),
+            ClassExtension::Patent(r) => r.author.clone(),
+            ClassExtension::Dataset(r) => r.author.clone(),
+            ClassExtension::Software(r) => r.author.clone(),
+            ClassExtension::Event(r) => {
                 collect_contributors_by_role(&r.contributors, &DataRole::Performer)
                     .or_else(|| {
                         collect_contributors_by_role(
@@ -224,7 +1050,7 @@ impl InputReference {
                     })
                     .or_else(|| collect_contributors_by_role(&r.contributors, &DataRole::Author))
             }
-            InputReference::AudioVisual(r) => {
+            ClassExtension::AudioVisual(r) => {
                 let explicit_author =
                     collect_contributors_by_role(&r.core.contributors, &DataRole::Author);
 
@@ -257,16 +1083,16 @@ impl InputReference {
     }
 
     pub fn editor(&self) -> Option<Contributor> {
-        match self {
-            InputReference::Monograph(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => {
                 collect_contributors_by_role(&r.contributors, &ContributorRole::Editor)
                     .or_else(|| r.editor.clone())
             }
-            InputReference::Collection(r) => {
+            ClassExtension::Collection(r) => {
                 collect_contributors_by_role(&r.contributors, &ContributorRole::Editor)
                     .or_else(|| r.editor.clone())
             }
-            InputReference::CollectionComponent(r) => r
+            ClassExtension::CollectionComponent(r) => r
                 .container
                 .as_ref()
                 .and_then(|c| match c {
@@ -276,41 +1102,41 @@ impl InputReference {
                 .or_else(|| {
                     collect_contributors_by_role(&r.contributors, &ContributorRole::Editor)
                 }),
-            InputReference::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.editor(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Serial(r) => {
+            ClassExtension::Serial(r) => {
                 collect_contributors_by_role(&r.contributors, &ContributorRole::Editor)
                     .or_else(|| r.editor.clone())
             }
-            InputReference::Classic(r) => r.editor.clone(),
-            InputReference::AudioVisual(_) => None,
+            ClassExtension::Classic(r) => r.editor.clone(),
+            ClassExtension::AudioVisual(_) => None,
             _ => None,
         }
     }
 
     /// Return the translator.
     pub fn translator(&self) -> Option<Contributor> {
-        match self {
-            InputReference::Monograph(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => {
                 collect_contributors_by_role(&r.contributors, &ContributorRole::Translator)
                     .or_else(|| r.translator.clone())
             }
-            InputReference::CollectionComponent(r) => {
+            ClassExtension::CollectionComponent(r) => {
                 collect_contributors_by_role(&r.contributors, &ContributorRole::Translator)
                     .or_else(|| r.translator.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 collect_contributors_by_role(&r.contributors, &ContributorRole::Translator)
                     .or_else(|| r.translator.clone())
             }
-            InputReference::Collection(r) => {
+            ClassExtension::Collection(r) => {
                 collect_contributors_by_role(&r.contributors, &ContributorRole::Translator)
                     .or_else(|| r.translator.clone())
             }
-            InputReference::Classic(r) => r.translator.clone(),
-            InputReference::AudioVisual(r) => {
+            ClassExtension::Classic(r) => r.translator.clone(),
+            ClassExtension::AudioVisual(r) => {
                 collect_contributors_by_role(&r.core.contributors, &ContributorRole::Translator)
             }
             _ => None,
@@ -319,23 +1145,23 @@ impl InputReference {
 
     /// Return the publisher.
     pub fn publisher(&self) -> Option<Publisher> {
-        match self {
-            InputReference::Monograph(r) => r.publisher.clone(),
-            InputReference::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.publisher.clone(),
+            ClassExtension::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Collection(r) => r.publisher.clone(),
-            InputReference::Serial(r) => r.publisher.clone(),
-            InputReference::Classic(r) => r.publisher.clone(),
-            InputReference::Dataset(r) => r.publisher.clone(),
-            InputReference::Standard(r) => r.publisher.clone(),
-            InputReference::Software(r) => r.publisher.clone(),
-            InputReference::AudioVisual(r) => r.publisher.clone(),
+            ClassExtension::Collection(r) => r.publisher.clone(),
+            ClassExtension::Serial(r) => r.publisher.clone(),
+            ClassExtension::Classic(r) => r.publisher.clone(),
+            ClassExtension::Dataset(r) => r.publisher.clone(),
+            ClassExtension::Standard(r) => r.publisher.clone(),
+            ClassExtension::Software(r) => r.publisher.clone(),
+            ClassExtension::AudioVisual(r) => r.publisher.clone(),
             _ => None,
         }
     }
@@ -359,59 +1185,64 @@ impl InputReference {
     }
 
     fn all_contributor_entries(&self) -> &[ContributorEntry] {
-        match self {
-            InputReference::Monograph(r) => &r.contributors,
-            InputReference::Collection(r) => &r.contributors,
-            InputReference::CollectionComponent(r) => &r.contributors,
-            InputReference::Serial(r) => &r.contributors,
-            InputReference::SerialComponent(r) => &r.contributors,
-            InputReference::Event(r) => &r.contributors,
-            InputReference::AudioVisual(r) => &r.core.contributors,
+        match &self.extension {
+            ClassExtension::Monograph(r) => &r.contributors,
+            ClassExtension::Collection(r) => &r.contributors,
+            ClassExtension::CollectionComponent(r) => &r.contributors,
+            ClassExtension::Serial(r) => &r.contributors,
+            ClassExtension::SerialComponent(r) => &r.contributors,
+            ClassExtension::Event(r) => &r.contributors,
+            ClassExtension::AudioVisual(r) => &r.core.contributors,
             _ => &[],
         }
     }
 
     /// Return the title.
     pub fn title(&self) -> Option<Title> {
-        match self {
-            InputReference::Monograph(r) => match (&r.title, &r.short_title) {
+        match &self.extension {
+            ClassExtension::Monograph(r) => match (&r.title, &r.short_title) {
                 (Some(Title::Single(long)), Some(short)) => {
                     Some(Title::Shorthand(short.clone(), long.clone()))
                 }
                 _ => r.title.clone(),
             },
-            InputReference::CollectionComponent(r) => r.title.clone(),
-            InputReference::SerialComponent(r) => r.title.clone(),
-            InputReference::Collection(r) => match (&r.title, &r.short_title) {
+            ClassExtension::CollectionComponent(r) => r.title.clone(),
+            ClassExtension::SerialComponent(r) => r.title.clone(),
+            ClassExtension::Collection(r) => match (&r.title, &r.short_title) {
                 (Some(Title::Single(long)), Some(short)) => {
                     Some(Title::Shorthand(short.clone(), long.clone()))
                 }
                 _ => r.title.clone(),
             },
-            InputReference::Serial(r) => match (&r.title, &r.short_title) {
+            ClassExtension::Serial(r) => match (&r.title, &r.short_title) {
                 (Some(Title::Single(long)), Some(short)) => {
                     Some(Title::Shorthand(short.clone(), long.clone()))
                 }
                 _ => r.title.clone(),
             },
-            InputReference::LegalCase(r) => r.title.clone(),
-            InputReference::Statute(r) => r.title.clone(),
-            InputReference::Treaty(r) => r.title.clone(),
-            InputReference::Hearing(r) => r.title.clone(),
-            InputReference::Regulation(r) => r.title.clone(),
-            InputReference::Brief(r) => r.title.clone(),
-            InputReference::Classic(r) => r.title.clone(),
-            InputReference::Patent(r) => r.title.clone(),
-            InputReference::Dataset(r) => r.title.clone(),
-            InputReference::Standard(r) => r.title.clone(),
-            InputReference::Software(r) => r.title.clone(),
-            InputReference::Event(r) => r.title.clone(),
-            InputReference::AudioVisual(r) => match (&r.core.title, &r.core.short_title) {
+            ClassExtension::LegalCase(r) => r.title.clone(),
+            ClassExtension::Statute(r) => r.title.clone(),
+            ClassExtension::Treaty(r) => r.title.clone(),
+            ClassExtension::Hearing(r) => r.title.clone(),
+            ClassExtension::Regulation(r) => r.title.clone(),
+            ClassExtension::Brief(r) => r.title.clone(),
+            ClassExtension::Classic(r) => r.title.clone(),
+            ClassExtension::Patent(r) => r.title.clone(),
+            ClassExtension::Dataset(r) => r.title.clone(),
+            ClassExtension::Standard(r) => r.title.clone(),
+            ClassExtension::Software(r) => r.title.clone(),
+            ClassExtension::Event(r) => r.title.clone(),
+            ClassExtension::AudioVisual(r) => match (&r.core.title, &r.core.short_title) {
                 (Some(Title::Single(long)), Some(short)) => {
                     Some(Title::Shorthand(short.clone(), long.clone()))
                 }
                 _ => r.core.title.clone(),
             },
+            ClassExtension::Unknown(data) => data
+                .fields
+                .get("title")
+                .and_then(JsonValue::as_str)
+                .map(|title| Title::Single(title.to_string())),
         }
     }
 
@@ -421,49 +1252,51 @@ impl InputReference {
 
     /// Return the creation or origination date.
     pub fn created(&self) -> Option<EdtfString> {
-        match self {
-            InputReference::Monograph(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::CollectionComponent(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::SerialComponent(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Collection(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Serial(_) => None,
-            InputReference::LegalCase(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Statute(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Treaty(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Hearing(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Regulation(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Brief(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Classic(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Patent(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Dataset(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Standard(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Software(r) => Self::non_empty_date(r.created.clone()),
-            InputReference::Event(_) => None,
-            InputReference::AudioVisual(r) => Self::non_empty_date(r.core.created.clone()),
+        match &self.extension {
+            ClassExtension::Monograph(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::CollectionComponent(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::SerialComponent(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Collection(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Serial(_) => None,
+            ClassExtension::LegalCase(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Statute(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Treaty(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Hearing(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Regulation(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Brief(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Classic(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Patent(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Dataset(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Standard(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Software(r) => Self::non_empty_date(r.created.clone()),
+            ClassExtension::Event(_) => None,
+            ClassExtension::AudioVisual(r) => Self::non_empty_date(r.core.created.clone()),
+            ClassExtension::Unknown(_) => None,
         }
     }
 
     /// Return the explicit publication or release date.
     pub fn issued(&self) -> Option<EdtfString> {
-        match self {
-            InputReference::Monograph(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::CollectionComponent(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::SerialComponent(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Collection(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Serial(_) => None,
-            InputReference::LegalCase(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Statute(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Treaty(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Hearing(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Regulation(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Brief(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Classic(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Patent(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Dataset(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Standard(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Software(r) => Self::non_empty_date(r.issued.clone()),
-            InputReference::Event(r) => r.date.clone(),
-            InputReference::AudioVisual(r) => Self::non_empty_date(r.core.issued.clone()),
+        match &self.extension {
+            ClassExtension::Monograph(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::CollectionComponent(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::SerialComponent(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Collection(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Serial(_) => None,
+            ClassExtension::LegalCase(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Statute(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Treaty(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Hearing(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Regulation(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Brief(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Classic(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Patent(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Dataset(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Standard(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Software(r) => Self::non_empty_date(r.issued.clone()),
+            ClassExtension::Event(r) => r.date.clone(),
+            ClassExtension::AudioVisual(r) => Self::non_empty_date(r.core.issued.clone()),
+            ClassExtension::Unknown(_) => None,
         }
     }
 
@@ -474,74 +1307,75 @@ impl InputReference {
 
     /// Return the DOI.
     pub fn doi(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.doi.clone(),
-            InputReference::CollectionComponent(r) => r.doi.clone(),
-            InputReference::SerialComponent(r) => r.doi.clone(),
-            InputReference::LegalCase(r) => r.doi.clone(),
-            InputReference::Dataset(r) => r.doi.clone(),
-            InputReference::Software(r) => r.doi.clone(),
-            InputReference::AudioVisual(_) => None,
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.doi.clone(),
+            ClassExtension::CollectionComponent(r) => r.doi.clone(),
+            ClassExtension::SerialComponent(r) => r.doi.clone(),
+            ClassExtension::LegalCase(r) => r.doi.clone(),
+            ClassExtension::Dataset(r) => r.doi.clone(),
+            ClassExtension::Software(r) => r.doi.clone(),
+            ClassExtension::AudioVisual(_) => None,
             _ => None,
         }
     }
 
     /// Return the ADS bibcode.
     pub fn ads_bibcode(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.ads_bibcode.clone(),
-            InputReference::SerialComponent(r) => r.ads_bibcode.clone(),
-            InputReference::AudioVisual(_) => None,
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.ads_bibcode.clone(),
+            ClassExtension::SerialComponent(r) => r.ads_bibcode.clone(),
+            ClassExtension::AudioVisual(_) => None,
             _ => None,
         }
     }
 
     /// Return the note.
     pub fn note(&self) -> Option<RichText> {
-        match self {
-            InputReference::Monograph(r) => r.note.clone(),
-            InputReference::CollectionComponent(r) => r.note.clone(),
-            InputReference::SerialComponent(r) => r.note.clone(),
-            InputReference::Collection(r) => r.note.clone(),
-            InputReference::Serial(r) => r.note.clone(),
-            InputReference::LegalCase(r) => r.note.clone(),
-            InputReference::Statute(r) => r.note.clone(),
-            InputReference::Treaty(r) => r.note.clone(),
-            InputReference::Standard(r) => r.note.clone(),
-            InputReference::Event(r) => r.note.clone(),
-            InputReference::AudioVisual(r) => r.note.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.note.clone(),
+            ClassExtension::CollectionComponent(r) => r.note.clone(),
+            ClassExtension::SerialComponent(r) => r.note.clone(),
+            ClassExtension::Collection(r) => r.note.clone(),
+            ClassExtension::Serial(r) => r.note.clone(),
+            ClassExtension::LegalCase(r) => r.note.clone(),
+            ClassExtension::Statute(r) => r.note.clone(),
+            ClassExtension::Treaty(r) => r.note.clone(),
+            ClassExtension::Standard(r) => r.note.clone(),
+            ClassExtension::Event(r) => r.note.clone(),
+            ClassExtension::AudioVisual(r) => r.note.clone(),
             _ => None,
         }
     }
 
     /// Return the URL.
     pub fn url(&self) -> Option<Url> {
-        match self {
-            InputReference::Monograph(r) => r.url.clone(),
-            InputReference::CollectionComponent(r) => r.url.clone(),
-            InputReference::SerialComponent(r) => r.url.clone(),
-            InputReference::Collection(r) => r.url.clone(),
-            InputReference::Serial(r) => r.url.clone(),
-            InputReference::LegalCase(r) => r.url.clone(),
-            InputReference::Statute(r) => r.url.clone(),
-            InputReference::Treaty(r) => r.url.clone(),
-            InputReference::Hearing(r) => r.url.clone(),
-            InputReference::Regulation(r) => r.url.clone(),
-            InputReference::Brief(r) => r.url.clone(),
-            InputReference::Classic(r) => r.url.clone(),
-            InputReference::Patent(r) => r.url.clone(),
-            InputReference::Dataset(r) => r.url.clone(),
-            InputReference::Standard(r) => r.url.clone(),
-            InputReference::Software(r) => r.url.clone(),
-            InputReference::Event(r) => r.url.clone(),
-            InputReference::AudioVisual(r) => r.url.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.url.clone(),
+            ClassExtension::CollectionComponent(r) => r.url.clone(),
+            ClassExtension::SerialComponent(r) => r.url.clone(),
+            ClassExtension::Collection(r) => r.url.clone(),
+            ClassExtension::Serial(r) => r.url.clone(),
+            ClassExtension::LegalCase(r) => r.url.clone(),
+            ClassExtension::Statute(r) => r.url.clone(),
+            ClassExtension::Treaty(r) => r.url.clone(),
+            ClassExtension::Hearing(r) => r.url.clone(),
+            ClassExtension::Regulation(r) => r.url.clone(),
+            ClassExtension::Brief(r) => r.url.clone(),
+            ClassExtension::Classic(r) => r.url.clone(),
+            ClassExtension::Patent(r) => r.url.clone(),
+            ClassExtension::Dataset(r) => r.url.clone(),
+            ClassExtension::Standard(r) => r.url.clone(),
+            ClassExtension::Software(r) => r.url.clone(),
+            ClassExtension::Event(r) => r.url.clone(),
+            ClassExtension::AudioVisual(r) => r.url.clone(),
+            ClassExtension::Unknown(_) => None,
         }
     }
 
     /// Return the publisher place.
     pub fn publisher_place(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .publisher
                 .as_ref()
                 .and_then(|p| p.place.clone().map(Into::into))
@@ -551,15 +1385,15 @@ impl InputReference {
                         _ => None,
                     })
                 }),
-            InputReference::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 _ => None,
             }),
-            InputReference::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 _ => None,
             }),
-            InputReference::Collection(r) => r
+            ClassExtension::Collection(r) => r
                 .publisher
                 .as_ref()
                 .and_then(|p| p.place.clone().map(Into::into))
@@ -569,25 +1403,25 @@ impl InputReference {
                         _ => None,
                     })
                 }),
-            InputReference::Serial(_) => None,
-            InputReference::Classic(r) => r
+            ClassExtension::Serial(_) => None,
+            ClassExtension::Classic(r) => r
                 .publisher
                 .as_ref()
                 .and_then(|p| p.place.clone().map(Into::into)),
-            InputReference::Dataset(r) => r
+            ClassExtension::Dataset(r) => r
                 .publisher
                 .as_ref()
                 .and_then(|p| p.place.clone().map(Into::into)),
-            InputReference::Standard(r) => r
+            ClassExtension::Standard(r) => r
                 .publisher
                 .as_ref()
                 .and_then(|p| p.place.clone().map(Into::into)),
-            InputReference::Software(r) => r
+            ClassExtension::Software(r) => r
                 .publisher
                 .as_ref()
                 .and_then(|p| p.place.clone().map(Into::into)),
-            InputReference::Event(r) => r.location.clone(),
-            InputReference::AudioVisual(r) => r
+            ClassExtension::Event(r) => r.location.clone(),
+            ClassExtension::AudioVisual(r) => r
                 .publisher
                 .as_ref()
                 .and_then(|p| p.place.clone().map(Into::into)),
@@ -597,8 +1431,8 @@ impl InputReference {
 
     /// Return the publisher as a string.
     pub fn publisher_str(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .publisher
                 .as_ref()
                 .map(|p| p.name.to_string())
@@ -608,15 +1442,15 @@ impl InputReference {
                         _ => None,
                     })
                 }),
-            InputReference::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str(),
                 _ => None,
             }),
-            InputReference::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str(),
                 _ => None,
             }),
-            InputReference::Collection(r) => r
+            ClassExtension::Collection(r) => r
                 .publisher
                 .as_ref()
                 .map(|p| p.name.to_string())
@@ -626,13 +1460,13 @@ impl InputReference {
                         _ => None,
                     })
                 }),
-            InputReference::Serial(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
-            InputReference::Classic(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
-            InputReference::Dataset(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
-            InputReference::Standard(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
-            InputReference::Software(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
-            InputReference::Event(r) => r.network.clone(),
-            InputReference::AudioVisual(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
+            ClassExtension::Serial(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
+            ClassExtension::Classic(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
+            ClassExtension::Dataset(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
+            ClassExtension::Standard(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
+            ClassExtension::Software(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
+            ClassExtension::Event(r) => r.network.clone(),
+            ClassExtension::AudioVisual(r) => r.publisher.as_ref().map(|p| p.name.to_string()),
             _ => None,
         }
     }
@@ -651,18 +1485,18 @@ impl InputReference {
 
     /// Return the genre/type as string, normalized to canonical kebab-case.
     pub fn genre(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => {
                 r.genre.as_ref().map(|g| Self::normalize_genre_medium(g))
             }
-            InputReference::CollectionComponent(r) => {
+            ClassExtension::CollectionComponent(r) => {
                 r.genre.as_ref().map(|g| Self::normalize_genre_medium(g))
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.genre.as_ref().map(|g| Self::normalize_genre_medium(g))
             }
-            InputReference::Event(r) => r.genre.as_ref().map(|g| Self::normalize_genre_medium(g)),
-            InputReference::AudioVisual(r) => r
+            ClassExtension::Event(r) => r.genre.as_ref().map(|g| Self::normalize_genre_medium(g)),
+            ClassExtension::AudioVisual(r) => r
                 .core
                 .genre
                 .as_ref()
@@ -673,24 +1507,24 @@ impl InputReference {
 
     /// Return the archive or repository name.
     pub fn archive(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.archive.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.archive.clone(),
             _ => None,
         }
     }
 
     /// Return the archive shelfmark or repository location.
     pub fn archive_location(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .archive_info
                 .as_ref()
                 .and_then(|info| info.location.clone())
                 .or_else(|| r.archive_location.clone()),
-            InputReference::CollectionComponent(r) => {
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.location.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.location.clone())
             }
             _ => None,
@@ -699,12 +1533,12 @@ impl InputReference {
 
     /// Return the archive name from structured ArchiveInfo.
     pub fn archive_name(&self) -> Option<MultilingualString> {
-        match self {
-            InputReference::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.name.clone()),
-            InputReference::CollectionComponent(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.name.clone()),
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.name.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.name.clone())
             }
             _ => None,
@@ -713,16 +1547,16 @@ impl InputReference {
 
     /// Return the archive geographic place from structured ArchiveInfo.
     pub fn archive_place(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .archive_info
                 .as_ref()
                 .and_then(|i| i.place.clone().map(Into::into)),
-            InputReference::CollectionComponent(r) => r
+            ClassExtension::CollectionComponent(r) => r
                 .archive_info
                 .as_ref()
                 .and_then(|i| i.place.clone().map(Into::into)),
-            InputReference::SerialComponent(r) => r
+            ClassExtension::SerialComponent(r) => r
                 .archive_info
                 .as_ref()
                 .and_then(|i| i.place.clone().map(Into::into)),
@@ -732,14 +1566,14 @@ impl InputReference {
 
     /// Return the archive collection name from structured ArchiveInfo.
     pub fn archive_collection(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => {
                 r.archive_info.as_ref().and_then(|i| i.collection.clone())
             }
-            InputReference::CollectionComponent(r) => {
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.collection.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.collection.clone())
             }
             _ => None,
@@ -748,16 +1582,16 @@ impl InputReference {
 
     /// Return the archive collection identifier from structured ArchiveInfo.
     pub fn archive_collection_id(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .archive_info
                 .as_ref()
                 .and_then(|i| i.collection_id.clone()),
-            InputReference::CollectionComponent(r) => r
+            ClassExtension::CollectionComponent(r) => r
                 .archive_info
                 .as_ref()
                 .and_then(|i| i.collection_id.clone()),
-            InputReference::SerialComponent(r) => r
+            ClassExtension::SerialComponent(r) => r
                 .archive_info
                 .as_ref()
                 .and_then(|i| i.collection_id.clone()),
@@ -767,12 +1601,12 @@ impl InputReference {
 
     /// Return the archive series from structured ArchiveInfo.
     pub fn archive_series(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.series.clone()),
-            InputReference::CollectionComponent(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.series.clone()),
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.series.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.series.clone())
             }
             _ => None,
@@ -781,12 +1615,12 @@ impl InputReference {
 
     /// Return the archive box number from structured ArchiveInfo.
     pub fn archive_box(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.r#box.clone()),
-            InputReference::CollectionComponent(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.r#box.clone()),
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.r#box.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.r#box.clone())
             }
             _ => None,
@@ -795,12 +1629,12 @@ impl InputReference {
 
     /// Return the archive folder from structured ArchiveInfo.
     pub fn archive_folder(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.folder.clone()),
-            InputReference::CollectionComponent(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.folder.clone()),
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.folder.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.folder.clone())
             }
             _ => None,
@@ -809,12 +1643,12 @@ impl InputReference {
 
     /// Return the archive item identifier from structured ArchiveInfo.
     pub fn archive_item(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.item.clone()),
-            InputReference::CollectionComponent(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.item.clone()),
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.item.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.item.clone())
             }
             _ => None,
@@ -823,12 +1657,12 @@ impl InputReference {
 
     /// Return the archive URL from structured ArchiveInfo.
     pub fn archive_url(&self) -> Option<Url> {
-        match self {
-            InputReference::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.url.clone()),
-            InputReference::CollectionComponent(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.archive_info.as_ref().and_then(|i| i.url.clone()),
+            ClassExtension::CollectionComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.url.clone())
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.archive_info.as_ref().and_then(|i| i.url.clone())
             }
             _ => None,
@@ -837,60 +1671,60 @@ impl InputReference {
 
     /// Return the publication status.
     pub fn status(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.status.clone(),
-            InputReference::CollectionComponent(r) => r.status.clone(),
-            InputReference::SerialComponent(r) => r.status.clone(),
-            InputReference::Standard(r) => r.status.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.status.clone(),
+            ClassExtension::CollectionComponent(r) => r.status.clone(),
+            ClassExtension::SerialComponent(r) => r.status.clone(),
+            ClassExtension::Standard(r) => r.status.clone(),
             _ => None,
         }
     }
 
     /// Return the eprint identifier.
     pub fn eprint_id(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.eprint.as_ref().map(|e| e.id.clone()),
-            InputReference::CollectionComponent(r) => r.eprint.as_ref().map(|e| e.id.clone()),
-            InputReference::SerialComponent(r) => r.eprint.as_ref().map(|e| e.id.clone()),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.eprint.as_ref().map(|e| e.id.clone()),
+            ClassExtension::CollectionComponent(r) => r.eprint.as_ref().map(|e| e.id.clone()),
+            ClassExtension::SerialComponent(r) => r.eprint.as_ref().map(|e| e.id.clone()),
             _ => None,
         }
     }
 
     /// Return the eprint server name.
     pub fn eprint_server(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.eprint.as_ref().map(|e| e.server.clone()),
-            InputReference::CollectionComponent(r) => r.eprint.as_ref().map(|e| e.server.clone()),
-            InputReference::SerialComponent(r) => r.eprint.as_ref().map(|e| e.server.clone()),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.eprint.as_ref().map(|e| e.server.clone()),
+            ClassExtension::CollectionComponent(r) => r.eprint.as_ref().map(|e| e.server.clone()),
+            ClassExtension::SerialComponent(r) => r.eprint.as_ref().map(|e| e.server.clone()),
             _ => None,
         }
     }
 
     /// Return the eprint subject class.
     pub fn eprint_class(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.eprint.as_ref().and_then(|e| e.class.clone()),
-            InputReference::CollectionComponent(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.eprint.as_ref().and_then(|e| e.class.clone()),
+            ClassExtension::CollectionComponent(r) => {
                 r.eprint.as_ref().and_then(|e| e.class.clone())
             }
-            InputReference::SerialComponent(r) => r.eprint.as_ref().and_then(|e| e.class.clone()),
+            ClassExtension::SerialComponent(r) => r.eprint.as_ref().and_then(|e| e.class.clone()),
             _ => None,
         }
     }
 
     /// Return the medium, normalized to canonical kebab-case.
     pub fn medium(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => {
+        match &self.extension {
+            ClassExtension::Monograph(r) => {
                 r.medium.as_ref().map(|m| Self::normalize_genre_medium(m))
             }
-            InputReference::CollectionComponent(r) => {
+            ClassExtension::CollectionComponent(r) => {
                 r.medium.as_ref().map(|m| Self::normalize_genre_medium(m))
             }
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 r.medium.as_ref().map(|m| Self::normalize_genre_medium(m))
             }
-            InputReference::AudioVisual(r) => {
+            ClassExtension::AudioVisual(r) => {
                 r.medium.as_ref().map(|m| Self::normalize_genre_medium(m))
             }
             _ => None,
@@ -899,50 +1733,50 @@ impl InputReference {
 
     /// Return the version.
     pub fn version(&self) -> Option<String> {
-        match self {
-            InputReference::Dataset(r) => r.version.clone(),
-            InputReference::Software(r) => r.version.clone(),
+        match &self.extension {
+            ClassExtension::Dataset(r) => r.version.clone(),
+            ClassExtension::Software(r) => r.version.clone(),
             _ => None,
         }
     }
 
     /// Return the abstract.
     pub fn abstract_text(&self) -> Option<RichText> {
-        match self {
-            InputReference::Monograph(r) => r.abstract_text.clone(),
-            InputReference::CollectionComponent(r) => r.abstract_text.clone(),
-            InputReference::SerialComponent(r) => r.abstract_text.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.abstract_text.clone(),
+            ClassExtension::CollectionComponent(r) => r.abstract_text.clone(),
+            ClassExtension::SerialComponent(r) => r.abstract_text.clone(),
             _ => None,
         }
     }
 
     /// Return the container-style title for parent works, reporters, or codes.
     pub fn container_title(&self) -> Option<Title> {
-        match self {
-            InputReference::Monograph(r) => r.container.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title().or_else(|| p.container_title()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title().or_else(|| p.container_title()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title().or_else(|| p.container_title()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Serial(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::Serial(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title().or_else(|| p.container_title()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::LegalCase(r) => r.reporter.clone().map(Title::Single),
-            InputReference::Statute(r) => r.code.clone().map(Title::Single),
-            InputReference::Treaty(r) => r.reporter.clone().map(Title::Single),
-            InputReference::Event(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::LegalCase(r) => r.reporter.clone().map(Title::Single),
+            ClassExtension::Statute(r) => r.code.clone().map(Title::Single),
+            ClassExtension::Treaty(r) => r.reporter.clone().map(Title::Single),
+            ClassExtension::Event(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title().or_else(|| p.container_title()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::AudioVisual(r) => r.container.as_ref().and_then(|c| match c {
+            ClassExtension::AudioVisual(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title().or_else(|| p.container_title()),
                 WorkRelation::Id(_) => None,
             }),
@@ -952,36 +1786,36 @@ impl InputReference {
 
     /// Return the volume.
     pub fn volume(&self) -> Option<NumOrStr> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .volume
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Volume))
                 .map(NumOrStr::Str),
-            InputReference::Collection(r) => r
+            ClassExtension::Collection(r) => r
                 .volume
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Volume))
                 .map(NumOrStr::Str),
-            InputReference::CollectionComponent(r) => r
+            ClassExtension::CollectionComponent(r) => r
                 .volume
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Volume))
                 .map(NumOrStr::Str),
-            InputReference::SerialComponent(r) => r
+            ClassExtension::SerialComponent(r) => r
                 .volume
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Volume))
                 .map(NumOrStr::Str),
-            InputReference::Classic(r) => r
+            ClassExtension::Classic(r) => r
                 .volume
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Volume))
                 .map(NumOrStr::Str),
-            InputReference::LegalCase(r) => r.volume.clone().map(NumOrStr::Str),
-            InputReference::Statute(r) => r.volume.clone().map(NumOrStr::Str),
-            InputReference::Treaty(r) => r.volume.clone().map(NumOrStr::Str),
-            InputReference::Regulation(r) => r.volume.clone().map(NumOrStr::Str),
+            ClassExtension::LegalCase(r) => r.volume.clone().map(NumOrStr::Str),
+            ClassExtension::Statute(r) => r.volume.clone().map(NumOrStr::Str),
+            ClassExtension::Treaty(r) => r.volume.clone().map(NumOrStr::Str),
+            ClassExtension::Regulation(r) => r.volume.clone().map(NumOrStr::Str),
             _ => self
                 .find_numbering(NumberingType::Volume)
                 .map(NumOrStr::Str),
@@ -990,8 +1824,8 @@ impl InputReference {
 
     /// Return the collection number (series number).
     pub fn collection_number(&self) -> Option<String> {
-        match self {
-            InputReference::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::CollectionComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.collection_number(),
                 WorkRelation::Id(_) => None,
             }),
@@ -1001,28 +1835,28 @@ impl InputReference {
 
     /// Return the issue.
     pub fn issue(&self) -> Option<NumOrStr> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .issue
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Issue))
                 .map(NumOrStr::Str),
-            InputReference::Collection(r) => r
+            ClassExtension::Collection(r) => r
                 .issue
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Issue))
                 .map(NumOrStr::Str),
-            InputReference::CollectionComponent(r) => r
+            ClassExtension::CollectionComponent(r) => r
                 .issue
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Issue))
                 .map(NumOrStr::Str),
-            InputReference::SerialComponent(r) => r
+            ClassExtension::SerialComponent(r) => r
                 .issue
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Issue))
                 .map(NumOrStr::Str),
-            InputReference::Classic(r) => r
+            ClassExtension::Classic(r) => r
                 .issue
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Issue))
@@ -1033,79 +1867,79 @@ impl InputReference {
 
     /// Return the pages.
     pub fn pages(&self) -> Option<NumOrStr> {
-        match self {
-            InputReference::CollectionComponent(r) => r.pages.clone(),
-            InputReference::SerialComponent(r) => r.pages.clone().map(NumOrStr::Str),
-            InputReference::LegalCase(r) => r.page.clone().map(NumOrStr::Str),
-            InputReference::Statute(r) => r.page.clone().map(NumOrStr::Str),
-            InputReference::Treaty(r) => r.page.clone().map(NumOrStr::Str),
+        match &self.extension {
+            ClassExtension::CollectionComponent(r) => r.pages.clone(),
+            ClassExtension::SerialComponent(r) => r.pages.clone().map(NumOrStr::Str),
+            ClassExtension::LegalCase(r) => r.page.clone().map(NumOrStr::Str),
+            ClassExtension::Statute(r) => r.page.clone().map(NumOrStr::Str),
+            ClassExtension::Treaty(r) => r.page.clone().map(NumOrStr::Str),
             _ => None,
         }
     }
 
     /// Return the authority (court, legislative body, standards org, etc.).
     pub fn authority(&self) -> Option<String> {
-        match self {
-            InputReference::LegalCase(r) => r.authority.clone(),
-            InputReference::Statute(r) => r.authority.clone(),
-            InputReference::Hearing(r) => r.authority.clone(),
-            InputReference::Regulation(r) => r.authority.clone(),
-            InputReference::Brief(r) => r.authority.clone(),
-            InputReference::Patent(r) => r.authority.clone(),
-            InputReference::Standard(r) => r.authority.clone(),
+        match &self.extension {
+            ClassExtension::LegalCase(r) => r.authority.clone(),
+            ClassExtension::Statute(r) => r.authority.clone(),
+            ClassExtension::Hearing(r) => r.authority.clone(),
+            ClassExtension::Regulation(r) => r.authority.clone(),
+            ClassExtension::Brief(r) => r.authority.clone(),
+            ClassExtension::Patent(r) => r.authority.clone(),
+            ClassExtension::Standard(r) => r.authority.clone(),
             _ => None,
         }
     }
 
     /// Return the reporter (legal reporter series).
     pub fn reporter(&self) -> Option<String> {
-        match self {
-            InputReference::LegalCase(r) => r.reporter.clone(),
-            InputReference::Treaty(r) => r.reporter.clone(),
+        match &self.extension {
+            ClassExtension::LegalCase(r) => r.reporter.clone(),
+            ClassExtension::Treaty(r) => r.reporter.clone(),
             _ => None,
         }
     }
 
     /// Return the code (legal code abbreviation).
     pub fn code(&self) -> Option<String> {
-        match self {
-            InputReference::Statute(r) => r.code.clone(),
-            InputReference::Regulation(r) => r.code.clone(),
+        match &self.extension {
+            ClassExtension::Statute(r) => r.code.clone(),
+            ClassExtension::Regulation(r) => r.code.clone(),
             _ => None,
         }
     }
 
     /// Return the section (legal section number).
     pub fn section(&self) -> Option<String> {
-        match self {
-            InputReference::Statute(r) => r.section.clone(),
-            InputReference::Regulation(r) => r.section.clone(),
-            InputReference::Classic(_) => self.find_numbering(NumberingType::Section),
+        match &self.extension {
+            ClassExtension::Statute(r) => r.section.clone(),
+            ClassExtension::Regulation(r) => r.section.clone(),
+            ClassExtension::Classic(_) => self.find_numbering(NumberingType::Section),
             _ => None,
         }
     }
 
     /// Return the generic document number.
     pub fn number(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .number
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Number)),
-            InputReference::Statute(r) => r.number.clone(),
-            InputReference::Collection(r) => r
+            ClassExtension::Statute(r) => r.number.clone(),
+            ClassExtension::Collection(r) => r
                 .number
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Number)),
-            InputReference::CollectionComponent(r) => r
+            ClassExtension::CollectionComponent(r) => r
                 .number
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Number)),
-            InputReference::SerialComponent(r) => r
+            ClassExtension::SerialComponent(r) => r
                 .number
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Number)),
-            InputReference::Classic(r) => r
+            ClassExtension::Classic(r) => r
                 .number
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Number)),
@@ -1115,32 +1949,32 @@ impl InputReference {
 
     /// Return the report identifier.
     pub fn report_number(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(_) => self.find_numbering(NumberingType::Report),
+        match &self.extension {
+            ClassExtension::Monograph(_) => self.find_numbering(NumberingType::Report),
             _ => None,
         }
     }
 
     /// Return the edition.
     pub fn edition(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r
+        match &self.extension {
+            ClassExtension::Monograph(r) => r
                 .edition
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Edition)),
-            InputReference::Collection(r) => r
+            ClassExtension::Collection(r) => r
                 .edition
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Edition)),
-            InputReference::CollectionComponent(r) => r
+            ClassExtension::CollectionComponent(r) => r
                 .edition
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Edition)),
-            InputReference::SerialComponent(r) => r
+            ClassExtension::SerialComponent(r) => r
                 .edition
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Edition)),
-            InputReference::Classic(r) => r
+            ClassExtension::Classic(r) => r
                 .edition
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Edition)),
@@ -1150,92 +1984,93 @@ impl InputReference {
 
     /// Return the accessed date.
     pub fn accessed(&self) -> Option<EdtfString> {
-        match self {
-            InputReference::Monograph(r) => r.accessed.clone(),
-            InputReference::CollectionComponent(r) => r.accessed.clone(),
-            InputReference::SerialComponent(r) => r.accessed.clone(),
-            InputReference::Collection(r) => r.accessed.clone(),
-            InputReference::Serial(r) => r.accessed.clone(),
-            InputReference::LegalCase(r) => r.accessed.clone(),
-            InputReference::Statute(r) => r.accessed.clone(),
-            InputReference::Treaty(r) => r.accessed.clone(),
-            InputReference::Hearing(r) => r.accessed.clone(),
-            InputReference::Regulation(r) => r.accessed.clone(),
-            InputReference::Brief(r) => r.accessed.clone(),
-            InputReference::Classic(r) => r.accessed.clone(),
-            InputReference::Patent(r) => r.accessed.clone(),
-            InputReference::Dataset(r) => r.accessed.clone(),
-            InputReference::Standard(r) => r.accessed.clone(),
-            InputReference::Software(r) => r.accessed.clone(),
-            InputReference::Event(r) => r.accessed.clone(),
-            InputReference::AudioVisual(r) => r.accessed.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.accessed.clone(),
+            ClassExtension::CollectionComponent(r) => r.accessed.clone(),
+            ClassExtension::SerialComponent(r) => r.accessed.clone(),
+            ClassExtension::Collection(r) => r.accessed.clone(),
+            ClassExtension::Serial(r) => r.accessed.clone(),
+            ClassExtension::LegalCase(r) => r.accessed.clone(),
+            ClassExtension::Statute(r) => r.accessed.clone(),
+            ClassExtension::Treaty(r) => r.accessed.clone(),
+            ClassExtension::Hearing(r) => r.accessed.clone(),
+            ClassExtension::Regulation(r) => r.accessed.clone(),
+            ClassExtension::Brief(r) => r.accessed.clone(),
+            ClassExtension::Classic(r) => r.accessed.clone(),
+            ClassExtension::Patent(r) => r.accessed.clone(),
+            ClassExtension::Dataset(r) => r.accessed.clone(),
+            ClassExtension::Standard(r) => r.accessed.clone(),
+            ClassExtension::Software(r) => r.accessed.clone(),
+            ClassExtension::Event(r) => r.accessed.clone(),
+            ClassExtension::AudioVisual(r) => r.accessed.clone(),
+            ClassExtension::Unknown(_) => None,
         }
     }
 
     /// Return the original publication date.
     pub fn original_date(&self) -> Option<EdtfString> {
-        match self {
-            InputReference::Monograph(r) => r.original.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Statute(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Treaty(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Hearing(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Regulation(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Brief(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Classic(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Patent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Dataset(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Standard(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Software(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Event(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
+            ClassExtension::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.csl_issued_date(),
                 WorkRelation::Id(_) => None,
             }),
@@ -1245,68 +2080,68 @@ impl InputReference {
 
     /// Return the original title.
     pub fn original_title(&self) -> Option<Title> {
-        match self {
-            InputReference::Monograph(r) => r.original.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Statute(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Treaty(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Hearing(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Regulation(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Brief(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Classic(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Patent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Dataset(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Standard(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Software(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Event(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
+            ClassExtension::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title(),
                 WorkRelation::Id(_) => None,
             }),
@@ -1316,68 +2151,68 @@ impl InputReference {
 
     /// Return the original publisher as a string.
     pub fn original_publisher_str(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.original.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Statute(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Treaty(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Hearing(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Regulation(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Brief(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Classic(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Patent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Dataset(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Standard(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Software(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Event(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
+            ClassExtension::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_str().filter(|value| !value.is_empty()),
                 WorkRelation::Id(_) => None,
             }),
@@ -1387,68 +2222,68 @@ impl InputReference {
 
     /// Return the original publisher place.
     pub fn original_publisher_place(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.original.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::CollectionComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::SerialComponent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::LegalCase(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Statute(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Statute(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Treaty(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Treaty(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Hearing(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Hearing(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Regulation(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Regulation(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Brief(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Brief(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Classic(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Classic(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Patent(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Patent(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Dataset(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Dataset(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Standard(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Standard(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Software(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Software(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Event(r) => r.original.as_ref().and_then(|c| match c {
+            ClassExtension::Event(r) => r.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
+            ClassExtension::AudioVisual(r) => r.core.original.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.publisher_place(),
                 WorkRelation::Id(_) => None,
             }),
@@ -1458,119 +2293,129 @@ impl InputReference {
 
     /// Return the ISBN.
     pub fn isbn(&self) -> Option<String> {
-        match self {
-            InputReference::Monograph(r) => r.isbn.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.isbn.clone(),
             _ => None,
         }
     }
 
     /// Return the ISSN.
     pub fn issn(&self) -> Option<String> {
-        match self {
-            InputReference::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
+        match &self.extension {
+            ClassExtension::SerialComponent(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(s) => s.issn(),
                 WorkRelation::Id(_) => None,
             }),
-            InputReference::Serial(r) => r.issn.clone(),
+            ClassExtension::Serial(r) => r.issn.clone(),
             _ => None,
         }
     }
 
     /// Return the Keywords.
     pub fn keywords(&self) -> Option<Vec<String>> {
-        match self {
-            InputReference::Monograph(r) => r.keywords.clone(),
-            InputReference::CollectionComponent(r) => r.keywords.clone(),
-            InputReference::SerialComponent(r) => r.keywords.clone(),
-            InputReference::Collection(r) => r.keywords.clone(),
-            InputReference::Serial(_) => None,
-            InputReference::LegalCase(r) => r.keywords.clone(),
-            InputReference::Statute(r) => r.keywords.clone(),
-            InputReference::Treaty(r) => r.keywords.clone(),
-            InputReference::Hearing(r) => r.keywords.clone(),
-            InputReference::Regulation(r) => r.keywords.clone(),
-            InputReference::Brief(r) => r.keywords.clone(),
-            InputReference::Classic(r) => r.keywords.clone(),
-            InputReference::Patent(r) => r.keywords.clone(),
-            InputReference::Dataset(r) => r.keywords.clone(),
-            InputReference::Standard(r) => r.keywords.clone(),
-            InputReference::Software(r) => r.keywords.clone(),
-            InputReference::Event(_) => None,
-            InputReference::AudioVisual(_) => None,
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.keywords.clone(),
+            ClassExtension::CollectionComponent(r) => r.keywords.clone(),
+            ClassExtension::SerialComponent(r) => r.keywords.clone(),
+            ClassExtension::Collection(r) => r.keywords.clone(),
+            ClassExtension::Serial(_) => None,
+            ClassExtension::LegalCase(r) => r.keywords.clone(),
+            ClassExtension::Statute(r) => r.keywords.clone(),
+            ClassExtension::Treaty(r) => r.keywords.clone(),
+            ClassExtension::Hearing(r) => r.keywords.clone(),
+            ClassExtension::Regulation(r) => r.keywords.clone(),
+            ClassExtension::Brief(r) => r.keywords.clone(),
+            ClassExtension::Classic(r) => r.keywords.clone(),
+            ClassExtension::Patent(r) => r.keywords.clone(),
+            ClassExtension::Dataset(r) => r.keywords.clone(),
+            ClassExtension::Standard(r) => r.keywords.clone(),
+            ClassExtension::Software(r) => r.keywords.clone(),
+            ClassExtension::Event(_) => None,
+            ClassExtension::AudioVisual(_) => None,
+            ClassExtension::Unknown(_) => None,
         }
     }
 
     /// Return the language.
     pub fn language(&self) -> Option<LangID> {
-        match self {
-            InputReference::Monograph(r) => r.language.clone(),
-            InputReference::CollectionComponent(r) => r.language.clone(),
-            InputReference::SerialComponent(r) => r.language.clone(),
-            InputReference::Collection(r) => r.language.clone(),
-            InputReference::Serial(r) => r.language.clone(),
-            InputReference::LegalCase(r) => r.language.clone(),
-            InputReference::Statute(r) => r.language.clone(),
-            InputReference::Treaty(r) => r.language.clone(),
-            InputReference::Hearing(r) => r.language.clone(),
-            InputReference::Regulation(r) => r.language.clone(),
-            InputReference::Brief(r) => r.language.clone(),
-            InputReference::Classic(r) => r.language.clone(),
-            InputReference::Patent(r) => r.language.clone(),
-            InputReference::Dataset(r) => r.language.clone(),
-            InputReference::Standard(r) => r.language.clone(),
-            InputReference::Software(r) => r.language.clone(),
-            InputReference::Event(r) => r.language.clone(),
-            InputReference::AudioVisual(r) => r.core.language.clone(),
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.language.clone(),
+            ClassExtension::CollectionComponent(r) => r.language.clone(),
+            ClassExtension::SerialComponent(r) => r.language.clone(),
+            ClassExtension::Collection(r) => r.language.clone(),
+            ClassExtension::Serial(r) => r.language.clone(),
+            ClassExtension::LegalCase(r) => r.language.clone(),
+            ClassExtension::Statute(r) => r.language.clone(),
+            ClassExtension::Treaty(r) => r.language.clone(),
+            ClassExtension::Hearing(r) => r.language.clone(),
+            ClassExtension::Regulation(r) => r.language.clone(),
+            ClassExtension::Brief(r) => r.language.clone(),
+            ClassExtension::Classic(r) => r.language.clone(),
+            ClassExtension::Patent(r) => r.language.clone(),
+            ClassExtension::Dataset(r) => r.language.clone(),
+            ClassExtension::Standard(r) => r.language.clone(),
+            ClassExtension::Software(r) => r.language.clone(),
+            ClassExtension::Event(r) => r.language.clone(),
+            ClassExtension::AudioVisual(r) => r.core.language.clone(),
+            ClassExtension::Unknown(_) => None,
         }
     }
 
     /// Return field-level language overrides.
     pub fn field_languages(&self) -> &FieldLanguageMap {
-        match self {
-            InputReference::Monograph(r) => &r.field_languages,
-            InputReference::CollectionComponent(r) => &r.field_languages,
-            InputReference::SerialComponent(r) => &r.field_languages,
-            InputReference::Collection(r) => &r.field_languages,
-            InputReference::Serial(r) => &r.field_languages,
-            InputReference::LegalCase(r) => &r.field_languages,
-            InputReference::Statute(r) => &r.field_languages,
-            InputReference::Treaty(r) => &r.field_languages,
-            InputReference::Hearing(r) => &r.field_languages,
-            InputReference::Regulation(r) => &r.field_languages,
-            InputReference::Brief(r) => &r.field_languages,
-            InputReference::Classic(r) => &r.field_languages,
-            InputReference::Patent(r) => &r.field_languages,
-            InputReference::Dataset(r) => &r.field_languages,
-            InputReference::Standard(r) => &r.field_languages,
-            InputReference::Software(r) => &r.field_languages,
-            InputReference::Event(r) => &r.field_languages,
-            InputReference::AudioVisual(r) => &r.field_languages,
+        match &self.extension {
+            ClassExtension::Monograph(r) => &r.field_languages,
+            ClassExtension::CollectionComponent(r) => &r.field_languages,
+            ClassExtension::SerialComponent(r) => &r.field_languages,
+            ClassExtension::Collection(r) => &r.field_languages,
+            ClassExtension::Serial(r) => &r.field_languages,
+            ClassExtension::LegalCase(r) => &r.field_languages,
+            ClassExtension::Statute(r) => &r.field_languages,
+            ClassExtension::Treaty(r) => &r.field_languages,
+            ClassExtension::Hearing(r) => &r.field_languages,
+            ClassExtension::Regulation(r) => &r.field_languages,
+            ClassExtension::Brief(r) => &r.field_languages,
+            ClassExtension::Classic(r) => &r.field_languages,
+            ClassExtension::Patent(r) => &r.field_languages,
+            ClassExtension::Dataset(r) => &r.field_languages,
+            ClassExtension::Standard(r) => &r.field_languages,
+            ClassExtension::Software(r) => &r.field_languages,
+            ClassExtension::Event(r) => &r.field_languages,
+            ClassExtension::AudioVisual(r) => &r.field_languages,
+            ClassExtension::Unknown(_) => &EMPTY_FIELD_LANGUAGES,
         }
     }
 
-    /// Set the reference ID.
+    /// Set the reference ID on the class-specific extension.
+    ///
+    /// For unknown-class references the id is stored as a `JsonValue::String`
+    /// inside `UnknownClassData::fields["id"]`. The wire schema requires
+    /// `id: string`, so round-trip is lossless for valid inputs.
     pub fn set_id(&mut self, id: impl Into<RefID>) {
         let id = id.into();
-
-        match self {
-            InputReference::Monograph(monograph) => monograph.id = Some(id),
-            InputReference::CollectionComponent(component) => component.id = Some(id),
-            InputReference::SerialComponent(component) => component.id = Some(id),
-            InputReference::Collection(collection) => collection.id = Some(id),
-            InputReference::Serial(serial) => serial.id = Some(id),
-            InputReference::LegalCase(r) => r.id = Some(id),
-            InputReference::Statute(r) => r.id = Some(id),
-            InputReference::Treaty(r) => r.id = Some(id),
-            InputReference::Hearing(r) => r.id = Some(id),
-            InputReference::Regulation(r) => r.id = Some(id),
-            InputReference::Brief(r) => r.id = Some(id),
-            InputReference::Classic(r) => r.id = Some(id),
-            InputReference::Patent(r) => r.id = Some(id),
-            InputReference::Dataset(r) => r.id = Some(id),
-            InputReference::Standard(r) => r.id = Some(id),
-            InputReference::Software(r) => r.id = Some(id),
-            InputReference::Event(r) => r.id = Some(id),
-            InputReference::AudioVisual(r) => r.id = Some(id),
+        match &mut self.extension {
+            ClassExtension::Monograph(monograph) => monograph.id = Some(id.clone()),
+            ClassExtension::CollectionComponent(component) => component.id = Some(id.clone()),
+            ClassExtension::SerialComponent(component) => component.id = Some(id.clone()),
+            ClassExtension::Collection(collection) => collection.id = Some(id.clone()),
+            ClassExtension::Serial(serial) => serial.id = Some(id.clone()),
+            ClassExtension::LegalCase(r) => r.id = Some(id.clone()),
+            ClassExtension::Statute(r) => r.id = Some(id.clone()),
+            ClassExtension::Treaty(r) => r.id = Some(id.clone()),
+            ClassExtension::Hearing(r) => r.id = Some(id.clone()),
+            ClassExtension::Regulation(r) => r.id = Some(id.clone()),
+            ClassExtension::Brief(r) => r.id = Some(id.clone()),
+            ClassExtension::Classic(r) => r.id = Some(id.clone()),
+            ClassExtension::Patent(r) => r.id = Some(id.clone()),
+            ClassExtension::Dataset(r) => r.id = Some(id.clone()),
+            ClassExtension::Standard(r) => r.id = Some(id.clone()),
+            ClassExtension::Software(r) => r.id = Some(id.clone()),
+            ClassExtension::Event(r) => r.id = Some(id.clone()),
+            ClassExtension::AudioVisual(r) => r.id = Some(id.clone()),
+            ClassExtension::Unknown(data) => {
+                data.fields
+                    .insert("id".to_string(), JsonValue::String(id.to_string()));
+            }
         }
     }
 
@@ -1580,8 +2425,8 @@ impl InputReference {
         reason = "Enum dispatch for reference types requires extensive branching"
     )]
     pub fn ref_type(&self) -> String {
-        match self {
-            InputReference::Monograph(r) => match r.r#type {
+        match &self.extension {
+            ClassExtension::Monograph(r) => match r.r#type {
                 MonographType::Book => {
                     if r.medium
                         .as_deref()
@@ -1620,7 +2465,7 @@ impl InputReference {
                     }
                 }
             },
-            InputReference::CollectionComponent(r) => match r.r#type {
+            ClassExtension::CollectionComponent(r) => match r.r#type {
                 MonographComponentType::Chapter => match r.genre.as_deref() {
                     Some("entry-dictionary") => "entry-dictionary".to_string(),
                     Some("entry-encyclopedia") => "entry-encyclopedia".to_string(),
@@ -1628,7 +2473,7 @@ impl InputReference {
                 },
                 MonographComponentType::Document => "paper-conference".to_string(),
             },
-            InputReference::SerialComponent(r) => {
+            ClassExtension::SerialComponent(r) => {
                 if r.genre.as_deref() == Some("entry-encyclopedia") {
                     return "entry-encyclopedia".to_string();
                 }
@@ -1655,29 +2500,29 @@ impl InputReference {
                     _ => "article-journal".to_string(),
                 }
             }
-            InputReference::Collection(r) => match r.r#type {
+            ClassExtension::Collection(r) => match r.r#type {
                 CollectionType::EditedBook => "book".to_string(),
                 _ => "collection".to_string(),
             },
-            InputReference::Serial(r) => match r.r#type {
+            ClassExtension::Serial(r) => match r.r#type {
                 SerialType::AcademicJournal => "article-journal".to_string(),
                 SerialType::Magazine => "article-magazine".to_string(),
                 SerialType::Newspaper => "article-newspaper".to_string(),
                 SerialType::BroadcastProgram => "broadcast".to_string(),
                 _ => "serial".to_string(),
             },
-            InputReference::LegalCase(_) => "legal-case".to_string(),
-            InputReference::Statute(_) => "statute".to_string(),
-            InputReference::Treaty(_) => "treaty".to_string(),
-            InputReference::Hearing(_) => "hearing".to_string(),
-            InputReference::Regulation(_) => "regulation".to_string(),
-            InputReference::Brief(_) => "brief".to_string(),
-            InputReference::Classic(_) => "classic".to_string(),
-            InputReference::Patent(_) => "patent".to_string(),
-            InputReference::Dataset(_) => "dataset".to_string(),
-            InputReference::Standard(_) => "standard".to_string(),
-            InputReference::Software(_) => "software".to_string(),
-            InputReference::Event(r) => {
+            ClassExtension::LegalCase(_) => "legal-case".to_string(),
+            ClassExtension::Statute(_) => "statute".to_string(),
+            ClassExtension::Treaty(_) => "treaty".to_string(),
+            ClassExtension::Hearing(_) => "hearing".to_string(),
+            ClassExtension::Regulation(_) => "regulation".to_string(),
+            ClassExtension::Brief(_) => "brief".to_string(),
+            ClassExtension::Classic(_) => "classic".to_string(),
+            ClassExtension::Patent(_) => "patent".to_string(),
+            ClassExtension::Dataset(_) => "dataset".to_string(),
+            ClassExtension::Standard(_) => "standard".to_string(),
+            ClassExtension::Software(_) => "software".to_string(),
+            ClassExtension::Event(r) => {
                 match r
                     .genre
                     .as_deref()
@@ -1692,12 +2537,29 @@ impl InputReference {
                     _ => "event".to_string(),
                 }
             }
-            InputReference::AudioVisual(r) => match r.r#type {
+            ClassExtension::AudioVisual(r) => match r.r#type {
                 AudioVisualType::Film => "motion-picture".to_string(),
                 AudioVisualType::Episode => "broadcast".to_string(),
                 AudioVisualType::Recording => "song".to_string(),
                 AudioVisualType::Broadcast => "broadcast".to_string(),
             },
+            ClassExtension::Unknown(data) => {
+                // Unknown classes round-trip but cannot route to a known
+                // CSL ref-type; the engine has no template branch for the
+                // raw class string, so rendering will fall through to the
+                // default path (typically empty output).
+                //
+                // TODO(csl26-1bdr): Layer 5 `CompatibilityWarning` plumbing
+                // will surface this as a soft-degrade warning rather than
+                // silent fall-through. Until then we return the raw class
+                // string so debug builds and logs can identify the value.
+                debug_assert!(
+                    !ReferenceClass::KNOWN.contains(&data.class.as_str()),
+                    "ClassExtension::Unknown should never wrap a known class string (got `{}`)",
+                    data.class
+                );
+                data.class.clone()
+            }
         }
     }
 }
@@ -1723,6 +2585,471 @@ fn collect_contributors_by_role(
         _ => Some(Contributor::ContributorList(ContributorList(
             matching.into_iter().cloned().collect(),
         ))),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::unreachable,
+    clippy::get_unwrap,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod discriminator_tests {
+    use super::{ClassExtension, InputReference, ReferenceClass};
+    use serde_json::{Value as JsonValue, json};
+
+    fn parse_reference(json: &str) -> Result<InputReference, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn public_discriminator_parses_representative_known_classes() {
+        // given a representative input for each known top-level class,
+        // when parsed via the flat-with-discriminator deserializer,
+        // then the `class()` accessor must return the matching typed variant
+        // (not Unknown, not a different known class).
+        let cases: &[(&str, ReferenceClass)] = &[
+            (
+                r#"{ "class": "monograph", "type": "book", "title": "B", "issued": "2024" }"#,
+                ReferenceClass::Monograph,
+            ),
+            (
+                r#"{
+                    "class": "legal-case",
+                    "title": "Smith v. Jones",
+                    "authority": "Supreme Court",
+                    "issued": "2024"
+                }"#,
+                ReferenceClass::LegalCase,
+            ),
+            (
+                r#"{ "class": "audio-visual", "type": "film", "title": "F", "issued": "2024" }"#,
+                ReferenceClass::AudioVisual,
+            ),
+        ];
+
+        for (json, expected_class) in cases {
+            let reference = parse_reference(json).unwrap_or_else(|err| {
+                panic!("expected `{expected_class:?}` to parse, got error: {err}\nJSON: {json}")
+            });
+            assert_eq!(
+                &reference.class(),
+                expected_class,
+                "class() must equal the expected variant for JSON: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn public_discriminator_rejects_unknown_field_on_known_class() {
+        // when an unknown-for-this-class field is present on a known class,
+        // then deserialization must fail with a serde-canonical "unknown field"
+        // error that names the offending field — not merely a generic schema error.
+        let err = parse_reference(
+            r#"{
+                "class": "legal-case",
+                "title": "Smith v. Jones",
+                "monograph-type": "book"
+            }"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("`monograph-type`"),
+            "error must quote the offending field name in backticks, got: {err}"
+        );
+        assert!(
+            err.contains("unknown field") || err.contains("did not match"),
+            "error must be a canonical unknown-field/match-failure error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn public_discriminator_captures_unknown_class_fields() {
+        // when an unknown class string is encountered,
+        // then the dispatcher must capture the class verbatim,
+        // preserve non-shared fields under `UnknownClassData::fields`,
+        // expose the shared `id` through the accessor (proves shared-fields
+        // extraction works on the unknown path too), and surface the raw class
+        // string via `ref_type()` per the documented soft-degrade contract.
+        let reference = parse_reference(
+            r#"{
+                "class": "dance-performance",
+                "id": "pina2011",
+                "title": "Pina",
+                "venue": "Berlin",
+                "duration-minutes": 103
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            reference.class(),
+            ReferenceClass::Unknown("dance-performance".into())
+        );
+
+        let unknown = reference.unknown_class().unwrap();
+        assert_eq!(unknown.class, "dance-performance");
+        assert_eq!(
+            unknown.fields.get("venue").and_then(JsonValue::as_str),
+            Some("Berlin"),
+            "captured non-shared field must be exactly the wire value"
+        );
+        assert_eq!(
+            unknown
+                .fields
+                .get("duration-minutes")
+                .and_then(JsonValue::as_u64),
+            Some(103),
+            "non-shared numeric field must preserve its JSON number type"
+        );
+        assert_eq!(reference.id().unwrap().as_str(), "pina2011");
+        match reference.title().unwrap() {
+            super::Title::Single(s) => assert_eq!(
+                s, "Pina",
+                "shared title must be the wire value for unknown-class refs"
+            ),
+            other => panic!("expected Title::Single, got {other:?}"),
+        }
+        assert_eq!(
+            reference.ref_type(),
+            "dance-performance",
+            "ref_type for unknown class must return the raw class string (Layer-5 will replace)"
+        );
+        assert!(
+            !ReferenceClass::KNOWN.contains(&reference.ref_type().as_str()),
+            "ref_type sentinel for unknown class must not collide with any known class string"
+        );
+    }
+
+    #[test]
+    fn public_discriminator_round_trips_flat_unknown_class() {
+        // given an unknown-class reference parsed from flat JSON,
+        // when re-serialized, the output must be structurally flat
+        // (no UnknownClassData wrapper, no `fields` key, top-level discriminator),
+        // and a second parse must yield a value equal to the first.
+        let reference = parse_reference(
+            r#"{
+                "class": "dance-performance",
+                "id": "pina2011",
+                "title": "Pina",
+                "venue": "Berlin"
+            }"#,
+        )
+        .unwrap();
+
+        let serialized: JsonValue = serde_json::to_value(&reference).unwrap();
+        let serialized_obj = serialized
+            .as_object()
+            .expect("must serialize as a JSON object");
+
+        assert_eq!(
+            serialized_obj.get("class").and_then(JsonValue::as_str),
+            Some("dance-performance"),
+            "discriminator must round-trip at the top level"
+        );
+        assert_eq!(
+            serialized_obj.get("venue").and_then(JsonValue::as_str),
+            Some("Berlin"),
+            "non-shared field must round-trip at the top level (flat structure)"
+        );
+        assert!(
+            !serialized_obj.contains_key("fields"),
+            "must not leak the internal UnknownClassData `fields` key, got: {serialized}"
+        );
+
+        let round_tripped: InputReference = serde_json::from_value(serialized).unwrap();
+        assert_eq!(round_tripped, reference);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // New tests covering the post-Copilot-review hardening paths.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn duplicate_class_field_is_rejected_with_canonical_serde_shape() {
+        // when the `class` discriminator appears twice on the wire,
+        // then the dispatcher must reject it with the canonical
+        // `duplicate field \`class\`` shape (matches serde's
+        // `de::Error::duplicate_field` output for compatibility).
+        let err = parse_reference(
+            r#"{
+                "class": "monograph",
+                "class": "legal-case",
+                "title": "X",
+                "issued": "2024"
+            }"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("duplicate field `class`"),
+            "must produce serde-canonical duplicate-field message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_non_class_field_is_rejected_with_canonical_serde_shape() {
+        // the non-class path was previously inconsistent (used `custom` with
+        // a free-form string while the `class` path used `duplicate_field`).
+        // both paths must now produce the identical canonical shape.
+        let err = parse_reference(
+            r#"{
+                "class": "monograph",
+                "title": "First",
+                "title": "Second",
+                "issued": "2024"
+            }"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("duplicate field `title`"),
+            "non-class duplicate must mirror the serde-canonical shape, got: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_class_field_is_rejected() {
+        let err = parse_reference(r#"{ "title": "Untyped", "issued": "2024" }"#)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("missing field `class`"),
+            "absence of the discriminator must produce a canonical missing-field error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn non_object_body_is_rejected_with_schema_error_not_io_error() {
+        // covers the `from_known` defensive branch: prior implementation
+        // surfaced this as an IO-wrapped error, which was misleading for
+        // schema bugs. The current path uses `de::Error::custom` so the
+        // surfaced message must be a plain schema error.
+        let err = serde_json::from_value::<InputReference>(json!(["not", "an", "object"]))
+            .unwrap_err()
+            .to_string();
+        // The visitor `expecting` message describes a flat reference object;
+        // serde's invalid-type machinery threads that through. Either the
+        // visitor's `expecting` text or our defensive message is acceptable.
+        assert!(
+            err.contains("flat reference object")
+                || err.contains("reference body must be a JSON object")
+                || err.contains("invalid type"),
+            "must produce a schema-shaped error, not an IO error, got: {err}"
+        );
+        assert!(
+            !err.contains("InvalidData"),
+            "must not leak the io::ErrorKind::InvalidData shape, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_class_ref_type_does_not_collide_with_known_classes() {
+        // regression guard for the Layer-5 soft-degrade contract: ref_type()
+        // for an unknown class must never accidentally route to a known
+        // CSL type-template branch.
+        for unknown in [
+            "dance-performance",
+            "happening",
+            "frobnicate",
+            "x-future-class",
+        ] {
+            let json =
+                format!(r#"{{ "class": "{unknown}", "id": "a", "title": "T", "issued": "2024" }}"#);
+            let reference = parse_reference(&json).unwrap();
+            assert!(
+                matches!(reference.class(), ReferenceClass::Unknown(ref s) if s == unknown),
+                "{unknown} must classify as Unknown",
+            );
+            assert!(
+                !ReferenceClass::KNOWN.contains(&reference.ref_type().as_str()),
+                "{unknown}: ref_type() returned {:?}, which is a KNOWN class — would mis-route at render",
+                reference.ref_type()
+            );
+        }
+    }
+
+    #[test]
+    fn accessor_and_extension_class_agree_for_every_known_variant() {
+        // forward-compat guard: every known class must parse such that
+        // `class()` agrees with the resident `ClassExtension` variant.
+        // Catches drift if a future change to the dispatcher routes a class
+        // string into the wrong extension box.
+        let cases: &[(&str, ReferenceClass, fn(&ClassExtension) -> bool)] = &[
+            (
+                r#"{ "class": "monograph", "type": "book", "title": "B", "issued": "2024" }"#,
+                ReferenceClass::Monograph,
+                |e| matches!(e, ClassExtension::Monograph(_)),
+            ),
+            (
+                r#"{ "class": "legal-case", "title": "S v J", "authority": "SC", "issued": "2024" }"#,
+                ReferenceClass::LegalCase,
+                |e| matches!(e, ClassExtension::LegalCase(_)),
+            ),
+            (
+                r#"{ "class": "audio-visual", "type": "film", "title": "F", "issued": "2024" }"#,
+                ReferenceClass::AudioVisual,
+                |e| matches!(e, ClassExtension::AudioVisual(_)),
+            ),
+            (
+                r#"{ "class": "patent", "title": "P", "patent-number": "US123", "issued": "2024" }"#,
+                ReferenceClass::Patent,
+                |e| matches!(e, ClassExtension::Patent(_)),
+            ),
+            (
+                r#"{ "class": "dataset", "title": "D", "issued": "2024" }"#,
+                ReferenceClass::Dataset,
+                |e| matches!(e, ClassExtension::Dataset(_)),
+            ),
+            (
+                r#"{ "class": "software", "title": "S", "issued": "2024" }"#,
+                ReferenceClass::Software,
+                |e| matches!(e, ClassExtension::Software(_)),
+            ),
+        ];
+
+        for (json, expected_class, extension_matches) in cases {
+            let reference = parse_reference(json).expect(json);
+            assert_eq!(
+                &reference.class(),
+                expected_class,
+                "class() drift on {json}"
+            );
+            assert!(
+                extension_matches(&reference.extension),
+                "ClassExtension variant drift on {json}: class()={:?}",
+                reference.class()
+            );
+        }
+    }
+
+    #[test]
+    fn set_id_updates_the_class_specific_extension_for_known_class() {
+        // `set_id` writes only into the class-specific extension (the
+        // duplicated top-level shared fields have been removed). Verify
+        // both the public accessor and direct extension inspection agree.
+        let mut reference = parse_reference(
+            r#"{ "class": "monograph", "type": "book", "title": "B", "id": "orig", "issued": "2024" }"#,
+        )
+        .unwrap();
+
+        reference.set_id(super::RefID::from("updated"));
+
+        assert_eq!(reference.id().unwrap().as_str(), "updated");
+        match &reference.extension {
+            ClassExtension::Monograph(m) => assert_eq!(
+                m.id.as_ref().map(|r| r.as_str()),
+                Some("updated"),
+                "set_id must update the class-specific extension copy"
+            ),
+            other => panic!("expected Monograph extension, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serialize_emits_flat_object_with_class_first_and_no_nesting() {
+        // regression guard for the flatten-proxy serialize path. The wire
+        // shape must be a flat object with `class` as a sibling of the
+        // typed fields — never nested as `{ "monograph": {...} }` and
+        // never reordered into the inner. Catches a future accidental
+        // change away from `#[serde(flatten)]` on FlatClassProxy.
+        let reference = parse_reference(
+            r#"{ "class": "monograph", "type": "book", "title": "Pina", "id": "pina2011", "issued": "2024" }"#,
+        )
+        .unwrap();
+
+        let value = serde_json::to_value(&reference).unwrap();
+        let obj = value
+            .as_object()
+            .expect("InputReference must serialize to a top-level JSON object");
+
+        assert_eq!(
+            obj.get("class").and_then(JsonValue::as_str),
+            Some("monograph"),
+            "class discriminator must sit at the top level"
+        );
+        assert_eq!(
+            obj.get("type").and_then(JsonValue::as_str),
+            Some("book"),
+            "typed fields must be flattened to the top level, not nested"
+        );
+        assert_eq!(
+            obj.get("id").and_then(JsonValue::as_str),
+            Some("pina2011"),
+            "shared `id` must be flattened from the extension to the top level"
+        );
+        assert!(
+            !obj.contains_key("monograph"),
+            "must not nest the inner struct under a class-named key, got: {value}"
+        );
+        assert!(
+            !obj.contains_key("extension"),
+            "must not leak the internal `extension` field name, got: {value}"
+        );
+    }
+
+    #[test]
+    fn round_trip_through_serde_value_preserves_every_known_class() {
+        // belt-and-suspenders: serialize → from_value → equality. Exercises
+        // the proxy serialize path for every known class via the existing
+        // accessor_and_extension fixture set, plus Unknown.
+        let cases = [
+            r#"{ "class": "monograph", "type": "book", "title": "B", "issued": "2024" }"#,
+            r#"{ "class": "legal-case", "title": "S v J", "authority": "SC", "issued": "2024" }"#,
+            r#"{ "class": "audio-visual", "type": "film", "title": "F", "issued": "2024" }"#,
+            r#"{ "class": "patent", "title": "P", "patent-number": "US123", "issued": "2024" }"#,
+            r#"{ "class": "dataset", "title": "D", "issued": "2024" }"#,
+            r#"{ "class": "software", "title": "S", "issued": "2024" }"#,
+            r#"{ "class": "dance-performance", "id": "p", "title": "P", "venue": "B" }"#,
+        ];
+        for json in cases {
+            let reference = parse_reference(json).expect(json);
+            let value = serde_json::to_value(&reference).unwrap();
+            let parsed: InputReference = serde_json::from_value(value).expect(json);
+            assert_eq!(reference, parsed, "round-trip drift on: {json}");
+        }
+    }
+
+    #[test]
+    fn set_id_keeps_unknown_class_fields_in_sync() {
+        // unknown-class refs store id as a JsonValue::String in
+        // UnknownClassData::fields; verify the documented behavior holds
+        // and round-trips through the public `id()` accessor.
+        let mut reference =
+            parse_reference(r#"{ "class": "dance-performance", "id": "orig", "title": "P" }"#)
+                .unwrap();
+
+        reference.set_id(super::RefID::from("updated"));
+
+        assert_eq!(reference.id().unwrap().as_str(), "updated");
+        let unknown = reference.unknown_class().unwrap();
+        assert_eq!(
+            unknown.fields.get("id").and_then(JsonValue::as_str),
+            Some("updated"),
+            "unknown-class set_id must update fields[\"id\"] as a JSON string"
+        );
+    }
+
+    #[cfg(feature = "schema")]
+    #[test]
+    fn public_discriminator_schema_contains_class_branches_and_strict_root() {
+        let schema = serde_json::to_value(schemars::schema_for!(InputReference)).unwrap();
+        let schema_text = serde_json::to_string(&schema).unwrap();
+
+        assert!(schema_text.contains("\"unevaluatedProperties\":false"));
+        assert!(schema_text.contains("\"const\":\"monograph\""));
+        assert!(schema_text.contains("\"const\":\"legal-case\""));
+        assert!(schema_text.contains("\"const\":\"audio-visual\""));
     }
 }
 

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -44,8 +44,8 @@ fn test_parse_csl_json_structural_author_populates_canonical_contributors() {
 
     assert!(reference.contributor(ContributorRole::Author).is_some());
 
-    match reference {
-        InputReference::Monograph(monograph) => assert!(
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => assert!(
             monograph
                 .contributors
                 .iter()
@@ -69,8 +69,8 @@ fn test_parse_csl_json_motion_picture_produces_audio_visual() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::AudioVisual(work) => {
+    match reference.extension() {
+        ClassExtension::AudioVisual(work) => {
             assert_eq!(work.r#type, AudioVisualType::Film);
             assert!(
                 work.core
@@ -98,8 +98,8 @@ fn test_parse_csl_json_broadcast_without_audio_roles_stays_serial_component() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::SerialComponent(component) => {
+    match reference.extension() {
+        ClassExtension::SerialComponent(component) => {
             assert!(component.author.is_some());
             let container_title =
                 component
@@ -135,8 +135,8 @@ fn test_parse_csl_json_broadcast_with_producers_stays_serial_component() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::SerialComponent(component) => {
+    match reference.extension() {
+        ClassExtension::SerialComponent(component) => {
             assert!(component.author.is_some());
             assert!(
                 component
@@ -177,8 +177,8 @@ fn test_parse_csl_json_broadcast_podcast_number_normalizes_with_no_prefix_added(
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::SerialComponent(component) => {
+    match reference.extension() {
+        ClassExtension::SerialComponent(component) => {
             assert_eq!(component.issue.as_deref(), Some("No. 443"));
         }
         other => panic!("expected serial component, got {:?}", other),
@@ -247,7 +247,7 @@ fn test_parse_csl_json_event_note_type_routes_to_event_with_chair_and_session() 
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    let InputReference::Event(event) = reference else {
+    let ClassExtension::Event(event) = reference.extension() else {
         panic!("expected event reference");
     };
 
@@ -320,7 +320,7 @@ fn test_parse_csl_json_containerless_article_maps_to_preprint() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    let InputReference::Monograph(preprint) = reference else {
+    let ClassExtension::Monograph(preprint) = reference.extension() else {
         panic!("expected preprint to map to a monograph");
     };
 
@@ -486,8 +486,8 @@ fn test_parse_csl_bill_record_prefers_container_title_as_title() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::Monograph(monograph) => {
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => {
             assert_eq!(monograph.r#type, MonographType::Document);
             assert_eq!(monograph.genre.as_deref(), Some("bill-record"));
             assert_eq!(
@@ -515,8 +515,8 @@ fn test_parse_csl_bill_proceeding_uses_number_as_surrogate_title() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::Monograph(monograph) => {
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => {
             assert_eq!(monograph.r#type, MonographType::Document);
             assert_eq!(monograph.genre.as_deref(), Some("bill-proceeding"));
             assert_eq!(monograph.title, Some(Title::Single("149".to_string())));
@@ -539,8 +539,8 @@ fn test_parse_csl_bill_with_title_and_authority_routes_to_hearing() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::Hearing(hearing) => {
+    match reference.extension() {
+        ClassExtension::Hearing(hearing) => {
             assert_eq!(
                 hearing.authority.as_deref(),
                 Some("U.S. Senate Committee on the Judiciary")
@@ -621,8 +621,8 @@ issued: "2019"
 
     let reference: InputReference = serde_yaml::from_str(yaml).expect("failed to parse YAML");
 
-    match &reference {
-        InputReference::AudioVisual(av) => {
+    match reference.extension() {
+        ClassExtension::AudioVisual(av) => {
             assert_eq!(av.r#type, AudioVisualType::Film);
             assert_eq!(av.core.title, Some(Title::Single("Parasite".to_string())));
             assert_eq!(av.core.issued.0, "2019");
@@ -670,8 +670,8 @@ issued: "1971"
 
     let reference: InputReference = serde_yaml::from_str(yaml).expect("failed to parse YAML");
 
-    match &reference {
-        InputReference::AudioVisual(av) => {
+    match reference.extension() {
+        ClassExtension::AudioVisual(av) => {
             assert_eq!(av.r#type, AudioVisualType::Episode);
             assert_eq!(
                 av.core.title,
@@ -742,8 +742,8 @@ issued: "1975"
 
     let reference: InputReference = serde_yaml::from_str(yaml).expect("failed to parse YAML");
 
-    match &reference {
-        InputReference::Monograph(_mono) => {
+    match reference.extension() {
+        ClassExtension::Monograph(_mono) => {
             // verify it parses as monograph
         }
         other => panic!("expected Monograph, got {:?}", other),
@@ -785,7 +785,7 @@ author:
 issued: "1962"
 "#;
     let r: InputReference = serde_yaml::from_str(yaml).unwrap();
-    if let InputReference::Monograph(m) = &r {
+    if let ClassExtension::Monograph(m) = r.extension() {
         assert!(
             m.contributors
                 .iter()
@@ -815,7 +815,7 @@ contributors:
 issued: "2020"
 "#;
     let r: InputReference = serde_yaml::from_str(yaml).unwrap();
-    if let InputReference::Monograph(m) = &r {
+    if let ClassExtension::Monograph(m) = r.extension() {
         let author_count = m
             .contributors
             .iter()
@@ -944,7 +944,7 @@ number: "PR90113"
 issued: "1962"
 "#;
     let r: InputReference = serde_yaml::from_str(yaml).unwrap();
-    if let InputReference::AudioVisual(av) = &r {
+    if let ClassExtension::AudioVisual(av) = r.extension() {
         assert!(
             av.numbering.iter().any(|n| n.value == "PR90113"),
             "catalog number not folded into numbering"
@@ -968,10 +968,11 @@ fn conversion_hydrates_structured_archive_info_from_legacy_fields() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    match reference {
-        InputReference::Monograph(monograph) => {
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => {
             let archive_info = monograph
                 .archive_info
+                .clone()
                 .expect("archive info should be hydrated");
             assert_eq!(
                 archive_info
@@ -1073,22 +1074,22 @@ fn conversion_promotes_paper_conference_event_metadata() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    let container = match &reference {
-        InputReference::CollectionComponent(r) => r.container.as_ref(),
+    let container = match reference.extension() {
+        ClassExtension::CollectionComponent(r) => r.container.as_ref(),
         other => panic!("expected CollectionComponent, got {:?}", other),
     };
 
     let collection = match container {
-        Some(WorkRelation::Embedded(inner)) => match inner.as_ref() {
-            InputReference::Collection(c) => c,
+        Some(WorkRelation::Embedded(inner)) => match inner.extension() {
+            ClassExtension::Collection(c) => c,
             other => panic!("expected Collection container, got {:?}", other),
         },
         other => panic!("expected embedded container, got {:?}", other),
     };
 
     let event = match collection.event.as_ref() {
-        Some(WorkRelation::Embedded(inner)) => match inner.as_ref() {
-            InputReference::Event(e) => e,
+        Some(WorkRelation::Embedded(inner)) => match inner.extension() {
+            ClassExtension::Event(e) => e,
             other => panic!("expected embedded Event, got {:?}", other),
         },
         other => panic!("expected embedded event relation, got {:?}", other),
@@ -1118,14 +1119,14 @@ fn conversion_paper_conference_without_event_fields_has_no_event() {
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    let container = match &reference {
-        InputReference::CollectionComponent(r) => r.container.as_ref(),
+    let container = match reference.extension() {
+        ClassExtension::CollectionComponent(r) => r.container.as_ref(),
         other => panic!("expected CollectionComponent, got {:?}", other),
     };
 
     let collection = match container {
-        Some(WorkRelation::Embedded(inner)) => match inner.as_ref() {
-            InputReference::Collection(c) => c,
+        Some(WorkRelation::Embedded(inner)) => match inner.extension() {
+            ClassExtension::Collection(c) => c,
             other => panic!("expected Collection container, got {:?}", other),
         },
         other => panic!("expected embedded container, got {:?}", other),
@@ -1160,8 +1161,8 @@ fn conversion_chapter_without_named_parent_keeps_volume_but_avoids_empty_contain
     let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
     let reference: InputReference = legacy.into();
 
-    let component = match &reference {
-        InputReference::CollectionComponent(component) => component,
+    let component = match reference.extension() {
+        ClassExtension::CollectionComponent(component) => component,
         other => panic!("expected CollectionComponent, got {:?}", other),
     };
 
@@ -1176,8 +1177,8 @@ fn conversion_chapter_without_named_parent_keeps_volume_but_avoids_empty_contain
     );
 
     let collection = match component.container.as_ref() {
-        Some(WorkRelation::Embedded(inner)) => match inner.as_ref() {
-            InputReference::Collection(collection) => collection,
+        Some(WorkRelation::Embedded(inner)) => match inner.extension() {
+            ClassExtension::Collection(collection) => collection,
             other => panic!("expected Collection container, got {:?}", other),
         },
         other => panic!("expected embedded collection container, got {:?}", other),
@@ -1241,13 +1242,13 @@ fn conversion_maps_original_publisher_metadata_into_original_relation() {
         Some("Boston".to_string())
     );
 
-    let InputReference::Monograph(book) = reference else {
+    let ClassExtension::Monograph(book) = reference.extension() else {
         panic!("expected monograph");
     };
     let Some(WorkRelation::Embedded(original)) = book.original.as_ref() else {
         panic!("expected embedded original relation");
     };
-    let InputReference::Monograph(original_book) = original.as_ref() else {
+    let ClassExtension::Monograph(original_book) = original.as_ref().extension() else {
         panic!("expected original relation to be a monograph");
     };
 
@@ -1288,13 +1289,13 @@ fn conversion_preserves_place_only_original_publication_metadata() {
         Some("Boston".to_string())
     );
 
-    let InputReference::Monograph(book) = reference else {
+    let ClassExtension::Monograph(book) = reference.extension() else {
         panic!("expected monograph");
     };
     let Some(WorkRelation::Embedded(original)) = book.original.as_ref() else {
         panic!("expected embedded original relation");
     };
-    let InputReference::Monograph(original_book) = original.as_ref() else {
+    let ClassExtension::Monograph(original_book) = original.as_ref().extension() else {
         panic!("expected original relation to be a monograph");
     };
 
@@ -1482,13 +1483,13 @@ fn conversion_maps_original_relation_for_legal_case_references() {
         Some("Old Press".to_string())
     );
 
-    let InputReference::LegalCase(case_ref) = reference else {
+    let ClassExtension::LegalCase(case_ref) = reference.extension() else {
         panic!("expected legal case");
     };
     let Some(WorkRelation::Embedded(original)) = case_ref.original.as_ref() else {
         panic!("expected embedded original");
     };
-    let InputReference::Monograph(original_book) = original.as_ref() else {
+    let ClassExtension::Monograph(original_book) = original.as_ref().extension() else {
         panic!("expected original relation to normalize to a monograph");
     };
     assert_eq!(

--- a/crates/citum-schema-data/src/reference/types/legal.rs
+++ b/crates/citum-schema-data/src/reference/types/legal.rs
@@ -21,8 +21,7 @@ use url::Url;
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct LegalCase {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,8 +80,7 @@ pub struct LegalCase {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Statute {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -147,8 +145,7 @@ pub struct Statute {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Treaty {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -204,8 +201,7 @@ pub struct Treaty {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Hearing {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -255,8 +251,7 @@ pub struct Hearing {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Regulation {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -312,8 +307,7 @@ pub struct Regulation {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Brief {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/citum-schema-data/src/reference/types/specialized.rs
+++ b/crates/citum-schema-data/src/reference/types/specialized.rs
@@ -24,7 +24,7 @@ use url::Url;
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Event {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -83,7 +83,6 @@ pub struct Event {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(from = "ClassicDeser", rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Classic {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -167,7 +166,7 @@ pub struct Classic {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct ClassicDeser {
     id: Option<RefID>,
     title: Option<Title>,
@@ -287,8 +286,7 @@ impl NormalizeNumbering for Classic {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Patent {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -353,8 +351,7 @@ pub struct Patent {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Dataset {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -420,8 +417,7 @@ pub struct Dataset {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Standard {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -477,8 +473,7 @@ pub struct Standard {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Software {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -648,7 +643,7 @@ pub struct AudioVisualWork {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct AudioVisualDeser {
     id: Option<RefID>,
     #[serde(default)]

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -76,7 +76,6 @@ fn collect_contributors_by_role(
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(from = "MonographDeser", rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Monograph {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -219,7 +218,7 @@ pub struct Monograph {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct MonographDeser {
     id: Option<RefID>,
     r#type: MonographType,
@@ -390,7 +389,6 @@ pub enum MonographType {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(from = "CollectionDeser", rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Collection {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -482,7 +480,7 @@ pub struct Collection {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct CollectionDeser {
     id: Option<RefID>,
     r#type: CollectionType,
@@ -598,7 +596,6 @@ pub enum CollectionType {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(from = "CollectionComponentDeser", rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct CollectionComponent {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -705,7 +702,7 @@ pub struct CollectionComponent {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct CollectionComponentDeser {
     id: Option<RefID>,
     r#type: MonographComponentType,
@@ -828,7 +825,6 @@ pub enum MonographComponentType {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(from = "SerialComponentDeser", rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct SerialComponent {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -948,7 +944,7 @@ pub struct SerialComponent {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct SerialComponentDeser {
     id: Option<RefID>,
     r#type: SerialComponentType,
@@ -1080,7 +1076,6 @@ pub enum SerialComponentType {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(from = "SerialDeser", rename_all = "kebab-case")]
-// deny_unknown_fields removed: incompatible with #[serde(tag)] on InputReference (serde limitation - tag field is replayed into inner struct)
 pub struct Serial {
     /// Unique identifier for this reference.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1129,7 +1124,7 @@ pub struct Serial {
 #[derive(Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct SerialDeser {
     id: Option<RefID>,
     r#type: SerialType,

--- a/crates/citum-schema-style/tests/json_deserialization.rs
+++ b/crates/citum-schema-style/tests/json_deserialization.rs
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use citum_schema_style::citation::{CitationItem, IntegralNameState};
 use citum_schema_style::options::{IntegralNameContexts, IntegralNameRule, IntegralNameScope};
-use citum_schema_style::reference::{InputReference, Monograph};
+use citum_schema_style::reference::{ClassExtension, InputReference, Monograph};
 use citum_schema_style::{InputBibliography, Style};
 
 #[test]
@@ -43,7 +43,7 @@ fn test_input_reference_doi_alias() {
         "DOI": "10.1001/test"
     }"#;
     let reference: InputReference = serde_json::from_str(json).unwrap();
-    if let InputReference::Monograph(m) = reference {
+    if let ClassExtension::Monograph(m) = reference.extension() {
         assert_eq!(m.doi, Some("10.1001/test".to_string()));
     } else {
         panic!("Expected Monograph");
@@ -60,8 +60,8 @@ fn test_input_reference_url_alias() {
         "URL": "https://example.com"
     }"#;
     let reference: InputReference = serde_json::from_str(json).unwrap();
-    if let InputReference::Monograph(m) = reference {
-        assert_eq!(m.url.unwrap().to_string(), "https://example.com/");
+    if let ClassExtension::Monograph(m) = reference.extension() {
+        assert_eq!(m.url.as_ref().unwrap().to_string(), "https://example.com/");
     } else {
         panic!("Expected Monograph");
     }
@@ -87,8 +87,8 @@ fn test_input_reference_archive_info_and_eprint_fields() {
     }"#;
 
     let reference: InputReference = serde_json::from_str(json).expect("reference should parse");
-    if let InputReference::Monograph(m) = reference {
-        let archive_info = m.archive_info.expect("archive info should exist");
+    if let ClassExtension::Monograph(m) = reference.extension() {
+        let archive_info = m.archive_info.clone().expect("archive info should exist");
         assert_eq!(
             archive_info
                 .name
@@ -105,7 +105,7 @@ fn test_input_reference_archive_info_and_eprint_fields() {
             "https://example.com/archive"
         );
 
-        let eprint = m.eprint.expect("eprint should exist");
+        let eprint = m.eprint.clone().expect("eprint should exist");
         assert_eq!(eprint.server, "arXiv");
         assert_eq!(eprint.id, "2301.00001");
         assert_eq!(eprint.class, Some("cs.AI".to_string()));

--- a/crates/citum-schema/tests/json_deserialization.rs
+++ b/crates/citum-schema/tests/json_deserialization.rs
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 use citum_schema::citation::{CitationItem, IntegralNameState};
 use citum_schema::options::{IntegralNameContexts, IntegralNameRule, IntegralNameScope};
-use citum_schema::reference::{InputReference, Monograph, NumberingType};
+use citum_schema::reference::{ClassExtension, InputReference, Monograph, NumberingType};
 use citum_schema::{InputBibliography, Style};
 
 #[test]
@@ -43,7 +43,7 @@ fn test_input_reference_doi_alias() {
         "DOI": "10.1001/test"
     }"#;
     let reference: InputReference = serde_json::from_str(json).unwrap();
-    if let InputReference::Monograph(m) = reference {
+    if let ClassExtension::Monograph(m) = reference.extension() {
         assert_eq!(m.doi, Some("10.1001/test".to_string()));
     } else {
         panic!("Expected Monograph");
@@ -60,8 +60,8 @@ fn test_input_reference_url_alias() {
         "URL": "https://example.com"
     }"#;
     let reference: InputReference = serde_json::from_str(json).unwrap();
-    if let InputReference::Monograph(m) = reference {
-        assert_eq!(m.url.unwrap().to_string(), "https://example.com/");
+    if let ClassExtension::Monograph(m) = reference.extension() {
+        assert_eq!(m.url.as_ref().unwrap().to_string(), "https://example.com/");
     } else {
         panic!("Expected Monograph");
     }
@@ -87,8 +87,8 @@ fn test_input_reference_archive_info_and_eprint_fields() {
     }"#;
 
     let reference: InputReference = serde_json::from_str(json).expect("reference should parse");
-    if let InputReference::Monograph(m) = reference {
-        let archive_info = m.archive_info.expect("archive info should exist");
+    if let ClassExtension::Monograph(m) = reference.extension() {
+        let archive_info = m.archive_info.clone().expect("archive info should exist");
         assert_eq!(
             archive_info
                 .name
@@ -105,7 +105,7 @@ fn test_input_reference_archive_info_and_eprint_fields() {
             "https://example.com/archive"
         );
 
-        let eprint = m.eprint.expect("eprint should exist");
+        let eprint = m.eprint.clone().expect("eprint should exist");
         assert_eq!(eprint.server, "arXiv");
         assert_eq!(eprint.id, "2301.00001");
         assert_eq!(eprint.class, Some("cs.AI".to_string()));

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -69,33 +69,590 @@
       }
     },
     "InputReference": {
-      "description": "The Reference model.",
       "oneOf": [
         {
           "description": "A monograph, such as a book or a report, is a monolithic work published or produced as a complete entity.",
           "type": "object",
           "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/MonographType"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              }
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "abstract-text": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "isbn": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ads-bibcode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              }
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive-location": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive-info": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ArchiveInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "eprint": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EprintInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "available-date": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "size": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "duration": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "references": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scale": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "class": {
               "type": "string",
               "const": "monograph"
             }
           },
-          "$ref": "#/$defs/Monograph",
+          "additionalProperties": false,
           "required": [
+            "type",
             "class"
           ]
         },
         {
-          "description": "A component of a larger Monograph, such as a chapter in a book.\nThe parent monograph is referenced by its ID.",
+          "description": "A component of a larger monograph, such as a chapter in a book.",
           "type": "object",
           "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/MonographComponentType"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              }
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              }
+            },
+            "pages": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/NumOrStr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "abstract-text": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive-info": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ArchiveInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "eprint": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EprintInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "class": {
               "type": "string",
               "const": "collection-component"
             }
           },
-          "$ref": "#/$defs/CollectionComponent",
+          "additionalProperties": false,
           "required": [
+            "type",
             "class"
           ]
         },
@@ -103,13 +660,283 @@
           "description": "A component of a larger serial publication; for example a journal or newspaper article.\nThe parent serial is referenced by its ID.",
           "type": "object",
           "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/SerialComponentType"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              }
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              }
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "abstract-text": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ads-bibcode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pages": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive-info": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ArchiveInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "eprint": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EprintInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "section": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "available-date": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "reviewed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "class": {
               "type": "string",
               "const": "serial-component"
             }
           },
-          "$ref": "#/$defs/SerialComponent",
+          "additionalProperties": false,
           "required": [
+            "type",
             "class"
           ]
         },
@@ -117,13 +944,213 @@
           "description": "A collection of works, such as an anthology or proceedings.",
           "type": "object",
           "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/CollectionType"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              }
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              }
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "isbn": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "event": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "collection"
             }
           },
-          "$ref": "#/$defs/Collection",
+          "additionalProperties": false,
           "required": [
+            "type",
             "class"
           ]
         },
@@ -131,13 +1158,128 @@
           "description": "A serial publication (journal, magazine, etc.).",
           "type": "object",
           "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/SerialType"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              }
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "issn": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "class": {
               "type": "string",
               "const": "serial"
             }
           },
-          "$ref": "#/$defs/Serial",
+          "additionalProperties": false,
           "required": [
+            "type",
             "class"
           ]
         },
@@ -145,12 +1287,146 @@
           "description": "A legal case (court decision).",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Case name (e.g., \"Brown v. Board of Education\")",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this case record derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority": {
+              "description": "Court or authority (e.g., \"U.S. Supreme Court\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "description": "Reporter volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reporter": {
+              "description": "Reporter abbreviation (e.g., \"U.S.\", \"F.2d\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "page": {
+              "description": "First page of case in reporter",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the legal work.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "issued": {
+              "description": "Decision date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "url": {
+              "description": "URL for the case.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "doi": {
+              "description": "DOI identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "legal-case"
             }
           },
-          "$ref": "#/$defs/LegalCase",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
@@ -159,12 +1435,160 @@
           "description": "A statute or legislative act.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Statute name (e.g., \"Civil Rights Act of 1964\")",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this statute derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority": {
+              "description": "Legislative body (e.g., \"U.S. Congress\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "description": "Code volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "code": {
+              "description": "Code abbreviation (e.g., \"U.S.C.\", \"Pub. L.\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "number": {
+              "description": "Statute or public-law number when present.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "page": {
+              "description": "Page or entry locator for session laws and registers.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the statute.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "section": {
+              "description": "Section or page number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "chapter-number": {
+              "description": "Optional chapter or session identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issued": {
+              "description": "Enactment or publication date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "url": {
+              "description": "URL for the statute.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "statute"
             }
           },
-          "$ref": "#/$defs/Statute",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
@@ -173,12 +1597,143 @@
           "description": "An international treaty or agreement.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Treaty name (e.g., \"Treaty of Versailles\")",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this treaty derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "description": "Parties to the treaty",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volume": {
+              "description": "Treaty series volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reporter": {
+              "description": "Treaty series abbreviation (e.g., \"U.N.T.S.\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "page": {
+              "description": "Page or treaty number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the treaty text.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "issued": {
+              "description": "Signing or ratification date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "url": {
+              "description": "URL for the treaty.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "treaty"
             }
           },
-          "$ref": "#/$defs/Treaty",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
@@ -187,12 +1742,125 @@
           "description": "A legislative or administrative hearing.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Hearing title",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this hearing record derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority": {
+              "description": "Legislative body conducting the hearing (e.g., \"U.S. Senate Committee on Finance\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session-number": {
+              "description": "Session or congress number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the hearing record.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "issued": {
+              "description": "Hearing date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "url": {
+              "description": "URL for the hearing record.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "hearing"
             }
           },
-          "$ref": "#/$defs/Hearing",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
@@ -201,12 +1869,139 @@
           "description": "An administrative regulation.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Regulation title",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this regulation derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority": {
+              "description": "Regulatory authority (e.g., \"EPA\", \"Federal Register\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "description": "Code volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the regulation text.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "code": {
+              "description": "Code abbreviation (e.g., \"C.F.R.\", \"Fed. Reg.\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "section": {
+              "description": "Section or page number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issued": {
+              "description": "Publication or effective date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "url": {
+              "description": "URL for the regulation.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "regulation"
             }
           },
-          "$ref": "#/$defs/Regulation",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
@@ -215,26 +2010,338 @@
           "description": "A legal brief or filing.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Brief title or case name",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this brief derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority": {
+              "description": "Court (e.g., \"U.S. Supreme Court\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "author": {
+              "description": "Author/filer of the brief",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "docket-number": {
+              "description": "Docket number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the brief.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "issued": {
+              "description": "Filing date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "url": {
+              "description": "URL for the brief.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "brief"
             }
           },
-          "$ref": "#/$defs/Brief",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
         },
         {
-          "description": "A classic work with standard citation forms.",
+          "description": "A classic work (Aristotle, Bible, etc.) with standard citation forms.",
           "type": "object",
           "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              }
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "classic"
             }
           },
-          "$ref": "#/$defs/Classic",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
@@ -243,13 +2350,171 @@
           "description": "A patent.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Patent title",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "description": "Inventor(s)",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "assignee": {
+              "description": "Assignee (patent holder)",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this patent derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "patent-number": {
+              "description": "Patent number (e.g., \"U.S. Patent No. 7,347,809\")",
+              "type": "string"
+            },
+            "application-number": {
+              "description": "Application number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the patented work.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "filing-date": {
+              "description": "Filing date",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "issued": {
+              "description": "Issue/grant date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "jurisdiction": {
+              "description": "Jurisdiction (e.g., \"US\", \"EP\", \"JP\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "authority": {
+              "description": "Patent office (e.g., \"U.S. Patent and Trademark Office\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "url": {
+              "description": "URL for the patent.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "patent"
             }
           },
-          "$ref": "#/$defs/Patent",
+          "additionalProperties": false,
           "required": [
+            "patent-number",
             "class"
           ]
         },
@@ -257,12 +2522,168 @@
           "description": "A research dataset.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Dataset title",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "description": "Dataset author(s)/creator(s)",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this dataset derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the dataset.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "issued": {
+              "description": "Publication/release date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "publisher": {
+              "description": "Publisher or repository (e.g., \"Zenodo\", \"Dryad\")",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "description": "Version number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "format": {
+              "description": "File format. Prefer IANA media types (e.g., `\"text/csv\"`) or common\nabbreviations (e.g., `\"NetCDF\"`, `\"HDF5\"`) where no IANA type exists.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "size": {
+              "description": "Dataset size (e.g., \"2.4 GB\", \"150,000 records\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "repository": {
+              "description": "Repository or archive name",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "doi": {
+              "description": "DOI identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "url": {
+              "description": "URL for the dataset.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the dataset.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "dataset"
             }
           },
-          "$ref": "#/$defs/Dataset",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
@@ -271,13 +2692,142 @@
           "description": "A technical standard or specification.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Standard title",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this standard derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "authority": {
+              "description": "Standards organization (e.g., \"ISO\", \"ANSI\", \"IEEE\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "standard-number": {
+              "description": "Standard number (e.g., \"ISO 8601\", \"IEEE 754-2008\")",
+              "type": "string"
+            },
+            "created": {
+              "description": "Creation or origination date of the standard.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "issued": {
+              "description": "Publication date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "status": {
+              "description": "Publication status. Canonical controlled-vocabulary values: `\"published\"`, `\"draft\"`, `\"withdrawn\"`.\nSee `docs/policies/ENUM_VOCABULARY_POLICY.md` for matching rules.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "publisher": {
+              "description": "Publisher (usually same as authority)",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "url": {
+              "description": "URL for the standard.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the document.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "standard"
             }
           },
-          "$ref": "#/$defs/Standard",
+          "additionalProperties": false,
           "required": [
+            "standard-number",
             "class"
           ]
         },
@@ -285,45 +2835,503 @@
           "description": "Software or source code.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Software title",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this software derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "description": "Author(s)/developer(s)",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "created": {
+              "description": "Creation or origination date of the software work.",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "issued": {
+              "description": "Release date",
+              "$ref": "#/$defs/EdtfString"
+            },
+            "publisher": {
+              "description": "Publisher or repository (e.g., \"GitHub\", \"Zenodo\")",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "description": "Version number (e.g., \"4.1.0\", \"v2.3.1\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "repository": {
+              "description": "Repository URL",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "license": {
+              "description": "SPDX license identifier preferred (e.g., `\"MIT\"`, `\"GPL-3.0-only\"`, `\"Apache-2.0\"`).\nSee <https://spdx.org/licenses/> for the authoritative identifier list.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platform": {
+              "description": "Platform (e.g., \"Windows\", \"macOS\", \"Linux\", \"cross-platform\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "doi": {
+              "description": "DOI identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "url": {
+              "description": "URL for the software.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the software documentation.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
             "class": {
               "type": "string",
               "const": "software"
             }
           },
-          "$ref": "#/$defs/Software",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
         },
         {
-          "description": "An event such as a conference, performance, or broadcast.",
+          "description": "Event metadata for conferences, performances, broadcasts, and recordings.",
           "type": "object",
           "properties": {
+            "id": {
+              "description": "Unique identifier for this reference.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "title": {
+              "description": "Event name (e.g., conference title, performance name).",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "container": {
+              "description": "Immediate container (e.g., broadcast program, proceedings volume).",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "series": {
+              "description": "Recurring event series (e.g., annual conference series).",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "original": {
+              "description": "Original work or publication from which this event derives.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "location": {
+              "description": "Event location (city, venue).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "date": {
+              "description": "Event date.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "available-date": {
+              "description": "Date the event became or will become publicly available.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "genre": {
+              "description": "Event genre (e.g., `\"conference\"`, `\"performance\"`, `\"broadcast\"`, `\"talk\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "network": {
+              "description": "Broadcaster, network, or streaming platform.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contributors": {
+              "description": "Unified contributor list with explicit role tags.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              }
+            },
+            "url": {
+              "description": "URL for the event.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "description": "Date the URL was accessed.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "description": "BCP 47 language of the event.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "description": "Per-field language overrides.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "description": "Freeform note.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "class": {
               "type": "string",
               "const": "event"
             }
           },
-          "$ref": "#/$defs/Event",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
         },
         {
-          "description": "An audio-visual work: film, TV episode, recording, or broadcast.",
+          "description": "An audio-visual work: film, TV episode, recording, or broadcast.\n\nThis is a work-like reference class. It represents the creative work\nwhen that work is the citee, not a fully modeled release hierarchy.",
           "type": "object",
           "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/AudioVisualType",
+              "default": "film"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contributors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              }
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "numbering": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              }
+            },
+            "number": {
+              "description": "Catalog or episode number shorthand (normalized into `numbering`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platform": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uri"
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              }
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "class": {
               "type": "string",
               "const": "audio-visual"
             }
           },
-          "$ref": "#/$defs/AudioVisualWork",
+          "additionalProperties": false,
           "required": [
             "class"
           ]
         }
-      ]
+      ],
+      "unevaluatedProperties": false
     },
     "RefID": {
       "description": "Unique identifier for a reference item.",
@@ -970,330 +3978,6 @@
         "server"
       ]
     },
-    "Monograph": {
-      "description": "A monograph, such as a book or a report, is a monolithic work published or produced as a complete entity.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "type": {
-          "$ref": "#/$defs/MonographType"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "short-title": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "container": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "editor": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "translator": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "contributors": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ContributorEntry"
-          }
-        },
-        "created": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "issued": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "publisher": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "abstract-text": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "isbn": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "doi": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ads-bibcode": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "volume": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issue": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "edition": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "part-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "supplement-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "printing-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "numbering": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Numbering"
-          }
-        },
-        "genre": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "medium": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "archive": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "archive-location": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "archive-info": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ArchiveInfo"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "eprint": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EprintInfo"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "original": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "available-date": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "size": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "duration": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "references": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "scale": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
     "MonographComponentType": {
       "description": "Discriminates monograph-component subtypes for style-directed formatting.",
       "oneOf": [
@@ -1323,256 +4007,6 @@
         }
       ]
     },
-    "CollectionComponent": {
-      "description": "A component of a larger monograph, such as a chapter in a book.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "type": {
-          "$ref": "#/$defs/MonographComponentType"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "translator": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "contributors": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ContributorEntry"
-          }
-        },
-        "created": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "issued": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "container": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "volume": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issue": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "edition": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "part-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "supplement-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "printing-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "numbering": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Numbering"
-          }
-        },
-        "pages": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NumOrStr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "abstract-text": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "doi": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "genre": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "medium": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "archive-info": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ArchiveInfo"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "eprint": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EprintInfo"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "original": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
     "SerialComponentType": {
       "description": "Discriminates serial-component subtypes for style-directed formatting.",
       "oneOf": [
@@ -1591,284 +4025,6 @@
           "type": "string",
           "const": "review"
         }
-      ]
-    },
-    "SerialComponent": {
-      "description": "A component of a larger serial publication; for example a journal or newspaper article.\nThe parent serial is referenced by its ID.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "type": {
-          "$ref": "#/$defs/SerialComponentType"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "translator": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "contributors": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ContributorEntry"
-          }
-        },
-        "created": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "issued": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "container": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "volume": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issue": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "edition": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "part-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "supplement-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "printing-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "numbering": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Numbering"
-          }
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "abstract-text": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "doi": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "ads-bibcode": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "pages": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "genre": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "medium": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "archive-info": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ArchiveInfo"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "eprint": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EprintInfo"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "section": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "available-date": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "reviewed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "required": [
-        "type"
       ]
     },
     "CollectionType": {
@@ -1894,214 +4050,6 @@
           "type": "string",
           "const": "edited-volume"
         }
-      ]
-    },
-    "Collection": {
-      "description": "A collection of works, such as an anthology or proceedings.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "type": {
-          "$ref": "#/$defs/CollectionType"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "short-title": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "container": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "editor": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "translator": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "contributors": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ContributorEntry"
-          }
-        },
-        "created": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "issued": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "publisher": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "volume": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issue": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "edition": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "part-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "supplement-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "printing-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "numbering": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Numbering"
-          }
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "isbn": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "event": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "type"
       ]
     },
     "SerialType": {
@@ -2149,1922 +4097,6 @@
         }
       ]
     },
-    "Serial": {
-      "description": "A serial publication (journal, magazine, etc.).",
-      "type": "object",
-      "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "type": {
-          "$ref": "#/$defs/SerialType"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "short-title": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "container": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "editor": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "contributors": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ContributorEntry"
-          }
-        },
-        "publisher": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "issn": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "LegalCase": {
-      "description": "A legal case (court decision).",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Case name (e.g., \"Brown v. Board of Education\")",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this case record derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "authority": {
-          "description": "Court or authority (e.g., \"U.S. Supreme Court\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "volume": {
-          "description": "Reporter volume",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "reporter": {
-          "description": "Reporter abbreviation (e.g., \"U.S.\", \"F.2d\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "page": {
-          "description": "First page of case in reporter",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the legal work.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "issued": {
-          "description": "Decision date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "url": {
-          "description": "URL for the case.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "doi": {
-          "description": "DOI identifier.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Statute": {
-      "description": "A statute or legislative act.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Statute name (e.g., \"Civil Rights Act of 1964\")",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this statute derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "authority": {
-          "description": "Legislative body (e.g., \"U.S. Congress\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "volume": {
-          "description": "Code volume",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "code": {
-          "description": "Code abbreviation (e.g., \"U.S.C.\", \"Pub. L.\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "number": {
-          "description": "Statute or public-law number when present.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "page": {
-          "description": "Page or entry locator for session laws and registers.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the statute.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "section": {
-          "description": "Section or page number",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "chapter-number": {
-          "description": "Optional chapter or session identifier.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issued": {
-          "description": "Enactment or publication date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "url": {
-          "description": "URL for the statute.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Treaty": {
-      "description": "An international treaty or agreement.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Treaty name (e.g., \"Treaty of Versailles\")",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this treaty derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "description": "Parties to the treaty",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "volume": {
-          "description": "Treaty series volume",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "reporter": {
-          "description": "Treaty series abbreviation (e.g., \"U.N.T.S.\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "page": {
-          "description": "Page or treaty number",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the treaty text.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "issued": {
-          "description": "Signing or ratification date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "url": {
-          "description": "URL for the treaty.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Hearing": {
-      "description": "A legislative or administrative hearing.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Hearing title",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this hearing record derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "authority": {
-          "description": "Legislative body conducting the hearing (e.g., \"U.S. Senate Committee on Finance\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "session-number": {
-          "description": "Session or congress number",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the hearing record.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "issued": {
-          "description": "Hearing date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "url": {
-          "description": "URL for the hearing record.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Regulation": {
-      "description": "An administrative regulation.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Regulation title",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this regulation derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "authority": {
-          "description": "Regulatory authority (e.g., \"EPA\", \"Federal Register\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "volume": {
-          "description": "Code volume",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the regulation text.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "code": {
-          "description": "Code abbreviation (e.g., \"C.F.R.\", \"Fed. Reg.\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "section": {
-          "description": "Section or page number",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issued": {
-          "description": "Publication or effective date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "url": {
-          "description": "URL for the regulation.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Brief": {
-      "description": "A legal brief or filing.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Brief title or case name",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this brief derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "authority": {
-          "description": "Court (e.g., \"U.S. Supreme Court\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "author": {
-          "description": "Author/filer of the brief",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "docket-number": {
-          "description": "Docket number",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the brief.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "issued": {
-          "description": "Filing date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "url": {
-          "description": "URL for the brief.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Classic": {
-      "description": "A classic work (Aristotle, Bible, etc.) with standard citation forms.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "container": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "editor": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "translator": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "volume": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issue": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "edition": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "part-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "supplement-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "printing-number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "numbering": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Numbering"
-          }
-        },
-        "created": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "issued": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "publisher": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Patent": {
-      "description": "A patent.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Patent title",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "description": "Inventor(s)",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "assignee": {
-          "description": "Assignee (patent holder)",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this patent derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "patent-number": {
-          "description": "Patent number (e.g., \"U.S. Patent No. 7,347,809\")",
-          "type": "string"
-        },
-        "application-number": {
-          "description": "Application number",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the patented work.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "filing-date": {
-          "description": "Filing date",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "issued": {
-          "description": "Issue/grant date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "jurisdiction": {
-          "description": "Jurisdiction (e.g., \"US\", \"EP\", \"JP\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "authority": {
-          "description": "Patent office (e.g., \"U.S. Patent and Trademark Office\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "url": {
-          "description": "URL for the patent.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "patent-number"
-      ]
-    },
-    "Dataset": {
-      "description": "A research dataset.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Dataset title",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "description": "Dataset author(s)/creator(s)",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this dataset derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the dataset.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "issued": {
-          "description": "Publication/release date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "publisher": {
-          "description": "Publisher or repository (e.g., \"Zenodo\", \"Dryad\")",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "version": {
-          "description": "Version number",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "format": {
-          "description": "File format. Prefer IANA media types (e.g., `\"text/csv\"`) or common\nabbreviations (e.g., `\"NetCDF\"`, `\"HDF5\"`) where no IANA type exists.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "size": {
-          "description": "Dataset size (e.g., \"2.4 GB\", \"150,000 records\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "repository": {
-          "description": "Repository or archive name",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "doi": {
-          "description": "DOI identifier.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "url": {
-          "description": "URL for the dataset.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the dataset.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Standard": {
-      "description": "A technical standard or specification.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Standard title",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this standard derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "authority": {
-          "description": "Standards organization (e.g., \"ISO\", \"ANSI\", \"IEEE\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "standard-number": {
-          "description": "Standard number (e.g., \"ISO 8601\", \"IEEE 754-2008\")",
-          "type": "string"
-        },
-        "created": {
-          "description": "Creation or origination date of the standard.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "issued": {
-          "description": "Publication date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "status": {
-          "description": "Publication status. Canonical controlled-vocabulary values: `\"published\"`, `\"draft\"`, `\"withdrawn\"`.\nSee `docs/policies/ENUM_VOCABULARY_POLICY.md` for matching rules.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "publisher": {
-          "description": "Publisher (usually same as authority)",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "url": {
-          "description": "URL for the standard.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the document.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "standard-number"
-      ]
-    },
-    "Software": {
-      "description": "Software or source code.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Software title",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this software derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "author": {
-          "description": "Author(s)/developer(s)",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Contributor"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "created": {
-          "description": "Creation or origination date of the software work.",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "issued": {
-          "description": "Release date",
-          "$ref": "#/$defs/EdtfString"
-        },
-        "publisher": {
-          "description": "Publisher or repository (e.g., \"GitHub\", \"Zenodo\")",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "version": {
-          "description": "Version number (e.g., \"4.1.0\", \"v2.3.1\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "repository": {
-          "description": "Repository URL",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "license": {
-          "description": "SPDX license identifier preferred (e.g., `\"MIT\"`, `\"GPL-3.0-only\"`, `\"Apache-2.0\"`).\nSee <https://spdx.org/licenses/> for the authoritative identifier list.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "platform": {
-          "description": "Platform (e.g., \"Windows\", \"macOS\", \"Linux\", \"cross-platform\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "doi": {
-          "description": "DOI identifier.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "url": {
-          "description": "URL for the software.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the software documentation.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "keywords": {
-          "description": "Keywords or subject tags.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Event": {
-      "description": "Event metadata for conferences, performances, broadcasts, and recordings.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for this reference.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "title": {
-          "description": "Event name (e.g., conference title, performance name).",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "container": {
-          "description": "Immediate container (e.g., broadcast program, proceedings volume).",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "series": {
-          "description": "Recurring event series (e.g., annual conference series).",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "original": {
-          "description": "Original work or publication from which this event derives.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "location": {
-          "description": "Event location (city, venue).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "date": {
-          "description": "Event date.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "available-date": {
-          "description": "Date the event became or will become publicly available.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "genre": {
-          "description": "Event genre (e.g., `\"conference\"`, `\"performance\"`, `\"broadcast\"`, `\"talk\"`).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "network": {
-          "description": "Broadcaster, network, or streaming platform.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "contributors": {
-          "description": "Unified contributor list with explicit role tags.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ContributorEntry"
-          }
-        },
-        "url": {
-          "description": "URL for the event.",
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "description": "Date the URL was accessed.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "description": "BCP 47 language of the event.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "description": "Per-field language overrides.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "description": "Freeform note.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
-    },
     "AudioVisualType": {
       "description": "Discriminates audio-visual subtypes for style-directed formatting.",
       "oneOf": [
@@ -4089,160 +4121,6 @@
           "const": "broadcast"
         }
       ]
-    },
-    "AudioVisualWork": {
-      "description": "An audio-visual work: film, TV episode, recording, or broadcast.\n\nThis is a work-like reference class. It represents the creative work\nwhen that work is the citee, not a fully modeled release hierarchy.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RefID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "type": {
-          "$ref": "#/$defs/AudioVisualType",
-          "default": "film"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Title"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "short-title": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "contributors": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/ContributorEntry"
-          }
-        },
-        "created": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "issued": {
-          "$ref": "#/$defs/EdtfString",
-          "default": ""
-        },
-        "original": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "language": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LangID"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "genre": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "container": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WorkRelation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "numbering": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Numbering"
-          }
-        },
-        "number": {
-          "description": "Catalog or episode number shorthand (normalized into `numbering`).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "publisher": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Publisher"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "medium": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "platform": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "url": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "format": "uri"
-        },
-        "accessed": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EdtfString"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "field-languages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/LangID"
-          }
-        },
-        "note": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RichText"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
## Status

PR for `docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md` (v0.3, merged in #716).

Tracking beans (all completed + archived):
- **csl26-odgh** — Layer 1–4 cutover (this PR's original implementation)
- **csl26-powf** — Copilot review hardening (Tier A + B fixes)
- **csl26-6bf3** — Hot-path perf refactor (Tier C fixes)

Open follow-up: **csl26-s4io** — Layer 5 `CompatibilityWarning` plumbing for unknown-class soft-degrade (deferred by design; tracked separately, not blocking this PR).

## What landed

The PR brings the InputReference class-discriminator cutover from Layers 1–4 to a clean, hot-path-tightened, reviewer-vetted final form. Three logical chunks fold into the single commit:

### 1. Layer 1–4 cutover (original work)

- **Schema-data storage cutover.** `InputReference` is now a thin struct holding only a `ClassExtension` overlay. The flat-with-discriminator dispatch lives at the wire boundary; known classes stay strict, unknown classes round-trip via `UnknownClassData`.
- **Layer 2 — citum-io constructors/exporters.** BibLaTeX, RIS, CSL-JSON, and hybrid JSON paths compile against the new model.
- **Layer 3 — migrate-facing constructors/tests.** CSL-to-Citum conversion uses the typed extension API.
- **Layer 4 — engine call-site rewrites.** Engine title/number/simple-variable/sorting paths no longer pattern-match on enum variants; they use `extension()` / `extension_mut()` and the typed accessors.

### 2. Copilot review — correctness / API surface (Tier A + B, csl26-powf)

Resolves 13 of the 16 Copilot inline comments:

- **Deleted** `crates/citum-schema-data/src/reference/discriminator/` (596 lines of parallel-types scaffolding that exposed a second public `InputReference`).
- `ref_type()` for `Unknown` class: `debug_assert!` non-collision with `ReferenceClass::KNOWN` + explicit `TODO(csl26-1bdr)` for Layer 5 plumbing.
- `as_event` / `as_audio_visual`: `.as_ref()` for parity with the other 17 `as_*` accessors.
- `from_known`: matches `&value` before consuming (no clone for the type check); defensive non-object branch uses `de::Error::custom` instead of the misleading `Error::io(InvalidData)`.
- New `duplicate_field_error<E: de::Error>` helper emits the canonical `duplicate field` shape for both class and non-class duplicate paths.
- Documentation added on `ReferenceClass::Unknown` (serde-skip rationale), `set_id` (unknown-class string-id wire constraint), the transitional PascalCase constructors (block-level `TODO(csl26-1bdr)` marker), and `EMPTY_FIELD_LANGUAGES` (HashMap::new is not const).

### 3. Copilot review — hot-path perf refactor (Tier C, csl26-6bf3)

Resolves the remaining 3 hot-path Copilot comments (#3251089405, #3251089475, #3251089491):

- **Deleted `SharedReferenceFields` entirely** and the 17 duplicated `pub(crate)` shared fields on `InputReference`. Cross-crate grep confirmed they were write-only; accessor methods already dispatched through the extension.
- **Construction**: `boxed_reference_constructor!` is now a one-liner. Zero JSON work on the construction path (was: `to_value` → `from_value` per reference).
- **Serialize**: new `FlatClassProxy<T>` with `#[serde(flatten)]` splats the typed inner directly through the parent serializer. No `serde_json::to_value` round-trip per serialization.
- **Deserialize**: `from_known` does one `from_value` per reference instead of two (the `SharedReferenceFields::from_body` round-trip is gone).
- **`set_id`**: single source of truth (writes only to the extension).
- **Visitor**: the `JsonMap` buffer in `visit_map` is kept and now flagged as structurally required — it's intrinsic to a custom dispatcher with a data-carrying `Unknown` fallback (serde's `#[serde(other)]` only handles unit variants).

## Verification

Local gate (run before push; pre-push hook re-runs):

```bash
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo nextest run
```

Result: **1284 passed** (up from 1282 at the start of the PR, accounting for added discriminator tests).

Schema regen: `docs/schemas/bib.json` is **wire-identical** to the prior commit (verified by `jq -S` diff).

### Test rigor

The in-module `discriminator_tests` is now 15 tests (up from 5 when the PR opened). Highlights:

- Structural JSON assertions on serialize output (no `contains()` on short substrings).
- Canonical serde-error-shape checks for duplicate class / duplicate non-class / missing class / unknown-field / non-object body.
- Accessor/extension agreement across six class variants (forward-compat guard against dispatcher drift).
- `set_id` sync coverage for both known and unknown classes.
- `ref_type` sentinel non-collision guard against the KNOWN class list.
- `serialize_emits_flat_object_with_class_first_and_no_nesting` — locks the new `FlatClassProxy` wire shape.
- `round_trip_through_serde_value_preserves_every_known_class` — Serialize → from_value → equality across all known classes plus Unknown.

## Review status

All 16 Copilot inline comments resolved (13 implemented, 3 hot-path refactored after explicit user direction; all threads replied to with fix references). Local `@reviewer` agent pass returned **PASS** with no findings.

## Out of scope (follow-up beans)

- **csl26-s4io** — Layer 5 `CompatibilityWarning` plumbing for unknown-class soft-degrade UX. Code carries an explicit `TODO(csl26-1bdr)` marker in `ref_type()` and a `debug_assert!` non-collision guard until then.
- Snake_case factory constructors to replace the transitional PascalCase `InputReference::Monograph(...)` set (touches ~79 call sites; deferred until factory shape is decided).
- Layer 8 broader schema-alignment corpus.

## Next steps

1. **Merge** is the user's action (per project policy). CI is green; reviewer pass is clean; perf hot-path is resolved.
2. After merge, open `csl26-s4io` for Layer 5 plumbing if/when the unknown-class soft-degrade UX is wanted.
