### PR TITLE
fix(ci): musl build + upgrade actions to Node 24

### DIFF
--- a/.beans/csl26-rjpo--fix-release-ci-exclude-citum-migrate-from-musl-bui.md
+++ b/.beans/csl26-rjpo--fix-release-ci-exclude-citum-migrate-from-musl-bui.md
@@ -1,0 +1,11 @@
+---
+# csl26-rjpo
+title: 'Fix release CI: exclude citum-migrate from musl builds + upgrade actions to Node.js 24'
+status: in-progress
+type: bug
+priority: high
+created_at: 2026-05-22T13:49:04Z
+updated_at: 2026-05-22T13:49:04Z
+---
+
+Linux musl build jobs failing (404 for rusty_v8 simdutf prebuilt). Fix: exclude citum-migrate from musl release builds in release-binary.sh + update install.sh to gracefully skip it + upgrade all workflow actions to Node.js 24 versions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       semver: ${{ steps.filter.outputs.semver }}
       release: ${{ steps.filter.outputs.release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -93,7 +93,7 @@ jobs:
     if: ${{ needs.changes.outputs.docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
     if: ${{ needs.changes.outputs.beans == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
           sudo install -m 0755 /tmp/beans /usr/local/bin/beans
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -138,10 +138,10 @@ jobs:
     if: ${{ needs.changes.outputs.scripts == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -164,13 +164,13 @@ jobs:
     if: ${{ needs.changes.outputs.release == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -202,10 +202,10 @@ jobs:
     if: ${{ needs.changes.outputs.infra == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -231,7 +231,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -280,7 +280,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -316,7 +316,7 @@ jobs:
           needs.changes.outputs.semver == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -49,7 +49,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -30,7 +30,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -44,7 +44,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       bump-level: ${{ steps.infer.outputs.level }}
       should-release: ${{ steps.infer.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -79,7 +79,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -218,7 +218,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -292,7 +292,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: build (${{ matrix.target }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -318,7 +318,7 @@ jobs:
           USE_CROSS: ${{ matrix.use_cross }}
         run: bash scripts/release-binary.sh "${{ matrix.target }}" "${{ github.ref_name }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: citum-${{ matrix.target }}
           path: release-out/${{ matrix.target }}/*
@@ -331,9 +331,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: release-artifacts
           pattern: citum-*
@@ -379,7 +379,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -410,13 +410,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -163,13 +163,18 @@ mkdir -p "$INSTALL_DIR"
 for c in $SELECTED; do
   src="${STAGE}/${c}${EXE_SUFFIX}"
   if [ ! -f "$src" ]; then
-    # citum-migrate is not included in musl Linux tarballs because rusty_v8
+    # citum-migrate is intentionally absent from musl Linux tarballs: rusty_v8
     # (its embedded V8 dependency) does not publish prebuilt musl static libs.
-    if [ "$c" = "citum-migrate" ]; then
-      printf '%s\n' "citum-installer: warning: citum-migrate has no prebuilt binary for ${TARGET}."
-      printf '%s\n' "  Install from source: cargo install citum-migrate --locked"
-      continue
-    fi
+    # On all other targets this is a real packaging regression — fail fast.
+    case "$TARGET" in
+      *-linux-musl)
+        if [ "$c" = "citum-migrate" ]; then
+          printf '%s\n' "citum-installer: warning: citum-migrate has no prebuilt binary for ${TARGET}."
+          printf '%s\n' "  Install from source: cargo install citum-migrate --locked"
+          continue
+        fi
+        ;;
+    esac
     err "tarball is missing ${c}${EXE_SUFFIX} — release may pre-date this component"
   fi
   install -m 0755 "$src" "${INSTALL_DIR}/${c}${EXE_SUFFIX}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -162,7 +162,16 @@ STAGE="${TMP}/citum-${VER_BARE}-${TARGET}"
 mkdir -p "$INSTALL_DIR"
 for c in $SELECTED; do
   src="${STAGE}/${c}${EXE_SUFFIX}"
-  [ -f "$src" ] || err "tarball is missing ${c}${EXE_SUFFIX} — release may pre-date this component"
+  if [ ! -f "$src" ]; then
+    # citum-migrate is not included in musl Linux tarballs because rusty_v8
+    # (its embedded V8 dependency) does not publish prebuilt musl static libs.
+    if [ "$c" = "citum-migrate" ]; then
+      printf '%s\n' "citum-installer: warning: citum-migrate has no prebuilt binary for ${TARGET}."
+      printf '%s\n' "  Install from source: cargo install citum-migrate --locked"
+      continue
+    fi
+    err "tarball is missing ${c}${EXE_SUFFIX} — release may pre-date this component"
+  fi
   install -m 0755 "$src" "${INSTALL_DIR}/${c}${EXE_SUFFIX}"
   say "installed ${c} -> ${INSTALL_DIR}/${c}${EXE_SUFFIX}"
 done

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -23,6 +23,15 @@ VERSION="${2:?usage: release-binary.sh <target> <version>}"
 OUT_DIR="${OUT_DIR:-release-out}"
 USE_CROSS="${USE_CROSS:-0}"
 
+# citum-migrate embeds V8 via deno_core/rusty_v8. rusty_v8 does not publish
+# prebuilt musl static libs, so the build fails with a 404 on musl targets.
+# citum-migrate is a dev-time migration tool, not a container workload, so
+# shipping it only on targets where V8 prebuilts exist is the correct trade-off.
+case "$TARGET" in
+  *-linux-musl) INCLUDE_MIGRATE="0" ;;
+  *)             INCLUDE_MIGRATE="1" ;;
+esac
+
 # Strip the leading `v` from the version for the tarball name; this
 # matches the on-disk filename convention many install scripts assume.
 VER_BARE="${VERSION#v}"
@@ -38,14 +47,23 @@ esac
 # Build. `cross` for musl + aarch64-linux (host-tool mismatch); cargo for
 # all native targets. `--locked` is required (CI shouldn't update the
 # lockfile mid-release).
-echo "==> Building citum + citum-server + citum-migrate for ${TARGET}"
+MIGRATE_BIN=""
+[[ "$INCLUDE_MIGRATE" == "1" ]] && MIGRATE_BIN="--bin citum-migrate"
+
+if [[ "$INCLUDE_MIGRATE" == "1" ]]; then
+  echo "==> Building citum + citum-server + citum-migrate for ${TARGET}"
+else
+  echo "==> Building citum + citum-server for ${TARGET} (citum-migrate skipped: no V8 musl prebuilt)"
+fi
 if [[ "$USE_CROSS" == "1" ]]; then
+  # shellcheck disable=SC2086
   cross build --release --locked --target "$TARGET" \
-    --bin citum --bin citum-server --bin citum-migrate
+    --bin citum --bin citum-server $MIGRATE_BIN
 else
   rustup target add "$TARGET" 2>/dev/null || true
+  # shellcheck disable=SC2086
   cargo build --release --locked --target "$TARGET" \
-    --bin citum --bin citum-server --bin citum-migrate
+    --bin citum --bin citum-server $MIGRATE_BIN
 fi
 
 # Stage tarball contents in a dedicated dir; the dir-name becomes the
@@ -54,7 +72,8 @@ STAGE_PATH="${OUT_DIR}/${TARGET}/${STAGE_DIR}"
 mkdir -p "$STAGE_PATH"
 cp "target/${TARGET}/release/citum${EXE_SUFFIX}"         "$STAGE_PATH/"
 cp "target/${TARGET}/release/citum-server${EXE_SUFFIX}"  "$STAGE_PATH/"
-cp "target/${TARGET}/release/citum-migrate${EXE_SUFFIX}" "$STAGE_PATH/"
+[[ "$INCLUDE_MIGRATE" == "1" ]] && \
+  cp "target/${TARGET}/release/citum-migrate${EXE_SUFFIX}" "$STAGE_PATH/"
 cp README.md "$STAGE_PATH/"
 # Ship both licenses if present; otherwise a single LICENSE file works.
 for f in LICENSE LICENSE-MIT LICENSE-APACHE LICENSE.txt; do
@@ -67,7 +86,8 @@ case "$TARGET" in
   *-apple-darwin)
     strip "${STAGE_PATH}/citum${EXE_SUFFIX}"         2>/dev/null || true
     strip "${STAGE_PATH}/citum-server${EXE_SUFFIX}"  2>/dev/null || true
-    strip "${STAGE_PATH}/citum-migrate${EXE_SUFFIX}" 2>/dev/null || true
+    [[ "$INCLUDE_MIGRATE" == "1" ]] && \
+      strip "${STAGE_PATH}/citum-migrate${EXE_SUFFIX}" 2>/dev/null || true
     ;;
   *-pc-windows-*)
     # MSVC strip isn't relevant; binaries built without debug info.
@@ -75,7 +95,8 @@ case "$TARGET" in
   *)
     strip --strip-unneeded "${STAGE_PATH}/citum${EXE_SUFFIX}"         2>/dev/null || true
     strip --strip-unneeded "${STAGE_PATH}/citum-server${EXE_SUFFIX}"  2>/dev/null || true
-    strip --strip-unneeded "${STAGE_PATH}/citum-migrate${EXE_SUFFIX}" 2>/dev/null || true
+    [[ "$INCLUDE_MIGRATE" == "1" ]] && \
+      strip --strip-unneeded "${STAGE_PATH}/citum-migrate${EXE_SUFFIX}" 2>/dev/null || true
     ;;
 esac
 


### PR DESCRIPTION
## Summary

- **Linux musl builds**: `citum-migrate` embeds V8 via `deno_core`/`rusty_v8`, which has no prebuilt musl static libs for the `simdutf` variant — causing a 404 in both musl release jobs. Excluded `citum-migrate` from `*-linux-musl` targets in `release-binary.sh`; updated `install.sh` to warn + suggest `cargo install` rather than hard-error when the binary is absent.
- **Node.js 24 actions**: All four workflows updated before the June 2 forced-Node-24 deadline: `actions/checkout` and `actions/setup-node` @v4→@v6; `actions/upload-artifact` @v4→@v6; `actions/download-artifact` @v4→@v7.

## After merge

Re-push the `v0.55.0` tag to trigger a fresh release run:

```bash
git tag -d v0.55.0
git push origin :refs/tags/v0.55.0
git tag -a v0.55.0 -m "Release v0.55.0"
git push origin v0.55.0
```

musl tarballs will contain `citum` + `citum-server` only; macOS and Windows tarballs include `citum-migrate` as before.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge + tag re-push: both Linux musl build jobs succeed
- [ ] macOS/Windows jobs still include `citum-migrate`
- [ ] No `Node.js 20 actions are deprecated` warnings in any run
