### PR TITLE
chore(release): drop macos-13 for darwin x86_64

### DIFF
--- a/.beans/csl26-bfa9--fix-release-pipeline-drop-macos-13-runner-for-darw.md
+++ b/.beans/csl26-bfa9--fix-release-pipeline-drop-macos-13-runner-for-darw.md
@@ -1,0 +1,28 @@
+---
+# csl26-bfa9
+title: 'Fix release pipeline: drop macos-13 runner for darwin x86_64 build'
+status: in-progress
+type: bug
+priority: high
+created_at: 2026-05-18T17:07:09Z
+updated_at: 2026-05-18T17:07:53Z
+---
+
+## Problem
+
+Release workflow (.github/workflows/release.yml) pins x86_64-apple-darwin build to os: macos-13. As of v0.53.0 (run 26045039933), this job hangs indefinitely on runner queue — 55 minutes before cancellation while every other matrix leg finished in 7-14 min. GitHub has wound down macos-13 hosted runner capacity.
+
+Net effect: v0.53.0 tag exists, but no GitHub Release, no crates.io publish, no JSR publish ever happened.
+
+## Tasks
+
+- [x] Branch chore/darwin-x86-runner from main
+- [x] Edit .github/workflows/release.yml: swap macos-13 → macos-latest for x86_64-apple-darwin
+- [ ] Commit, push, open PR with copilot review
+- [ ] After merge: delete remote v0.53.0 tag (CONFIRM), retag at fixed commit, push
+- [ ] Watch release workflow run, verify all 5 build jobs + release + publish-crates + publish-jsr succeed
+- [ ] Confirm GitHub Release exists, crates.io shows 0.53.0, JSR shows 0.53.0
+
+## Rationale
+
+Apple Silicon runners cross-build x86_64-apple-darwin natively (universal Xcode linker). Workspace has no build.rs, no native C deps, only rustls TLS. scripts/release-binary.sh already calls rustup target add on non-cross legs, so no script change needed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,7 +286,7 @@ jobs:
             os: ubuntu-latest
             use_cross: "1"
           - target: x86_64-apple-darwin
-            os: macos-13      # last Intel runner; macos-latest is arm64
+            os: macos-latest  # arm64 host cross-builds x86_64 via Apple's universal linker
             use_cross: "0"
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Summary

- Swap `x86_64-apple-darwin` release-matrix runner from `macos-13` → `macos-latest`.
- macos-13 hosted capacity is wound down — the v0.53.0 release was cancelled after that leg queued/hung 55 min while every other matrix leg finished in 7–14 min ([run 26045039933](https://github.com/citum/citum-core/actions/runs/26045039933)).
- Apple Silicon runners cross-compile `x86_64-apple-darwin` natively via the universal Xcode linker. Workspace has no `build.rs`, no native C deps, and uses rustls (not system OpenSSL), so the cross-build is straightforward.
- `scripts/release-binary.sh` already runs `rustup target add` on non-cross legs, so no script change needed.

## Follow-up

After merge, the v0.53.0 tag will be moved to the resulting commit and re-pushed to trigger the full release pipeline (GitHub Release + crates.io + JSR).

Bean: `csl26-bfa9`.

## Test plan

- [ ] CI green on this PR
- [ ] Copilot review integrated
- [ ] After merge: retag v0.53.0, watch tag-triggered workflow, confirm all 5 build jobs (incl. `x86_64-apple-darwin` < 20 min) + `release` + `publish-crates` + `publish-jsr` succeed
- [ ] Confirm GitHub Release v0.53.0 published with all 5 tarballs, `SHA256SUMS`, `install.sh`
- [ ] Confirm crates.io and JSR both show 0.53.0
