### PR TITLE
fix(release): repoint schema-version paths to src/version.rs

### DIFF
--- a/.beans/archive/csl26-efsm--fixrelease-repoint-style-schema-version-sed-paths.md
+++ b/.beans/archive/csl26-efsm--fixrelease-repoint-style-schema-version-sed-paths.md
@@ -1,0 +1,65 @@
+---
+# csl26-efsm
+title: 'fix(release): repoint STYLE_SCHEMA_VERSION sed paths after schema modularization'
+status: completed
+type: bug
+priority: high
+created_at: 2026-05-17T18:34:24Z
+updated_at: 2026-05-17T18:34:24Z
+---
+
+The schema modularization in commit a905d891 ("refactor(schema): modularize
+style schema") moved `pub const STYLE_SCHEMA_VERSION` out of
+`crates/citum-schema-style/src/lib.rs` and into a new `src/version.rs`
+module. Several release-pipeline call sites still point at the old `lib.rs`
+path and will fail silently or noisily when the workflow next runs:
+
+- `.github/workflows/release.yml`
+  - line 138: `git add crates/citum-schema-style/src/lib.rs ...`
+  - lines 168-169: `sed -n 's/.../\1/p' crates/citum-schema-style/src/lib.rs`
+  - lines 248-251: `git diff ... grep -qE '^(crates/citum-schema-style/src/lib.rs|...)'` and the matching sed
+- `scripts/bump.py`
+  - line 18: `SCHEMA_STYLE_LIB = REPO_ROOT / "crates/citum-schema-style/src/lib.rs"`
+  - line 98 error message: "Could not find STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/lib.rs"
+- `scripts/test_release_workflow.py`
+  - `SCHEMA_LIB` was already repointed at `src/version.rs` in PR #733 as
+    the minimal change to unblock CI for the docs work that surfaced this
+    bug. The release workflow itself is still broken.
+
+Discovered when PR #733 (docs: integration recipes) added a `scripts/`
+file that triggered the `Hygiene Checks — Scripts` job — which had been
+skipped on prior PRs by the path filter. The release workflow has been
+broken on main since 2026-05-16 ~22:00 UTC; nobody has tried to cut a
+release since then.
+
+Fix: replace every `crates/citum-schema-style/src/lib.rs` reference above
+with `crates/citum-schema-style/src/version.rs`. Verify by running
+`python3 -m unittest scripts.test_release_workflow` and by dry-running
+the schema-bump step locally (`python3 scripts/bump.py schema patch
+--yes --no-commit --no-tag --no-validate`).
+
+## Summary of Changes
+
+Repointed all `STYLE_SCHEMA_VERSION` call sites from
+`crates/citum-schema-style/src/lib.rs` to `src/version.rs`:
+
+- `.github/workflows/release.yml` — 4 occurrences (1 `git add` path,
+  2 `sed` source paths, 1 `grep -qE` pattern in the auto-tag job).
+- `scripts/bump.py` — 3 occurrences (constant on line 18 plus error
+  messages on lines 98 and 258; the line-258 reference was not listed
+  in the original bean but caught by post-edit grep).
+- `scripts/test_release_workflow.py` — 1 occurrence, mirroring the
+  one-line fix already shipped in PR #733 (commit 67707c4b) so this
+  PR is self-contained.
+
+Verified with `python3 -m unittest scripts.test_release_workflow
+scripts.test_infer_release_bump` (23/23 passing) and a full local
+dry-run of `python3 scripts/bump.py schema patch --yes --no-commit
+--no-tag --no-validate` (succeeded; side-effect file writes reverted
+with `git checkout --` before commit).
+
+Note: `scripts/test_infer_release_bump.py:121` still passes a literal
+`"crates/citum-schema-style/src/lib.rs"` string as a sample non-artifact
+path; the `infer-release-bump.py` logic only pattern-matches the
+`docs/schemas/` prefix, so the test fixture is path-agnostic and was
+left as-is to avoid diff noise.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
           python3 scripts/bump.py schema "${{ steps.resolve.outputs.level }}" \
             --yes --no-commit --no-tag --no-validate
           cargo run --bin citum --features schema -- schema --out-dir docs/schemas
-          git add crates/citum-schema-style/src/lib.rs \
+          git add crates/citum-schema-style/src/version.rs \
             docs/reference/SCHEMA_VERSIONING.md \
             docs/schemas
           if ! git diff --cached --quiet; then
@@ -166,7 +166,7 @@ jobs:
         run: |
           SCHEMA_VERSION=$(sed -n \
             's/.*STYLE_SCHEMA_VERSION: \&str = "\([^"]*\)".*/\1/p' \
-            crates/citum-schema-style/src/lib.rs)
+            crates/citum-schema-style/src/version.rs)
           if [ -z "$SCHEMA_VERSION" ]; then
             echo "Error: STYLE_SCHEMA_VERSION not found" >&2
             exit 1
@@ -245,10 +245,10 @@ jobs:
       - name: Tag schema release when schema changed
         run: |
           if git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD \
-            | grep -qE '^(crates/citum-schema-style/src/lib.rs|docs/schemas/)'; then
+            | grep -qE '^(crates/citum-schema-style/src/version.rs|docs/schemas/)'; then
             SCHEMA_VERSION=$(sed -n \
               's/.*STYLE_SCHEMA_VERSION: \&str = "\([^"]*\)".*/\1/p' \
-              crates/citum-schema-style/src/lib.rs)
+              crates/citum-schema-style/src/version.rs)
             if [ -z "$SCHEMA_VERSION" ]; then
               echo "Error: STYLE_SCHEMA_VERSION not found" >&2
               exit 1

--- a/scripts/bump.py
+++ b/scripts/bump.py
@@ -15,7 +15,7 @@ from typing import Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SCHEMA_STYLE_LIB = REPO_ROOT / "crates/citum-schema-style/src/lib.rs"
+SCHEMA_STYLE_LIB = REPO_ROOT / "crates/citum-schema-style/src/version.rs"
 SCHEMA_DOC = REPO_ROOT / "docs/reference/SCHEMA_VERSIONING.md"
 RELEASE_WORKFLOW = REPO_ROOT / ".github/workflows/release.yml"
 TRACK_CHOICES = ("schema", "code", "engine", "all")
@@ -95,7 +95,7 @@ def read_schema_version() -> str:
     match = re.search(r'pub const STYLE_SCHEMA_VERSION: &str = "([^"]+)";', content)
     if match is None:
         raise BumpError(
-            "Could not find STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/lib.rs"
+            "Could not find STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/version.rs"
         )
     return match.group(1)
 
@@ -255,7 +255,7 @@ def update_schema_version(plan: ReleasePlan) -> None:
     pattern = r'(pub const STYLE_SCHEMA_VERSION: &str = ")([^"]+)(";)'
     updated, count = re.subn(pattern, rf"\g<1>{plan.new_version}\g<3>", content, count=1)
     if count != 1:
-        raise BumpError("Failed to update STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/lib.rs")
+        raise BumpError("Failed to update STYLE_SCHEMA_VERSION in crates/citum-schema-style/src/version.rs")
     SCHEMA_STYLE_LIB.write_text(updated, encoding="utf-8")
 
 

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -12,7 +12,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release.yml"
 RELEASE_CONFIG_PATH = REPO_ROOT / "release.toml"
-SCHEMA_LIB = REPO_ROOT / "crates/citum-schema-style/src/lib.rs"
+SCHEMA_LIB = REPO_ROOT / "crates/citum-schema-style/src/version.rs"
 
 
 class ReleaseWorkflowTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Repoints all `STYLE_SCHEMA_VERSION` call sites in the release pipeline from `crates/citum-schema-style/src/lib.rs` to `crates/citum-schema-style/src/version.rs` — fixing a regression introduced by the schema modularization in `a905d891` ("refactor(schema): modularize style schema") that has left the release workflow broken on `main` since 2026-05-16. Closes bean `csl26-efsm`.

## Why this slipped past CI

The `Hygiene Checks — Scripts` job has a path filter that only triggers when `scripts/` changes. The schema-modularization commit didn't touch `scripts/`, so the regression sat unnoticed until PR #733 (docs: integration recipes) added a `scripts/` file and surfaced it. PR #733 already shipped the one-line `scripts/test_release_workflow.py` repoint (commit `67707c4b`) as the minimal unblock for its own CI — this PR ports that one-liner and adds the actual workflow + bump.py fixes.

## Files changed

- **`.github/workflows/release.yml`** — 4 occurrences: 1 `git add` path, 2 `sed` source paths, 1 `grep -qE` pattern in the auto-tag job.
- **`scripts/bump.py`** — 3 occurrences: the `SCHEMA_STYLE_LIB` constant on line 18, plus error message strings on lines 98 and 258. (Line 258 was not in the original bean; caught by post-edit grep.)
- **`scripts/test_release_workflow.py`** — 1 occurrence, mirrors PR #733 commit `67707c4b` so this PR is self-contained.
- **`.beans/`** — `csl26-efsm` created + archived (completed) in same commit.

The constant name `SCHEMA_STYLE_LIB` in `bump.py` is left alone — renaming has no functional benefit and bloats the diff. `scripts/test_infer_release_bump.py:121` is also left alone — it passes a literal `lib.rs` string as a sample non-artifact path, but the underlying `infer-release-bump.py` only pattern-matches the `docs/schemas/` prefix, so the fixture is path-agnostic.

## Coordination with PR #735

PR #735 (`release/v0.51-publish-setup`) also modifies `release.yml`, but only **appends new jobs** (binary build matrix, publish-crates) at the end of the file. It does not touch any of the four old-path call sites fixed here, so the two PRs merge mechanically regardless of order.

## Verification (all green locally)

- [x] `python3 -m unittest scripts.test_release_workflow scripts.test_infer_release_bump` — 23/23 passing
- [x] `python3 scripts/bump.py schema patch --yes --no-commit --no-tag --no-validate` — successful dry-run, side-effect file writes reverted with `git checkout --` before commit
- [x] `grep -rn "schema-style/src/lib.rs" .github/ scripts/` — only the intentional `test_infer_release_bump.py:121` fixture string remains

## Test plan

- [x] `Hygiene Checks — Scripts` job goes green (this is the failing job that surfaced the bug)
- [x] No regressions in workspace tests
- [ ] After merge, the next `release/next` PR should run cleanly through the schema-bump → tag pipeline
