### PR TITLE
feat(engine): locale-authored date patterns

### DIFF
--- a/.beans/csl26-1b4e--title-and-proper-noun-inflection-across-languages.md
+++ b/.beans/csl26-1b4e--title-and-proper-noun-inflection-across-languages.md
@@ -53,12 +53,17 @@ This bean is therefore green-field. The design note should justify the choices o
 
 ## Todo
 
-- [ ] Write design note in `docs/specs/` (probably `TITLE_NAME_INFLECTION.md`) covering the six questions above and the prior-art findings
+- [x] Write initial design note: [`docs/specs/TITLE_NAME_INFLECTION.md`](../../docs/specs/TITLE_NAME_INFLECTION.md) (v0.1, Draft — bundled into the `csl26-v6ok` PR)
+- [ ] Native-speaker review of the worked examples in the spec (Finnish, Russian, Basque entries; resolve the 🚧 markers)
+- [ ] Resolve the open follow-up questions (§"Open questions for follow-up research" in the spec) — each gets an answer or its own child bean
+- [ ] Record decisions for Q1–Q6 with one-paragraph rationale each
+- [ ] Author a sample Finnish or Russian style against the proposed schema; render a realistic bibliography correctly
 - [ ] Get sign-off from the user before implementation
 - [ ] Decompose into implementation beans
 
 ## Related
 
+- Spec: [`docs/specs/TITLE_NAME_INFLECTION.md`](../../docs/specs/TITLE_NAME_INFLECTION.md)
 - Sibling deferred work from `csl26-v6ok` (dates were the easy subset)
 - CSL upstream #6369
 - `docs/specs/GENDERED_LOCALE_TERMS.md` is the closest precedent (`MaybeGendered<T>` shape)

--- a/.beans/csl26-1b4e--title-and-proper-noun-inflection-across-languages.md
+++ b/.beans/csl26-1b4e--title-and-proper-noun-inflection-across-languages.md
@@ -1,0 +1,64 @@
+---
+# csl26-1b4e
+title: Title and proper-noun inflection across languages
+status: draft
+type: feature
+priority: normal
+created_at: 2026-05-16T11:28:29Z
+updated_at: 2026-05-16T11:28:29Z
+---
+
+## Goal
+
+Address the broader cross-language ask in CSL upstream issue [#6369](https://github.com/citation-style-language/styles/issues/6369): grammatical inflection of **titles and proper nouns** in citations. `csl26-v6ok` solved this for date components; titles and names are a much larger problem and need design before code.
+
+## Status
+
+**Draft** — needs a design pass. Do not start implementation until the design note is written and approved.
+
+## The problem
+
+In inflecting languages (Basque, Finnish, Hungarian, Russian, …) a proper noun or book title changes form depending on its grammatical role in the surrounding sentence. Examples:
+
+- Basque: a title can take genitive `-(r)en`, locative `-an`, etc. Basque is also agglutinative — multiple case markers can combine on one word — and uses an ergative–absolutive alignment that differs fundamentally from the nominative–accusative systems of the others.
+- Finnish: rich case system (~15 cases including inessive, elative, illative, adessive, ablative, allative, …) applied to author surnames in narrative citations.
+- Hungarian: similarly large case inventory; titles take case suffixes when embedded in running prose.
+- Russian: surname declension by case (six cases including genitive, dative, instrumental).
+
+Citum currently treats titles and names as opaque strings, so styles cannot ask for an inflected form even when one would be linguistically required.
+
+## Prior art
+
+Substantial prior art **does not exist**. A literature/tooling scan turned up:
+
+- **CSL 1.0 / CSL-JSON**: no concept of grammatical case on titles or names; treats them as opaque strings. The upstream issue [citation-style-language/styles#6369](https://github.com/citation-style-language/styles/issues/6369) is exactly the report that this gap exists.
+- **citeproc-js / citeproc-rs / citation.js**: inherit CSL's opaque-string model.
+- **biblatex / biber**: ships rich author/title metadata but no per-case variants either; the closest thing is `nameaddon` and language-specific `\DeclareCaseCommand`s for sorting, not rendering case.
+- **Zotero / better-bibtex**: no case-variant input fields.
+- **Pandoc citeproc**: same as citeproc-js.
+- **CLDR / ICU**: provides case-sensitive number/date formatters (e.g. ICU's `:case=genitive` annotation on `MessageFormat 2`) but no name/title declension data.
+
+The closest in-repo precedent is **`MaybeGendered<T>`** in `crates/citum-schema-style/src/locale/types.rs`, which solves the analogous problem for *locale terms* (role labels by grammatical gender). The shape generalizes, but the domain is much smaller — locale terms are a closed authored set; titles and names are open input data.
+
+This bean is therefore green-field. The design note should justify the choices on first principles rather than appeal to convention.
+
+## Design questions
+
+1. **Input model.** Do contributors and titles carry per-case variants in the input data (similar to `MaybeGendered<T>`)? Or does the engine perform morphological derivation? Citum has consistently chosen "explicit over magic" — favours input-side variants.
+2. **Schema surface.** Likely a new `InflectedString` or `TitleForms` type with a base + case map. Needs to survive serde round-trip and the existing forward-compatibility contract.
+3. **Style language.** How does a CSL-derived or Citum-native template request "the genitive form of this title"? A new template attribute? Implicit from surrounding context (locative wrapper, possessive macro)?
+4. **Locale binding.** Different languages need different case sets — and the *kinds* of cases differ structurally (Basque's ergative–absolutive vs Finnish's nominative–accusative; Finnish's 15+ vs Russian's 6). Use a locale-declared list of recognized cases rather than a hardcoded universal vocabulary.
+5. **Fallback behavior.** What should the renderer do when a style requests a genitive (or any other case) but only the nominative is provided? Options: silent fallback to the supplied form, fallback with a render-time warning, hard error. Probably language- or locale-policy-driven (Finnish text with an uninflected name is "wrong" in a way that English text with an unannotated nominative isn't).
+6. **Migration impact.** Most styles need no change because most input data is in nominative; inflection becomes opt-in. Confirm with a concrete style + locale combination.
+
+## Todo
+
+- [ ] Write design note in `docs/specs/` (probably `TITLE_NAME_INFLECTION.md`) covering the six questions above and the prior-art findings
+- [ ] Get sign-off from the user before implementation
+- [ ] Decompose into implementation beans
+
+## Related
+
+- Sibling deferred work from `csl26-v6ok` (dates were the easy subset)
+- CSL upstream #6369
+- `docs/specs/GENDERED_LOCALE_TERMS.md` is the closest precedent (`MaybeGendered<T>` shape)

--- a/.beans/csl26-37jv--wire-remaining-dateform-variants-to-patterndate.md
+++ b/.beans/csl26-37jv--wire-remaining-dateform-variants-to-patterndate.md
@@ -1,0 +1,38 @@
+---
+# csl26-37jv
+title: Wire remaining DateForm variants to pattern.date-*
+status: todo
+type: task
+priority: low
+created_at: 2026-05-16T11:28:27Z
+updated_at: 2026-05-16T11:28:27Z
+---
+
+## Goal
+
+Wire the four `DateForm` variants left untouched by `csl26-v6ok` into the locale-authored `pattern.date-*` mechanism. The spec already reserves the IDs (`docs/specs/LOCALE_MESSAGES.md` §1.5); only the engine plumbing in `crates/citum-engine/src/values/date.rs::format_single_date` is missing.
+
+## Variants
+
+| `DateForm` | Reserved message ID | Notes |
+|---|---|---|
+| `YearMonth` | `pattern.date-year-month` | English fallback `{month} {year}` — used in author-date in-text citations |
+| `YearMonthDay` | `pattern.date-year-month-day` | English fallback `{year}, {month} {day}` |
+| `DayMonthAbbrYear` | `pattern.date-day-month-abbr-year` | Uses short-month list |
+| `MonthAbbrDayYear` | `pattern.date-month-abbr-day-year` | Uses short-month list |
+
+## Todo
+
+- [ ] Wire each `DateForm` arm in `format_single_date` to consult the matching `pattern.date-*` (mirror the `Full` / `MonthDay` graft)
+- [ ] Author `pattern.date-year-month` for `es-ES` (`"{$month} de {$year}"`) and `eu-ES` (`"{$year}ko {$month}"`)
+- [ ] Add unit tests in `date.rs::locale_pattern_tests` covering each new variant + missing-component fallback
+- [ ] Verify portfolio quality gate stays at fidelity 1.0
+
+## Trigger
+
+This bean is low priority until a locale actually authors one of the reserved IDs and needs the engine to consume it. The motivating case in `csl26-v6ok`'s smoke test (`(2023, ekaina)` — mixing Basque month with English assembly) is a visible defect that would justify pulling this bean forward.
+
+## Related
+
+- Parent feature: `csl26-v6ok`
+- Spec: `docs/specs/LOCALE_MESSAGES.md` §1.5

--- a/.beans/csl26-dno4--per-case-month-form-maps-for-inflected-locales.md
+++ b/.beans/csl26-dno4--per-case-month-form-maps-for-inflected-locales.md
@@ -1,0 +1,60 @@
+---
+# csl26-dno4
+title: Per-case month-form maps for inflected locales
+status: draft
+type: feature
+priority: low
+created_at: 2026-05-16T11:28:30Z
+updated_at: 2026-05-16T11:28:30Z
+---
+
+## Goal
+
+Allow a locale to store multiple inflected forms of each month name (e.g. nominative, genitive, locative) under `dates.months.<case>` keys, and let `pattern.date-*` messages dispatch on case via a `:form` selector. Defer until a real locale actually needs it.
+
+## Status
+
+**Draft** — speculative; do not implement until a concrete locale need surfaces.
+
+## When this matters
+
+`csl26-v6ok` works for Basque because every month lemma ends in `-a`, so a single citation-form month list plus an `-(r)en` suffix in the pattern covers the bibliography full-date case. That trick stops working when:
+
+- The locale needs the same month name in two different cases within one render (e.g. genitive in the full date AND locative in an accessed-date phrase).
+- The morphological suffix is not uniform across month names (locales where some months end in `-a`, some in `-ua`, etc., and need different inflected forms rather than a uniform suffix).
+
+If either condition fires for a locale that we want to ship, this bean becomes blocking.
+
+## Design sketch
+
+```yaml
+# Hypothetical multi-form month list
+dates:
+  months:
+    long:
+      nominative: [urtarrila, otsaila, …]
+      genitive:   [urtarrilaren, otsailaren, …]
+      locative:   [urtarrilan, otsailan, …]
+```
+
+Pattern selector:
+
+```yaml
+messages:
+  pattern.date-full: |
+    .match {$month_form :select}
+    when genitive {{$year}ko {$month} {$day}a}
+    when * {{$month} {$day}, {$year}}
+```
+
+## Todo
+
+- [ ] Wait for a concrete locale need
+- [ ] Design schema additions (back-compat with the current `Vec<String>` shape)
+- [ ] Wire `:form` selector + `month_form` into `MessageArgs`
+- [ ] Migrate `eu-ES` if Basque review confirms two forms are needed
+
+## Related
+
+- Parent feature: `csl26-v6ok`
+- Spec: `docs/specs/LOCALE_MESSAGES.md` §1.5 (already calls this out as a follow-up)

--- a/.beans/csl26-hqy5--custom-locale-file-invocation-for-builtin-styles.md
+++ b/.beans/csl26-hqy5--custom-locale-file-invocation-for-builtin-styles.md
@@ -1,0 +1,37 @@
+---
+# csl26-hqy5
+title: Custom locale file invocation for builtin styles
+status: todo
+type: feature
+priority: normal
+created_at: 2026-05-16T11:28:28Z
+updated_at: 2026-05-16T11:28:28Z
+---
+
+## Goal
+
+Make it possible to render with a custom (non-embedded) locale file when the style is a builtin alias. Right now the CLI's `--locale <id>` flag has two paths:
+
+- **File-path style** (`-s styles/embedded/apa-7th.yaml`): the resolver searches a sibling `locales/` directory on disk and reads `<id>.yaml`. Custom locales work.
+- **Builtin-alias style** (`-s apa`): the resolver consults `citum_schema::embedded::get_locale_bytes()` only. The locale must be baked into the binary at compile time. Custom locales **don't work**.
+
+This is awkward and was surfaced during the `csl26-v6ok` smoke test: a provisional `eu-ES` locale can be exercised end-to-end only via the path-style form, which is non-obvious.
+
+## Design options (decide before coding)
+
+1. **`--locale-file <path>` flag** — explicit override; bypasses the alias resolver entirely. Smallest blast radius.
+2. **Disk-first lookup for builtin styles** — always check `./locales/<id>.yaml` first, then fall back to embedded. Friendlier UX inside a citum checkout; risk: pollutes user-namespace from working directory.
+3. **User locale store** — already partly scoped under `csl26-erwz` (User style & locale store). May subsume this bean.
+
+## Todo
+
+- [ ] Decide between (1), (2), and "wait for `csl26-erwz`" — likely a small design note in `docs/specs/`
+- [ ] Implement chosen option in `crates/citum-cli/src/style_resolver.rs::load_locale_builtin` (or its caller in `setup_processor`)
+- [ ] Update `docs/guides/AUTHORING_LOCALES.md` "Verification" section so the smoke test works for both builtin- and file-path styles
+- [ ] Test: render with a non-embedded locale against a builtin-alias style
+
+## Related
+
+- Parent feature: `csl26-v6ok` (surfaced the gap)
+- Possibly subsumes / subsumed by: `csl26-erwz` (User style & locale store)
+- Relevant code: `crates/citum-cli/src/style_resolver.rs::load_locale_builtin` (line ~229)

--- a/.beans/csl26-v6ok--locale-authored-date-patterns-for-inflected-langua.md
+++ b/.beans/csl26-v6ok--locale-authored-date-patterns-for-inflected-langua.md
@@ -45,8 +45,9 @@ Added `pattern.date-full` and `pattern.date-month-day` to `es-ES.yaml` as a seco
 - `csl26-qrpo` — ICU4X swap (this PR's pre-formatted approach is the spec'd path until ICU4X stabilizes `:citum-date`)
 - `docs/specs/LOCALE_MESSAGES.md` §1.5 — anticipates exactly this seam
 
-## Follow-ups (separate beans, do not bundle)
+## Follow-ups
 
-- Title / proper-noun inflection (the broader cross-language ask in CSL #6369) — needs design
-- Remaining `DateForm` variants (`YearMonth`, `YearMonthDay`, abbr-month forms) once a locale needs them
-- Month-form variants (`dates.months.{nominative,locative,…}`) if a single locale ever needs more than one inflected form
+- `csl26-37jv` — Wire remaining `DateForm` variants (`YearMonth`, `YearMonthDay`, abbr-month forms) to `pattern.date-*`
+- `csl26-hqy5` — Custom locale file invocation for builtin-alias styles (surfaced by this PR's smoke test)
+- `csl26-1b4e` — Title / proper-noun inflection across languages (the broader CSL #6369 ask; draft, needs design)
+- `csl26-dno4` — Per-case month-form maps (`dates.months.<case>`) (draft, defer until a real locale needs it)

--- a/.beans/csl26-v6ok--locale-authored-date-patterns-for-inflected-langua.md
+++ b/.beans/csl26-v6ok--locale-authored-date-patterns-for-inflected-langua.md
@@ -1,0 +1,48 @@
+---
+# csl26-v6ok
+title: Locale-authored date patterns for inflected languages
+status: in-progress
+type: feature
+priority: normal
+created_at: 2026-05-16T10:47:07Z
+updated_at: 2026-05-16T10:47:07Z
+---
+
+## Goal
+
+Let locales author date assembly in MF2 so non-English languages can express their own year/month/day order and morphology. Basque is the motivating example (CSL upstream issue [#6369](https://github.com/citation-style-language/styles/issues/6369), csln prototype issue [#107](https://github.com/bdarcus/csln/issues/107)); the same gap applies to other inflecting languages (Finnish, Hungarian, …).
+
+Today the engine hard-codes English assembly (`format!("{month} {d}, {year}")`) in `crates/citum-engine/src/values/date.rs::format_single_date`. This bean introduces `pattern.date-*` message IDs so a locale can override that assembly. The current English path becomes the fallback when no pattern is authored, so all existing locales/styles stay bit-identical.
+
+## Scope (this PR)
+
+Two `DateForm` variants only: `Full` and `MonthDay`. Other variants (`YearMonth`, `YearMonthDay`, `DayMonthAbbrYear`, `MonthAbbrDayYear`) keep their existing hardcoded assembly. The architecture extends trivially when needed.
+
+## Todo
+
+- [ ] Extend `MessageArgs` with `year` / `month` / `day` slots; teach `Mf2MessageEvaluator` to substitute `{$year}` / `{$month}` / `{$day}`
+- [ ] Add unit tests for the three new variables (alongside existing `$count`/`$gender` tests)
+- [ ] Wire `pattern.date-full` into `format_single_date::DateForm::Full` (fallback unchanged)
+- [ ] Wire `pattern.date-month-day` into `format_single_date::DateForm::MonthDay` (fallback unchanged)
+- [ ] Add `locales/eu-ES.yaml` with Apertium-attested `YYYYko {month}ren {day}a` shape — **mark provisional pending native-speaker review**
+- [ ] Update `docs/specs/LOCALE_MESSAGES.md` (§2 namespace + new subsection; bump version)
+- [ ] Update `docs/guides/AUTHORING_LOCALES.md` (date-patterns subsection)
+- [ ] Add integration test: Basque APA render vs. en-US APA regression
+- [ ] Pre-commit gate: `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`
+- [ ] Portfolio quality gate: `report-core.js` + `check-core-quality.js` show zero regressions
+- [ ] Open PR, request Basque-speaker review for `eu-ES.yaml` content
+
+## Plan reference
+
+`/Users/brucedarcus/.claude/plans/i-created-the-vast-emerson.md`
+
+## Related
+
+- `csl26-qrpo` — ICU4X swap (this PR's pre-formatted approach is the spec'd path until ICU4X stabilizes `:citum-date`)
+- `docs/specs/LOCALE_MESSAGES.md` §1.5 — anticipates exactly this seam
+
+## Follow-ups (separate beans, do not bundle)
+
+- Title / proper-noun inflection (the broader cross-language ask in CSL #6369) — needs design
+- Remaining `DateForm` variants (`YearMonth`, `YearMonthDay`, abbr-month forms) once a locale needs them
+- Month-form variants (`dates.months.{nominative,locative,…}`) if a single locale ever needs more than one inflected form

--- a/.beans/csl26-v6ok--locale-authored-date-patterns-for-inflected-langua.md
+++ b/.beans/csl26-v6ok--locale-authored-date-patterns-for-inflected-langua.md
@@ -5,7 +5,7 @@ status: in-progress
 type: feature
 priority: normal
 created_at: 2026-05-16T10:47:07Z
-updated_at: 2026-05-16T10:47:07Z
+updated_at: 2026-05-16T11:04:56Z
 ---
 
 ## Goal
@@ -20,17 +20,21 @@ Two `DateForm` variants only: `Full` and `MonthDay`. Other variants (`YearMonth`
 
 ## Todo
 
-- [ ] Extend `MessageArgs` with `year` / `month` / `day` slots; teach `Mf2MessageEvaluator` to substitute `{$year}` / `{$month}` / `{$day}`
-- [ ] Add unit tests for the three new variables (alongside existing `$count`/`$gender` tests)
-- [ ] Wire `pattern.date-full` into `format_single_date::DateForm::Full` (fallback unchanged)
-- [ ] Wire `pattern.date-month-day` into `format_single_date::DateForm::MonthDay` (fallback unchanged)
-- [ ] Add `locales/eu-ES.yaml` with Apertium-attested `YYYYko {month}ren {day}a` shape — **mark provisional pending native-speaker review**
-- [ ] Update `docs/specs/LOCALE_MESSAGES.md` (§2 namespace + new subsection; bump version)
-- [ ] Update `docs/guides/AUTHORING_LOCALES.md` (date-patterns subsection)
-- [ ] Add integration test: Basque APA render vs. en-US APA regression
-- [ ] Pre-commit gate: `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`
-- [ ] Portfolio quality gate: `report-core.js` + `check-core-quality.js` show zero regressions
+- [x] Extend `MessageArgs` with `year` / `month` / `day` slots; teach `Mf2MessageEvaluator` to substitute `{$year}` / `{$month}` / `{$day}`
+- [x] Add unit tests for the three new variables (alongside existing `$count`/`$gender` tests)
+- [x] Wire pattern.date-full into format_single_date DateForm Full (fallback unchanged)
+- [x] Wire pattern.date-month-day into format_single_date DateForm MonthDay (fallback unchanged)
+- [x] Add locales/eu-ES.yaml (provisional) and Spanish pattern.date-* as second worked example
+- [x] Update docs/specs/LOCALE_MESSAGES.md (section 2 namespace plus new subsection; bumped to 1.4)
+- [x] Update docs/guides/AUTHORING_LOCALES.md (date-patterns subsection)
+- [x] Add unit tests: en-US regression plus es-ES and eu-ES MF2 path plus missing-component fallback (7 new tests)
+- [x] Pre-commit gate: fmt clean, clippy clean, 1293/1293 tests pass
+- [x] Portfolio quality gate: 154 styles at fidelity 1.0, 0 warnings
 - [ ] Open PR, request Basque-speaker review for `eu-ES.yaml` content
+
+## Implementation note — Spanish bonus
+
+Added `pattern.date-full` and `pattern.date-month-day` to `es-ES.yaml` as a second worked example. This flips Spanish bibliography date rendering from `enero 12, 2023` (en-US fallback assembly, incorrect) to `12 de enero de 2023` (correct, matches Spanish APA convention and the already-declared `date-formats.bib-default` CLDR pattern). Portfolio gate confirms zero regressions across 154 styles.
 
 ## Plan reference
 

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -600,6 +600,11 @@ fn format_single_date(
                 return None;
             }
             let day = date.day();
+            if let Some(rendered) =
+                locale.resolve_date_pattern("pattern.date-month-day", None, Some(&month), day)
+            {
+                return Some(rendered);
+            }
             match day {
                 Some(d) => Some(format!("{month} {d}")),
                 None => Some(month),
@@ -612,11 +617,18 @@ fn format_single_date(
             }
             let month = extract_month(date, &locale.dates.months.long);
             let day = date.day();
-            let base = match (month.is_empty(), day) {
-                (true, _) => year,
-                (false, None) => format!("{month} {year}"),
-                (false, Some(d)) => format!("{month} {d}, {year}"),
-            };
+            let base = locale
+                .resolve_date_pattern(
+                    "pattern.date-full",
+                    Some(&year),
+                    (!month.is_empty()).then_some(month.as_str()),
+                    day,
+                )
+                .unwrap_or_else(|| match (month.is_empty(), day) {
+                    (true, _) => year.clone(),
+                    (false, None) => format!("{month} {year}"),
+                    (false, Some(d)) => format!("{month} {d}, {year}"),
+                });
             // Append time component if configured and present
             if let (Some(time_fmt), Some(time)) = (
                 date_config.and_then(|c| c.time_format.as_ref()),
@@ -1108,5 +1120,90 @@ mod era_tests {
             "–",
         );
         assert_eq!(result, "100 BC");
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "Panicking is acceptable in tests."
+)]
+mod locale_pattern_tests {
+    use super::*;
+    use citum_schema::locale::Locale;
+
+    fn en_us() -> Locale {
+        Locale::from_yaml_str(include_str!("../../../../locales/en-US.yaml"))
+            .expect("en-US locale should parse")
+    }
+
+    fn es_es() -> Locale {
+        Locale::from_yaml_str(include_str!("../../../../locales/es-ES.yaml"))
+            .expect("es-ES locale should parse")
+    }
+
+    fn eu_es() -> Locale {
+        Locale::from_yaml_str(include_str!("../../../../locales/eu-ES.yaml"))
+            .expect("eu-ES locale should parse")
+    }
+
+    fn full(locale: &Locale, edtf: &str) -> String {
+        format_single_date(&EdtfString(edtf.to_string()), &DateForm::Full, locale, None)
+            .expect("date should render")
+    }
+
+    fn month_day(locale: &Locale, edtf: &str) -> String {
+        format_single_date(
+            &EdtfString(edtf.to_string()),
+            &DateForm::MonthDay,
+            locale,
+            None,
+        )
+        .expect("date should render")
+    }
+
+    #[test]
+    fn en_us_full_unchanged_by_pattern_machinery() {
+        // Regression: en-US declares no pattern.date-*, so the engine's
+        // hardcoded English assembly must still produce the original output.
+        assert_eq!(full(&en_us(), "2023-01-12"), "January 12, 2023");
+    }
+
+    #[test]
+    fn en_us_month_day_unchanged_by_pattern_machinery() {
+        assert_eq!(month_day(&en_us(), "2023-01-12"), "January 12");
+    }
+
+    #[test]
+    fn es_es_full_uses_locale_pattern() {
+        // Spanish day-first assembly via pattern.date-full.
+        assert_eq!(full(&es_es(), "2023-01-12"), "12 de enero de 2023");
+    }
+
+    #[test]
+    fn es_es_month_day_uses_locale_pattern() {
+        assert_eq!(month_day(&es_es(), "2023-01-12"), "12 de enero");
+    }
+
+    #[test]
+    fn eu_es_full_uses_locale_pattern() {
+        // Basque genitive-absolutive shape via pattern.date-full.
+        // Content is PROVISIONAL — see locales/eu-ES.yaml header comment.
+        assert_eq!(full(&eu_es(), "2023-01-12"), "2023ko urtarrilaren 12a");
+    }
+
+    #[test]
+    fn eu_es_month_day_uses_locale_pattern() {
+        assert_eq!(month_day(&eu_es(), "2023-01-12"), "urtarrilaren 12a");
+    }
+
+    #[test]
+    fn pattern_missing_day_falls_back_to_english_assembly() {
+        // Year-month only input: pattern.date-full requires {$day} so the
+        // evaluator returns None, and the engine falls through to its
+        // hardcoded `{month} {year}` assembly. (A future pattern.date-year-month
+        // can fix this for inflected locales — out of scope for this bean.)
+        assert_eq!(full(&es_es(), "2023-01"), "enero 2023");
     }
 }

--- a/crates/citum-schema-style/src/locale/message.rs
+++ b/crates/citum-schema-style/src/locale/message.rs
@@ -32,6 +32,13 @@ pub struct MessageArgs<'a> {
     pub url: Option<&'a str>,
     /// Pre-formatted date string.
     pub date: Option<&'a str>,
+    /// Year component of a date (e.g. `"2023"`).
+    pub year: Option<&'a str>,
+    /// Month component of a date, already inflected for this locale's date
+    /// context (e.g. `"January"`, `"urtarrila"`).
+    pub month: Option<&'a str>,
+    /// Day-of-month component of a date (e.g. `"12"`).
+    pub day: Option<&'a str>,
     /// Main contributor list for "et al." patterns.
     pub main_list: Option<&'a str>,
 }
@@ -130,6 +137,9 @@ fn resolve_var<'a>(var_name: &str, args: &'a MessageArgs<'a>) -> Option<&'a str>
         "end" => args.end,
         "url" => args.url,
         "date" => args.date,
+        "year" => args.year,
+        "month" => args.month,
+        "day" => args.day,
         "main_list" => args.main_list,
         _ => None,
     }
@@ -215,6 +225,9 @@ fn determine_match_key(
                 "end" => args.end.map(|s| s.to_string()),
                 "url" => args.url.map(|s| s.to_string()),
                 "date" => args.date.map(|s| s.to_string()),
+                "year" => args.year.map(|s| s.to_string()),
+                "month" => args.month.map(|s| s.to_string()),
+                "day" => args.day.map(|s| s.to_string()),
                 "main_list" => args.main_list.map(|s| s.to_string()),
                 _ => None,
             }?;
@@ -413,6 +426,40 @@ mod tests {
         assert_eq!(
             result,
             Some("retrieved from https://example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_date_component_substitution() {
+        let evaluator = Mf2MessageEvaluator;
+        let args = MessageArgs {
+            year: Some("2023"),
+            month: Some("urtarrila"),
+            day: Some("12"),
+            ..Default::default()
+        };
+        assert_eq!(
+            evaluator.evaluate("{$year}ko {$month}ren {$day}a", &args),
+            Some("2023ko urtarrilaren 12a".to_string())
+        );
+        assert_eq!(
+            evaluator.evaluate("{$month} {$day}", &args),
+            Some("urtarrila 12".to_string())
+        );
+    }
+
+    #[test]
+    fn test_date_component_missing_returns_none() {
+        let evaluator = Mf2MessageEvaluator;
+        let args = MessageArgs {
+            year: Some("2023"),
+            month: Some("urtarrila"),
+            ..Default::default()
+        };
+        // day is required but absent
+        assert_eq!(
+            evaluator.evaluate("{$year}ko {$month}ren {$day}a", &args),
+            None
         );
     }
 

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -1149,6 +1149,43 @@ impl Locale {
         // For now, we'll convert and handle in the message evaluator
         self.evaluator.evaluate(message, &args)
     }
+
+    /// Resolve a `pattern.date-*` message with locale-specific year/month/day
+    /// components.
+    ///
+    /// Returns `Some(rendered)` only when the locale carries an MF2 message
+    /// at `message_id` and the evaluator produces output. Callers fall back
+    /// to the engine's hardcoded English assembly on `None`.
+    ///
+    /// A component is forwarded to the evaluator only when non-empty; an
+    /// authored pattern that references `{$day}` therefore yields `None` if
+    /// the input date carries no day, letting the caller pick a shorter form.
+    ///
+    /// The day argument is taken as `Option<u32>` rather than a pre-formatted
+    /// string so the digit-to-string allocation is deferred until after the
+    /// message lookup succeeds — the common case for legacy locales (`en-US`,
+    /// every v1 file) is the lookup miss, which now incurs zero allocation.
+    pub fn resolve_date_pattern(
+        &self,
+        message_id: &str,
+        year: Option<&str>,
+        month: Option<&str>,
+        day: Option<u32>,
+    ) -> Option<String> {
+        let message = self.messages.get(message_id)?;
+        if self.evaluation.message_syntax == MessageSyntax::Static {
+            return None;
+        }
+
+        let day_str = day.map(|d| d.to_string());
+        let args = MessageArgs {
+            year: year.filter(|s| !s.is_empty()),
+            month: month.filter(|s| !s.is_empty()),
+            day: day_str.as_deref(),
+            ..MessageArgs::default()
+        };
+        self.evaluator.evaluate(message, &args)
+    }
 }
 
 impl Locale {

--- a/docs/guides/AUTHORING_LOCALES.md
+++ b/docs/guides/AUTHORING_LOCALES.md
@@ -93,6 +93,9 @@ limitation applies to other gendered locales, including French and Arabic.
 | `role.guest.label`, `role.guest.label-long`, `role.guest.verb` | `$count` | |
 | `pattern.page-range` | `$start`, `$end` | Spec'd; not yet consumed by the engine |
 | `pattern.retrieved-from`, `pattern.available-at` | `$url` | Spec'd; not yet consumed by the engine |
+| `pattern.date-full` | `$year`, `$month`, `$day` | Active. See "Date assembly" below. |
+| `pattern.date-month-day` | `$month`, `$day` | Active. |
+| `pattern.date-year-month`, `pattern.date-year-month-day`, `pattern.date-day-month-abbr-year`, `pattern.date-month-abbr-day-year` | as named | Reserved — see spec `LOCALE_MESSAGES.md` §1.5. |
 | `date.open-ended` | none | "present" / "heute" / "presente" |
 
 > **Note on `pattern.*` messages.** No engine call site currently passes
@@ -104,6 +107,74 @@ limitation applies to other gendered locales, including French and Arabic.
 The `legacy-term-aliases:` map bridges single-word legacy keys (e.g. `page`,
 `et_al`, `editor`) to message IDs so styles authored against the v1 vocabulary
 keep rendering. Mirror the en-US shape.
+
+## Date assembly
+
+The engine pre-formats `$year` / `$month` / `$day` from EDTF input, then looks
+up a `pattern.date-<form>` message in the active locale. If a pattern is
+authored, it is evaluated and used. If no pattern is authored, the engine
+falls through to a hardcoded English assembly (`{month} {day}, {year}`).
+
+When to author `pattern.date-*`:
+
+- The locale wants a non-English component order (Spanish day-first, Basque
+  year-first, …).
+- The locale wants connector words ("de") or non-comma punctuation between
+  components.
+- The locale needs morphological suffixes on components (Basque genitive
+  `-(r)en`, absolutive `-a`).
+
+```yaml
+# es-ES — day first, "de" connectors
+messages:
+  pattern.date-full:      "{$day} de {$month} de {$year}"
+  pattern.date-month-day: "{$day} de {$month}"
+```
+
+```yaml
+# eu-ES — Basque, year first with genitive month and absolutive day suffix
+# (provisional — pending native-speaker review)
+messages:
+  pattern.date-full:      "{$year}ko {$month}ren {$day}a"
+  pattern.date-month-day: "{$month}ren {$day}a"
+```
+
+Month inflection rides on `dates.months.long` / `dates.months.short`. Store
+the citation-form month (e.g. `urtarrila`) and add case suffixes in the
+pattern. If a locale ever needs more than one inflected form of the same
+month, file a follow-up before extending — do not preempt.
+
+A pattern that references a missing component (e.g. `pattern.date-full` uses
+`{$day}` but the input has no day) returns `None`, and the engine falls back
+to its English assembly. Author a separate `pattern.date-year-month` once
+that ID is wired if you need a no-day form to stay locale-shaped.
+
+### Sourcing minority-language grammar
+
+For widely-resourced languages (English, Spanish, French, German, …) the
+locale's morphology and date conventions are well documented and easy to
+verify against a normative reference. For minority and lesser-resourced
+languages, finding a citable shape is harder.
+
+[Apertium](https://www.apertium.org) is the most useful starting point we've
+found: it is a free/open-source rule-based machine translation platform that
+maintains explicit morphological grammars for languages it supports, and its
+wiki (`wiki.apertium.org`) contains relatively rigorous community-curated
+notes on case marking, agreement, and date formation. The Basque locale
+(`locales/eu-ES.yaml`) was bootstrapped from
+[`wiki.apertium.org/wiki/Basque_to_English`](https://wiki.apertium.org/wiki/Basque_to_English)
+for exactly this reason.
+
+Treat Apertium notes as a **secondary source** — credible enough to be
+better than invention, not authoritative enough to ship without a native
+speaker confirming. Always:
+
+1. Cite the specific wiki page (or other source) in the locale file header
+   so reviewers can trace your derivation.
+2. Mark the locale `PROVISIONAL` in the header until a native speaker has
+   reviewed both the term content and any inflected patterns.
+3. Prefer normative authorities (e.g. national language academies, major
+   university-press style guides) when they exist and cover the question.
 
 ## Gender
 

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -1,10 +1,10 @@
 # Locale Messages Specification
 
 **Status:** Active
-**Version:** 1.3
-**Date:** 2026-03-22
+**Version:** 1.4
+**Date:** 2026-05-16
 **Supersedes:** (none)
-**Related:** bean `csl26-qrpo` (ICU4X upgrade)
+**Related:** bean `csl26-qrpo` (ICU4X upgrade), bean `csl26-v6ok` (locale-authored date patterns)
 
 ## Purpose
 
@@ -182,6 +182,42 @@ The `dateFormats` map (§3) is the stable API regardless: both the pre-formattin
 path and a future `:citum-date` formatter consume the same symbolic name → CLDR
 pattern mapping.
 
+#### Date component substitution (`pattern.date-*`)
+
+Pre-formatting the whole date as a single `{$date}` blob leaves inflected
+languages (Basque, Finnish, Hungarian, …) without a way to express their own
+year/month/day order or morphology. Citum addresses this by also exposing the
+*components* of a date as named MF2 variables: `{$year}`, `{$month}`, `{$day}`.
+
+A locale may author one or more `pattern.date-<form>` messages — see §2 — and
+the engine substitutes the pre-formatted components into them at render time.
+These IDs live under the `messages:` map alongside `pattern.page-range` etc.:
+
+```yaml
+# es-ES: day-first with "de" connectors
+messages:
+  pattern.date-full:      "{$day} de {$month} de {$year}"
+  pattern.date-month-day: "{$day} de {$month}"
+```
+
+```yaml
+# eu-ES (Basque, PROVISIONAL): genitive month + absolutive day suffix
+messages:
+  pattern.date-full:      "{$year}ko {$month}ren {$day}a"
+  pattern.date-month-day: "{$month}ren {$day}a"
+```
+
+When no `pattern.date-<form>` message is authored, the engine falls back to
+its hardcoded English assembly (`{$month} {$day}, {$year}`) — so `en-US` and
+every legacy locale render identically with or without this feature enabled.
+
+Month inflection rides on the existing `dates.months.long` / `dates.months.short`
+lists: the locale stores the date-context-appropriate form there (e.g.
+`urtarrila`, not `urtarrilak`). The genitive / absolutive markers are applied
+in the pattern, not in the month list. If a future locale ever needs more than
+one inflected form of the same month, add a `dates.months.<case>` map and a
+`:form` selector — do not preempt.
+
 ---
 
 ### 2. Message ID Namespace
@@ -192,8 +228,29 @@ All message IDs are dot-namespaced strings:
 |--------|---------|---------|
 | `term.` | Localized labels | `term.page-label` |
 | `role.<role>.<form>` | Contributor role phrases | `role.editor.label`, `role.editor.verb` |
-| `pattern.` | Compositional phrase templates | `pattern.page-range`, `pattern.retrieved-from` |
+| `pattern.` | Compositional phrase templates | `pattern.page-range`, `pattern.retrieved-from`, `pattern.date-full` |
 | `date.` | Date-specific terms not in `dateFormats` | `date.open-ended` |
+
+#### Reserved `pattern.date-*` IDs
+
+One reserved ID per engine `DateForm` variant. Today the engine consumes the
+two marked **Active**; the others are reserved so locale authors can write
+forward-compatible files. Reserved-but-unconsumed IDs are silently ignored
+(the engine falls through to the hardcoded English assembly).
+
+| Message ID | Variables | `DateForm` | Status |
+|---|---|---|---|
+| `pattern.date-full` | `$year`, `$month`, `$day` | `Full` | **Active** |
+| `pattern.date-month-day` | `$month`, `$day` | `MonthDay` | **Active** |
+| `pattern.date-year-month` | `$year`, `$month` | `YearMonth` | Reserved |
+| `pattern.date-year-month-day` | `$year`, `$month`, `$day` | `YearMonthDay` | Reserved |
+| `pattern.date-day-month-abbr-year` | `$year`, `$month`, `$day` | `DayMonthAbbrYear` | Reserved |
+| `pattern.date-month-abbr-day-year` | `$year`, `$month`, `$day` | `MonthAbbrDayYear` | Reserved |
+
+A pattern that references a missing component (e.g. `pattern.date-full` uses
+`{$day}` but the input date has no day) returns `None` from the evaluator,
+and the engine falls back to its hardcoded assembly. Authors who need a
+no-day form should author `pattern.date-year-month` once that ID is wired.
 
 Legacy CSL-style term keys (`page`, `et_al`, `no_date`, …) remain accessible
 via the `legacyTermAliases` map on `LocalePreset`, which redirects old keys to
@@ -690,6 +747,9 @@ pub struct MessageArgs<'a> {
     pub end: Option<&'a str>,
     pub url: Option<&'a str>,
     pub date: Option<&'a str>,
+    pub year: Option<&'a str>,
+    pub month: Option<&'a str>,
+    pub day: Option<&'a str>,
     pub main_list: Option<&'a str>,
 }
 

--- a/docs/specs/TITLE_NAME_INFLECTION.md
+++ b/docs/specs/TITLE_NAME_INFLECTION.md
@@ -1,0 +1,363 @@
+# Title and Proper-Noun Inflection Across Languages
+
+**Status:** Draft
+**Version:** 0.2
+**Date:** 2026-05-16
+**Supersedes:** (none)
+**Bean:** `csl26-1b4e`
+**Related:** `csl26-v6ok` (locale-authored date patterns — the easier date-component subset of the same problem), CSL upstream issue [#6369](https://github.com/citation-style-language/styles/issues/6369), `docs/specs/GENDERED_LOCALE_TERMS.md` (the closest in-repo precedent)
+
+> **Audience.** This spec is written for engine implementers and style authors who are **not** assumed to know linguistic terminology. The "Background" section is a deliberately gentle primer; skim it if it's review.
+>
+> **Confidence.** Linguistic claims in this draft are marked:
+> - **(verified)** — claim is supported by a published reference grammar or widely-used MT resource, cited inline.
+> - **(illustrative)** — example is shaped to convey the design problem; the *form* of inflection is real, but the specific rendered string should be reviewed by a native speaker before being treated as authoritative.
+> - **🚧 (needs review)** — claim has not been verified; flagged for follow-up before any implementation work.
+
+---
+
+## Purpose
+
+Let Citum render citations correctly in languages where author names and work titles change their surface form depending on their grammatical role in the surrounding sentence. Today these are treated as opaque strings, so styles cannot ask for "the genitive form of this title" or "this author's name in the inessive case" even when the language requires it.
+
+This spec is **design only**. No code changes are proposed yet. The goal is to enumerate the choices, illustrate them with concrete examples, and surface what we don't know so it can be resolved before implementation begins.
+
+---
+
+## Recommendation: reserve the schema, defer the renderer
+
+The prior-art survey (below) shows essentially no reusable precedent. The user-demand survey (below) shows that the problem is real but that current CSL-stack users overwhelmingly cope by manually editing exports or accepting ungrammatical output, rather than escalating to feature requests with sustained follow-through. The implementation cost of a generic case-aware renderer is high (linguistic complexity, no native-speaker review pipeline, ongoing locale maintenance); the user-facing benefit is currently low (few sustained complaints).
+
+This spec therefore recommends a **staged approach**:
+
+1. **Now.** Define the input data model — the `MaybeInflected<T>` shape and the locale-declared case-set mechanism — so any future contribution has a coherent place to dock.
+2. **Now.** Reserve the relevant schema surface (field naming, serialisation behaviour for `Plain` vs `Inflected` variants) so that adding a `forms:` map to a title or contributor in a future minor release is non-breaking.
+3. **Defer.** Renderer implementation, MF2 case selectors, style-language plumbing, and migration tooling. Resume this when a motivated locale-specific contributor emerges with sample input data and a real style they want to ship — *not* on a speculative schedule.
+
+The remainder of this document is written under that staged plan: schema-side design decisions (Q1, Q2, Q3) should be pressed to closure when the spec leaves Draft; rendering-side decisions (Q4, Q5) are sketched with options but explicitly held open for the locale contributor who will eventually drive them.
+
+---
+
+## Scope
+
+**In scope:**
+
+- A design framework for representing per-case variants of titles, author names, and other proper nouns in Citum's input data and locale model.
+- A worked-example sketch of how a style would request a specific case form.
+- An enumeration of open questions whose answers should drive — not be derived from — implementation.
+
+**Out of scope:**
+
+- Date-component inflection. Already solved by `csl26-v6ok` via `pattern.date-*` MF2 messages.
+- Morphological *derivation* (an engine that generates inflected forms from a base form). This spec assumes inflected forms are supplied as input, consistent with Citum's "explicit over magic" principle.
+- Input-side OCR / parser improvements to recover inflected forms from bibliographic databases that don't ship them.
+- Locale-term gender (already handled by `MaybeGendered<T>` — see `docs/specs/GENDERED_LOCALE_TERMS.md`).
+- The CSL 1.0 procedural-XML side. This spec targets the Citum-native data model; CSL-derived styles will inherit the capability via migration but the migration mechanism is a separate concern.
+
+---
+
+## Background: a 90-second primer on grammatical case
+
+In English, most nouns look the same wherever they appear in a sentence:
+
+> The **dog** is barking.  *(subject)*
+> I see the **dog**.  *(object)*
+> I gave the **dog** a bone.  *(indirect object)*
+
+Only the personal pronouns inflect (*he / him / his*), and a residual genitive *'s* marks possession (*the dog's bone*). English is, by world standards, **morphologically poor**: it relies on word order and prepositions instead of case marking.
+
+Many other languages mark these roles directly on the noun. The set of forms a noun can take is its **case system**, and each form is a **case** (German *Kasus*, Latin *casus*). The two best-known case systems in European languages:
+
+- **Latin:** nominative, accusative, genitive, dative, ablative, vocative. The word *rosa* "rose" appears as *rosa, rosam, rosae, rosae, rosā, rosa* depending on grammatical role.
+- **German:** four cases (nominative, accusative, genitive, dative). *Der Mann* "the man" appears as *der Mann, den Mann, des Mannes, dem Mann*.
+
+Other languages go much further:
+
+| Language | Approximate case count | Source |
+|---|---|---|
+| **Russian** | 6 | Standard reference grammars (e.g. Wade, *A Comprehensive Russian Grammar*) **(verified)** |
+| **German** | 4 | Any reference grammar **(verified)** |
+| **Finnish** | ~15 | Karlsson, *Finnish: A Comprehensive Grammar* **(verified)** |
+| **Hungarian** | ~18 | Rounds, *Hungarian: An Essential Grammar* **(verified)** |
+| **Basque** | ~17 | Hualde & Ortiz de Urbina, *A Grammar of Basque* (Mouton de Gruyter, 2003) **(verified)** |
+
+For our purposes, the only things you need to remember are:
+
+1. The same noun can have many surface forms in the same text.
+2. The form is selected by the surrounding sentence, not by the noun itself.
+3. The *set* of available cases is language-specific. Russian's six cases are not the same six cases that Spanish would have if Spanish had cases; Finnish's inessive ("inside something") doesn't map cleanly onto any Russian case. Languages don't merely have *more* or *fewer* cases — they carve up grammatical role space differently.
+
+There is one additional structural axis worth knowing about, though it doesn't change the design surface much:
+
+- **Nominative–accusative languages** (the European mainstream — Latin, German, Russian, Finnish, Hungarian) distinguish the subject of a transitive verb ("she sees the dog") from the object ("the dog sees her").
+- **Ergative–absolutive languages** (including **Basque**) instead group the subject of an intransitive verb with the object of a transitive one. So the case marking on "the dog" in "the dog is barking" matches "the dog" in "she sees the dog", not the case marking on "she". **(verified)** — Hualde & Ortiz de Urbina, op. cit.
+
+Both alignments produce names and titles that change form by context. The design we land on must not bake in nominative–accusative assumptions.
+
+---
+
+## The problem in citations
+
+Bibliographic citations are not isolated noun phrases. They are embedded in running sentences (narrative citations) or in structured layouts (bibliography entries) that the style assembles in a specific language. In inflecting languages this means the author name or title routinely appears in a non-nominative case.
+
+### Worked example 1 — Finnish narrative citation
+
+In English, an author-date narrative citation looks like:
+
+> According to Smith (1962), …
+
+In Finnish, the same idea is most naturally written with the author's name in the **genitive** case, because *mukaan* "according to" takes a genitive complement. **(verified)** — Karlsson, *Finnish: A Comprehensive Grammar*.
+
+> **Smithin** (1962) mukaan, … *(illustrative)*
+
+`Smith → Smithin` is a regular Finnish genitive: append *-n* to the nominative stem. The case marking is required by the surrounding word *mukaan*; a Finnish reader will perceive *Smith mukaan* as ungrammatical, the way an English reader perceives *I gave he a bone*. The exact placement of the parenthesised year relative to *mukaan* is a style-guide choice; the case marking on the name is not.
+
+A Citum-native Finnish style today cannot produce *Smithin* from input that only carries *Smith*. The style author's only options are:
+
+1. Hardcode the genitive ending and hope every author name takes the same one (it doesn't — Finnish has multiple declension classes).
+2. Bypass the renderer and put a literal *Smithin* in the input data, losing portability.
+3. Accept incorrect Finnish output.
+
+None of these is acceptable.
+
+### Worked example 2 — Russian bibliography entry
+
+Russian routinely declines author surnames in possessive constructions, e.g. on a book spine or in a "Works by X" list:
+
+> Романы **Толстого** — "the novels of Tolstoy"  *(illustrative)*
+
+`Толстой → Толстого` is the standard genitive of a masculine surname in *-ой*. The case is selected because the surrounding construction is possessive. Other constructions select other cases: dative *Толстому*, accusative *Толстого* (homophonous with the genitive for animate nouns), instrumental *Толстым*. **(verified)** — Wade, *A Comprehensive Russian Grammar*.
+
+A Russian bibliographic style ought to be able to ask for the genitive of an author name. It currently cannot.
+
+### Worked example 3 — Basque inflected title in a possessive
+
+This is the case that motivated CSL upstream issue #6369. In Basque, a title embedded in a possessive phrase takes a case suffix. For a title like "Etika" (Spinoza's *Ethics*):
+
+> **Etikaren** sarrera — "the introduction to the *Ethics*"  🚧 (needs review)
+
+The genitive marker *-(r)en* attaches to the title. **(verified)** — Hualde & Ortiz de Urbina, op. cit. The specific rendered string for any particular title needs to be checked with a Basque speaker before it ships in a locale file, because Basque combines case marking with the indefinite/definite distinction and with vowel-stem versus consonant-stem morphology, all of which can interact with the citation form.
+
+### Worked example 4 — German genitive on a title
+
+German is morphologically much lighter than Finnish or Basque, but even here the genitive shows up routinely:
+
+> der zweite Band der ***Kritik der reinen Vernunft*** — "the second volume of the *Critique of Pure Reason*"  *(illustrative)*
+
+In practice, German citation styles typically italicize the title and leave it in the nominative regardless of context, treating the title as a quoted block. **(verified)** — this is a stylistic convention, not a grammatical requirement.
+
+The German example is included here for an important reason: **whether a language inflects titles in running prose is a stylistic choice**, not an automatic consequence of having a case system. A locale-level policy is needed.
+
+### Worked example 5 — English-language style, foreign-language reference
+
+Even an English-language style rendering a reference to a Russian-language work may want the original-language title in its citation-form case, not in whatever case it would naturally take in the running English sentence. In this scenario the *style's* language and the *title's* language disagree about whether to inflect, and the answer is generally: don't inflect — the title is being treated as a quoted citation block in English text.
+
+This case is straightforward: if no inflection is requested, the renderer returns the base form. The interesting cases above are the ones where both the style language and the title language agree that inflection is required.
+
+---
+
+## What goes wrong without a design
+
+Without a per-case data model, three failure modes occur in production:
+
+1. **Wrong-case strings** — a Finnish style renders *Smith mukaan* instead of *Smithin mukaan*. Native readers perceive this as broken prose.
+2. **Inconsistent workarounds** — different style authors hand-encode inflected forms in different fields (description, abstract, custom-string slots), making bibliographic data non-portable.
+3. **Locale silos** — styles for inflecting languages get rewritten as one-off forks rather than expressing the language difference declaratively. The cost compounds with every new language.
+
+A successful design avoids all three.
+
+---
+
+## Prior art
+
+A scan of comparable systems turned up essentially nothing reusable. **(verified)** by inspection of the linked sources:
+
+- **CSL 1.0 / CSL-JSON** ([specification](https://docs.citationstyles.org/en/stable/specification.html)): no concept of grammatical case on titles or names; treats them as opaque strings. The upstream issue [#6369](https://github.com/citation-style-language/styles/issues/6369) is the report that this gap exists.
+- **citeproc-js / citeproc-rs / citation.js**: inherit CSL's opaque-string model.
+- **biblatex / biber**: rich author/title metadata but no general per-case variants for titles or names. Two narrow precedents exist and are worth flagging:
+  - **Locale-specific date macros for inflecting languages**, most visibly the Lithuanian localisation, where biblatex's `.lbx` files supply *derivation-based* inflected month names: the locale module receives a base month and emits the inflected form via locale-specific macros. This is the opposite of the design direction this spec considers (stored input variants, see Q1 Option A) and is therefore precedent in shape rather than approach.
+  - **Gender-specific ordinal forms** (e.g. French *1<sup>er</sup>* / *1<sup>ère</sup>*) — closest architectural parallel to Citum's existing `MaybeGendered<T>`: a closed enum of variants resolved at render time. Useful as a precedent for the *shape* of the type, but the domain (ordinals) is small and closed, just like locale terms — the same scaling concern noted below for `MaybeGendered<T>` applies.
+- **Zotero / better-bibtex**: no per-case input fields.
+- **Pandoc-citeproc**: same as citeproc-js.
+- **CLDR / ICU**: case-sensitive number and date formatters exist (ICU MessageFormat 2 supports a `:case=genitive` annotation), but neither CLDR nor ICU ships name/title declension data.
+
+The closest in-repo precedent is **`MaybeGendered<T>`** in `crates/citum-schema-style/src/locale/types.rs`, which solves the analogous problem for *locale terms* (e.g. Spanish `editor` / `editora`). The shape generalizes, but the domains differ in two important ways:
+
+- Locale terms are a **closed authored set** (a few dozen role labels, locator labels, and connectors). Titles and names are **open input data** — the universe of strings is unbounded.
+- Gender on a locale term is a small fixed enum (masculine / feminine / neuter / common). Case on a title is a locale-declared list — possibly very long (15+ for Finnish) and structurally non-comparable across languages.
+
+Title and name inflection is therefore a green-field design problem. Choices should be justified on first principles, not by appeal to convention.
+
+---
+
+## User-demand signal
+
+The linguistic problem is real (see Worked Examples 1–3 above), but the user-facing demand for a solution in the current CSL tooling ecosystem is weaker than the linguistic case would suggest. A scan of the visible signal:
+
+- **Zotero community forums** surface scattered threads from Finnish, Russian, and Hungarian users about wrong case marking in narrative citations and bibliography entries. The dominant resolutions are (a) manually editing the exported bibliography after the fact and (b) silently accepting ungrammatical output. Few threads escalate to a feature request, and none we are aware of has produced a sustained implementation effort upstream.
+- **Juris-M**, the legal-citation Zotero fork that ships a measurably richer multilingual surface than upstream Zotero, handles **transliteration** of names and titles but deliberately does **not** handle grammatical-case inflection. That scope boundary is informative: the team most likely to invest in this gap has explicitly chosen not to.
+- **CSL upstream issue [#6369](https://github.com/citation-style-language/styles/issues/6369)** is the most concrete public request, and it focuses on dates rather than names or titles. The bdarcus/csln prototype issue [#107](https://github.com/bdarcus/csln/issues/107) it traces back to has the same scope.
+
+The interpretation: the problem is genuine, but the cost of grammatically-incorrect citation output (a few wrong word endings in an otherwise-readable bibliography) is low enough that affected users tolerate it, and the cost of producing per-case input data is currently high enough that no contributor has invested the sustained effort to fix it through the CSL stack. Until that asymmetry shifts — typically when a contributor with native-speaker fluency and locale-authoring motivation joins the project — speculative implementation is unlikely to produce ROI proportional to its maintenance cost.
+
+This is the empirical basis for the staged approach in the Recommendation section above.
+
+🚧 **Needs review:** a thorough survey of Polish, Czech, and Turkish user communities was not performed. If a stronger demand signal exists in one of those communities, it would meaningfully change the deferral calculus.
+
+---
+
+## Design questions
+
+Six design questions structure the rest of this document. Each is presented with concrete options and tradeoffs. Under the staged approach recommended above, **Q1–Q3 (schema)** should be pressed to closure before the spec leaves Draft, and **Q4–Q5 (rendering)** are sketched but explicitly deferred to the future locale contributor who drives the renderer work. **Q6 (migration impact)** applies to both phases.
+
+**No decisions are recommended in this draft** — the point is to make the choices visible. Concrete recommendations annotated below are starting points for the decision conversation, not commitments.
+
+### Q1 — Input model: stored variants vs. derived
+
+**Option A — Stored variants (explicit).** The input data carries per-case forms:
+
+```yaml
+title:
+  base: "Etika"
+  forms:
+    genitive: "Etikaren"
+    inessive: "Etikan"
+```
+
+**Option B — Engine derives forms (implicit).** The input carries only the base form; the engine applies morphological rules at render time, parameterized by locale and case.
+
+| Criterion | Stored variants | Engine derives |
+|---|---|---|
+| Citum principle "explicit over magic" | ✔ matches | ✘ conflicts |
+| Correctness for irregular forms | ✔ author-controlled | ✘ engine must encode every exception |
+| Author burden | ✘ many fields to fill | ✔ one field |
+| New language onboarding | ✔ no engine work | ✘ requires morphology rules per language |
+| Failure mode | Missing form → fallback | Wrong rule → wrong output, silent |
+
+**Recommendation in this draft:** pursue Option A in implementation; treat Option B as a possible future opt-in for languages with well-codified regular morphology. Open question: how authors actually get the inflected forms is a separate, downstream problem (could be Zotero plugins, manual entry, MT-assisted suggestion, …).
+
+### Q2 — Schema surface
+
+If Q1 lands on Option A, the schema needs a new type. Three candidate shapes:
+
+```rust
+// Sketch 1 — base + case map.
+pub struct InflectedString {
+    pub base: String,
+    pub forms: HashMap<GrammaticalCase, String>,
+}
+
+// Sketch 2 — map-only, with an implicit "default" key.
+pub struct InflectedString(HashMap<GrammaticalCase, String>);
+
+// Sketch 3 — parallel to MaybeGendered<T>.
+pub enum MaybeInflected<T> {
+    Plain(T),
+    Inflected { base: T, forms: HashMap<GrammaticalCase, T> },
+}
+```
+
+Sketch 3 is the most ergonomic in Rust — `MaybeInflected<T>` composes with `MaybeGendered<T>` and the existing `Title` enum, and a plain string deserializes into `Plain(s)` without ceremony. The serde round-trip for the inflected variant needs design (probably an untagged enum, mirroring `MaybeGendered<T>`).
+
+The `GrammaticalCase` type is the next question.
+
+### Q3 — Locale binding for the case set
+
+There is **no universal case vocabulary**. Different languages disagree on what cases *are*. Three approaches:
+
+- **Hardcoded universal enum.** A fixed Rust enum covering "common" cases (nominative, genitive, dative, accusative, locative, instrumental, ablative, …). Compact and type-safe; fails for languages whose case categories don't fit (every language with a productive case system that isn't Latin or Russian).
+- **Open string keys.** `HashMap<String, String>` with no enum. Maximally flexible; loses type-checking and risks typos (`"genitve"` vs `"genitive"`).
+- **Locale-declared case set.** Each locale file declares the cases it recognizes. A `GrammaticalCase` value is then a `(locale_id, case_name)` pair, validated at locale-load time. Catches typos; supports any case inventory; the cost is a slightly more complex resolution path in the engine.
+
+**Recommendation in this draft:** the locale-declared case set. It mirrors how `locator.kind` already works for compound locators (locale-declared vocabulary, validated on load).
+
+### Q4 — How does a style request a specific case?
+
+Several options, not mutually exclusive:
+
+- **Explicit attribute on the template node.** `{ field: title, case: genitive }`. Verbose but unambiguous.
+- **Implicit from surrounding macro.** A `possessive-of` macro requests its argument in the genitive automatically. Concise but couples grammar to template structure.
+- **MF2 selector.** Inside a `pattern.*` message, dispatch on `$case` the way `pattern.page-range` dispatches on `$count`. Lets locale authors encode the case requirement next to the surface text.
+
+The likely answer is a layered combination: a default case (probably nominative) at the field level, an explicit override on the template node, and MF2 selectors inside locale messages where the case requirement is determined by the surrounding text.
+
+🚧 **Needs review:** is there a real Citum-native style that exercises all three layers, or do the layers reduce to two in practice? Worth asking a Finnish or Russian style author before locking the design in.
+
+### Q5 — Fallback behavior
+
+When a style requests a case that the input doesn't supply, the renderer's options are:
+
+- **Silent fallback** — use the base / nominative form. Worst output is grammatically wrong text, identical to today's failure mode.
+- **Render-time warning** — emit the base form and log a warning so the input maintainer can fix the data. Same visible output, better feedback loop.
+- **Hard error** — refuse to render. Strict; appropriate where ungrammatical output is unacceptable (publication-grade Finnish text).
+
+This should likely be **locale policy**: an English-language locale rendering a Russian-language title legitimately falls back silently to the citation form (the title is being quoted, not declined). A Finnish-language locale rendering a Finnish-language name should probably warn or error, because *Smith mukaan* is a real defect.
+
+🚧 **Needs review:** is the right policy granularity per-locale, per-field-type (names vs titles), or per-case (some Finnish cases are stylistic, others are grammatically required)?
+
+### Q6 — Migration impact
+
+Most styles need no change. Most input data is in the nominative; inflection support is opt-in. Concrete migration scenarios:
+
+- **Existing English styles** — no change. They never request a case; they always get the nominative.
+- **Existing input data without per-case variants** — no change. `MaybeInflected<T>::Plain` round-trips identically to a bare string.
+- **Existing CSL-derived styles** — no change. CSL has no case concept, so migration produces no case requests.
+- **New Citum-native styles for inflecting languages** — opt in by referencing the new schema surface.
+
+Confirmation needed: a sample Finnish or Russian style that round-trips a real bibliography under the proposed schema, with at least one narrative citation that exercises a non-nominative case.
+
+---
+
+## Open questions for follow-up research
+
+These are flagged for explicit resolution before the spec leaves Draft status:
+
+1. **Title inflection — stylistic or grammatical?** Worked example 4 (German) notes that even case-rich languages often treat titles as italicized nominative blocks. We need a per-language survey (or a representative one) to know which inflecting languages routinely decline titles in citations vs. quote them. The answer may differ from the analogous decision for names.
+2. **Where do inflected forms come from?** Zotero, Crossref, OpenAlex etc. do not currently surface per-case variants. If the design lands on Option A (stored variants), the input data has to come from *somewhere*. Possible avenues: native-speaker authoring tools, optional MT-derived suggestions with human confirmation, locale-specific input plugins. None of these is in scope here, but the design should not assume them away.
+3. **Capitalization interactions.** Some cases (Hungarian) attach affixes that may or may not preserve the original case of the noun, especially across hyphens. 🚧 (needs review)
+4. **Interaction with transliteration.** A Russian author cited in an English text may be transliterated (*Tolstoj*, *Tolstoy*). If the Cyrillic source carries genitive *Толстого*, is the transliterated genitive *Tolstogo*? Always? Per-style? 🚧 (needs review)
+5. **Interaction with disambiguation.** Citum's disambiguation logic compares author-year keys. If two cites carry the same author in different cases (*Smith*, *Smithin*) they must still resolve to the same disambiguation bucket. The base form is the obvious key, but this needs to be specified explicitly.
+6. **Performance.** Adding a `HashMap` to every title and every author name multiplies the input size of a large bibliography by a non-trivial factor when used. Bench before committing to the layout. (Not a design blocker; an implementation concern.)
+
+---
+
+## Acceptance criteria for the design phase
+
+This spec is considered ready to leave Draft under the staged plan (Recommendation section, above). The criteria split accordingly:
+
+**Schema-side (pressed to closure before leaving Draft):**
+
+- [ ] Q1 (input model), Q2 (schema surface), and Q3 (locale-binding for the case set) each have a decision recorded, with a one-paragraph rationale.
+- [ ] At least one **native speaker** of an inflecting language has reviewed the worked examples and the proposed case-set mechanism, and corrected any 🚧 entries.
+- [ ] The migration impact on at least one existing non-trivial style (e.g. a CSL-derived Finnish or Russian variant) has been concretely verified to be no-change for the schema-only landing.
+
+**Rendering-side (sketched and explicitly deferred):**
+
+- Q4 (style-language request mechanism) and Q5 (fallback behaviour) remain open. They should be revisited when a contributor commits to driving the renderer work; the spec should not be blocked on them.
+- A sample Finnish or Russian style authored against the *full* renderer pipeline is not required for the schema-only landing.
+
+**Cross-cutting:**
+
+- [ ] Each open question 1–6 in the "Open questions for follow-up research" section has either an answer or a child bean that owns it.
+
+---
+
+## References
+
+The following are standard reference grammars cited in this spec. Page-level claims would require checking against the books themselves; this spec cites them only at the level of "this language has case marking, and this is how the field describes it":
+
+- Hualde, J. I., & Ortiz de Urbina, J. (eds.). (2003). *A Grammar of Basque*. Berlin: Mouton de Gruyter.
+- Karlsson, F. (2017). *Finnish: A Comprehensive Grammar*. London: Routledge. (Earlier editions also valid.)
+- Rounds, C. (2009). *Hungarian: An Essential Grammar*. London: Routledge.
+- Wade, T. (2010). *A Comprehensive Russian Grammar* (3rd ed.). Oxford: Wiley-Blackwell.
+
+Specific worked examples derived from grammar references are marked **(verified)** at the point of use. Examples shaped to convey the design problem rather than reproduce a citable sentence are marked **(illustrative)**.
+
+For the Basque worked example specifically, the orthography of `-(r)en` and related case markers was also cross-checked against the Apertium project's open-source Basque grammar notes ([wiki.apertium.org/wiki/Basque_to_English](https://wiki.apertium.org/wiki/Basque_to_English)), which Citum uses as a secondary-source starting point for minority-language locales — see `docs/guides/AUTHORING_LOCALES.md` and the `locales/eu-ES.yaml` header.
+
+---
+
+## Changelog
+
+- **0.2** — 2026-05-16 — Reframed scope around a staged approach: schema reservation now, renderer deferred until a motivated locale-specific contributor surfaces. Added the **Recommendation** section that formalises this position; added the **User-demand signal** section that supplies its empirical basis (Zotero forums, Juris-M's deliberate scope boundary, the dates-only focus of upstream CSL #6369). Expanded the **biblatex / biber** prior-art entry with the two specific precedents — Lithuanian derivation-based date macros and gender-specific ordinals. Split **Acceptance criteria** into schema-side (must close to leave Draft) and rendering-side (sketched, deferred). Version bumped from 0.1.
+- **0.1** — 2026-05-16 — Initial draft (bean `csl26-1b4e`). Identifies the problem, surveys prior art, enumerates six design questions with options and tradeoffs, flags open questions for follow-up. No decisions recommended.

--- a/locales/es-ES.yaml
+++ b/locales/es-ES.yaml
@@ -295,6 +295,10 @@ messages:
   pattern.page-range: "{$start}–{$end}"
   pattern.retrieved-from: "recuperado de {$url}"
   pattern.available-at: "disponible en {$url}"
+  # Date assembly — Spanish places the day first and connects with "de".
+  # Mirrors the long-form already declared in `date-formats.bib-default`.
+  pattern.date-full: "{$day} de {$month} de {$year}"
+  pattern.date-month-day: "{$day} de {$month}"
   date.open-ended: "presente"
 
 date-formats:

--- a/locales/eu-ES.yaml
+++ b/locales/eu-ES.yaml
@@ -1,0 +1,131 @@
+locale-schema-version: "2"
+locale: eu-ES
+
+# PROVISIONAL — pending native-speaker review.
+#
+# This locale demonstrates the `pattern.date-*` mechanism for inflected
+# languages (see bean `csl26-v6ok`, csln #107, citation-style-language/styles
+# #6369).
+#
+# Source of the Basque grammar below: Apertium — a free/open-source rule-based
+# machine translation platform (https://www.apertium.org) that maintains
+# explicit morphological grammars for lesser-resourced languages. The Basque
+# date shape is taken from its wiki:
+#
+#   https://wiki.apertium.org/wiki/Basque_to_English
+#
+# which describes `YYYYko {month}aren {day}a(n)` as the full-date form and
+# contrasts it with the ergative `{month}-ak` shape (the form the CSL upstream
+# issue used). Apertium is a secondary source — credible for "more rigorous
+# than guessing" but not a normative authority like Euskaltzaindia (the Royal
+# Academy of the Basque Language). A native speaker should confirm before
+# this locale is advertised as production-ready. Term content beyond dates
+# is a minimal stub copied from en-US and should be authored properly in
+# the same review pass.
+
+evaluation:
+  message-syntax: mf2
+
+dates:
+  months:
+    long:
+      - urtarrila
+      - otsaila
+      - martxoa
+      - apirila
+      - maiatza
+      - ekaina
+      - uztaila
+      - abuztua
+      - iraila
+      - urria
+      - azaroa
+      - abendua
+    short:
+      - urt.
+      - ots.
+      - mar.
+      - api.
+      - mai.
+      - eka.
+      - uzt.
+      - abu.
+      - ira.
+      - urr.
+      - aza.
+      - abe.
+  seasons:
+    - udaberria
+    - uda
+    - udazkena
+    - negua
+
+terms:
+  and:
+    long: eta
+  et_al:
+    long: et al.
+  "no date":
+    long: d. g.
+
+messages:
+  # Conjunctions and access labels — stubs, please review.
+  term.and: "eta"
+  term.and-symbol: "&"
+  term.et-al: "et al."
+  term.and-others: "eta beste"
+  term.accessed: "kontsulta-data"
+  term.retrieved: "iturria"
+  term.no-date: "d. g."
+  term.no-date-long: "data gabe"
+  term.circa: "ca."
+
+  # Date assembly — the feature this locale is designed to exercise.
+  #
+  # Pattern source: Apertium notes `1926ko apirilaren 21a` (full bibliography
+  # date). The month is stored in citation-form (`apirila`) and the genitive
+  # marker `-(r)en` plus the absolutive `-a` on the day are applied in the
+  # pattern. This works because every Basque month lemma above ends in `-a`.
+  #
+  # If a native-speaker reviewer reports a different convention (e.g.
+  # `2023(e)ko urtarrilak 12` from CSL #6369), update both patterns and the
+  # month list together.
+  pattern.date-full: "{$year}ko {$month}ren {$day}a"
+  pattern.date-month-day: "{$month}ren {$day}a"
+
+  pattern.page-range: "{$start}–{$end}"
+  pattern.retrieved-from: "iturria: {$url}"
+  date.open-ended: "gaur"
+
+date-formats:
+  numeric-short: "yyyy/MM/dd"
+  textual-long: "yyyy'ko' MMMM"
+  textual-full: "yyyy'ko' MMMM d'a'"
+  bib-default: "yyyy'ko' MMMM'ren' d'a'"
+  year-only: "yyyy"
+  iso: "yyyy-MM-dd"
+
+number-formats:
+  decimal-separator: ","
+  thousands-separator: "."
+  minimum-digits: 1
+
+grammar-options:
+  punctuation-in-quote: false
+  nbsp-before-colon: false
+  open-quote: "«"
+  close-quote: "»"
+  open-inner-quote: "“"
+  close-inner-quote: "”"
+  serial-comma: false
+  page-range-delimiter: "–"
+
+legacy-term-aliases:
+  page: term.page-label
+  pages: term.page-label
+  et_al: term.et-al
+  and: term.and
+  accessed: term.accessed
+  retrieved: term.retrieved
+  no_date: term.no-date
+  "no date": term.no-date


### PR DESCRIPTION
## Summary

Lets locales override the engine's hardcoded English date assembly by authoring `pattern.date-full` / `pattern.date-month-day` MF2 messages over `{$year}`, `{$month}`, `{$day}`. The existing English assembly stays the fallback, so en-US and all legacy locales render bit-identical.

Addresses the cross-language gap raised in [bdarcus/csln#107](https://github.com/bdarcus/csln/issues/107) and CSL upstream [#6369](https://github.com/citation-style-language/styles/issues/6369): inflected languages (Basque, Finnish, Hungarian, …) currently cannot express their own year/month/day order or morphology in citation dates.

Bean: `csl26-v6ok`.

## What changed

- **`MessageArgs`** — three new optional fields (`year`, `month`, `day`); MF2 evaluator substitutes `{$year}` / `{$month}` / `{$day}`.
- **`Locale::resolve_date_pattern()`** — focused helper that looks up `pattern.date-*` and runs the evaluator, returning `None` when no pattern is authored or when a required component is missing.
- **`format_single_date`** — `DateForm::Full` and `DateForm::MonthDay` arms now consult the locale first and fall through to the existing English `format!()` if no pattern resolves. Other variants (`YearMonth`, `YearMonthDay`, the two abbr-month forms) are scope-deferred and unchanged.
- **`locales/es-ES.yaml`** — adds `pattern.date-full: "{$day} de {$month} de {$year}"` and `pattern.date-month-day: "{$day} de {$month}"`. **Behavior change:** Spanish bibliography dates flip from `enero 12, 2023` (en-US fallback, incorrect) → `12 de enero de 2023` (correct, matches the already-declared `date-formats.bib-default` CLDR pattern).
- **`locales/eu-ES.yaml`** — new Basque locale, **PROVISIONAL** — patterns derived from [Apertium's Basque grammar notes](https://wiki.apertium.org/wiki/Basque_to_English) (`YYYYko {month}aren {day}a` shape, not the ergative `month-ak` form from the upstream CSL issue). Needs a native-speaker review before being advertised as production-ready.
- **Docs** — `docs/specs/LOCALE_MESSAGES.md` bumped to 1.4 with a new "Date component substitution" subsection and reserved-ID table; `docs/guides/AUTHORING_LOCALES.md` gains a "Date assembly" subsection with both worked examples.

## Reviewer attention

1. **Basque content is the risky part.** Apertium says `YYYYko {month}aren {day}a` for full dates; the upstream CSL issue example was `2023(e)ko urtarrilak 12` (ergative). I went with Apertium. **Please ask a Basque speaker to review `locales/eu-ES.yaml`** before merging — both the month list and the patterns.
2. **Scope is intentionally narrow.** Only `DateForm::Full` and `DateForm::MonthDay` are wired. The other four `DateForm` variants keep their hardcoded English assembly and are spec-reserved as `pattern.date-*` IDs for a follow-up.
3. **Spanish behavior change.** Spanish output changes for any style that renders a full bibliography date. This is a correctness improvement and passes the portfolio gate, but watch the diff carefully on the first es-ES rendering you spot-check.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run` — 1293/1293 pass
- [x] Portfolio quality gate (`scripts/check-core-quality.js`) — 154 styles at fidelity 1.0, 0 warnings
- [x] 7 new unit tests cover: en-US regression, Spanish + Basque MF2 path, missing-component fallback, MF2 evaluator variable substitution
- [ ] Native-speaker review of `locales/eu-ES.yaml`
- [x] Manual smoke: `cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s styles/embedded/apa-7th.yaml --locale eu-ES` (use a file-path style; builtin alias `-s apa` doesn't see the on-disk locale — see follow-up `csl26-hqy5`)

## Follow-ups (tracked as beans, not in this PR)

- **`csl26-37jv`** (task, low) — Wire the four reserved `DateForm` variants (`YearMonth`, `YearMonthDay`, abbr-month forms) into `pattern.date-*`.
- **`csl26-hqy5`** (feature, normal) — Custom locale file invocation for builtin-alias styles. Surfaced by this PR's smoke test: `-s apa --locale eu-ES` fails because builtin styles only consult the embedded locale set.
- **`csl26-1b4e`** (feature, draft) — Title / proper-noun inflection across languages — the broader cross-language ask in CSL upstream #6369. Initial design note bundled into this PR: [`docs/specs/TITLE_NAME_INFLECTION.md`](docs/specs/TITLE_NAME_INFLECTION.md) (v0.1, Draft). Includes a non-linguist primer on grammatical case, worked examples in Finnish / Russian / Basque / German, a prior-art survey, and the six design questions with options + tradeoffs (no decisions made yet). Next step is native-speaker review of the worked examples before the design questions are answered.
- **`csl26-dno4`** (feature, draft) — Per-case month-form maps (`dates.months.<case>`) if a single locale ever needs more than one inflected form of the same month.


