### PR TITLE
fix(release): repair jsr publish metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
         type: choice
         options:
           - release-pr
+          - publish-jsr
 
 permissions:
   contents: read
@@ -23,7 +24,7 @@ jobs:
   # ── Step 1: Detect what changed and infer bump level ──────────────
   detect:
     if: |
-      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_dispatch' && inputs.command == 'release-pr') ||
       (github.event.pull_request.merged == true &&
        github.event.pull_request.head.ref != 'release/next' &&
        !startsWith(github.event.pull_request.title, 'chore(release)'))
@@ -401,9 +402,15 @@ jobs:
   # JSR uses GitHub OIDC trusted publishing, so this job needs
   # id-token: write but no registry token secret. The package must be
   # linked to citum/citum-core in the JSR package settings first.
+  # This job intentionally does not wait for the binary build matrix:
+  # it builds its own package, and metadata/OIDC failures should surface
+  # quickly. Use workflow_dispatch command=publish-jsr to recover a JSR
+  # publish after a tag workflow failure; the selected ref supplies the
+  # package version from Cargo.toml.
   publish-jsr:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.command == 'publish-jsr')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/build-jsr-package.sh
+++ b/scripts/build-jsr-package.sh
@@ -38,7 +38,7 @@ cat > "$PACKAGE_DIR/jsr.json" <<JSON
 {
   "name": "@citum/citum",
   "version": "$VERSION",
-  "license": "(MIT OR Apache-2.0)",
+  "license": "MIT",
   "exports": {
     ".": "./citum_bindings.js"
   },

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -65,8 +65,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
             self.publish_crates_script,
         )
 
-    def test_jsr_package_license_uses_compound_spdx_expression(self) -> None:
-        self.assertIn('"license": "(MIT OR Apache-2.0)"', self.build_jsr_script)
+    def test_jsr_package_license_uses_jsr_supported_identifier(self) -> None:
+        self.assertIn('"license": "MIT"', self.build_jsr_script)
+        self.assertNotIn('"license": "(MIT OR Apache-2.0)"', self.build_jsr_script)
         self.assertNotIn('"license": "MIT OR Apache-2.0"', self.build_jsr_script)
 
     def test_publish_jsr_tag_job_uses_oidc_and_publishes(self) -> None:
@@ -79,11 +80,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
         assert publish_jsr is not None
         block = publish_jsr.group("block")
 
-        self.assertIn(
-            "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')",
-            block,
-        )
-        self.assertIn("needs: build", block)
+        self.assertIn("startsWith(github.ref, 'refs/tags/v')", block)
+        self.assertIn("inputs.command == 'publish-jsr'", block)
+        self.assertNotIn("needs: build", block)
         self.assertIn("id-token: write", block)
         self.assertIn("run: ./scripts/build-jsr-package.sh", block)
         self.assertIn("working-directory: target/jsr/citum", block)
@@ -93,6 +92,10 @@ class ReleaseWorkflowTests(unittest.TestCase):
             r"- name: Publish to JSR[\s\S]*?run: npx --yes jsr publish",
             "publish-jsr must include a real publish step after dry-run",
         )
+
+    def test_release_workflow_has_fast_manual_jsr_publish_recovery(self) -> None:
+        self.assertIn("- publish-jsr", self.workflow)
+        self.assertNotIn("- publish-crates", self.workflow)
 
     def test_crate_changelogs_are_absent(self) -> None:
         tracked = subprocess.run(


### PR DESCRIPTION
## Summary
- Change generated JSR metadata to use `"license": "MIT"`, which matches JSR license validation for SPDX identifiers while still packaging both license files.
- Add a manual `workflow_dispatch` `publish-jsr` command so JSR recovery can run directly on `main` without waiting for the binary build matrix.
- Keep crates recovery on the existing `scripts/publish-crates.sh`; all crates except `citum` are already at 0.53.1, and `citum` is blocked by crates.io deleted-name cooldown.

## Test Plan
- `python3 -m unittest scripts/test_release_workflow.py`
- `./scripts/build-jsr-package.sh`
- `cd target/jsr/citum && npx --yes jsr publish --dry-run --allow-dirty`
