### PR TITLE
ci: optimize semver-checks baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,5 +338,4 @@ jobs:
         continue-on-error: true
         run: |
           cargo semver-checks \
-            --workspace \
-            --baseline-rev ${{ github.event.pull_request.base.sha }}
+            --workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,10 +101,7 @@ jobs:
         continue-on-error: true
         id: semver
         run: |
-          LAST_TAG=$(git tag --sort=-version:refname -l 'v*' | head -1)
-          if [ -z "$LAST_TAG" ]; then
-            echo "breaking=false" >> "$GITHUB_OUTPUT"
-          elif cargo semver-checks --workspace --baseline-rev "$LAST_TAG" 2>&1; then
+          if cargo semver-checks --workspace 2>&1; then
             echo "breaking=false" >> "$GITHUB_OUTPUT"
           else
             echo "breaking=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Removes the `--baseline-rev` flags from `ci.yml` and `release.yml`. Now that the crates are published, `cargo-semver-checks` can use its default crates.io lookup, which is much faster than compiling the baseline from a git revision.