### PR TITLE
docs(release): add jsr package readme

### DIFF
--- a/crates/citum-bindings/README-JSR.md
+++ b/crates/citum-bindings/README-JSR.md
@@ -1,0 +1,117 @@
+# @citum/citum
+
+WebAssembly and TypeScript bindings for the Citum citation renderer.
+
+This package exposes the browser/JavaScript entry points from
+`citum-bindings`. It is meant for applications that already have a Citum YAML
+style and bibliography data, and need to validate styles, render citations, or
+format a document in JavaScript.
+
+## Install
+
+```bash
+deno add jsr:@citum/citum
+```
+
+```ts
+import init, {
+  formatDocument,
+  getStyleMetadata,
+  materializeStyle,
+  renderBibliography,
+  renderCitation,
+  validateStyle,
+} from "jsr:@citum/citum";
+
+await init();
+```
+
+## Inputs
+
+- Styles are Citum YAML strings.
+- References are JSON strings containing either an object map keyed by ID or a
+  CSL-JSON-style array with `id` fields.
+- `renderCitation` accepts one Citum citation JSON payload.
+- Functions throw JavaScript exceptions when parsing, validation, or rendering
+  fails.
+
+```ts
+const styleYaml = await Deno.readTextFile(
+  "./styles/american-sociological-association.yaml",
+);
+
+const refsJson = JSON.stringify({
+  smith2020: {
+    class: "monograph",
+    type: "book",
+    title: "Sample Work",
+    issued: "2020",
+  },
+});
+
+const citationJson = JSON.stringify({
+  items: [{ id: "smith2020" }],
+});
+```
+
+## API
+
+Validate a style:
+
+```ts
+validateStyle(styleYaml);
+```
+
+Render one citation to HTML:
+
+```ts
+const citationHtml = renderCitation(styleYaml, refsJson, citationJson);
+```
+
+Render a full bibliography to HTML:
+
+```ts
+const bibliographyHtml = renderBibliography(styleYaml, refsJson);
+```
+
+Materialize template presets in a style:
+
+```ts
+const expandedStyleYaml = materializeStyle(styleYaml);
+```
+
+Read style metadata:
+
+```ts
+const metadata = JSON.parse(getStyleMetadata(styleYaml));
+```
+
+Format a document in one call:
+
+```ts
+const result = JSON.parse(
+  formatDocument(
+    JSON.stringify({
+      style: { kind: "yaml", value: styleYaml },
+      output_format: "html",
+      refs: JSON.parse(refsJson),
+      citations: [
+        {
+          id: "cite-1",
+          items: [{ id: "smith2020" }],
+        },
+      ],
+    }),
+  ),
+);
+```
+
+In WASM, Citum does not have the resolver chain used by the CLI and server.
+For `formatDocument`, pass an inline YAML style with
+`{ "kind": "yaml", "value": "..." }`. Style IDs and remote URIs require an
+external resolver before calling this package.
+
+## License
+
+Package metadata is `MIT` for JSR compatibility. Citum is dual-licensed under
+MIT OR Apache-2.0. See `LICENSE` and `LICENSE-APACHE`.

--- a/scripts/build-jsr-package.sh
+++ b/scripts/build-jsr-package.sh
@@ -30,7 +30,7 @@ wasm-pack build "$CRATE_DIR" \
   --release \
   --features full-wasm
 
-cp "$REPO_ROOT/README.md" "$PACKAGE_DIR/README.md"
+cp "$REPO_ROOT/crates/citum-bindings/README-JSR.md" "$PACKAGE_DIR/README.md"
 cp "$REPO_ROOT/LICENSE" "$PACKAGE_DIR/LICENSE"
 cp "$REPO_ROOT/LICENSE-APACHE" "$PACKAGE_DIR/LICENSE-APACHE"
 

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -15,6 +15,7 @@ RELEASE_CONFIG_PATH = REPO_ROOT / "release.toml"
 SCHEMA_LIB = REPO_ROOT / "crates/citum-schema-style/src/version.rs"
 PUBLISH_CRATES_SCRIPT = REPO_ROOT / "scripts/publish-crates.sh"
 BUILD_JSR_SCRIPT = REPO_ROOT / "scripts/build-jsr-package.sh"
+JSR_README_SOURCE = REPO_ROOT / "crates/citum-bindings/README-JSR.md"
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
@@ -26,6 +27,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         cls.release_config = RELEASE_CONFIG_PATH.read_text(encoding="utf-8")
         cls.publish_crates_script = PUBLISH_CRATES_SCRIPT.read_text(encoding="utf-8")
         cls.build_jsr_script = BUILD_JSR_SCRIPT.read_text(encoding="utf-8")
+        cls.jsr_readme_source = JSR_README_SOURCE.read_text(encoding="utf-8")
 
     def test_release_branch_is_always_release_next(self) -> None:
         self.assertIn('echo "branch=release/next" >> "$GITHUB_OUTPUT"', self.workflow)
@@ -69,6 +71,12 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn('"license": "MIT"', self.build_jsr_script)
         self.assertNotIn('"license": "(MIT OR Apache-2.0)"', self.build_jsr_script)
         self.assertNotIn('"license": "MIT OR Apache-2.0"', self.build_jsr_script)
+
+    def test_jsr_package_uses_package_specific_readme(self) -> None:
+        self.assertIn("crates/citum-bindings/README-JSR.md", self.build_jsr_script)
+        self.assertNotIn('cp "$REPO_ROOT/README.md"', self.build_jsr_script)
+        self.assertIn("# @citum/citum", self.jsr_readme_source)
+        self.assertIn("Package metadata is `MIT` for JSR compatibility", self.jsr_readme_source)
 
     def test_publish_jsr_tag_job_uses_oidc_and_publishes(self) -> None:
         publish_jsr = re.search(


### PR DESCRIPTION
## Summary
- Add a package-specific README source for `@citum/citum` focused on the WASM/TypeScript API.
- Copy that README into the generated JSR package instead of the generic repo README.
- Keep JSR metadata license as `MIT`, while documenting the dual-license files shipped with the package.

## Test Plan
- `python3 -m unittest scripts/test_release_workflow.py`
- `./scripts/build-jsr-package.sh`
- inspected `target/jsr/citum/README.md`, `jsr.json`, `LICENSE`, and `LICENSE-APACHE`
- `cd target/jsr/citum && npx --yes jsr publish --dry-run --allow-dirty`
