### PR TITLE
docs(cli): add curl binary install path

### DIFF
--- a/docs/developer.html
+++ b/docs/developer.html
@@ -126,10 +126,14 @@
         <section class="doc-section" id="cli">
             <div class="doc-section-header">
                 <h2>CLI</h2>
-                <p>Install with Cargo and use the <code>citum</code> binary directly.</p>
+                <p>Pre-built binaries for Linux, macOS, and Windows — no Rust toolchain required. Or build from source with Cargo.</p>
             </div>
             <div class="workshop-block">
-                <div class="workshop-label">Install</div>
+                <div class="workshop-label">Install (pre-built binary)</div>
+                <pre><code>curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh</code></pre>
+            </div>
+            <div class="workshop-block" style="margin-top: 1rem;">
+                <div class="workshop-label">Install (from source)</div>
                 <pre><code>cargo install citum</code></pre>
             </div>
             <div class="workshop-block" style="margin-top: 1rem;">


### PR DESCRIPTION
## Summary

- Adds `curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh` as a pre-built binary install option in the CLI section of `docs/developer.html`
- Presents it first (no Rust toolchain required), with `cargo install citum` kept as the from-source alternative
- Covers Linux, macOS, and Windows (x86_64-pc-windows-msvc)

## Test plan

- [ ] Verify the CLI section in `docs/developer.html` renders two install blocks with correct labels
- [ ] Confirm the curl URL matches the release asset path in `scripts/install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)