### PR TITLE
feat: implement tolerant enums and locale terms for forward compatibility

### DIFF
--- a/.beans/archive/csl26-2a0b--forward-compatibility-spec-scenario-test-corpus.md
+++ b/.beans/archive/csl26-2a0b--forward-compatibility-spec-scenario-test-corpus.md
@@ -1,13 +1,13 @@
 ---
 # csl26-2a0b
 title: Forward-compatibility spec + scenario test corpus
-status: in-progress
+status: completed
 type: task
 priority: high
 tags:
     - forward-compat
 created_at: 2026-05-15T14:41:05Z
-updated_at: 2026-05-16T12:48:55Z
+updated_at: 2026-05-16T14:13:54Z
 ---
 
 Audit + tests + spec to confirm and document the forward-compat strategy: older engines should soft-degrade with warnings on new attribute enums / option fields / locale terms, hard-fail only on template grammar changes and unknown InputReference class.
@@ -22,4 +22,4 @@ Related: csl26-piea, csl26-fuw7
 - [x] Cross-link from DESIGN_PRINCIPLES, SCHEMA_VERSIONING, ENUM_VOCABULARY_POLICY, EXTENSIBILITY_STRATEGY
 - [x] Update bean csl26-fuw7 body to point at the new spec
 - [x] File follow-up beans for each declared!=observed gap row (csl26-ld6e, csl26-0ksu, csl26-acfh, csl26-o1z5, csl26-1bdr)
-- [ ] PR with snapshot summary table
+- [x] PR with snapshot summary table

--- a/.beans/archive/csl26-ld6e--tolerant-deserializer-for-attribute-enums-forward.md
+++ b/.beans/archive/csl26-ld6e--tolerant-deserializer-for-attribute-enums-forward.md
@@ -1,13 +1,13 @@
 ---
 # csl26-ld6e
 title: Tolerant deserializer for attribute enums (forward compat)
-status: todo
+status: completed
 type: feature
 priority: high
 tags:
     - forward-compat
 created_at: 2026-05-15T14:48:03Z
-updated_at: 2026-05-16T14:14:09Z
+updated_at: 2026-05-16T16:31:33Z
 ---
 
 Promote forward-compat rows 01, 02, 03, 04 in crates/citum-engine/tests/snapshots/forward_compat_gaps.snap from observed=HardFail to observed=SoftDegrade.

--- a/.beans/archive/csl26-o1z5--tolerant-locale-term-key-lookup.md
+++ b/.beans/archive/csl26-o1z5--tolerant-locale-term-key-lookup.md
@@ -1,13 +1,13 @@
 ---
 # csl26-o1z5
 title: Tolerant locale term-key lookup
-status: todo
+status: completed
 type: feature
 priority: normal
 tags:
     - forward-compat
 created_at: 2026-05-15T14:48:14Z
-updated_at: 2026-05-16T14:14:19Z
+updated_at: 2026-05-16T16:31:38Z
 ---
 
 Promote forward-compat row 08 from observed=HardFail to observed=SoftDegrade.

--- a/.beans/archive/csl26-s4io--inputreference-layer-5-compatibilitywarning-for-un.md
+++ b/.beans/archive/csl26-s4io--inputreference-layer-5-compatibilitywarning-for-un.md
@@ -1,13 +1,13 @@
 ---
 # csl26-s4io
 title: 'InputReference Layer 5: CompatibilityWarning for unknown class'
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
     - forward-compat
 created_at: 2026-05-16T00:15:48Z
-updated_at: 2026-05-16T12:49:19Z
+updated_at: 2026-05-16T14:13:49Z
 parent: csl26-1bdr
 ---
 

--- a/.beans/csl26-0ksu--capture-unknown-fields-wrapper-for-style-schemas.md
+++ b/.beans/csl26-0ksu--capture-unknown-fields-wrapper-for-style-schemas.md
@@ -7,9 +7,7 @@ priority: high
 tags:
     - forward-compat
 created_at: 2026-05-15T14:48:07Z
-updated_at: 2026-05-16T12:48:55Z
-blocked_by:
-    - csl26-2a0b
+updated_at: 2026-05-16T14:14:04Z
 ---
 
 Promote forward-compat rows 05 and 06 from observed=HardFail to observed=SoftDegrade.

--- a/.beans/csl26-acfh--surface-silent-unknown-field-acceptance-on-referen.md
+++ b/.beans/csl26-acfh--surface-silent-unknown-field-acceptance-on-referen.md
@@ -7,12 +7,10 @@ priority: normal
 tags:
     - forward-compat
 created_at: 2026-05-15T14:48:11Z
-updated_at: 2026-05-16T12:48:55Z
-blocked_by:
-    - csl26-2a0b
+updated_at: 2026-05-16T14:15:58Z
 ---
 
-Promote forward-compat row 07 from observed=Pass (silent) to observed=SoftDegrade (warning).
+Promote forward-compat row 07 from observed=HardFail to observed=SoftDegrade (warning).
 
 Reference data structs cannot use deny_unknown_fields due to serde's #[serde(tag)] limitation on InputReference, so unknown keys are silently discarded today. Add a Deserializer hook that records skipped keys during reference parsing and emits a CompatibilityWarning per dropped key. The render still proceeds without the extra data.
 

--- a/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
+++ b/.beans/csl26-fuw7--write-versioning-policy-docs-before-first-public-r.md
@@ -9,10 +9,8 @@ tags:
     - dx
     - forward-compat
 created_at: 2026-02-24T17:28:17Z
-updated_at: 2026-05-16T12:48:56Z
+updated_at: 2026-05-16T14:13:59Z
 parent: csl26-li63
-blocked_by:
-    - csl26-yipx
 ---
 
 Before any public release or first external user, finish the normative

--- a/.beans/csl26-ld6e--tolerant-deserializer-for-attribute-enums-forward.md
+++ b/.beans/csl26-ld6e--tolerant-deserializer-for-attribute-enums-forward.md
@@ -7,9 +7,7 @@ priority: high
 tags:
     - forward-compat
 created_at: 2026-05-15T14:48:03Z
-updated_at: 2026-05-16T12:48:55Z
-blocked_by:
-    - csl26-2a0b
+updated_at: 2026-05-16T14:14:09Z
 ---
 
 Promote forward-compat rows 01, 02, 03, 04 in crates/citum-engine/tests/snapshots/forward_compat_gaps.snap from observed=HardFail to observed=SoftDegrade.

--- a/.beans/csl26-o1z5--tolerant-locale-term-key-lookup.md
+++ b/.beans/csl26-o1z5--tolerant-locale-term-key-lookup.md
@@ -7,9 +7,7 @@ priority: normal
 tags:
     - forward-compat
 created_at: 2026-05-15T14:48:14Z
-updated_at: 2026-05-16T12:48:55Z
-blocked_by:
-    - csl26-2a0b
+updated_at: 2026-05-16T14:14:19Z
 ---
 
 Promote forward-compat row 08 from observed=HardFail to observed=SoftDegrade.

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -599,7 +599,7 @@ fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem
             items.push(SemanticItem::Contributor(c.contributor.clone()));
         }
         TemplateComponent::Title(t) => items.push(SemanticItem::Title(t.title.clone())),
-        TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term)),
+        TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term.clone())),
         TemplateComponent::Group(g) => {
             for child in &g.group {
                 to_semantic_items(child, items);

--- a/crates/citum-cli/src/commands.rs
+++ b/crates/citum-cli/src/commands.rs
@@ -1642,14 +1642,29 @@ fn run_check(args: CheckArgs) -> Result<(), Box<dyn Error>> {
     for path in args.bibliography {
         let display = path.display().to_string();
         let status = match load_bibliography(&path) {
-            Ok(_) => CheckItem {
-                kind: "bibliography",
-                path: display,
-                ok: true,
-                schema_version: None,
-                warnings: None,
-                error: None,
-            },
+            Ok(bib) => {
+                let mut warnings = Vec::new();
+                let class_warnings = citum_engine::api::unknown_reference_class_warnings(&bib);
+                warnings.extend(class_warnings.into_iter().map(|w| w.message));
+
+                // For enums, we need a processor context
+                let processor = citum_engine::Processor::new(citum_schema::Style::default(), bib);
+                let enum_warnings = citum_engine::api::unknown_enum_warnings(&processor);
+                warnings.extend(enum_warnings.into_iter().map(|w| w.message));
+
+                CheckItem {
+                    kind: "bibliography",
+                    path: display,
+                    ok: true,
+                    schema_version: None,
+                    warnings: if warnings.is_empty() {
+                        None
+                    } else {
+                        Some(warnings)
+                    },
+                    error: None,
+                }
+            }
             Err(e) => CheckItem {
                 kind: "bibliography",
                 path: display,
@@ -1734,6 +1749,12 @@ fn check_style_input(style_input: &str) -> CheckItem {
                     style.version
                 ));
             }
+
+            // Capture unknown enums and term keys from the style AST
+            let processor =
+                citum_engine::Processor::new(style.clone(), citum_engine::Bibliography::new());
+            let enum_warnings = citum_engine::api::unknown_enum_warnings(&processor);
+            warnings.extend(enum_warnings.into_iter().map(|w| w.message));
 
             CheckItem {
                 kind: "style",

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -8,7 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use crate::api::AnnotationStyle;
 use crate::error::ProcessorError;
 use crate::processor::Processor;
-use crate::reference::Bibliography;
+use crate::reference::{Bibliography, Citation};
 use crate::render::djot::Djot;
 use crate::render::format::OutputFormat;
 use crate::render::html::Html;
@@ -16,8 +16,13 @@ use crate::render::latex::Latex;
 use crate::render::plain::PlainText;
 use crate::render::typst::Typst;
 use citum_schema::Style;
-use citum_schema::data::citation::Citation;
-use citum_schema::reference::ReferenceClass;
+use citum_schema::locale::{GeneralTerm, TermForm};
+use citum_schema::reference::{
+    ClassExtension, CollectionType, ContributorRole as ReferenceRole, MonographComponentType,
+    MonographType, ReferenceClass, SerialComponentType,
+};
+use citum_schema::template::ContributorRole as TemplateRole;
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -142,6 +147,7 @@ pub fn format_document_with_style(
 
     let mut processor = Processor::new(style, request.refs);
     warnings.extend(unknown_reference_class_warnings(&processor.bibliography));
+    warnings.extend(unknown_enum_warnings(&processor));
 
     if let Some(opts) = &request.document_options {
         if let Some(show_semantics) = opts.show_semantics {
@@ -233,7 +239,8 @@ pub fn format_document_with_style(
     })
 }
 
-fn unknown_reference_class_warnings(bibliography: &Bibliography) -> Vec<Warning> {
+/// Scan the bibliography for unknown reference classes and return compatibility warnings.
+pub fn unknown_reference_class_warnings(bibliography: &Bibliography) -> Vec<Warning> {
     bibliography
         .iter()
         .filter_map(|(ref_id, reference)| {
@@ -251,6 +258,154 @@ fn unknown_reference_class_warnings(bibliography: &Bibliography) -> Vec<Warning>
             })
         })
         .collect()
+}
+
+/// Scan the style and bibliography for unknown enum variants and term keys.
+///
+/// Returns a list of structured compatibility warnings for encounter of
+/// unknown variants that were captured via the tolerant-enum mechanism.
+pub fn unknown_enum_warnings(processor: &Processor) -> Vec<Warning> {
+    let mut warnings = Vec::new();
+
+    // 1. Scan bibliography
+    for (ref_id, reference) in &processor.bibliography {
+        match reference.extension() {
+            ClassExtension::Monograph(r) => {
+                if let MonographType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown monograph type '{s}'; rendering will use default monograph formatting."),
+                    });
+                }
+            }
+            ClassExtension::Collection(r) => {
+                if let CollectionType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown collection type '{s}'; rendering will use default collection formatting."),
+                    });
+                }
+            }
+            ClassExtension::CollectionComponent(r) => {
+                if let MonographComponentType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown monograph component type '{s}'; rendering will use default chapter formatting."),
+                    });
+                }
+            }
+            ClassExtension::SerialComponent(r) => {
+                if let SerialComponentType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown serial component type '{s}'; rendering will use default article formatting."),
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        for contributor in reference.all_contributor_entries() {
+            if let ReferenceRole::Unknown(s) = &contributor.role {
+                warnings.push(Warning {
+                    level: WarningLevel::Warning,
+                    code: "unknown_enum_variant".to_string(),
+                    citation_id: None,
+                    ref_id: Some(ref_id.clone()),
+                    message: format!("Reference '{ref_id}' uses unknown contributor role '{s}'; this role may be ignored during rendering."),
+                });
+            }
+        }
+    }
+
+    // 2. Scan Style
+    if let Some(templates) = &processor.style.templates {
+        for (name, template) in templates {
+            scan_template_for_unknowns(template, &format!("template '{name}'"), &mut warnings);
+        }
+    }
+    if let Some(citation) = &processor.style.citation
+        && let Some(template) = &citation.template
+    {
+        scan_template_for_unknowns(template, "citation layout", &mut warnings);
+    }
+    if let Some(bib) = &processor.style.bibliography
+        && let Some(template) = &bib.template
+    {
+        scan_template_for_unknowns(template, "bibliography layout", &mut warnings);
+    }
+
+    warnings
+}
+
+fn scan_template_for_unknowns(
+    components: &[citum_schema::template::TemplateComponent],
+    location: &str,
+    warnings: &mut Vec<Warning>,
+) {
+    use citum_schema::template::TemplateComponent;
+    for component in components {
+        match component {
+            TemplateComponent::Term(t) => {
+                if let GeneralTerm::Unknown(s) = &t.term {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown locale term key '{s}'; this term may render as empty."),
+                    });
+                }
+                if let Some(TermForm::Unknown(s)) = &t.form {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown term form '{s}'; falling back to long form."),
+                    });
+                }
+            }
+            TemplateComponent::Contributor(c) => {
+                if let TemplateRole::Unknown(s) = &c.contributor {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown contributor role '{s}'; this role may be ignored."),
+                    });
+                }
+            }
+            TemplateComponent::Date(d) => {
+                if let citum_schema::template::DateForm::Unknown(s) = &d.form {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown date form '{s}'; falling back to year only."),
+                    });
+                }
+            }
+            TemplateComponent::Group(g) => {
+                scan_template_for_unknowns(&g.group, location, warnings);
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Process citations and return formatted text.

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -15,7 +15,7 @@ mod types;
 
 pub use document::{
     FormatDocumentError, FormatDocumentRequest, FormatDocumentResult, format_document,
-    format_document_with_style,
+    format_document_with_style, unknown_enum_warnings, unknown_reference_class_warnings,
 };
 pub use style_input::StyleInput;
 pub use types::{

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -26,7 +26,7 @@ impl Processor {
             GroupHeading::Literal { literal } => Some(literal.clone()),
             GroupHeading::Term { term, form } => self.locale.resolved_general_term(
                 term,
-                form.unwrap_or(citum_schema::locale::TermForm::Long),
+                &form.clone().unwrap_or(citum_schema::locale::TermForm::Long),
                 None,
             ),
             GroupHeading::Localized { localized } => self.resolve_localized_heading(localized),
@@ -74,7 +74,7 @@ impl Processor {
             BibliographyPartitionHeading::Literal { literal } => Some(literal.clone()),
             BibliographyPartitionHeading::Term { term, form } => self.locale.resolved_general_term(
                 term,
-                form.unwrap_or(citum_schema::locale::TermForm::Long),
+                &form.clone().unwrap_or(citum_schema::locale::TermForm::Long),
                 None,
             ),
             BibliographyPartitionHeading::Localized { localized } => {

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -25,13 +25,13 @@ fn join_integral_groups(rendered_groups: Vec<String>, locale: &Locale) -> String
         1 => rendered_groups.into_iter().next().unwrap_or_default(),
         2 => {
             let conjunction = locale
-                .resolved_general_term(&GeneralTerm::And, TermForm::Long, None)
+                .resolved_general_term(&GeneralTerm::And, &TermForm::Long, None)
                 .unwrap_or_else(|| locale.and_term(false).to_string());
             rendered_groups.join(&format!(" {} ", conjunction.trim()))
         }
         _ => {
             let conjunction = locale
-                .resolved_general_term(&GeneralTerm::And, TermForm::Long, None)
+                .resolved_general_term(&GeneralTerm::And, &TermForm::Long, None)
                 .unwrap_or_else(|| locale.and_term(false).to_string());
             let final_delimiter = if locale.grammar_options.serial_comma {
                 format!(", {} ", conjunction.trim())

--- a/crates/citum-engine/src/processor/document/notes.rs
+++ b/crates/citum-engine/src/processor/document/notes.rs
@@ -403,7 +403,7 @@ impl Processor {
             .or_else(|| {
                 self.locale.resolved_general_term(
                     &citum_schema::locale::GeneralTerm::Ibid,
-                    citum_schema::locale::TermForm::Long,
+                    &citum_schema::locale::TermForm::Long,
                     None,
                 )
             })

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1358,7 +1358,7 @@ impl Renderer<'_> {
 
         if let Some(long) = options.locale.resolved_general_term(
             &citum_schema::locale::GeneralTerm::NoDate,
-            citum_schema::locale::TermForm::Long,
+            &citum_schema::locale::TermForm::Long,
             None,
         ) {
             values.value = long;

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -23,18 +23,18 @@ fn map_contributor_gender(gender: ContributorGender) -> GrammaticalGender {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(super) enum RoleGenderRequest {
     Specific(GrammaticalGender),
-    NeutralOnly,
+    Neutral,
 }
 
 fn requested_role_gender(
     component: &TemplateContributor,
     reference: &Reference,
 ) -> Option<RoleGenderRequest> {
-    if let Some(gender) = component.gender {
-        return Some(RoleGenderRequest::Specific(gender));
+    if let Some(gender) = &component.gender {
+        return Some(RoleGenderRequest::Specific(gender.clone()));
     }
 
     let data_role = contributor_role_to_reference_role(&component.contributor)?;
@@ -48,7 +48,7 @@ fn requested_role_gender(
     if genders.all(|gender| gender == first) {
         Some(RoleGenderRequest::Specific(first))
     } else {
-        Some(RoleGenderRequest::NeutralOnly)
+        Some(RoleGenderRequest::Neutral)
     }
 }
 
@@ -61,12 +61,12 @@ fn resolve_role_term_by_request(
 ) -> Option<String> {
     match requested_gender {
         Some(RoleGenderRequest::Specific(gender)) => {
-            locale.resolved_role_term(role, plural, term_form, Some(gender))
+            locale.resolved_role_term(role, plural, &term_form, Some(gender))
         }
-        Some(RoleGenderRequest::NeutralOnly) => {
-            locale.resolved_role_term_neutral(role, plural, term_form)
+        Some(RoleGenderRequest::Neutral) => {
+            locale.resolved_role_term_neutral(role, plural, &term_form)
         }
-        None => locale.resolved_role_term(role, plural, term_form, None),
+        None => locale.resolved_role_term(role, plural, &term_form, None),
     }
 }
 
@@ -86,7 +86,7 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
         RoleLabelPreset::VerbPrefix => {
             let term = options
                 .locale
-                .resolved_role_term(role, plural, TermForm::Verb, None);
+                .resolved_role_term(role, plural, &TermForm::Verb, None);
             (
                 term.map(|t| {
                     super::format_role_term::<F>(&t, fmt, effective_rendering, options, "", " ")
@@ -97,7 +97,7 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
         RoleLabelPreset::VerbShortPrefix => {
             let term = options
                 .locale
-                .resolved_role_term(role, plural, TermForm::VerbShort, None);
+                .resolved_role_term(role, plural, &TermForm::VerbShort, None);
             (
                 term.map(|t| {
                     super::format_role_term::<F>(&t, fmt, effective_rendering, options, "", " ")
@@ -220,7 +220,8 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
             };
             let term = options
                 .locale
-                .resolved_role_term(role, plural, term_form, None);
+                .resolved_role_term(role, plural, &term_form, None);
+
             (
                 term.map(|t| {
                     super::format_role_term::<F>(&t, fmt, effective_rendering, options, "", " ")

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -47,7 +47,7 @@ pub(super) fn contributor_role_to_reference_role(
         ContributorRole::Editor => Some(citum_schema::reference::ContributorRole::Editor),
         ContributorRole::Translator => Some(citum_schema::reference::ContributorRole::Translator),
         ContributorRole::Recipient => Some(citum_schema::reference::ContributorRole::Recipient),
-        ContributorRole::Chair => Some(citum_schema::reference::ContributorRole::Custom(
+        ContributorRole::Chair => Some(citum_schema::reference::ContributorRole::Unknown(
             "chair".to_string(),
         )),
         ContributorRole::Interviewer => Some(citum_schema::reference::ContributorRole::Interviewer),
@@ -55,28 +55,28 @@ pub(super) fn contributor_role_to_reference_role(
         ContributorRole::Director => Some(citum_schema::reference::ContributorRole::Director),
         ContributorRole::Composer => Some(citum_schema::reference::ContributorRole::Composer),
         ContributorRole::Illustrator => Some(citum_schema::reference::ContributorRole::Illustrator),
-        ContributorRole::Inventor => Some(citum_schema::reference::ContributorRole::Custom(
+        ContributorRole::Inventor => Some(citum_schema::reference::ContributorRole::Unknown(
             "inventor".to_string(),
         )),
-        ContributorRole::Counsel => Some(citum_schema::reference::ContributorRole::Custom(
+        ContributorRole::Counsel => Some(citum_schema::reference::ContributorRole::Unknown(
             "counsel".to_string(),
         )),
         ContributorRole::CollectionEditor => Some(
-            citum_schema::reference::ContributorRole::Custom("collection-editor".to_string()),
+            citum_schema::reference::ContributorRole::Unknown("collection-editor".to_string()),
         ),
-        ContributorRole::ContainerAuthor => Some(citum_schema::reference::ContributorRole::Custom(
-            "container-author".to_string(),
-        )),
+        ContributorRole::ContainerAuthor => Some(
+            citum_schema::reference::ContributorRole::Unknown("container-author".to_string()),
+        ),
         ContributorRole::EditorialDirector => Some(
-            citum_schema::reference::ContributorRole::Custom("editorial-director".to_string()),
+            citum_schema::reference::ContributorRole::Unknown("editorial-director".to_string()),
         ),
-        ContributorRole::TextualEditor => Some(citum_schema::reference::ContributorRole::Custom(
+        ContributorRole::TextualEditor => Some(citum_schema::reference::ContributorRole::Unknown(
             "textual-editor".to_string(),
         )),
-        ContributorRole::OriginalAuthor => Some(citum_schema::reference::ContributorRole::Custom(
+        ContributorRole::OriginalAuthor => Some(citum_schema::reference::ContributorRole::Unknown(
             "original-author".to_string(),
         )),
-        ContributorRole::ReviewedAuthor => Some(citum_schema::reference::ContributorRole::Custom(
+        ContributorRole::ReviewedAuthor => Some(citum_schema::reference::ContributorRole::Unknown(
             "reviewed-author".to_string(),
         )),
         ContributorRole::Interviewee | ContributorRole::Publisher => None,

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -109,22 +109,22 @@ fn lookup_role_contributor(
             reference.contributor(DataRole::Illustrator)
         }
         ResolvedRole::BuiltIn(ContributorRole::ContainerAuthor) => {
-            reference.contributor(DataRole::Custom("container-author".to_string()))
+            reference.contributor(DataRole::Unknown("container-author".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::CollectionEditor) => {
-            reference.contributor(DataRole::Custom("collection-editor".to_string()))
+            reference.contributor(DataRole::Unknown("collection-editor".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::EditorialDirector) => {
-            reference.contributor(DataRole::Custom("editorial-director".to_string()))
+            reference.contributor(DataRole::Unknown("editorial-director".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::TextualEditor) => {
-            reference.contributor(DataRole::Custom("textual-editor".to_string()))
+            reference.contributor(DataRole::Unknown("textual-editor".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::OriginalAuthor) => {
-            reference.contributor(DataRole::Custom("original-author".to_string()))
+            reference.contributor(DataRole::Unknown("original-author".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::ReviewedAuthor) => {
-            reference.contributor(DataRole::Custom("reviewed-author".to_string()))
+            reference.contributor(DataRole::Unknown("reviewed-author".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::Recipient) => {
             reference.contributor(DataRole::Recipient)
@@ -134,13 +134,13 @@ fn lookup_role_contributor(
         }
         ResolvedRole::BuiltIn(ContributorRole::Guest) => reference.contributor(DataRole::Guest),
         ResolvedRole::BuiltIn(ContributorRole::Chair) => {
-            reference.contributor(DataRole::Custom("chair".to_string()))
+            reference.contributor(DataRole::Unknown("chair".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::Inventor) => {
-            reference.contributor(DataRole::Custom("inventor".to_string()))
+            reference.contributor(DataRole::Unknown("inventor".to_string()))
         }
         ResolvedRole::BuiltIn(ContributorRole::Counsel) => {
-            reference.contributor(DataRole::Custom("counsel".to_string()))
+            reference.contributor(DataRole::Unknown("counsel".to_string()))
         }
         ResolvedRole::Custom(role) => match role.as_str() {
             "compiler" => reference.contributor(DataRole::Compiler),
@@ -149,7 +149,7 @@ fn lookup_role_contributor(
             "host" => reference.contributor(DataRole::Host),
             "producer" | "executive-producer" => reference.contributor(DataRole::Producer),
             "writer" => reference.contributor(DataRole::Writer),
-            _ => reference.contributor(DataRole::Custom(role.clone())),
+            _ => reference.contributor(DataRole::Unknown(role.clone())),
         },
         _ => None,
     }

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -399,6 +399,7 @@ fn format_range_start(
                 (false, Some(d)) => format!("{month} {d}, {year}"),
             }
         }
+        _ => extract_year(date),
     }
 }
 
@@ -511,6 +512,7 @@ fn inline_disamb_suffix(formatted: &str, form: &DateForm, year: &str, suffix: &s
         | DateForm::DayMonthAbbrYear
         | DateForm::MonthAbbrDayYear => formatted.rfind(year),
         DateForm::MonthDay => None,
+        _ => None,
     };
 
     let Some(index) = year_index else {
@@ -689,6 +691,7 @@ fn format_single_date(
                 (false, Some(d)) => Some(format!("{month} {d}, {year}")),
             }
         }
+        _ => Some(extract_year(date)),
     }
 }
 
@@ -720,7 +723,7 @@ impl ComponentValues for TemplateDate {
             if matches!(self.date, TemplateDateVar::Issued)
                 && let Some(nd) = options.locale.resolved_general_term(
                     &GeneralTerm::NoDate,
-                    TermForm::Short,
+                    &TermForm::Short,
                     None,
                 )
             {

--- a/crates/citum-engine/src/values/locator.rs
+++ b/crates/citum-engine/src/values/locator.rs
@@ -180,7 +180,7 @@ fn render_segment_with_label_str(
         LabelForm::None => TermForm::Short, // Shouldn't reach here
     };
 
-    if let Some(term) = locale.resolved_locator_term(&seg.label, plural, term_form, None) {
+    if let Some(term) = locale.resolved_locator_term(&seg.label, plural, &term_form, None) {
         let strip_periods = kind_cfg
             .and_then(|k| k.strip_label_periods)
             .or(global_strip)

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -125,7 +125,7 @@ fn resolve_number_label<F: crate::render::format::OutputFormat<Output = String>>
 
         options
             .locale
-            .resolved_locator_term(&locator_type, plural, term_form, requested_gender)
+            .resolved_locator_term(&locator_type, plural, &term_form, requested_gender)
             .map(|t| {
                 let term_str = if crate::values::should_strip_periods(effective_rendering, options)
                 {
@@ -167,7 +167,7 @@ impl ComponentValues for TemplateNumber {
                     &self.number,
                     label_form,
                     &value,
-                    self.gender,
+                    self.gender.clone(),
                     effective_rendering,
                     options,
                     &fmt,

--- a/crates/citum-engine/src/values/term.rs
+++ b/crates/citum-engine/src/values/term.rs
@@ -22,10 +22,10 @@ impl ComponentValues for TemplateTerm {
     ) -> Option<ProcValues<F::Output>> {
         let effective_rendering = self.rendering.clone();
 
-        let form = self.form.unwrap_or(TermForm::Long);
+        let form = self.form.clone().unwrap_or(TermForm::Long);
         let mut value = options
             .locale
-            .resolved_general_term(&self.term, form, self.gender)
+            .resolved_general_term(&self.term, &form, self.gender.clone())
             .unwrap_or_default();
 
         // Apply strip-periods if configured

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -680,7 +680,7 @@ fn test_collection_editor_role_label_derives_gender_from_reference_data() {
         abbreviation_map: None,
     };
     let reference = make_custom_role_reference(
-        citum_schema::reference::ContributorRole::Custom("collection-editor".to_string()),
+        citum_schema::reference::ContributorRole::Unknown("collection-editor".to_string()),
         &[ContributorGender::Feminine],
     );
     let hints = ProcHints::default();

--- a/crates/citum-engine/tests/forward_compatibility.rs
+++ b/crates/citum-engine/tests/forward_compatibility.rs
@@ -67,21 +67,113 @@ struct Scenario {
     follow_up: &'static str,
 }
 
+use citum_schema::locale::{GeneralTerm, TermForm};
+use citum_schema::reference::{
+    ClassExtension, CollectionType, ContributorRole, MonographComponentType, MonographType,
+    SerialComponentType,
+};
+use citum_schema::template::{DateForm, TemplateComponent};
+
 fn parse_style(yaml: &str) -> Outcome {
     match Style::from_yaml_str(yaml) {
-        Ok(_) => Outcome::Pass,
+        Ok(style) => {
+            if style_has_unknowns(&style) {
+                Outcome::SoftDegrade
+            } else {
+                Outcome::Pass
+            }
+        }
         Err(_) => Outcome::HardFail,
     }
+}
+
+fn style_has_unknowns(style: &Style) -> bool {
+    if let Some(templates) = &style.templates {
+        for template in templates.values() {
+            if template_has_unknowns(template) {
+                return true;
+            }
+        }
+    }
+    if let Some(citation) = &style.citation
+        && let Some(template) = &citation.template
+        && template_has_unknowns(template)
+    {
+        return true;
+    }
+    if let Some(bib) = &style.bibliography
+        && let Some(template) = &bib.template
+        && template_has_unknowns(template)
+    {
+        return true;
+    }
+    false
+}
+
+fn template_has_unknowns(components: &[TemplateComponent]) -> bool {
+    for component in components {
+        match component {
+            TemplateComponent::Term(t) => {
+                if matches!(t.term, GeneralTerm::Unknown(_)) {
+                    return true;
+                }
+                if let Some(TermForm::Unknown(_)) = &t.form {
+                    return true;
+                }
+            }
+            TemplateComponent::Contributor(c) => {
+                if matches!(
+                    c.contributor,
+                    citum_schema::template::ContributorRole::Unknown(_)
+                ) {
+                    return true;
+                }
+            }
+            TemplateComponent::Date(d) => {
+                if matches!(d.form, DateForm::Unknown(_)) {
+                    return true;
+                }
+            }
+            TemplateComponent::Group(g) if template_has_unknowns(&g.group) => {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 fn parse_bibliography(yaml: &str) -> Outcome {
     match serde_yaml::from_str::<InputBibliography>(yaml) {
         Ok(bibliography) => {
-            if bibliography
-                .references
-                .iter()
-                .any(|reference| matches!(reference.class(), ReferenceClass::Unknown(_)))
-            {
+            let has_unknown = bibliography.references.iter().any(|reference| {
+                if matches!(reference.class(), ReferenceClass::Unknown(_)) {
+                    return true;
+                }
+                let ext_unknown = match reference.extension() {
+                    ClassExtension::Monograph(r) => {
+                        matches!(r.r#type, MonographType::Unknown(_))
+                    }
+                    ClassExtension::Collection(r) => {
+                        matches!(r.r#type, CollectionType::Unknown(_))
+                    }
+                    ClassExtension::CollectionComponent(r) => {
+                        matches!(r.r#type, MonographComponentType::Unknown(_))
+                    }
+                    ClassExtension::SerialComponent(r) => {
+                        matches!(r.r#type, SerialComponentType::Unknown(_))
+                    }
+                    _ => false,
+                };
+
+                ext_unknown
+                    || reference
+                        .all_contributor_entries()
+                        .iter()
+                        .any(|c| matches!(c.role, ContributorRole::Unknown(_)))
+            });
+
+            if has_unknown {
                 Outcome::SoftDegrade
             } else {
                 Outcome::Pass

--- a/crates/citum-engine/tests/snapshots/forward_compat_gaps.snap
+++ b/crates/citum-engine/tests/snapshots/forward_compat_gaps.snap
@@ -7,15 +7,15 @@
 # A row is a GAP when declared != observed. GAP rows roll up to follow-up beans.
 #
 
-01-attr-enum-template        | Attribute enum in template                              | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
-02-attr-enum-data            | Attribute enum in reference data                        | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
+01-attr-enum-template        | Attribute enum in template                              | declared=SoftDegrade observed=SoftDegrade ok  | csl26-ld6e tolerant-enum-deserializer
+02-attr-enum-data            | Attribute enum in reference data                        | declared=SoftDegrade observed=SoftDegrade ok  | csl26-ld6e tolerant-enum-deserializer
 02b-discriminator-class      | Unknown InputReference class                            | declared=SoftDegrade observed=SoftDegrade ok  | csl26-odgh inputreference-discriminator-design
-03-locale-form               | Locale TermForm value                                   | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
-04-date-form                 | DateForm value in template                              | declared=SoftDegrade observed=HardFail    GAP | csl26-ld6e tolerant-enum-deserializer
+03-locale-form               | Locale TermForm value                                   | declared=SoftDegrade observed=SoftDegrade ok  | csl26-ld6e tolerant-enum-deserializer
+04-date-form                 | DateForm value in template                              | declared=SoftDegrade observed=SoftDegrade ok  | csl26-ld6e tolerant-enum-deserializer
 05-new-option-key            | New key inside style option struct                      | declared=SoftDegrade observed=HardFail    GAP | csl26-0ksu capture-unknown-fields-wrapper
 06-new-top-level-section     | New top-level Style section                             | declared=SoftDegrade observed=HardFail    GAP | csl26-0ksu capture-unknown-fields-wrapper
 07-new-reference-field       | New optional field on reference type                    | declared=SoftDegrade observed=HardFail    GAP | csl26-acfh reference-data-silent-acceptance
-08-new-locale-term-key       | New locale term key                                     | declared=SoftDegrade observed=HardFail    GAP | csl26-o1z5 tolerant-locale-lookup
+08-new-locale-term-key       | New locale term key                                     | declared=SoftDegrade observed=SoftDegrade ok  | csl26-o1z5 tolerant-locale-lookup
 09-custom-namespace          | Namespaced custom.* metadata (control)                  | declared=Pass        observed=Pass        ok  | —
 10-version-only-signal       | Style version bumped without other changes (control)    | declared=Pass        observed=Pass        ok  | —
 11-template-grammar          | New TemplateComponent variant (opt-out)                 | declared=HardFail    observed=HardFail    ok  | —

--- a/crates/citum-migrate/src/template_compiler/node_compiler.rs
+++ b/crates/citum-migrate/src/template_compiler/node_compiler.rs
@@ -179,8 +179,8 @@ impl TemplateCompiler {
     pub(super) fn compile_term(&self, term: &citum_schema::TermBlock) -> Option<TemplateComponent> {
         Some(TemplateComponent::Term(
             citum_schema::template::TemplateTerm {
-                term: term.term,
-                form: Some(term.form),
+                term: term.term.clone(),
+                form: Some(term.form.clone()),
                 rendering: self.convert_formatting(&term.formatting),
                 ..Default::default()
             },

--- a/crates/citum-schema-data/src/lib.rs
+++ b/crates/citum-schema-data/src/lib.rs
@@ -15,6 +15,9 @@ use std::collections::HashMap;
 
 /// Document-level abbreviation map type.
 pub mod abbreviation;
+/// Declarative macros.
+#[macro_use]
+pub mod macros;
 /// Citation input model.
 #[allow(missing_docs, reason = "internal derives")]
 pub mod citation;

--- a/crates/citum-schema-data/src/macros.rs
+++ b/crates/citum-schema-data/src/macros.rs
@@ -1,0 +1,86 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+*/
+
+/// Generates a string-backed enum that gracefully captures unknown variants.
+///
+/// The macro handles custom `serde::Deserialize` and `serde::Serialize` to ensure
+/// unknown string values are captured into an `Unknown(String)` variant instead
+/// of failing the parse. It also configures `schemars` and `specta` to skip the
+/// `Unknown` variant, maintaining a strictly closed public schema for producers.
+#[macro_export]
+macro_rules! tolerant_enum {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $(#[$vmeta:meta])*
+                $variant:ident = $val:expr
+            ),+ $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+        #[cfg_attr(feature = "bindings", derive(specta::Type))]
+        #[non_exhaustive]
+        $vis enum $name {
+            $(
+                $(#[$vmeta])*
+                #[cfg_attr(any(feature = "schema", feature = "bindings"), serde(rename = $val))]
+                $variant,
+            )+
+            #[doc = "Fallback for forward-compatibility."]
+            #[cfg_attr(feature = "schema", schemars(skip))]
+            #[cfg_attr(feature = "bindings", specta(skip))]
+            Unknown(String),
+        }
+
+        impl $name {
+            #[doc = "Returns the string value associated with this variant."]
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                match self {
+                    $( Self::$variant => $val, )+
+                    Self::Unknown(s) => s.as_str(),
+                }
+            }
+        }
+
+        impl serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct Visitor;
+                impl<'de> serde::de::Visitor<'de> for Visitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("a string")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Ok(match value {
+                            $( $val => $name::$variant, )+
+                            _ => $name::Unknown(value.to_owned()),
+                        })
+                    }
+                }
+                deserializer.deserialize_str(Visitor)
+            }
+        }
+    }
+}

--- a/crates/citum-schema-data/src/reference/contributor.rs
+++ b/crates/citum-schema-data/src/reference/contributor.rs
@@ -183,31 +183,26 @@ impl fmt::Display for ContributorList {
     }
 }
 
-/// A contributor role for use in the unified contributors list.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-#[non_exhaustive]
-pub enum ContributorRole {
-    Author,
-    Editor,
-    Translator,
-    Director,
-    Performer,
-    Composer,
-    Illustrator,
-    Narrator,
-    Host,
-    Guest,
-    Interviewer,
-    Recipient,
-    Compiler,
-    Producer,
-    Writer,
-    /// An open extension point for domain-specific roles.
-    #[serde(untagged)]
-    Custom(String),
+crate::tolerant_enum! {
+    /// A contributor role for use in the unified contributors list.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub enum ContributorRole {
+        Author = "author",
+        Editor = "editor",
+        Translator = "translator",
+        Director = "director",
+        Performer = "performer",
+        Composer = "composer",
+        Illustrator = "illustrator",
+        Narrator = "narrator",
+        Host = "host",
+        Guest = "guest",
+        Interviewer = "interviewer",
+        Recipient = "recipient",
+        Compiler = "compiler",
+        Producer = "producer",
+        Writer = "writer"
+    }
 }
 
 /// A single entry in a reference's contributors list.

--- a/crates/citum-schema-data/src/reference/conversion.rs
+++ b/crates/citum-schema-data/src/reference/conversion.rs
@@ -603,7 +603,7 @@ fn from_collection_component_ref(
     }
     if let Some(container_author) = container_author.clone() {
         contributors.push(ContributorEntry {
-            role: ContributorRole::Custom("container-author".to_string()),
+            role: ContributorRole::Unknown("container-author".to_string()),
             contributor: container_author,
             gender: None,
         });
@@ -1555,14 +1555,14 @@ fn from_event_ref(legacy: csl_legacy::csl_json::Reference, ctx: RefContext) -> I
     );
     push_legacy_contributor(
         &mut contributors,
-        ContributorRole::Custom("chair".to_string()),
+        ContributorRole::Unknown("chair".to_string()),
         chair_names,
     );
     push_legacy_contributor(&mut contributors, ContributorRole::Producer, producer_names);
     push_legacy_contributor(&mut contributors, ContributorRole::Host, host_names);
     if let Some(organizer_name) = legacy.publisher.clone() {
         contributors.push(ContributorEntry {
-            role: ContributorRole::Custom("organizer".to_string()),
+            role: ContributorRole::Unknown("organizer".to_string()),
             contributor: Contributor::SimpleName(SimpleName {
                 name: organizer_name.into(),
                 location: None,

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -1045,7 +1045,7 @@ impl InputReference {
                     .or_else(|| {
                         collect_contributors_by_role(
                             &r.contributors,
-                            &DataRole::Custom("organizer".to_string()),
+                            &DataRole::Unknown("organizer".to_string()),
                         )
                     })
                     .or_else(|| collect_contributors_by_role(&r.contributors, &DataRole::Author))
@@ -1184,7 +1184,8 @@ impl InputReference {
             .collect()
     }
 
-    fn all_contributor_entries(&self) -> &[ContributorEntry] {
+    /// Return all contributor entries regardless of role.
+    pub fn all_contributor_entries(&self) -> &[ContributorEntry] {
         match &self.extension {
             ClassExtension::Monograph(r) => &r.contributors,
             ClassExtension::Collection(r) => &r.contributors,
@@ -2464,6 +2465,7 @@ impl InputReference {
                         "document".to_string()
                     }
                 }
+                _ => r.r#type.as_str().to_string(),
             },
             ClassExtension::CollectionComponent(r) => match r.r#type {
                 MonographComponentType::Chapter => match r.genre.as_deref() {
@@ -2472,6 +2474,7 @@ impl InputReference {
                     _ => "chapter".to_string(),
                 },
                 MonographComponentType::Document => "paper-conference".to_string(),
+                _ => r.r#type.as_str().to_string(),
             },
             ClassExtension::SerialComponent(r) => {
                 if r.genre.as_deref() == Some("entry-encyclopedia") {

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -278,7 +278,7 @@ fn test_parse_csl_json_event_note_type_routes_to_event_with_chair_and_session() 
         event
             .contributors
             .iter()
-            .any(|entry| entry.role == ContributorRole::Custom("chair".to_string())),
+            .any(|entry| entry.role == ContributorRole::Unknown("chair".to_string())),
         "chair should be preserved as a custom contributor role"
     );
     assert_eq!(

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -348,40 +348,38 @@ impl From<MonographDeser> for Monograph {
     }
 }
 
-/// Discriminates monograph subtypes for style-directed formatting.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-#[non_exhaustive]
-pub enum MonographType {
-    /// A book or monograph (default).
-    #[default]
-    Book,
-    /// A technical manual or user guide.
-    Manual,
-    /// A technical or institutional report.
-    Report,
-    /// An academic thesis or dissertation.
-    Thesis,
-    /// A webpage or standalone web document.
-    Webpage,
-    /// A standalone post (e.g., social media, forum).
-    Post,
-    /// An interview treated as a standalone monographic source.
-    Interview,
-    /// An unpublished manuscript or archival document.
-    Manuscript,
-    /// A preprint hosted on a preprint server (arXiv, bioRxiv, SSRN, etc.).
-    ///
-    /// The preprint server has a custodial relationship with the work (hosting and
-    /// preservation), not an editorial one. This parallels an archived manuscript
-    /// held by a repository.
-    Preprint,
-    /// A letter, email, or other personal communication.
-    PersonalCommunication,
-    /// A generic standalone document that does not fit a more specific subtype.
-    Document,
+crate::tolerant_enum! {
+    /// Discriminates monograph subtypes for style-directed formatting.
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub enum MonographType {
+        /// A book or monograph (default).
+        #[default]
+        Book = "book",
+        /// A technical manual or user guide.
+        Manual = "manual",
+        /// A technical or institutional report.
+        Report = "report",
+        /// An academic thesis or dissertation.
+        Thesis = "thesis",
+        /// A webpage or standalone web document.
+        Webpage = "webpage",
+        /// A standalone post (e.g., social media, forum).
+        Post = "post",
+        /// An interview treated as a standalone monographic source.
+        Interview = "interview",
+        /// An unpublished manuscript or archival document.
+        Manuscript = "manuscript",
+        /// A preprint hosted on a preprint server (arXiv, bioRxiv, SSRN, etc.).
+        ///
+        /// The preprint server has a custodial relationship with the work (hosting and
+        /// preservation), not an editorial one. This parallels an archived manuscript
+        /// held by a repository.
+        Preprint = "preprint",
+        /// A letter, email, or other personal communication.
+        PersonalCommunication = "personal-communication",
+        /// A generic standalone document that does not fit a more specific subtype.
+        Document = "document"
+    }
 }
 
 /// A collection of works, such as an anthology or proceedings.
@@ -573,22 +571,20 @@ impl From<CollectionDeser> for Collection {
     }
 }
 
-/// Discriminates collection subtypes for style-directed formatting.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-#[non_exhaustive]
-pub enum CollectionType {
-    /// A curated anthology of independent works (e.g., short stories, essays).
-    #[default]
-    Anthology,
-    /// Published proceedings of a conference or symposium.
-    Proceedings,
-    /// A book assembled from contributions by multiple authors under an editor.
-    EditedBook,
-    /// An edited volume that may span multiple books or a series.
-    EditedVolume,
+crate::tolerant_enum! {
+    /// Discriminates collection subtypes for style-directed formatting.
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub enum CollectionType {
+        /// A curated anthology of independent works (e.g., short stories, essays).
+        #[default]
+        Anthology = "anthology",
+        /// Published proceedings of a conference or symposium.
+        Proceedings = "proceedings",
+        /// A book assembled from contributions by multiple authors under an editor.
+        EditedBook = "edited-book",
+        /// An edited volume that may span multiple books or a series.
+        EditedVolume = "edited-volume"
+    }
 }
 
 /// A component of a larger monograph, such as a chapter in a book.
@@ -805,18 +801,16 @@ impl From<CollectionComponentDeser> for CollectionComponent {
     }
 }
 
-/// Discriminates monograph-component subtypes for style-directed formatting.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-#[non_exhaustive]
-pub enum MonographComponentType {
-    /// A chapter within a book or edited volume.
-    #[default]
-    Chapter,
-    /// A document component that does not fit a more specific subtype.
-    Document,
+crate::tolerant_enum! {
+    /// Discriminates monograph-component subtypes for style-directed formatting.
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub enum MonographComponentType {
+        /// A chapter within a book or edited volume.
+        #[default]
+        Chapter = "chapter",
+        /// A document component that does not fit a more specific subtype.
+        Document = "document"
+    }
 }
 
 /// A component of a larger serial publication; for example a journal or newspaper article.
@@ -1056,19 +1050,18 @@ impl From<SerialComponentDeser> for SerialComponent {
     }
 }
 
-/// Discriminates serial-component subtypes for style-directed formatting.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[cfg_attr(feature = "bindings", derive(Type))]
-#[serde(rename_all = "kebab-case")]
-pub enum SerialComponentType {
-    /// A peer-reviewed or editorial article in a journal, magazine, or newspaper.
-    #[default]
-    Article,
-    /// A post within an online serial (blog, news site, social feed).
-    Post,
-    /// A review published in a serial (book review, film review, etc.).
-    Review,
+crate::tolerant_enum! {
+    /// Discriminates serial-component subtypes for style-directed formatting.
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub enum SerialComponentType {
+        /// A peer-reviewed or editorial article in a journal, magazine, or newspaper.
+        #[default]
+        Article = "article",
+        /// A post within an online serial (blog, news site, social feed).
+        Post = "post",
+        /// A review published in a serial (book review, film review, etc.).
+        Review = "review"
+    }
 }
 
 /// A serial publication (journal, magazine, etc.).

--- a/crates/citum-schema-style/src/lint.rs
+++ b/crates/citum-schema-style/src/lint.rs
@@ -133,7 +133,7 @@ pub fn lint_style_against_locale(style: &Style, locale: &Locale) -> LintReport {
     for requirement in requirements {
         match requirement.kind {
             LocaleRequirementKind::General { term, form } => {
-                if locale.resolved_general_term(&term, form, None).is_none() {
+                if locale.resolved_general_term(&term, &form, None).is_none() {
                     report.warning(
                         requirement.path,
                         format!(
@@ -143,8 +143,8 @@ pub fn lint_style_against_locale(style: &Style, locale: &Locale) -> LintReport {
                 }
             }
             LocaleRequirementKind::Role { role, form } => {
-                let singular = locale.resolved_role_term(&role, false, form, None);
-                let plural = locale.resolved_role_term(&role, true, form, None);
+                let singular = locale.resolved_role_term(&role, false, &form, None);
+                let plural = locale.resolved_role_term(&role, true, &form, None);
                 if singular.is_none() || plural.is_none() {
                     report.warning(
                         requirement.path,
@@ -155,8 +155,8 @@ pub fn lint_style_against_locale(style: &Style, locale: &Locale) -> LintReport {
                 }
             }
             LocaleRequirementKind::Locator { locator, form } => {
-                let singular = lint_locator_term(locale, &locator, false, form);
-                let plural = lint_locator_term(locale, &locator, true, form);
+                let singular = lint_locator_term(locale, &locator, false, form.clone());
+                let plural = lint_locator_term(locale, &locator, true, form.clone());
                 if singular.is_none() || plural.is_none() {
                     report.warning(
                         requirement.path,
@@ -203,7 +203,7 @@ fn lint_locator_term(
                     forms.singular.as_str().to_string()
                 }
             }),
-        _ => locale.resolved_locator_term(locator, plural, form, None),
+        _ => locale.resolved_locator_term(locator, plural, &form, None),
     }
 }
 
@@ -363,8 +363,8 @@ fn collect_bibliography_spec_requirements(
                 requirements.push(LocaleRequirement {
                     path: format!("{path}.groups[{index}].heading"),
                     kind: LocaleRequirementKind::General {
-                        term: *term,
-                        form: form.unwrap_or(TermForm::Long),
+                        term: term.clone(),
+                        form: form.clone().unwrap_or(TermForm::Long),
                     },
                 });
             }
@@ -392,8 +392,8 @@ fn collect_template_requirements(
             TemplateComponent::Term(term) => requirements.push(LocaleRequirement {
                 path: component_path,
                 kind: LocaleRequirementKind::General {
-                    term: term.term,
-                    form: term.form.unwrap_or(TermForm::Long),
+                    term: term.term.clone(),
+                    form: term.form.clone().unwrap_or(TermForm::Long),
                 },
             }),
             TemplateComponent::Contributor(contributor) => {

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -626,13 +626,13 @@ impl Locale {
         value.resolve_neutral().map(String::as_str)
     }
 
-    fn resolve_no_date_value(
-        value: &SimpleTerm,
-        form: TermForm,
+    fn resolve_no_date_value<'a>(
+        value: &'a SimpleTerm,
+        form: &TermForm,
         requested_gender: Option<GrammaticalGender>,
-    ) -> Option<&str> {
+    ) -> Option<&'a str> {
         match requested_gender {
-            Some(GrammaticalGender::Common) => match form {
+            Some(GrammaticalGender::Common) => match *form {
                 TermForm::Long => value
                     .long
                     .resolve_strict(Some(GrammaticalGender::Common))
@@ -653,11 +653,13 @@ impl Locale {
                     .resolve_strict(Some(GrammaticalGender::Common))
                     .map(String::as_str),
             },
-            _ => match form {
+            _ => match *form {
                 TermForm::Long => Self::resolve_gendered_value(&value.long, requested_gender),
-                TermForm::Short => Self::resolve_gendered_value(&value.short, requested_gender)
-                    .filter(|value| !value.is_empty())
-                    .or_else(|| Self::resolve_gendered_value(&value.long, requested_gender)),
+                TermForm::Short => {
+                    Self::resolve_gendered_value(&value.short, requested_gender.clone())
+                        .filter(|value| !value.is_empty())
+                        .or_else(|| Self::resolve_gendered_value(&value.long, requested_gender))
+                }
                 _ => Self::resolve_gendered_value(&value.long, requested_gender),
             },
         }
@@ -668,16 +670,18 @@ impl Locale {
         &self,
         role: &ContributorRole,
         plural: bool,
-        form: TermForm,
+        form: &TermForm,
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<&str> {
         let term = self.roles.get(role)?;
         let simple = if plural { &term.plural } else { &term.singular };
-        let term_text = match form {
+        let term_text = match *form {
             TermForm::Long => Self::resolve_gendered_value(&simple.long, requested_gender),
-            TermForm::Short => Self::resolve_gendered_value(&simple.short, requested_gender)
-                .filter(|value| !value.is_empty())
-                .or_else(|| Self::resolve_gendered_value(&simple.long, requested_gender)),
+            TermForm::Short => {
+                Self::resolve_gendered_value(&simple.short, requested_gender.clone())
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| Self::resolve_gendered_value(&simple.long, requested_gender))
+            }
             TermForm::Verb => Self::resolve_gendered_value(&term.verb.long, None),
             TermForm::VerbShort => Self::resolve_gendered_value(&term.verb.short, None)
                 .filter(|value| !value.is_empty())
@@ -696,11 +700,11 @@ impl Locale {
         &self,
         role: &ContributorRole,
         plural: bool,
-        form: TermForm,
+        form: &TermForm,
     ) -> Option<&str> {
         let term = self.roles.get(role)?;
         let simple = if plural { &term.plural } else { &term.singular };
-        let term_text = match form {
+        let term_text = match *form {
             TermForm::Long => Self::resolve_gendered_value_neutral(&simple.long),
             TermForm::Short => Self::resolve_gendered_value_neutral(&simple.short)
                 .filter(|value| !value.is_empty())
@@ -723,12 +727,15 @@ impl Locale {
         &self,
         role: &ContributorRole,
         plural: bool,
-        form: TermForm,
+        form: &TermForm,
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<String> {
         if let Some(message_id) = Self::role_message_id(role, form)
-            && let Some(resolved) =
-                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), requested_gender)
+            && let Some(resolved) = self.resolve_message_text(
+                message_id,
+                Some(u64::from(plural) + 1),
+                requested_gender.clone(),
+            )
         {
             return Some(resolved);
         }
@@ -742,7 +749,7 @@ impl Locale {
         &self,
         role: &ContributorRole,
         plural: bool,
-        form: TermForm,
+        form: &TermForm,
     ) -> Option<String> {
         if let Some(message_id) = Self::role_message_id(role, form)
             && let Some(resolved) = self.resolve_message_text(
@@ -763,11 +770,11 @@ impl Locale {
         &self,
         locator: &LocatorType,
         plural: bool,
-        form: TermForm,
+        form: &TermForm,
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<&str> {
         let term = self.locators.get(locator)?;
-        let form_term = match form {
+        let form_term = match *form {
             TermForm::Long => &term.long,
             TermForm::Short => &term.short,
             TermForm::Symbol => &term.symbol,
@@ -787,17 +794,20 @@ impl Locale {
         &self,
         locator: &LocatorType,
         plural: bool,
-        form: TermForm,
+        form: &TermForm,
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<String> {
         if let Some(message_id) = Self::locator_message_id(locator, form)
-            && let Some(resolved) =
-                self.resolve_message_text(message_id, Some(u64::from(plural) + 1), requested_gender)
+            && let Some(resolved) = self.resolve_message_text(
+                message_id,
+                Some(u64::from(plural) + 1),
+                requested_gender.clone(),
+            )
         {
             return Some(resolved);
         }
 
-        self.locator_term(locator, plural, form, requested_gender)
+        self.locator_term(locator, plural, form, requested_gender.clone())
             .map(ToOwned::to_owned)
             .or_else(|| {
                 if let LocatorType::Custom(key) = locator {
@@ -831,11 +841,11 @@ impl Locale {
             .filter(|value| !value.is_empty())
     }
 
-    /// Get a general term by type and form.
+    /// Resolve a general term to a borrowed string.
     pub fn general_term(
         &self,
         term: &GeneralTerm,
-        form: TermForm,
+        form: &TermForm,
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<&str> {
         // Legacy borrowed lookup path: prefer plain v2 messages first, then
@@ -860,11 +870,14 @@ impl Locale {
         if *term != GeneralTerm::NoDate
             && let Some(simple) = self.terms.general.get(term)
         {
-            return match form {
+            return match *form {
                 TermForm::Long => Self::resolve_gendered_value(&simple.long, requested_gender),
-                TermForm::Short => Self::resolve_gendered_value(&simple.short, requested_gender)
-                    .filter(|value| !value.is_empty())
-                    .or_else(|| Self::resolve_gendered_value(&simple.long, requested_gender)),
+                TermForm::Short => {
+                    Self::resolve_gendered_value(&simple.short, requested_gender.clone())
+                        .filter(|value| !value.is_empty())
+                        .or_else(|| Self::resolve_gendered_value(&simple.long, requested_gender))
+                }
+
                 _ => Self::resolve_gendered_value(&simple.long, requested_gender),
             };
         }
@@ -937,11 +950,12 @@ impl Locale {
     pub fn resolved_general_term(
         &self,
         term: &GeneralTerm,
-        form: TermForm,
+        form: &TermForm,
         requested_gender: Option<GrammaticalGender>,
     ) -> Option<String> {
         if let Some(message_id) = Self::general_message_id(term, form)
-            && let Some(resolved) = self.resolve_message_text(message_id, None, requested_gender)
+            && let Some(resolved) =
+                self.resolve_message_text(message_id, None, requested_gender.clone())
         {
             return Some(resolved);
         }
@@ -991,7 +1005,7 @@ impl Locale {
     }
 
     /// Map a GeneralTerm to its canonical message ID suffix (e.g., GeneralTerm::EtAl → "et-al").
-    fn general_term_to_message_id(term: &GeneralTerm) -> &'static str {
+    fn general_term_to_message_id(term: &GeneralTerm) -> &str {
         match term {
             GeneralTerm::And => "and",
             GeneralTerm::EtAl => "et-al",
@@ -1023,11 +1037,12 @@ impl Locale {
             GeneralTerm::Section => "section",
             GeneralTerm::OriginalWorkPublished => "original-work-published",
             GeneralTerm::PersonalCommunication => "personal-communication",
+            GeneralTerm::Unknown(s) => s.as_str(),
         }
     }
 
     /// Map a GeneralTerm to its legacy CSL key string for alias lookup.
-    fn general_term_to_legacy_key(term: &GeneralTerm) -> &'static str {
+    fn general_term_to_legacy_key(term: &GeneralTerm) -> &str {
         match term {
             GeneralTerm::EtAl => "et_al",
             GeneralTerm::NoDate => "no_date",
@@ -1035,7 +1050,7 @@ impl Locale {
         }
     }
 
-    fn role_message_id(role: &ContributorRole, form: TermForm) -> Option<&'static str> {
+    fn role_message_id(role: &ContributorRole, form: &TermForm) -> Option<&'static str> {
         let prefix = match role {
             ContributorRole::Editor => "role.editor",
             ContributorRole::Translator => "role.translator",
@@ -1043,7 +1058,7 @@ impl Locale {
             _ => return None,
         };
 
-        match form {
+        match *form {
             TermForm::Long => Some(match prefix {
                 "role.editor" => "role.editor.label-long",
                 "role.translator" => "role.translator.label-long",
@@ -1062,11 +1077,11 @@ impl Locale {
                 "role.guest" => "role.guest.verb",
                 _ => return None,
             }),
-            TermForm::Symbol => None,
+            _ => None,
         }
     }
 
-    fn locator_message_id(locator: &LocatorType, form: TermForm) -> Option<&'static str> {
+    fn locator_message_id(locator: &LocatorType, form: &TermForm) -> Option<&'static str> {
         let prefix = match locator {
             LocatorType::Page => "term.page-label",
             LocatorType::Chapter => "term.chapter-label",
@@ -1077,7 +1092,7 @@ impl Locale {
             _ => return None,
         };
 
-        match form {
+        match *form {
             TermForm::Long => Some(match prefix {
                 "term.page-label" => "term.page-label-long",
                 "term.chapter-label" => "term.chapter-label-long",
@@ -1088,11 +1103,11 @@ impl Locale {
                 _ => return None,
             }),
             TermForm::Short => Some(prefix),
-            TermForm::Symbol | TermForm::Verb | TermForm::VerbShort => None,
+            _ => None,
         }
     }
 
-    fn general_message_id(term: &GeneralTerm, form: TermForm) -> Option<&'static str> {
+    fn general_message_id(term: &GeneralTerm, form: &TermForm) -> Option<&'static str> {
         match (term, form) {
             (GeneralTerm::And, _) => Some("term.and"),
             (GeneralTerm::EtAl, _) => Some("term.et-al"),
@@ -1108,12 +1123,13 @@ impl Locale {
         }
     }
 
-    fn gender_selector_key(gender: GrammaticalGender) -> &'static str {
+    fn gender_selector_key(gender: &GrammaticalGender) -> &str {
         match gender {
             GrammaticalGender::Masculine => "masculine",
             GrammaticalGender::Feminine => "feminine",
             GrammaticalGender::Neuter => "neuter",
             GrammaticalGender::Common => "common",
+            GrammaticalGender::Unknown(s) => s.as_str(),
         }
     }
 
@@ -1128,7 +1144,7 @@ impl Locale {
         // Build MessageArgs for the evaluator
         let args = MessageArgs {
             count,
-            gender: gender.map(Self::gender_selector_key),
+            gender: gender.as_ref().map(Self::gender_selector_key),
             ..MessageArgs::default()
         };
 
@@ -1348,7 +1364,7 @@ impl Locale {
                     long: Self::extract_singular_plural(value.long.as_ref().as_ref()),
                     short: Self::extract_singular_plural(value.short.as_ref().as_ref()),
                     symbol: Self::extract_singular_plural(value.symbol.as_ref().as_ref()),
-                    gender: value.gender,
+                    gender: value.gender.clone(),
                 };
                 locale.locators.insert(locator_type, locator_term);
             }
@@ -1811,15 +1827,15 @@ mod tests {
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.role_term(&ContributorRole::Editor, false, TermForm::Short, None),
+            locale.role_term(&ContributorRole::Editor, false, &TermForm::Short, None),
             Some("ed.")
         );
         assert_eq!(
-            locale.role_term(&ContributorRole::Editor, true, TermForm::Short, None),
+            locale.role_term(&ContributorRole::Editor, true, &TermForm::Short, None),
             Some("eds.")
         );
         assert_eq!(
-            locale.role_term(&ContributorRole::Translator, false, TermForm::Verb, None),
+            locale.role_term(&ContributorRole::Translator, false, &TermForm::Verb, None),
             Some("translated by")
         );
     }
@@ -1829,11 +1845,11 @@ mod tests {
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Long, None),
+            locale.general_term(&GeneralTerm::NoDate, &TermForm::Long, None),
             Some("no date")
         );
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Short, None),
+            locale.general_term(&GeneralTerm::NoDate, &TermForm::Short, None),
             Some("n.d.")
         );
     }
@@ -1844,11 +1860,11 @@ mod tests {
         locale.terms.no_date = Some("n.d.".to_string());
 
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Short, None),
+            locale.general_term(&GeneralTerm::NoDate, &TermForm::Short, None),
             Some("n.d.")
         );
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Long, None),
+            locale.general_term(&GeneralTerm::NoDate, &TermForm::Long, None),
             Some("n.d.")
         );
     }
@@ -1950,11 +1966,11 @@ terms:
 
         let locale = Locale::from_yaml_str(yaml).unwrap();
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Long, None),
+            locale.general_term(&GeneralTerm::NoDate, &TermForm::Long, None),
             Some("no date")
         );
         assert_eq!(
-            locale.general_term(&GeneralTerm::NoDate, TermForm::Short, None),
+            locale.general_term(&GeneralTerm::NoDate, &TermForm::Short, None),
             Some("n.d.")
         );
         assert_eq!(locale.terms.no_date.as_deref(), Some("n.d."));
@@ -2028,11 +2044,11 @@ locale: en-US
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short, None),
+            locale.resolved_locator_term(&LocatorType::Page, false, &TermForm::Short, None),
             Some("p.".to_string())
         );
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, true, TermForm::Short, None),
+            locale.resolved_locator_term(&LocatorType::Page, true, &TermForm::Short, None),
             Some("pp.".to_string())
         );
     }
@@ -2055,7 +2071,7 @@ locators:
             locale.resolved_locator_term(
                 &LocatorType::Custom("reel".to_string()),
                 false,
-                TermForm::Short,
+                &TermForm::Short,
                 None,
             ),
             Some("reel".to_string())
@@ -2064,7 +2080,7 @@ locators:
             locale.resolved_locator_term(
                 &LocatorType::Custom("movement".to_string()),
                 false,
-                TermForm::Short,
+                &TermForm::Short,
                 None,
             ),
             Some("movement".to_string())
@@ -2086,7 +2102,7 @@ terms:
         .expect("legacy locator terms should parse");
 
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short, None),
+            locale.resolved_locator_term(&LocatorType::Page, false, &TermForm::Short, None),
             Some("pg.".to_string())
         );
     }
@@ -2111,7 +2127,7 @@ locators:
         .expect("mixed locator forms should parse");
 
         assert_eq!(
-            locale.resolved_locator_term(&LocatorType::Page, false, TermForm::Short, None),
+            locale.resolved_locator_term(&LocatorType::Page, false, &TermForm::Short, None),
             Some("p.".to_string())
         );
     }
@@ -2141,11 +2157,11 @@ terms:
         let locale = Locale::en_us();
 
         assert_eq!(
-            locale.resolved_role_term(&ContributorRole::Editor, false, TermForm::Long, None),
+            locale.resolved_role_term(&ContributorRole::Editor, false, &TermForm::Long, None),
             Some("editor".to_string())
         );
         assert_eq!(
-            locale.resolved_role_term(&ContributorRole::Editor, true, TermForm::Long, None),
+            locale.resolved_role_term(&ContributorRole::Editor, true, &TermForm::Long, None),
             Some("editors".to_string())
         );
     }
@@ -2178,7 +2194,7 @@ roles:
             locale.role_term(
                 &ContributorRole::Editor,
                 false,
-                TermForm::Long,
+                &TermForm::Long,
                 Some(GrammaticalGender::Feminine),
             ),
             Some("editora")
@@ -2187,7 +2203,7 @@ roles:
             locale.role_term(
                 &ContributorRole::Editor,
                 true,
-                TermForm::Long,
+                &TermForm::Long,
                 Some(GrammaticalGender::Common),
             ),
             Some("equipo editorial")
@@ -2211,7 +2227,7 @@ terms:
         assert_eq!(
             locale.general_term(
                 &GeneralTerm::NoDate,
-                TermForm::Long,
+                &TermForm::Long,
                 Some(GrammaticalGender::Common),
             ),
             Some("s. f.")
@@ -2229,7 +2245,7 @@ terms:
             locale.resolved_role_term(
                 &ContributorRole::Editor,
                 false,
-                TermForm::Long,
+                &TermForm::Long,
                 Some(GrammaticalGender::Feminine),
             ),
             Some("editora".to_string())
@@ -2246,7 +2262,7 @@ terms:
             locale.resolved_role_term(
                 &ContributorRole::Editor,
                 true,
-                TermForm::Long,
+                &TermForm::Long,
                 Some(GrammaticalGender::Masculine),
             ),
             Some("editores".to_string())
@@ -2255,13 +2271,13 @@ terms:
             locale.resolved_role_term(
                 &ContributorRole::Translator,
                 true,
-                TermForm::Long,
+                &TermForm::Long,
                 Some(GrammaticalGender::Feminine),
             ),
             Some("traductoras".to_string())
         );
         assert_eq!(
-            locale.resolved_role_term_neutral(&ContributorRole::Editor, true, TermForm::Long),
+            locale.resolved_role_term_neutral(&ContributorRole::Editor, true, &TermForm::Long),
             Some("equipo editorial".to_string())
         );
     }
@@ -2292,7 +2308,7 @@ roles:
             locale.resolved_role_term(
                 &ContributorRole::Editor,
                 false,
-                TermForm::Long,
+                &TermForm::Long,
                 Some(GrammaticalGender::Feminine),
             ),
             Some("editora heredada".to_string())

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -20,38 +20,38 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// Form for term lookup.
-///
-/// Specifies which form variant of a term should be used in citation output.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum TermForm {
-    /// Long form of a term (e.g., "page" vs "p.").
-    Long,
-    /// Short form of a term (e.g., "p." vs "page").
-    Short,
-    /// Verb form of a term (e.g., "edited by").
-    Verb,
-    /// Short verb form of a term (e.g., "ed." vs "edited by").
-    VerbShort,
-    /// Symbol form of a term (e.g., "§" for section).
-    Symbol,
+crate::str_enum! {
+    /// Form for term lookup.
+    ///
+    /// Specifies which form variant of a term should be used in citation output.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub enum TermForm {
+        /// Long form of a term (e.g., "page" vs "p.").
+        Long = "long",
+        /// Short form of a term (e.g., "p." vs "page").
+        Short = "short",
+        /// Verb form of a term (e.g., "edited by").
+        Verb = "verb",
+        /// Short verb form of a term (e.g., "ed." vs "edited by").
+        VerbShort = "verb-short",
+        /// Symbol form of a term (e.g., "§" for section).
+        Symbol = "symbol"
+    }
 }
 
-/// Grammatical gender used for locale agreement and term selection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum GrammaticalGender {
-    /// Masculine grammatical gender.
-    Masculine,
-    /// Feminine grammatical gender.
-    Feminine,
-    /// Neuter grammatical gender.
-    Neuter,
-    /// Common or shared grammatical gender.
-    Common,
+crate::str_enum! {
+    /// Grammatical gender used for locale agreement and term selection.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub enum GrammaticalGender {
+        /// Masculine grammatical gender.
+        Masculine = "masculine",
+        /// Feminine grammatical gender.
+        Feminine = "feminine",
+        /// Neuter grammatical gender.
+        Neuter = "neuter",
+        /// Common or shared grammatical gender.
+        Common = "common"
+    }
 }
 
 /// A value that may vary by grammatical gender.
@@ -110,6 +110,7 @@ impl<T> MaybeGendered<T> {
                 GrammaticalGender::Feminine => feminine.as_ref(),
                 GrammaticalGender::Neuter => neuter.as_ref(),
                 GrammaticalGender::Common => common.as_ref(),
+                _ => None,
             },
         }
     }
@@ -173,77 +174,77 @@ impl MaybeGendered<String> {
     }
 }
 
-/// A list of general terms for citation formatting.
-///
-/// These are the standard terms that appear in bibliographies and citations,
-/// including prepositions (in, at, from, by), punctuation terms (and, et al),
-/// date-related terms (accessed, no-date, circa), locator terms (page, chapter, volume),
-/// and special phrases (ibid, forthcoming, available-at).
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum GeneralTerm {
-    #[default]
-    /// The preposition "in" (e.g., "in Smith, 2020").
-    In,
-    /// The term used for access dates (e.g., "accessed May 1").
-    Accessed,
-    /// The term used for retrieval statements (e.g., "retrieved from URL").
-    Retrieved,
-    /// The preposition "at" (e.g., "at the conference").
-    At,
-    /// The preposition "from" (e.g., "from the publisher").
-    From,
-    /// The preposition "of" (e.g., "special issue of").
-    Of,
-    /// The preposition "to" (e.g., "from x to y").
-    To,
-    /// The preposition "by" (e.g., "by John Smith").
-    By,
-    /// The term used when no date is available (e.g., "n.d.").
-    NoDate,
-    /// The term used for anonymous authorship (e.g., "anonymous").
-    Anonymous,
-    /// The term used for approximate dates (e.g., "circa").
-    Circa,
-    /// The phrase used for availability statements (e.g., "available at URL").
-    AvailableAt,
-    /// The term used for immediately repeated citations (e.g., "ibid.").
-    Ibid,
-    /// The conjunction "and" (e.g., "Smith and Jones").
-    And,
-    /// The abbreviation for omitted additional names (e.g., "et al.").
-    EtAl,
-    /// The phrase "and others" (generic use).
-    AndOthers,
-    /// The term used for forthcoming works (e.g., "forthcoming").
-    Forthcoming,
-    /// The term used for online resources (e.g., "online").
-    Online,
-    /// The adverb "here".
-    Here,
-    /// The term used for deposited materials.
-    Deposited,
-    /// The phrase used to introduce reviewed works (e.g., "review of").
-    ReviewOf,
-    /// The phrase used for original publication references (e.g., "originally published").
-    OriginalWorkPublished,
-    /// The term used for patents (e.g., "patent").
-    Patent,
-    /// The general term for volume locators (e.g., "volume", "vol.").
-    Volume,
-    /// The general term for issue locators (e.g., "issue", "no.").
-    Issue,
-    /// The general term for page locators (e.g., "page", "p.", "pp.").
-    Page,
-    /// The general term for chapter locators (e.g., "chapter", "ch.").
-    Chapter,
-    /// The general term for editions (e.g., "edition", "ed.").
-    Edition,
-    /// The general term for section locators (e.g., "section", "§").
-    Section,
-    /// The label for personal communications (e.g., "personal communication").
-    PersonalCommunication,
+crate::str_enum! {
+    /// A list of general terms for citation formatting.
+    ///
+    /// These are the standard terms that appear in bibliographies and citations,
+    /// including prepositions (in, at, from, by), punctuation terms (and, et al),
+    /// date-related terms (accessed, no-date, circa), locator terms (page, chapter, volume),
+    /// and special phrases (ibid, forthcoming, available-at).
+    #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+    pub enum GeneralTerm {
+        #[default]
+        /// The preposition "in" (e.g., "in Smith, 2020").
+        In = "in",
+        /// The term used for access dates (e.g., "accessed May 1").
+        Accessed = "accessed",
+        /// The term used for retrieval statements (e.g., "retrieved from URL").
+        Retrieved = "retrieved",
+        /// The preposition "at" (e.g., "at the conference").
+        At = "at",
+        /// The preposition "from" (e.g., "from the publisher").
+        From = "from",
+        /// The preposition "of" (e.g., "special issue of").
+        Of = "of",
+        /// The preposition "to" (e.g., "from x to y").
+        To = "to",
+        /// The preposition "by" (e.g., "by John Smith").
+        By = "by",
+        /// The term used when no date is available (e.g., "n.d.").
+        NoDate = "no-date",
+        /// The term used for anonymous authorship (e.g., "anonymous").
+        Anonymous = "anonymous",
+        /// The term used for approximate dates (e.g., "circa").
+        Circa = "circa",
+        /// The phrase used for availability statements (e.g., "available at URL").
+        AvailableAt = "available-at",
+        /// The term used for immediately repeated citations (e.g., "ibid.").
+        Ibid = "ibid",
+        /// The conjunction "and" (e.g., "Smith and Jones").
+        And = "and",
+        /// The abbreviation for omitted additional names (e.g., "et al.").
+        EtAl = "et-al",
+        /// The phrase "and others" (generic use).
+        AndOthers = "and-others",
+        /// The term used for forthcoming works (e.g., "forthcoming").
+        Forthcoming = "forthcoming",
+        /// The term used for online resources (e.g., "online").
+        Online = "online",
+        /// The adverb "here".
+        Here = "here",
+        /// The term used for deposited materials.
+        Deposited = "deposited",
+        /// The phrase used to introduce reviewed works (e.g., "review of").
+        ReviewOf = "review-of",
+        /// The phrase used for original publication references (e.g., "originally published").
+        OriginalWorkPublished = "original-work-published",
+        /// The term used for patents (e.g., "patent").
+        Patent = "patent",
+        /// The general term for volume locators (e.g., "volume", "vol.").
+        Volume = "volume",
+        /// The general term for issue locators (e.g., "issue", "no.").
+        Issue = "issue",
+        /// The general term for page locators (e.g., "page", "p.", "pp.").
+        Page = "page",
+        /// The general term for chapter locators (e.g., "chapter", "ch.").
+        Chapter = "chapter",
+        /// The general term for editions (e.g., "edition", "ed.").
+        Edition = "edition",
+        /// The general term for section locators (e.g., "section", "§").
+        Section = "section",
+        /// The label for personal communications (e.g., "personal communication").
+        PersonalCommunication = "personal-communication"
+    }
 }
 
 /// General terms used in citations and bibliographies.

--- a/crates/citum-schema-style/src/macros.rs
+++ b/crates/citum-schema-style/src/macros.rs
@@ -5,8 +5,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 //! Declarative macros for the Citum ecosystem.
 
-/// Generates a string-backed enum and its `as_str` method.
-/// Preserves any doc comments and derive macros on the enum and its variants.
+/// Generates a string-backed enum that gracefully captures unknown variants.
 #[macro_export]
 macro_rules! str_enum {
     (
@@ -19,21 +18,65 @@ macro_rules! str_enum {
         }
     ) => {
         $(#[$meta])*
+        #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+        #[cfg_attr(feature = "bindings", derive(specta::Type))]
         #[non_exhaustive]
         $vis enum $name {
             $(
                 $(#[$vmeta])*
-                #[doc = "String-backed enum variant."]
+                #[cfg_attr(any(feature = "schema", feature = "bindings"), serde(rename = $val))]
                 $variant,
             )+
+            #[doc = "Fallback for forward-compatibility."]
+            #[cfg_attr(feature = "schema", schemars(skip))]
+            #[cfg_attr(feature = "bindings", specta(skip))]
+            Unknown(String),
         }
 
         impl $name {
             #[doc = "Returns the string value associated with this variant."]
-            pub fn as_str(&self) -> &'static str {
+            #[must_use]
+            pub fn as_str(&self) -> &str {
                 match self {
                     $( Self::$variant => $val, )+
+                    Self::Unknown(s) => s.as_str(),
                 }
+            }
+        }
+
+        impl serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct Visitor;
+                impl<'de> serde::de::Visitor<'de> for Visitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str("a string")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        Ok(match value {
+                            $( $val => $name::$variant, )+
+                            _ => $name::Unknown(value.to_owned()),
+                        })
+                    }
+                }
+                deserializer.deserialize_str(Visitor)
             }
         }
     }

--- a/crates/citum-schema-style/src/renderer.rs
+++ b/crates/citum-schema-style/src/renderer.rs
@@ -74,7 +74,7 @@ impl Renderer {
 
     /// Render a term block by looking up the term and applying formatting.
     fn render_term(&self, block: &TermBlock) -> String {
-        let text = render_legacy_term(block.term, block.form);
+        let text = render_legacy_term(&block.term, &block.form);
         self.apply_formatting(&text, &block.formatting)
     }
 
@@ -249,7 +249,7 @@ impl Renderer {
 }
 
 /// Render a legacy general term using an explicit term/form mapping.
-fn render_legacy_term(term: crate::locale::GeneralTerm, form: crate::locale::TermForm) -> String {
+fn render_legacy_term(term: &crate::locale::GeneralTerm, form: &crate::locale::TermForm) -> String {
     use crate::locale::GeneralTerm as T;
     use crate::locale::TermForm as F;
 
@@ -304,38 +304,8 @@ fn render_legacy_term(term: crate::locale::GeneralTerm, form: crate::locale::Ter
         (T::ReviewOf, _) => "review of".to_string(),
         (T::OriginalWorkPublished, _) => "originally published".to_string(),
         (T::Patent, _) => "patent".to_string(),
-        (term, _) => match term {
-            T::NoDate => "no date".to_string(),
-            T::Page => "page".to_string(),
-            T::Chapter => "chapter".to_string(),
-            T::Section => "section".to_string(),
-            T::Volume => "volume".to_string(),
-            T::Issue => "issue".to_string(),
-            T::Edition => "edition".to_string(),
-            T::In => "in".to_string(),
-            T::Accessed => "accessed".to_string(),
-            T::Retrieved => "retrieved".to_string(),
-            T::At => "at".to_string(),
-            T::From => "from".to_string(),
-            T::Of => "of".to_string(),
-            T::To => "to".to_string(),
-            T::By => "by".to_string(),
-            T::Anonymous => "anonymous".to_string(),
-            T::Circa => "circa".to_string(),
-            T::AvailableAt => "available at".to_string(),
-            T::Ibid => "ibid.".to_string(),
-            T::And => "and".to_string(),
-            T::EtAl => "et al.".to_string(),
-            T::AndOthers => "and others".to_string(),
-            T::Forthcoming => "forthcoming".to_string(),
-            T::Online => "online".to_string(),
-            T::Here => "here".to_string(),
-            T::Deposited => "deposited".to_string(),
-            T::ReviewOf => "review of".to_string(),
-            T::OriginalWorkPublished => "originally published".to_string(),
-            T::Patent => "patent".to_string(),
-            T::PersonalCommunication => "personal communication".to_string(),
-        },
+        (T::Unknown(s), _) => s.clone(),
+        (term, _) => term.as_str().to_string(),
     }
 }
 

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -720,9 +720,7 @@ pub enum ContributorForm {
 
 crate::str_enum! {
     /// Contributor roles.
-    #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
-    #[cfg_attr(feature = "schema", derive(JsonSchema))]
-    #[serde(rename_all = "kebab-case")]
+    #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
     pub enum ContributorRole {
         #[default] Author = "author",
         Chair = "chair",
@@ -781,20 +779,20 @@ pub enum DateVariable {
     EventDate,
 }
 
-/// Date rendering forms.
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum DateForm {
-    #[default]
-    Year,
-    YearMonth,
-    Full,
-    MonthDay,
-    YearMonthDay,
-    DayMonthAbbrYear,
-    /// Abbreviated month + day + year in US order: "Jan 15, 2024".
-    MonthAbbrDayYear,
+crate::str_enum! {
+    /// Date rendering forms.
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub enum DateForm {
+        #[default]
+        Year = "year",
+        YearMonth = "year-month",
+        Full = "full",
+        MonthDay = "month-day",
+        YearMonthDay = "year-month-day",
+        DayMonthAbbrYear = "day-month-abbr-year",
+        /// Abbreviated month + day + year in US order: "Jan 15, 2024".
+        MonthAbbrDayYear = "month-abbr-day-year"
+    }
 }
 
 /// A title component.

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -3733,7 +3733,7 @@
     },
     "ContributorRole": {
       "description": "A contributor role for use in the unified contributors list.",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "string",
           "enum": [
@@ -3753,10 +3753,6 @@
             "producer",
             "writer"
           ]
-        },
-        {
-          "description": "An open extension point for domain-specific roles.",
-          "type": "string"
         }
       ]
     },

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -991,104 +991,29 @@
       "description": "Contributor roles.",
       "oneOf": [
         {
-          "description": "String-backed enum variant.",
           "type": "string",
-          "const": "author"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "chair"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "editor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "translator"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "director"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "publisher"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "recipient"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "interviewer"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "interviewee"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "guest"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "inventor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "counsel"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "composer"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "collection-editor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "container-author"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "editorial-director"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "textual-editor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "illustrator"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "original-author"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "reviewed-author"
+          "enum": [
+            "author",
+            "chair",
+            "editor",
+            "translator",
+            "director",
+            "publisher",
+            "recipient",
+            "interviewer",
+            "interviewee",
+            "guest",
+            "inventor",
+            "counsel",
+            "composer",
+            "collection-editor",
+            "container-author",
+            "editorial-director",
+            "textual-editor",
+            "illustrator",
+            "original-author",
+            "reviewed-author"
+          ]
         }
       ]
     },

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -623,104 +623,29 @@
       "description": "Contributor roles.",
       "oneOf": [
         {
-          "description": "String-backed enum variant.",
           "type": "string",
-          "const": "author"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "chair"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "editor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "translator"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "director"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "publisher"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "recipient"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "interviewer"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "interviewee"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "guest"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "inventor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "counsel"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "composer"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "collection-editor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "container-author"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "editorial-director"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "textual-editor"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "illustrator"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "original-author"
-        },
-        {
-          "description": "String-backed enum variant.",
-          "type": "string",
-          "const": "reviewed-author"
+          "enum": [
+            "author",
+            "chair",
+            "editor",
+            "translator",
+            "director",
+            "publisher",
+            "recipient",
+            "interviewer",
+            "interviewee",
+            "guest",
+            "inventor",
+            "counsel",
+            "composer",
+            "collection-editor",
+            "container-author",
+            "editorial-director",
+            "textual-editor",
+            "illustrator",
+            "original-author",
+            "reviewed-author"
+          ]
         }
       ]
     },


### PR DESCRIPTION
This PR completes the forward-compatibility documentation phase and implements the tolerant-enum strategy for attribute enums and locale term keys.

### Key Changes
- **Tolerant Enums:** Introduced `tolerant_enum!` macro in `citum-schema-data` and updated `str_enum!` to capture unknown variants into `Unknown(String)`.
- **Enum Conversion:** Converted `ContributorRole`, `DateForm`, `TermForm`, `GrammaticalGender`, `GeneralTerm`, and structural subtypes to use the tolerant macro.
- **AST Warning Scans:** Implemented scanners in `citum-engine` to emit `CompatibilityWarning` items when unknown variants are detected in styles or bibliographies.
- **Verification:** Updated forward-compatibility integration tests and snapshot. Rows **01-04** and **08** now correctly observe `SoftDegrade` (ok).
- **Bean Lifecycle:** Archived completed beans `csl26-2a0b`, `csl26-s4io`, `csl26-ld6e`, and `csl26-o1z5`.

### Status
- [x] Compilation fixed across workspace (handling non-Copy types).
- [x] Integration tests passing.
- [x] Gaps snapshot updated.

Closes #725 (self-reference updated)