### PR TITLE
fix(release): repair publish dry runs

### DIFF
--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -38,7 +38,7 @@ schema = ["dep:schemars", "citum-schema/schema", "citum-schema-data/schema"]
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-citum-io = { workspace = true }
+citum-io = { path = "../citum-io" }
 rstest = "0.26"
 tempfile = "3.8"
 tracing.workspace = true

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -176,6 +176,10 @@ is_expected_dry_run_dependency_gap() {
     if grep -F "no matching package named \`$crate\` found" "$output_file" >/dev/null; then
       return 0
     fi
+    if grep -F "failed to select a version for the requirement \`$crate =" "$output_file" >/dev/null \
+      && grep -F "candidate versions found which didn't match" "$output_file" >/dev/null; then
+      return 0
+    fi
   done
   return 1
 }
@@ -204,7 +208,7 @@ for idx in "${!SELECTED_CRATES[@]}"; do
     status=$?
     if [[ "$DRY_RUN" != "" ]] && is_expected_dry_run_dependency_gap "$output_file"; then
       echo "    dry-run note: crates.io has not seen every internal dependency yet."
-      echo "    This is expected before the first ordered publish; real publish mode still fails here."
+      echo "    This is expected before the first ordered publish; real publish mode uploads crates in order."
       rm -f "$output_file"
       continue
     fi

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -13,6 +13,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release.yml"
 RELEASE_CONFIG_PATH = REPO_ROOT / "release.toml"
 SCHEMA_LIB = REPO_ROOT / "crates/citum-schema-style/src/version.rs"
+PUBLISH_CRATES_SCRIPT = REPO_ROOT / "scripts/publish-crates.sh"
+BUILD_JSR_SCRIPT = REPO_ROOT / "scripts/build-jsr-package.sh"
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
@@ -22,6 +24,8 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         cls.release_config = RELEASE_CONFIG_PATH.read_text(encoding="utf-8")
+        cls.publish_crates_script = PUBLISH_CRATES_SCRIPT.read_text(encoding="utf-8")
+        cls.build_jsr_script = BUILD_JSR_SCRIPT.read_text(encoding="utf-8")
 
     def test_release_branch_is_always_release_next(self) -> None:
         self.assertIn('echo "branch=release/next" >> "$GITHUB_OUTPUT"', self.workflow)
@@ -45,6 +49,50 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn('"git-cliff", "-o", "CHANGELOG.md"', self.release_config)
         self.assertIn("git rev-parse --show-toplevel", self.release_config)
         self.assertIn("$repo/CHANGELOG.md", self.release_config)
+
+    def test_publish_crates_dry_run_accepts_current_dependency_gap_wording(self) -> None:
+        """Cargo may report unpublished internal deps as version selection gaps."""
+        self.assertIn(
+            "failed to select a version for the requirement \\`$crate =",
+            self.publish_crates_script,
+        )
+        self.assertIn(
+            "candidate versions found which didn't match",
+            self.publish_crates_script,
+        )
+        self.assertIn(
+            "no matching package named \\`$crate\\` found",
+            self.publish_crates_script,
+        )
+
+    def test_jsr_package_license_uses_compound_spdx_expression(self) -> None:
+        self.assertIn('"license": "(MIT OR Apache-2.0)"', self.build_jsr_script)
+        self.assertNotIn('"license": "MIT OR Apache-2.0"', self.build_jsr_script)
+
+    def test_publish_jsr_tag_job_uses_oidc_and_publishes(self) -> None:
+        publish_jsr = re.search(
+            r"\n  publish-jsr:\n(?P<block>.*?)(?=\n  [a-zA-Z0-9_-]+:|\Z)",
+            self.workflow,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(publish_jsr)
+        assert publish_jsr is not None
+        block = publish_jsr.group("block")
+
+        self.assertIn(
+            "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')",
+            block,
+        )
+        self.assertIn("needs: build", block)
+        self.assertIn("id-token: write", block)
+        self.assertIn("run: ./scripts/build-jsr-package.sh", block)
+        self.assertIn("working-directory: target/jsr/citum", block)
+        self.assertIn("run: npx --yes jsr publish --dry-run", block)
+        self.assertRegex(
+            block,
+            r"- name: Publish to JSR[\s\S]*?run: npx --yes jsr publish",
+            "publish-jsr must include a real publish step after dry-run",
+        )
 
     def test_crate_changelogs_are_absent(self) -> None:
         tracked = subprocess.run(


### PR DESCRIPTION
## Summary
- repair release dry-runs so Cargo's current unpublished internal dependency wording is treated as an expected dry-run-only gap
- keep the citum-engine dev-dependency on citum-io path-only so publish verification strips it and avoids the engine/io cycle
- add release workflow regression coverage for the dry-run wording and the JSR publish job shape

## Why
PR #746 failed because the generated release PR hit a dry-run publish error that was expected in substance but no longer matched the script's old Cargo error wording. This fix belongs on `main`; after it merges, the release workflow can regenerate `release/next` cleanly.

JSR publishing is already wired through the tag workflow. The package build and local JSR dry-run pass; this PR adds guards so the OIDC publish path, dry-run step, and compound SPDX license do not regress.

## Validation
- `python3 -m unittest scripts/test_release_workflow.py`
- `cargo publish -p citum-engine --locked --dry-run --allow-dirty`
- `./scripts/build-jsr-package.sh && cd target/jsr/citum && npx --yes jsr publish --dry-run`
- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`

## Notes
The commit and push hooks reported pre-existing soft-stale bean advisories for `csl26-93wp` and `csl26-rfct`. I used the hook-provided `IGNORE_SOFT_STALE=1` override because those advisories are unrelated to this release fix.
