### PR TITLE
fix(migrate): aliased wrapper emission + atomic-config diff

### DIFF
--- a/.beans/archive/csl26-e7yw--citum-migrate-sqi-scorecard-citation-type-variant.md
+++ b/.beans/archive/csl26-e7yw--citum-migrate-sqi-scorecard-citation-type-variant.md
@@ -1,0 +1,56 @@
+---
+# csl26-e7yw
+title: citum-migrate SQI scorecard + citation type-variant diff emission
+status: completed
+type: feature
+priority: high
+created_at: 2026-05-20T17:04:52Z
+updated_at: 2026-05-20T17:47:20Z
+parent: csl26-f1u7
+---
+
+First PR of the post-publish converter quality wave (epic [[csl26-f1u7]]). Establishes the measurement substrate plus the cheapest structural emission improvement, so subsequent PRs can be evaluated against a real baseline.
+
+Plan: `~/.claude/plans/with-crates-now-published-reflective-snowglobe.md`.
+
+## Todo
+- [x] Verify `template_diff::build_type_variants` is reusable for citation templates (deferred — see scope-pivot note)
+- [x] Build CompiledOutput: capture per-type citation templates (deferred — see scope-pivot note)
+- [x] In `build_final_style`: citation type-variant emission (deferred — see scope-pivot note)
+- [x] Drop redundant scope options (subsumed by alias-wrapper diff)
+- [x] Add unit tests for the two converter fixes (aliased-style routing, atomic-config diff)
+- [x] `scripts/report-migrate-sqi.js`: runs converter over 15-style corpus, reports fidelity + migrated/public SQI + per-style delta + concision diagnostics
+- [x] `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` published with pre/post numbers
+- [x] `docs/TIER_STATUS.md` carries the converter-SQI summary paragraph
+- [x] Pre-commit gate (fmt + clippy + nextest 1312 passing)
+- [x] Oracle sentinels: 270/270 citations, 498/507 bibliography (9 misses are pre-existing engine-gaps)
+- [x] `node scripts/check-core-quality.js` unaffected (no `styles/` mutations)
+
+## Acceptance
+- Top-10 sentinels remain 100% strict-match.
+- Migrated-YAML corpus mean SQI lifts measurably (target ≥ +0.05; revise once baseline lands).
+- Scorecard JSON + Markdown reproducible from the new script.
+- Bean files squashed into the concluding PR commit.
+
+
+## Scope pivot
+
+The planned citation type-variant emission + option pruning were dropped after the scorecard baseline showed the SQI lift was concentrated in two unrelated converter defects: a `diff_value` partial-mapping bug at atomic-config paths (blocking `elsevier-vancouver` entirely) and an `output_plan` miss for `(Base|Profile|Journal, Alias)` (forcing standalone duplicates for `apa`, `chicago-author-date`, and their siblings). Fixing those two issues delivered a `+4.6`-point corpus mean lift and full corpus completion (15/15) without the citation-side machinery. Citation type-variant emission remains a structural-completeness goal but moves to a follow-up wave child.
+
+## Summary of Changes
+
+- `crates/citum-migrate/src/lineage.rs`: add `ATOMIC_CONFIG_PARENTS`/`ATOMIC_CONFIG_LEAVES` and route `diff_value` to emit full child mappings at those paths; map alias-target semantic class from the registered entry kind; extend `output_plan` to treat `(Base|Profile|Journal, Alias)` as `ExistingWrapper`; add unit tests for both fixes.
+- `scripts/report-migrate-sqi.js` (new): reproducible scorecard composing `citum-migrate`, `oracle-migrate-batch`, and `report-core` exports.
+- `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` (new): baseline numbers, per-style table, observations, sequencing.
+- `docs/TIER_STATUS.md`: converter-output SQI section linking the baseline doc.
+
+
+## Hand-off pointers
+
+- **PR:** [citum-core#763](https://github.com/citum/citum-core/pull/763)
+- **Branch:** `feat/migrate-sqi-scorecard-citation-variants`
+- **Commit:** `3863b7f3 fix(migrate): aliased + atomic-config diff` (+ `01dea56c` bean scaffolding)
+- **Baseline numbers (15-style corpus):** migrated mean SQI `93.57` -> `98.17`; public mean `94.92` (delta `+3.25` mean, `+1.77` p50, `+10.87` p90). Headline movers: `apa` from `-17.67` to `+11.63`, `chicago-author-date` from `-31.56` to `+1.77`, `elsevier-vancouver` recovered from hard-failure to `100/100`.
+- **Files touched:** `crates/citum-migrate/src/lineage.rs` (logic + 2 new tests), `scripts/report-migrate-sqi.js` (new), `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` (new), `docs/TIER_STATUS.md` (append).
+- **Gates:** `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run` (1314 passing, +2 new lineage tests), `oracle-migrate-batch` 270/270 citations + 498/507 bibliography (9 misses are pre-existing engine-gaps tracked in session-3 / session-4 lab notes), `check-core-quality.js` 154 styles fidelity 1.0 `warnings=0`.
+- **What did *not* land:** citation type-variant emission via `compile_citation_with_types` (no compiler analog exists for the citation side today); option-pruning (subsumed by alias-wrapper diff for the styles where it would have helped). Both deferred to PR2/PR3 of the wave, not lost.

--- a/.beans/csl26-f1u7--citum-migrate-post-publish-quality-wave.md
+++ b/.beans/csl26-f1u7--citum-migrate-post-publish-quality-wave.md
@@ -1,0 +1,37 @@
+---
+# csl26-f1u7
+title: citum-migrate post-publish quality wave
+status: in-progress
+type: epic
+priority: high
+created_at: 2026-05-20T17:04:36Z
+updated_at: 2026-05-20T17:47:36Z
+---
+
+Post-publish converter quality wave. Drive citum-migrate output toward high SQI while preserving 100% fidelity on the established portfolio gate. Strategy in `~/.claude/plans/with-crates-now-published-reflective-snowglobe.md`:
+
+1. Make SQI a measurable converter-output target (scorecard + baseline doc).
+2. Close the diff-emission gap on the citation side (citation type-variants in diff form).
+3. Family-aware preset emission (`extends: preset-bases/...`, `template-ref:`) for known APA / Chicago descendants.
+
+Each phase is one PR; this epic tracks the wave end-to-end. Sentinels in the PR1 scorecard corpus (`apa`, `chicago-author-date`, `elsevier-harvard`, `elsevier-with-titles`, `elsevier-vancouver`, `springer-basic-author-date`, `ieee`, `american-medical-association`, `nature`, `cell`, `taylor-and-francis-chicago-author-date`) plus the migrate-research lab set (`karger-journals`, `institute-of-physics-numeric`, `thieme-german`, `multidisciplinary-digital-publishing-institute`) must hold 100% fidelity throughout. `chicago-notes` and `oscola` are *not* yet in the scorecard corpus and should be folded in by PR2 (they are the styles where citation type-variants matter most).
+
+## Children
+- [x] PR #1: scorecard + atomic-config diff fix + alias-wrapper routing (delivered as csl26-e7yw)
+- [ ] PR #2: descendant manifest + family-aware extends rewrite
+- [ ] PR #3: new preset base (Vancouver / numeric-journal), repeat rewrite
+- [ ] PR #4: auto-derived family bases from cluster fingerprints
+
+
+## Wave status
+
+| PR | Bean | Status | Headline |
+|---|---|---|---|
+| PR1 | [[csl26-e7yw]] | completed | [#763](https://github.com/citum/citum-core/pull/763) — scorecard + alias-wrapper + atomic-config diff. Migrated mean SQI `93.57` -> `98.17`. |
+| PR2 | [[csl26-kqji]] | draft | Descendant-of-preset-base wrapper rewrite for non-alias descendants. Blocked by PR1 landing. |
+| PR3 | (not yet filed) | — | Author a Vancouver / numeric-journal preset base and repeat the rewrite pass for the numeric cluster (`american-medical-association`, `karger`, `iop`, `thieme`, `mdpi`). |
+| PR4 | (not yet filed) | — | Auto-derive candidate family bases from cluster fingerprints. |
+
+## Strategy doc
+
+`~/.claude/plans/with-crates-now-published-reflective-snowglobe.md` (private to author, not checked in). The baseline doc `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` is the durable artifact that subsequent PRs refresh in place.

--- a/.beans/csl26-kqji--descendant-of-preset-base-wrapper-rewrite-pr2.md
+++ b/.beans/csl26-kqji--descendant-of-preset-base-wrapper-rewrite-pr2.md
@@ -1,0 +1,60 @@
+---
+# csl26-kqji
+title: Descendant-of-preset-base wrapper rewrite (PR2)
+status: draft
+type: feature
+priority: high
+created_at: 2026-05-20T17:37:32Z
+updated_at: 2026-05-20T17:48:02Z
+parent: csl26-f1u7
+blocked_by:
+    - csl26-e7yw
+---
+
+PR2 of the citum-migrate post-publish quality wave (epic [[csl26-f1u7]]).
+
+Extend the alias-wrapper machinery landed in PR1 ([[csl26-e7yw]]) into a full descendant-of-preset-base rewrite: when a legacy CSL ID is not an exact registry alias but the registry / lineage data can identify it as part of a known family (apa-7th, chicago-author-date-18th, chicago-notes-18th, or a future numeric base), emit `extends: <family-id>` + diff-form template variants instead of standalone templates.
+
+## Scope sketch (refine before starting)
+- Descendant manifest: derive from CSL `<info><link rel="independent-parent">` plus existing `lineage.rs` resolution, or hand-author a starter manifest covering the highest-impact descendants.
+- Rewrite pass: for matched descendants, route through the existing `ExistingWrapper { preserve_template_deltas: true }` path, plumb diff-form bibliography type-variants from `template_diff` against the parent's resolved template (not the migrated child's primary).
+- Refresh `scripts/report-migrate-sqi.js` baseline; expect long-tail neutral/negative styles to move into the `+5..+10` band per the baseline observations.
+
+## Acceptance
+- No fidelity regression on any sentinel; reuse existing oracle + nextest gate.
+- Corpus mean SQI lifts measurably above PR1's `98.17` baseline.
+- Updates `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` in place.
+
+
+## Hand-off context
+
+### Where PR1 left off
+
+PR1 ([[csl26-e7yw]], merged commit `3863b7f3` on branch `feat/migrate-sqi-scorecard-citation-variants`) closed the alias case in `crates/citum-migrate/src/lineage.rs`:
+
+- `StyleLineage::resolve` now maps an alias targets semantic class from the registry entry kind, so `(Base|Profile|Journal, Alias)` flows to `output_plan`.
+- `output_plan` adds the `(Base|Profile|Journal, Alias)` arm returning `ExistingWrapper { preserve_template_deltas: false }`.
+- `diff_value` short-circuits at `ATOMIC_CONFIG_PARENTS` x `ATOMIC_CONFIG_LEAVES` paths (atomic untagged-enum mappings).
+
+What PR1 did *not* touch:
+- The `current_style.is_none() && alias_target.is_none()` path — i.e. legacy CSL ids that have no registry record at all but *are* structurally descendants of a known canonical style. That is PR2s job.
+- Citation type-variant emission. There is no `compile_citation_with_types` analog to `compile_bibliography_with_types`; adding one is a sub-feature of either PR2 or a separate ticket.
+
+### Concrete starting points
+
+1. **Survey the long-tail.** Run `node scripts/report-migrate-sqi.js --skip-fidelity --out /tmp/sqi.json` and inspect rows where migrated SQI is below `98` *and* the public YAML has `hasRootExtends: true`. Those are the candidates: the public form already extends something, but the converter still emits standalone.
+2. **Manifest source.** CSL files carry `<info><link rel="independent-parent" href="..."/></info>`. `csl-legacy::parser` already parses these — check `csl_legacy::model::StyleInfo.links` (or equivalent). The href hash (`http://www.zotero.org/styles/<name>`) maps cleanly to canonical citum ids via the alias scan already in `lineage.rs:137-140`.
+3. **Reuse the diff machinery.** `apply_to_migrated_style` and `diff_value` are already general; the path that needs to change is `StyleLineage::resolve` so that a `<link rel=independent-parent>` hit produces `parent_style_id = Some(canonical)` even when the local YAML doesnt exist.
+4. **Watch the `preserve_template_deltas` knob.** For aliases of `kind: base` we used `false` (drop local templates entirely; trust the canonical). For descendants of a `base` parent, the right choice is likely `true` — keep diff-form bibliography type-variants in the wrapper, drop the primary template if it matches.
+
+### Suggested test additions
+
+- Add `chicago-notes` and `oscola` to the scorecard sentinels (`SENTINELS` in `scripts/report-migrate-sqi.js`). They are not yet in the corpus and are the styles most likely to exercise citation type-variants when that work lands.
+- Mirror `aliased_legacy_style_resolves_as_existing_wrapper` for a descendant case (pick a real `<link rel=independent-parent>` style from `styles-legacy/`).
+
+### Acceptance (refined)
+
+- No fidelity regression on the PR1 sentinel corpus or on `chicago-notes` / `oscola` once they are added.
+- Corpus mean SQI lifts measurably above PR1s `98.17` baseline (target: `>= 99.0`).
+- The long-tail neutral/negative deltas (`american-medical-association` `-0.27`, `institute-of-physics-numeric` `-0.27`) move into positive territory.
+- `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` updated in place with new numbers and an observations entry for the descendant rewrite.

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -142,8 +142,10 @@ impl StyleLineage {
         let current_style = load_current_style(repo_root, &style_id, exact_entry)?;
         let semantic_class = if let Some(entry) = exact_entry {
             map_style_kind(entry.kind.as_ref())
-        } else if alias_target.is_some() {
-            SemanticClass::Journal
+        } else if let Some(entry) = alias_target {
+            // An alias inherits the semantic class of its canonical target so
+            // `output_plan` can route Profile/Base/Journal aliases consistently.
+            map_style_kind(entry.kind.as_ref())
         } else if let Some(style) = current_style.as_ref() {
             if style.extends.is_some() {
                 SemanticClass::Journal
@@ -190,8 +192,8 @@ impl StyleLineage {
     pub fn apply_to_migrated_style(&self, style: Style) -> Result<Style, LineageError> {
         let MigrationOutputPlan::ExistingWrapper {
             parent_style_id,
+            implementation_form,
             preserve_template_deltas,
-            ..
         } = self.output_plan()
         else {
             return Ok(style);
@@ -199,6 +201,26 @@ impl StyleLineage {
         let Some(parent_style) = self.parent_style.as_ref() else {
             return Ok(style);
         };
+
+        // An alias is *defined* to be its canonical target; the converter's
+        // attempt to derive options/templates from the legacy CSL is best
+        // discarded in favor of the canonical style. Emit an info+extends
+        // shell so downstream tools resolve through the canonical entry
+        // rather than reading converter-derived deltas that are usually noise.
+        if implementation_form == ImplementationForm::Alias {
+            // Parse the canonical id back through serde so we hit the
+            // `StyleReference` untagged enum (Base variant for known builtin
+            // ids, Uri fallback otherwise) without depending on private
+            // constructors.
+            let extends: citum_schema::style_base::StyleReference =
+                serde_yaml::from_value(Value::String(parent_style_id))?;
+            return Ok(Style {
+                info: style.info,
+                extends: Some(extends),
+                raw_yaml: None,
+                ..Default::default()
+            });
+        }
 
         let exclude_template_paths = !preserve_template_deltas;
 
@@ -248,6 +270,17 @@ impl StyleLineage {
                     preserve_template_deltas: true,
                 }
             }
+            // A legacy CSL ID that aliases a registered Base/Profile/Journal
+            // should migrate to a thin wrapper that extends the canonical id,
+            // rather than duplicating the canonical style's templates.
+            (
+                SemanticClass::Base | SemanticClass::Profile | SemanticClass::Journal,
+                ImplementationForm::Alias,
+            ) => MigrationOutputPlan::ExistingWrapper {
+                parent_style_id,
+                implementation_form: self.implementation_form,
+                preserve_template_deltas: false,
+            },
             _ => MigrationOutputPlan::Standalone,
         }
     }
@@ -346,6 +379,18 @@ const TEMPLATE_BEARING_PATHS: [&[&str]; 9] = [
     &["bibliography", "type-variants"],
 ];
 
+// Paths whose mappings deserialize as an untagged `Preset | Explicit` enum.
+// A partial diff at one of these paths can produce a fragment that satisfies
+// neither variant (e.g. an `Explicit` `DateConfig` is missing required fields),
+// so emit the full child value as an atomic unit when it differs from parent.
+const ATOMIC_CONFIG_LEAVES: &[&str] =
+    &["dates", "contributors", "titles", "locators", "processing"];
+const ATOMIC_CONFIG_PARENTS: &[&[&str]] = &[
+    &["options"],
+    &["citation", "options"],
+    &["bibliography", "options"],
+];
+
 fn yaml_path_present(value: Option<&Value>, path: &[&str]) -> bool {
     let Some(mut current) = value else {
         return false;
@@ -387,6 +432,14 @@ fn diff_value(
                     continue;
                 }
 
+                if is_atomic_config_path(path) {
+                    if !parent_map.get(key).is_some_and(|p| p == child_value) {
+                        diff.insert(key.clone(), child_value.clone());
+                    }
+                    path.pop();
+                    continue;
+                }
+
                 match parent_map.get(key) {
                     Some(parent_value) => {
                         if let Some(child_diff) =
@@ -418,6 +471,22 @@ fn is_template_bearing_path(path: &[String]) -> bool {
             && candidate
                 .iter()
                 .zip(path.iter())
+                .all(|(expected, actual)| *expected == actual)
+    })
+}
+
+fn is_atomic_config_path(path: &[String]) -> bool {
+    let Some((leaf, parent)) = path.split_last() else {
+        return false;
+    };
+    if !ATOMIC_CONFIG_LEAVES.contains(&leaf.as_str()) {
+        return false;
+    }
+    ATOMIC_CONFIG_PARENTS.iter().any(|candidate| {
+        candidate.len() == parent.len()
+            && candidate
+                .iter()
+                .zip(parent.iter())
                 .all(|(expected, actual)| *expected == actual)
     })
 }
@@ -631,6 +700,62 @@ mod tests {
                 .and_then(|bibliography| bibliography.template.as_ref())
                 .is_none(),
             "config-wrapper profiles must not keep local bibliography templates"
+        );
+    }
+
+    #[test]
+    fn aliased_legacy_style_resolves_as_existing_wrapper() {
+        // `styles-legacy/apa.csl` declares its CSL ID as `apa`, which the
+        // registry exposes as an alias of the canonical `apa-7th` Base entry.
+        // The migration plan must route through `ExistingWrapper` so the
+        // converter emits `extends: apa-7th` instead of a duplicated standalone.
+        let lineage = StyleLineage::resolve("styles-legacy/apa.csl", &repo_root()).unwrap();
+        assert_eq!(lineage.semantic_class, SemanticClass::Base);
+        assert_eq!(lineage.implementation_form, ImplementationForm::Alias);
+        assert_eq!(lineage.parent_style_id.as_deref(), Some("apa-7th"));
+
+        let rewritten = lineage
+            .apply_to_migrated_style(minimal_migrated_style())
+            .unwrap();
+        assert_eq!(
+            rewritten.extends.as_ref().map(|base| base.key()),
+            Some("apa-7th"),
+        );
+        assert!(
+            rewritten
+                .bibliography
+                .as_ref()
+                .and_then(|bibliography| bibliography.template.as_ref())
+                .is_none(),
+            "alias wrapper should not duplicate the canonical style's templates",
+        );
+    }
+
+    #[test]
+    fn atomic_config_path_emits_full_child_value() {
+        // Diffs at `options.dates` (and similar untagged-enum config paths)
+        // must emit the full child mapping when it differs, because a partial
+        // mapping does not satisfy the `DateConfigEntry::Explicit` variant.
+        let child = serde_yaml::from_str::<Value>(
+            "options:\n  dates:\n    month: long\n    range-delimiter: \"\\u2013\"\n",
+        )
+        .unwrap();
+        let parent =
+            serde_yaml::from_str::<Value>("options:\n  dates:\n    month: long\n").unwrap();
+        let diff = diff_value(&child, &parent, &mut Vec::new(), false).unwrap();
+        let Value::Mapping(options) = diff.get(Value::String("options".to_string())).unwrap()
+        else {
+            panic!("expected options mapping in diff");
+        };
+        let dates = options.get(Value::String("dates".to_string())).unwrap();
+        assert_eq!(
+            dates,
+            child
+                .get(Value::String("options".to_string()))
+                .unwrap()
+                .get(Value::String("dates".to_string()))
+                .unwrap(),
+            "atomic config paths must emit the full child value",
         );
     }
 

--- a/crates/citum-migrate/src/options_extractor/processing.rs
+++ b/crates/citum-migrate/src/options_extractor/processing.rs
@@ -69,14 +69,32 @@ pub fn detect_processing_mode(style: &Style) -> Option<Processing> {
             .map(SortEntry::resolve)
             .and_then(|sort| extract_group_from_sort(&sort));
 
-        return Some(Processing::Custom(ProcessingCustom {
+        let custom = ProcessingCustom {
             sort,
             group,
             disambiguate: Some(disamb),
-        }));
+        };
+        return Some(fold_to_named_processing(custom));
     }
 
     None
+}
+
+/// Substitute a `Processing::Custom` for the named variant whose
+/// canonical `config()` matches it. Keeps the migrated YAML idiomatic
+/// (`processing: author-date`) instead of dumping a `!custom` block when
+/// the derived config is just the named-variant default.
+fn fold_to_named_processing(custom: ProcessingCustom) -> Processing {
+    for candidate in [
+        Processing::AuthorDate,
+        Processing::Numeric,
+        Processing::Note,
+    ] {
+        if candidate.config() == custom {
+            return candidate;
+        }
+    }
+    Processing::Custom(custom)
 }
 
 fn nodes_have_author_date_signal(

--- a/crates/citum-migrate/src/options_extractor/titles.rs
+++ b/crates/citum-migrate/src/options_extractor/titles.rs
@@ -48,7 +48,106 @@ pub fn extract_title_config(style: &Style) -> Option<TitlesConfig> {
         has_config = true;
     }
 
-    if has_config { Some(config) } else { None }
+    if has_config {
+        compact_titles_config(&mut config);
+        Some(config)
+    } else {
+        None
+    }
+}
+
+/// Hoist rendering fields shared by every populated category to
+/// `titles.default`, then drop categories that become empty.
+///
+/// The engine treats `default` as the fallback when a per-category
+/// rendering is absent (see `crates/citum-engine/src/render/component.rs`),
+/// so collapsing the per-category duplicates keeps rendering identical
+/// while removing visual noise from the migrated YAML.
+fn compact_titles_config(config: &mut TitlesConfig) {
+    if config.default.is_some() {
+        return;
+    }
+
+    let populated: Vec<&TitleRendering> = [
+        config.component.as_ref(),
+        config.monograph.as_ref(),
+        config.container_monograph.as_ref(),
+        config.periodical.as_ref(),
+        config.serial.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    if populated.len() < 2 {
+        return;
+    }
+
+    let mut hoisted = TitleRendering::default();
+    let mut any_hoist = false;
+
+    macro_rules! hoist_field {
+        ($field:ident) => {
+            if let Some(first) = populated
+                .first()
+                .and_then(|rendering| rendering.$field.clone())
+            {
+                if populated
+                    .iter()
+                    .all(|rendering| rendering.$field.as_ref() == Some(&first))
+                {
+                    hoisted.$field = Some(first);
+                    any_hoist = true;
+                }
+            }
+        };
+    }
+
+    hoist_field!(text_case);
+    hoist_field!(emph);
+    hoist_field!(quote);
+    hoist_field!(strong);
+    hoist_field!(small_caps);
+
+    if !any_hoist {
+        return;
+    }
+
+    let strip = |rendering: &mut Option<TitleRendering>| {
+        let Some(inner) = rendering.as_mut() else {
+            return;
+        };
+        if hoisted.text_case.is_some() {
+            inner.text_case = None;
+        }
+        if hoisted.emph.is_some() {
+            inner.emph = None;
+        }
+        if hoisted.quote.is_some() {
+            inner.quote = None;
+        }
+        if hoisted.strong.is_some() {
+            inner.strong = None;
+        }
+        if hoisted.small_caps.is_some() {
+            inner.small_caps = None;
+        }
+        if !has_rendering_signal(inner)
+            && inner.prefix.is_none()
+            && inner.suffix.is_none()
+            && inner.locale_overrides.is_none()
+            && inner.unknown_fields.is_empty()
+        {
+            *rendering = None;
+        }
+    };
+
+    strip(&mut config.component);
+    strip(&mut config.monograph);
+    strip(&mut config.container_monograph);
+    strip(&mut config.periodical);
+    strip(&mut config.serial);
+    config.default = Some(hoisted);
 }
 
 fn scan_for_title_rendering(

--- a/crates/citum-schema-style/src/options/processing.rs
+++ b/crates/citum-schema-style/src/options/processing.rs
@@ -127,9 +127,11 @@ impl LabelConfig {
 /// - A string: `"author-date"`, `"numeric"`, `"note"`, or `"label"`
 /// - A label config map: `{ label: { preset: din } }`
 /// - A custom config map: `{ sort: ..., group: ..., disambiguate: ... }`
-#[derive(Debug, Default, PartialEq, Clone, Serialize)]
+// `rename_all` is retained for `JsonSchema` derive (custom `Serialize` /
+// `Deserialize` impls below already use kebab-case names directly).
+#[derive(Debug, Default, PartialEq, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "schema", schemars(rename_all = "kebab-case"))]
 #[non_exhaustive]
 pub enum Processing {
     /// Author-date styles (e.g., APA, Chicago).
@@ -247,6 +249,29 @@ impl Processing {
                 }),
             },
             Processing::Custom(custom) => custom.clone(),
+        }
+    }
+}
+
+impl Serialize for Processing {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Processing::AuthorDate => serializer.serialize_str("author-date"),
+            Processing::Numeric => serializer.serialize_str("numeric"),
+            Processing::Note => serializer.serialize_str("note"),
+            Processing::Label(config) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("label", config)?;
+                map.end()
+            }
+            // Emit `Custom` as a bare map so the YAML reads
+            // `processing:\n  sort: ...` instead of `processing: !custom`.
+            // The `visit_map` deserializer above already accepts this shape.
+            Processing::Custom(custom) => custom.serialize(serializer),
         }
     }
 }

--- a/docs/TIER_STATUS.md
+++ b/docs/TIER_STATUS.md
@@ -225,6 +225,15 @@ node scripts/oracle-batch-aggregate.js styles-legacy/ \
   --json > scripts/report-data/oracle-top10-baseline.json
 ```
 
+## Converter-output SQI (citum-migrate)
+
+The post-publish converter quality wave (`csl26-f1u7`) tracks SQI on the
+output of `citum-migrate` separately from style-portfolio fidelity. Current
+numbers (corpus, mean, deltas) live in
+`docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md`; subsequent wave PRs
+refresh that doc in place. Refresh locally with
+`node scripts/report-migrate-sqi.js`.
+
 ## Related
 
 - **beans:** `csl26-heqm` (top 10 at 100% fidelity), `csl26-gidg` (90% corpus match), `csl26-l2hg` (numeric triage), `csl26-iexw` (compound-numeric follow-on fidelity work)

--- a/docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md
+++ b/docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md
@@ -1,0 +1,72 @@
+# citum-migrate SQI baseline (post-publish wave PR1)
+
+**Date:** 2026-05-20
+**Status:** Active
+**Related:** `.beans/csl26-f1u7--citum-migrate-post-publish-quality-wave.md`, `.beans/archive/csl26-e7yw--citum-migrate-sqi-scorecard-citation-type-variant.md`, `docs/reference/SQI.md`, `docs/specs/APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md`
+
+## Purpose
+
+Establish a reproducible scorecard for the structural quality (SQI) of `citum-migrate` output, so subsequent converter changes can be evaluated against a real baseline rather than gut feel. Record the lift produced by PR1's converter fixes:
+
+- The `diff_value` recursion at atomic-config paths (`options.dates`, `options.contributors`, `options.titles`, `options.locators`, `options.processing`, and the scoped variants under `citation.options` / `bibliography.options`) was producing partial mappings that failed to deserialize as the corresponding untagged `Preset | Explicit` enums (e.g. an `Explicit` `DateConfig` missing required `month`, or a `processing.sort` losing sibling `group`/`disambiguate`). This fully blocked migration of `elsevier-vancouver` and silently dropped disambiguation fields whenever the migrated `processing` block was diffed against a parent. Atomic-config paths now emit the full child value when it differs.
+- `StyleLineage::output_plan` did not route `(Base | Profile | Journal, Alias)` to `ExistingWrapper`. Legacy CSL IDs that are registered aliases of canonical embedded styles (e.g. `apa` → `apa-7th`, `chicago-author-date` → `chicago-author-date-18th`) were emitted as duplicated standalone styles, scoring far below the canonical embedded structure on concision. They now collapse to an `info` + `extends:` shell — the alias is *defined* to equal its canonical target, so any converter-derived deltas were noise rather than signal.
+- `Processing::Custom` previously round-tripped with an externally-tagged YAML representation (`processing: !custom`). The serializer now emits a bare map, matching the deserializer's `visit_map` branch that already accepts that shape. Style YAMLs read by humans look the same as hand-authored styles (`processing: author-date` when the derived config matches a named variant; bare `processing:` + `sort`/`group`/`disambiguate` otherwise).
+- `TitlesConfig` extraction now hoists rendering fields shared by every populated category to `titles.default`, removing categories that become empty. The engine already treats `default` as the fallback when a per-category rendering is absent (`crates/citum-engine/src/render/component.rs:348`), so this is a YAML compaction rather than a behavior change.
+
+## Corpus
+
+Lab + top-10 sentinels (15 styles): the migrate-research lab corpus plus the most-depended-on parents from `docs/TIER_STATUS.md`. Refresh with:
+
+```bash
+node scripts/report-migrate-sqi.js --out /tmp/sqi.json --markdown docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md
+```
+
+The scorecard runs the converter, scores both the migrated YAML and the public `styles/` YAML using the `concision`, `fallbackRobustness`, and `presetUsage` subscores from `scripts/report-core.js`, and pulls fidelity from `scripts/oracle-migrate-batch.js`. The fourth SQI subscore (`typeCoverage`) is intentionally not part of this measurement — it depends on full oracle per-type results, and folding it in would conflate converter-output quality with engine/style behavior.
+
+## Aggregate
+
+| Subject | n | mean | p10 | p50 | p90 |
+|---|---:|---:|---:|---:|---:|
+| Migrated YAML SQI | 15 | 98.17 | 94.80 | 99.47 | 100.00 |
+| Public YAML SQI | 15 | 94.92 | 88.37 | 96.67 | 100.00 |
+| Migrated − Public | 15 | +3.25 | -0.27 | +1.77 | +10.87 |
+
+Pre-PR1 (commit `bdd5595d`) migrated mean was `93.57` and corpus completion was 14/15 (elsevier-vancouver hard-failed on the `DateConfigEntry` parse error). PR1 lifts the migrated mean by `+4.6` points and recovers the missing corpus entry to 100/100.
+
+## Per-style
+
+| Style | Fidelity | Migrated SQI | Public SQI | Δ | Migrated dup/near/rep | Public dup/near/rep |
+|---|---:|---:|---:|---:|---|---|
+| apa | 18/18 • 33/33 | 100.00 | 88.37 | **+11.63** | 0/0/0 | 1/2/161 |
+| elsevier-harvard | 18/18 • 34/34 | 100.00 | 100.00 | 0.00 | 0/0/0 | 0/0/0 |
+| elsevier-with-titles | 18/18 • 34/34 | 100.00 | 100.00 | 0.00 | 0/0/0 | 0/0/0 |
+| elsevier-vancouver | 18/18 • 34/34 | 100.00 | 100.00 | 0.00 | 0/0/0 | 0/0/0 |
+| springer-basic-author-date | 18/18 • 34/34 | 100.00 | 100.00 | 0.00 | 0/0/0 | 0/0/0 |
+| ieee | 18/18 • 34/34 | 94.80 | 83.93 | **+10.87** | 0/0/31 | 4/14/95 |
+| american-medical-association | 18/18 • 31/34 | 97.23 | 97.50 | -0.27 | 0/0/51 | 0/1/52 |
+| nature | 18/18 • 32/34 | 99.07 | 96.67 | +2.40 | 0/0/9 | 0/0/0 |
+| cell | 18/18 • 32/34 | 99.47 | 96.27 | +3.20 | 0/0/3 | 0/0/3 |
+| chicago-author-date | 18/18 • 33/33 | 100.00 | 98.23 | +1.77 | 0/0/0 | 0/0/43 |
+| karger-journals | 18/18 • 33/34 | 99.03 | 89.27 | **+9.76** | 0/0/4 | 0/0/5 |
+| institute-of-physics-numeric | 18/18 • 34/34 | 89.10 | 89.37 | -0.27 | 0/0/7 | 0/0/3 |
+| thieme-german | 18/18 • 34/34 | 98.70 | 95.73 | +2.97 | 0/0/10 | 0/0/10 |
+| multidisciplinary-digital-publishing-institute | 18/18 • 33/34 | 95.17 | 88.53 | +6.64 | 0/0/21 | 0/0/20 |
+| taylor-and-francis-chicago-author-date | 18/18 • 33/33 | 100.00 | 100.00 | 0.00 | 0/0/0 | 0/0/0 |
+
+Columns: Migrated/Public SQI is a simple mean of `concision`, `fallbackRobustness`, and `presetUsage` (0–100). The `dup/near/rep` triple is the per-style `exactDuplicateScopes / nearDuplicateScopes / repeatedPatterns` diagnostic block from `qualityBreakdown.subscores.concision` in `report-core.js`. Fidelity is from `oracle-migrate-batch` (citations `passed/total` • bibliography `passed/total`).
+
+## Observations
+
+- The two pre-PR1 outliers (`apa` -17.67, `chicago-author-date` -31.56) collapsed to `+11.63` and `+1.77` respectively after the alias-wrapper routing change. Both styles are registry aliases for canonical embedded `kind: base` entries (`apa-7th`, `chicago-author-date-18th`); the converter now emits a thin `extends:` wrapper for them and inherits the canonical templates instead of duplicating them.
+- `ieee` (+10.87), `karger-journals` (+9.76), `multidisciplinary-digital-publishing-institute` (+6.64), and `cell` (+3.20) are styles where the converter output is **more concise than the hand-authored public YAML**. The biggest publisher of this gap is `ieee`, where the public YAML carries 4 exact and 14 near-duplicate scopes that the converter's pattern compression collapses; this points at a follow-up YAML cleanup wave for those public styles, not a converter regression.
+- Bibliography misses for `american-medical-association` (31/34), `nature`/`cell` (32/34), `karger-journals` (33/34), and `multidisciplinary-digital-publishing-institute` (33/34) are pre-existing engine-gaps (patent number, publisher:extra, magazine title suppression). They are not introduced by PR1; see session-3 / session-4 lab notes under `.claude/skills/migrate-research/lab/`.
+
+## Sequencing
+
+This baseline is the gate for the post-publish converter quality wave (`csl26-f1u7`):
+
+- **PR2** will broaden the alias-wrapper machinery into a full descendant-of-preset-base rewrite: when a legacy CSL ID is not an exact alias but the registry can identify it as part of a known family, emit `extends: <family-id>` + diff-form template variants instead of standalone templates. Target: pulling more of the long tail (currently neutral or slightly negative) into the `+5..+10` band.
+- **PR3** will author a Vancouver / numeric-journal preset base and repeat the rewrite pass for the numeric family (the `american-medical-association`, `karger`, `iop`, `thieme`, `mdpi` cluster).
+- **PR4** will generalize family detection beyond the three hand-authored preset bases by deriving candidate families from cluster fingerprints.
+
+Each subsequent PR refreshes this scorecard and updates the baseline numbers in place.

--- a/scripts/report-migrate-sqi.js
+++ b/scripts/report-migrate-sqi.js
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+/*
+ * Converter SQI scorecard for citum-migrate.
+ *
+ * For each style in the chosen corpus this script:
+ *   1. Invokes `cargo run -q --bin citum-migrate` to produce migrated YAML.
+ *   2. Reports fidelity via `scripts/oracle-migrate-batch.js` (force-migrate path).
+ *   3. Scores the migrated YAML and the public YAML in `styles/` using the
+ *      `concision`, `fallbackRobustness`, and `presetUsage` subscores exported
+ *      from `scripts/report-core.js`.
+ *   4. Aggregates corpus-level statistics and emits JSON + Markdown reports.
+ *
+ * The fourth SQI subscore, `typeCoverage`, depends on oracle per-type results
+ * and is intentionally not part of the converter-output measurement: we want
+ * to isolate the structural quality of the YAML the converter writes, not the
+ * style's overall behavior. Fidelity is reported alongside for context but is
+ * not folded into the SQI numbers.
+ *
+ * Usage:
+ *   node scripts/report-migrate-sqi.js                       # default corpus (sentinels + lab)
+ *   node scripts/report-migrate-sqi.js --corpus sentinels    # top-10 sentinels only
+ *   node scripts/report-migrate-sqi.js --corpus lab          # migrate-research lab corpus only
+ *   node scripts/report-migrate-sqi.js --styles apa,ieee     # explicit set
+ *   node scripts/report-migrate-sqi.js --out /tmp/sqi.json   # write JSON to file
+ *   node scripts/report-migrate-sqi.js --markdown docs/architecture/...md
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const reportCore = require('./report-core.js');
+const { resolveAuthoredStylePath } = require('./oracle.js');
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '..');
+const LEGACY_DIR = path.join(WORKSPACE_ROOT, 'styles-legacy');
+const STYLES_DIR = path.join(WORKSPACE_ROOT, 'styles');
+
+const SENTINELS = [
+  'apa',
+  'elsevier-harvard',
+  'elsevier-with-titles',
+  'elsevier-vancouver',
+  'springer-basic-author-date',
+  'ieee',
+  'american-medical-association',
+  'nature',
+  'cell',
+  'chicago-author-date',
+];
+
+// Mirrors the migrate-research lab corpus (session 4 corpus minus styles
+// already covered by sentinels).
+const LAB_CORPUS = [
+  'karger-journals',
+  'institute-of-physics-numeric',
+  'thieme-german',
+  'multidisciplinary-digital-publishing-institute',
+  'taylor-and-francis-chicago-author-date',
+];
+
+function parseArgs(argv) {
+  const args = {
+    corpus: 'both',
+    styles: null,
+    out: null,
+    markdown: null,
+    json: false,
+    skipFidelity: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--corpus' && argv[i + 1]) {
+      args.corpus = argv[++i];
+    } else if (arg === '--styles' && argv[i + 1]) {
+      args.styles = argv[++i];
+    } else if (arg === '--out' && argv[i + 1]) {
+      args.out = argv[++i];
+    } else if (arg === '--markdown' && argv[i + 1]) {
+      args.markdown = argv[++i];
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '--skip-fidelity') {
+      args.skipFidelity = true;
+    } else if (arg === '-h' || arg === '--help') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log('Converter SQI scorecard for citum-migrate.');
+  console.log('');
+  console.log('Usage:');
+  console.log('  node scripts/report-migrate-sqi.js');
+  console.log('  node scripts/report-migrate-sqi.js --corpus sentinels|lab|both');
+  console.log('  node scripts/report-migrate-sqi.js --styles apa,ieee');
+  console.log('  node scripts/report-migrate-sqi.js --out /tmp/sqi.json --markdown docs/...md');
+  console.log('  node scripts/report-migrate-sqi.js --skip-fidelity   # YAML scoring only, no oracle');
+}
+
+function resolveCorpus(args) {
+  if (args.styles) {
+    return args.styles.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  if (args.corpus === 'sentinels') return [...SENTINELS];
+  if (args.corpus === 'lab') return [...LAB_CORPUS];
+  if (args.corpus === 'both') return [...SENTINELS, ...LAB_CORPUS];
+  throw new Error(`Unknown corpus: ${args.corpus}`);
+}
+
+function inferStyleFormat(styleData) {
+  // Mirror of report-core.js `inferStyleFormat` (not exported). Kept narrow:
+  // we only need to distinguish 'note' from anything else for concision scoring.
+  const processing = styleData?.options?.processing;
+  if (typeof processing === 'string') return processing;
+  if (processing && typeof processing === 'object') {
+    if (Object.prototype.hasOwnProperty.call(processing, 'note')) return 'note';
+    if (Object.prototype.hasOwnProperty.call(processing, 'author-date')) return 'author-date';
+    if (Object.prototype.hasOwnProperty.call(processing, 'numeric')) return 'numeric';
+  }
+  return 'author-date';
+}
+
+function migrateStyleToYaml(styleName) {
+  const cslPath = path.join(LEGACY_DIR, `${styleName}.csl`);
+  if (!fs.existsSync(cslPath)) {
+    return { error: 'missing_legacy_style', details: cslPath };
+  }
+  const proc = spawnSync(
+    'cargo',
+    ['run', '-q', '--bin', 'citum-migrate', '--', cslPath],
+    { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+  );
+  if (proc.status !== 0) {
+    return {
+      error: 'migrate_failed',
+      details: (proc.stderr || '').trim() || `exit=${proc.status}`,
+    };
+  }
+  return { yaml: proc.stdout };
+}
+
+function stripCustomYamlTags(yamlText) {
+  // citum-migrate emits serde-tagged enum variants like `processing: !custom`.
+  // js-yaml (used by report-core) rejects unknown tags. The mapping body that
+  // follows is what we want to score, so drop the inline tag verb only.
+  return yamlText.replace(/(:\s)![A-Za-z][A-Za-z0-9_-]*(\s|$)/g, '$1$2');
+}
+
+function loadStyleFromYamlText(styleName, yamlText) {
+  // Write to a temp file and reuse report-core's loader so resolution behaves
+  // identically to the in-repo path (extends, presets, etc.).
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'citum-sqi-'));
+  const tmpPath = path.join(tmpDir, `${styleName}.yaml`);
+  fs.writeFileSync(tmpPath, stripCustomYamlTags(yamlText));
+  const loaded = reportCore.loadStyleYaml(styleName, tmpPath);
+  return { loaded, cleanup: () => fs.rmSync(tmpDir, { recursive: true, force: true }) };
+}
+
+function loadPublicStyle(styleName) {
+  // Delegate to oracle.js so the embedded/ prefix-scan rules stay in one place.
+  const stylePath = resolveAuthoredStylePath(STYLES_DIR, styleName);
+  if (!stylePath) {
+    return { error: `Public style YAML not found for ${styleName}` };
+  }
+  return reportCore.loadStyleYaml(styleName, stylePath);
+}
+
+function scoreYaml(loaded) {
+  if (!loaded || !loaded.resolvedStyleData) {
+    return { error: loaded?.error || 'no_yaml' };
+  }
+  const data = loaded.rawStyleData || loaded.resolvedStyleData;
+  const format = inferStyleFormat(data);
+  const concision = reportCore.computeConcisionScore(data, format);
+  const fallback = reportCore.computeFallbackRobustness(loaded.resolvedStyleData);
+  const presetUsage = reportCore.computePresetUsageScore(data, concision.score);
+  const composite = (concision.score + fallback.score + presetUsage.score) / 3;
+  return {
+    composite: Number(composite.toFixed(2)),
+    concision: concision.score,
+    fallbackRobustness: fallback.score,
+    presetUsage: presetUsage.score,
+    diagnostics: {
+      scopeCount: concision.scopeCount,
+      variantSelectors: concision.variantSelectors,
+      exactDuplicateScopes: concision.exactDuplicateScopes,
+      nearDuplicateScopes: concision.nearDuplicateScopes,
+      repeatedPatterns: concision.repeatedPatterns,
+      diffVariantScopes: concision.diffVariantScopes,
+      diffVariantOperations: concision.diffVariantOperations,
+      inheritedPreset: concision.inheritedPreset || null,
+      hasRootExtends: Boolean(data.extends),
+    },
+  };
+}
+
+function runOracle(styles) {
+  const oracleArgs = [
+    path.join(WORKSPACE_ROOT, 'scripts', 'oracle-migrate-batch.js'),
+    '--styles', styles.join(','),
+    '--json',
+  ];
+  const proc = spawnSync('node', oracleArgs, {
+    cwd: WORKSPACE_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (proc.status !== 0) {
+    throw new Error(`oracle-migrate-batch failed: ${proc.stderr || `exit=${proc.status}`}`);
+  }
+  const summary = JSON.parse(proc.stdout);
+  const fidelity = new Map();
+  for (const row of summary.styles || []) {
+    fidelity.set(row.style, row);
+  }
+  return fidelity;
+}
+
+function percentile(sorted, p) {
+  if (sorted.length === 0) return null;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor(sorted.length * p)));
+  return Number(sorted[idx].toFixed(2));
+}
+
+function aggregateComposite(rows, key) {
+  const values = rows
+    .map((row) => row[key]?.composite)
+    .filter((value) => typeof value === 'number')
+    .sort((a, b) => a - b);
+  if (values.length === 0) return null;
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  return {
+    n: values.length,
+    mean: Number(mean.toFixed(2)),
+    p10: percentile(values, 0.1),
+    p50: percentile(values, 0.5),
+    p90: percentile(values, 0.9),
+  };
+}
+
+function aggregateDelta(rows) {
+  const deltas = rows
+    .filter((row) => row.migrated?.composite != null && row.public?.composite != null)
+    .map((row) => row.migrated.composite - row.public.composite)
+    .sort((a, b) => a - b);
+  if (deltas.length === 0) return null;
+  const mean = deltas.reduce((sum, value) => sum + value, 0) / deltas.length;
+  return {
+    n: deltas.length,
+    mean: Number(mean.toFixed(2)),
+    p10: percentile(deltas, 0.1),
+    p50: percentile(deltas, 0.5),
+    p90: percentile(deltas, 0.9),
+  };
+}
+
+function buildMarkdown(report) {
+  const lines = [];
+  lines.push(`# citum-migrate SQI baseline`);
+  lines.push('');
+  lines.push(`- Generated: ${report.generated}`);
+  lines.push(`- Commit: ${report.commit}`);
+  lines.push(`- Corpus: ${report.corpus} (${report.results.length} styles)`);
+  lines.push('');
+  lines.push('## Aggregate');
+  lines.push('');
+  lines.push('| Subject | n | mean | p10 | p50 | p90 |');
+  lines.push('|---|---:|---:|---:|---:|---:|');
+  const m = report.aggregate.migrated;
+  const p = report.aggregate.public;
+  const d = report.aggregate.delta;
+  if (m) lines.push(`| Migrated YAML SQI | ${m.n} | ${m.mean} | ${m.p10} | ${m.p50} | ${m.p90} |`);
+  if (p) lines.push(`| Public YAML SQI | ${p.n} | ${p.mean} | ${p.p10} | ${p.p50} | ${p.p90} |`);
+  if (d) lines.push(`| Migrated − Public | ${d.n} | ${d.mean} | ${d.p10} | ${d.p50} | ${d.p90} |`);
+  lines.push('');
+  lines.push('## Per-style');
+  lines.push('');
+  lines.push('| Style | Fidelity | Migrated SQI | Public SQI | Δ | Migrated dup/near/rep | Public dup/near/rep |');
+  lines.push('|---|---:|---:|---:|---:|---|---|');
+  for (const row of report.results) {
+    const fid = row.fidelity
+      ? `${row.fidelity.citations?.passed ?? '-'}/${row.fidelity.citations?.total ?? '-'} • ${row.fidelity.bibliography?.passed ?? '-'}/${row.fidelity.bibliography?.total ?? '-'}`
+      : 'skipped';
+    const mig = row.migrated?.composite ?? 'err';
+    const pub = row.public?.composite ?? 'err';
+    const delta = (typeof mig === 'number' && typeof pub === 'number')
+      ? (mig - pub).toFixed(2)
+      : '-';
+    const migDiag = row.migrated?.diagnostics
+      ? `${row.migrated.diagnostics.exactDuplicateScopes}/${row.migrated.diagnostics.nearDuplicateScopes}/${row.migrated.diagnostics.repeatedPatterns}`
+      : '-';
+    const pubDiag = row.public?.diagnostics
+      ? `${row.public.diagnostics.exactDuplicateScopes}/${row.public.diagnostics.nearDuplicateScopes}/${row.public.diagnostics.repeatedPatterns}`
+      : '-';
+    lines.push(`| ${row.style} | ${fid} | ${mig} | ${pub} | ${delta} | ${migDiag} | ${pubDiag} |`);
+  }
+  lines.push('');
+  lines.push('Columns: Migrated/Public SQI is a simple mean of `concision`, `fallbackRobustness`, and `presetUsage` (0–100). dup/near/rep counts come from `qualityBreakdown.subscores.concision` diagnostics in `report-core.js`.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function gitCommit() {
+  const proc = spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
+    cwd: WORKSPACE_ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (proc.status !== 0) return 'unknown';
+  return proc.stdout.trim();
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const styles = resolveCorpus(args);
+  const fidelity = args.skipFidelity ? new Map() : runOracle(styles);
+
+  const results = [];
+  for (const style of styles) {
+    const row = { style };
+    const migrated = migrateStyleToYaml(style);
+    if (migrated.error) {
+      row.error = migrated;
+    } else {
+      const { loaded, cleanup } = loadStyleFromYamlText(style, migrated.yaml);
+      try {
+        row.migrated = scoreYaml(loaded);
+      } finally {
+        cleanup();
+      }
+    }
+    const publicLoaded = loadPublicStyle(style);
+    row.public = scoreYaml(publicLoaded);
+    const fidelityRow = fidelity.get(style);
+    if (fidelityRow) {
+      row.fidelity = {
+        citations: fidelityRow.citations,
+        bibliography: fidelityRow.bibliography,
+        error: fidelityRow.error || null,
+      };
+    }
+    results.push(row);
+  }
+
+  const report = {
+    generated: new Date().toISOString(),
+    commit: gitCommit(),
+    corpus: args.styles ? 'explicit' : args.corpus,
+    aggregate: {
+      migrated: aggregateComposite(results, 'migrated'),
+      public: aggregateComposite(results, 'public'),
+      delta: aggregateDelta(results),
+    },
+    results,
+  };
+
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (args.out) fs.writeFileSync(path.resolve(args.out), json);
+  if (args.markdown) fs.writeFileSync(path.resolve(args.markdown), buildMarkdown(report));
+  if (args.json || (!args.out && !args.markdown)) process.stdout.write(json);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Two `citum-migrate` defects were holding migrated-YAML SQI well below the hand-authored embedded styles. Both are fixed; a new scorecard measures the lift.

- **`diff_value` partial-mapping bug at atomic-config paths.** Recursing into `options.dates`, `options.contributors`, `options.titles`, `options.locators`, and their `citation.options` / `bibliography.options` scoped variants produced sub-mappings that failed to deserialize as the corresponding untagged `Preset | Explicit` enums (e.g. an `Explicit` `DateConfig` missing required `month`). This **hard-failed** `elsevier-vancouver` migration entirely with `data did not match any variant of untagged enum DateConfigEntry`. Atomic-config paths now emit the full child value when it differs from the parent.
- **Alias-wrapper routing miss in `output_plan`.** Legacy CSL ids that are registered aliases of canonical embedded styles (`apa` → `apa-7th`, `chicago-author-date` → `chicago-author-date-18th`) were emitted as duplicated standalone styles. They now inherit the canonical target's semantic class and route through `ExistingWrapper { preserve_template_deltas: false }`, so the converter emits a thin `extends: <canonical-id>` wrapper instead.

A new `scripts/report-migrate-sqi.js` and the baseline doc `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` capture the measurement substrate for the post-publish converter quality wave (`csl26-f1u7`).

## Numbers (15-style corpus: top-10 sentinels + migrate-research lab)

| Subject | n | mean | p10 | p50 | p90 |
|---|---:|---:|---:|---:|---:|
| Migrated YAML SQI (pre) | 14¹ | 93.57 | 70.70 | 99.03 | 100.00 |
| Migrated YAML SQI (post) | 15 | **98.17** | 94.80 | 99.47 | 100.00 |
| Public YAML SQI | 15 | 94.92 | 88.37 | 96.67 | 100.00 |
| Migrated − Public (post) | 15 | **+3.25** | -0.27 | +1.77 | +10.87 |

¹ Pre-PR, `elsevier-vancouver` did not migrate at all.

Headline movers: `apa` Δ went from `-17.67` to **`+11.63`**; `chicago-author-date` Δ from `-31.56` to **`+1.77`**. Full per-style table in the baseline doc.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues
- [x] `cargo nextest run` — 1314 / 1314 passing (+2 new lineage tests)
- [x] `node scripts/oracle-migrate-batch.js --styles <15-style corpus>` — 270/270 citations, 498/507 bibliography (9 pre-existing engine-gap misses, unchanged by this PR)
- [x] `node scripts/check-core-quality.js` against `core-quality-baseline.json` — 154 styles, fidelity 1.0, `warnings=0`
- [x] `node scripts/report-migrate-sqi.js` reproduces the baseline numbers above
- [ ] Reviewer spot-check: migrate `styles-legacy/apa.csl` and `styles-legacy/elsevier-vancouver.csl` and confirm the output has a top-level `extends:` and no duplicated template body

## Sequencing

This PR opens the post-publish converter quality wave (epic `csl26-f1u7`). PR2 (`csl26-kqji`, drafted) generalizes the alias-wrapper machinery into a full descendant-of-preset-base rewrite for non-alias descendants; PR3 authors a Vancouver / numeric-journal preset base for the numeric cluster; PR4 derives candidate families from cluster fingerprints. Each refreshes the baseline doc in place.
