### PR TITLE
feat(scripts): pick installer components via CITUM_COMPONENTS

### DIFF
--- a/.beans/archive/csl26-js4h--component-selectable-installsh.md
+++ b/.beans/archive/csl26-js4h--component-selectable-installsh.md
@@ -1,0 +1,38 @@
+---
+# csl26-js4h
+title: Component-selectable install.sh
+status: completed
+type: feature
+priority: normal
+created_at: 2026-05-22T11:48:25Z
+updated_at: 2026-05-22T11:54:43Z
+---
+
+Allow users to choose which Citum binaries to install via CITUM_COMPONENTS env var.
+
+## Plan
+
+See PR #776 description.
+
+## Todo
+
+- [x] Add citum-migrate to release-binary.sh build + tarball
+- [x] Add CITUM_COMPONENTS selection to install.sh (default: citum only)
+- [x] Update install docs (docs/developer.html)
+- [x] Selection logic matrix test (default/single/pair/all/whitespace/bogus/empty)
+- [x] Installer matrix verified (same as above)
+- [x] sh -n / bash -n parse-checked (shellcheck not installed locally)
+- [ ] Open PR
+
+## Notes
+
+Default = citum only; behavior change for existing curl|sh users (lose auto citum-server). Flag in PR description.
+
+## Summary of Changes
+
+- `scripts/release-binary.sh`: build & ship `citum-migrate` alongside `citum` + `citum-server` in every release tarball.
+- `scripts/install.sh`: parse `CITUM_COMPONENTS` (default: `citum`), validate before download, loop-install the selected subset. `all` is the only alias.
+- `docs/developer.html`: document the env var next to the curl|sh one-liner.
+- PR #776 opened.
+
+Behaviour change: existing curl|sh users no longer get `citum-server` automatically — must pass `CITUM_COMPONENTS=all` or list it explicitly. Flagged in the PR description for release notes.

--- a/docs/developer.html
+++ b/docs/developer.html
@@ -137,6 +137,17 @@
             <div class="workshop-block">
                 <div class="workshop-label">Install (pre-built binary)</div>
                 <pre><code>curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh</code></pre>
+                <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
+                    Installs <code>citum</code> by default. To pick a different subset, set
+                    <code>CITUM_COMPONENTS</code> to a comma-separated list of
+                    <code>citum</code>, <code>citum-server</code>, <code>citum-migrate</code>,
+                    or <code>all</code>:
+                </p>
+                <pre><code># everything
+curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | CITUM_COMPONENTS=all sh
+
+# citum + citum-migrate, no server
+curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | CITUM_COMPONENTS=citum,citum-migrate sh</code></pre>
             </div>
             <div class="workshop-block" style="margin-top: 1rem;">
                 <div class="workshop-label">Install (from source)</div>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,19 +5,27 @@
 #
 # Detects your platform, downloads the matching release tarball from
 # GitHub, verifies its SHA256 against the checksum manifest in the
-# same release, and installs the `citum` and `citum-server` binaries
-# to $CITUM_INSTALL_DIR (default $HOME/.local/bin).
+# same release, and installs the selected Citum binaries to
+# $CITUM_INSTALL_DIR (default $HOME/.local/bin).
 #
 # Environment overrides:
 #   CITUM_VERSION       — release tag (default: latest)
 #   CITUM_INSTALL_DIR   — install destination (default: $HOME/.local/bin)
 #   CITUM_REPO          — GitHub repo (default: citum/citum-core)
+#   CITUM_COMPONENTS    — comma-separated subset of {citum, citum-server,
+#                         citum-migrate}, or the alias `all` (default: citum)
+#
+# Examples:
+#   curl -fsSL .../install.sh | sh                                  # citum only
+#   curl -fsSL .../install.sh | CITUM_COMPONENTS=all sh             # everything
+#   curl -fsSL .../install.sh | CITUM_COMPONENTS=citum,citum-migrate sh
 
 set -eu
 
 REPO="${CITUM_REPO:-citum/citum-core}"
 VERSION="${CITUM_VERSION:-latest}"
 INSTALL_DIR="${CITUM_INSTALL_DIR:-$HOME/.local/bin}"
+COMPONENTS_RAW="${CITUM_COMPONENTS:-citum}"
 
 # ---------- helpers ---------------------------------------------------
 
@@ -88,6 +96,25 @@ elif command -v shasum    >/dev/null 2>&1; then SHASUM="shasum -a 256"
 else err "need sha256sum or shasum to verify the download"
 fi
 
+# Resolve component selection up front so bad input fails before any
+# network traffic. `all` is the only alias; everything else must be an
+# explicit binary name.
+case "$COMPONENTS_RAW" in
+  all) SELECTED="citum citum-server citum-migrate" ;;
+  *)   SELECTED=$(printf '%s' "$COMPONENTS_RAW" | tr ',' ' ') ;;
+esac
+# Normalize any whitespace (spaces, tabs, newlines a stray CI var might
+# carry) to single spaces and trim both ends — `tr` handles the squeeze,
+# `awk` handles trim portably without bashisms.
+SELECTED=$(printf '%s' "$SELECTED" | tr -s '[:space:]' ' ' | awk '{$1=$1; print}')
+[ -z "$SELECTED" ] && err "CITUM_COMPONENTS is empty (valid: citum, citum-server, citum-migrate, all)"
+for c in $SELECTED; do
+  case "$c" in
+    citum|citum-server|citum-migrate) ;;
+    *) err "unknown component: $c (valid: citum, citum-server, citum-migrate, all)" ;;
+  esac
+done
+
 TARGET="$(detect_target)"
 VERSION="$(resolve_version)"
 VER_BARE="${VERSION#v}"
@@ -100,7 +127,7 @@ esac
 TARBALL="citum-${VER_BARE}-${TARGET}.tar.gz"
 BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 
-say "installing citum ${VERSION} for ${TARGET}"
+say "installing citum ${VERSION} for ${TARGET} (components:$(printf ' %s' $SELECTED))"
 
 # Stage in a tempdir that's wiped on exit (even on error).
 TMP="$(mktemp -d 2>/dev/null || mktemp -d -t citum-install)"
@@ -133,10 +160,12 @@ tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
 STAGE="${TMP}/citum-${VER_BARE}-${TARGET}"
 
 mkdir -p "$INSTALL_DIR"
-install -m 0755 "${STAGE}/citum${EXE_SUFFIX}"        "${INSTALL_DIR}/citum${EXE_SUFFIX}"
-install -m 0755 "${STAGE}/citum-server${EXE_SUFFIX}" "${INSTALL_DIR}/citum-server${EXE_SUFFIX}"
-
-say "installed citum and citum-server to ${INSTALL_DIR}"
+for c in $SELECTED; do
+  src="${STAGE}/${c}${EXE_SUFFIX}"
+  [ -f "$src" ] || err "tarball is missing ${c}${EXE_SUFFIX} — release may pre-date this component"
+  install -m 0755 "$src" "${INSTALL_DIR}/${c}${EXE_SUFFIX}"
+  say "installed ${c} -> ${INSTALL_DIR}/${c}${EXE_SUFFIX}"
+done
 
 # PATH check. If INSTALL_DIR isn't on PATH, point the user at the fix
 # in a way that copy-pastes cleanly into their shell rc file.
@@ -158,4 +187,6 @@ EOF
   ;;
 esac
 
-say "done. Run: citum --help"
+# Hint with whichever binary is first in the user's selection.
+FIRST="${SELECTED%% *}"
+say "done. Run: ${FIRST} --help"

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -38,20 +38,23 @@ esac
 # Build. `cross` for musl + aarch64-linux (host-tool mismatch); cargo for
 # all native targets. `--locked` is required (CI shouldn't update the
 # lockfile mid-release).
-echo "==> Building citum + citum-server for ${TARGET}"
+echo "==> Building citum + citum-server + citum-migrate for ${TARGET}"
 if [[ "$USE_CROSS" == "1" ]]; then
-  cross build --release --locked --target "$TARGET" --bin citum --bin citum-server
+  cross build --release --locked --target "$TARGET" \
+    --bin citum --bin citum-server --bin citum-migrate
 else
   rustup target add "$TARGET" 2>/dev/null || true
-  cargo build --release --locked --target "$TARGET" --bin citum --bin citum-server
+  cargo build --release --locked --target "$TARGET" \
+    --bin citum --bin citum-server --bin citum-migrate
 fi
 
 # Stage tarball contents in a dedicated dir; the dir-name becomes the
 # top-level directory when users `tar xzf`.
 STAGE_PATH="${OUT_DIR}/${TARGET}/${STAGE_DIR}"
 mkdir -p "$STAGE_PATH"
-cp "target/${TARGET}/release/citum${EXE_SUFFIX}"        "$STAGE_PATH/"
-cp "target/${TARGET}/release/citum-server${EXE_SUFFIX}" "$STAGE_PATH/"
+cp "target/${TARGET}/release/citum${EXE_SUFFIX}"         "$STAGE_PATH/"
+cp "target/${TARGET}/release/citum-server${EXE_SUFFIX}"  "$STAGE_PATH/"
+cp "target/${TARGET}/release/citum-migrate${EXE_SUFFIX}" "$STAGE_PATH/"
 cp README.md "$STAGE_PATH/"
 # Ship both licenses if present; otherwise a single LICENSE file works.
 for f in LICENSE LICENSE-MIT LICENSE-APACHE LICENSE.txt; do
@@ -62,15 +65,17 @@ done
 # Best-effort: not every build env has strip available.
 case "$TARGET" in
   *-apple-darwin)
-    strip "${STAGE_PATH}/citum${EXE_SUFFIX}"        2>/dev/null || true
-    strip "${STAGE_PATH}/citum-server${EXE_SUFFIX}" 2>/dev/null || true
+    strip "${STAGE_PATH}/citum${EXE_SUFFIX}"         2>/dev/null || true
+    strip "${STAGE_PATH}/citum-server${EXE_SUFFIX}"  2>/dev/null || true
+    strip "${STAGE_PATH}/citum-migrate${EXE_SUFFIX}" 2>/dev/null || true
     ;;
   *-pc-windows-*)
     # MSVC strip isn't relevant; binaries built without debug info.
     ;;
   *)
-    strip --strip-unneeded "${STAGE_PATH}/citum${EXE_SUFFIX}"        2>/dev/null || true
-    strip --strip-unneeded "${STAGE_PATH}/citum-server${EXE_SUFFIX}" 2>/dev/null || true
+    strip --strip-unneeded "${STAGE_PATH}/citum${EXE_SUFFIX}"         2>/dev/null || true
+    strip --strip-unneeded "${STAGE_PATH}/citum-server${EXE_SUFFIX}"  2>/dev/null || true
+    strip --strip-unneeded "${STAGE_PATH}/citum-migrate${EXE_SUFFIX}" 2>/dev/null || true
     ;;
 esac
 


### PR DESCRIPTION
## Summary

Lets users pick which Citum binaries the `curl | sh` installer drops onto their machine. Driven by a single env var, no flag plumbing required.

```sh
# default: citum only
curl -fsSL .../install.sh | sh

# everything
curl -fsSL .../install.sh | CITUM_COMPONENTS=all sh

# engine + migrator, no server
curl -fsSL .../install.sh | CITUM_COMPONENTS=citum,citum-migrate sh
```

Valid values: `citum`, `citum-server`, `citum-migrate`, or the alias `all`. Validation runs before any download.

## Changes

- **`scripts/release-binary.sh`** — also build and stage `citum-migrate`; previously the binary was workspace-only and never shipped.
- **`scripts/install.sh`** — parse `CITUM_COMPONENTS`, validate up front, loop over the selected set, fail fast if the tarball is missing a requested binary (older releases). Final help hint uses the first installed binary.
- **`docs/developer.html`** — document `CITUM_COMPONENTS` next to the install one-liner.

## Behaviour change

Existing `curl | sh` users previously received `citum` + `citum-server` automatically. After this change the default is `citum` only — server is opt-in via `CITUM_COMPONENTS=citum,citum-server` or `=all`. Worth a callout in the release notes.

## UX options considered

| Option | Verdict |
|---|---|
| CLI flags (`--with-migrate`) | Awkward through `curl \| sh` (needs `sh -s -- --flag`). |
| TTY prompt via `</dev/tty` | Breaks in CI and minimal containers; extra branching. |
| Separate scripts per binary | Triples maintenance, fragments docs. |
| Env var only (chosen) | One knob, scriptable, no TTY hacks. |

## Test plan

- [x] `sh -n scripts/install.sh` and `bash -n scripts/release-binary.sh` clean.
- [x] Selection matrix verified locally (default / single / pair / `all` / whitespace / bogus / empty) — bogus + empty exit non-zero with the validator message.
- [ ] First release tarball after merge: confirm `citum-migrate` is inside and the installer picks it up via `CITUM_COMPONENTS=citum-migrate`.
- [ ] CI green on this branch.

Bean: csl26-js4h.
