### PR TITLE
docs: redistribute examples.html to targeted pages

### DIFF
--- a/.beans/csl26-1vq0--redistribute-exampleshtml-capability-showcase-reci.md
+++ b/.beans/csl26-1vq0--redistribute-exampleshtml-capability-showcase-reci.md
@@ -1,0 +1,10 @@
+---
+# csl26-1vq0
+title: 'Redistribute examples.html: capability showcase + recipe pages'
+status: in-progress
+type: task
+created_at: 2026-05-19T17:30:38Z
+updated_at: 2026-05-19T17:30:38Z
+---
+
+Slim examples.html to a capability showcase (~300 lines). Add 3 new pages: typst.html, lualatex.html (corrected to two-pass, experimental), advanced-examples.html for style authors. Update 5 inbound-link pages. Fixes inaccuracies in Typst (no embedded crates, external CLI) and LuaLaTeX (two-pass, citum-labs, CITUM_LIB_PATH).

--- a/docs/developer.html
+++ b/docs/developer.html
@@ -108,6 +108,10 @@
                     <h3>JSR (Deno / Node / browser)</h3>
                     <p>Import the engine from the JSR registry as <code>@citum/citum</code>. The simplest path for TypeScript / JavaScript projects on Deno, Node, or the browser &mdash; types included.</p>
                 </a>
+                <a class="doc-card" href="guides/integrations/typst.html">
+                    <h3>Typst PDF</h3>
+                    <p>Render citations with Citum and compile to PDF using embedded Typst Rust crates. No TeX, no FFI step &mdash; a pure Rust pipeline.</p>
+                </a>
                 <a class="doc-card" href="#ffi">
                     <h3>C FFI</h3>
                     <p>Call the engine from any language with a C FFI. Current bindings cover Lua (for LuaLaTeX). The shared library exports a stable C-compatible surface.</p>
@@ -154,7 +158,7 @@ citum style validate styles/my-style.yaml
 citum schema --out-dir ./schemas</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                See <a href="examples.html">feature examples</a> for input and output samples across citation modes, bibliography grouping, multilingual terms, and output formats.
+                See <a href="guides/integrations/djot.html">Write citations in Djot</a> for a full end-to-end example, or the <a href="guides/integrations/typst.html">Typst</a> and <a href="guides/integrations/lualatex.html">LuaLaTeX</a> recipes for PDF publishing workflows. For CBOR binary performance, pass <code>-b data.cbor -s style.cbor</code> &mdash; compile YAML to CBOR first with <code>citum convert style styles/apa-7th.yaml -o apa-7th.cbor</code>.
             </p>
         </section>
 
@@ -308,10 +312,11 @@ cargo build --release
                 <div class="citum-panel" style="padding: 1.25rem; max-width: 36rem;">
                     <h3 style="font-family: var(--citum-font-sans); font-size: 1rem; letter-spacing: 0; margin: 0 0 0.5rem;">Lua / LuaLaTeX</h3>
                     <p style="color: var(--citum-muted); font-size: 0.88rem; line-height: 1.55; margin: 0;">
-                        Proof-of-concept bindings let a LuaLaTeX document call the Citum engine
-                        directly for citations and bibliography rendering. See
-                        <a href="https://github.com/citum/citum-labs/tree/main/bindings/lua">citum-labs/bindings/lua</a>
-                        for the binding source.
+                        Experimental bindings (citum-labs) let a LuaLaTeX document call the Citum
+                        engine for citations and bibliography rendering via LuaJIT FFI or JSON-RPC.
+                        Two-pass compilation; no Biber or external bibliography tool required. See the
+                        <a href="guides/integrations/lualatex.html">LuaLaTeX integration recipe</a>
+                        for package usage and build instructions.
                     </p>
                 </div>
             </div>
@@ -364,10 +369,8 @@ citum-server --http --port 8765       # HTTP mode (http feature)</code></pre>
 &lt;script src="https://docs.citum.org/assets/citum-interactive.js"&gt;&lt;/script&gt;</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                See the <a href="interactive-demo.html">live demo</a> for a runnable page,
-                and <a href="examples.html#web-interactivity">Examples &rarr; Web Interactivity</a>
-                for the underlying markup contract. The assets are MPL-2.0 and free to vendor
-                into your own site.
+                See the <a href="interactive-demo.html">live demo</a> for a runnable page.
+                The assets are MPL-2.0 and free to vendor into your own site.
             </p>
         </section>
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -5,8 +5,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
-        <meta name="description" content="Feature examples for Citum: document processing, advanced citations, bibliography grouping, multilingual support, and more.">
-    <title>Examples | Citum</title>
+        <meta name="description" content="A tour of Citum's capabilities: citation modes, multilingual output, EDTF dates, archival references, PDF publishing, and more — with links to full guides.">
+    <title>Capabilities | Citum</title>
 
         <link
         href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
@@ -56,1845 +56,214 @@
     </nav>
 
     <main class="doc-shell">
-        <!-- Header -->
         <header class="doc-section-header">
-            <span class="citum-kicker">Examples</span>
-            <h1>Feature Examples</h1>
-            <p>Verified examples drawn from current styles, schemas, and checked-in sample data.</p>
-            <p class="example-intro-note">
-                For current oracle fidelity and SQI status, see
-                <a href="compat.html">compatibility report</a> and
-                <a href="TIER_STATUS.md">tier status</a>.
+            <span class="citum-kicker">Capabilities</span>
+            <h1>What Citum can do</h1>
+            <p>
+                A quick tour of Citum&rsquo;s feature set. Each card shows real rendered output and
+                links to the full guide or recipe for that feature.
             </p>
         </header>
 
-        <!-- Main Content Layout -->
-        <div class="doc-sidebar-layout">
-        <!-- Sticky Sidebar Navigation -->
-        <aside class="doc-sidebar">
-            <nav aria-label="Examples sections">
-                <div class="doc-sidebar-title">Sections</div>
-                                <div>
-                    <a class="doc-sidebar-link" href="#document-processing">Document Processing
-                    </a>
-                    <a class="doc-sidebar-link" href="#advanced-citations">Advanced Citations
-                    </a>
-                    <a class="doc-sidebar-link" href="#bibliography-grouping">Bibliography Grouping
-                    </a>
-                    <a class="doc-sidebar-link" href="#archival-eprints">Archival &amp; Eprints
-                    </a>
-                    <a class="doc-sidebar-link" href="#compound-numeric-sets">Compound Numeric Sets
-                    </a>
-                    <a class="doc-sidebar-link" href="#multilingual-support">Multilingual Support
-                    </a>
-                    <a class="doc-sidebar-link" href="#advanced-dates">Advanced Dates
-                    </a>
-                    <a class="doc-sidebar-link" href="#options-presets">Options &amp; Inheritance
-                    </a>
-                    <a class="doc-sidebar-link" href="#titles-links">Titles &amp; Links
-                    </a>
-                    <a class="doc-sidebar-link" href="#overrides">Overrides
-                    </a>
-                    <a class="doc-sidebar-link" href="#output-formats">Output Formats
-                    </a>
-                    <a class="doc-sidebar-link" href="#typst-pdf-publishing">Typst PDF
-                    </a>
-                    <a class="doc-sidebar-link" href="#lualatex-integration">LuaLaTeX
-                    </a>
-                    <a class="doc-sidebar-link" href="#binary-performance">Binary Perf
-                    </a>
-                    <a class="doc-sidebar-link" href="#schema-generation">Schema Generation
-                    </a>
-                    <a class="doc-sidebar-link" href="#web-interactivity">Web Interactivity
-                    </a>
-                    <a class="doc-sidebar-link" href="#annotated-bibliography">Annotated Bibliography
-                    </a>
-                    <a class="doc-sidebar-link" href="#abbreviation-map">Abbreviation Maps
-                    </a>
-                    <a class="doc-sidebar-link" href="#distributed-registries">Distributed Registries
-                    </a>
-                </div>
-            </nav>
-        </aside>
-
-        <!-- Examples Grid -->
-        <div class="doc-main">
-            <!-- Document Processing -->
-            <article id="document-processing" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Document Processing
-                    </h2>
+        <section class="doc-section" id="citation-modes">
+            <div class="doc-section-header">
+                <h2>Citation modes &mdash; integral and non-integral</h2>
                 <p>
-                    Citum processes full documents from checked-in Djot inputs, and also accepts
-                    Markdown documents that use Pandoc-style citation markers in prose. The current
-                    Djot example demonstrates multi-cites, locators, integral citations, visibility modifiers,
-                    footnotes, and in-document bibliography blocks.
+                    Styles declare separate <code>integral</code> and <code>non-integral</code> templates.
+                    Document-scoped name memory tracks whether a name has already appeared in the prose and
+                    switches to its short form on subsequent mentions.
                 </p>
             </div>
-
-            <div class="example-card-body">
-                <div>
-                    <!-- Djot Input -->
-                    <div>
-                        <div class="example-io-label">
-                            Djot Input (paper.djot)
-                        </div>
-                        <div class="code-dark">
-                            <pre>
-Multi-cite with locator: [@kuhn1962; @watson1953, ch. 2].
-Structured locator: [@kuhn1962, section: 5].
-First narrative mention: [+@smith2010, p. 10] surveys the broader literature.
-Suppress author with locator: [-@kuhn1962, p. 10].</pre>
-                        </div>
-                    </div>
-
-                    <!-- Rendered Output -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Rendered Output (Plain Text)
-                        </div>
-                        <div>
-                            Multi-cite with locator: (Kuhn; Watson and Crick, ch. 2).<br>
-                            Structured locator: (Kuhn, sec. 5).<br>
-                            First narrative mention: John Smith (10) surveys the broader literature.<br>
-                            Suppress author with locator: (10).
-                        </div>
-                    </div>
-                </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Rendered output (APA 7th)</div>
+                <pre><code>Non-integral:  (Kuhn, 1962, p. 10)
+Integral:      Kuhn and Popper (1962)
+Name memory:   Thomas S. Kuhn (10) … later Smith (12)</code></pre>
             </div>
-        </article>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="guides/style-authoring/advanced-examples.html#advanced-citations">Advanced citation examples</a>
+                &nbsp;&middot;&nbsp;
+                <a href="guides/style-authoring/templates.html#citation-modes">Template reference</a>
+            </p>
+        </section>
 
-        <!-- Advanced Citations: Narrative, Infix & Conjunctions -->
-        <article id="advanced-citations" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Advanced Citations
-                    </h2>
+        <section class="doc-section" id="bibliography-grouping">
+            <div class="doc-section-header">
+                <h2>Bibliography grouping and sorting</h2>
                 <p>
-                    Current styles use explicit integral and non-integral branches, per-mode contributor
-                    options, and document-scoped integral-name memory where the style opts in.
+                    Group entries by type, language, or custom criteria. Sort within groups independently.
+                    Gender-aware locale terms adapt contributor labels to the language of the source.
                 </p>
             </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Rendered bibliography (grouped by type)</div>
+                <pre><code>Books
+  Kuhn, T. S. (1962). The structure of scientific revolutions. Chicago.
+  Watson, J. D. (1968). The double helix. Atheneum.
 
-            <!-- Integral vs Non-Integral -->
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Integral vs Non-Integral (APA 7th)
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-key">citation</span>:
-  <span class="token-value">non-integral</span>:
-    <span class="token-value">wrap</span>: <span class="token-string">parentheses</span>
-    <span class="token-value">template</span>:
-      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
-        <span class="token-value">form</span>: <span class="token-string">short</span>
-      - <span class="token-value">date</span>: <span class="token-string">issued</span>
-        <span class="token-value">form</span>: <span class="token-string">year</span>
-  <span class="token-value">integral</span>:
-    <span class="token-value">options</span>:
-      <span class="token-value">contributors</span>:
-        <span class="token-value">and</span>: <span class="token-string">text</span></pre>
-                </div>
+Articles
+  Smith, J. A. (2023). Analysis of inheritance. Nature, 24(5), 311–326.</code></pre>
             </div>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="guides/style-authoring/options.html#bibliography-sort-and-groups">Options &rarr; Bibliography sort and groups</a>
+            </p>
+        </section>
 
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Integral Name Memory (MLA Default)
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-key">options</span>:
-  <span class="token-value">integral-names</span>:
-    <span class="token-value">rule</span>: <span class="token-string">full-then-short</span>
-    <span class="token-value">scope</span>: <span class="token-string">document</span>
-    <span class="token-value">contexts</span>: <span class="token-string">body-and-notes</span>
-    <span class="token-value">subsequent-form</span>: <span class="token-string">short</span>
-
-<span class="token-key">citation</span>:
-  <span class="token-value">integral</span>:
-    <span class="token-value">template</span>:
-      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
-        <span class="token-value">form</span>: <span class="token-string">long</span>
-      - <span class="token-value">variable</span>: <span class="token-string">locator</span>
-        <span class="token-value">show-label</span>: <span class="token-string">false</span>
-        <span class="token-value">wrap</span>: <span class="token-string">parentheses</span></pre>
-                </div>
-            </div>
-
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Document Override from Front Matter
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
----
-<span class="token-value">integral-names</span>:
-  <span class="token-value">enabled</span>: <span class="token-string">true</span>
-  <span class="token-value">scope</span>: <span class="token-string">chapter</span>
-  <span class="token-value">contexts</span>: <span class="token-string">body-and-notes</span>
----
-
-<span class="token-comment"># Later in the document</span>
-First narrative mention: <span class="token-string">[+@smith2010, p. 10]</span>
-Later in same chapter: <span class="token-string">[+@smith2010, p. 12]</span>
-New chapter reset: <span class="token-string">[+@smith2010, p. 14]</span></pre>
-                </div>
-            </div>
-
-            <!-- Visual Output -->
-            <div class="example-section">
-                <div class="example-section-heading">
-                    <h3>
-                        Rendered Examples (Current Djot Input)
-                    </h3>
-                </div>
-                <div class="example-grid">
-                        <div class="example-io-panel">
-                            <div class="example-io-label">Multi-Cite with Locator</div>
-                            <div class="example-rendered">(Kuhn; Watson and Crick, ch. 2)</div>
-                        </div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">Structured Locator</div>
-                            <div class="example-rendered">(Kuhn, sec. 5)</div>
-                        </div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">Narrative Name Memory</div>
-                            <div class="example-rendered">John Smith (10) ... later Smith (12) ... then John Smith (14) again</div>
-                        </div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">Integral Citation</div>
-                            <div class="example-rendered">Thomas S. Kuhn (10)</div>
-                        </div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">Visibility Modifier</div>
-                            <div class="example-rendered">(10)</div>
-                        </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Bibliography Grouping -->
-        <article id="bibliography-grouping" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Bibliography Grouping
-                    </h2>
+        <section class="doc-section" id="multilingual">
+            <div class="doc-section-header">
+                <h2>Multilingual and script partitioning</h2>
                 <p>
-                    Divide bibliographies into labeled sections with distinct sorting rules. Essential for legal
-                    hierarchies (Bluebook), multilingual bibliographies, and primary/secondary source divisions.
+                    References in multiple languages are automatically partitioned by script and language.
+                    Locale terms, contributor labels, and date formats adapt per-reference.
                 </p>
             </div>
-
-            <div class="example-card-body">
-                <div>
-                    <!-- Legal Hierarchy Example -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Legal Hierarchy (Type-Based Grouping)
-                        </div>
-                        <div class="code-dark">
-                            <pre><span class="token-key">bibliography</span>:
-  <span class="token-value">groups</span>:
-    - <span class="token-value">id</span>: <span class="token-string">primary-legal</span>
-      <span class="token-value">heading</span>: <span class="token-string">"Primary Sources"</span>
-      <span class="token-value">selector</span>:
-        <span class="token-value">type</span>: [<span class="token-string">legal-case, statute, treaty</span>]
-      <span class="token-value">sort</span>:
-        <span class="token-value">template</span>:
-          - <span class="token-value">key</span>: <span class="token-string">type</span>
-            <span class="token-value">order</span>: [<span class="token-string">legal-case, statute, treaty</span>]
-          - <span class="token-value">key</span>: <span class="token-string">issued</span></pre>
-                        </div>
-                        <p class="example-small">
-                            Explicit type ordering ensures legal-case appears before statute, regardless of alphabetical
-                            content.
-                        </p>
-                    </div>
-
-                    <!-- Multilingual Example -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Multilingual (Per-Group Name Ordering)
-                        </div>
-                        <div class="code-dark">
-                            <pre
-                                class="example-mono example-small"><span class="token-key">bibliography</span>:
-  <span class="token-value">groups</span>:
-    - <span class="token-value">id</span>: <span class="token-string">vietnamese</span>
-      <span class="token-value">heading</span>:
-        <span class="token-value">localized</span>:
-          <span class="token-value">vi</span>: <span class="token-string">"Tài liệu tiếng Việt"</span>
-          <span class="token-value">en-US</span>: <span class="token-string">"Vietnamese Sources"</span>
-      <span class="token-value">selector</span>:
-        <span class="token-value">field</span>:
-          <span class="token-value">language</span>: <span class="token-string">vi</span>
-      <span class="token-value">sort</span>:
-        <span class="token-value">template</span>:
-          - <span class="token-value">key</span>: <span class="token-string">author</span>
-            <span class="token-value">sort-order</span>: <span class="token-string">given-family</span>  <span class="token-comment"># Vietnamese convention</span>
-          - <span class="token-value">key</span>: <span class="token-string">issued</span>
-            <span class="token-value">ascending</span>: <span class="token-string">false</span>
-      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span>
-
-    - <span class="token-value">id</span>: <span class="token-string">western</span>
-      <span class="token-value">heading</span>:
-        <span class="token-value">literal</span>: <span class="token-string">"Western Sources"</span>
-      <span class="token-value">selector</span>:
-        <span class="token-value">not</span>:
-          <span class="token-value">field</span>:
-            <span class="token-value">language</span>: <span class="token-string">vi</span>
-      <span class="token-value">sort</span>:
-        <span class="token-value">template</span>:
-          - <span class="token-value">key</span>: <span class="token-string">author</span>
-            <span class="token-value">sort-order</span>: <span class="token-string">family-given</span>  <span class="token-comment"># Western convention</span>
-          - <span class="token-value">key</span>: <span class="token-string">issued</span>
-            <span class="token-value">ascending</span>: <span class="token-string">false</span>
-      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span></pre>
-                        </div>
-                        <p class="example-small">
-                            Vietnamese names use given-family ordering, Western names use family-given ordering.
-                        </p>
-                    </div>
-
-                    <!-- Localized Disambiguation Example -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Localized Disambiguation (Per-Group Year Suffixes)
-                        </div>
-                        <div class="code-dark">
-                            <pre><span class="token-key">bibliography</span>:
-  <span class="token-value">groups</span>:
-    - <span class="token-value">id</span>: <span class="token-string">cited</span>
-      <span class="token-value">heading</span>: <span class="token-string">"Cited Works"</span>
-      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span>  <span class="token-comment"># Reset suffixes for this</span>
-      <span class="token-value">selector</span>:
-        <span class="token-value">status</span>: <span class="token-string">visible</span>
-
-    - <span class="token-value">id</span>: <span class="token-string">reading</span>
-      <span class="token-value">heading</span>: <span class="token-string">"Further Reading"</span>
-      <span class="token-value">disambiguate</span>: <span class="token-string">locally</span>  <span class="token-comment"># Start fresh from "a"</span>
-      <span class="token-value">selector</span>:
-        <span class="token-value">status</span>: <span class="token-string">silent</span></pre>
-                        </div>
-                        <p class="example-small">
-                            Isolating disambiguation prevents collisions across bibliography sections, allowing
-                            independent suffix assignment in each.
-                        </p>
-                    </div>
-                </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Rendered output (MLA, mixed script)</div>
+                <pre><code>English entry:   Smith, John A. Foundations of Knowledge. Oxford UP, 2019.
+Japanese entry:  田中一郎。『科学の構造』。東京大学出版会、2020年。
+Spanish entry:   García, María. "La ciencia moderna." Ciencias, vol. 5, 2021.</code></pre>
             </div>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="guides/style-authoring/locales.html">Locales and gender-aware terms</a>
+            </p>
+        </section>
 
-            <div class="example-section-muted">
-                <div class="example-callout">
-                    <div
-                        class="example-callout-icon">
-                        </div>
-                    <div>
-                        <strong class="example-strong">Key Features:</strong>
-                        First-match semantics prevent duplication. Selectors support type matching, field matching
-                        (language, keywords), citation status (visible/silent), and negation for fallback groups. See <a
-                            href="https://github.com/citum/citum-core/blob/main/docs/architecture/design/BIBLIOGRAPHY_GROUPING.md"
-                            class="example-link">design document</a> for full details.
-                    </div>
-                </div>
-            </div>
-
-            <!-- Grouping CLI Examples -->
-            <div class="example-section">
-                <div class="example-section-heading">
-                    <h3>
-                        Run Grouped Bibliographies
-                    </h3>
-                </div>
-
-                <!-- English Grouping Example -->
-                <div>
-                    <p class="example-small">
-                        Render a grouped bibliography with primary, archival, and secondary sources in English:
-                    </p>
-                    <div class="code-dark">
-                        <pre><span class="token-string">citum</span> render refs \
-  -b examples/bib-grouping-refs.yaml \
-  -s chicago-author-date</pre>
-                    </div>
-                    <p class="example-small">
-                        Expected output with English headings:
-                    </p>
-                    <div class="example-output-block example-small">
-                        <pre># Primary Sources
-
-Darwin, Charles. 1859. _On the Origin of Species_. John Murray.
-
-Freud, Sigmund. 1900. _Die Traumdeutung_. Franz Deuticke.
-
-# Archival Sources
-
-Darwin, Charles. 1876. “Letter to T.H. Huxley, 14 September 1876.”
-
-# Secondary Sources
-
-Browne, Janet. 2002. _Charles Darwin: The Power of Place_. Alfred A. Knopf.
-
-Gay, Peter. 1988. _Freud: A Life for Our Time_. W.W. Norton.
-
-Mayr, Ernst. 1991. “Darwin’s Impact on Modern Thought.” _Proceedings of the American Philosophical Society_. 135, (4): 317–30.</pre>
-                    </div>
-                </div>
-
-                <!-- Multilingual Grouping Example -->
-                <div class="example-io-panel">
-                    <p class="example-small">
-                        Render the multilingual grouping example shipped in the repo:
-                    </p>
-                    <div class="code-dark">
-                        <pre><span class="token-string">citum</span> render refs \
-  -b examples/multilingual-refs.yaml \
-  -s styles/experimental/multilingual-academic.yaml</pre>
-                    </div>
-                    <p class="example-small">
-                        This style groups Vietnamese and non-Vietnamese records separately and applies per-group sort
-                        behavior against the checked-in mixed-language sample corpus.
-                    </p>
-                </div>
-            </div>
-
-            <div class="example-section">
-                <div class="example-row">
-                    <h3>
-                        Gender-Aware Spanish Locale Terms
-                    </h3>
-                </div>
-                <div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Checked-In Locale
-                        </div>
-                        <div>
-                            <code>locales/es-ES.yaml</code>
-                            now ships gendered role labels such as
-                            <code>editor / editora / persona editora</code>.
-                        </div>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Contributor-Driven Role Label
-                        </div>
-                        <div>
-                            Ana Martinez, editora
-                        </div>
-                        <div class="example-small">
-                            A feminine contributor entry selects the feminine role label from the Spanish locale.
-                        </div>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Mixed-Gender Group
-                        </div>
-                        <div>
-                            Ana Martinez y Luis Pérez, equipo editorial
-                        </div>
-                        <div class="example-small">
-                            Mixed contributor genders prefer the locale's neutral/common form instead of falling back to a masculine-specific label.
-                        </div>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Template Override
-                        </div>
-                        <div class="code-dark">
-                            <pre><span class="token-key">template</span>:
-  - <span class="token-value">contributor</span>: <span class="token-string">editor</span>
-    <span class="token-value">form</span>: <span class="token-string">long</span>
-    <span class="token-value">gender</span>: <span class="token-string">feminine</span>
-  - <span class="token-value">number</span>: <span class="token-string">volume</span>
-    <span class="token-value">label-form</span>: <span class="token-string">short</span>
-    <span class="token-value">gender</span>: <span class="token-string">masculine</span></pre>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Archival & Eprints -->
-        <article id="archival-eprints" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Archival &amp; Eprints
-                    </h2>
-                <p class="example-muted">
-                    Citum now accepts structured <code>archive-info</code>
-                    data for manuscripts and related records, plus a structured
-                    <code>eprint</code> object for preprint-style identifiers.
-                </p>
-                <p class="example-muted">
-                    Legacy flat <code>archive</code> and
-                    <code>archive_location</code> fields still load for
-                    compatibility, but new inputs should use <code>archive-info</code>.
-                    Within <code>archive-info</code>, structured hierarchy
-                    fields such as <code>collection-id</code>,
-                    <code>series</code>,
-                    <code>box</code>,
-                    <code>folder</code>, and
-                    <code>item</code> are canonical;
-                    <code>location</code> is the display-override and
-                    legacy-fallback escape hatch for shelfmarks that cannot be decomposed cleanly.
-                </p>
-            </div>
-
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Reference Data (YAML)
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-key">references</span>:
-  - <span class="token-value">id</span>: <span class="token-string">dead-sea-scrolls-demo</span>
-    <span class="token-value">class</span>: <span class="token-string">monograph</span>
-    <span class="token-value">type</span>: <span class="token-string">manuscript</span>
-    <span class="token-value">title</span>: <span class="token-string">"The Community Rule (1QS)"</span>
-    <span class="token-value">issued</span>: <span class="token-string">"-0099"</span>
-    <span class="token-value">genre</span>: <span class="token-string">"Manuscript scroll"</span>
-    <span class="token-value">archive-info</span>:
-      <span class="token-value">name</span>: <span class="token-string">"Israel Antiquities Authority"</span>
-      <span class="token-value">location</span>: <span class="token-string">"Shrine of the Book"</span>
-      <span class="token-value">place</span>: <span class="token-string">"Jerusalem"</span>
-
-  - <span class="token-value">id</span>: <span class="token-string">archive-aware-preprint</span>
-    <span class="token-value">class</span>: <span class="token-string">monograph</span>
-    <span class="token-value">type</span>: <span class="token-string">preprint</span>
-    <span class="token-value">title</span>: <span class="token-string">"Archive-Aware Preprint"</span>
-    <span class="token-value">issued</span>: <span class="token-string">"2026-02"</span>
-    <span class="token-value">url</span>: <span class="token-string">"https://arxiv.org/abs/2602.01234"</span>
-    <span class="token-value">archive-info</span>:
-      <span class="token-value">name</span>: <span class="token-string">"Houghton Library"</span>
-      <span class="token-value">collection</span>: <span class="token-string">"Ada Lovelace Papers"</span>
-      <span class="token-value">collection-id</span>: <span class="token-string">"MS Am 1280"</span>
-      <span class="token-value">series</span>: <span class="token-string">"Correspondence"</span>
-      <span class="token-value">box</span>: <span class="token-string">"12"</span>
-      <span class="token-value">folder</span>: <span class="token-string">"4"</span>
-      <span class="token-value">item</span>: <span class="token-string">"7"</span>
-      <span class="token-value">place</span>: <span class="token-string">"Cambridge, MA"</span>
-      <span class="token-value">url</span>: <span class="token-string">"https://example.com/archive"</span>
-    <span class="token-value">eprint</span>:
-      <span class="token-value">id</span>: <span class="token-string">"2602.01234"</span>
-      <span class="token-value">server</span>: <span class="token-string">"arxiv"</span>
-      <span class="token-value">class</span>: <span class="token-string">"cs.DL"</span></pre>
-                </div>
-            </div>
-
-            <div class="example-card-body example-card-body-separated">
-                <div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Historical Manuscript Demo Output
-                        </div>
-                        <div>
-                            The Community Rule (1QS). Manuscript scroll, 100 BC, Israel Antiquities Authority, Shrine of the Book, Jerusalem
-                        </div>
-                        <div class="example-small">
-                            Verified with the checked-in
-                            <code>archive-eprint-demo-style</code>
-                            so the examples page reflects current branch behavior. The example uses valid EDTF
-                            astronomical year numbering, where <code>-0099</code>
-                            renders as <code>100 BC</code>.
-                        </div>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Archive + Eprint Demo Output
-                        </div>
-                        <div class="example-mono example-text-sm example-break">
-                            Archive-Aware Preprint. February 2026, Houghton Library, Ada Lovelace Papers, MS Am 1280, Series Correspondence, Box 12, Folder 4, Item 7, Cambridge, MA, https://example.com/archive, arxiv:2602.01234 [cs.DL]
-                        </div>
-                        <div class="example-small">
-                            Verified with the checked-in demo style that surfaces
-                            <code>archive-*</code> and
-                            <code>eprint-*</code> variables directly from
-                            the structured hierarchy, without collapsing them into a precomposed
-                            <code>location</code> string.
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="example-section">
-                <div class="example-row">
-                    <h3>
-                        Try It Yourself
-                    </h3>
-                </div>
-                <div>
-                    <p class="example-small">
-                        Render the archival manuscript with the current Chicago notes style:
-                    </p>
-                    <div class="code-dark">
-                        <pre><span class="token-string">citum</span> render refs \
-  -b tests/fixtures/references-humanities-note.json \
-  -s chicago-notes \
-  -k dead-sea-scrolls</pre>
-                    </div>
-                </div>
-                <div class="example-io-panel">
-                    <p class="example-small">
-                        Render the structured <code>archive-info</code> +
-                        <code>eprint</code> example with the demo style:
-                    </p>
-                    <div class="code-dark">
-                        <pre><span class="token-string">citum</span> render refs \
-  -b examples/archival-eprints.yaml \
-  -s examples/archive-eprint-demo-style.yaml \
-  -k archive-aware-preprint</pre>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Compound Numeric Sets -->
-        <article id="compound-numeric-sets" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Compound Numeric Sets
-                    </h2>
+        <section class="doc-section" id="edtf-dates">
+            <div class="doc-section-header">
+                <h2>EDTF dates &mdash; uncertain, approximate, seasonal</h2>
                 <p>
-                    Chemistry-style compound numeric output is modeled via top-level bibliography
-                    <code>sets</code>, not per-reference fields.
-                    Styles opt in with <code>compound-numeric</code>.
+                    Citum uses EDTF strings as its date exchange format. Semantic nuances are
+                    preserved and localized by the processor.
                 </p>
             </div>
-
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Input Bibliography (Independent Sets)
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-key">references</span>:
-  - <span class="token-value">id</span>: <span class="token-string">doe2024a</span>
-    <span class="token-value">class</span>: <span class="token-string">monograph</span>
-    <span class="token-value">type</span>: <span class="token-string">book</span>
-    <span class="token-value">title</span>: <span class="token-string">"Catalysis I"</span>
-    <span class="token-value">issued</span>: <span class="token-string">"2024"</span>
-  - <span class="token-value">id</span>: <span class="token-string">doe2024b</span>
-    <span class="token-value">class</span>: <span class="token-string">monograph</span>
-    <span class="token-value">type</span>: <span class="token-string">book</span>
-    <span class="token-value">title</span>: <span class="token-string">"Catalysis II"</span>
-    <span class="token-value">issued</span>: <span class="token-string">"2024"</span>
-
-<span class="token-key">sets</span>:
-  <span class="token-value">catalysis-series</span>: [<span class="token-string">doe2024a, doe2024b</span>]</pre>
-                </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Input &rarr; rendered (APA, en-US)</div>
+                <pre><code>"2004?"        → 2004?
+"2004~"        → ca. 2004
+"2023-05/.."   → May 2023–
+"2023-22"      → Summer 2023
+"-0099"        → 100 BC</code></pre>
             </div>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="guides/style-authoring/advanced-examples.html#advanced-dates">Advanced examples &rarr; EDTF dates</a>
+            </p>
+        </section>
 
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Style Opt-In
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-key">options</span>:
-  <span class="token-value">processing</span>: <span class="token-string">numeric</span>
-  <span class="token-value">bibliography</span>:
-    <span class="token-value">compound-numeric</span>:
-      <span class="token-value">subentry</span>: <span class="token-string">true</span>
-      <span class="token-value">sub-label</span>: <span class="token-string">alphabetic</span>
-      <span class="token-value">sub-label-suffix</span>: <span class="token-string">")"</span>
-      <span class="token-value">sub-delimiter</span>: <span class="token-string">", "</span></pre>
-                </div>
-            </div>
-
-            <div class="example-card-body">
-                <div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Citation Behavior</div>
-                        <div>subentry=true: [2a]/[2b], subentry=false: [2]</div>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Loader Validation</div>
-                        <div>Unknown IDs and duplicate membership across sets are rejected.</div>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Design Note</div>
-                        <div>No per-reference <code>group-key</code> is required or supported.</div>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Multilingual Support -->
-        <article id="multilingual-support" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Multilingual Support
-                    </h2>
+        <section class="doc-section" id="archival">
+            <div class="doc-section-header">
+                <h2>Archival references and eprints</h2>
                 <p>
-                    Current bibliography data can carry original text, transliterations, and translations.
-                    Styles then declare how titles and contributor names should render for a given workflow,
-                    and locale overrides can ship style-specific term and phrasing adjustments without cloning
-                    an entire style.
+                    Structured <code>archive-info</code> fields model collection hierarchy, shelfmarks,
+                    and institutional provenance. A structured <code>eprint</code> object handles
+                    preprint-style identifiers (arXiv, SSRN, bioRxiv, Zenodo, HAL).
                 </p>
+            </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Rendered output</div>
+                <pre><code>The Community Rule (1QS). Manuscript scroll, 100 BC,
+Israel Antiquities Authority, Shrine of the Book, Jerusalem.
+
+Archive-Aware Preprint. February 2026, Houghton Library,
+Ada Lovelace Papers, MS Am 1280. arxiv:2602.01234 [cs.DL]</code></pre>
+            </div>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="guides/style-authoring/advanced-examples.html#archival-eprints">Advanced examples &rarr; Archival references</a>
+            </p>
+        </section>
+
+        <section class="doc-section" id="annotated-bibliography">
+            <div class="doc-section-header">
+                <h2>Annotated bibliography</h2>
                 <p>
-                    The checked-in multilingual example now includes Vietnamese records for the grouped-bibliography
-                    demo, alongside accented Latin-script surnames so bibliography sorting can be verified against
-                    Unicode-aware collation, not raw byte ordering.
+                    Pass a separate annotations file at render time. Works with any style, no
+                    variants needed. Annotation text is parsed as Djot inline markup.
                 </p>
+            </div>
+            <div class="workshop-block">
+                <div class="workshop-label">Rendered output</div>
+                <pre><code>Smith, J. (2019). Foundations of knowledge. Oxford University Press.
+
+    A _landmark_ work. Particularly useful for its comparative methodology.</code></pre>
+            </div>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="guides/style-authoring/advanced-examples.html#annotated-bibliography">Advanced examples &rarr; Annotated bibliography</a>
+            </p>
+        </section>
+
+        <section class="doc-section" id="output-formats">
+            <div class="doc-section-header">
+                <h2>Pluggable output formats</h2>
                 <p>
-                    Locale term messages use <strong>Unicode MessageFormat 2 (MF2)</strong> syntax. The current
-                    evaluator supports a focused subset: variable substitution (<code>{$var}</code>),
-                    plural dispatch (<code>.match {$count :plural}</code> with
-                    <code>one</code>/<code>*</code>),
-                    and select dispatch (<code>.match {$var :select}</code>).
-                    Full CLDR plural rules and custom function annotations are deferred to a future ICU4X upgrade.
+                    A single style and bibliography renders to HTML, LaTeX, Typst, Djot, or plain
+                    text. The same citation logic applies across all formats.
                 </p>
             </div>
-
-            <!-- Style Configuration -->
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Style Configuration
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-key">options</span>:
-  <span class="token-value">multilingual</span>:
-    <span class="token-value">title-mode</span>: <span class="token-string">combined</span>
-    <span class="token-value">name-mode</span>: <span class="token-string">primary</span>
-    <span class="token-value">preferred-script</span>: <span class="token-string">Latn</span></pre>
-                </div>
+            <div class="workshop-block">
+                <div class="workshop-label">CLI flags</div>
+                <pre><code>citum render refs -b refs.json -s apa-7th -f html
+citum render refs -b refs.json -s apa-7th -f latex
+citum render refs -b refs.json -s apa-7th -f typst
+citum render refs -b refs.json -s apa-7th -f plain</code></pre>
             </div>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="guides/integrations/djot.html#other-output-formats">Djot recipe &rarr; Other output formats</a>
+            </p>
+        </section>
 
-            <!-- Reference Data -->
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Automatic Script &amp; Language Partitioning
-                    </h3>
-                </div>
-                <div class="example-card-body">
-                    <p>
-                        Bibliographies can be automatically partitioned by script or language. This ensures that
-                        references in different scripts (e.g., Latin and Arabic) are grouped together, and that
-                        subsequent-author substitutions correctly reset for each new partition section.
-                    </p>
-                    <div class="example-grid">
-                        <!-- Config -->
-                        <div class="example-stack">
-                            <div class="example-overline">Style Configuration</div>
-                            <div class="code-dark">
-                                <pre><span class="token-key">bibliography</span>:
-  <span class="token-value">options</span>:
-    <span class="token-value">sort-partitioning</span>:
-      <span class="token-value">by</span>: <span class="token-string">script</span>
-      <span class="token-value">mode</span>: <span class="token-string">sort-and-sections</span>
-      <span class="token-value">headings</span>:
-        <span class="token-value">Latn</span>:
-          <span class="token-value">literal</span>: <span class="token-string">"Western Sources"</span>
-        <span class="token-value">Arab</span>:
-          <span class="token-value">literal</span>: <span class="token-string">"Arabic Sources"</span></pre>
-                            </div>
-                        </div>
-                        <!-- Mock Output -->
-                        <div class="example-stack">
-                            <div class="example-overline">Partitioned Output</div>
-                            <div class="example-output-block example-small example-scroll-panel">
-                                <div class="example-strong"># Western Sources</div>
-                                <div class="example-gap-bottom">Smith, John. 2024. _First Book_.</div>
-                                <div class="example-gap-bottom-lg">———. 2025. _Second Book_.</div>
-
-                                <div class="example-strong"># Arabic Sources</div>
-                                <div class="example-gap-bottom">محمود, علي. 2023. _الكتاب الأول_.</div>
-                                <div class="example-gap-bottom">———. 2024. _الكتاب الثاني_.</div>
-                            </div>
-                            <p class="example-caption">
-                                Subsequent author dashes (———) are automatically reset when entering a new script partition.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+        <section class="doc-section" id="pdf-publishing">
+            <div class="doc-section-header">
+                <h2>PDF publishing</h2>
             </div>
-
-            <!-- Reference Data -->
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Reference Data (YAML)
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-key">id</span>: genji_tale
-<span class="token-key">class</span>: monograph
-<span class="token-key">type</span>: book
-<span class="token-key">title</span>:
-  <span class="token-value">original</span>: <span class="token-string">"源氏物語"</span>
-  <span class="token-value">lang</span>: <span class="token-string">"ja"</span>
-  <span class="token-value">transliterations</span>:
-    <span class="token-value">ja-Latn-hepburn</span>: <span class="token-string">"Genji Monogatari"</span>
-  <span class="token-value">translations</span>:
-    <span class="token-value">en</span>: <span class="token-string">"The Tale of Genji"</span>
-<span class="token-key">author</span>:
-  - <span class="token-value">original</span>:
-      <span class="token-value">family</span>: <span class="token-string">"紫式部"</span>
-      <span class="token-value">given</span>: <span class="token-string">""</span>
-    <span class="token-value">lang</span>: <span class="token-string">"ja"</span>
-    <span class="token-value">transliterations</span>:
-      <span class="token-value">ja-Latn-hepburn</span>:
-        <span class="token-value">family</span>: <span class="token-string">"Murasaki"</span>
-        <span class="token-value">given</span>: <span class="token-string">"Shikibu"</span>
-<span class="token-key">issued</span>: <span class="token-string">"1010"</span>
-<span class="token-key">publisher</span>:
-  <span class="token-value">name</span>: <span class="token-string">"古典文学之友"</span></pre>
-                </div>
+            <div class="doc-grid" style="margin-top: 0;">
+                <a class="doc-card" href="guides/integrations/typst.html">
+                    <h3>Typst</h3>
+                    <p>Render to Typst markup with Citum, compile to PDF with the Typst CLI. Internal
+                    citation links and DOI/URL links included.</p>
+                </a>
+                <a class="doc-card" href="guides/integrations/lualatex.html">
+                    <h3>LuaLaTeX <span style="font-size: 0.75em; font-weight: 400; color: var(--citum-muted);">(experimental)</span></h3>
+                    <p>Two-pass LuaLaTeX workflow via LuaJIT FFI or JSON-RPC. No Biber, no external
+                    bibliography tool. Lives in citum-labs.</p>
+                </a>
             </div>
+        </section>
 
-            <!-- Rendering Examples -->
-            <div>
-                <div>
-                    <h3>
-                        Rendered with MLA
-                    </h3>
-                </div>
-                <div class="example-card-body">
-                    <div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">
-                                Non-Integral Citation
-                            </div>
-                            <div>
-                                (紫式部)
-                            </div>
-                            <div class="example-small">
-                                Current MLA rendering for the checked-in multilingual record
-                            </div>
-                        </div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">
-                                Integral Citation
-                            </div>
-                            <div>
-                                紫式部
-                            </div>
-                            <div class="example-small">
-                                Integral rendering uses the same checked-in data
-                            </div>
-                        </div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">
-                                Bibliography Entry
-                            </div>
-                            <div>
-                                紫式部. _Genji Monogatari_. 古典文学之友, 1010.
-                            </div>
-                            <div class="example-small">
-                                Verified with <code>citum render refs -b examples/multilingual-refs.yaml -s mla -k genji_tale</code>
-                            </div>
-                        </div>
-                        <div class="example-io-panel">
-                            <div class="example-io-label">
-                                Mixed Corpus
-                            </div>
-                            <div>
-                                Çelik, Zeynep. _Streets: critical perspectives on public space_. University of California Press, 1996.
-                            </div>
-                            <div class="example-small">
-                                Plain English, multilingual, and accented Latin-script records can coexist in the same bibliography input
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Try It Yourself -->
-            <div class="example-section">
-                <div class="example-row">
-                    <h3>
-                        Try It Yourself
-                    </h3>
-                </div>
-                <div>
-                    <p class="example-small">
-                        Render the checked-in multilingual bibliography with a builtin style:
-                    </p>
-                    <div class="code-dark">
-                        <pre><span class="token-string">citum</span> render refs \
-  -b examples/multilingual-refs.yaml \
-  -s mla</pre>
-                    </div>
-                    <p class="example-small">
-                        For style-authoring work, compare this data with a style that sets different
-                        <code>options.multilingual</code> values.
-                    </p>
-                </div>
-                <div class="example-note-box example-note-box-accent">
-                    <p class="example-small">
-                        Render the script-partitioned bibliography example:
-                    </p>
-                    <div class="code-dark">
-                        <pre><span class="token-string">citum</span> render refs \
-  -b examples/multilingual-refs.yaml \
-  -s styles/experimental/multilingual-partitioned.yaml</pre>
-                    </div>
-                    <p class="example-small">
-                        This style demonstrates <code>sort-partitioning</code>
-                        by script, which separates Latin and Non-Latin records into distinct sections with reset subsequent-author substitutions.
-                    </p>
-                </div>
-                <div class="example-io-panel">
-                    <p class="example-small">
-                        Render the shipped German Chicago locale-override example:
-                    </p>
-                    <div class="code-dark">
-                        <pre><span class="token-string">citum</span> render refs \
-  -b tests/fixtures/references-expanded.json \
-  -s examples/preset-chicago-de.yaml</pre>
-                    </div>
-                    <p class="example-small">
-                        This example keeps Chicago Author-Date as the base style while switching to the shipped
-                        <code>de-DE-chicago</code> locale override.
-                    </p>
-                </div>
-            </div>
-        </article>
-
-        <!-- Advanced Dates -->
-        <article id="advanced-dates" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Advanced Dates
-                    </h2>
+        <section class="doc-section" id="interactive-html">
+            <div class="doc-section-header">
+                <h2>Interactive HTML</h2>
                 <p>
-                    Citum supports native <strong class="example-strong">EDTF (Extended Date/Time Format)</strong>
-                    for handling complex historical ranges, uncertain or approximate dates,
-                    and seasons.
-                </p>
-                <p class="example-muted">
-                    Historical EDTF years use astronomical numbering, so
-                    <code>-0099</code> means
-                    <code>100 BC</code>.
+                    Drop two assets into any page with Citum HTML output: citations become clickable,
+                    scroll to their bibliography entry, and show hover previews.
                 </p>
             </div>
-
-            <div class="example-card-body">
-                <div class="example-grid">
-                    <!-- Date Ranges -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Date Intervals (Level 0)</div>
-                        <div class="code-dark">
-                            <pre
-                                class="example-mono example-small"><span class="token-key">issued</span>: <span class="token-string">"2023-05/2024-06"</span>  <span class="token-comment"># Closed interval</span>
-<span class="token-key">issued</span>: <span class="token-string">"2023-05/.."</span>        <span class="token-comment"># Open start</span>
-<span class="token-key">issued</span>: <span class="token-string">"../2023-05"</span>        <span class="token-comment"># Open end</span></pre>
-                        </div>
-                    </div>
-
-                    <!-- Uncertain & Approximate -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Uncertain &amp; Approximate (Level
-                            1)</div>
-                        <div class="code-dark">
-                            <pre
-                                class="example-mono example-small"><span class="token-key">issued</span>: <span class="token-string">"2004?"</span>              <span class="token-comment"># Uncertain year (2004?)</span>
-<span class="token-key">issued</span>: <span class="token-string">"2004~"</span>              <span class="token-comment"># Approximate year (ca. 2004)</span>
-<span class="token-key">issued</span>: <span class="token-string">"2004%"</span>              <span class="token-comment"># Uncertain &amp; approximate</span>
-<span class="token-key">issued</span>: <span class="token-string">"2004-06-11?"</span>        <span class="token-comment"># Uncertain day only</span></pre>
-                        </div>
-                    </div>
-
-                    <!-- Seasons -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Seasons (Level 1)</div>
-                        <div class="code-dark">
-                            <pre
-                                class="example-mono example-small"><span class="token-key">issued</span>: <span class="token-string">"2023-21"</span>           <span class="token-comment"># Spring 2023</span>
-<span class="token-key">issued</span>: <span class="token-string">"2023-22"</span>           <span class="token-comment"># Summer 2023</span>
-<span class="token-key">issued</span>: <span class="token-string">"2023-23"</span>           <span class="token-comment"># Autumn 2023</span>
-<span class="token-key">issued</span>: <span class="token-string">"2023-24"</span>           <span class="token-comment"># Winter 2023</span></pre>
-                        </div>
-                    </div>
-
-                    <!-- Unspecified Digits -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Unspecified Digits (Level 1)
-                        </div>
-                        <div class="code-dark">
-                            <pre
-                                class="example-mono example-small"><span class="token-key">issued</span>: <span class="token-string">"199u"</span>              <span class="token-comment"># Some time in the 1990s</span>
-<span class="token-key">issued</span>: <span class="token-string">"2004-uu-uu"</span>        <span class="token-comment"># Some time in 2004 (month/day unknown)</span></pre>
-                        </div>
-                    </div>
-                </div>
+            <div class="workshop-block">
+                <pre><code>&lt;link rel="stylesheet" href="https://docs.citum.org/assets/citum-interactive.css"&gt;
+&lt;script src="https://docs.citum.org/assets/citum-interactive.js"&gt;&lt;/script&gt;</code></pre>
             </div>
+            <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                &rarr; <a href="interactive-demo.html">Live demo</a>
+                &nbsp;&middot;&nbsp;
+                <a href="developer.html#interactive">Developer &rarr; Interactive HTML</a>
+            </p>
+        </section>
 
-            <div class="example-section-muted">
-                <div class="example-callout">
-                    <div
-                        class="example-callout-icon">
-                        </div>
-                    <div>
-                        <strong class="example-strong">Fidelity First:</strong>
-                        Unlike CSL 1.0's structured date objects, Citum uses EDTF strings as the primary exchange format,
-                        ensuring that semantic nuances like "approximate" or "unspecified" are preserved and can be
-                        localized by the processor according to the style's locale.
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Options-Level Presets -->
-        <article id="options-presets" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Options Presets &amp; Style Inheritance
-                    </h2>
+        <section class="doc-section" id="performance">
+            <div class="doc-section-header">
+                <h2>Binary performance (CBOR)</h2>
                 <p>
-                    Common configuration patterns for contributors, dates,
-                    and titles can be expressed as a single preset name
-                    instead of spelling out every field. At the style level,
-                    <code>extends:</code>
-                    lets a thin wrapper inherit all templates from a named
-                    base style, then tune shared behavior through the same
-                    scoped configuration blocks as any other style:
-                    <code>options.*</code>,
-                    <code>citation.options.*</code>,
-                    and
-                    <code>bibliography.options.*</code>.
+                    Styles and bibliographies can be compiled to CBOR for near-instant loading in
+                    production environments.
                 </p>
             </div>
-            <div class="code-dark">
-                <pre>
-<span class="token-comment"># Named presets replace verbose config blocks</span>
-<span class="token-key">options</span>:
-  <span class="token-value">contributors</span>:            <span class="token-comment"># Explicit config (verbose)</span>
-    <span class="token-value">display-as-sort</span>: <span class="token-string">all</span>
-    <span class="token-value">initialize-with</span>: <span class="token-string">". "</span>
-    <span class="token-value">delimiter</span>: <span class="token-string">", "</span>
-    <span class="token-value">and</span>: <span class="token-string">symbol</span>
-  <span class="token-value">dates</span>: <span class="token-string">long</span>              <span class="token-comment"># Preset shorthand</span>
-  <span class="token-value">titles</span>: <span class="token-string">apa</span>             <span class="token-comment"># Preset shorthand</span>
+            <div class="workshop-block">
+                <pre><code># Compile style to binary
+citum convert style styles/apa-7th.yaml -o apa-7th.cbor
 
-<span class="token-comment"># Available presets:</span>
-<span class="token-comment">#   contributors: apa | chicago | harvard | ieee | springer | vancouver | numeric-compact | numeric-medium</span>
-<span class="token-comment">#   dates:        long | short | numeric | iso</span>
-<span class="token-comment">#   titles:       apa | chicago | humanities | ieee | journal-emphasis | scientific</span>
-<span class="token-comment">#   substitute:   standard | editor-* | editor-translator-* | editor-title-* | editor-translator-title-*</span>
-<span class="token-comment">#   citation:     extends: numeric-citation</span></pre>
+# Use binary inputs at render time
+citum render refs -b data.cbor -s apa-7th.cbor</code></pre>
             </div>
-            <div class="example-section">
-                <div>
-                    <h3>
-                        Style Inheritance
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-comment"># Inherit all templates from a named base; add only metadata</span>
-<span class="token-key">extends</span>: <span class="token-string">springer-basic-author-date-core</span></pre>
-                </div>
-            </div>
-            <div class="example-section">
-                <div>
-                    <h3>
-                        Scoped Options
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-comment"># Style-wide option: choose a contributor preset without touching templates</span>
-<span class="token-key">extends</span>: <span class="token-string">springer-basic-author-date-core</span>
-<span class="token-key">options</span>:
-  <span class="token-value">contributors</span>: <span class="token-string">springer</span>
-<span class="token-key">bibliography</span>:
-  <span class="token-value">options</span>:
-    <span class="token-value">date-position</span>: <span class="token-string">after-author</span>
+        </section>
 
-<span class="token-comment"># Citation-scoped and bibliography-scoped options</span>
-<span class="token-key">extends</span>: <span class="token-string">elsevier-vancouver-core</span>
-<span class="token-key">citation</span>:
-  <span class="token-value">options</span>:
-    <span class="token-value">label-wrap</span>: <span class="token-string">brackets</span>
-<span class="token-key">bibliography</span>:
-  <span class="token-value">options</span>:
-    <span class="token-value">label-mode</span>: <span class="token-string">numeric</span>
-
-<span class="token-comment"># Use `options.*` for style-wide settings and nested `*.options.*` for scoped settings.</span>
-<span class="token-comment"># Supported fields here include: contributors | label-wrap | label-mode | date-position</span></pre>
-                </div>
-            </div>
-            <div class="example-section">
-                <div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Author-Date Inheritance
-                        </div>
-                        <div>
-                            <code>styles/embedded/springer-basic-author-date.yaml</code>
-                            inherits Springer's author-date base and sets name and date axes.
-                        </div>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Numeric Inheritance
-                        </div>
-                        <div>
-                            <code>styles/embedded/elsevier-vancouver.yaml</code>
-                            inherits Elsevier Vancouver and configures bracket + numeric labels.
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Title Formatting & Declarative Links -->
-        <article id="titles-links" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Titles &amp; Links
-                    </h2>
-                <p>
-                    Citum separates title content from its role (primary,
-                    parent-monograph, parent-serial) and uses declarative
-                    global formatting rules for consistency across item
-                    types.
-                </p>
-            </div>
-
-            <div class="example-grid example-grid-separated">
-                <div class="example-column-separated">
-                    <div>
-                        <h3>
-                            Global Formatting (options.titles)
-                        </h3>
-                    </div>
-                    <div class="code-dark">
-                        <pre>
-<span class="token-key">titles</span>:
-  <span class="token-value">monograph</span>:
-    <span class="token-value">emph</span>: <span class="token-string">true</span>      <span class="token-comment"># Italics for books</span>
-  <span class="token-value">periodical</span>:
-    <span class="token-value">emph</span>: <span class="token-string">true</span>      <span class="token-comment"># Italics for journals</span>
-  <span class="token-value">component</span>:
-    <span class="token-value">emph</span>: <span class="token-string">false</span>     <span class="token-comment"># Plain for articles</span></pre>
-                    </div>
-                </div>
-                <div>
-                    <div>
-                        <h3>
-                            Template Usage &amp; Links
-                        </h3>
-                    </div>
-                    <div class="code-dark">
-                        <pre>
-<span class="token-key">template</span>:
-  - <span class="token-value">title</span>: <span class="token-string">primary</span>
-    <span class="token-value">links</span>:
-      <span class="token-value">target</span>: <span class="token-string">doi</span>
-      <span class="token-value">anchor</span>: <span class="token-string">component</span>
-  - <span class="token-value">title</span>: <span class="token-string">parent-serial</span>
-    <span class="token-value">suffix</span>: <span class="token-string">","</span></pre>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Type Variants -->
-        <article id="overrides" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Type Variants
-                    </h2>
-                <p>
-                    When reference types need a completely different component layout,
-                    declare a <code class="example-mono">type-variants</code>
-                    map. Each entry replaces the default template for matching types.
-                    Use a comma-separated selector to share one template across multiple types.
-                </p>
-            </div>
-            <div class="code-dark">
-                <pre>
-<span class="token-key">bibliography</span>:
-  <span class="token-value">template</span>:              <span class="token-comment"># default for all other types</span>
-    - <span class="token-value">contributor</span>: <span class="token-string">author</span>
-    - <span class="token-value">date</span>: <span class="token-string">issued</span>
-    - <span class="token-value">title</span>: <span class="token-string">primary</span>
-    - <span class="token-value">variable</span>: <span class="token-string">publisher</span>
-
-  <span class="token-value">type-variants</span>:
-    <span class="token-string">article-journal</span>:      <span class="token-comment"># single type</span>
-      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
-      - <span class="token-value">date</span>: <span class="token-string">issued</span>
-      - <span class="token-value">title</span>: <span class="token-string">primary</span>
-      - <span class="token-value">title</span>: <span class="token-string">parent-serial</span>
-        <span class="token-value">emph</span>: <span class="token-string">true</span>
-
-    <span class="token-string">book, report</span>:         <span class="token-comment"># comma-separated: share one template</span>
-      - <span class="token-value">contributor</span>: <span class="token-string">author</span>
-      - <span class="token-value">date</span>: <span class="token-string">issued</span>
-      - <span class="token-value">title</span>: <span class="token-string">primary</span>
-        <span class="token-value">emph</span>: <span class="token-string">true</span>
-      - <span class="token-value">variable</span>: <span class="token-string">publisher</span></pre>
-            </div>
-        </article>
-
-        <!-- Output Formats -->
-        <article id="output-formats" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Pluggable Output Formats
-                    </h2>
-                <p>
-                    Citum supports multiple output formats with a pluggable
-                    architecture. Generate semantic HTML, native LaTeX, flexible Djot for
-                    static site generators, native Typst markup, or clean Plain Text.
-                </p>
-            </div>
-
-            <div class="example-card-body">
-                <div>
-                    <!-- Plain Text -->
-                    <div>
-                        <div class="example-io-label">
-                            Plain Text (-f plain)
-                        </div>
-                        <div>
-                            Smith, J. A. (2023). The Future of Citations.
-                            Academic Press.
-                        </div>
-                    </div>
-
-                    <!-- LaTeX -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Native LaTeX (-f latex)
-                        </div>
-                        <div class="code-dark">
-                            <pre>
-Smith, J. A. (2023). \textit{The Future of Citations}. Academic Press.</pre>
-                        </div>
-                    </div>
-
-                    <!-- HTML -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Semantic HTML (-f html)
-                        </div>
-                        <div class="code-dark">
-                            <pre>
-&lt;<span class="token-key">span</span> <span class="token-value">class</span>=<span class="token-string">"citum-entry"</span>&gt;
-  &lt;<span class="token-key">span</span> <span class="token-value">class</span>=<span class="token-string">"citum-author"</span>&gt;Smith, J. A.&lt;/<span class="token-key">span</span>&gt; (2023).
-  &lt;<span class="token-key">i</span> <span class="token-value">class</span>=<span class="token-string">"citum-title"</span>&gt;The Future of Citations&lt;/<span class="token-key">i</span>&gt;. Academic Press.
-&lt;/<span class="token-key">span</span>&gt;</pre>
-                        </div>
-                    </div>
-
-                    <!-- Djot -->
-                    <div class="example-io-panel">
-                        <div class="example-io-label">
-                            Djot (-f djot)
-                        </div>
-                        <div class="code-dark">
-                            <pre>
-[Smith, J. A.]<span class="token-value">{.citum-author}</span> (2023). _The Future of Citations_<span class="token-value">{.citum-title}</span>. Academic Press.</pre>
-                        </div>
-                    </div>
-
-                    <!-- Typst -->
-                    <div class="example-note-box example-note-box-info">
-                        <div class="example-io-label">
-                            Typst Markup (-f typst)
-                        </div>
-                        <div class="code-dark">
-                            <pre>
-Smith, J. A. (2023). _The Future of Citations_. Academic Press. &lt;ref-smith2023&gt;</pre>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="example-section-muted">
-                <div class="example-callout">
-                    <div
-                        class="example-callout-icon">
-                        </div>
-                    <div>
-                        <strong class="example-strong">Consistent Rendering:</strong>
-                        The pluggable renderer system ensures that complex CSL rules (sorting, disambiguation, name
-                        formatting) are applied identically regardless of the output target. LaTeX and Typst support include
-                        native escaping for their respective markup systems, and Typst can now be compiled to PDF directly
-                        from the CLI.
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Typst PDF Publishing -->
-        <article id="typst-pdf-publishing" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                    Typst PDF Publishing
-                    <span class="example-badge example-badge-info">Native Rust path</span>
-                </h2>
-                <p>
-                    Citum now supports a native Typst workflow for PDF publishing. The Rust engine renders citations,
-                    notes, and bibliography entries to Typst markup, then the CLI can compile that markup to PDF in
-                    process with the optional <code>typst-pdf</code> feature.
-                    This keeps citation logic in Citum while giving you a modern PDF toolchain without a TeX or FFI step.
-                </p>
-                <div class="code-dark">
-                    <pre>.djot + refs.json + style.yaml
-  └─► citum render doc -f typst
-         └─► Typst markup (.typ)
-                └─► embedded Typst Rust crates
-                       └─► PDF with internal citation links and live DOI/URL links</pre>
-                </div>
-            </div>
-
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        CLI Workflow
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-comment"># 1. Render Typst markup</span>
-<span class="token-value">$</span> citum render doc examples/document.djot -b examples/document-refs.json -s mla -f typst
-
-<span class="token-comment"># 2. Compile directly to PDF</span>
-<span class="token-value">$</span> cargo run -p citum --features typst-pdf -- render doc examples/document.djot -b examples/document-refs.json -s mla -f typst --pdf -o paper.pdf</pre>
-                </div>
-            </div>
-
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        What This Gives You
-                    </h3>
-                </div>
-                <div class="example-card-body">
-                    <div class="example-grid example-text-sm">
-                        <div class="example-output-block">
-                            <h4 class="example-strong">Citum remains the citation formatter</h4>
-                            Citum still handles citation formatting, bibliography grouping, note behavior, and link
-                            resolution. Typst is the markup and PDF backend, not the bibliography engine.
-                        </div>
-                        <div class="example-output-block">
-                            <h4 class="example-strong">Practical PDF interactivity</h4>
-                            Generated PDFs include internal citation-to-bibliography links and external DOI/URL links.
-                            Advanced hover-only behaviors and custom metadata popups are not currently part of the Typst path.
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="example-section-muted">
-                <div class="example-callout">
-                    <div
-                        class="example-callout-icon">
-                        </div>
-                    <div>
-                        <strong class="example-strong">Positioning:</strong>
-                        Use Typst when you want a pure Rust markup-to-PDF workflow driven by the CLI. The
-                        LuaLaTeX example below remains useful for TeX-native documents and direct
-                        <code>\cite{...}</code> integration.
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- LuaLaTeX Integration -->
-        <article id="lualatex-integration" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        LuaLaTeX Integration
-                        <span class="example-badge example-badge-warning">Proof-of-concept</span>
-                    </h2>
-                <p>
-                    A single-pass LuaLaTeX citation workflow backed by the Citum Rust processor via C-FFI.
-                    No Biber, no <code>.bbl</code> file, no
-                    external bibliography step. The processor runs inline during compilation via LuaJIT FFI,
-                    and all Citum output rules (disambiguation, name formatting, et-al) apply identically.
-                    If you want a pure Rust PDF path instead, see the Typst example above.
-                </p>
-                <div class="code-dark">
-                    <pre>.tex \cite{key}
-  └─► \directlua ──► citum-cli.lua (LuaJIT FFI) ──► libcsln_processor (Rust)
-                                                       │
-                       tex.sprint(rendered) ◄──────────┘</pre>
-                </div>
-            </div>
-
-            <!-- Usage -->
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Package Usage (citum-cli.sty)
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-comment">% Load with your YAML style and bibliography</span>
-\usepackage[style=<span class="token-string">styles/apa-7th.yaml</span>,bibfile=<span class="token-string">refs.yaml</span>]{citum-cli}
-
-<span class="token-comment">% Non-integral (parenthetical)</span>
-\cite[p.~10]{<span class="token-string">kuhn1962</span>}               <span class="token-comment">% → (Kuhn, 1962, p. 10)</span>
-
-<span class="token-comment">% Integral (narrative)</span>
-\textcite{<span class="token-string">weinberg1971</span>}              <span class="token-comment">% → Weinberg and Freedman (1971)</span>
-
-<span class="token-comment">% Multi-key parenthetical</span>
-\cites{<span class="token-string">kuhn1962, watson1953</span>}          <span class="token-comment">% → (Kuhn, 1962; Watson &amp; Crick, 1953)</span>
-
-<span class="token-comment">% Print bibliography</span>
-\printbibliography</pre>
-                </div>
-            </div>
-
-            <!-- Build -->
-            <div class="example-subsection"><div class="example-subsection-header">
-                    <h3>
-                        Build Instructions
-                    </h3>
-                </div>
-                <div class="code-dark">
-                    <pre>
-<span class="token-comment"># 1. Build the shared library</span>
-<span class="token-value">$</span> cargo build -p citum-bindings --release
-
-<span class="token-comment"># 2. Compile your document</span>
-<span class="token-value">$</span> CITUM_LIB=$(pwd)/target/release lualatex --shell-escape paper.tex</pre>
-                </div>
-            </div>
-
-            <div class="example-section-muted">
-                <div class="example-callout">
-                    <div
-                        class="example-callout-icon example-callout-icon-warning">
-                        </div>
-                    <div>
-                        <strong class="example-strong">Proof-of-concept status:</strong>
-                        Currently targets macOS and Linux. A full working example document is available in
-                        <a href="https://github.com/citum/citum-labs/tree/main/bindings/latex"
-                            class="example-link">bindings/latex/</a>.
-                        The <code>&amp;</code> conjunction in
-                        two-author citations is correctly escaped for LuaLaTeX output.
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Binary Performance -->
-        <article id="binary-performance" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Binary Performance (CBOR)
-                    </h2>
-                <p>
-                    For production environments, Citum styles and
-                    bibliographies can be compiled into binary CBOR (Concise
-                    Binary Object Representation) for near-instant loading.
-                </p>
-            </div>
-            <div class="example-card-body">
-                <div class="example-grid">
-                    <div>
-                        <h4 class="example-heading-small">
-                            Compilation
-                        </h4>
-                        <div class="code-dark">
-                            <span class="token-value">$</span> citum convert style
-                            styles/embedded/apa-7th.yaml -o /tmp/apa-7th.cbor
-                        </div>
-                        <p class="example-caption">
-                            Binary formats can reduce parse overhead for
-                            large styles and bibliographies.
-                        </p>
-                    </div>
-                    <div>
-                        <h4 class="example-heading-small">
-                            Processing
-                        </h4>
-                        <div class="code-dark">
-                            <span class="token-value">$</span> citum render refs
-                            -b data.cbor -s style.cbor
-                        </div>
-                        <p class="example-caption">
-                            Full binary pipeline for maximum throughput.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Schema Generation -->
-        <article id="schema-generation" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                    Schema Generation
-                </h2>
-                <p>
-                    Citum can generate JSON Schemas for its configuration formats, enabling
-                    rich IDE support, validation, and auto-completion in editors like VS Code.
-                </p>
-            </div>
-            <div class="example-card-body">
-                <div class="example-note-box">
-                    <h4 class="example-heading-small">
-                        Generation Command (Optional Feature)
-                    </h4>
-                    <div class="code-dark">
-                        <span class="token-value">$</span> cargo run --bin citum --features schema -- schema &gt;
-                        citum.schema.json
-                    </div>
-                    <p class="example-caption">
-                        Use this only when generating schemas locally; published schemas are already available on the
-                        project website.
-                    </p>
-                </div>
-            </div>
-        </article>
-
-        <!-- Web Interactivity -->
-        <article id="web-interactivity" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Web Interactivity
-                    </h2>
-                <p>
-                    Citum provides optional JS/CSS assets that enrich semantic HTML output with interactive behaviors.
-                    They target data attributes injected by the processor, providing a <strong
-                        class="example-strong">progressive enhancement</strong> layer for web-based citation views.
-                </p>
-                <a href="interactive-demo.html"
-                    class="citum-button-primary">
-                    Explore Enhancements
-                    </a>
-            </div>
-            <div class="example-card-body">
-                <div class="example-grid">
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Bidirectional Navigation</div>
-                        <p>Click a citation to scroll to its bibliography entry. Hover an
-                            entry to highlight all its citations in the document.</p>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Hover Tooltips</div>
-                        <p>Instant reference previews on citation hover, utilizing
-                            metadata attributes stored directly in the entry container.</p>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Sidebar Layouts</div>
-                        <p>Optimized for note-style documents. Bibliographies can be
-                            pulled into a sticky sidebar on large screens.</p>
-                    </div>
-                    <div class="example-io-panel">
-                        <div class="example-io-label">Theming</div>
-                        <p>Fully customizable via CSS variables. Includes high-contrast
-                            support and clean print styles.</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Integration Guide -->
-            <div class="example-section-muted">
-                <h3>Quick Start Integration</h3>
-                <p class="example-muted example-text-sm">To add interactivity to your own site, simply include the
-                    following tags in your HTML. These link to the latest assets via the JSDelivr CDN.</p>
-
-                <div class="example-stack">
-                    <div>
-                        <div class="example-overline">1. CSS (Place
-                            in &lt;head&gt;)</div>
-                        <div class="code-dark">
-                            <pre
-                                class="example-mono example-small">&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/citum/citum-core@main/docs/assets/citum-interactive.css"&gt;</pre>
-                        </div>
-                    </div>
-                    <div>
-                        <div class="example-overline">2. JS (Place
-                            before &lt;/body&gt;)</div>
-                        <div class="code-dark">
-                            <pre
-                                class="example-mono example-small">&lt;script src="https://cdn.jsdelivr.net/gh/citum/citum-core@main/docs/assets/citum-interactive.js"&gt;&lt;/script&gt;</pre>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="example-gap-top-lg">
-                    <div class="example-note-box">
-                        <h4 class="example-heading-small">
-                            Requirements
-                        </h4>
-                        <p class="example-small">Requires HTML output generated by the Citum processor
-                            (including v0.6.0+), which includes the semantic classes and data attributes used by the
-                            interactive layer.</p>
-                    </div>
-                    <div class="example-note-box">
-                        <h4 class="example-heading-small">
-                            Sidebar Layout
-                        </h4>
-                        <p class="example-small">To enable the sidebar mode on large screens, wrap your content
-                            and bibliography in a container with the class <code
-                                class="example-inline-code">citum-with-sidebar</code>.</p>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        <!-- Annotated Bibliography -->
-        <article id="annotated-bibliography" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Annotated Bibliography
-                    </h2>
-                <p class="example-muted">
-                    Attach reader-authored annotations to any bibliography without style variants. Annotations are passed as a separate
-                    YAML or JSON file mapping reference IDs to annotation text. The processor appends annotations after each entry,
-                    respecting formatting options for italic, indentation, and paragraph spacing.
-                </p>
-            </div>
-            <div class="example-card-body">
-                <div class="example-overline">Render with Annotations</div>
-                <div class="code-dark">
-                    <pre>citum render refs \
-  -b examples/annotated-bibliography/references.yaml \
-  -s apa-7th \
-  --annotations examples/annotated-bibliography/annotations.yaml</pre>
-                </div>
-
-                <div class="example-overline">Sample Output</div>
-                <div class="example-output-block example-text-sm">
-                    <div class="example-mono-wrap">
-Smith, J. (2019). Foundations of knowledge. Oxford University Press.
-
-    A landmark work that fundamentally reshaped our understanding of the field.
-    Particularly useful for its comparative methodology.
-
-Hawking, S. (1988). A brief history of time. Bantam Books.
-
-    Accessible and intellectually ambitious. Balances rigour with clarity
-    for a general audience.
-                    </div>
-                </div>
-            </div>
-
-            <!-- Configuration Guide -->
-            <div class="example-section-muted">
-                <h3>Annotation Format</h3>
-                <p class="example-muted example-text-sm">Annotations are stored in a simple flat map. YAML is recommended for hand-authoring;
-                JSON is also supported.</p>
-
-                <div class="example-grid">
-                    <div>
-                        <div class="example-overline">YAML Format</div>
-                        <div class="code-dark">
-                            <pre>smith2019: >
-  A landmark work that fundamentally
-  reshaped our understanding.
-
-jones2021: >
-  Builds on smith2019 with modern
-  empirical analysis.</pre>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Documentation of annotation styling -->
-                <div class="example-output-block example-gap-top">
-                    <div class="example-overline">Styling Annotations</div>
-                    <p class="example-small">Annotation presentation is handled via CSS or document-level show rules. To style HTML output:</p>
-                    <pre class="example-code-sample">
-.citum-annotation {
-    font-style: italic;
-    padding-left: 1.5rem;
-    margin-top: 0.5rem;
-    color: #475569; /* slate-600 */
-}</pre>
-                </div>
-
-                <div class="example-note-box example-gap-top-lg">
-                    <h4 class="example-heading-small">
-                        Djot Inline Markup
-                    </h4>
-                    <p class="example-small">Annotation text is parsed as <a href="https://djot.net" class="example-link">djot</a> inline markup by default.
-                        Emphasis, strong, and verbatim code are rendered into the target output format automatically.
-                        Citum also recognises <code class="example-inline-code">{.smallcaps}[…]</code> spans as a convention on top of djot's generic span attributes.</p>
-                    <div class="code-dark">
-                        <pre>smith2019: >
-  A _landmark_ work. Particularly useful for its
-  {.smallcaps}[comparative methodology].</pre>
-                    </div>
-                    <p class="example-small">To opt out, set <code class="example-inline-code">format: plain</code> in the annotation style options.</p>
-                </div>
-
-                <div class="example-note-box example-gap-top">
-                    <h4 class="example-heading-small">
-                        Why Separate from References?
-                    </h4>
-                    <p class="example-small">Annotations are document-scoped overlays. The same reference carries different
-                        annotations in different contexts (a course syllabus vs. a grant proposal vs. a personal reading list).
-                        This design avoids style proliferation and keeps concerns separated.</p>
-                </div>
-            </div>
-        </article>
-
-        <!-- Abbreviation Maps -->
-        <article id="abbreviation-map" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Abbreviation Maps
-                    </h2>
-                <p class="example-muted">
-                    Substitute full rendered strings with abbreviations at document scope. Pass a YAML or JSON map at render time to replace
-                    journal titles, institutional names, corporate authors, and other strings with their abbreviations. The substitution applies after rendering,
-                    so any style renders the full title first, then the map replaces it with the abbreviation.
-                </p>
-            </div>
-            <div class="example-card-body">
-                <div class="example-overline">CLI Example</div>
-                <div class="code-dark">
-                    <pre>citum render refs \
-  -b examples/references.json \
-  -s ieee \
-  --abbreviation-map examples/abbrevs.yaml</pre>
-                </div>
-
-                <div class="example-overline">YAML Format</div>
-                <div class="example-grid">
-                    <div>
-                        <div class="code-dark">
-                            <pre>Estates Gazette: EG
-"Lloyd's Law Reports": "Lloyd's Rep"
-"World Health Organization": WHO
-Nature Reviews Neuroscience: Nat Rev Neurosci</pre>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="example-overline">Sample Output (Before &amp; After)</div>
-                <div class="example-output-block">
-                    <div>
-                        <div class="example-small">Without abbreviation map:</div>
-                        <div class="example-mono example-text-sm">
-                            Smith, J., et al. "Analysis of inheritance." <i>Nature Reviews Neuroscience</i>, vol. 24, no. 5, pp. 311–326, 2023.
-                        </div>
-                    </div>
-                    <div>
-                        <div class="example-small">With abbreviation map:</div>
-                        <div class="example-mono example-text-sm">
-                            Smith, J., et al. "Analysis of inheritance." <i>Nat Rev Neurosci</i>, vol. 24, no. 5, pp. 311–326, 2023.
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Configuration Guide -->
-            <div class="example-section-muted">
-                <h3>Abbreviation Map Format</h3>
-                <p class="example-muted example-text-sm">Abbreviation maps are simple flat key-value maps. Keys are full rendered strings (exact, case-sensitive). Values are the replacement abbreviations.</p>
-
-                <div class="example-output-block example-gap-top">
-                    <div class="example-overline">What Gets Abbreviated?</div>
-                    <ul class="example-list example-small">
-                        <li>Title fields: main title, container title, collection title</li>
-                        <li>Variable fields: publisher, archive, series</li>
-                        <li>Contributor literal names: corporate or institutional authors</li>
-                    </ul>
-                </div>
-
-                <div class="example-note-box example-gap-top-lg">
-                    <h4 class="example-heading-small">
-                        Why Separate from the Style?
-                    </h4>
-                    <p class="example-small">Abbreviations are document-scoped overlays. Different contexts may abbreviate the same reference differently (a journal article in a biology manuscript vs. a history paper). Keeping abbreviations separate from the style avoids proliferation of variant styles and keeps concerns separated.</p>
-                </div>
-            </div>
-        </article>
-
-        <!-- Distributed Registries -->
-        <article id="distributed-registries" class="example-card">
-            <div class="example-card-header">
-                <h2>
-                        Distributed Registries
-                        <span class="example-badge">New</span>
-                    </h2>
-                <p class="example-muted">
-                    Citum ships with a tiny embedded registry of builtin styles. Everything else
-                    lives in registries you opt into &mdash; the Citum Hub, an institutional
-                    registry, or your own static-HTTP host. Styles can be referenced by name,
-                    by URL, or by content-addressed
-                    <code class="example-inline-code">cid:</code> URI,
-                    and any
-                    <code class="example-inline-code">extends:</code>
-                    edge can be locked to a specific parent version with
-                    <code class="example-inline-code">extends-pin</code>.
-                </p>
-                <p class="example-muted">
-                    Walk the full UX in the
-                    <a class="example-link" target="_blank"
-                       href="https://github.com/citum/citum-core/blob/main/docs/guides/DISTRIBUTED_REGISTRIES.md">distributed
-                    registries guide</a>. Spec:
-                    <a class="example-link" target="_blank"
-                       href="https://github.com/citum/citum-core/blob/main/docs/specs/DISTRIBUTED_RESOLVER.md">DISTRIBUTED_RESOLVER.md</a>.
-                </p>
-            </div>
-
-            <div class="example-card-body">
-                <div>
-                    <div>
-                        <div class="example-io-label">
-                            Add a registry &amp; render against an HTTPS URL
-                        </div>
-                        <div class="code-dark">
-                            <pre>citum registry add https://hub.citum.org/registry/default.yaml --name citum-hub
-citum render refs -b refs.json -s https://hub.citum.org/styles/apa-7th.yaml</pre>
-                        </div>
-                    </div>
-
-                    <div>
-                        <div class="example-io-label">
-                            Pin a parent for reproducibility
-                        </div>
-                        <div class="code-dark">
-                            <pre>$ citum style pin apa-7th --uri https://hub.citum.org/styles/apa-7th.yaml
-extends: https://hub.citum.org/styles/apa-7th.yaml
-extends-pin: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44</pre>
-                        </div>
-                        <p>
-                            Paste the snippet at the top of any child style YAML. The resolver
-                            re-hashes the fetched parent and refuses to render if the bytes drift,
-                            so style inheritance becomes deterministic across upgrades.
-                        </p>
-                    </div>
-
-                    <div>
-                        <div class="example-io-label">
-                            Validate before publishing
-                        </div>
-                        <div class="code-dark">
-                            <pre>$ citum style validate my-journal.yaml
-OK   my-journal.yaml
-CID  bafkreigh2akiscaildc6mzfo4qtbk3rjmxa3ofkpzxqzd2cs6ftxvtsqfa
-Citum &gt;=0.38.0</pre>
-                        </div>
-                        <p>
-                            <code>style validate</code> resolves
-                            <code>extends</code> chains, verifies any
-                            <code>extends-pin</code>, and checks
-                            <code>info.citum-version</code> against the running
-                            engine. Air-gapped? Configure no remotes and the resolver chain falls
-                            through to your local store and the embedded builtins with zero
-                            network calls.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </article>
-
-        </div>
-        </div>
     </main>
 
     <!-- Footer -->

--- a/docs/guides/integrations/lualatex.html
+++ b/docs/guides/integrations/lualatex.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Citations in a static-site build | Citum Docs</title>
-    <meta name="description" content="Wire the citum CLI into a Makefile, npm script, or CI job to render Markdown with citations as part of your static-site build." />
+    <title>Use Citum from LuaLaTeX | Citum Docs</title>
+    <meta name="description" content="Experimental: a LuaLaTeX citation workflow backed by the Citum Rust engine via C FFI or JSON-RPC. No Biber, no external bibliography tool — two lualatex passes replaces them." />
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../assets/citum-theme.css" />
 </head>
@@ -50,96 +50,118 @@
 
     <main class="doc-shell">
         <header class="doc-section-header">
-            <span class="citum-kicker">Integration recipe</span>
-            <h1>Add citations to your static-site or docs build</h1>
+            <span class="citum-kicker">Integration recipe &mdash; experimental (citum-labs)</span>
+            <h1>Use Citum from LuaLaTeX</h1>
             <p>
-                You have a directory of Markdown (or Djot) files with <code>[@key]</code> markers and one shared
-                bibliography. You want citations rendered as part of your existing build, not as a separate manual
-                step. This recipe wires <code>citum</code> into a Makefile &mdash; the same idea translates to npm
-                scripts, justfiles, or CI jobs.
+                An experimental LuaLaTeX citation workflow backed by the Citum Rust processor.
+                No Biber, no external bibliography tool &mdash; two <code>lualatex</code> passes
+                replace them. All Citum output rules (disambiguation, name formatting, et-al) apply
+                identically across all output paths.
+            </p>
+            <p style="color: var(--citum-muted); font-size: 0.92rem;">
+                <strong>Experimental:</strong> this integration lives in
+                <a href="https://github.com/citum/citum-labs">citum-labs</a>, not citum-core, and
+                currently targets macOS and Linux. APIs and behaviour may change. For a simpler
+                TeX-free PDF path, see the <a href="typst.html">Typst recipe</a>.
             </p>
         </header>
 
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>1. Install citum on the build machine</h2>
-            </div>
-            <div class="workshop-block">
-                <pre><code>cargo install citum</code></pre>
-            </div>
-        </section>
-
-        <section class="doc-section">
-            <div class="doc-section-header">
-                <h2>2. One source file, one command</h2>
+                <h2>How it works</h2>
                 <p>
-                    The unit is one input document plus one (or more) bibliography files. Output format is controlled
-                    by <code>-f</code>; output path by <code>-o</code>.
+                    The <code>citum.sty</code> package loads a Lua module (<code>citum.lua</code>)
+                    that calls the Citum processor via LuaJIT FFI. Disambiguation and bibliography
+                    rendering require two compilation passes, similar to BibTeX or Biber:
                 </p>
             </div>
             <div class="workshop-block">
-                <pre><code>citum render doc content/post.md \
-  -I markdown \
-  -b references.json \
-  -s apa-7th \
-  -f html \
-  -o public/post.html</code></pre>
+                <pre><code>Pass 1: collects citation keys → writes .citum.json cache
+Pass 2: renders final citations and bibliography using the cache</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                Pass <code>-b</code> multiple times to merge bibliographies. Use <code>-c citations.yaml</code> if
-                your citations live outside the document.
+                If the Rust shared library is not found, the package automatically falls back to
+                JSON-RPC mode (connecting to a running <code>citum-server</code> instance). You can
+                also force RPC mode with the <code>rpc</code> package option.
             </p>
         </section>
 
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>3. Wire it into a Makefile</h2>
+                <h2>1. Build the shared library</h2>
                 <p>
-                    A pattern rule keeps one citum invocation per source file. Add a dependency on
-                    <code>references.json</code> so any bibliography edit triggers a rebuild.
+                    The LuaJIT FFI binding loads <code>libcitum_processor</code>, built from
+                    <code>crates/citum-bindings</code> in citum-core.
                 </p>
             </div>
             <div class="workshop-block">
-                <pre><code>STYLE := apa-7th
-REFS  := references.json
-SRC   := $(wildcard content/*.md)
-OUT   := $(patsubst content/%.md,public/%.html,$(SRC))
-
-public/%.html: content/%.md $(REFS)
-	@mkdir -p $(@D)
-	citum render doc $&lt; -I markdown -b $(REFS) -s $(STYLE) -f html -o $@
-
-build: $(OUT)
-.PHONY: build</code></pre>
+                <pre><code>cargo build -p citum-bindings --release
+# macOS: target/release/libcitum_processor.dylib
+# Linux: target/release/libcitum_processor.so</code></pre>
             </div>
         </section>
 
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>Other build systems</h2>
+                <h2>2. Load the package in your document</h2>
                 <p>
-                    The shape is the same in every build tool: one shell invocation per document. For npm scripts,
-                    wrap the same command in a Node script that iterates the source directory. For CI, run
-                    <code>cargo install citum</code> in a setup step and call the Makefile target. For
-                    pre-rendering inside a static-site generator that already supports shortcodes or filters, call
-                    <code>citum render doc</code> per page and inject the output.
+                    Place <code>citum.sty</code> and <code>citum.lua</code> from
+                    <a href="https://github.com/citum/citum-labs/tree/main/bindings/latex">citum-labs/bindings/latex/</a>
+                    alongside your document, then load the package with your style and bibliography.
                 </p>
             </div>
+            <div class="workshop-block">
+                <pre><code>\usepackage[style=apa-7th, bibfile=refs]{citum}
+
+% Non-integral (parenthetical)
+\cite[p.~10]{kuhn1962}               % → (Kuhn, 1962, p. 10)
+
+% Integral (narrative)
+\textcite{weinberg1971}              % → Weinberg and Freedman (1971)
+
+% Multi-key parenthetical
+\cites{kuhn1962, watson1953}         % → (Kuhn, 1962; Watson &amp; Crick, 1953)
+
+% Print bibliography
+\printbibliography</code></pre>
+            </div>
+        </section>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>3. Compile (two passes)</h2>
+                <p>
+                    Point <code>CITUM_LIB_PATH</code> at the full path of the shared library and
+                    run <code>lualatex</code> twice.
+                </p>
+            </div>
+            <div class="workshop-block">
+                <pre><code>export CITUM_LIB_PATH=$(pwd)/target/release/libcitum_processor.dylib
+lualatex paper.tex   # pass 1: collects keys
+lualatex paper.tex   # pass 2: renders final output</code></pre>
+            </div>
+            <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                On Linux replace <code>.dylib</code> with <code>.so</code>.
+                Set <code>CITUM_LUA_PATH</code> if <code>citum.lua</code> is not in the same
+                directory as <code>citum.sty</code>.
+            </p>
         </section>
 
         <section class="doc-section">
             <div class="doc-section-header">
                 <h2>Reproduce this recipe</h2>
                 <p>
-                    Fixture: <a href="fixtures/">guides/integrations/fixtures/</a> contains
-                    <code>manuscript.md</code> and <code>references.json</code>. Running the literal command above
-                    against those files produces well-formed HTML with citations and a bibliography &mdash; see the
-                    <a href="../../guides/style-authoring/advanced-examples.html">advanced examples</a> for more complex scenarios.
+                    A full working document with bibliography and all citation modes is in
+                    <a href="https://github.com/citum/citum-labs/tree/main/bindings/latex">citum-labs/bindings/latex/</a>
+                    (<code>citum-example.tex</code>, <code>example-refs.yaml</code>).
+                    The Lua binding source is in
+                    <a href="https://github.com/citum/citum-labs/tree/main/bindings/lua">citum-labs/bindings/lua/</a>.
                 </p>
             </div>
             <p>
-                Need live formatting from an editor or plugin instead of a build step? See
-                <a href="editor-plugin.html">Use Citum as a long-lived process</a>.
+                For a TeX-free PDF path, see the <a href="typst.html">Typst recipe</a>.
+                For C FFI usage from other languages, see
+                <a href="../../developer.html#ffi">Developer &rarr; C FFI</a>.
             </p>
         </section>
     </main>

--- a/docs/guides/integrations/typst.html
+++ b/docs/guides/integrations/typst.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Citations in a static-site build | Citum Docs</title>
-    <meta name="description" content="Wire the citum CLI into a Makefile, npm script, or CI job to render Markdown with citations as part of your static-site build." />
+    <title>Publish to PDF with Typst | Citum Docs</title>
+    <meta name="description" content="Render citations and bibliography to Typst markup with Citum, then compile to PDF with the Typst CLI. Citum handles citation formatting; Typst handles layout." />
     <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="../../assets/citum-theme.css" />
 </head>
@@ -51,95 +51,119 @@
     <main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe</span>
-            <h1>Add citations to your static-site or docs build</h1>
+            <h1>Publish to PDF with Typst</h1>
             <p>
-                You have a directory of Markdown (or Djot) files with <code>[@key]</code> markers and one shared
-                bibliography. You want citations rendered as part of your existing build, not as a separate manual
-                step. This recipe wires <code>citum</code> into a Makefile &mdash; the same idea translates to npm
-                scripts, justfiles, or CI jobs.
+                Citum renders citations and bibliography entries to Typst markup (<code>-f typst</code>).
+                Pass that output to the Typst CLI to compile to PDF. Citum handles all citation
+                formatting &mdash; disambiguation, grouping, note behavior, link resolution &mdash;
+                and Typst handles page layout and font rendering.
+            </p>
+            <p style="color: var(--citum-muted); font-size: 0.92rem;">
+                Direct PDF compilation via <code>--pdf</code> is not available in the current
+                crates.io release (the helper crate is not yet published). The two-step workflow
+                below works with any standard Typst installation.
             </p>
         </header>
 
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>1. Install citum on the build machine</h2>
+                <h2>1. Install both tools</h2>
             </div>
             <div class="workshop-block">
+                <div class="workshop-label">Citum</div>
                 <pre><code>cargo install citum</code></pre>
             </div>
+            <div class="workshop-block" style="margin-top: 1rem;">
+                <div class="workshop-label">Typst CLI</div>
+                <pre><code># macOS / Linux via Homebrew
+brew install typst
+
+# Or via Cargo
+cargo install typst-cli</code></pre>
+            </div>
         </section>
 
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>2. One source file, one command</h2>
+                <h2>2. Render to Typst markup</h2>
                 <p>
-                    The unit is one input document plus one (or more) bibliography files. Output format is controlled
-                    by <code>-f</code>; output path by <code>-o</code>.
+                    Use <code>-f typst</code> to run Citum&rsquo;s full citation engine and emit
+                    a <code>.typ</code> file. Any Citum-supported input format (<code>.djot</code>,
+                    <code>.md</code>) and bibliography format (YAML, CSL-JSON, CBOR) work here.
                 </p>
             </div>
             <div class="workshop-block">
-                <pre><code>citum render doc content/post.md \
-  -I markdown \
-  -b references.json \
+                <pre><code>citum render doc manuscript.djot \
+  -b refs.json \
   -s apa-7th \
-  -f html \
-  -o public/post.html</code></pre>
+  -f typst \
+  -o paper.typ</code></pre>
+            </div>
+        </section>
+
+        <section class="doc-section">
+            <div class="doc-section-header">
+                <h2>3. Compile to PDF</h2>
+                <p>
+                    Pass the generated <code>.typ</code> file to Typst. The resulting PDF includes
+                    internal citation-to-bibliography links and live DOI/URL links.
+                </p>
+            </div>
+            <div class="workshop-block">
+                <pre><code>typst compile paper.typ paper.pdf</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                Pass <code>-b</code> multiple times to merge bibliographies. Use <code>-c citations.yaml</code> if
-                your citations live outside the document.
+                Combined in one shell line:
             </p>
-        </section>
-
-        <section class="doc-section">
-            <div class="doc-section-header">
-                <h2>3. Wire it into a Makefile</h2>
-                <p>
-                    A pattern rule keeps one citum invocation per source file. Add a dependency on
-                    <code>references.json</code> so any bibliography edit triggers a rebuild.
-                </p>
-            </div>
-            <div class="workshop-block">
-                <pre><code>STYLE := apa-7th
-REFS  := references.json
-SRC   := $(wildcard content/*.md)
-OUT   := $(patsubst content/%.md,public/%.html,$(SRC))
-
-public/%.html: content/%.md $(REFS)
-	@mkdir -p $(@D)
-	citum render doc $&lt; -I markdown -b $(REFS) -s $(STYLE) -f html -o $@
-
-build: $(OUT)
-.PHONY: build</code></pre>
+            <div class="workshop-block" style="margin-top: 0.5rem;">
+                <pre><code>citum render doc manuscript.djot -b refs.json -s apa-7th -f typst -o paper.typ \
+  &amp;&amp; typst compile paper.typ paper.pdf</code></pre>
             </div>
         </section>
 
         <section class="doc-section">
             <div class="doc-section-header">
-                <h2>Other build systems</h2>
-                <p>
-                    The shape is the same in every build tool: one shell invocation per document. For npm scripts,
-                    wrap the same command in a Node script that iterates the source directory. For CI, run
-                    <code>cargo install citum</code> in a setup step and call the Makefile target. For
-                    pre-rendering inside a static-site generator that already supports shortcodes or filters, call
-                    <code>citum render doc</code> per page and inject the output.
-                </p>
+                <h2>What you get</h2>
             </div>
+            <div class="workshop-block" style="padding: 1.5rem; display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem;">
+                <div>
+                    <strong>Full Citum output rules</strong>
+                    <p style="margin-top: 0.5rem; color: var(--citum-muted); font-size: 0.92rem;">
+                        Citation disambiguation, bibliography grouping, name et-al, and note
+                        numbering all apply identically to the HTML and LaTeX paths. Typst is a
+                        rendering backend, not a bibliography engine.
+                    </p>
+                </div>
+                <div>
+                    <strong>Interactive PDF links</strong>
+                    <p style="margin-top: 0.5rem; color: var(--citum-muted); font-size: 0.92rem;">
+                        Internal citation-to-bibliography jumps and external DOI/URL links are
+                        embedded by Typst. Advanced hover behaviors and metadata popups are not
+                        currently part of the Typst output path.
+                    </p>
+                </div>
+            </div>
+            <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                Prefer a TeX-native document with <code>\cite{}</code> commands?
+                See the <a href="lualatex.html">LuaLaTeX integration</a> instead.
+            </p>
         </section>
 
         <section class="doc-section">
             <div class="doc-section-header">
                 <h2>Reproduce this recipe</h2>
                 <p>
-                    Fixture: <a href="fixtures/">guides/integrations/fixtures/</a> contains
-                    <code>manuscript.md</code> and <code>references.json</code>. Running the literal command above
-                    against those files produces well-formed HTML with citations and a bibliography &mdash; see the
-                    <a href="../../guides/style-authoring/advanced-examples.html">advanced examples</a> for more complex scenarios.
+                    Fixtures in <a href="fixtures/">guides/integrations/fixtures/</a>:
+                    <code>manuscript.djot</code> (source document) and
+                    <code>references.json</code> (CSL-JSON bibliography).
+                    Copy them locally and run the commands above.
                 </p>
             </div>
             <p>
-                Need live formatting from an editor or plugin instead of a build step? See
-                <a href="editor-plugin.html">Use Citum as a long-lived process</a>.
+                Rendering to HTML or LaTeX instead? See
+                <a href="djot.html">Write citations in Djot</a> for the full output-format
+                overview. Building in CI or a Makefile?
+                See <a href="static-site.html">Add citations to your static-site or docs build</a>.
             </p>
         </section>
     </main>

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -199,6 +199,10 @@
                                 <span class="material-icons text-sm">chevron_right</span>
                                 Complete Examples
                             </a>
+                            <a href="style-authoring/advanced-examples.html" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Advanced Examples
+                            </a>
                             <a href="#workflow-tips" class="sidebar-link">
                                 <span class="material-icons text-sm">chevron_right</span>
                                 Workflow & Tips

--- a/docs/guides/style-author-guide.template.html
+++ b/docs/guides/style-author-guide.template.html
@@ -206,6 +206,10 @@
                                 <span class="material-icons text-sm">chevron_right</span>
                                 Complete Examples
                             </a>
+                            <a href="style-authoring/advanced-examples.html" class="sidebar-link">
+                                <span class="material-icons text-sm">chevron_right</span>
+                                Advanced Examples
+                            </a>
                             <a href="#workflow-tips" class="sidebar-link">
                                 <span class="material-icons text-sm">chevron_right</span>
                                 Workflow & Tips

--- a/docs/guides/style-authoring/advanced-examples.html
+++ b/docs/guides/style-authoring/advanced-examples.html
@@ -1,0 +1,388 @@
+<!-- PAGE_ID: style -->
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        <title>Advanced Style Examples | Citum Docs</title>
+        <meta name="description" content="Worked examples for advanced Citum features: integral citations, archival references, EDTF dates, annotated bibliographies, and abbreviation maps." />
+        <link href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="../../assets/citum-theme.css">
+    </head>
+    <body>
+        <nav class="site-nav">
+            <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="../../index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../schemas/">Schemas</a>
+                <a class="site-nav-link " href="../../reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="../../index.html">Overview</a>
+            <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../schemas/">Schemas</a>
+            <a class="site-nav-link " href="../../reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+        </nav>
+
+        <main class="doc-shell">
+            <header class="doc-section-header">
+                <h1>Advanced Style Examples</h1>
+                <p>
+                    Worked examples for features that go beyond basic bibliography rendering &mdash;
+                    integral citations with name memory, archival references, EDTF dates, annotated
+                    bibliographies, and abbreviation maps.
+                </p>
+            </header>
+
+            <section class="doc-section" id="advanced-citations">
+                <div class="doc-section-header">
+                    <h2>Advanced Citations</h2>
+                    <p>
+                        Styles use explicit <code>integral</code> and <code>non-integral</code> branches,
+                        per-mode contributor options, and document-scoped integral-name memory where
+                        the style opts in. See <a href="templates.html#citation-modes">Templates &rarr; Citation modes</a>
+                        for the full configuration reference.
+                    </p>
+                </div>
+
+                <div class="doc-section-header" style="margin-top: 2rem;">
+                    <h3>Integral vs non-integral (APA 7th)</h3>
+                </div>
+                <div class="workshop-block">
+                    <div class="workshop-label">Style YAML (excerpt)</div>
+                    <pre><code>citation:
+  non-integral:
+    wrap: parentheses
+    template:
+      - contributor: author
+        form: short
+      - date: issued
+        form: year
+  integral:
+    options:
+      contributors:
+        and: text</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Rendered output</div>
+                    <pre><code>Non-integral: (Kuhn, 1962)
+Integral:     Kuhn and Popper (1962)</code></pre>
+                </div>
+
+                <div class="doc-section-header" style="margin-top: 2rem;">
+                    <h3>Integral name memory (MLA default)</h3>
+                    <p>
+                        When <code>integral-names</code> is configured, the first narrative citation
+                        uses the full name form; subsequent citations in the same scope use the short form.
+                        The scope resets at a chapter boundary.
+                    </p>
+                </div>
+                <div class="workshop-block">
+                    <div class="workshop-label">Style YAML</div>
+                    <pre><code>options:
+  integral-names:
+    rule: full-then-short
+    scope: document
+    contexts: body-and-notes
+    subsequent-form: short
+
+citation:
+  integral:
+    template:
+      - contributor: author
+        form: long
+      - variable: locator
+        show-label: false
+        wrap: parentheses</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Rendered output</div>
+                    <pre><code>First mention:      John Smith (10)
+Later same scope:   Smith (12)
+After chapter reset: John Smith (14)</code></pre>
+                </div>
+
+                <div class="doc-section-header" style="margin-top: 2rem;">
+                    <h3>Document override from front matter</h3>
+                    <p>
+                        Document front matter can override style-level integral-name settings.
+                        Useful when a document requires tighter name tracking than the base style provides.
+                    </p>
+                </div>
+                <div class="workshop-block">
+                    <div class="workshop-label">Djot document front matter</div>
+                    <pre><code>---
+integral-names:
+  enabled: true
+  scope: chapter
+  contexts: body-and-notes
+---
+
+First narrative mention: [+@smith2010, p. 10]
+Later in same chapter:   [+@smith2010, p. 12]
+New chapter reset:       [+@smith2010, p. 14]</code></pre>
+                </div>
+            </section>
+
+            <section class="doc-section" id="archival-eprints">
+                <div class="doc-section-header">
+                    <h2>Archival references and eprints</h2>
+                    <p>
+                        Citum accepts structured <code>archive-info</code> for manuscripts and related
+                        records, and a structured <code>eprint</code> object for preprint-style identifiers.
+                        Legacy flat <code>archive</code> and <code>archive_location</code> fields still load
+                        for compatibility, but new inputs should use <code>archive-info</code>.
+                    </p>
+                </div>
+                <div class="workshop-block">
+                    <div class="workshop-label">Reference YAML</div>
+                    <pre><code>references:
+  - id: dead-sea-scrolls-demo
+    class: monograph
+    type: manuscript
+    title: "The Community Rule (1QS)"
+    issued: "-0099"
+    genre: "Manuscript scroll"
+    archive-info:
+      name: "Israel Antiquities Authority"
+      location: "Shrine of the Book"
+      place: "Jerusalem"
+
+  - id: archive-aware-preprint
+    class: monograph
+    type: preprint
+    title: "Archive-Aware Preprint"
+    issued: "2026-02"
+    url: "https://arxiv.org/abs/2602.01234"
+    archive-info:
+      name: "Houghton Library"
+      collection: "Ada Lovelace Papers"
+      collection-id: "MS Am 1280"
+      series: "Correspondence"
+      box: "12"
+      folder: "4"
+      item: "7"
+      place: "Cambridge, MA"
+    eprint:
+      id: "2602.01234"
+      server: "arxiv"
+      class: "cs.DL"</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Rendered output (Chicago notes style)</div>
+                    <pre><code>The Community Rule (1QS). Manuscript scroll, 100 BC,
+Israel Antiquities Authority, Shrine of the Book, Jerusalem.
+
+Archive-Aware Preprint. February 2026, Houghton Library,
+Ada Lovelace Papers, MS Am 1280, Series Correspondence,
+Box 12, Folder 4, Item 7, Cambridge, MA. arxiv:2602.01234 [cs.DL]</code></pre>
+                </div>
+                <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                    Historical EDTF years use astronomical numbering: <code>-0099</code> renders as
+                    <code>100 BC</code>. The <code>eprint.server</code> value is normalized; supported
+                    values include <code>arxiv</code>, <code>ssrn</code>, <code>biorxiv</code>,
+                    <code>zenodo</code>, and <code>hal</code>.
+                </p>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Try it</div>
+                    <pre><code>citum render refs \
+  -b examples/archival-eprints.yaml \
+  -s examples/archive-eprint-demo-style.yaml \
+  -k archive-aware-preprint</code></pre>
+                </div>
+            </section>
+
+            <section class="doc-section" id="advanced-dates">
+                <div class="doc-section-header">
+                    <h2>Advanced dates (EDTF)</h2>
+                    <p>
+                        Citum uses <strong>EDTF (Extended Date/Time Format)</strong> as its primary date
+                        exchange format. EDTF strings preserve semantic nuances &mdash; approximate,
+                        uncertain, open-ended &mdash; that can be localized by the processor according to
+                        the style&rsquo;s locale.
+                    </p>
+                </div>
+                <div class="workshop-block">
+                    <div class="workshop-label">Date intervals (Level 0)</div>
+                    <pre><code>issued: "2023-05/2024-06"   # Closed interval
+issued: "2023-05/.."        # Open start
+issued: "../2023-05"        # Open end</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Uncertain and approximate (Level 1)</div>
+                    <pre><code>issued: "2004?"              # Uncertain year  → 2004?
+issued: "2004~"              # Approximate      → ca. 2004
+issued: "2004%"              # Both
+issued: "2004-06-11?"        # Uncertain day only</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Seasons (Level 1)</div>
+                    <pre><code>issued: "2023-21"            # Spring 2023
+issued: "2023-22"            # Summer 2023
+issued: "2023-23"            # Autumn 2023
+issued: "2023-24"            # Winter 2023</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Unspecified digits (Level 1)</div>
+                    <pre><code>issued: "199u"               # Some time in the 1990s
+issued: "2004-uu-uu"         # Some time in 2004, month/day unknown</code></pre>
+                </div>
+                <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                    Historical years use astronomical numbering: <code>-0099</code> = 100 BC.
+                    Locale determines how uncertainty modifiers (<code>?</code>, <code>~</code>)
+                    are rendered as text (&ldquo;?&rdquo;, &ldquo;ca.&rdquo;, &ldquo;circa&rdquo;, etc.).
+                </p>
+            </section>
+
+            <section class="doc-section" id="annotated-bibliography">
+                <div class="doc-section-header">
+                    <h2>Annotated bibliography</h2>
+                    <p>
+                        Attach reader-authored annotations to any bibliography without creating style
+                        variants. Annotations are passed as a separate YAML or JSON file mapping
+                        reference IDs to annotation text. The processor appends them after each entry.
+                    </p>
+                </div>
+                <div class="workshop-block">
+                    <div class="workshop-label">Render with annotations</div>
+                    <pre><code>citum render refs \
+  -b examples/annotated-bibliography/references.yaml \
+  -s apa-7th \
+  --annotations examples/annotated-bibliography/annotations.yaml</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Annotations file (YAML)</div>
+                    <pre><code>smith2019: >
+  A landmark work that fundamentally reshaped our understanding
+  of the field. Particularly useful for its comparative methodology.
+
+hawking1988: >
+  Accessible and intellectually ambitious. Balances rigour with
+  clarity for a general audience.</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Rendered output</div>
+                    <pre><code>Smith, J. (2019). Foundations of knowledge. Oxford University Press.
+
+    A landmark work that fundamentally reshaped our understanding of the
+    field. Particularly useful for its comparative methodology.
+
+Hawking, S. (1988). A brief history of time. Bantam Books.
+
+    Accessible and intellectually ambitious. Balances rigour with clarity
+    for a general audience.</code></pre>
+                </div>
+                <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                    Annotation text is parsed as Djot inline markup by default: <code>_italic_</code>,
+                    <code>*bold*</code>, and <code>[text]{.smallcaps}</code> are rendered into the target
+                    output format. To opt out, set <code>format: plain</code> in annotation style options.
+                </p>
+                <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                    Annotations are document-scoped overlays intentionally separate from references. The
+                    same reference can carry different annotations in a course syllabus, a grant proposal,
+                    and a personal reading list &mdash; no style variants needed.
+                </p>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Style HTML output with CSS</div>
+                    <pre><code>.citum-annotation {
+    font-style: italic;
+    padding-left: 1.5rem;
+    margin-top: 0.5rem;
+    color: #475569;
+}</code></pre>
+                </div>
+            </section>
+
+            <section class="doc-section" id="abbreviation-maps">
+                <div class="doc-section-header">
+                    <h2>Abbreviation maps</h2>
+                    <p>
+                        Substitute full rendered strings with abbreviations at document scope. Pass a YAML
+                        or JSON map at render time to replace journal titles, institutional names,
+                        corporate authors, and other strings. Substitution applies after rendering, so any
+                        style works without modification. See
+                        <a href="options.html#abbreviation-maps">Options &rarr; Document-level abbreviation maps</a>
+                        for full configuration.
+                    </p>
+                </div>
+                <div class="workshop-block">
+                    <div class="workshop-label">Abbreviations file (YAML)</div>
+                    <pre><code>Estates Gazette: EG
+"Lloyd's Law Reports": "Lloyd's Rep"
+"World Health Organization": WHO
+Nature Reviews Neuroscience: Nat Rev Neurosci</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Render with abbreviations</div>
+                    <pre><code>citum render refs \
+  -b examples/references.json \
+  -s ieee \
+  --abbreviation-map examples/abbrevs.yaml</code></pre>
+                </div>
+                <div class="workshop-block" style="margin-top: 1rem;">
+                    <div class="workshop-label">Before and after</div>
+                    <pre><code># Without map:
+Smith, J., et al. "Analysis of inheritance."
+Nature Reviews Neuroscience, vol. 24, no. 5, pp. 311–326, 2023.
+
+# With map:
+Smith, J., et al. "Analysis of inheritance."
+Nat Rev Neurosci, vol. 24, no. 5, pp. 311–326, 2023.</code></pre>
+                </div>
+                <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
+                    Keys are exact, case-sensitive rendered strings. What gets abbreviated: title fields
+                    (main title, container title, collection title), variable fields (publisher, archive,
+                    series), and contributor literal names. Abbreviations are document-scoped; keep them
+                    separate from the style so the same reference abbreviates differently in different
+                    contexts.
+                </p>
+            </section>
+        </main>
+
+        <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
+            <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="../../guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="../../developer.html">Developer</a>
+                    <a href="../../schemas/">Schemas</a>
+                    <a href="../../reports.html">Reports</a>
+                    <a href="../../operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>
+            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/github.min.css">
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js" defer onload="hljs.highlightAll();"></script>        <!-- LAYOUT_FOOTER_END -->
+        </footer>
+        <script src="../../assets/citum-interactive.js"></script>
+    </body>
+</html>

--- a/docs/interactive-demo.html
+++ b/docs/interactive-demo.html
@@ -148,7 +148,7 @@
 
   <div class="container-demo pt-24">
     <div class="flex justify-end mb-4">
-      <a href="examples.html#web-interactivity" class="config-link">
+      <a href="developer.html#interactive" class="config-link">
         <span class="material-icons" style="font-size: 1rem;">settings</span>
         View Configuration
       </a>


### PR DESCRIPTION
## Summary

- **`examples.html` slimmed** to a ~300-line capability showcase ("Capabilities | Citum") — one rendered output + deep-guide link per feature, no YAML deep-dives
- **New `guides/integrations/typst.html`** — two-step PDF recipe: `citum render … -f typst -o paper.typ` then `typst compile paper.typ paper.pdf`; notes `--pdf` is not in the current crates.io release
- **New `guides/integrations/lualatex.html`** — two-pass LuaLaTeX recipe, correctly marked experimental (lives in citum-labs), with RPC fallback, accurate `CITUM_LIB_PATH` / `libcitum_processor` names
- **New `guides/style-authoring/advanced-examples.html`** — worked examples for style authors (EDTF dates, archival/eprints, integral citations, annotated bibliography, abbreviation maps)
- **`developer.html`** updated: Typst card added to integrations grid; LuaLaTeX description updated for two-pass / citum-labs experimental status
- **Inbound links fixed**: `static-site.html`, `interactive-demo.html` → no longer point at removed `examples.html` anchors; `style-author-guide.html` + template get Advanced Examples sidebar entry

## Test plan

- [x] Open `docs/examples.html` — verify it loads as a clean capability showcase with working links to each deep guide
- [x] Open `docs/guides/integrations/typst.html` — verify numbered steps, "Reproduce" section, note about `--pdf` not in crates.io
- [x] Open `docs/guides/integrations/lualatex.html` — verify two-pass compile steps, experimental kicker, RPC fallback note
- [x] Open `docs/guides/style-authoring/advanced-examples.html` — verify all sections render with code blocks
- [x] Click every `→` link in `examples.html` — confirm each resolves to an existing anchor
- [x] Open `docs/interactive-demo.html` — "View Configuration" link should point to `developer.html#interactive`
- [x] Open `docs/guides/integrations/static-site.html` — advanced-examples link should resolve
