### PR TITLE
docs: fix site nav, integration sidebars, version badges

### DIFF
--- a/.beans/csl26-a2nz--fix-site-nav-sidebars-capabilities-nav-version-bad.md
+++ b/.beans/csl26-a2nz--fix-site-nav-sidebars-capabilities-nav-version-bad.md
@@ -1,0 +1,10 @@
+---
+# csl26-a2nz
+title: 'Fix site nav: sidebars, Capabilities nav, version badges, mobile'
+status: in-progress
+type: task
+created_at: 2026-05-19T17:55:01Z
+updated_at: 2026-05-19T17:55:01Z
+---
+
+1) Remove spurious version badges from 7 style-authoring pages; 2) Add advanced-examples.html to style-authoring sidebar; 3) Add sidebar to 7 integration pages; 4) Add Capabilities to top nav (all 29 pages); 5) Fix mobile sidebar (display:none → horizontal strip)

--- a/docs/architecture/design-principles.html
+++ b/docs/architecture/design-principles.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link active" href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../developer.html">Developer</a>
+                <a class="site-nav-link " href="../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link active" href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../developer.html">Developer</a>
+            <a class="site-nav-link " href="../developer.html">Integrate</a>
             <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -179,7 +181,7 @@ only for types that need a structurally different component set. Use option pres
                 </div>
                 <div class="site-footer-links">
                     <a href="../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../developer.html">Developer</a>
+                    <a href="../developer.html">Integrate</a>
                     <a href="../schemas/">Schemas</a>
                     <a href="../reports.html">Reports</a>
                     <a href="../operating.html">Contributing</a>

--- a/docs/architecture/migration-strategy.html
+++ b/docs/architecture/migration-strategy.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link active" href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../developer.html">Developer</a>
+                <a class="site-nav-link " href="../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link active" href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../developer.html">Developer</a>
+            <a class="site-nav-link " href="../developer.html">Integrate</a>
             <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -333,7 +335,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../developer.html">Developer</a>
+                    <a href="../developer.html">Integrate</a>
                     <a href="../schemas/">Schemas</a>
                     <a href="../reports.html">Reports</a>
                     <a href="../operating.html">Contributing</a>

--- a/docs/assets/citum-theme.css
+++ b/docs/assets/citum-theme.css
@@ -1016,8 +1016,16 @@ a {
   }
 
   .doc-sidebar {
-    display: none;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.25rem;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
     position: static;
+  }
+
+  .doc-sidebar-title {
+    display: none;
   }
 
   .doc-shell {

--- a/docs/developer.html
+++ b/docs/developer.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="developer.html">Developer</a>
+                <a class="site-nav-link active" href="developer.html">Integrate</a>
                 <a class="site-nav-link " href="interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="developer.html">Developer</a>
+            <a class="site-nav-link active" href="developer.html">Integrate</a>
             <a class="site-nav-link " href="interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
@@ -398,7 +400,7 @@ citum-server --http --port 8765       # HTTP mode (http feature)</code></pre>
                 </div>
                 <div class="site-footer-links">
                     <a href="guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="developer.html">Developer</a>
+                    <a href="developer.html">Integrate</a>
                     <a href="schemas/">Schemas</a>
                     <a href="reports.html">Reports</a>
                     <a href="operating.html">Contributing</a>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -28,8 +28,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
                 <a class="site-nav-link " href="interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
@@ -46,8 +47,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
             <a class="site-nav-link " href="interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
@@ -276,7 +278,7 @@ citum render refs -b data.cbor -s apa-7th.cbor</code></pre>
                 </div>
                 <div class="site-footer-links">
                     <a href="guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="developer.html">Developer</a>
+                    <a href="developer.html">Integrate</a>
                     <a href="schemas/">Schemas</a>
                     <a href="reports.html">Reports</a>
                     <a href="operating.html">Contributing</a>

--- a/docs/guides/integrations/djot.html
+++ b/docs/guides/integrations/djot.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="../../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="../../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -48,7 +50,18 @@
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <main class="doc-shell">
+    <div class="doc-sidebar-layout">
+<aside class="doc-sidebar" aria-label="Integration recipes">
+    <div class="doc-sidebar-title">Recipes</div>
+    <a class="doc-sidebar-link" href="scholar-cli.html">CLI / Scholar</a>
+    <a class="doc-sidebar-link active" href="djot.html">Djot</a>
+    <a class="doc-sidebar-link" href="static-site.html">Static sites</a>
+    <a class="doc-sidebar-link" href="rust-library.html">Rust library</a>
+    <a class="doc-sidebar-link" href="editor-plugin.html">Editor plugin</a>
+    <a class="doc-sidebar-link" href="typst.html">Typst PDF</a>
+    <a class="doc-sidebar-link" href="lualatex.html">LuaLaTeX</a>
+</aside>
+<main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe</span>
             <h1>Write citations in Djot &mdash; Citum&rsquo;s native format</h1>
@@ -189,6 +202,7 @@ citum render doc manuscript.djot -b references.json -s apa-7th --pdf -o paper.pd
             </p>
         </section>
     </main>
+</div>
 
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
@@ -199,7 +213,7 @@ citum render doc manuscript.djot -b references.json -s apa-7th --pdf -o paper.pd
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/integrations/editor-plugin.html
+++ b/docs/guides/integrations/editor-plugin.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="../../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="../../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -48,7 +50,18 @@
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <main class="doc-shell">
+    <div class="doc-sidebar-layout">
+<aside class="doc-sidebar" aria-label="Integration recipes">
+    <div class="doc-sidebar-title">Recipes</div>
+    <a class="doc-sidebar-link" href="scholar-cli.html">CLI / Scholar</a>
+    <a class="doc-sidebar-link" href="djot.html">Djot</a>
+    <a class="doc-sidebar-link" href="static-site.html">Static sites</a>
+    <a class="doc-sidebar-link" href="rust-library.html">Rust library</a>
+    <a class="doc-sidebar-link active" href="editor-plugin.html">Editor plugin</a>
+    <a class="doc-sidebar-link" href="typst.html">Typst PDF</a>
+    <a class="doc-sidebar-link" href="lualatex.html">LuaLaTeX</a>
+</aside>
+<main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe</span>
             <h1>Use Citum as a long-lived process from your editor or plugin</h1>
@@ -221,6 +234,7 @@ for await (const line of lines) {
             </div>
         </section>
     </main>
+</div>
 
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
@@ -231,7 +245,7 @@ for await (const line of lines) {
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/integrations/lualatex.html
+++ b/docs/guides/integrations/lualatex.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="../../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="../../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -48,7 +50,18 @@
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <main class="doc-shell">
+    <div class="doc-sidebar-layout">
+<aside class="doc-sidebar" aria-label="Integration recipes">
+    <div class="doc-sidebar-title">Recipes</div>
+    <a class="doc-sidebar-link" href="scholar-cli.html">CLI / Scholar</a>
+    <a class="doc-sidebar-link" href="djot.html">Djot</a>
+    <a class="doc-sidebar-link" href="static-site.html">Static sites</a>
+    <a class="doc-sidebar-link" href="rust-library.html">Rust library</a>
+    <a class="doc-sidebar-link" href="editor-plugin.html">Editor plugin</a>
+    <a class="doc-sidebar-link" href="typst.html">Typst PDF</a>
+    <a class="doc-sidebar-link active" href="lualatex.html">LuaLaTeX</a>
+</aside>
+<main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe &mdash; experimental (citum-labs)</span>
             <h1>Use Citum from LuaLaTeX</h1>
@@ -165,6 +178,7 @@ lualatex paper.tex   # pass 2: renders final output</code></pre>
             </p>
         </section>
     </main>
+</div>
 
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
@@ -175,7 +189,7 @@ lualatex paper.tex   # pass 2: renders final output</code></pre>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/integrations/rust-library.html
+++ b/docs/guides/integrations/rust-library.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="../../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="../../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -48,7 +50,18 @@
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <main class="doc-shell">
+    <div class="doc-sidebar-layout">
+<aside class="doc-sidebar" aria-label="Integration recipes">
+    <div class="doc-sidebar-title">Recipes</div>
+    <a class="doc-sidebar-link" href="scholar-cli.html">CLI / Scholar</a>
+    <a class="doc-sidebar-link" href="djot.html">Djot</a>
+    <a class="doc-sidebar-link" href="static-site.html">Static sites</a>
+    <a class="doc-sidebar-link active" href="rust-library.html">Rust library</a>
+    <a class="doc-sidebar-link" href="editor-plugin.html">Editor plugin</a>
+    <a class="doc-sidebar-link" href="typst.html">Typst PDF</a>
+    <a class="doc-sidebar-link" href="lualatex.html">LuaLaTeX</a>
+</aside>
+<main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe</span>
             <h1>Embed Citum in a Rust binary or library</h1>
@@ -274,6 +287,7 @@ println!("\n{}", result.bibliography.content);</code></pre>
             </p>
         </section>
     </main>
+</div>
 
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
@@ -284,7 +298,7 @@ println!("\n{}", result.bibliography.content);</code></pre>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/integrations/scholar-cli.html
+++ b/docs/guides/integrations/scholar-cli.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="../../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="../../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -48,7 +50,18 @@
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <main class="doc-shell">
+    <div class="doc-sidebar-layout">
+<aside class="doc-sidebar" aria-label="Integration recipes">
+    <div class="doc-sidebar-title">Recipes</div>
+    <a class="doc-sidebar-link active" href="scholar-cli.html">CLI / Scholar</a>
+    <a class="doc-sidebar-link" href="djot.html">Djot</a>
+    <a class="doc-sidebar-link" href="static-site.html">Static sites</a>
+    <a class="doc-sidebar-link" href="rust-library.html">Rust library</a>
+    <a class="doc-sidebar-link" href="editor-plugin.html">Editor plugin</a>
+    <a class="doc-sidebar-link" href="typst.html">Typst PDF</a>
+    <a class="doc-sidebar-link" href="lualatex.html">LuaLaTeX</a>
+</aside>
+<main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe</span>
             <h1>Format a Markdown or Djot document on the command line</h1>
@@ -161,6 +174,7 @@ citum convert refs legacy.json --from csl-json -o refs.yaml</code></pre>
             </p>
         </section>
     </main>
+</div>
 
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
@@ -171,7 +185,7 @@ citum convert refs legacy.json --from csl-json -o refs.yaml</code></pre>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/integrations/static-site.html
+++ b/docs/guides/integrations/static-site.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="../../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="../../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -48,7 +50,18 @@
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <main class="doc-shell">
+    <div class="doc-sidebar-layout">
+<aside class="doc-sidebar" aria-label="Integration recipes">
+    <div class="doc-sidebar-title">Recipes</div>
+    <a class="doc-sidebar-link" href="scholar-cli.html">CLI / Scholar</a>
+    <a class="doc-sidebar-link" href="djot.html">Djot</a>
+    <a class="doc-sidebar-link active" href="static-site.html">Static sites</a>
+    <a class="doc-sidebar-link" href="rust-library.html">Rust library</a>
+    <a class="doc-sidebar-link" href="editor-plugin.html">Editor plugin</a>
+    <a class="doc-sidebar-link" href="typst.html">Typst PDF</a>
+    <a class="doc-sidebar-link" href="lualatex.html">LuaLaTeX</a>
+</aside>
+<main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe</span>
             <h1>Add citations to your static-site or docs build</h1>
@@ -143,6 +156,7 @@ build: $(OUT)
             </p>
         </section>
     </main>
+</div>
 
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
@@ -153,7 +167,7 @@ build: $(OUT)
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/integrations/typst.html
+++ b/docs/guides/integrations/typst.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link active" href="../../developer.html">Developer</a>
+                <a class="site-nav-link active" href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link active" href="../../developer.html">Developer</a>
+            <a class="site-nav-link active" href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -48,7 +50,18 @@
         </div>        <!-- LAYOUT_NAV_END -->
     </nav>
 
-    <main class="doc-shell">
+    <div class="doc-sidebar-layout">
+<aside class="doc-sidebar" aria-label="Integration recipes">
+    <div class="doc-sidebar-title">Recipes</div>
+    <a class="doc-sidebar-link" href="scholar-cli.html">CLI / Scholar</a>
+    <a class="doc-sidebar-link" href="djot.html">Djot</a>
+    <a class="doc-sidebar-link" href="static-site.html">Static sites</a>
+    <a class="doc-sidebar-link" href="rust-library.html">Rust library</a>
+    <a class="doc-sidebar-link" href="editor-plugin.html">Editor plugin</a>
+    <a class="doc-sidebar-link active" href="typst.html">Typst PDF</a>
+    <a class="doc-sidebar-link" href="lualatex.html">LuaLaTeX</a>
+</aside>
+<main class="doc-shell">
         <header class="doc-section-header">
             <span class="citum-kicker">Integration recipe</span>
             <h1>Publish to PDF with Typst</h1>
@@ -167,6 +180,7 @@ cargo install typst-cli</code></pre>
             </p>
         </section>
     </main>
+</div>
 
     <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
         <!-- LAYOUT_FOOTER_START -->
@@ -177,7 +191,7 @@ cargo install typst-cli</code></pre>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -85,8 +85,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../developer.html">Developer</a>
+                <a class="site-nav-link " href="../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -103,8 +104,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../developer.html">Developer</a>
+            <a class="site-nav-link " href="../developer.html">Integrate</a>
             <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -1051,7 +1053,7 @@ Always pair opening prefix with closing suffix. For structural wrapping (e.g. pa
                 </div>
                 <div class="site-footer-links">
                     <a href="../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../developer.html">Developer</a>
+                    <a href="../developer.html">Integrate</a>
                     <a href="../schemas/">Schemas</a>
                     <a href="../reports.html">Reports</a>
                     <a href="../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/advanced-examples.html
+++ b/docs/guides/style-authoring/advanced-examples.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -57,6 +59,20 @@
                     bibliographies, and abbreviation maps.
                 </p>
             </header>
+
+            <div class="doc-sidebar-layout">
+                <aside class="doc-sidebar" aria-label="Style authoring sections">
+                    <div class="doc-sidebar-title">Guide</div>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/start.html">Start</a>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/style-anatomy.html">Style Anatomy</a>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/templates.html">Templates</a>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/options.html">Options</a>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
+                    <a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+                    <a class="doc-sidebar-link active" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
+                </aside>
+                <div>
 
             <section class="doc-section" id="advanced-citations">
                 <div class="doc-section-header">
@@ -361,6 +377,8 @@ Nat Rev Neurosci, vol. 24, no. 5, pp. 311–326, 2023.</code></pre>
                     contexts.
                 </p>
             </section>
+                </div>
+            </div>
         </main>
 
         <footer style="padding: 3rem 0; border-top: 1px solid var(--citum-border); background: var(--citum-surface);">
@@ -372,7 +390,7 @@ Nat Rev Neurosci, vol. 24, no. 5, pp. 311–326, 2023.</code></pre>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/inheritance-and-registries.html
+++ b/docs/guides/style-authoring/inheritance-and-registries.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -53,7 +55,6 @@
                 <span class="citum-kicker">Style authoring</span>
                 <h1>Inheritance and Registries</h1>
                 <p>Reuse base styles, pin remote parents, and validate distributed style dependencies.</p>
-                <div class="version-badges"><span class="version-badge" data-feature="style-inheritance-pins" data-status="active">active</span><span class="version-badge" data-feature="style-inheritance-pins">schema 0.38.0+</span><span class="version-badge" data-feature="style-inheritance-pins">engine 0.38.0+</span><span class="version-badge" data-feature="distributed-registries" data-status="active">active</span><span class="version-badge" data-feature="distributed-registries">schema 0.38.0+</span><span class="version-badge" data-feature="distributed-registries">engine 0.38.0+</span></div>
             </header>
 
             <div class="doc-sidebar-layout">
@@ -66,6 +67,7 @@
 <a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
 <a class="doc-sidebar-link active" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
                 </aside>
                 <article class="doc-prose">
                     <h2 id="extending-a-style">Extending a style</h2><p>Use <code>extends</code> when a style is mainly a tuned wrapper around an existing base.
@@ -117,7 +119,7 @@ checks pins, and applies <code>info.citum-version</code> requirements.</p>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/locales.html
+++ b/docs/guides/style-authoring/locales.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -53,7 +55,6 @@
                 <span class="citum-kicker">Style authoring</span>
                 <h1>Locales and Gender-Aware Terms</h1>
                 <p>Use locale terms for roles, labels, locators, and grammatical agreement.</p>
-                <div class="version-badges"><span class="version-badge" data-feature="gender-aware-locale-terms" data-status="active">active</span><span class="version-badge" data-feature="gender-aware-locale-terms">schema 0.49.0+</span><span class="version-badge" data-feature="gender-aware-locale-terms">engine 0.49.0+</span></div>
             </header>
 
             <div class="doc-sidebar-layout">
@@ -66,6 +67,7 @@
 <a class="doc-sidebar-link active" href="../../guides/style-authoring/locales.html">Locales</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
                 </aside>
                 <article class="doc-prose">
                     <h2 id="locale-owned-text">Locale-owned text</h2><p>Use locale terms for text that varies by language: page labels, role labels,
@@ -158,7 +160,7 @@ required plumbing.</div>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/options.html
+++ b/docs/guides/style-authoring/options.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -53,7 +55,6 @@
                 <span class="citum-kicker">Style authoring</span>
                 <h1>Options, Sorting, and Document Inputs</h1>
                 <p>Configure shared formatting behavior without duplicating templates.</p>
-                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span><span class="version-badge" data-feature="abbreviation-map" data-status="active">active</span><span class="version-badge" data-feature="abbreviation-map">schema 0.49.0+</span><span class="version-badge" data-feature="abbreviation-map">engine 0.49.0+</span></div>
             </header>
 
             <div class="doc-sidebar-layout">
@@ -66,6 +67,7 @@
 <a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
                 </aside>
                 <article class="doc-prose">
                     <h2 id="global-options">Global options</h2><p>Global options apply across citation and bibliography rendering unless a
@@ -153,7 +155,7 @@ full rendered strings after value extraction and before output assembly.</p>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/start.html
+++ b/docs/guides/style-authoring/start.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -53,7 +55,6 @@
                 <span class="citum-kicker">Style authoring</span>
                 <h1>Start Writing Citum Styles</h1>
                 <p>Learn the mental model for Citum styles and why the YAML format is different from CSL 1.0.</p>
-                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span></div>
             </header>
 
             <div class="doc-sidebar-layout">
@@ -66,6 +67,7 @@
 <a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
                 </aside>
                 <article class="doc-prose">
                     <h2 id="how-citum-differs">How Citum Differs</h2><p>Citum replaces procedural CSL XML with declarative YAML. A style describes the
@@ -139,7 +141,7 @@ distinction in the style. The engine should not silently guess style intent.</di
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/style-anatomy.html
+++ b/docs/guides/style-authoring/style-anatomy.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -53,7 +55,6 @@
                 <span class="citum-kicker">Style authoring</span>
                 <h1>Style File Anatomy</h1>
                 <p>The required top-level pieces of a Citum style file.</p>
-                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span></div>
             </header>
 
             <div class="doc-sidebar-layout">
@@ -66,6 +67,7 @@
 <a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
                 </aside>
                 <article class="doc-prose">
                     <h2 id="top-level-structure">Top-level structure</h2><p>Every Citum style has four practical layers:</p>
@@ -134,7 +136,7 @@ YAML Language Server use it for autocomplete and inline validation.</p>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/templates.html
+++ b/docs/guides/style-authoring/templates.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -53,7 +55,6 @@
                 <span class="citum-kicker">Style authoring</span>
                 <h1>Templates and Type Variants</h1>
                 <p>Build citation and bibliography output from explicit template components.</p>
-                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span></div>
             </header>
 
             <div class="doc-sidebar-layout">
@@ -66,6 +67,7 @@
 <a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/validation.html">Validation</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
                 </aside>
                 <article class="doc-prose">
                     <h2 id="template-components">Template components</h2><p>Templates are ordered component lists. Each component names the data it renders
@@ -160,7 +162,7 @@ citations.</p>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/guides/style-authoring/validation.html
+++ b/docs/guides/style-authoring/validation.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../../developer.html">Developer</a>
+                <a class="site-nav-link " href="../../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../../index.html">Overview</a>
+                <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../../developer.html">Developer</a>
+            <a class="site-nav-link " href="../../developer.html">Integrate</a>
             <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
@@ -53,7 +55,6 @@
                 <span class="citum-kicker">Style authoring</span>
                 <h1>Validation and Compatibility</h1>
                 <p>Check styles before publishing and understand the existing version enforcement boundaries.</p>
-                <div class="version-badges"><span class="version-badge" data-feature="style-authoring" data-status="active">active</span><span class="version-badge" data-feature="style-authoring">schema 0.1.0+</span><span class="version-badge" data-feature="style-authoring">engine 0.1.0+</span><span class="version-badge" data-feature="style-inheritance-pins" data-status="active">active</span><span class="version-badge" data-feature="style-inheritance-pins">schema 0.38.0+</span><span class="version-badge" data-feature="style-inheritance-pins">engine 0.38.0+</span></div>
             </header>
 
             <div class="doc-sidebar-layout">
@@ -66,6 +67,7 @@
 <a class="doc-sidebar-link" href="../../guides/style-authoring/locales.html">Locales</a>
 <a class="doc-sidebar-link" href="../../guides/style-authoring/inheritance-and-registries.html">Inheritance</a>
 <a class="doc-sidebar-link active" href="../../guides/style-authoring/validation.html">Validation</a>
+<a class="doc-sidebar-link" href="../../guides/style-authoring/advanced-examples.html">Advanced Examples</a>
                 </aside>
                 <article class="doc-prose">
                     <h2 id="validate-before-publishing">Validate before publishing</h2><p>Run the end-to-end style validator before publishing or comparing fidelity.</p>
@@ -119,7 +121,7 @@ artifacts</li>
                 </div>
                 <div class="site-footer-links">
                     <a href="../../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../../developer.html">Developer</a>
+                    <a href="../../developer.html">Integrate</a>
                     <a href="../../schemas/">Schemas</a>
                     <a href="../../reports.html">Reports</a>
                     <a href="../../operating.html">Contributing</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link active" href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
                 <a class="site-nav-link " href="interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link active" href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
             <a class="site-nav-link " href="interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
@@ -107,7 +109,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="developer.html">Developer</a>
+                    <a href="developer.html">Integrate</a>
                     <a href="schemas/">Schemas</a>
                     <a href="reports.html">Reports</a>
                     <a href="operating.html">Contributing</a>

--- a/docs/interactive-demo.html
+++ b/docs/interactive-demo.html
@@ -120,8 +120,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
                 <a class="site-nav-link active" href="interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
@@ -138,8 +139,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
             <a class="site-nav-link active" href="interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
@@ -245,7 +247,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="developer.html">Developer</a>
+                    <a href="developer.html">Integrate</a>
                     <a href="schemas/">Schemas</a>
                     <a href="reports.html">Reports</a>
                     <a href="operating.html">Contributing</a>

--- a/docs/operating.html
+++ b/docs/operating.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
                 <a class="site-nav-link " href="interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
             <a class="site-nav-link " href="interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
@@ -128,7 +130,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="developer.html">Developer</a>
+                    <a href="developer.html">Integrate</a>
                     <a href="schemas/">Schemas</a>
                     <a href="reports.html">Reports</a>
                     <a href="operating.html">Contributing</a>

--- a/docs/policies/type-addition-policy.html
+++ b/docs/policies/type-addition-policy.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link active" href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../developer.html">Developer</a>
+                <a class="site-nav-link " href="../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link active" href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../developer.html">Developer</a>
+            <a class="site-nav-link " href="../developer.html">Integrate</a>
             <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -709,7 +711,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../developer.html">Developer</a>
+                    <a href="../developer.html">Integrate</a>
                     <a href="../schemas/">Schemas</a>
                     <a href="../reports.html">Reports</a>
                     <a href="../operating.html">Contributing</a>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
                 <a class="site-nav-link " href="interactive-demo.html">Demo</a>
                 <a class="site-nav-link active" href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
             <a class="site-nav-link " href="interactive-demo.html">Demo</a>
             <a class="site-nav-link active" href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
@@ -99,7 +101,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="developer.html">Developer</a>
+                    <a href="developer.html">Integrate</a>
                     <a href="schemas/">Schemas</a>
                     <a href="reports.html">Reports</a>
                     <a href="operating.html">Contributing</a>

--- a/docs/reports.html
+++ b/docs/reports.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="developer.html">Developer</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
                 <a class="site-nav-link " href="interactive-demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link active" href="reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="developer.html">Developer</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
             <a class="site-nav-link " href="interactive-demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link active" href="reports.html">Reports</a>
@@ -99,7 +101,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="developer.html">Developer</a>
+                    <a href="developer.html">Integrate</a>
                     <a href="schemas/">Schemas</a>
                     <a href="reports.html">Reports</a>
                     <a href="operating.html">Contributing</a>

--- a/docs/schemas/index.html
+++ b/docs/schemas/index.html
@@ -21,8 +21,9 @@
             </div>
             <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
                 <a class="site-nav-link " href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../developer.html">Developer</a>
+                <a class="site-nav-link " href="../developer.html">Integrate</a>
                 <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
                 <a class="site-nav-link active" href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -39,8 +40,9 @@
         </div>
         <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
             <a class="site-nav-link " href="../index.html">Overview</a>
+                <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../developer.html">Developer</a>
+            <a class="site-nav-link " href="../developer.html">Integrate</a>
             <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
             <a class="site-nav-link active" href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
@@ -174,7 +176,7 @@
                 </div>
                 <div class="site-footer-links">
                     <a href="../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../developer.html">Developer</a>
+                    <a href="../developer.html">Integrate</a>
                     <a href="../schemas/">Schemas</a>
                     <a href="../reports.html">Reports</a>
                     <a href="../operating.html">Contributing</a>


### PR DESCRIPTION
## Summary

- **Version badges removed** from 7 style-authoring pages — the `active · schema 0.1.0+ · engine 0.1.0+` spans were placeholder content with no meaning to visitors
- **Style-authoring sidebar** now includes Advanced Examples on all 8 pages (including `advanced-examples.html` itself, which was missing a sidebar entirely)
- **Integration recipe sidebar** added to all 7 `guides/integrations/` pages — a left rail listing all 7 recipes with the current page highlighted; previously there was no way to navigate between recipes without going back to `developer.html`
- **Capabilities in top nav** on all 29 pages — "Capabilities" inserted between Overview and Style Authoring; path prefix adjusts correctly per page depth (root / 1-deep / 2-deep)
- **Mobile sidebar** changed from `display: none` to a horizontal scroll strip so section navigation is available on phones

## Test plan

- [x] Open any style-authoring page (e.g. `guides/style-authoring/start.html`) — no version badges below the heading; sidebar shows all 8 entries including Advanced Examples
- [x] Open `guides/style-authoring/advanced-examples.html` — sidebar appears with Advanced Examples highlighted active
- [x] Open any integration page (e.g. `guides/integrations/djot.html`) — left sidebar lists all 7 recipes with current page highlighted
- [x] Top nav on every page shows "Capabilities" between "Overview" and "Style Authoring"
- [x] Narrow viewport (≤768px): sidebar renders as horizontal scrollable strip, not hidden
