### PR TITLE
ci(release): drop intel macos binary artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,9 +286,6 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             use_cross: "1"
-          - target: x86_64-apple-darwin
-            os: macos-latest  # arm64 host cross-builds x86_64 via Apple's universal linker
-            use_cross: "0"
           - target: aarch64-apple-darwin
             os: macos-latest
             use_cross: "0"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,7 +54,7 @@ The release is automated end-to-end. Day-to-day, the work is:
    the `auto-tag` job, which pushes `v<x.y.z>` (and `schema-v<x.y.z>`
    when the schema changed). The tag push fans out to:
 
-   - `build` (~10–15 min, parallel matrix across 5 targets)
+   - `build` (~10–15 min, parallel matrix across 4 targets)
    - `release` (~1 min, gated on `build`) — creates the GitHub Release
      with tarballs + `SHA256SUMS` + `install.sh`
    - `publish-crates` (~5 min, gated on `build`) — runs
@@ -68,7 +68,7 @@ The release is automated end-to-end. Day-to-day, the work is:
 
 | Job | Trigger | Time | Notes |
 |---|---|---|---|
-| `build` | `push: tags: ["v*"]` | ~15 min | Matrix: x86_64-musl, aarch64-musl, x86_64-darwin, aarch64-darwin, x86_64-windows. Uses `cross` for aarch64-musl. |
+| `build` | `push: tags: ["v*"]` | ~15 min | Matrix: x86_64-musl, aarch64-musl, aarch64-darwin, x86_64-windows. Uses `cross` for aarch64-musl. |
 | `release` | `needs: build` | ~1 min | Aggregates per-target `.sha256` into one `SHA256SUMS`; uploads tarballs + `install.sh` to GitHub Release. |
 | `publish-crates` | `needs: build` | ~5 min | Idempotent; safe to re-run from the Actions UI. |
 | `publish-jsr` | `needs: build` | ~5 min | Uses JSR trusted publishing via GitHub OIDC; no JSR token secret. |
@@ -100,6 +100,14 @@ citum-server --version
 The install script verifies the SHA256 of the downloaded tarball
 against the release's `SHA256SUMS` before extracting; a checksum
 mismatch aborts before any files are written.
+
+GitHub Release tarballs support Apple Silicon macOS only. Intel macOS
+users should install from source:
+
+```sh
+cargo install citum --locked
+cargo install citum-server --locked
+```
 
 ## First-time setup (one-time, before the very first release)
 
@@ -208,8 +216,8 @@ output is not committed.
 ## Locally dry-run a binary build
 
 ```sh
-./scripts/release-binary.sh x86_64-apple-darwin v0.52.0
-ls release-out/x86_64-apple-darwin/
+./scripts/release-binary.sh aarch64-apple-darwin v0.52.0
+ls release-out/aarch64-apple-darwin/
 ```
 
 Produces the tarball + `.sha256` exactly as the CI matrix would. Useful

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,9 +42,15 @@ detect_target() {
       esac ;;
     Darwin)
       case "$arch" in
-        x86_64)              echo "x86_64-apple-darwin" ;;
+        x86_64)
+          if command -v sysctl >/dev/null 2>&1 \
+            && [ "$(sysctl -in sysctl.proc_translated 2>/dev/null || printf 0)" = "1" ]; then
+            echo "aarch64-apple-darwin"
+          else
+            err "prebuilt Intel macOS binaries are no longer shipped; install from source with: cargo install citum --locked && cargo install citum-server --locked"
+          fi ;;
         arm64)               echo "aarch64-apple-darwin" ;;
-        *) err "unsupported macOS arch: $arch (supported: x86_64, arm64)" ;;
+        *) err "unsupported macOS arch: $arch (supported prebuilt arch: arm64)" ;;
       esac ;;
     MINGW*|MSYS*|CYGWIN*)    echo "x86_64-pc-windows-msvc" ;;
     *) err "unsupported OS: $os (supported: Linux, Darwin, Windows via Git Bash)" ;;

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release.yml"
 RELEASE_CONFIG_PATH = REPO_ROOT / "release.toml"
 SCHEMA_LIB = REPO_ROOT / "crates/citum-schema-style/src/version.rs"
+INSTALL_SCRIPT = REPO_ROOT / "scripts/install.sh"
 PUBLISH_CRATES_SCRIPT = REPO_ROOT / "scripts/publish-crates.sh"
 BUILD_JSR_SCRIPT = REPO_ROOT / "scripts/build-jsr-package.sh"
 JSR_README_SOURCE = REPO_ROOT / "crates/citum-bindings/README-JSR.md"
@@ -25,6 +26,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         cls.release_config = RELEASE_CONFIG_PATH.read_text(encoding="utf-8")
+        cls.install_script = INSTALL_SCRIPT.read_text(encoding="utf-8")
         cls.publish_crates_script = PUBLISH_CRATES_SCRIPT.read_text(encoding="utf-8")
         cls.build_jsr_script = BUILD_JSR_SCRIPT.read_text(encoding="utf-8")
         cls.jsr_readme_source = JSR_README_SOURCE.read_text(encoding="utf-8")
@@ -104,6 +106,19 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def test_release_workflow_has_fast_manual_jsr_publish_recovery(self) -> None:
         self.assertIn("- publish-jsr", self.workflow)
         self.assertNotIn("- publish-crates", self.workflow)
+
+    def test_release_binary_matrix_drops_intel_macos_but_keeps_windows(self) -> None:
+        self.assertNotIn("target: x86_64-apple-darwin", self.workflow)
+        self.assertIn("target: aarch64-apple-darwin", self.workflow)
+        self.assertIn("target: x86_64-pc-windows-msvc", self.workflow)
+
+    def test_installer_does_not_map_intel_macos_to_missing_tarball(self) -> None:
+        self.assertNotIn('echo "x86_64-apple-darwin"', self.install_script)
+        self.assertIn("prebuilt Intel macOS binaries are no longer shipped", self.install_script)
+        self.assertIn("cargo install citum --locked", self.install_script)
+        self.assertIn("cargo install citum-server --locked", self.install_script)
+        self.assertIn('arm64)               echo "aarch64-apple-darwin"', self.install_script)
+        self.assertIn("sysctl.proc_translated", self.install_script)
 
     def test_crate_changelogs_are_absent(self) -> None:
         tracked = subprocess.run(


### PR DESCRIPTION
## Summary

- Remove the x86_64 macOS target from the release binary matrix.
- Keep Windows plus Linux musl and Apple Silicon macOS release artifacts.
- Make the installer fail clearly on Intel macOS with a Cargo source-install path.
- Update release docs and regression tests for the four-target matrix.

## Validation

- python3 -m unittest scripts/test_release_workflow.py
- python3 -m unittest scripts/test_infer_release_bump.py scripts/test_coverage_analysis.py scripts/test_release_workflow.py
