### PR TITLE
feat(migrate): use template parent wrappers

### DIFF
--- a/.beans/csl26-39tm--output-driven-migration-compression-and-alias-ux-e.md
+++ b/.beans/csl26-39tm--output-driven-migration-compression-and-alias-ux-e.md
@@ -1,0 +1,21 @@
+---
+# csl26-39tm
+title: Output-driven migration compression and alias UX evidence
+status: todo
+type: feature
+priority: high
+created_at: 2026-05-20T19:32:13Z
+updated_at: 2026-05-20T19:32:37Z
+parent: csl26-f1u7
+blocked_by:
+    - csl26-kqji
+---
+
+Follow-up split from PR2 after the XML/AST medoid compaction attempt proved fidelity-risky.
+
+Scope:
+- Build structural compression from output-driven inference/oracle evidence, not by flattening parsed CSL XML branches.
+- Target apa-6th-edition specifically: reduce migrated output below 1,500 LOC without treating APA 6th as an alias of APA 7th and without bibliography/citation oracle regression.
+- Emit machine-readable evidence for future UX: exact registry alias status, parent/template link, canonical target, emitted form, preserved deltas, discarded deltas, and output-size reduction.
+- Design optional UI choices around evidence-backed actions: keep standalone, register local alias, or propose global alias. Global aliases require reviewed equivalence, not ancestry/template evidence.
+- Revisit long-tail styles such as american-medical-association and institute-of-physics-numeric only where output-driven deltas prove the compression is behavior-preserving.

--- a/.beans/csl26-kqji--descendant-of-preset-base-wrapper-rewrite-pr2.md
+++ b/.beans/csl26-kqji--descendant-of-preset-base-wrapper-rewrite-pr2.md
@@ -1,11 +1,11 @@
 ---
 # csl26-kqji
 title: Descendant-of-preset-base wrapper rewrite (PR2)
-status: draft
+status: in-progress
 type: feature
 priority: high
 created_at: 2026-05-20T17:37:32Z
-updated_at: 2026-05-20T17:48:02Z
+updated_at: 2026-05-20T19:06:07Z
 parent: csl26-f1u7
 blocked_by:
     - csl26-e7yw

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -8,6 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 use citum_schema::Style;
 use citum_schema::embedded;
 use citum_schema::registry::{StyleKind, StyleRegistry};
+use csl_legacy::model::InfoLink;
 use serde_yaml::{Mapping, Value};
 use std::fmt;
 use std::fs;
@@ -27,6 +28,7 @@ pub enum SemanticClass {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImplementationForm {
     Alias,
+    TemplateDescendant,
     ConfigWrapper,
     StructuralWrapper,
     Standalone,
@@ -125,7 +127,11 @@ impl StyleLineage {
     ///
     /// Returns an error when the current style or its established parent cannot
     /// be read or parsed from repo-owned YAML.
-    pub fn resolve(input_path: &str, repo_root: &Path) -> Result<Self, LineageError> {
+    pub fn resolve(
+        input_path: &str,
+        repo_root: &Path,
+        legacy_links: &[InfoLink],
+    ) -> Result<Self, LineageError> {
         let style_id = Path::new(input_path)
             .file_stem()
             .and_then(|stem| stem.to_str())
@@ -138,6 +144,7 @@ impl StyleLineage {
             .styles
             .iter()
             .find(|entry| entry.aliases.iter().any(|alias| alias == &style_id));
+        let parent_link_target = resolve_parent_link_target(&registry, legacy_links);
 
         let current_style = load_current_style(repo_root, &style_id, exact_entry)?;
         let semantic_class = if let Some(entry) = exact_entry {
@@ -146,6 +153,8 @@ impl StyleLineage {
             // An alias inherits the semantic class of its canonical target so
             // `output_plan` can route Profile/Base/Journal aliases consistently.
             map_style_kind(entry.kind.as_ref())
+        } else if parent_link_target.is_some() {
+            SemanticClass::Journal
         } else if let Some(style) = current_style.as_ref() {
             if style.extends.is_some() {
                 SemanticClass::Journal
@@ -155,18 +164,32 @@ impl StyleLineage {
         } else {
             SemanticClass::Unknown
         };
-        let parent_style_id = current_style
+        let established_parent = current_style
             .as_ref()
             .and_then(|style| style.extends.as_ref())
             .map(|base| base.key().to_string())
             .or_else(|| alias_target.map(|entry| entry.id.clone()));
-        let parent_style = parent_style_id
-            .as_deref()
-            .map(|parent| load_style_by_id(repo_root, parent))
-            .transpose()?;
+        let mut parent_style_id = established_parent.clone().or(parent_link_target);
+        let parent_style = if let Some(parent) = parent_style_id.clone() {
+            match load_style_by_id(repo_root, &parent) {
+                Ok(style) => Some(style),
+                Err(err) if established_parent.is_none() => {
+                    parent_style_id = None;
+                    tracing::debug!(
+                        "Ignoring legacy parent link `{parent}` because no Citum parent style could be loaded: {err}"
+                    );
+                    None
+                }
+                Err(err) => return Err(err),
+            }
+        } else {
+            None
+        };
 
         let implementation_form = if current_style.is_none() && alias_target.is_some() {
             ImplementationForm::Alias
+        } else if current_style.is_none() && parent_style_id.is_some() {
+            ImplementationForm::TemplateDescendant
         } else if let Some(style) = current_style.as_ref() {
             derive_implementation_form(style)
         } else {
@@ -281,6 +304,14 @@ impl StyleLineage {
                 implementation_form: self.implementation_form,
                 preserve_template_deltas: false,
             },
+            (
+                SemanticClass::Base | SemanticClass::Profile | SemanticClass::Journal,
+                ImplementationForm::TemplateDescendant,
+            ) => MigrationOutputPlan::ExistingWrapper {
+                parent_style_id,
+                implementation_form: self.implementation_form,
+                preserve_template_deltas: true,
+            },
             _ => MigrationOutputPlan::Standalone,
         }
     }
@@ -343,6 +374,37 @@ fn load_style_by_id(repo_root: &Path, style_id: &str) -> Result<Style, LineageEr
 fn load_style_from_path(path: &Path) -> Result<Style, LineageError> {
     let yaml = fs::read_to_string(path)?;
     Ok(Style::from_yaml_str(&yaml)?)
+}
+
+fn resolve_parent_link_target(registry: &StyleRegistry, links: &[InfoLink]) -> Option<String> {
+    links.iter().find_map(|link| {
+        let rel = link.rel.as_deref()?;
+        if !matches!(rel, "template" | "independent-parent") {
+            return None;
+        }
+        let linked_id = zotero_style_id(&link.href)?;
+        resolve_registry_id(registry, linked_id)
+    })
+}
+
+fn zotero_style_id(href: &str) -> Option<&str> {
+    href.strip_prefix("http://www.zotero.org/styles/")
+        .or_else(|| href.strip_prefix("https://www.zotero.org/styles/"))
+        .filter(|id| !id.is_empty())
+}
+
+fn resolve_registry_id(registry: &StyleRegistry, style_id: &str) -> Option<String> {
+    registry
+        .styles
+        .iter()
+        .find(|entry| entry.id == style_id)
+        .or_else(|| {
+            registry
+                .styles
+                .iter()
+                .find(|entry| entry.aliases.iter().any(|alias| alias == style_id))
+        })
+        .map(|entry| entry.id.clone())
 }
 
 fn derive_implementation_form(style: &Style) -> ImplementationForm {
@@ -562,7 +624,7 @@ mod tests {
     #[test]
     fn resolves_embedded_profile_as_config_wrapper() {
         let lineage =
-            StyleLineage::resolve("styles-legacy/elsevier-harvard.csl", &repo_root()).unwrap();
+            StyleLineage::resolve("styles-legacy/elsevier-harvard.csl", &repo_root(), &[]).unwrap();
 
         assert_eq!(lineage.style_id, "elsevier-harvard");
         assert_eq!(lineage.semantic_class, SemanticClass::Profile);
@@ -589,6 +651,7 @@ mod tests {
         let lineage = StyleLineage::resolve(
             "styles-legacy/disability-and-rehabilitation.csl",
             &repo_root(),
+            &[],
         )
         .unwrap();
 
@@ -616,6 +679,7 @@ mod tests {
         let lineage = StyleLineage::resolve(
             "styles-legacy/american-society-of-mechanical-engineers.csl",
             &repo_root(),
+            &[],
         )
         .unwrap();
 
@@ -637,9 +701,12 @@ mod tests {
 
     #[test]
     fn resolves_unknown_style_as_unknown() {
-        let lineage =
-            StyleLineage::resolve("styles-legacy/definitely-unknown-style.csl", &repo_root())
-                .unwrap();
+        let lineage = StyleLineage::resolve(
+            "styles-legacy/definitely-unknown-style.csl",
+            &repo_root(),
+            &[],
+        )
+        .unwrap();
 
         assert_eq!(lineage.semantic_class, SemanticClass::Unknown);
         assert_eq!(lineage.implementation_form, ImplementationForm::Unknown);
@@ -676,7 +743,7 @@ mod tests {
     #[test]
     fn config_wrapper_output_sets_extends_and_strips_templates() {
         let lineage =
-            StyleLineage::resolve("styles-legacy/elsevier-harvard.csl", &repo_root()).unwrap();
+            StyleLineage::resolve("styles-legacy/elsevier-harvard.csl", &repo_root(), &[]).unwrap();
         let rewritten = lineage
             .apply_to_migrated_style(minimal_migrated_style())
             .unwrap();
@@ -709,7 +776,7 @@ mod tests {
         // registry exposes as an alias of the canonical `apa-7th` Base entry.
         // The migration plan must route through `ExistingWrapper` so the
         // converter emits `extends: apa-7th` instead of a duplicated standalone.
-        let lineage = StyleLineage::resolve("styles-legacy/apa.csl", &repo_root()).unwrap();
+        let lineage = StyleLineage::resolve("styles-legacy/apa.csl", &repo_root(), &[]).unwrap();
         assert_eq!(lineage.semantic_class, SemanticClass::Base);
         assert_eq!(lineage.implementation_form, ImplementationForm::Alias);
         assert_eq!(lineage.parent_style_id.as_deref(), Some("apa-7th"));
@@ -729,6 +796,53 @@ mod tests {
                 .is_none(),
             "alias wrapper should not duplicate the canonical style's templates",
         );
+    }
+
+    #[test]
+    fn template_descendant_resolves_canonical_parent_alias() {
+        let links = vec![InfoLink {
+            href: "http://www.zotero.org/styles/chicago-author-date".to_string(),
+            rel: Some("template".to_string()),
+        }];
+        let lineage =
+            StyleLineage::resolve("styles-legacy/anglia.csl", &repo_root(), &links).unwrap();
+
+        assert_eq!(lineage.semantic_class, SemanticClass::Journal);
+        assert_eq!(
+            lineage.implementation_form,
+            ImplementationForm::TemplateDescendant
+        );
+        assert_eq!(
+            lineage.parent_style_id.as_deref(),
+            Some("chicago-author-date-18th")
+        );
+        assert_eq!(
+            lineage.output_plan(),
+            MigrationOutputPlan::ExistingWrapper {
+                parent_style_id: "chicago-author-date-18th".to_string(),
+                implementation_form: ImplementationForm::TemplateDescendant,
+                preserve_template_deltas: true,
+            }
+        );
+    }
+
+    #[test]
+    fn unresolved_template_parent_preserves_standalone_output() {
+        let links = vec![InfoLink {
+            href: "http://www.zotero.org/styles/apa-6th-edition".to_string(),
+            rel: Some("template".to_string()),
+        }];
+        let lineage = StyleLineage::resolve(
+            "styles-legacy/effective-altruism-wiki.csl",
+            &repo_root(),
+            &links,
+        )
+        .unwrap();
+
+        assert_eq!(lineage.semantic_class, SemanticClass::Unknown);
+        assert_eq!(lineage.implementation_form, ImplementationForm::Unknown);
+        assert!(lineage.parent_style_id.is_none());
+        assert_eq!(lineage.output_plan(), MigrationOutputPlan::Standalone);
     }
 
     #[test]
@@ -764,6 +878,7 @@ mod tests {
         let lineage = StyleLineage::resolve(
             "styles-legacy/american-society-of-mechanical-engineers.csl",
             &repo_root(),
+            &[],
         )
         .unwrap();
         let rewritten = lineage

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -161,7 +161,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let enable_provenance = cli.debug_variable.is_some();
     let tracker = ProvenanceTracker::new(enable_provenance);
     let workspace_root = workspace_root_for_style_path(path);
-    let lineage = StyleLineage::resolve(path, &workspace_root)?;
+
+    let text = fs::read_to_string(path)?;
+    let doc = Document::parse(&text)?;
+    let legacy_style = parse_style(doc.root_element())?;
+
+    let lineage = StyleLineage::resolve(path, &workspace_root, &legacy_style.info.links)?;
 
     tracing::debug!("Migrating {path} to Citum...");
     tracing::debug!(
@@ -171,10 +176,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         lineage.parent_style_id.as_deref().unwrap_or("none")
     );
     log_migration_output_plan(&lineage);
-
-    let text = fs::read_to_string(path)?;
-    let doc = Document::parse(&text)?;
-    let legacy_style = parse_style(doc.root_element())?;
 
     let MigrationOptions {
         mut options,

--- a/scripts/report-migrate-sqi.js
+++ b/scripts/report-migrate-sqi.js
@@ -50,6 +50,8 @@ const SENTINELS = [
   'nature',
   'cell',
   'chicago-author-date',
+  'chicago-notes',
+  'oscola',
 ];
 
 // Mirrors the migrate-research lab corpus (session 4 corpus minus styles
@@ -61,6 +63,12 @@ const LAB_CORPUS = [
   'multidisciplinary-digital-publishing-institute',
   'taylor-and-francis-chicago-author-date',
 ];
+
+const DIAGNOSTIC_STYLES = [
+  'apa-6th-edition',
+];
+
+const PATHOLOGICAL_OUTPUT_LINES = 1500;
 
 function parseArgs(argv) {
   const args = {
@@ -174,7 +182,7 @@ function loadPublicStyle(styleName) {
   return reportCore.loadStyleYaml(styleName, stylePath);
 }
 
-function scoreYaml(loaded) {
+function scoreYaml(loaded, yamlText = null) {
   if (!loaded || !loaded.resolvedStyleData) {
     return { error: loaded?.error || 'no_yaml' };
   }
@@ -199,8 +207,67 @@ function scoreYaml(loaded) {
       diffVariantOperations: concision.diffVariantOperations,
       inheritedPreset: concision.inheritedPreset || null,
       hasRootExtends: Boolean(data.extends),
+      outputLines: yamlText ? countLines(yamlText) : null,
+      templateComponents: countTemplateComponents(data),
+      bibliographyTemplateComponents: countSectionTemplateComponents(data.bibliography),
+      bibliographyTypeVariantScopes: countTypeVariantScopes(data.bibliography),
+      citationTemplateComponents: countSectionTemplateComponents(data.citation),
+      citationTypeVariantScopes: countTypeVariantScopes(data.citation),
+      pathologicalOutput: yamlText ? countLines(yamlText) > PATHOLOGICAL_OUTPUT_LINES : false,
     },
   };
+}
+
+function countLines(text) {
+  return text.trimEnd().split(/\r?\n/).length;
+}
+
+function countTemplateComponents(styleData) {
+  return countSectionTemplateComponents(styleData?.citation)
+    + countSectionTemplateComponents(styleData?.bibliography)
+    + countSectionTypeVariantComponents(styleData?.citation)
+    + countSectionTypeVariantComponents(styleData?.bibliography);
+}
+
+function countSectionTemplateComponents(section) {
+  return countComponentList(section?.template);
+}
+
+function countSectionTypeVariantComponents(section) {
+  const variants = section?.['type-variants'];
+  if (!variants || typeof variants !== 'object') return 0;
+  let total = 0;
+  for (const variant of Object.values(variants)) {
+    if (Array.isArray(variant)) {
+      total += countComponentList(variant);
+    } else if (variant && typeof variant === 'object') {
+      total += countComponentList(variant.add?.map((op) => op.component));
+    }
+  }
+  return total;
+}
+
+function countTypeVariantScopes(section) {
+  const variants = section?.['type-variants'];
+  if (!variants || typeof variants !== 'object') return 0;
+  return Object.keys(variants).length;
+}
+
+function countComponentList(list) {
+  if (!Array.isArray(list)) return 0;
+  let total = 0;
+  for (const component of list) {
+    total += countComponent(component);
+  }
+  return total;
+}
+
+function countComponent(component) {
+  if (!component || typeof component !== 'object') return 0;
+  if (Array.isArray(component.group)) {
+    return 1 + countComponentList(component.group);
+  }
+  return 1;
 }
 
 function runOracle(styles) {
@@ -284,8 +351,8 @@ function buildMarkdown(report) {
   lines.push('');
   lines.push('## Per-style');
   lines.push('');
-  lines.push('| Style | Fidelity | Migrated SQI | Public SQI | Δ | Migrated dup/near/rep | Public dup/near/rep |');
-  lines.push('|---|---:|---:|---:|---:|---|---|');
+  lines.push('| Style | Fidelity | Migrated SQI | Public SQI | Δ | LOC | Migrated dup/near/rep | Public dup/near/rep |');
+  lines.push('|---|---:|---:|---:|---:|---:|---|---|');
   for (const row of report.results) {
     const fid = row.fidelity
       ? `${row.fidelity.citations?.passed ?? '-'}/${row.fidelity.citations?.total ?? '-'} • ${row.fidelity.bibliography?.passed ?? '-'}/${row.fidelity.bibliography?.total ?? '-'}`
@@ -301,10 +368,22 @@ function buildMarkdown(report) {
     const pubDiag = row.public?.diagnostics
       ? `${row.public.diagnostics.exactDuplicateScopes}/${row.public.diagnostics.nearDuplicateScopes}/${row.public.diagnostics.repeatedPatterns}`
       : '-';
-    lines.push(`| ${row.style} | ${fid} | ${mig} | ${pub} | ${delta} | ${migDiag} | ${pubDiag} |`);
+    const loc = row.migrated?.diagnostics?.outputLines ?? '-';
+    lines.push(`| ${row.style} | ${fid} | ${mig} | ${pub} | ${delta} | ${loc} | ${migDiag} | ${pubDiag} |`);
   }
   lines.push('');
-  lines.push('Columns: Migrated/Public SQI is a simple mean of `concision`, `fallbackRobustness`, and `presetUsage` (0–100). dup/near/rep counts come from `qualityBreakdown.subscores.concision` diagnostics in `report-core.js`.');
+  lines.push('Columns: Migrated/Public SQI is a simple mean of `concision`, `fallbackRobustness`, and `presetUsage` (0–100). LOC is migrated YAML output lines. dup/near/rep counts come from `qualityBreakdown.subscores.concision` diagnostics in `report-core.js`.');
+  if (report.diagnostics?.migratedOutputs?.length) {
+    lines.push('');
+    lines.push('## Output Diagnostics');
+    lines.push('');
+    lines.push('| Style | LOC | Template components | Bibliography template | Bibliography variants | Pathological |');
+    lines.push('|---|---:|---:|---:|---:|---|');
+    for (const row of report.diagnostics.migratedOutputs) {
+      const diag = row.migrated?.diagnostics;
+      lines.push(`| ${row.style} | ${diag?.outputLines ?? '-'} | ${diag?.templateComponents ?? '-'} | ${diag?.bibliographyTemplateComponents ?? '-'} | ${diag?.bibliographyTypeVariantScopes ?? '-'} | ${diag?.pathologicalOutput ? 'yes' : 'no'} |`);
+    }
+  }
   lines.push('');
   return lines.join('\n');
 }
@@ -333,7 +412,7 @@ function main() {
     } else {
       const { loaded, cleanup } = loadStyleFromYamlText(style, migrated.yaml);
       try {
-        row.migrated = scoreYaml(loaded);
+        row.migrated = scoreYaml(loaded, migrated.yaml);
       } finally {
         cleanup();
       }
@@ -361,12 +440,35 @@ function main() {
       delta: aggregateDelta(results),
     },
     results,
+    diagnostics: {
+      migratedOutputs: collectMigratedOutputDiagnostics(DIAGNOSTIC_STYLES),
+    },
   };
 
   const json = `${JSON.stringify(report, null, 2)}\n`;
   if (args.out) fs.writeFileSync(path.resolve(args.out), json);
   if (args.markdown) fs.writeFileSync(path.resolve(args.markdown), buildMarkdown(report));
   if (args.json || (!args.out && !args.markdown)) process.stdout.write(json);
+}
+
+function collectMigratedOutputDiagnostics(styles) {
+  const rows = [];
+  for (const style of styles) {
+    const row = { style };
+    const migrated = migrateStyleToYaml(style);
+    if (migrated.error) {
+      row.error = migrated;
+    } else {
+      const { loaded, cleanup } = loadStyleFromYamlText(style, migrated.yaml);
+      try {
+        row.migrated = scoreYaml(loaded, migrated.yaml);
+      } finally {
+        cleanup();
+      }
+    }
+    rows.push(row);
+  }
+  return rows;
 }
 
 try {


### PR DESCRIPTION
## Summary

- Resolve legacy `template` and `independent-parent` links after CSL parsing.
- Route parent-derived styles through `extends` wrappers while preserving template deltas.
- Add `chicago-notes` and `oscola` to the migration SQI sentinel set.
- Add migrated output LOC and template-size diagnostics, with `apa-6th-edition` tracked explicitly as pathological output.
- Create follow-up bean `csl26-39tm` for output-driven compression and alias UX evidence.

## Scope note

This PR intentionally does not claim the APA 6th structural compression problem is solved. An XML/AST medoid compaction attempt reduced line count but regressed oracle behavior, so it was cut. The remaining compression work belongs in the output-driven follow-up.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `cargo test -p citum-migrate lineage -- --nocapture`
- `node scripts/report-migrate-sqi.js --skip-fidelity --out /tmp/sqi-safe.json --markdown /tmp/sqi-safe.md`
- `cargo run -q --bin citum-migrate -- styles-legacy/apa-6th-edition.csl | wc -l`
