### PR TITLE
fix(migrate): reject unsafe wrapper minimization

### DIFF
--- a/.beans/archive/csl26-dqtx--reference-corpus-exposes-apa-6-vs-7-semantic-diffe.md
+++ b/.beans/archive/csl26-dqtx--reference-corpus-exposes-apa-6-vs-7-semantic-diffe.md
@@ -1,11 +1,11 @@
 ---
 # csl26-dqtx
 title: Reference corpus exposes APA 6 vs 7 semantic differences
-status: todo
+status: completed
 type: bug
 priority: critical
 created_at: 2026-05-21T00:14:54Z
-updated_at: 2026-05-21T00:15:11Z
+updated_at: 2026-05-21T00:49:40Z
 parent: csl26-f1u7
 blocking:
     - csl26-tjqn
@@ -51,3 +51,9 @@ Once the corpus exposes real differences, csl26-tjqn (default minimize) and csl2
 - Blocks: csl26-tjqn (cannot make auto-minimize the default until the oracle gate is trustworthy)
 - Blocks: csl26-ly8d (same reason — extending minimize to more parents amplifies the false-positive risk)
 - Reverses (partially): the apa-6th-edition row in `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` and the corresponding compression-accepted ✓ in the scorecard. Once the corpus is expanded, the row should flip back to standalone (5,661 LOC) with the gap visibility coming from the *fixture coverage* rather than a fake 5-LOC win.
+
+
+
+## Resolution
+
+Implemented strict normalized-output minimization acceptance and expanded clustered citation coverage. APA 6 is rejected as an unsafe apa-7th wrapper candidate by scorecard evidence; no-flag migration remains standalone. The remaining 5,661-line standalone output is tracked separately as converter bloat in csl26-kd28.

--- a/.beans/csl26-kd28--reduce-apa-6-standalone-migration-bloat.md
+++ b/.beans/csl26-kd28--reduce-apa-6-standalone-migration-bloat.md
@@ -1,0 +1,31 @@
+---
+# csl26-kd28
+title: Reduce APA 6 standalone migration bloat
+status: todo
+type: bug
+priority: high
+created_at: 2026-05-21T11:24:18Z
+updated_at: 2026-05-21T11:24:18Z
+parent: csl26-f1u7
+---
+
+APA 6 no-flag migration currently emits a standalone YAML file around 5,661 lines:
+
+```bash
+cargo run -q --bin citum-migrate -- styles-legacy/apa-6th-edition.csl | wc -l
+```
+
+Strict minimization evidence proves the 5-line `apa-7th` wrapper is unsafe: APA 6 and APA 7 differ in citation and bibliography behavior. The remaining size problem is therefore converter bloat, not a justification for wrapper inheritance.
+
+## Scope
+
+- Measure where the standalone output expands: citation templates, bibliography type variants, contributor/date/title options, conditionals, and XML fallback output.
+- Remove duplicated or mechanically equivalent generated structures while preserving APA 6 semantics.
+- Prefer converter-level improvements over style-specific hard-coding.
+- Keep no-flag APA 6 standalone unless a future strict equivalence gate proves a safe parent candidate.
+
+## Acceptance
+
+- `citum-migrate styles-legacy/apa-6th-edition.csl` emits materially fewer lines than the current ~5,661 baseline.
+- Strict minimization still rejects the unsafe APA 7 wrapper unless semantic equivalence actually changes.
+- Existing oracle, SQI, clippy, and nextest gates pass.

--- a/.beans/csl26-ly8d--output-driven-compression-for-apa-6th-edition-pr4.md
+++ b/.beans/csl26-ly8d--output-driven-compression-for-apa-6th-edition-pr4.md
@@ -11,17 +11,17 @@ blocked_by:
     - csl26-39tm
 ---
 
-Follow-up to PR3 (csl26-39tm). PR3 shipped `--minimize-wrapper` for reverse-template-link candidates and delivered the apa-6th-edition win (5,661 → 5 LOC, fidelity 10/37 → 33/34 bib, oracle-gated). The mdpi case (template-link candidate american-chemical-society) was scored but rejected because the minimize path doesn't currently fire for template-link parents — only reverse-template-link triggers `promote_family_candidate`.
+Follow-up to PR3 (csl26-39tm). PR3 shipped `--minimize-wrapper` for reverse-template-link candidates. The apparent apa-6th-edition win (5,661 → 5 LOC) was later rejected by strict APA 6/APA 7 evidence; that candidate must not be accepted without strict equivalence. The mdpi case (template-link candidate american-chemical-society) was scored but rejected because the minimize path doesn't currently fire for template-link parents — only reverse-template-link triggers `promote_family_candidate`.
 
 Scope for this PR: extend the minimize path so template-link and independent-parent-link candidates also benefit. Concretely, allow `--minimize-wrapper` to operate whenever `parent_style_id` is set on the lineage (from any source: registry-alias, template-link, independent-parent-link, reverse-template-link, local-extends). Then the scorecard's A/B test will pick up mdpi and the numeric cluster as compression candidates.
 
 Acceptance:
-- Migrated apa-6th LOC < 1,500.
-- Oracle citation pass >= 18/18, bibliography pass >= 10/37 (the standalone baseline measured at PR3 landing time).
+- APA 6 remains rejected unless strict citation and bibliography equivalence proves a candidate safe.
+- Oracle citation and bibliography fidelity do not regress for existing standalone baselines.
 - Same harness optionally applied to multidisciplinary-digital-publishing-institute (template-link candidate american-chemical-society) where fidelity allows.
 - Baseline doc `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` refreshed in place.
 - No regression on any existing sentinel.
 
 Starting points:
-- `MigrationEvidence` already records discovered candidates and emitted form; PR4 should extend it with per-scope equivalence results.
+- `MigrationEvidence` records discovered candidates and emitted form; a future minimization expansion should report per-scope equivalence results.
 - Today's `apply_to_migrated_style` calls `diff_value` with `exclude_template_paths = !preserve_template_deltas`. For oracle-driven compression the equivalence check needs to run per template scope, not at the YAML-diff level — likely a new pass after `apply_to_migrated_style`.

--- a/.beans/csl26-tjqn--auto-minimize-wrapper-by-default-for-proven-candid.md
+++ b/.beans/csl26-tjqn--auto-minimize-wrapper-by-default-for-proven-candid.md
@@ -5,7 +5,7 @@ status: todo
 type: feature
 priority: high
 created_at: 2026-05-21T00:10:10Z
-updated_at: 2026-05-21T00:10:24Z
+updated_at: 2026-05-21T11:24:18Z
 parent: csl26-f1u7
 ---
 
@@ -15,22 +15,30 @@ Result: the bean csl26-39tm's literal target ("reduce migrated output below 1,50
 
 ## Scope
 
-Make minimization the default outcome when oracle evidence proves it safe. Two viable approaches; pick during planning:
+Make minimization the default outcome when oracle evidence proves it safe. Rejected implementation approach:
 
-1. **Cached-decision lookup.** The scorecard (or a CI step) writes a checked-in manifest `crates/citum-migrate/data/minimization-decisions.yaml` listing legacy CSL ids whose minimized form has been oracle-verified equivalent to standalone. The binary loads this manifest and auto-promotes the candidate parent when migrating a listed style. Lightweight; keeps oracle out of the binary.
+1. **Cached-decision lookup.** The scorecard (or a CI step) writes a checked-in manifest `crates/citum-migrate/data/minimization-decisions.yaml` listing legacy CSL ids whose minimized form has been oracle-verified equivalent to standalone. This was tried in PR #768 and rejected: loading a source-tree YAML file from the binary is checkout-shaped, distribution-hostile, and masks converter bloat.
 
-2. **In-binary oracle gate.** Add citum-engine as a dep, embed a fixed reference corpus (`tests/fixtures/references-expanded.json` + `citations-expanded.json`), render both standalone and wrapper-minimized forms internally, decide. Heavier; binary size grows; but no manifest drift risk.
+Any future design must be distribution-safe and must not make APA 6 default to an APA 7 wrapper unless strict citation and bibliography equivalence proves that safe.
 
 ## Acceptance
 
-- `cargo run --bin citum-migrate -- styles-legacy/apa-6th-edition.csl` with no flags emits the 5-LOC minimized form.
-- Oracle citation pass >= 18/18 and bibliography pass >= 33/34 on the minimized form.
+- No-flag migration emits a minimized wrapper only for candidates with strict citation and bibliography equivalence.
+- APA 6 is not minimized to APA 7 unless strict evidence changes.
 - No regression for any existing sentinel in the SQI scorecard.
 - Default behavior for legacy CSL ids with no proven compression candidate is unchanged.
-- Decision audit trail: the evidence sidecar reports whether the chosen form came from the cached manifest, in-binary oracle gate, or the caller's explicit flags.
+- Decision audit trail: the evidence sidecar reports whether the chosen form came from default behavior or the caller's explicit flags.
 
 ## Related
 
 - Parent epic: csl26-f1u7
 - Sibling: csl26-ly8d (extend minimize to template-link / independent-parent-link parents) — both should land before csl26-f1u7 closes.
 - Original capability bean: csl26-39tm (completed, archived; capability shipped but default behavior gap left open)
+
+
+
+## Current state
+
+Reopened after PR #768 review. A checked YAML manifest loaded by the binary is not an acceptable default-routing mechanism: it is checkout-shaped, distribution-hostile, and risks masking converter bloat. The strict SQI gate now rejects unsafe candidates, but default minimization remains unresolved.
+
+Next work should first reduce known standalone converter bloat (see csl26-kd28) and then revisit any default minimization design with a distribution-safe runtime story.

--- a/crates/citum-migrate/src/cli.rs
+++ b/crates/citum-migrate/src/cli.rs
@@ -20,9 +20,10 @@ pub(crate) struct CliArgs {
     /// Default off keeps the CLI surface deterministic for existing callers.
     pub(crate) emit_evidence: Option<PathBuf>,
     /// Family-candidate routing mode for styles where no parent link is
-    /// available in the source CSL. `Off` (default) preserves standalone
-    /// output; `Auto` promotes any reverse-template-link the lineage resolver
-    /// discovered; `Explicit(id)` forces the given canonical id.
+    /// available in the source CSL. The default preserves standalone output;
+    /// `Off` explicitly disables promotion; `Auto` promotes any
+    /// reverse-template-link the lineage resolver discovered; `Explicit(id)`
+    /// forces the given canonical id.
     pub(crate) family_candidate: FamilyCandidateMode,
     /// When set alongside a promoted family-candidate parent, emit a minimal
     /// wrapper form (info + extends only) instead of the full diff. Default
@@ -34,6 +35,8 @@ pub(crate) struct CliArgs {
 /// CLI selection mode for `--family-candidate`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum FamilyCandidateMode {
+    /// Default no-op routing; preserve standalone output.
+    Default,
     /// Standalone migration only; do not promote any discovered candidate.
     Off,
     /// Promote whatever the lineage resolver discovered via reverse template
@@ -113,7 +116,7 @@ pub(crate) fn parse_cli_args(args: &[String]) -> CliArgs {
     let mut template_dir: Option<PathBuf> = None;
     let mut min_template_confidence = 0.70_f64;
     let mut emit_evidence: Option<PathBuf> = None;
-    let mut family_candidate = FamilyCandidateMode::Off;
+    let mut family_candidate = FamilyCandidateMode::Default;
     let mut minimize_wrapper = false;
 
     let mut iter = args.iter().skip(1).peekable();
@@ -219,7 +222,7 @@ pub(super) fn print_help(program_name: &str) {
         "  --emit-evidence <path>          Write machine-readable migration evidence JSON to <path>"
     );
     tracing::debug!(
-        "  --family-candidate <mode>       Route through discovered family parent: off|auto|<id>"
+        "  --family-candidate <mode>       Family-candidate routing: off|auto|<id> (default: off)"
     );
     tracing::debug!(
         "  --minimize-wrapper              Emit minimal wrapper (info + extends only) when promoting family-candidate"

--- a/crates/citum-migrate/src/evidence.rs
+++ b/crates/citum-migrate/src/evidence.rs
@@ -83,6 +83,61 @@ pub enum EmittedForm {
     },
 }
 
+/// Source of the minimization decision for this invocation.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum MinimizationDecisionSource {
+    /// The caller explicitly disabled family-candidate routing.
+    ExplicitOff,
+    /// The caller explicitly requested family-candidate routing.
+    ExplicitFlags,
+    /// No checked or explicit decision was available.
+    None,
+}
+
+/// Outcome of the minimization decision for this invocation.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum MinimizationDecisionOutcome {
+    /// The decision source selected a candidate parent for family routing.
+    ///
+    /// Check `emitted_form.minimized` to distinguish a minimized wrapper from
+    /// an explicitly promoted wrapper that still preserves migrated deltas.
+    Accepted,
+    /// The candidate was rejected and standalone output was preserved.
+    Rejected,
+    /// The decision source did not select any candidate.
+    NotSelected,
+}
+
+/// Audit trail for explicit wrapper minimization routing.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct MinimizationDecisionAudit {
+    /// Source that controlled minimization routing.
+    pub source: MinimizationDecisionSource,
+    /// Decision outcome.
+    pub outcome: MinimizationDecisionOutcome,
+    /// Parent style id selected or rejected by the decision.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_style_id: Option<String>,
+    /// Human-readable decision reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl MinimizationDecisionAudit {
+    /// Build an audit entry for an invocation with no applicable decision.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            source: MinimizationDecisionSource::None,
+            outcome: MinimizationDecisionOutcome::NotSelected,
+            parent_style_id: None,
+            reason: Some("no minimization decision selected this style".to_string()),
+        }
+    }
+}
+
 /// Full evidence record for a single migration invocation.
 #[derive(Debug, Clone, Serialize)]
 pub struct MigrationEvidence {
@@ -95,6 +150,8 @@ pub struct MigrationEvidence {
     pub discovered_parents: Vec<FamilyCandidate>,
     /// The form the migration actually emitted.
     pub emitted_form: EmittedForm,
+    /// Audit trail for explicit minimization decisions.
+    pub minimization_decision: MinimizationDecisionAudit,
     /// Template-bearing paths whose diffs were preserved in the wrapper.
     /// Empty for standalone output or when `preserve_template_deltas=false`.
     pub preserved_template_paths: Vec<String>,
@@ -153,6 +210,7 @@ mod tests {
                 source: ParentDiscoverySource::ReverseTemplateLink,
             }],
             emitted_form: EmittedForm::Standalone,
+            minimization_decision: MinimizationDecisionAudit::none(),
             preserved_template_paths: Vec::new(),
             discarded_template_paths: Vec::new(),
             standalone_output_lines: 5662,

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -6,7 +6,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 //! Migration-time style lineage and wrapper classification.
 
 use crate::evidence::{
-    EmittedForm, FamilyCandidate, MigrationEvidence, ParentDiscoverySource, RegistryAliasStatus,
+    EmittedForm, FamilyCandidate, MigrationEvidence, MinimizationDecisionAudit,
+    ParentDiscoverySource, RegistryAliasStatus,
 };
 use citum_schema::Style;
 use citum_schema::embedded;
@@ -278,6 +279,7 @@ impl StyleLineage {
         standalone_lines: usize,
         emitted_form: EmittedForm,
         emitted_lines: usize,
+        minimization_decision: MinimizationDecisionAudit,
         preserved_template_paths: Vec<String>,
         discarded_template_paths: Vec<String>,
     ) -> MigrationEvidence {
@@ -331,6 +333,7 @@ impl StyleLineage {
             registry_alias_status,
             discovered_parents,
             emitted_form,
+            minimization_decision,
             preserved_template_paths,
             discarded_template_paths,
             standalone_output_lines: standalone_lines,
@@ -1264,6 +1267,7 @@ mod tests {
             5662,
             crate::evidence::EmittedForm::Standalone,
             5662,
+            crate::evidence::MinimizationDecisionAudit::none(),
             Vec::new(),
             Vec::new(),
         );

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -21,7 +21,10 @@ use citum_migrate::{
     OptionsExtractor, analysis,
     compilation::{self, XmlCompilationOutput as XmlFallback},
     debug_output::DebugOutputFormatter,
-    evidence::EmittedForm,
+    evidence::{
+        EmittedForm, MinimizationDecisionAudit, MinimizationDecisionOutcome,
+        MinimizationDecisionSource,
+    },
     fixups::{
         ensure_numeric_locator_citation_component, ensure_personal_communication_omitted,
         move_group_wrap_to_citation_items, normalize_author_date_locator_citation_component,
@@ -168,7 +171,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let legacy_style = parse_style(doc.root_element())?;
 
     let mut lineage = StyleLineage::resolve(path, &workspace_root, &legacy_style.info.links)?;
-    apply_family_candidate_routing(&mut lineage, &workspace_root, &cli.family_candidate, path)?;
+    let routing =
+        apply_family_candidate_routing(&mut lineage, &workspace_root, &cli.family_candidate, path)?;
 
     tracing::debug!("Migrating {path} to Citum...");
     tracing::debug!(
@@ -262,30 +266,65 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let emitted_lines = count_yaml_lines(&style)?;
 
-    if let Some(evidence_path) = cli.emit_evidence.as_deref() {
-        write_evidence_sidecar(
-            evidence_path,
-            &lineage,
-            standalone_lines,
-            emitted_lines,
-            cli.minimize_wrapper,
-        )?;
-    }
+    write_optional_evidence(
+        &cli,
+        &lineage,
+        standalone_lines,
+        emitted_lines,
+        cli.minimize_wrapper,
+        routing.audit,
+    )?;
 
     output_style_and_debug(&style, cli.debug_variable.as_deref(), &tracker)?;
     Ok(())
 }
 
+fn write_optional_evidence(
+    cli: &CliArgs,
+    lineage: &StyleLineage,
+    standalone_lines: usize,
+    emitted_lines: usize,
+    minimized: bool,
+    minimization_decision: MinimizationDecisionAudit,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(evidence_path) = cli.emit_evidence.as_deref() {
+        write_evidence_sidecar(
+            evidence_path,
+            lineage,
+            standalone_lines,
+            emitted_lines,
+            minimized,
+            minimization_decision,
+        )?;
+    }
+    Ok(())
+}
+
+/// Effective family-candidate routing after applying explicit flags.
+struct FamilyCandidateRouting {
+    audit: MinimizationDecisionAudit,
+}
+
 /// Promote a discovered family-candidate parent into the lineage's active
-/// routing slot when the CLI mode requests it.
+/// routing slot when explicit flags request it.
 fn apply_family_candidate_routing(
     lineage: &mut StyleLineage,
     workspace_root: &Path,
     mode: &FamilyCandidateMode,
     path: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<FamilyCandidateRouting, Box<dyn std::error::Error>> {
     match mode {
-        FamilyCandidateMode::Off => {}
+        FamilyCandidateMode::Default => Ok(FamilyCandidateRouting {
+            audit: MinimizationDecisionAudit::none(),
+        }),
+        FamilyCandidateMode::Off => Ok(FamilyCandidateRouting {
+            audit: MinimizationDecisionAudit {
+                source: MinimizationDecisionSource::ExplicitOff,
+                outcome: MinimizationDecisionOutcome::NotSelected,
+                parent_style_id: None,
+                reason: Some("caller disabled family-candidate routing".to_string()),
+            },
+        }),
         FamilyCandidateMode::Auto => {
             let promoted = lineage.promote_family_candidate(workspace_root, None)?;
             if !promoted {
@@ -293,12 +332,31 @@ fn apply_family_candidate_routing(
                     "No family-candidate parent discovered for {path}; staying standalone."
                 );
             }
+            Ok(FamilyCandidateRouting {
+                audit: MinimizationDecisionAudit {
+                    source: MinimizationDecisionSource::ExplicitFlags,
+                    outcome: if promoted {
+                        MinimizationDecisionOutcome::Accepted
+                    } else {
+                        MinimizationDecisionOutcome::NotSelected
+                    },
+                    parent_style_id: lineage.parent_style_id.clone(),
+                    reason: Some("caller requested --family-candidate auto".to_string()),
+                },
+            })
         }
         FamilyCandidateMode::Explicit(id) => {
             lineage.promote_family_candidate(workspace_root, Some(id))?;
+            Ok(FamilyCandidateRouting {
+                audit: MinimizationDecisionAudit {
+                    source: MinimizationDecisionSource::ExplicitFlags,
+                    outcome: MinimizationDecisionOutcome::Accepted,
+                    parent_style_id: Some(id.clone()),
+                    reason: Some("caller forced a family-candidate parent".to_string()),
+                },
+            })
         }
     }
-    Ok(())
 }
 
 /// Build the migration evidence record and write it as a JSON sidecar at the
@@ -309,6 +367,7 @@ fn write_evidence_sidecar(
     standalone_lines: usize,
     emitted_lines: usize,
     minimized: bool,
+    minimization_decision: MinimizationDecisionAudit,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let emitted_form = describe_emitted_form(lineage, minimized);
     // Classify which template-bearing scopes the wrapper retained vs
@@ -322,6 +381,7 @@ fn write_evidence_sidecar(
         standalone_lines,
         emitted_form,
         emitted_lines,
+        minimization_decision,
         preserved,
         discarded,
     );
@@ -424,15 +484,20 @@ fn resolve_style_name_and_templates(
 
 fn workspace_root_for_style_path(path: &str) -> PathBuf {
     let style_path = Path::new(path);
-    if style_path.is_absolute() {
-        style_path
-            .ancestors()
-            .find(|p| p.join("Cargo.toml").exists())
-            .unwrap_or(style_path.parent().unwrap_or(Path::new(".")))
-            .to_path_buf()
+    let rooted_style_path = if style_path.is_absolute() {
+        style_path.to_path_buf()
     } else {
-        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
-    }
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(style_path)
+    };
+
+    let workspace_root = rooted_style_path
+        .ancestors()
+        .find(|p| p.join("Cargo.toml").exists())
+        .unwrap_or(rooted_style_path.parent().unwrap_or(Path::new(".")))
+        .to_path_buf();
+    fs::canonicalize(&workspace_root).unwrap_or(workspace_root)
 }
 
 #[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
@@ -717,6 +782,76 @@ mod tests {
         Citation, CslNode, Formatting, Group, Info, Layout, Sort as LegacySort,
         SortKey as LegacySortKey, Style as LegacyStyle, Text,
     };
+    use std::sync::{Mutex, OnceLock};
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("crate should live under crates/citum-migrate")
+            .to_path_buf()
+    }
+
+    fn cwd_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("cwd lock should not be poisoned")
+    }
+
+    #[test]
+    fn workspace_root_resolves_relative_paths_from_subdirectories() {
+        let _guard = cwd_lock();
+        let original_cwd = std::env::current_dir().expect("current dir should be available");
+        std::env::set_current_dir(repo_root().join("crates"))
+            .expect("test should enter repo subdirectory");
+
+        let workspace_root = workspace_root_for_style_path("../styles-legacy/apa-6th-edition.csl");
+
+        std::env::set_current_dir(original_cwd).expect("test should restore cwd");
+        assert_eq!(workspace_root, repo_root());
+    }
+
+    #[test]
+    fn explicit_off_preserves_standalone_output() {
+        let mut lineage =
+            StyleLineage::resolve("styles-legacy/apa-6th-edition.csl", &repo_root(), &[])
+                .expect("lineage should resolve");
+        let routing = apply_family_candidate_routing(
+            &mut lineage,
+            &repo_root(),
+            &FamilyCandidateMode::Off,
+            "styles-legacy/apa-6th-edition.csl",
+        )
+        .expect("explicit off should apply");
+
+        assert!(lineage.parent_style_id.is_none());
+        assert_eq!(
+            routing.audit.source,
+            MinimizationDecisionSource::ExplicitOff
+        );
+    }
+
+    #[test]
+    fn default_family_candidate_mode_preserves_standalone_output() {
+        let mut lineage =
+            StyleLineage::resolve("styles-legacy/apa-6th-edition.csl", &repo_root(), &[])
+                .expect("lineage should resolve");
+        let routing = apply_family_candidate_routing(
+            &mut lineage,
+            &repo_root(),
+            &FamilyCandidateMode::Default,
+            "styles-legacy/apa-6th-edition.csl",
+        )
+        .expect("default routing should apply");
+
+        assert!(lineage.parent_style_id.is_none());
+        assert_eq!(routing.audit.source, MinimizationDecisionSource::None);
+        assert_eq!(
+            routing.audit.outcome,
+            MinimizationDecisionOutcome::NotSelected
+        );
+    }
 
     fn legacy_sort(keys: &[&str]) -> LegacySort {
         LegacySort {

--- a/docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md
+++ b/docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md
@@ -1,8 +1,8 @@
-# citum-migrate SQI baseline (post-publish wave PR1–PR3)
+# citum-migrate SQI baseline (post-publish wave PR1–PR3, corrected)
 
 **Date:** 2026-05-20
 **Status:** Active
-**Related:** `.beans/csl26-f1u7--citum-migrate-post-publish-quality-wave.md`, `.beans/archive/csl26-e7yw--citum-migrate-sqi-scorecard-citation-type-variant.md`, `.beans/archive/csl26-kqji--descendant-of-preset-base-wrapper-rewrite-pr2.md`, `.beans/archive/csl26-39tm--output-driven-migration-compression-and-alias-ux-e.md`, `docs/reference/SQI.md`, `docs/specs/APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md`
+**Related:** `.beans/csl26-f1u7--citum-migrate-post-publish-quality-wave.md`, `.beans/archive/csl26-e7yw--citum-migrate-sqi-scorecard-citation-type-variant.md`, `.beans/archive/csl26-kqji--descendant-of-preset-base-wrapper-rewrite-pr2.md`, `.beans/archive/csl26-39tm--output-driven-migration-compression-and-alias-ux-e.md`, `.beans/archive/csl26-dqtx--reference-corpus-exposes-apa-6-vs-7-semantic-diffe.md`, `.beans/csl26-tjqn--auto-minimize-wrapper-by-default-for-proven-candid.md`, `.beans/csl26-kd28--reduce-apa-6-standalone-migration-bloat.md`, `docs/reference/SQI.md`, `docs/specs/APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md`
 
 ## Purpose
 
@@ -26,20 +26,29 @@ Establish a reproducible scorecard for the structural quality (SQI) of `citum-mi
 - Added reverse `<info><link rel="template">` discovery in `StyleLineage::resolve`. When a legacy style has no other parent link, the resolver scans embedded canonical styles for one that declares the legacy id as its historical template source. The discovered candidate is recorded inertly on `StyleLineage::family_candidate`.
 - Added `--family-candidate off|auto|<id>` to opt into routing a discovered candidate through `ExistingWrapper { preserve_template_deltas: true }`.
 - Added `--minimize-wrapper`: when used with `--family-candidate`, the migration emits a minimal wrapper (`info` + `extends` + only options that materially differ from parent), inheriting all template-bearing scopes from the candidate parent. Default off; existing callers see no behavior change.
-- The SQI scorecard now A/B-tests every compression candidate: standalone form vs. minimized form, both oracle-verified. The minimized form replaces the standalone in scorecard reporting only when oracle citation pass ≥ standalone, bibliography pass ≥ standalone, and the minimized LOC is strictly smaller than standalone.
+- The SQI scorecard now A/B-tests every compression candidate: standalone form vs. minimized form, both oracle-verified. PR3 used fuzzy pass-count preservation plus LOC improvement as the acceptance gate.
 - `apa-6th-edition` is now a sentinel.
 
-### Result on apa-6th-edition
+### PR4 correction (strict minimization)
 
-| | Standalone | Minimized (PR3) |
+- `csl26-dqtx` tightened scorecard minimization acceptance. Candidate wrappers must now preserve strict normalized citation and bibliography output before they can replace standalone migration output. Fuzzy oracle pass counts remain diagnostic; they no longer prove minimization safety.
+- `csl26-tjqn` remains open. Making minimization default requires a distribution-safe runtime design and must not hide converter bloat behind an unsafe wrapper.
+- `apa-6th-edition` is rejected against `apa-7th` by strict scorecard evidence. The old 5-line wrapper was an unsafe semantic compression because strict APA 6/APA 7 output differs even though fuzzy diagnostics made the candidate look beneficial.
+
+### Corrected result on apa-6th-edition
+
+| | Standalone | Minimized candidate |
 |---|---:|---:|
 | LOC | 5,661 | **5** |
-| Migrated SQI | 66.67 | **100.00** |
-| Oracle citations | 18/18 | 18/18 |
-| Oracle bibliography | 10/37 | **33/34** |
-| `pathologicalOutput` | yes | no |
+| Migrated SQI | 66.67 | 100.00 |
+| Fuzzy oracle citations | 18/18 | 18/18 |
+| Strict minimization citations | 1/1 | 0/1 |
+| Fuzzy oracle bibliography | 10/37 | 33/34 |
+| Strict normalized equivalence | n/a | **fail** |
+| Accepted for minimization | n/a | **no** |
+| Default no-flag output | **standalone** | not emitted |
 
-The minimized form is not an alias of apa-7th: the migrator demonstrates output equivalence via the oracle reference corpus before swapping the standalone form for the inheritance shell. When the bibliography fixture set was expanded under the standalone form (37 references via converter-emitted type-variants), most rendered worse than the parent's template would have; inheriting apa-7th's templates verbatim recovers fidelity (33 of the 34 base references match) while reducing emitted LOC by 99.9 %.
+The minimized form is a useful diagnostic candidate but not a safe output form. The strict gate exposes APA 6 vs. APA 7 citation and bibliography differences, including first/subsequent clustered citation behavior and bibliography rendering differences. No-flag `citum-migrate styles-legacy/apa-6th-edition.csl` stays standalone; reducing its 5,661-line output is a converter-quality follow-up, not a wrapper-inheritance shortcut.
 
 ## Corpus
 
@@ -49,7 +58,7 @@ The minimized form is not an alias of apa-7th: the migrator demonstrates output 
 node scripts/report-migrate-sqi.js --out /tmp/sqi.json --markdown docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md
 ```
 
-The scorecard runs `citum-migrate --emit-evidence`, reports fidelity via `scripts/oracle-migrate-batch.js`, scores both the migrated YAML and the public `styles/` YAML using `concision`, `fallbackRobustness`, and `presetUsage`. For every style whose evidence shows a discovered candidate AND whose initial emitted form is `standalone`, the scorecard also runs migrate with `--family-candidate auto --minimize-wrapper`, runs oracle on the minimized YAML directly, and swaps the row to the minimized form when the acceptance gate holds.
+The scorecard runs `citum-migrate --emit-evidence`, reports fidelity via `scripts/oracle-migrate-batch.js`, scores both the migrated YAML and the public `styles/` YAML using `concision`, `fallbackRobustness`, and `presetUsage`. For every style whose evidence shows a discovered candidate AND whose initial emitted form is `standalone`, the scorecard also runs migrate with `--family-candidate auto --minimize-wrapper`, runs oracle on the minimized YAML directly, and swaps the row to the minimized form only when strict normalized citation and bibliography equivalence holds and the minimized form is shorter.
 
 ## Aggregate
 
@@ -59,14 +68,14 @@ The scorecard runs `citum-migrate --emit-evidence`, reports fidelity via `script
 | Public YAML SQI | 17 | 92.46 | 83.93 | 96.27 | 100.00 |
 | Migrated − Public | 17 | +3.87 | -0.27 | +2.40 | +10.87 |
 
-PR3 lifted the mean from PR2's 94.69 to 96.54 by minimizing `apa-6th-edition` (66.67 → 100.00).
+PR3 appeared to lift the mean from PR2's 94.69 to 96.54 by minimizing `apa-6th-edition` (66.67 → 100.00). The PR4 correction rejects that lift as unsafe; APA 6 remains a 66.67 standalone sentinel until APA 6 behavior is represented directly.
 
 ## Per-style
 
 | Style | Fidelity | Migrated SQI | Public SQI | Δ | LOC | Form |
 |---|---:|---:|---:|---:|---:|---|
 | apa | 18/18 • 33/33 | 100.00 | 88.37 | **+11.63** | 5 | alias wrapper |
-| apa-6th-edition | 18/18 • 33/34 | 100.00 | – | – | 5 | minimized wrapper (extends apa-7th) |
+| apa-6th-edition | 18/18 • 10/37 | 66.67 | – | – | 5,661 | standalone (strict minimization rejected) |
 | elsevier-harvard | 18/18 • 34/34 | 100.00 | 100.00 | 0.00 | 67 | descendant wrapper |
 | elsevier-with-titles | 18/18 • 34/34 | 100.00 | 100.00 | 0.00 | 24 | descendant wrapper |
 | elsevier-vancouver | 18/18 • 34/34 | 100.00 | 100.00 | 0.00 | 52 | descendant wrapper |
@@ -88,15 +97,15 @@ PR3 lifted the mean from PR2's 94.69 to 96.54 by minimizing `apa-6th-edition` (6
 
 | Style | Candidate parent | Discovery source | Standalone LOC → Minimized LOC | Standalone fidelity → Minimized fidelity | Accepted |
 |---|---|---|---:|---|:---:|
-| apa-6th-edition | apa-7th | reverse-template-link | 5,661 → 5 | 18/18 • 10/37 → 18/18 • 33/34 | ✓ |
+| apa-6th-edition | apa-7th | reverse-template-link | 5,661 → 5 | strict citations 1/1 → 0/1; bibliography 10/37 → 33/34; strict equivalence fails | ✗ |
 | multidisciplinary-digital-publishing-institute | american-chemical-society | template-link | 237 → 237 | 18/18 • 33/34 → 18/18 • 33/34 | ✗ |
 
-The mdpi rejection is structural: its candidate parent is discovered via a `template-link` in the source CSL rather than a `reverse-template-link` from an embedded canonical style, so `promote_family_candidate` doesn't fire and `--minimize-wrapper` returns the standalone form unchanged. Bringing template-link candidates into the minimize path is the natural next step (see `csl26-ly8d`).
+The APA 6 rejection is semantic: the minimized `apa-7th` wrapper is shorter and improves some fuzzy bibliography diagnostics, but it is not strict-output equivalent to APA 6. The mdpi rejection is structural: its candidate parent is discovered via a `template-link` in the source CSL rather than a `reverse-template-link` from an embedded canonical style, so `promote_family_candidate` doesn't fire and `--minimize-wrapper` returns the standalone form unchanged. Bringing template-link candidates into the minimize path is the natural next step (see `csl26-ly8d`).
 
 ## Observations
 
 - The two pre-PR1 outliers (`apa` -17.67, `chicago-author-date` -31.56) collapsed to `+11.63` and `+1.77` respectively after PR1's alias-wrapper routing. Both styles are registry aliases for canonical embedded `kind: base` entries; the converter emits a thin `extends:` wrapper and inherits the canonical templates instead of duplicating them.
-- PR3's apa-6th-edition compression is the largest single-style lift of the wave: 5,661 LOC → 5 LOC, SQI 66.67 → 100.00, with a *fidelity gain* (10/37 → 33/34 bibliography) rather than a regression. The reference corpus exposed that apa-7th's templates render the apa-6th item set more accurately than the converter-derived apa-6th templates do — likely because the converter's coverage of the 37-reference type-variant set is incomplete while apa-7th's base templates handle the 34-reference core set cleanly.
+- The earlier apa-6th-edition compression was a false lift: 5,661 LOC → 5 LOC looked attractive under fuzzy diagnostics, but strict normalized output rejects the APA 7 wrapper as semantically unsafe. APA 6 is retained as a standalone sentinel; its 5,661-line output remains a converter-efficiency bug.
 - `ieee` (+10.87), `karger-journals` (+9.76), `multidisciplinary-digital-publishing-institute` (+6.64), and `cell` (+3.20) remain styles where the converter is more concise than the hand-authored public YAML. Public YAML cleanup is a separate follow-up.
 - Bibliography misses for `american-medical-association` (31/34), `nature`/`cell` (32/34), `karger-journals` (33/34), and `mdpi` (33/34) are pre-existing engine gaps (patent number, publisher:extra, magazine title suppression) — not introduced by PR1–PR3.
 
@@ -104,9 +113,11 @@ The mdpi rejection is structural: its candidate parent is discovered via a `temp
 
 - **PR1** ([[csl26-e7yw]]): SQI scorecard, alias-wrapper routing, atomic-config diff fix.
 - **PR2** ([[csl26-kqji]], #766): descendant-of-preset-base wrapper rewrite.
-- **PR3** ([[csl26-39tm]], #767): evidence emission, reverse-template-link discovery, `--minimize-wrapper`, apa-6th-edition 5,661 → 5 LOC with fidelity improvement.
-- **PR4** ([[csl26-ly8d]]): extend the minimize path to template-link candidates (mdpi and the numeric cluster) so they can be considered for compression too.
-- **PR5** (not yet filed): author a Vancouver / numeric-journal preset base and repeat the rewrite pass.
-- **PR6** (not yet filed): auto-derive candidate families from cluster fingerprints.
+- **PR3** ([[csl26-39tm]], #767): evidence emission, reverse-template-link discovery, `--minimize-wrapper`.
+- **PR4** ([[csl26-dqtx]]): strict wrapper-minimization acceptance; apa-6th-edition is rejected as an unsafe apa-7th wrapper.
+- **PR5** ([[csl26-kd28]]): reduce apa-6th-edition standalone migration bloat by improving converter output, not by treating APA 6 as an APA 7 wrapper.
+- **PR6** ([[csl26-tjqn]], [[csl26-ly8d]]): revisit safe default minimization and broader parent-link minimization once converter bloat and runtime-distribution design are resolved.
+- **PR7** (not yet filed): author a Vancouver / numeric-journal preset base and repeat the rewrite pass.
+- **PR8** (not yet filed): auto-derive candidate families from cluster fingerprints.
 
 Each subsequent PR refreshes this scorecard and updates the baseline numbers in place.

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -376,6 +376,55 @@ function buildMigrateCommand(absStylePath, migrateOptions = {}, allFeatures = fa
   return parts.join(' ');
 }
 
+function expandCitationsForCitum(testCitations) {
+  const clustered = new Map();
+  const citations = [];
+
+  for (const cite of testCitations) {
+    if (!Array.isArray(cite.clusters)) {
+      citations.push(cite);
+      continue;
+    }
+
+    const clusterIds = [];
+    cite.clusters.forEach((cluster, index) => {
+      const clusterId = `${cite.id}__${cluster.id || index + 1}`;
+      clusterIds.push(clusterId);
+      citations.push({
+        ...cluster,
+        id: clusterId,
+        items: cluster.items || [],
+        'suppress-author': cluster['suppress-author'] === true,
+      });
+    });
+    clustered.set(cite.id, clusterIds);
+  }
+
+  return { citations, clustered };
+}
+
+function collapseClusteredCitumCitations(rendered, clustered) {
+  if (!clustered.size) {
+    return rendered;
+  }
+
+  const citations = { ...rendered.citations };
+  for (const [id, clusterIds] of clustered.entries()) {
+    citations[id] = clusterIds
+      .map((clusterId) => citations[clusterId])
+      .filter((part) => part != null)
+      .join(' | ');
+    for (const clusterId of clusterIds) {
+      delete citations[clusterId];
+    }
+  }
+
+  return {
+    ...rendered,
+    citations,
+  };
+}
+
 // Resolve an already-authored Citum YAML for a style name. Searches
 // `styles/<name>.yaml`, then `styles/embedded/<name>.yaml` (the canonical
 // parents shipped inside the citum binary), then a base-name prefix match
@@ -497,10 +546,14 @@ function renderWithCitumProcessor(stylePath, refsData, testItems, testCitations,
 
     const scope = cliOptions.scope || 'both';
     const bibliographyOnly = scope === 'bibliography';
+    const citumCitationInput = expandCitationsForCitum(testCitations);
 
     fs.writeFileSync(workspace.refsFile, JSON.stringify(refsDataForProcessor(refsData), null, 2));
     if (!bibliographyOnly) {
-      fs.writeFileSync(workspace.citationsFile, JSON.stringify(testCitations, null, 2));
+      fs.writeFileSync(
+        workspace.citationsFile,
+        JSON.stringify(citumCitationInput.citations, null, 2)
+      );
     }
 
     if (!citumStylePath) {
@@ -542,7 +595,10 @@ function renderWithCitumProcessor(stylePath, refsData, testItems, testCitations,
       return { error: `Processor failed: ${errorMsg}`, citations: { passed: 0, total: 0 }, bibliography: { passed: 0, total: 0 } };
     }
 
-    return parseCitumRenderOutput(output, testItems);
+    return collapseClusteredCitumCitations(
+      parseCitumRenderOutput(output, testItems),
+      citumCitationInput.clustered
+    );
   } finally {
     cleanupOracleTempWorkspace(workspace);
   }
@@ -616,7 +672,10 @@ function equivalentCitationText(oracleText, citumText, citationId, options = {})
 
 function collectCitationTypes(citation, testItems) {
   const types = new Set();
-  for (const item of citation.items || []) {
+  const items = Array.isArray(citation.clusters)
+    ? citation.clusters.flatMap((cluster) => cluster.items || [])
+    : citation.items || [];
+  for (const item of items) {
     const ref = testItems[item.id];
     if (ref && ref.type) {
       types.add(ref.type);
@@ -973,6 +1032,8 @@ module.exports = {
   parseArgs,
   parseCitumRenderOutput,
   refsDataForProcessor,
+  expandCitationsForCitum,
+  collapseClusteredCitumCitations,
   renderWithCitumProcessor,
   resolveAuthoredStylePath,
   runOracle,

--- a/scripts/oracle.test.js
+++ b/scripts/oracle.test.js
@@ -12,6 +12,8 @@ const {
   normalizeFixtureItems,
   parseCitumRenderOutput,
   refsDataForProcessor,
+  expandCitationsForCitum,
+  collapseClusteredCitumCitations,
   resolveAuthoredStylePath,
 } = require('./oracle');
 const {
@@ -171,6 +173,39 @@ test('loadFixtures preserves raw wrapped fixtures for processor rendering', () =
   assert.ok(refsData.sets);
   assert.ok(testItems['zwart1983']);
   assert.ok(testItems['johnson2021-patent']);
+});
+
+test('clustered citation fixtures expand for Citum and collapse back to oracle id', () => {
+  const { citations, clustered } = expandCitationsForCitum([
+    {
+      id: 'apa-four-author-first-subsequent',
+      clusters: [
+        { id: 'first', items: [{ id: 'ITEM-29' }] },
+        { id: 'subsequent', items: [{ id: 'ITEM-29' }] },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(citations.map((citation) => citation.id), [
+    'apa-four-author-first-subsequent__first',
+    'apa-four-author-first-subsequent__subsequent',
+  ]);
+  const collapsed = collapseClusteredCitumCitations(
+    {
+      citations: {
+        'apa-four-author-first-subsequent__first': '(Smith, Lee, Kumar, & Zhou, 2021)',
+        'apa-four-author-first-subsequent__subsequent': '(Smith et al, 2021)',
+      },
+      bibliography: [],
+    },
+    clustered
+  );
+
+  assert.equal(
+    collapsed.citations['apa-four-author-first-subsequent'],
+    '(Smith, Lee, Kumar, & Zhou, 2021) | (Smith et al, 2021)'
+  );
+  assert.equal(collapsed.citations['apa-four-author-first-subsequent__first'], undefined);
 });
 
 test('refsDataForProcessor preserves wrapped fixture sets', () => {

--- a/scripts/report-migrate-sqi.js
+++ b/scripts/report-migrate-sqi.js
@@ -34,10 +34,17 @@ const { spawnSync } = require('child_process');
 
 const reportCore = require('./report-core.js');
 const { resolveAuthoredStylePath } = require('./oracle.js');
+const { normalizeText } = require('./oracle-utils.js');
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '..');
 const LEGACY_DIR = path.join(WORKSPACE_ROOT, 'styles-legacy');
 const STYLES_DIR = path.join(WORKSPACE_ROOT, 'styles');
+const MINIMIZATION_CITATIONS_FIXTURE = path.join(
+  WORKSPACE_ROOT,
+  'tests',
+  'fixtures',
+  'citations-minimization.json'
+);
 
 const SENTINELS = [
   'apa',
@@ -219,17 +226,23 @@ function attemptMinimization(styleName) {
 /**
  * Run the migrate-batch oracle on a pre-built YAML by writing it to a temp
  * file named after the style and invoking `oracle.js` with that path.
- * Returns `{ citations: { passed, total }, bibliography: { passed, total } }`
- * or `null` if the oracle fails.
+ * Returns the parsed oracle section objects for `citations` and
+ * `bibliography`, including their `entries` arrays when present. Either
+ * section can be `null` if the oracle did not produce that section. Returns
+ * `null` when the oracle output cannot be parsed or lacks both sections.
  */
-function oracleForYaml(styleName, yamlText) {
+function oracleForYaml(styleName, yamlText, options = {}) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'citum-min-oracle-'));
   const yamlPath = path.join(tmpDir, `${styleName}.yaml`);
   try {
     fs.writeFileSync(yamlPath, yamlText);
+    const oracleArgs = [path.join(WORKSPACE_ROOT, 'scripts', 'oracle.js'), yamlPath, '--json'];
+    if (options.citationsFixture) {
+      oracleArgs.push('--citations-fixture', options.citationsFixture);
+    }
     const proc = spawnSync(
       'node',
-      [path.join(WORKSPACE_ROOT, 'scripts', 'oracle.js'), yamlPath, '--json'],
+      oracleArgs,
       { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
     );
     // oracle.js exits with status 1 whenever fidelity is below 100%, even
@@ -249,6 +262,41 @@ function oracleForYaml(styleName, yamlText) {
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
+}
+
+function sectionPassCount(section) {
+  return section?.passed ?? 0;
+}
+
+function normalizedEqual(left, right) {
+  if (typeof left !== 'string' || typeof right !== 'string') {
+    return false;
+  }
+  return normalizeText(left) === normalizeText(right);
+}
+
+function strictSectionEquivalent(section) {
+  if (!section || !Array.isArray(section.entries) || section.entries.length === 0) {
+    return false;
+  }
+  return section.entries.every((entry) => normalizedEqual(entry.oracle, entry.citum));
+}
+
+function evaluateMinimizationAcceptance({ baseOracle, minOracle, minLoc, baseLoc }) {
+  const strict = {
+    citations: strictSectionEquivalent(minOracle?.citations),
+    bibliography: strictSectionEquivalent(minOracle?.bibliography),
+  };
+  const passCountsHold = minOracle != null
+    && sectionPassCount(minOracle.citations) >= sectionPassCount(baseOracle?.citations)
+    && sectionPassCount(minOracle.bibliography) >= sectionPassCount(baseOracle?.bibliography);
+  const locImproves = minLoc < baseLoc;
+  return {
+    accepted: passCountsHold && locImproves && strict.citations && strict.bibliography,
+    strict,
+    passCountsHold,
+    locImproves,
+  };
 }
 
 function stripCustomYamlTags(yamlText) {
@@ -475,7 +523,7 @@ function buildMarkdown(report) {
     lines.push('');
     lines.push('## Compression candidates');
     lines.push('');
-    lines.push('Styles where the migrator discovered a candidate parent via the registry, a source CSL link, or a reverse `<info><link rel="template">` in an embedded canonical style. The scorecard tries the minimized wrapper form (`--family-candidate auto --minimize-wrapper`) for each candidate and accepts it only when oracle citation pass ≥ standalone AND bibliography pass ≥ standalone.');
+    lines.push('Styles where the migrator discovered a candidate parent via the registry, a source CSL link, or a reverse `<info><link rel="template">` in an embedded canonical style. The scorecard tries the minimized wrapper form (`--family-candidate auto --minimize-wrapper`) for each candidate and accepts it only when oracle citation pass ≥ standalone, bibliography pass ≥ standalone, LOC decreases, and every minimized citation/bibliography entry is strictly equivalent after normalization.');
     lines.push('');
     lines.push('| Style | Candidate parent | Discovery source | Standalone LOC → Minimized LOC | Standalone fidelity → Minimized fidelity | Accepted |');
     lines.push('|---|---|---|---:|---|:---:|');
@@ -565,11 +613,9 @@ function main() {
     ) {
       const min = attemptMinimization(style);
       if (min && min.yaml) {
-        const minOracle = oracleForYaml(style, min.yaml);
-        const baseCit = row.fidelity?.citations?.passed ?? 0;
-        const baseBib = row.fidelity?.bibliography?.passed ?? 0;
-        const minCit = minOracle?.citations?.passed ?? -1;
-        const minBib = minOracle?.bibliography?.passed ?? -1;
+        const strictFixtureOptions = { citationsFixture: MINIMIZATION_CITATIONS_FIXTURE };
+        const baseStrictOracle = oracleForYaml(style, migrated.yaml, strictFixtureOptions);
+        const minOracle = oracleForYaml(style, min.yaml, strictFixtureOptions);
         const minLoc = min.evidence?.emitted_output_lines ?? Number.MAX_SAFE_INTEGER;
         const baseLoc = row.evidence?.standalone_output_lines
           ?? row.migrated?.diagnostics?.outputLines
@@ -580,17 +626,23 @@ function main() {
         // converter did not promote the family candidate (e.g. mdpi's
         // template-link parent path bypasses the minimize branch); marking
         // those as compressed would be misleading.
-        const accepted = minOracle != null
-          && minCit >= baseCit
-          && minBib >= baseBib
-          && minLoc < baseLoc;
+        const acceptance = evaluateMinimizationAcceptance({
+          baseOracle: baseStrictOracle ?? row.fidelity,
+          minOracle,
+          minLoc,
+          baseLoc,
+        });
+        const accepted = acceptance.accepted;
         row.minimization = {
           attempted: true,
           accepted,
+          strict: acceptance.strict,
+          passCountsHold: acceptance.passCountsHold,
+          locImproves: acceptance.locImproves,
           standalone: {
             outputLines: row.migrated?.diagnostics?.outputLines ?? null,
-            citations: row.fidelity?.citations ?? null,
-            bibliography: row.fidelity?.bibliography ?? null,
+            citations: baseStrictOracle?.citations ?? row.fidelity?.citations ?? null,
+            bibliography: baseStrictOracle?.bibliography ?? row.fidelity?.bibliography ?? null,
           },
           minimized: {
             outputLines: min.evidence?.emitted_output_lines ?? null,
@@ -660,9 +712,17 @@ function collectMigratedOutputDiagnostics(styles) {
   return rows;
 }
 
-try {
-  main();
-} catch (err) {
-  console.error(`Error: ${err.message}`);
-  process.exit(1);
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
 }
+
+module.exports = {
+  evaluateMinimizationAcceptance,
+  normalizedEqual,
+  strictSectionEquivalent,
+};

--- a/scripts/report-migrate-sqi.test.js
+++ b/scripts/report-migrate-sqi.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  evaluateMinimizationAcceptance,
+  normalizedEqual,
+  strictSectionEquivalent,
+} = require('./report-migrate-sqi');
+
+test('normalizedEqual ignores markup but preserves semantic text differences', () => {
+  assert.equal(normalizedEqual('<i>Title</i>.', 'Title'), true);
+  assert.equal(normalizedEqual('(Smith, Lee, Kumar, & Zhou, 2021)', '(Smith et al, 2021)'), false);
+});
+
+test('strictSectionEquivalent rejects fuzzy APA citation drift', () => {
+  assert.equal(
+    strictSectionEquivalent({
+      entries: [
+        {
+          oracle: '(John Smith, Lee, Kumar, & Zhou, 2021)',
+          citum: '(Smith, Lee, Kumar, et al, 2021)',
+          match: true,
+        },
+      ],
+    }),
+    false
+  );
+});
+
+test('evaluateMinimizationAcceptance requires strict minimized oracle equivalence', () => {
+  const baseOracle = {
+    citations: { passed: 1 },
+    bibliography: { passed: 1 },
+  };
+  const minOracle = {
+    citations: {
+      passed: 1,
+      entries: [
+        {
+          oracle: '(John Smith, Lee, Kumar, & Zhou, 2021)',
+          citum: '(Smith, Lee, Kumar, et al, 2021)',
+          match: true,
+        },
+      ],
+    },
+    bibliography: {
+      passed: 1,
+      entries: [
+        {
+          oracle: 'Hawking, S. (1988). A Brief History of Time. New York: Bantam Dell Publishing Group',
+          citum: 'Hawking, S. (1988). A Brief History of Time. Bantam Dell Publishing Group',
+          match: true,
+        },
+      ],
+    },
+  };
+
+  const acceptance = evaluateMinimizationAcceptance({
+    baseOracle,
+    minOracle,
+    minLoc: 5,
+    baseLoc: 5661,
+  });
+
+  assert.equal(acceptance.passCountsHold, true);
+  assert.equal(acceptance.locImproves, true);
+  assert.deepEqual(acceptance.strict, { citations: false, bibliography: false });
+  assert.equal(acceptance.accepted, false);
+});
+
+test('evaluateMinimizationAcceptance accepts strict equivalent smaller output', () => {
+  const minOracle = {
+    citations: {
+      passed: 1,
+      entries: [{ oracle: '(Kuhn, 1962)', citum: '(Kuhn, 1962)', match: true }],
+    },
+    bibliography: {
+      passed: 1,
+      entries: [{ oracle: 'Kuhn, T. S. (1962). Title', citum: 'Kuhn, T. S. (1962). Title' }],
+    },
+  };
+
+  const acceptance = evaluateMinimizationAcceptance({
+    baseOracle: { citations: { passed: 1 }, bibliography: { passed: 1 } },
+    minOracle,
+    minLoc: 10,
+    baseLoc: 100,
+  });
+
+  assert.equal(acceptance.accepted, true);
+});

--- a/tests/fixtures/citations-minimization.json
+++ b/tests/fixtures/citations-minimization.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "apa-four-author-first-subsequent",
+    "items": [
+      {
+        "id": "ITEM-29"
+      }
+    ],
+    "clusters": [
+      {
+        "id": "first",
+        "items": [
+          {
+            "id": "ITEM-29"
+          }
+        ]
+      },
+      {
+        "id": "subsequent",
+        "items": [
+          {
+            "id": "ITEM-29"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- Tightens SQI wrapper-minimization acceptance so candidates must preserve strict normalized citation and bibliography output, not just fuzzy pass counts.
- Adds clustered APA 6/APA 7 citation fixture coverage and oracle support for clustered citation scenarios.
- Proves `apa-6th-edition` is unsafe to minimize to an `apa-7th` wrapper; no-flag runtime migration remains standalone.
- Removes the earlier checked-manifest runtime-routing approach; APA 6 output bloat is now tracked as converter work in `csl26-kd28`.

## Behavioral notes

- `citum-migrate styles-legacy/apa-6th-edition.csl` still emits standalone output.
- `scripts/report-migrate-sqi.js` still attempts the minimized candidate and reports it rejected when strict equivalence fails.
- Evidence JSON now records explicit CLI minimization/routing decisions only; there is no default manifest source.

## Test plan

- [x] `node --test scripts/oracle.test.js scripts/report-migrate-sqi.test.js`
- [x] `cargo test -p citum-migrate`
- [x] `node scripts/report-migrate-sqi.js --styles apa-6th-edition --out /tmp/citum-apa6-sqi.json --json`
- [x] `cargo run -q --bin citum-migrate -- styles-legacy/apa-6th-edition.csl | wc -l`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run`
- [x] `./scripts/check-bean-hygiene.sh && git diff --check`
