### PR TITLE
chore(release): wire publish + binary pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       beans: ${{ steps.filter.outputs.beans }}
       infra: ${{ steps.filter.outputs.infra }}
       semver: ${{ steps.filter.outputs.semver }}
+      release: ${{ steps.filter.outputs.release }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -70,6 +71,18 @@ jobs:
               - 'crates/citum-engine/**'
               - 'crates/citum-cli/**'
               - 'crates/citum-bindings/**'
+            release:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'RELEASING.md'
+              - 'scripts/build-jsr-package.sh'
+              - 'scripts/install.sh'
+              - 'scripts/publish-crates.sh'
+              - 'scripts/release-binary.sh'
+              - 'crates/citum-bindings/**'
+              - 'crates/citum-cli/Cargo.toml'
 
   hygiene-docs:
     name: Hygiene Checks — Docs
@@ -141,6 +154,44 @@ jobs:
             scripts/test_infer_release_bump.py \
             scripts/test_coverage_analysis.py \
             scripts/test_release_workflow.py
+
+  release-dry-runs:
+    name: Release Dry Runs
+    needs: changes
+    if: ${{ needs.changes.outputs.release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-dry-runs
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Dry-run crates.io publish scripts
+        run: |
+          ./scripts/publish-crates.sh --dry-run
+          ./scripts/publish-crates.sh --dry-run --skip citum
+          ./scripts/publish-crates.sh --dry-run --only citum
+
+      - name: Build JSR package
+        run: ./scripts/build-jsr-package.sh
+
+      - name: Dry-run JSR publish
+        working-directory: target/jsr/citum
+        run: npx --yes jsr publish --dry-run
 
   hygiene-infra:
     name: Hygiene Checks — Infra

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,3 +392,45 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: bash scripts/publish-crates.sh
+
+  # ── Step 7: Publish WASM/TypeScript bindings to JSR ───────────────
+  # JSR uses GitHub OIDC trusted publishing, so this job needs
+  # id-token: write but no registry token secret. The package must be
+  # linked to citum/citum-core in the JSR package settings first.
+  publish-jsr:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: publish-jsr
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Build JSR package
+        run: ./scripts/build-jsr-package.sh
+
+      - name: Dry-run JSR publish
+        working-directory: target/jsr/citum
+        run: npx --yes jsr publish --dry-run
+
+      - name: Publish to JSR
+        working-directory: target/jsr/citum
+        run: npx --yes jsr publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  push:
+    tags: ["v*"]
   workflow_dispatch:
     inputs:
       command:
@@ -261,3 +263,132 @@ jobs:
               git push origin "$TAG"
             fi
           fi
+
+  # ── Step 4: Build cross-platform binaries on tag push ─────────────
+  # Triggered only by `push: tags: ["v*"]` — orthogonal to the
+  # pull_request-gated steps above. Each matrix job builds citum +
+  # citum-server for its target and uploads the tarball + SHA256 as
+  # job artifacts. The `release` job aggregates them in the next step.
+  build:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: "0"
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: "1"
+          - target: x86_64-apple-darwin
+            os: macos-13      # last Intel runner; macos-latest is arm64
+            use_cross: "0"
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            use_cross: "0"
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            use_cross: "0"
+    runs-on: ${{ matrix.os }}
+    name: build (${{ matrix.target }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install musl-tools (linux only)
+        if: contains(matrix.target, 'linux-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Install cross (when needed)
+        if: matrix.use_cross == '1'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build, package, checksum
+        shell: bash
+        env:
+          USE_CROSS: ${{ matrix.use_cross }}
+        run: bash scripts/release-binary.sh "${{ matrix.target }}" "${{ github.ref_name }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: citum-${{ matrix.target }}
+          path: release-out/${{ matrix.target }}/*
+
+  # ── Step 5: Create the GitHub Release with all artifacts ──────────
+  release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          pattern: citum-*
+          merge-multiple: true
+
+      - name: Aggregate SHA256SUMS
+        run: |
+          set -euo pipefail
+          cd release-artifacts
+          # Each per-target script emitted `<hash>  <tarball>` in a
+          # per-arch .sha256 file; concat into one canonical manifest.
+          cat ./*.sha256 > SHA256SUMS
+          rm ./*.sha256
+          echo "=== SHA256SUMS ==="
+          cat SHA256SUMS
+
+      - name: Copy install.sh into the release payload
+        run: cp scripts/install.sh release-artifacts/install.sh
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Auto-generated release notes from PRs since last tag.
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag \
+            release-artifacts/*.tar.gz \
+            release-artifacts/SHA256SUMS \
+            release-artifacts/install.sh
+
+  # ── Step 6: Publish to crates.io ──────────────────────────────────
+  # `needs: build` so cross-platform compilation is the strongest
+  # pre-publish signal: `cargo publish` is irreversible apart from
+  # `yank`, so we treat "won't compile on Windows" as a blocker.
+  # The script is idempotent — re-running after partial failure
+  # skips already-published versions.
+  publish-crates:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: publish-crates
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: bash scripts/publish-crates.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ on:
           - release-pr
 
 permissions:
-  pull-requests: write
-  contents: write
-  issues: write
+  contents: read
 
 jobs:
   # ── Step 1: Detect what changed and infer bump level ──────────────
@@ -75,6 +73,10 @@ jobs:
     needs: detect
     if: needs.detect.outputs.should-release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -215,6 +217,8 @@ jobs:
       github.event.pull_request.merged == true &&
       github.event.pull_request.head.ref == 'release/next'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,10 +594,8 @@ name = "citum"
 version = "0.52.0"
 dependencies = [
  "ciborium",
- "citum-bindings",
  "citum-engine",
  "citum-io",
- "citum-pdf",
  "citum-resolver-api",
  "citum-schema",
  "citum-schema-data",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,9 @@ categories = ["text-processing"]
 [workspace.lints.rust]
 missing_docs = "deny"
 unsafe_code = "deny"
-# Features removed from citum-cli for the v1 crates.io publish (typst-pdf,
-# typescript) still appear in cfg-gated source as dead code; declare the
-# cfg names here so check-cfg doesn't warn on them workspace-wide.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("typst-pdf", "typescript"))'] }
+# The removed citum-cli `typescript` feature still appears in cfg-gated
+# source as dead code; declare it so check-cfg stays quiet workspace-wide.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("typescript"))'] }
 
 [workspace.lints.rustdoc]
 bare_urls = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,17 +111,17 @@ ignored = ["csl-legacy", "specta", "multibase"]
 # pin here stays in sync on bump.
 [workspace.dependencies]
 tracing = "0.1"
-citum-edtf = { path = "crates/citum-edtf", version = "0.50.0" }
-citum-resolver-api = { path = "crates/citum-resolver-api", version = "0.50.0" }
-citum-schema-data = { path = "crates/citum-schema-data", version = "0.50.0" }
-citum-schema-style = { path = "crates/citum-schema-style", version = "0.50.0" }
-citum-schema = { path = "crates/citum-schema", version = "0.50.0" }
-csl-legacy = { path = "crates/csl-legacy", version = "0.50.0" }
-citum-engine = { path = "crates/citum-engine", version = "0.50.0" }
-citum-io = { path = "crates/citum-io", version = "0.50.0" }
-citum-migrate = { path = "crates/citum-migrate", version = "0.50.0" }
-citum_store = { path = "crates/citum_store", version = "0.50.0" }
-citum-server = { path = "crates/citum-server", version = "0.50.0" }
+citum-edtf = { path = "crates/citum-edtf", version = "0.52.0" }
+citum-resolver-api = { path = "crates/citum-resolver-api", version = "0.52.0" }
+citum-schema-data = { path = "crates/citum-schema-data", version = "0.52.0" }
+citum-schema-style = { path = "crates/citum-schema-style", version = "0.52.0" }
+citum-schema = { path = "crates/citum-schema", version = "0.52.0" }
+csl-legacy = { path = "crates/csl-legacy", version = "0.52.0" }
+citum-engine = { path = "crates/citum-engine", version = "0.52.0" }
+citum-io = { path = "crates/citum-io", version = "0.52.0" }
+citum-migrate = { path = "crates/citum-migrate", version = "0.52.0" }
+citum_store = { path = "crates/citum_store", version = "0.52.0" }
+citum-server = { path = "crates/citum-server", version = "0.52.0" }
 
 [profile.dev]
 debug = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.52.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Citum citation engine — schema, processor, and migration tools"
-repository = "https://github.com/bdarcus/citum-core"
+repository = "https://github.com/citum/citum-core"
 homepage = "https://citum.org"
 authors = ["Bruce D'Arcus <bdarcus@gmail.com>"]
 keywords = ["citation", "bibliography", "csl"]
@@ -32,6 +32,10 @@ categories = ["text-processing"]
 [workspace.lints.rust]
 missing_docs = "deny"
 unsafe_code = "deny"
+# Features removed from citum-cli for the v1 crates.io publish (typst-pdf,
+# typescript) still appear in cfg-gated source as dead code; declare the
+# cfg names here so check-cfg doesn't warn on them workspace-wide.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("typst-pdf", "typescript"))'] }
 
 [workspace.lints.rustdoc]
 bare_urls = "warn"
@@ -98,10 +102,26 @@ missing_safety_doc = "deny"        # Safety-critical items must be documented
 tabs_in_doc_comments = "deny"      # Enforce consistent formatting
 
 [workspace.metadata.cargo-shear]
-ignored = ["csl_legacy", "specta", "multibase"]
+ignored = ["csl-legacy", "specta", "multibase"]
 
+# Workspace-internal crates. Each `path` makes local dev resolve to the
+# in-tree crate; each `version` is required for `cargo publish` to accept
+# the dep (path-only deps cannot be published). `release.toml` has
+# `shared-version = true`, so every internal crate moves together and the
+# pin here stays in sync on bump.
 [workspace.dependencies]
 tracing = "0.1"
+citum-edtf = { path = "crates/citum-edtf", version = "0.50.0" }
+citum-resolver-api = { path = "crates/citum-resolver-api", version = "0.50.0" }
+citum-schema-data = { path = "crates/citum-schema-data", version = "0.50.0" }
+citum-schema-style = { path = "crates/citum-schema-style", version = "0.50.0" }
+citum-schema = { path = "crates/citum-schema", version = "0.50.0" }
+csl-legacy = { path = "crates/csl-legacy", version = "0.50.0" }
+citum-engine = { path = "crates/citum-engine", version = "0.50.0" }
+citum-io = { path = "crates/citum-io", version = "0.50.0" }
+citum-migrate = { path = "crates/citum-migrate", version = "0.50.0" }
+citum_store = { path = "crates/citum_store", version = "0.50.0" }
+citum-server = { path = "crates/citum-server", version = "0.50.0" }
 
 [profile.dev]
 debug = 0

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,11 +9,12 @@ are marked explicitly.
 | Channel | Format | Audience |
 |---|---|---|
 | **crates.io** | 12 published crates (see list below) | Rust developers (`cargo install citum`, library users) |
+| **JSR** | `@citum/citum` WASM + TypeScript package | JavaScript, TypeScript, Deno, and browser integrations |
 | **GitHub Releases** | Cross-platform tarballs + `SHA256SUMS` + `install.sh` | End-users (`curl ... \| sh`), distro packagers |
 
 Out of scope for now (deliberately): Homebrew tap, npm wrapper, Docker
 image. Each can be added later as an additional job that consumes the
-GitHub Release artifacts already produced.
+GitHub Release artifacts or WASM package already produced.
 
 ### Published crates (12)
 
@@ -58,6 +59,8 @@ The release is automated end-to-end. Day-to-day, the work is:
      with tarballs + `SHA256SUMS` + `install.sh`
    - `publish-crates` (~5 min, gated on `build`) — runs
      `scripts/publish-crates.sh` against `CARGO_REGISTRY_TOKEN`
+   - `publish-jsr` (~5 min, gated on `build`) — builds the WASM/TypeScript
+     package and publishes `@citum/citum` to JSR using GitHub OIDC
 
 4. **Verify** (described in [§ Post-release verification](#post-release-verification)).
 
@@ -68,6 +71,7 @@ The release is automated end-to-end. Day-to-day, the work is:
 | `build` | `push: tags: ["v*"]` | ~15 min | Matrix: x86_64-musl, aarch64-musl, x86_64-darwin, aarch64-darwin, x86_64-windows. Uses `cross` for aarch64-musl. |
 | `release` | `needs: build` | ~1 min | Aggregates per-target `.sha256` into one `SHA256SUMS`; uploads tarballs + `install.sh` to GitHub Release. |
 | `publish-crates` | `needs: build` | ~5 min | Idempotent; safe to re-run from the Actions UI. |
+| `publish-jsr` | `needs: build` | ~5 min | Uses JSR trusted publishing via GitHub OIDC; no JSR token secret. |
 
 The pre-existing `detect` / `release-pr` / `auto-tag` jobs are gated
 on `pull_request` events and don't fire on tag push — there's no
@@ -88,6 +92,9 @@ curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.
 # Sanity:
 citum --version
 citum-server --version
+
+# JavaScript/WASM package:
+# Verify https://jsr.io/@citum/citum shows the new version.
 ```
 
 The install script verifies the SHA256 of the downloaded tarball
@@ -96,26 +103,39 @@ mismatch aborts before any files are written.
 
 ## First-time setup (one-time, before the very first release)
 
-1. **crates.io account.** Sign in at https://crates.io via GitHub.
+### crates.io first publish and `citum` name claim
 
-2. **`citum` crate name.** As of writing the `citum` name on crates.io
-   is squatted by a 2020 placeholder. Email `help@crates.io` citing
-   the `rust-lang/crates.io` policy on unused names to request reclaim.
-   If denied, rename `[package].name` in `crates/citum-cli/Cargo.toml`
-   to `citum-cli` — the binary stays named `citum` via the `[[bin]]`
-   block.
+1. **crates.io account.** Sign in at https://crates.io via GitHub and
+   verify the account email address.
 
-3. **API token.** crates.io → Account → API Tokens → Generate, with
-   scopes `publish-new` + `publish-update`. Save the value.
+2. **First-use API token.** crates.io → Account → API Tokens → Generate,
+   with scopes `publish-new` + `publish-update`. Save the value.
 
-4. **GitHub secret.** Repo Settings → Secrets and variables → Actions
+3. **GitHub secret.** Repo Settings → Secrets and variables → Actions
    → New repository secret named `CARGO_REGISTRY_TOKEN` (GitHub
    secret names accept only uppercase letters, digits, and
    underscores — no hyphens).
 
-5. **GitHub team.** Confirm `https://github.com/orgs/citum/teams/cargo-release`
-   exists (create if not). After the first publish completes, run
-   locally:
+4. **Pre-publish supporting crates.** Before the `citum` name becomes
+   available, publish every internal dependency in order:
+
+   ```sh
+   CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh --skip citum
+   ```
+
+5. **Claim `citum`.** At the availability window from crates.io support,
+   repeatedly attempt only the final CLI crate. The real source of truth
+   is `cargo publish`; do not rely on the web UI or API cache alone.
+
+   ```sh
+   until CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh --only citum; do
+     date
+     sleep 60
+   done
+   ```
+
+6. **GitHub team.** Confirm `https://github.com/orgs/citum/teams/cargo-release`
+   exists (create if not). After the first publish completes, run locally:
 
    ```sh
    for c in citum-edtf citum-resolver-api csl-legacy \
@@ -126,16 +146,33 @@ mismatch aborts before any files are written.
    done
    ```
 
-6. **Rotate the token.** After step 5, generate a fresh crates.io
+7. **Rotate the token.** Generate a fresh crates.io
    token scoped to just those 12 crate names (no `publish-new` —
    they all exist now), replace the GitHub secret, and revoke the
    original wide-scope token.
+
+### JSR first publish
+
+1. **JSR account and scope.** Sign in at https://jsr.io and create or
+   confirm the `citum` scope.
+
+2. **Package.** Create or confirm package `@citum/citum`.
+
+3. **Trusted publishing.** In the JSR package settings, link the package
+   to the GitHub repository `citum/citum-core` and allow publishing from
+   the release workflow. The workflow uses GitHub OIDC (`id-token: write`)
+   and does not need a JSR token secret.
+
+4. **First publish.** The tag workflow runs `scripts/build-jsr-package.sh`,
+   validates with `npx --yes jsr publish --dry-run`, then publishes from
+   `target/jsr/citum`.
 
 ## Recovery
 
 | Failure | Recovery |
 |---|---|
 | `publish-crates` partial fail | Re-run the job from the Actions UI. The script's idempotency check skips already-published versions. |
+| `publish-jsr` fail before publish | Fix the package build or JSR trusted-publishing settings, then re-run the job from the Actions UI. |
 | Bad release tarball | `gh release delete v<x.y.z> --cleanup-tag`, fix the issue, re-tag and let the workflow re-run. |
 | Bad crate published | `cargo yank --version <x.y.z> <crate>`. **Cannot un-yank with the same version**; bump to the next version and re-publish. |
 | Tag pushed before workflow updated | Delete the tag locally (`git tag -d v<x.y.z>`) and on remote (`git push origin :refs/tags/v<x.y.z>`); fix workflow; re-push. |
@@ -144,19 +181,32 @@ mismatch aborts before any files are written.
 
 ```sh
 ./scripts/publish-crates.sh --dry-run
+./scripts/publish-crates.sh --dry-run --skip citum
+./scripts/publish-crates.sh --dry-run --only citum
 ```
 
-Does no uploads. The leaf crates (`citum-edtf`, `citum-resolver-api`,
-`csl-legacy`) will succeed cleanly. Dependents fail with
-"no matching package … found" because their internal deps aren't on
-crates.io yet — that's expected in dry-run mode, and resolves in
-production where each successful publish makes the next dependent's
-dep available.
+Does no uploads. Before the first real publish, the leaf crates
+(`citum-edtf`, `citum-resolver-api`, `csl-legacy`) verify cleanly.
+Dependent crates report the expected "no matching package … found"
+registry gap for internal dependencies; the script treats that as a
+dry-run-only note and continues. In production, each successful publish
+makes the next dependent's version available.
+
+## Locally dry-run the JSR package
+
+```sh
+./scripts/build-jsr-package.sh
+cd target/jsr/citum
+npx --yes jsr publish --dry-run
+```
+
+The generated package is intentionally staged under `target/`; wasm-pack
+output is not committed.
 
 ## Locally dry-run a binary build
 
 ```sh
-./scripts/release-binary.sh x86_64-apple-darwin v0.51.0
+./scripts/release-binary.sh x86_64-apple-darwin v0.52.0
 ls release-out/x86_64-apple-darwin/
 ```
 
@@ -171,5 +221,5 @@ CITUM_INSTALL_DIR=/tmp/citum-test ./scripts/install.sh
 /tmp/citum-test/citum --version
 
 # Against a specific release:
-CITUM_VERSION=v0.51.0 CITUM_INSTALL_DIR=/tmp/citum-test ./scripts/install.sh
+CITUM_VERSION=v0.52.0 CITUM_INSTALL_DIR=/tmp/citum-test ./scripts/install.sh
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,175 @@
+# Releasing Citum
+
+This file documents how Citum releases work. Most of the pipeline is
+automated by `.github/workflows/release.yml`; the human review points
+are marked explicitly.
+
+## What ships, where
+
+| Channel | Format | Audience |
+|---|---|---|
+| **crates.io** | 12 published crates (see list below) | Rust developers (`cargo install citum`, library users) |
+| **GitHub Releases** | Cross-platform tarballs + `SHA256SUMS` + `install.sh` | End-users (`curl ... \| sh`), distro packagers |
+
+Out of scope for now (deliberately): Homebrew tap, npm wrapper, Docker
+image. Each can be added later as an additional job that consumes the
+GitHub Release artifacts already produced.
+
+### Published crates (12)
+
+| Order | Crate | Notes |
+|---|---|---|
+| 1 | `citum-edtf` | Leaf — Extended Date/Time Format parser |
+| 2 | `citum-resolver-api` | Leaf — style resolution interfaces |
+| 3 | `csl-legacy` | Leaf — CSL 1.0 parsers (infrastructure) |
+| 4 | `citum-schema-data` | Bibliographic data schema |
+| 5 | `citum-schema-style` | Style schema |
+| 6 | `citum-schema` | Facade re-exporting `-data` + `-style` |
+| 7 | `citum-engine` | Core citation processor |
+| 8 | `citum-io` | I/O + format conversion |
+| 9 | `citum_store` | Style + reference storage |
+| 10 | `citum-migrate` | CSL 1.0 → Citum migration |
+| 11 | `citum-server` | JSON-RPC server (binary: `citum-server`) |
+| 12 | `citum` | CLI (binary: `citum`) |
+
+Publish order matters because each crate's dependents need it
+available on crates.io. `scripts/publish-crates.sh` enforces the
+order and is idempotent: re-running after partial failure skips
+already-published versions.
+
+## Cut a release
+
+The release is automated end-to-end. Day-to-day, the work is:
+
+1. **Merge conventional commits to `main`.** The `detect` and
+   `release-pr` jobs in `release.yml` watch every PR merge and open
+   (or update) a `release/next` PR with the inferred version bump.
+
+2. **Review the `release/next` PR.** It bumps `[workspace.package].version`,
+   regenerates schemas (if relevant), and updates the changelog via
+   `git-cliff`. Land it when you're ready to release.
+
+3. **Watch the tag-push pipeline.** Merging `release/next` triggers
+   the `auto-tag` job, which pushes `v<x.y.z>` (and `schema-v<x.y.z>`
+   when the schema changed). The tag push fans out to:
+
+   - `build` (~10–15 min, parallel matrix across 5 targets)
+   - `release` (~1 min, gated on `build`) — creates the GitHub Release
+     with tarballs + `SHA256SUMS` + `install.sh`
+   - `publish-crates` (~5 min, gated on `build`) — runs
+     `scripts/publish-crates.sh` against `CARGO_REGISTRY_TOKEN`
+
+4. **Verify** (described in [§ Post-release verification](#post-release-verification)).
+
+## What fires on tag push
+
+| Job | Trigger | Time | Notes |
+|---|---|---|---|
+| `build` | `push: tags: ["v*"]` | ~15 min | Matrix: x86_64-musl, aarch64-musl, x86_64-darwin, aarch64-darwin, x86_64-windows. Uses `cross` for aarch64-musl. |
+| `release` | `needs: build` | ~1 min | Aggregates per-target `.sha256` into one `SHA256SUMS`; uploads tarballs + `install.sh` to GitHub Release. |
+| `publish-crates` | `needs: build` | ~5 min | Idempotent; safe to re-run from the Actions UI. |
+
+The pre-existing `detect` / `release-pr` / `auto-tag` jobs are gated
+on `pull_request` events and don't fire on tag push — there's no
+overlap.
+
+## Post-release verification
+
+After the tag-push pipeline completes:
+
+```sh
+# Library install (Rust developers):
+cargo install citum --locked
+cargo install citum-server --locked
+
+# End-user install (everyone):
+curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh
+
+# Sanity:
+citum --version
+citum-server --version
+```
+
+The install script verifies the SHA256 of the downloaded tarball
+against the release's `SHA256SUMS` before extracting; a checksum
+mismatch aborts before any files are written.
+
+## First-time setup (one-time, before the very first release)
+
+1. **crates.io account.** Sign in at https://crates.io via GitHub.
+
+2. **`citum` crate name.** As of writing the `citum` name on crates.io
+   is squatted by a 2020 placeholder. Email `help@crates.io` citing
+   the `rust-lang/crates.io` policy on unused names to request reclaim.
+   If denied, rename `[package].name` in `crates/citum-cli/Cargo.toml`
+   to `citum-cli` — the binary stays named `citum` via the `[[bin]]`
+   block.
+
+3. **API token.** crates.io → Account → API Tokens → Generate, with
+   scopes `publish-new` + `publish-update`. Save the value.
+
+4. **GitHub secret.** Repo Settings → Secrets and variables → Actions
+   → New repository secret named `CARGO_REGISTRY_TOKEN` (GitHub
+   secret names accept only uppercase letters, digits, and
+   underscores — no hyphens).
+
+5. **GitHub team.** Confirm `https://github.com/orgs/citum/teams/cargo-release`
+   exists (create if not). After the first publish completes, run
+   locally:
+
+   ```sh
+   for c in citum-edtf citum-resolver-api csl-legacy \
+            citum-schema-data citum-schema-style citum-schema \
+            citum-engine citum-io citum_store \
+            citum-migrate citum-server citum; do
+     cargo owner --add github:citum:cargo-release "$c"
+   done
+   ```
+
+6. **Rotate the token.** After step 5, generate a fresh crates.io
+   token scoped to just those 12 crate names (no `publish-new` —
+   they all exist now), replace the GitHub secret, and revoke the
+   original wide-scope token.
+
+## Recovery
+
+| Failure | Recovery |
+|---|---|
+| `publish-crates` partial fail | Re-run the job from the Actions UI. The script's idempotency check skips already-published versions. |
+| Bad release tarball | `gh release delete v<x.y.z> --cleanup-tag`, fix the issue, re-tag and let the workflow re-run. |
+| Bad crate published | `cargo yank --version <x.y.z> <crate>`. **Cannot un-yank with the same version**; bump to the next version and re-publish. |
+| Tag pushed before workflow updated | Delete the tag locally (`git tag -d v<x.y.z>`) and on remote (`git push origin :refs/tags/v<x.y.z>`); fix workflow; re-push. |
+
+## Locally dry-run a publish
+
+```sh
+./scripts/publish-crates.sh --dry-run
+```
+
+Does no uploads. The leaf crates (`citum-edtf`, `citum-resolver-api`,
+`csl-legacy`) will succeed cleanly. Dependents fail with
+"no matching package … found" because their internal deps aren't on
+crates.io yet — that's expected in dry-run mode, and resolves in
+production where each successful publish makes the next dependent's
+dep available.
+
+## Locally dry-run a binary build
+
+```sh
+./scripts/release-binary.sh x86_64-apple-darwin v0.51.0
+ls release-out/x86_64-apple-darwin/
+```
+
+Produces the tarball + `.sha256` exactly as the CI matrix would. Useful
+when changing build flags or adding new bundled files.
+
+## Locally test the installer
+
+```sh
+# Against a release that exists:
+CITUM_INSTALL_DIR=/tmp/citum-test ./scripts/install.sh
+/tmp/citum-test/citum --version
+
+# Against a specific release:
+CITUM_VERSION=v0.51.0 CITUM_INSTALL_DIR=/tmp/citum-test ./scripts/install.sh
+```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -153,17 +153,19 @@ mismatch aborts before any files are written.
 
 ### JSR first publish
 
-1. **JSR account and scope.** Sign in at https://jsr.io and create or
-   confirm the `citum` scope.
+1. **JSR account, scope, and package.** Sign in at https://jsr.io, then
+   open https://jsr.io/new. JSR creates scopes from the package-publish
+   form: in the **Scope** selector, choose the existing `citum` scope if
+   it is listed, or choose the create-new-scope option and enter `citum`.
+   Then set the package name to `citum`, producing `@citum/citum`.
+   This is not a token setup step.
 
-2. **Package.** Create or confirm package `@citum/citum`.
-
-3. **Trusted publishing.** In the JSR package settings, link the package
+2. **Trusted publishing.** In the JSR package settings, link the package
    to the GitHub repository `citum/citum-core` and allow publishing from
    the release workflow. The workflow uses GitHub OIDC (`id-token: write`)
    and does not need a JSR token secret.
 
-4. **First publish.** The tag workflow runs `scripts/build-jsr-package.sh`,
+3. **First publish.** The tag workflow runs `scripts/build-jsr-package.sh`,
    validates with `npx --yes jsr publish --dry-run`, then publishes from
    `target/jsr/citum`.
 

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -3,8 +3,12 @@ name = "citum"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-publish = false
 repository.workspace = true
+homepage.workspace = true
+description = "Citum CLI: render, validate, convert, and migrate citation styles, references, and documents"
+readme = "../../README.md"
+keywords = ["citation", "bibliography", "csl", "citeproc", "scholarly"]
+categories = ["command-line-utilities", "text-processing"]
 
 [[bin]]
 name = "citum"
@@ -22,22 +26,23 @@ ciborium = "0.2"
 strsim = "0.11"
 schemars = { version = "1.2.1", features = ["indexmap2"], optional = true }
 ratatui = { version = "0.30.0", default-features = false, features = ["crossterm_0_29"] }
-citum_schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
-citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
-citum_engine = { package = "citum-engine", path = "../citum-engine" }
-citum_io = { package = "citum-io", path = "../citum-io" }
-citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }
-citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
-citum-pdf = { path = "../citum-pdf", optional = true }
-citum-bindings = { path = "../citum-bindings", optional = true }
-citum-server = { path = "../citum-server", optional = true }
+citum-schema = { workspace = true, features = ["legacy-convert"] }
+citum-schema-data = { workspace = true }
+citum-engine = { workspace = true }
+citum-io = { workspace = true }
+citum_store = { workspace = true, features = ["http"] }
+citum-resolver-api = { workspace = true }
+citum-server = { workspace = true, optional = true }
 url = { version = "2.5", features = ["serde"] }
 
+# Features intentionally removed for the v1 crates.io publish: `typst-pdf`
+# (depended on the unpublished `citum-pdf` crate) and `typescript` (depended
+# on the unpublished `citum-bindings` crate). The cfg-gated code paths
+# remain in src/ as dead code; check-cfg below silences warnings. `--pdf`
+# at runtime returns a clear error pointing users at `typst compile`.
 [features]
 default = []
-schema = ["dep:schemars", "citum_schema/schema", "dep:citum-server", "citum-server/schema-types"]
-typst-pdf = ["dep:citum-pdf"]
-typescript = ["dep:citum-bindings", "citum-bindings/typescript"]
+schema = ["dep:schemars", "citum-schema/schema", "dep:citum-server", "citum-server/schema-types"]
 
 [lints]
 workspace = true

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -35,11 +35,10 @@ citum-resolver-api = { workspace = true }
 citum-server = { workspace = true, optional = true }
 url = { version = "2.5", features = ["serde"] }
 
-# Features intentionally removed for the v1 crates.io publish: `typst-pdf`
-# (depended on the unpublished `citum-pdf` crate) and `typescript` (depended
-# on the unpublished `citum-bindings` crate). The cfg-gated code paths
-# remain in src/ as dead code; check-cfg below silences warnings. `--pdf`
-# at runtime returns a clear error pointing users at `typst compile`.
+# Features intentionally removed for the v1 crates.io publish: `typescript`
+# depended on the unpublished `citum-bindings` crate. Its cfg-gated code path
+# remains in src/ as dead code; workspace check-cfg silences that warning.
+# `--pdf` always returns a clear error pointing users at `typst compile`.
 [features]
 default = []
 schema = ["dep:schemars", "citum-schema/schema", "dep:citum-server", "citum-server/schema-types"]

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -255,9 +255,9 @@ pub(crate) enum RenderCommands {
                       citum render doc manuscript.djot -b refs.json -s apa-7th -f html\n\n  \
                       Render Markdown with Pandoc-style citations:\n    \
                       citum render doc manuscript.md --input-format markdown -b refs.json -s apa-7th\n\n  \
-                      Render to PDF (requires 'typst-pdf' feature):\n    \
-                      citum render doc manuscript.djot -b refs.json -s apa-7th\n\
-                      -f typst -o paper.pdf --pdf"
+                      Render to Typst, then PDF (typst CLI required):\n    \
+                      citum render doc manuscript.djot -b refs.json -s apa-7th -f typst -o paper.typ\n    \
+                      typst compile paper.typ"
     )]
     Doc(RenderDocArgs),
 
@@ -603,7 +603,8 @@ pub(crate) struct RenderDocArgs {
     #[arg(short = 'o', long)]
     pub(crate) output: Option<PathBuf>,
 
-    /// Compile Typst output to PDF (requires `typst-pdf` feature)
+    /// Compile Typst output to PDF (not in v1 cargo-install builds; use
+    /// `-f typst` then `typst compile`)
     #[arg(long)]
     pub(crate) pdf: bool,
 

--- a/crates/citum-cli/src/typst_pdf.rs
+++ b/crates/citum-cli/src/typst_pdf.rs
@@ -3,28 +3,27 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 */
 
-//! Typst PDF compilation shim — delegates to the `citum-pdf` crate when the
-//! `typst-pdf` feature is enabled.
+//! Typst PDF compilation shim. Bundled-Typst PDF output isn't available in
+//! the crates.io-published `citum` binary because the `citum-pdf` helper
+//! crate isn't yet on crates.io. Users on the published binary should run
+//! `citum render doc … -f typst -o paper.typ && typst compile paper.typ`.
 
 use std::error::Error;
 use std::path::Path;
 
-#[cfg(feature = "typst-pdf")]
 /// Compile a generated Typst document to PDF.
-pub fn compile_document_to_pdf(
-    source: &str,
-    output: &Path,
-    keep_source: bool,
-) -> Result<(), Box<dyn Error>> {
-    citum_pdf::compile_document_to_pdf(source, output, keep_source)
-}
-
-#[cfg(not(feature = "typst-pdf"))]
-/// Compile a generated Typst document to PDF.
+///
+/// Returns an error in the v1 published build: bundled PDF compilation
+/// requires the `citum-pdf` crate, which is not yet on crates.io. Users
+/// can install Typst separately (https://typst.app/docs/) and run
+/// `typst compile <source.typ>` on the output of
+/// `citum render doc … -f typst`.
 pub fn compile_document_to_pdf(
     _source: &str,
     _output: &Path,
     _keep_source: bool,
 ) -> Result<(), Box<dyn Error>> {
-    Err("Typst PDF compilation requires building `citum` with the `typst-pdf` feature.".into())
+    Err(
+        "Direct PDF output is not available in this build. Generate Typst with `-f typst -o <file>.typ` and compile with `typst compile <file>.typ`. See https://typst.app for installation.".into(),
+    )
 }

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -12,14 +12,14 @@ name = "citum_engine"
 crate-type = ["rlib"]
 
 [dependencies]
-citum_schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
-citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
-csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
+citum-schema = { workspace = true, features = ["legacy-convert"] }
+citum-schema-data = { workspace = true }
+csl-legacy = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 thiserror = "2.0"
-citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }
+citum-edtf = { workspace = true, features = ["serde"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 winnow = "1.0"
 jotdown = "0.10"
@@ -33,11 +33,11 @@ schemars = { version = "1.2.1", features = ["derive"], optional = true }
 default = ["icu"]
 icu = ["dep:icu_collator", "dep:icu_locale"]
 ffi = []
-schema = ["dep:schemars", "citum_schema/schema", "citum_schema_data/schema"]
+schema = ["dep:schemars", "citum-schema/schema", "citum-schema-data/schema"]
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-citum_io = { package = "citum-io", path = "../citum-io" }
+citum-io = { workspace = true }
 rstest = "0.26"
 tempfile = "3.8"
 tracing.workspace = true

--- a/crates/citum-io/Cargo.toml
+++ b/crates/citum-io/Cargo.toml
@@ -7,9 +7,9 @@ description = "Citum I/O and format conversion library"
 repository.workspace = true
 
 [dependencies]
-citum-schema = { package = "citum-schema", path = "../citum-schema", features = ["legacy-convert"] }
-citum-engine = { package = "citum-engine", path = "../citum-engine" }
-csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
+citum-schema = { workspace = true, features = ["legacy-convert"] }
+citum-engine = { workspace = true }
+csl-legacy = { workspace = true }
 biblatex = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/citum-migrate/Cargo.toml
+++ b/crates/citum-migrate/Cargo.toml
@@ -12,8 +12,8 @@ path = "src/main.rs"
 
 [dependencies]
 tracing.workspace = true
-csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
-citum_schema = { package = "citum-schema", path = "../citum-schema" }
+csl-legacy = { workspace = true }
+citum-schema = { workspace = true }
 deno_core = "0.400.0"
 indexmap = "2.13.0"
 roxmltree = "0.21"

--- a/crates/citum-schema-data/Cargo.toml
+++ b/crates/citum-schema-data/Cargo.toml
@@ -11,14 +11,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = { version = "1.2.1", features = ["derive", "url2", "indexmap2"], optional = true }
 specta = { version = "2.0.0-rc.23", features = ["derive", "serde_json", "indexmap", "url"], optional = true }
-citum_edtf = { package = "citum-edtf", path = "../citum-edtf", features = ["serde"] }
+citum-edtf = { workspace = true, features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
-csl_legacy = { package = "csl-legacy", path = "../csl-legacy", optional = true }
+csl-legacy = { workspace = true, optional = true }
 indexmap = { version = "2", features = ["serde"] }
 
 [features]
 default = []
-legacy-convert = ["dep:csl_legacy"]
+legacy-convert = ["dep:csl-legacy"]
 schema = ["dep:schemars"]
 bindings = ["dep:specta"]
 

--- a/crates/citum-schema-style/Cargo.toml
+++ b/crates/citum-schema-style/Cargo.toml
@@ -13,10 +13,10 @@ serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 schemars = { version = "1.2.1", features = ["derive", "url2", "indexmap2"], optional = true }
 specta = { version = "2.0.0-rc.23", features = ["derive"], optional = true }
-csl_legacy = { package = "csl-legacy", path = "../csl-legacy", optional = true }
+csl-legacy = { workspace = true, optional = true }
 indexmap = { version = "2", features = ["serde"] }
-citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data" }
-citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
+citum-schema-data = { workspace = true }
+citum-resolver-api = { workspace = true }
 sha2 = "0.11"
 cid = { version = "0.11", default-features = false, features = ["alloc"] }
 multihash = { version = "0.19", default-features = false, features = ["alloc"] }
@@ -25,9 +25,9 @@ semver = "1"
 [features]
 default = []
 icu = []
-legacy-convert = ["dep:csl_legacy", "citum_schema_data/legacy-convert"]
-schema = ["dep:schemars", "citum_schema_data/schema"]
-bindings = ["dep:specta", "citum_schema_data/bindings"]
+legacy-convert = ["dep:csl-legacy", "citum-schema-data/legacy-convert"]
+schema = ["dep:schemars", "citum-schema-data/schema"]
+bindings = ["dep:specta", "citum-schema-data/bindings"]
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/citum-schema/Cargo.toml
+++ b/crates/citum-schema/Cargo.toml
@@ -7,15 +7,15 @@ description = "Citum citation and bibliography data schema types"
 repository.workspace = true
 
 [dependencies]
-citum_schema_data = { package = "citum-schema-data", path = "../citum-schema-data", default-features = false }
-citum_schema_style = { package = "citum-schema-style", path = "../citum-schema-style", default-features = false }
+citum-schema-data = { workspace = true }
+citum-schema-style = { workspace = true }
 
 [features]
 default = []
-icu = ["citum_schema_style/icu"]
-legacy-convert = ["citum_schema_data/legacy-convert", "citum_schema_style/legacy-convert"]
-schema = ["citum_schema_data/schema", "citum_schema_style/schema"]
-bindings = ["citum_schema_data/bindings", "citum_schema_style/bindings"]
+icu = ["citum-schema-style/icu"]
+legacy-convert = ["citum-schema-data/legacy-convert", "citum-schema-style/legacy-convert"]
+schema = ["citum-schema-data/schema", "citum-schema-style/schema"]
+bindings = ["citum-schema-data/bindings", "citum-schema-style/bindings"]
 
 [dev-dependencies]
 tracing.workspace = true

--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -5,17 +5,20 @@ edition.workspace = true
 authors = ["Bruce D'Arcus <bdarcus@gmail.com>"]
 license.workspace = true
 description = "Citum JSON-RPC server for citation and bibliography processing"
-publish = false
 repository.workspace = true
+homepage.workspace = true
+readme = "../../README.md"
+keywords = ["citation", "bibliography", "csl", "citeproc", "json-rpc"]
+categories = ["command-line-utilities", "text-processing"]
 
 [[bin]]
 name = "citum-server"
 path = "src/main.rs"
 
 [dependencies]
-citum-engine = { package = "citum-engine", path = "../citum-engine" }
-citum-schema = { package = "citum-schema", path = "../citum-schema" }
-citum_store = { package = "citum_store", path = "../citum_store", features = ["http"] }
+citum-engine = { workspace = true }
+citum-schema = { workspace = true }
+citum_store = { workspace = true, features = ["http"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }

--- a/crates/citum_store/Cargo.toml
+++ b/crates/citum_store/Cargo.toml
@@ -3,18 +3,22 @@ name = "citum_store"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-publish = false
 repository.workspace = true
+homepage.workspace = true
+description = "Citum style and reference storage layer — registry, cache, and resolver chain"
+readme = "../../README.md"
+keywords = ["citation", "csl", "storage", "registry"]
+categories = ["caching", "text-processing"]
 
 [dependencies]
-citum-schema = { package = "citum-schema", path = "../citum-schema" }
+citum-schema = { workspace = true }
+citum-resolver-api = { workspace = true }
 dirs = "6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 ciborium = "0.2"
 thiserror = "2.0"
-citum_resolver_api = { package = "citum-resolver-api", path = "../citum-resolver-api" }
 toml = "1.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
 sha2 = { version = "0.11", optional = true }
@@ -26,7 +30,7 @@ gix = { version = "0.83", default-features = false, features = ["blocking-networ
 
 [features]
 hub = []
-http = ["citum_resolver_api/http", "dep:reqwest", "dep:sha2", "dep:tempfile", "dep:cid", "dep:multihash", "dep:multibase", "dep:gix"]
+http = ["citum-resolver-api/http", "dep:reqwest", "dep:sha2", "dep:tempfile", "dep:cid", "dep:multihash", "dep:multibase", "dep:gix"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/csl-legacy/Cargo.toml
+++ b/crates/csl-legacy/Cargo.toml
@@ -3,8 +3,12 @@ name = "csl-legacy"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-publish = false
 repository.workspace = true
+homepage.workspace = true
+description = "Legacy CSL 1.0 XML and CSL-JSON parsers — infrastructure for the Citum migration pipeline"
+readme = "../../README.md"
+keywords = ["citation", "csl", "parser", "xml"]
+categories = ["parser-implementations", "text-processing"]
 
 [dependencies]
 indexmap = "2.13.0"

--- a/scripts/build-jsr-package.sh
+++ b/scripts/build-jsr-package.sh
@@ -32,6 +32,7 @@ wasm-pack build "$CRATE_DIR" \
 
 cp "$REPO_ROOT/README.md" "$PACKAGE_DIR/README.md"
 cp "$REPO_ROOT/LICENSE" "$PACKAGE_DIR/LICENSE"
+cp "$REPO_ROOT/LICENSE-APACHE" "$PACKAGE_DIR/LICENSE-APACHE"
 
 cat > "$PACKAGE_DIR/jsr.json" <<JSON
 {
@@ -48,7 +49,8 @@ cat > "$PACKAGE_DIR/jsr.json" <<JSON
       "citum_bindings_bg.wasm",
       "citum_bindings_bg.wasm.d.ts",
       "README.md",
-      "LICENSE"
+      "LICENSE",
+      "LICENSE-APACHE"
     ]
   }
 }

--- a/scripts/build-jsr-package.sh
+++ b/scripts/build-jsr-package.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Build the Citum WASM/TypeScript package for JSR.
+#
+# The Rust crate remains the source of truth. This script stages the generated
+# wasm-bindgen output plus JSR package metadata under target/jsr/citum.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CRATE_DIR="$REPO_ROOT/crates/citum-bindings"
+PACKAGE_DIR="$REPO_ROOT/target/jsr/citum"
+
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  echo "error: wasm-pack is required. Install it with \`cargo install wasm-pack\`." >&2
+  exit 1
+fi
+
+VERSION=$(sed -n '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p;}' "$REPO_ROOT/Cargo.toml" | head -1)
+if [[ "$VERSION" == "" ]]; then
+  echo "error: workspace package version not found in Cargo.toml" >&2
+  exit 1
+fi
+
+rm -rf "$PACKAGE_DIR"
+mkdir -p "$PACKAGE_DIR"
+
+wasm-pack build "$CRATE_DIR" \
+  --target web \
+  --out-dir "$PACKAGE_DIR" \
+  --release \
+  --features full-wasm
+
+cp "$REPO_ROOT/README.md" "$PACKAGE_DIR/README.md"
+cp "$REPO_ROOT/LICENSE" "$PACKAGE_DIR/LICENSE"
+
+cat > "$PACKAGE_DIR/jsr.json" <<JSON
+{
+  "name": "@citum/citum",
+  "version": "$VERSION",
+  "license": "MIT OR Apache-2.0",
+  "exports": {
+    ".": "./citum_bindings.js"
+  },
+  "publish": {
+    "include": [
+      "citum_bindings.js",
+      "citum_bindings.d.ts",
+      "citum_bindings_bg.wasm",
+      "citum_bindings_bg.wasm.d.ts",
+      "README.md",
+      "LICENSE"
+    ]
+  }
+}
+JSON
+
+echo "==> Built JSR package at $PACKAGE_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env sh
+# Citum installer.
+#
+#   curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh
+#
+# Detects your platform, downloads the matching release tarball from
+# GitHub, verifies its SHA256 against the checksum manifest in the
+# same release, and installs the `citum` and `citum-server` binaries
+# to $CITUM_INSTALL_DIR (default $HOME/.local/bin).
+#
+# Environment overrides:
+#   CITUM_VERSION       — release tag (default: latest)
+#   CITUM_INSTALL_DIR   — install destination (default: $HOME/.local/bin)
+#   CITUM_REPO          — GitHub repo (default: citum/citum-core)
+
+set -eu
+
+REPO="${CITUM_REPO:-citum/citum-core}"
+VERSION="${CITUM_VERSION:-latest}"
+INSTALL_DIR="${CITUM_INSTALL_DIR:-$HOME/.local/bin}"
+
+# ---------- helpers ---------------------------------------------------
+
+say()    { printf '%s\n'    "citum-installer: $*"; }
+err()    { printf '%s\n' >&2 "citum-installer: error: $*"; exit 1; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || err "required command not found: $1"
+}
+
+# Detect platform triple. Maps `uname -s` + `uname -m` to the target
+# names produced by scripts/release-binary.sh.
+detect_target() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64|amd64)        echo "x86_64-unknown-linux-musl" ;;
+        aarch64|arm64)       echo "aarch64-unknown-linux-musl" ;;
+        *) err "unsupported Linux arch: $arch (supported: x86_64, aarch64)" ;;
+      esac ;;
+    Darwin)
+      case "$arch" in
+        x86_64)              echo "x86_64-apple-darwin" ;;
+        arm64)               echo "aarch64-apple-darwin" ;;
+        *) err "unsupported macOS arch: $arch (supported: x86_64, arm64)" ;;
+      esac ;;
+    MINGW*|MSYS*|CYGWIN*)    echo "x86_64-pc-windows-msvc" ;;
+    *) err "unsupported OS: $os (supported: Linux, Darwin, Windows via Git Bash)" ;;
+  esac
+}
+
+# Resolve "latest" via the GitHub redirect; gives us the actual tag.
+resolve_version() {
+  if [ "$VERSION" = "latest" ]; then
+    # https://api.github.com/.../releases/latest is rate-limited
+    # unauthenticated; the redirect URL is not.
+    redirect=$(curl -fsSLI -o /dev/null -w '%{url_effective}\n' \
+      "https://github.com/${REPO}/releases/latest")
+    VERSION="${redirect##*/}"
+    [ -z "$VERSION" ] && err "failed to resolve latest version"
+  fi
+  case "$VERSION" in
+    v*) ;;
+    *) VERSION="v${VERSION}" ;;
+  esac
+  echo "$VERSION"
+}
+
+# ---------- main ------------------------------------------------------
+
+need_cmd curl
+need_cmd tar
+need_cmd uname
+
+# sha256 verification is non-negotiable for a curl|bash installer.
+SHASUM=""
+if   command -v sha256sum >/dev/null 2>&1; then SHASUM="sha256sum"
+elif command -v shasum    >/dev/null 2>&1; then SHASUM="shasum -a 256"
+else err "need sha256sum or shasum to verify the download"
+fi
+
+TARGET="$(detect_target)"
+VERSION="$(resolve_version)"
+VER_BARE="${VERSION#v}"
+
+TARBALL="citum-${VER_BARE}-${TARGET}.tar.gz"
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+say "installing citum ${VERSION} for ${TARGET}"
+
+# Stage in a tempdir that's wiped on exit (even on error).
+TMP="$(mktemp -d 2>/dev/null || mktemp -d -t citum-install)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+say "downloading ${TARBALL}"
+curl --fail --location --silent --show-error \
+  --output "${TMP}/${TARBALL}" \
+  "${BASE_URL}/${TARBALL}"
+
+say "downloading SHA256SUMS"
+curl --fail --location --silent --show-error \
+  --output "${TMP}/SHA256SUMS" \
+  "${BASE_URL}/SHA256SUMS"
+
+# Verify against the release's checksum manifest. Extract just the line
+# for our tarball; verify only that line. This sidesteps shasum's
+# behavior of needing every file in SHA256SUMS to be present.
+say "verifying checksum"
+expected=$(awk -v f="$TARBALL" '$2 == f || $2 == "*"f {print $1}' "${TMP}/SHA256SUMS")
+[ -z "$expected" ] && err "no checksum entry for ${TARBALL} in SHA256SUMS"
+
+actual=$(cd "$TMP" && $SHASUM "$TARBALL" | awk '{print $1}')
+[ "$expected" != "$actual" ] && err "checksum mismatch (expected $expected, got $actual)"
+say "checksum ok"
+
+# Extract and install.
+say "extracting"
+tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
+STAGE="${TMP}/citum-${VER_BARE}-${TARGET}"
+
+mkdir -p "$INSTALL_DIR"
+install -m 0755 "${STAGE}/citum"        "${INSTALL_DIR}/citum"
+install -m 0755 "${STAGE}/citum-server" "${INSTALL_DIR}/citum-server"
+
+say "installed citum and citum-server to ${INSTALL_DIR}"
+
+# PATH check. If INSTALL_DIR isn't on PATH, point the user at the fix
+# in a way that copy-pastes cleanly into their shell rc file.
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    cat <<EOF
+
+  ${INSTALL_DIR} is not on your PATH. Add this line to your shell
+  config (~/.bashrc, ~/.zshrc, ~/.config/fish/config.fish, etc.):
+
+      export PATH="${INSTALL_DIR}:\$PATH"
+
+  Then restart your shell, or run:
+
+      export PATH="${INSTALL_DIR}:\$PATH"
+
+EOF
+  ;;
+esac
+
+say "done. Run: citum --help"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,7 @@ resolve_version() {
 # ---------- main ------------------------------------------------------
 
 need_cmd curl
+need_cmd install
 need_cmd tar
 need_cmd uname
 
@@ -84,6 +85,11 @@ fi
 TARGET="$(detect_target)"
 VERSION="$(resolve_version)"
 VER_BARE="${VERSION#v}"
+
+EXE_SUFFIX=""
+case "$TARGET" in
+  *-pc-windows-*) EXE_SUFFIX=".exe" ;;
+esac
 
 TARBALL="citum-${VER_BARE}-${TARGET}.tar.gz"
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
@@ -121,8 +127,8 @@ tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
 STAGE="${TMP}/citum-${VER_BARE}-${TARGET}"
 
 mkdir -p "$INSTALL_DIR"
-install -m 0755 "${STAGE}/citum"        "${INSTALL_DIR}/citum"
-install -m 0755 "${STAGE}/citum-server" "${INSTALL_DIR}/citum-server"
+install -m 0755 "${STAGE}/citum${EXE_SUFFIX}"        "${INSTALL_DIR}/citum${EXE_SUFFIX}"
+install -m 0755 "${STAGE}/citum-server${EXE_SUFFIX}" "${INSTALL_DIR}/citum-server${EXE_SUFFIX}"
 
 say "installed citum and citum-server to ${INSTALL_DIR}"
 

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Publish all Citum crates to crates.io in dependency order.
+#
+# Idempotent: each crate's published version on crates.io is checked
+# first; already-published versions are skipped. Safe to re-run after
+# partial failure (e.g. transient registry errors), or to re-trigger
+# the publish job from the GitHub Actions UI without yanking anything.
+#
+# Required env: CARGO_REGISTRY_TOKEN — set in repo secrets in CI; for
+# local runs, paste from https://crates.io/me.
+#
+# Usage:
+#   CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh
+#   CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh --dry-run
+
+set -euo pipefail
+
+if [[ "${CARGO_REGISTRY_TOKEN:-}" == "" && "${1:-}" != "--dry-run" ]]; then
+  echo "error: CARGO_REGISTRY_TOKEN is not set" >&2
+  exit 1
+fi
+
+DRY_RUN=""
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN="--dry-run --allow-dirty"
+  echo "==> Running in dry-run mode (no uploads, dirty tree allowed)"
+fi
+
+# Strict dependency order. Each crate must publish before any crate
+# that depends on it. Updating this list:
+#   1. Add new internal crates here in dep-graph topological order.
+#   2. After adding, verify with `cargo tree -p <new-crate>` that no
+#      earlier entry in this list depends on the new one (cycle check).
+CRATES=(
+  citum-edtf
+  citum-resolver-api
+  csl-legacy
+  citum-schema-data
+  citum-schema-style
+  citum-schema
+  citum-engine
+  citum-io
+  citum_store
+  citum-migrate
+  citum-server
+  citum
+)
+
+# Sparse-index propagation delay between publishes. After a successful
+# `cargo publish`, the new version takes a few seconds to appear in the
+# sparse index that the next crate's `cargo publish` will query. 10s is
+# generous; 5s usually works. Skipped for the last crate (no dependent).
+PROPAGATION_DELAY=10
+
+published_version_for() {
+  # Query crates.io for the highest published version of a crate.
+  # Empty string if the crate doesn't exist or has no versions.
+  local crate="$1"
+  curl --silent --fail "https://crates.io/api/v1/crates/${crate}" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("crate",{}).get("max_version",""))' \
+    2>/dev/null || echo ""
+}
+
+local_version_for() {
+  # Read [package].version (or workspace inherited) for a crate.
+  local crate="$1"
+  cargo metadata --no-deps --format-version 1 \
+    | python3 -c "import json,sys; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='${crate}'))"
+}
+
+for crate in "${CRATES[@]}"; do
+  local_ver=$(local_version_for "$crate")
+  published_ver=$(published_version_for "$crate")
+
+  echo ""
+  echo "==> $crate"
+  echo "    local:     $local_ver"
+  echo "    published: ${published_ver:-<not on crates.io>}"
+
+  if [[ "$published_ver" == "$local_ver" ]]; then
+    echo "    skip: already published at $local_ver"
+    continue
+  fi
+
+  echo "    publishing ${crate}@${local_ver}..."
+  # shellcheck disable=SC2086 # DRY_RUN is intentionally word-split
+  cargo publish -p "$crate" --locked $DRY_RUN
+
+  last_idx=$(( ${#CRATES[@]} - 1 ))
+  if [[ "$crate" != "${CRATES[$last_idx]}" && "$DRY_RUN" == "" ]]; then
+    echo "    waiting ${PROPAGATION_DELAY}s for sparse index..."
+    sleep "$PROPAGATION_DELAY"
+  fi
+done
+
+echo ""
+echo "==> Done. Run \`cargo owner --add github:citum:cargo-release <crate>\` for any newly-published crate."

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -12,17 +12,69 @@
 # Usage:
 #   CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh
 #   CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh --dry-run
+#   CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh --skip citum
+#   CARGO_REGISTRY_TOKEN=... ./scripts/publish-crates.sh --only citum
 
 set -euo pipefail
 
-if [[ "${CARGO_REGISTRY_TOKEN:-}" == "" && "${1:-}" != "--dry-run" ]]; then
+DRY_RUN=""
+ONLY_CRATE=""
+SKIP_CRATES=()
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/publish-crates.sh [--dry-run] [--only <crate>] [--skip <crate> ...]
+
+Publishes Citum crates to crates.io in dependency order.
+
+Options:
+  --dry-run       Run `cargo publish --dry-run --allow-dirty`.
+  --only <crate>  Publish only one crate from the ordered list.
+  --skip <crate>  Skip a crate from the ordered list. Repeatable.
+  -h, --help      Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN="--dry-run --allow-dirty"
+      shift
+      ;;
+    --only)
+      if [[ "${2:-}" == "" ]]; then
+        echo "error: --only requires a crate name" >&2
+        exit 2
+      fi
+      ONLY_CRATE="$2"
+      shift 2
+      ;;
+    --skip)
+      if [[ "${2:-}" == "" ]]; then
+        echo "error: --skip requires a crate name" >&2
+        exit 2
+      fi
+      SKIP_CRATES+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${CARGO_REGISTRY_TOKEN:-}" == "" && "$DRY_RUN" == "" ]]; then
   echo "error: CARGO_REGISTRY_TOKEN is not set" >&2
   exit 1
 fi
 
-DRY_RUN=""
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN="--dry-run --allow-dirty"
+if [[ "$DRY_RUN" != "" ]]; then
   echo "==> Running in dry-run mode (no uploads, dirty tree allowed)"
 fi
 
@@ -46,6 +98,55 @@ CRATES=(
   citum
 )
 
+contains_crate() {
+  local needle="$1"
+  shift
+  local crate
+  for crate in "$@"; do
+    if [[ "$crate" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ "$ONLY_CRATE" != "" && ${#SKIP_CRATES[@]} -gt 0 ]]; then
+  echo "error: --only cannot be combined with --skip" >&2
+  exit 2
+fi
+
+if [[ "$ONLY_CRATE" != "" ]] && ! contains_crate "$ONLY_CRATE" "${CRATES[@]}"; then
+  echo "error: unknown crate for --only: $ONLY_CRATE" >&2
+  exit 2
+fi
+
+if [[ ${#SKIP_CRATES[@]} -gt 0 ]]; then
+  for skipped in "${SKIP_CRATES[@]}"; do
+    if ! contains_crate "$skipped" "${CRATES[@]}"; then
+      echo "error: unknown crate for --skip: $skipped" >&2
+      exit 2
+    fi
+  done
+fi
+
+SELECTED_CRATES=()
+for crate in "${CRATES[@]}"; do
+  if [[ "$ONLY_CRATE" != "" && "$crate" != "$ONLY_CRATE" ]]; then
+    continue
+  fi
+  if [[ ${#SKIP_CRATES[@]} -gt 0 ]] && contains_crate "$crate" "${SKIP_CRATES[@]}"; then
+    continue
+  fi
+  SELECTED_CRATES+=("$crate")
+done
+
+if [[ ${#SELECTED_CRATES[@]} -eq 0 ]]; then
+  echo "error: no crates selected" >&2
+  exit 2
+fi
+
+echo "==> Selected crates: ${SELECTED_CRATES[*]}"
+
 # Sparse-index propagation delay between publishes. After a successful
 # `cargo publish`, the new version takes a few seconds to appear in the
 # sparse index that the next crate's `cargo publish` will query. 10s is
@@ -68,7 +169,19 @@ local_version_for() {
     | python3 -c "import json,sys; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='${crate}'))"
 }
 
-for crate in "${CRATES[@]}"; do
+is_expected_dry_run_dependency_gap() {
+  local output_file="$1"
+  local crate
+  for crate in "${CRATES[@]}"; do
+    if grep -F "no matching package named \`$crate\` found" "$output_file" >/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+for idx in "${!SELECTED_CRATES[@]}"; do
+  crate="${SELECTED_CRATES[$idx]}"
   local_ver=$(local_version_for "$crate")
   published_ver=$(published_version_for "$crate")
 
@@ -83,11 +196,24 @@ for crate in "${CRATES[@]}"; do
   fi
 
   echo "    publishing ${crate}@${local_ver}..."
+  output_file=$(mktemp)
   # shellcheck disable=SC2086 # DRY_RUN is intentionally word-split
-  cargo publish -p "$crate" --locked $DRY_RUN
+  if cargo publish -p "$crate" --locked $DRY_RUN 2>&1 | tee "$output_file"; then
+    rm -f "$output_file"
+  else
+    status=$?
+    if [[ "$DRY_RUN" != "" ]] && is_expected_dry_run_dependency_gap "$output_file"; then
+      echo "    dry-run note: crates.io has not seen every internal dependency yet."
+      echo "    This is expected before the first ordered publish; real publish mode still fails here."
+      rm -f "$output_file"
+      continue
+    fi
+    rm -f "$output_file"
+    exit "$status"
+  fi
 
-  last_idx=$(( ${#CRATES[@]} - 1 ))
-  if [[ "$crate" != "${CRATES[$last_idx]}" && "$DRY_RUN" == "" ]]; then
+  last_idx=$(( ${#SELECTED_CRATES[@]} - 1 ))
+  if [[ "$idx" -ne "$last_idx" && "$DRY_RUN" == "" ]]; then
     echo "    waiting ${PROPAGATION_DELAY}s for sparse index..."
     sleep "$PROPAGATION_DELAY"
   fi

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Build the citum + citum-server binaries for one target triple, pack
+# them into a release tarball, and emit a SHA256 for the tarball.
+#
+# Called per-target from the release.yml build matrix. Outputs land at
+# ./release-out/<target>/citum-<version>-<target>.tar.gz plus a sibling
+# .sha256 file containing one `<hash>  <tarball-name>` line (sha256sum
+# format) ready for aggregation into the release-wide SHA256SUMS.
+#
+# Usage (with explicit args; mirrors how the workflow invokes it):
+#   ./scripts/release-binary.sh <target> <version>
+# Example:
+#   ./scripts/release-binary.sh x86_64-unknown-linux-musl v0.51.0
+#
+# Env overrides:
+#   USE_CROSS=1   force `cross build` (musl on linux, aarch64-cross).
+#   OUT_DIR=path  override ./release-out.
+
+set -euo pipefail
+
+TARGET="${1:?usage: release-binary.sh <target> <version>}"
+VERSION="${2:?usage: release-binary.sh <target> <version>}"
+OUT_DIR="${OUT_DIR:-release-out}"
+USE_CROSS="${USE_CROSS:-0}"
+
+# Strip the leading `v` from the version for the tarball name; this
+# matches the on-disk filename convention many install scripts assume.
+VER_BARE="${VERSION#v}"
+STAGE_DIR="citum-${VER_BARE}-${TARGET}"
+TARBALL_NAME="${STAGE_DIR}.tar.gz"
+
+# Windows binaries get .exe; everything else is bare.
+EXE_SUFFIX=""
+case "$TARGET" in
+  *-pc-windows-*) EXE_SUFFIX=".exe" ;;
+esac
+
+# Build. `cross` for musl + aarch64-linux (host-tool mismatch); cargo for
+# all native targets. `--locked` is required (CI shouldn't update the
+# lockfile mid-release).
+echo "==> Building citum + citum-server for ${TARGET}"
+if [[ "$USE_CROSS" == "1" ]]; then
+  cross build --release --locked --target "$TARGET" --bin citum --bin citum-server
+else
+  rustup target add "$TARGET" 2>/dev/null || true
+  cargo build --release --locked --target "$TARGET" --bin citum --bin citum-server
+fi
+
+# Stage tarball contents in a dedicated dir; the dir-name becomes the
+# top-level directory when users `tar xzf`.
+STAGE_PATH="${OUT_DIR}/${TARGET}/${STAGE_DIR}"
+mkdir -p "$STAGE_PATH"
+cp "target/${TARGET}/release/citum${EXE_SUFFIX}"        "$STAGE_PATH/"
+cp "target/${TARGET}/release/citum-server${EXE_SUFFIX}" "$STAGE_PATH/"
+cp README.md "$STAGE_PATH/"
+# Ship both licenses if present; otherwise a single LICENSE file works.
+for f in LICENSE LICENSE-MIT LICENSE-APACHE LICENSE.txt; do
+  [[ -f "$f" ]] && cp "$f" "$STAGE_PATH/" || true
+done
+
+# Strip the binaries to keep tarballs small (no debug info; ~3-5x smaller).
+# Best-effort: not every build env has strip available.
+case "$TARGET" in
+  *-apple-darwin)
+    strip "${STAGE_PATH}/citum${EXE_SUFFIX}"        2>/dev/null || true
+    strip "${STAGE_PATH}/citum-server${EXE_SUFFIX}" 2>/dev/null || true
+    ;;
+  *-pc-windows-*)
+    # MSVC strip isn't relevant; binaries built without debug info.
+    ;;
+  *)
+    strip --strip-unneeded "${STAGE_PATH}/citum${EXE_SUFFIX}"        2>/dev/null || true
+    strip --strip-unneeded "${STAGE_PATH}/citum-server${EXE_SUFFIX}" 2>/dev/null || true
+    ;;
+esac
+
+# Tar it up.
+TARBALL_PATH="${OUT_DIR}/${TARGET}/${TARBALL_NAME}"
+echo "==> Packaging ${TARBALL_NAME}"
+tar -czf "$TARBALL_PATH" -C "${OUT_DIR}/${TARGET}" "$STAGE_DIR"
+
+# Emit the SHA256 in sha256sum(1) format. The release job concats every
+# per-target .sha256 into one SHA256SUMS attached to the GitHub Release.
+SHA256_PATH="${TARBALL_PATH}.sha256"
+if command -v sha256sum >/dev/null; then
+  ( cd "${OUT_DIR}/${TARGET}" && sha256sum "$TARBALL_NAME" > "${TARBALL_NAME}.sha256" )
+else
+  # macOS native shasum.
+  ( cd "${OUT_DIR}/${TARGET}" && shasum -a 256 "$TARBALL_NAME" > "${TARBALL_NAME}.sha256" )
+fi
+
+echo "==> Done: ${TARBALL_PATH}"
+echo "    $(cat "$SHA256_PATH")"


### PR DESCRIPTION
## Summary

Wires `crates.io` publish + cross-platform binary releases + `curl|bash` installer into the existing `release.yml` pipeline. After this lands, merging a `release/next` PR will (a) tag, (b) build binaries for 5 targets, (c) attach tarballs + `SHA256SUMS` + `install.sh` to a new GitHub Release, and (d) publish 12 crates to crates.io in dependency order — all automated.

This is the wiring; the **first real release won't fire until the next `release/next` PR merges** (see the `RELEASING.md` cut-a-release flow). That gives time to set up the manual prerequisites (token, secret, team) listed below.

## Files at a glance

- **New scripts** (`scripts/`): `publish-crates.sh` (idempotent crates.io publish, dep-ordered), `release-binary.sh` (cross-compile + tarball + sha256), `install.sh` (end-user installer with checksum verification).
- **Workflow** (`.github/workflows/release.yml`): three new tag-push jobs — `build` (5-target matrix), `release` (GH Release with artifacts), `publish-crates` (crates.io upload).
- **New doc**: `RELEASING.md` (release flow, recovery, first-time setup, local dry-runs).
- **Cargo metadata**: flipped `publish = false` on `citum` (CLI), `citum-server`, `csl-legacy`, `citum_store`; added missing crate metadata; refactored to centralized `[workspace.dependencies]` with version pins; normalized dep keys to hyphenated names.
- **Source**: minor edits to `citum-cli/src/typst_pdf.rs` and `args.rs` (improved `--pdf` error message; trimmed `typst-pdf` / `typescript` features from published `citum` for v1).

## Verification (all green locally)

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no issues
- [x] `cargo nextest run --workspace` — 1298/1298 passed
- [x] `./scripts/publish-crates.sh --dry-run` — leaf crates upload-OK (dependents fail in dry-run because their internal deps aren't on crates.io yet; resolves at real-publish time when each successful publish makes the dep available)
- [x] `./scripts/release-binary.sh aarch64-apple-darwin v0.50.0` — produced 16.3 MB tarball with `citum` + `citum-server` + README + LICENSE, sha256 emitted
- [x] Extracted tarball, ran both binaries — `citum --version` / `citum-server --version` work
- [x] `./scripts/install.sh` against a nonexistent version — fails cleanly on 404 (will need first GH Release for the success path)

## Decisions captured here for review

1. **`citum` name squat**: released from crates.io team; just need to grab it
2. **`csl-legacy` + `citum_store` to be published too**: they're hard deps of crates we want to publish; can't keep them `publish = false`.
3. **`typst-pdf` / `typescript` features removed from published `citum`**: the helper crates (`citum-pdf`, `citum-bindings`) aren't on crates.io yet. PDF goes via 2-step workflow (`-f typst` then `typst compile`); docs already note this. Easy to re-enable in a v2.
4. **No Homebrew / npm / Docker in v1**: the GH Release artifacts are the substrate for all of them; can add jobs in a follow-up without rework.
5. **`shared-version = true`** already in `release.toml` — every internal crate moves together; the workspace deps version pin stays in sync on bump.

## Manual setup needed BEFORE first release (per `RELEASING.md` § First-time setup)

- [ ] Reclaim `citum` from crates.io (email `help@crates.io`)
- [x] Generate crates.io API token (scopes: `publish-new` + `publish-update`)
- [x] Add it as the `CARGO_REGISTRY_TOKEN` GitHub secret
- [x] Confirm `https://github.com/orgs/citum/teams/cargo-release` exists
- [ ] After first successful publish, run the `cargo owner --add` loop and rotate the token to scoped

## Test plan

- [ ] Visual review of `RELEASING.md`
- [ ] Visual review of the new workflow jobs (sanity-check matrix targets, secret names, `cargo install`-able after publish)
- [ ] Confirm decisions 1–5 above match your intent before merging
- [ ] After merge → next `release/next` PR → watch tag-push pipeline → verify `cargo install citum`, `cargo install citum-server`, and `curl | sh` all produce working binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
