### PR TITLE
chore: update licensing and attribution model

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,11 @@
+# Authors
+
+The Citum core engine was designed, architected, and originally implemented 
+by **Bruce D'Arcus**, beginning with the initial prototype (csln) in 2023.
+
+## Core Maintainers
+* Bruce D'Arcus (@bdarcus) — Founder & Lead Developer
+
+## Contributors
+* Thank you to all the community members who have contributed code, 
+  documentation, and bug fixes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2026 Bruce Darcus
+Copyright (c) 2023-2026 Bruce D'Arcus and Citum contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2023-2026 Bruce D'Arcus and Citum contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/crates/citum-analyze/src/analyzer.rs
+++ b/crates/citum-analyze/src/analyzer.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::collections::HashMap;

--- a/crates/citum-analyze/src/batch_test.rs
+++ b/crates/citum-analyze/src/batch_test.rs
@@ -1,12 +1,12 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "bin crate")]
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Batch Migration Tester

--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Analyzes CSL 1.0 styles in a directory to collect statistics

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use roxmltree::Document;

--- a/crates/citum-analyze/src/ranker.rs
+++ b/crates/citum-analyze/src/ranker.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::collections::HashMap;

--- a/crates/citum-analyze/src/savings.rs
+++ b/crates/citum-analyze/src/savings.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::collections::{HashMap, HashSet};

--- a/crates/citum-analyze/src/util.rs
+++ b/crates/citum-analyze/src/util.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::borrow::Cow;

--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citum cross-language bindings.

--- a/crates/citum-bindings/tests/integration.rs
+++ b/crates/citum-bindings/tests/integration.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use clap::builder::styling::{AnsiColor, Effects, Styles};

--- a/crates/citum-cli/src/commands/bindings.rs
+++ b/crates/citum-cli/src/commands/bindings.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `bindings` subcommand: export language bindings (TypeScript only, today).

--- a/crates/citum-cli/src/commands/catalog.rs
+++ b/crates/citum-cli/src/commands/catalog.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style catalog: row type, source filter, pagination, formatting, and

--- a/crates/citum-cli/src/commands/check.rs
+++ b/crates/citum-cli/src/commands/check.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `check` subcommand: validates style, bibliography, and citation inputs.

--- a/crates/citum-cli/src/commands/convert.rs
+++ b/crates/citum-cli/src/commands/convert.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `convert` subcommands: typed (style/locale/citations) and refs.

--- a/crates/citum-cli/src/commands/doctor.rs
+++ b/crates/citum-cli/src/commands/doctor.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `doctor` subcommand: environment and registry health summary.

--- a/crates/citum-cli/src/commands/lint.rs
+++ b/crates/citum-cli/src/commands/lint.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Lint subcommands for style and locale files.

--- a/crates/citum-cli/src/commands/locale.rs
+++ b/crates/citum-cli/src/commands/locale.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Locale subcommands: list, add, remove.

--- a/crates/citum-cli/src/commands/mod.rs
+++ b/crates/citum-cli/src/commands/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! CLI subcommand dispatch and shared aliases.

--- a/crates/citum-cli/src/commands/registry.rs
+++ b/crates/citum-cli/src/commands/registry.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Registry I/O, configuration, and `registry` subcommands.

--- a/crates/citum-cli/src/commands/render/human.rs
+++ b/crates/citum-cli/src/commands/render/human.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Human-readable reference and citation rendering helpers.

--- a/crates/citum-cli/src/commands/render/json.rs
+++ b/crates/citum-cli/src/commands/render/json.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! JSON reference and citation rendering.

--- a/crates/citum-cli/src/commands/render/mod.rs
+++ b/crates/citum-cli/src/commands/render/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `render` subcommands: render a document (`render doc`) or render references

--- a/crates/citum-cli/src/commands/schema.rs
+++ b/crates/citum-cli/src/commands/schema.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `schema` subcommand: emit JSON schemas for Citum data types and RPC methods.

--- a/crates/citum-cli/src/commands/style.rs
+++ b/crates/citum-cli/src/commands/style.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style query subcommands: list, search, info, cid, pin, validate, browse.

--- a/crates/citum-cli/src/commands/style_install.rs
+++ b/crates/citum-cli/src/commands/style_install.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Install and remove user-installed styles, and the style-browser action shim.

--- a/crates/citum-cli/src/commands/util.rs
+++ b/crates/citum-cli/src/commands/util.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Shared CLI helpers: interactive prompts and input validation.

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "bin")]

--- a/crates/citum-cli/src/output.rs
+++ b/crates/citum-cli/src/output.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::lint::{LintReport, LintSeverity};

--- a/crates/citum-cli/src/style_browser.rs
+++ b/crates/citum-cli/src/style_browser.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::commands::StyleCatalogRow;

--- a/crates/citum-cli/src/style_resolver.rs
+++ b/crates/citum-cli/src/style_resolver.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_engine::Processor;

--- a/crates/citum-cli/src/table.rs
+++ b/crates/citum-cli/src/table.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 /// Unified table builder for CLI list output.

--- a/crates/citum-cli/src/typst_pdf.rs
+++ b/crates/citum-cli/src/typst_pdf.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Typst PDF compilation shim. Bundled-Typst PDF output isn't available in

--- a/crates/citum-edtf/src/lib.rs
+++ b/crates/citum-edtf/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `citum_edtf` - A modern EDTF (Extended Date/Time Format) parser

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Document-level batch formatting API.

--- a/crates/citum-engine/src/api/forward_compat.rs
+++ b/crates/citum-engine/src/api/forward_compat.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Forward-compat unknown-field walking for `citum check`.

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Interactive document-level API for batch citation formatting.

--- a/crates/citum-engine/src/api/style_input.rs
+++ b/crates/citum-engine/src/api/style_input.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style resolution input type for interactive APIs.

--- a/crates/citum-engine/src/api/types.rs
+++ b/crates/citum-engine/src/api/types.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Request and response types for the interactive document API.

--- a/crates/citum-engine/src/error.rs
+++ b/crates/citum-engine/src/error.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use thiserror::Error;

--- a/crates/citum-engine/src/ffi/mod.rs
+++ b/crates/citum-engine/src/ffi/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! C-FFI for the Citum processor.

--- a/crates/citum-engine/src/grouping/mod.rs
+++ b/crates/citum-engine/src/grouping/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Bibliography grouping support.

--- a/crates/citum-engine/src/grouping/selector.rs
+++ b/crates/citum-engine/src/grouping/selector.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Selector evaluation for bibliography grouping.

--- a/crates/citum-engine/src/grouping/sorting.rs
+++ b/crates/citum-engine/src/grouping/sorting.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Group-specific sorting for bibliography grouping.

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citum Processor

--- a/crates/citum-engine/src/processor/bibliography/compound.rs
+++ b/crates/citum-engine/src/processor/bibliography/compound.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Compound-entry merging for numeric bibliography styles.

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Grouped bibliography rendering with configurable selectors and sorting.

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Bibliography processing and rendering.

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citation rendering orchestration.

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::reference::{Bibliography, Reference};

--- a/crates/citum-engine/src/processor/document/djot/mod.rs
+++ b/crates/citum-engine/src/processor/document/djot/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Djot document parsing and HTML conversion adapter.

--- a/crates/citum-engine/src/processor/document/djot/parsing.rs
+++ b/crates/citum-engine/src/processor/document/djot/parsing.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Djot-specific parsing logic using winnow.

--- a/crates/citum-engine/src/processor/document/integral_names.rs
+++ b/crates/citum-engine/src/processor/document/integral_names.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Integral-name state handling for document processing.

--- a/crates/citum-engine/src/processor/document/markdown.rs
+++ b/crates/citum-engine/src/processor/document/markdown.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Markdown document parsing for Pandoc-style citations.

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Document-level citation processing.

--- a/crates/citum-engine/src/processor/document/note_support.rs
+++ b/crates/citum-engine/src/processor/document/note_support.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Shared note-processing state and helper functions.

--- a/crates/citum-engine/src/processor/document/notes.rs
+++ b/crates/citum-engine/src/processor/document/notes.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Note-style document rendering and numbering helpers.

--- a/crates/citum-engine/src/processor/document/output.rs
+++ b/crates/citum-engine/src/processor/document/output.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Document-output helpers shared by the processing pipeline.

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! High-level document-processing orchestration.

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::processor::Processor;

--- a/crates/citum-engine/src/processor/document/types.rs
+++ b/crates/citum-engine/src/processor/document/types.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Shared document-processing types and parser contracts.

--- a/crates/citum-engine/src/processor/labels.rs
+++ b/crates/citum-engine/src/processor/labels.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Label generation for alphanumeric citation styles.

--- a/crates/citum-engine/src/processor/matching.rs
+++ b/crates/citum-engine/src/processor/matching.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Matching logic for determining if references share primary contributors.

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! The Citum processor for rendering citations and bibliographies.

--- a/crates/citum-engine/src/processor/note_context.rs
+++ b/crates/citum-engine/src/processor/note_context.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Note-context normalization and citation position inference.

--- a/crates/citum-engine/src/processor/rendering/collapse.rs
+++ b/crates/citum-engine/src/processor/rendering/collapse.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citation number and compound subentry collapsing.

--- a/crates/citum-engine/src/processor/rendering/grouped/component_predicates.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/component_predicates.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Pure predicates over `TemplateComponent` and `Reference` used by grouped

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::super::{

--- a/crates/citum-engine/src/processor/rendering/grouped/grouping.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/grouping.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Author-group formation for grouped citation rendering.

--- a/crates/citum-engine/src/processor/rendering/grouped/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Grouped citation rendering.

--- a/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Sentence-initial context handling for bibliography entries and note-style

--- a/crates/citum-engine/src/processor/rendering/grouped/template_policy.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/template_policy.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Bibliography-template policy for `article-journal` and anonymous

--- a/crates/citum-engine/src/processor/rendering/grouped_fallback.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped_fallback.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Shared parameter types for grouped citation rendering.

--- a/crates/citum-engine/src/processor/rendering/helpers.rs
+++ b/crates/citum-engine/src/processor/rendering/helpers.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::TemplateComponent;

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for citation and bibliography output.

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::*;

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Processor construction and configuration helpers.

--- a/crates/citum-engine/src/processor/sorting.rs
+++ b/crates/citum-engine/src/processor/sorting.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Sorting logic for bibliography and citation entries.

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::*;

--- a/crates/citum-engine/src/reference.rs
+++ b/crates/citum-engine/src/reference.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Reference types for the Citum processor.

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::collections::HashMap;

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::render::component::{ProcTemplate, render_component_with_format};

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{Config, bibliography::BibliographyConfig};

--- a/crates/citum-engine/src/render/djot.rs
+++ b/crates/citum-engine/src/render/djot.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Djot output format.

--- a/crates/citum-engine/src/render/format.rs
+++ b/crates/citum-engine/src/render/format.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Output format trait for pluggable renderers.

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! HTML output format.

--- a/crates/citum-engine/src/render/latex.rs
+++ b/crates/citum-engine/src/render/latex.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! LaTeX output format.

--- a/crates/citum-engine/src/render/mod.rs
+++ b/crates/citum-engine/src/render/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering utilities for Citum templates.

--- a/crates/citum-engine/src/render/org.rs
+++ b/crates/citum-engine/src/render/org.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Org-mode output format.

--- a/crates/citum-engine/src/render/plain.rs
+++ b/crates/citum-engine/src/render/plain.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Plain text output format.

--- a/crates/citum-engine/src/render/rich_text.rs
+++ b/crates/citum-engine/src/render/rich_text.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Djot and org-mode inline markup rendering for free-text fields.

--- a/crates/citum-engine/src/render/test_formats.rs
+++ b/crates/citum-engine/src/render/test_formats.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(test)]

--- a/crates/citum-engine/src/render/typst.rs
+++ b/crates/citum-engine/src/render/typst.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Typst output format.

--- a/crates/citum-engine/src/sort_partitioning.rs
+++ b/crates/citum-engine/src/sort_partitioning.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Multilingual bibliography partitioning helpers.

--- a/crates/citum-engine/src/sort_support.rs
+++ b/crates/citum-engine/src/sort_support.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Shared bibliography sort-key normalization and collation helpers.

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Role-label resolution for contributor rendering.

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for contributors (authors, editors, translators).

--- a/crates/citum-engine/src/values/contributor/names.rs
+++ b/crates/citum-engine/src/values/contributor/names.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Name-formatting helpers for contributor rendering.

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Author-substitution logic for contributor rendering.

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for date fields with locale-aware formatting.

--- a/crates/citum-engine/src/values/list.rs
+++ b/crates/citum-engine/src/values/list.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for list components with configurable delimiters.

--- a/crates/citum-engine/src/values/locator.rs
+++ b/crates/citum-engine/src/values/locator.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Locator rendering logic for citations.

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Value extraction for template components.

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for numeric variables (volume, issue, pages, citation numbers, etc.).

--- a/crates/citum-engine/src/values/range.rs
+++ b/crates/citum-engine/src/values/range.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Shared helpers for collapsing ordered consecutive numbering into spans.

--- a/crates/citum-engine/src/values/term.rs
+++ b/crates/citum-engine/src/values/term.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for localized term components.

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::*;

--- a/crates/citum-engine/src/values/text_case.rs
+++ b/crates/citum-engine/src/values/text_case.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Title text-case transforms.

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for title fields with smartening, form selection,

--- a/crates/citum-engine/src/values/variable.rs
+++ b/crates/citum-engine/src/values/variable.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Rendering logic for simple variables (DOI, URL, ISBN, etc.).

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-engine/tests/domain_fixtures.rs
+++ b/crates/citum-engine/tests/domain_fixtures.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_engine::Processor;

--- a/crates/citum-engine/tests/forward_compatibility.rs
+++ b/crates/citum-engine/tests/forward_compatibility.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Forward-compatibility scenario corpus.

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-engine/tests/io.rs
+++ b/crates/citum-engine/tests/io.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! BDD behavioral integration tests for bibliography I/O operations.

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-engine/tests/multilingual_names.rs
+++ b/crates/citum-engine/tests/multilingual_names.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_engine::values::resolve_multilingual_name;

--- a/crates/citum-engine/tests/name_form_initialization.rs
+++ b/crates/citum-engine/tests/name_form_initialization.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-engine/tests/regression_interview.rs
+++ b/crates/citum-engine/tests/regression_interview.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 mod common;

--- a/crates/citum-io/src/biblatex.rs
+++ b/crates/citum-io/src/biblatex.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Biblatex entry conversion to Citum `InputReference`.

--- a/crates/citum-io/src/lib.rs
+++ b/crates/citum-io/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citum I/O and format conversion library.

--- a/crates/citum-migrate/src/analysis/bibliography.rs
+++ b/crates/citum-migrate/src/analysis/bibliography.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::AndOptions;

--- a/crates/citum-migrate/src/analysis/citation.rs
+++ b/crates/citum-migrate/src/analysis/citation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::template::WrapPunctuation;

--- a/crates/citum-migrate/src/analysis/mod.rs
+++ b/crates/citum-migrate/src/analysis/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 pub mod bibliography;

--- a/crates/citum-migrate/src/base_detector.rs
+++ b/crates/citum-migrate/src/base_detector.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Detects narrow formatting families for migration fixups.

--- a/crates/citum-migrate/src/bib_postprocess.rs
+++ b/crates/citum-migrate/src/bib_postprocess.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Inferred bibliography template postprocessing and repair.

--- a/crates/citum-migrate/src/bin/migrate_all.rs
+++ b/crates/citum-migrate/src/bin/migrate_all.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "bin")]

--- a/crates/citum-migrate/src/bin/update_style_info.rs
+++ b/crates/citum-migrate/src/bin/update_style_info.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "bin")]

--- a/crates/citum-migrate/src/citation_validate.rs
+++ b/crates/citum-migrate/src/citation_validate.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Inferred citation template validation and contributor normalization.

--- a/crates/citum-migrate/src/cli.rs
+++ b/crates/citum-migrate/src/cli.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! CLI argument parsing for citum-migrate.

--- a/crates/citum-migrate/src/compilation.rs
+++ b/crates/citum-migrate/src/compilation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Unified compilation pipeline from CSL 1.0 to Citum templates.

--- a/crates/citum-migrate/src/compressor.rs
+++ b/crates/citum-migrate/src/compressor.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::{CslnNode, ItemType};

--- a/crates/citum-migrate/src/debug_output.rs
+++ b/crates/citum-migrate/src/debug_output.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Formats provenance debug output for display.

--- a/crates/citum-migrate/src/evidence.rs
+++ b/crates/citum-migrate/src/evidence.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Machine-readable evidence describing migration lineage decisions.

--- a/crates/citum-migrate/src/fixups/locator.rs
+++ b/crates/citum-migrate/src/fixups/locator.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::template::{

--- a/crates/citum-migrate/src/fixups/media.rs
+++ b/crates/citum-migrate/src/fixups/media.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::template::{

--- a/crates/citum-migrate/src/fixups/mod.rs
+++ b/crates/citum-migrate/src/fixups/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "lib/crate")]

--- a/crates/citum-migrate/src/fixups/template.rs
+++ b/crates/citum-migrate/src/fixups/template.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::template::{

--- a/crates/citum-migrate/src/info_extractor.rs
+++ b/crates/citum-migrate/src/info_extractor.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::{CitationField, StyleInfo, StyleLink, StylePerson, StyleSource};

--- a/crates/citum-migrate/src/js_runtime.rs
+++ b/crates/citum-migrate/src/js_runtime.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use deno_core::{JsRuntime, RuntimeOptions, serde_v8, v8};

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! citum-migrate

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Migration-time style lineage and wrapper classification.

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "bin")]

--- a/crates/citum-migrate/src/options_extractor/bibliography.rs
+++ b/crates/citum-migrate/src/options_extractor/bibliography.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::grouping::{

--- a/crates/citum-migrate/src/options_extractor/contributors.rs
+++ b/crates/citum-migrate/src/options_extractor/contributors.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{

--- a/crates/citum-migrate/src/options_extractor/dates.rs
+++ b/crates/citum-migrate/src/options_extractor/dates.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{DateConfig, MonthFormat};

--- a/crates/citum-migrate/src/options_extractor/locators.rs
+++ b/crates/citum-migrate/src/options_extractor/locators.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::LocatorConfig;

--- a/crates/citum-migrate/src/options_extractor/mod.rs
+++ b/crates/citum-migrate/src/options_extractor/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Extracts global style options from CSL 1.0 structures into Citum Config.

--- a/crates/citum-migrate/src/options_extractor/numbers.rs
+++ b/crates/citum-migrate/src/options_extractor/numbers.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::PageRangeFormat;

--- a/crates/citum-migrate/src/options_extractor/processing.rs
+++ b/crates/citum-migrate/src/options_extractor/processing.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{

--- a/crates/citum-migrate/src/options_extractor/tests.rs
+++ b/crates/citum-migrate/src/options_extractor/tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::*;

--- a/crates/citum-migrate/src/options_extractor/titles.rs
+++ b/crates/citum-migrate/src/options_extractor/titles.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{TextCase, TitleRendering, TitlesConfig};

--- a/crates/citum-migrate/src/passes/deduplicate.rs
+++ b/crates/citum-migrate/src/passes/deduplicate.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::{

--- a/crates/citum-migrate/src/passes/grouping.rs
+++ b/crates/citum-migrate/src/passes/grouping.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::template::{

--- a/crates/citum-migrate/src/passes/mod.rs
+++ b/crates/citum-migrate/src/passes/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 pub mod deduplicate;

--- a/crates/citum-migrate/src/passes/reorder.rs
+++ b/crates/citum-migrate/src/passes/reorder.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::template::{TemplateComponent, TemplateGroup};

--- a/crates/citum-migrate/src/provenance.rs
+++ b/crates/citum-migrate/src/provenance.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Provenance tracking for variable migration.

--- a/crates/citum-migrate/src/template_compiler/bibliography.rs
+++ b/crates/citum-migrate/src/template_compiler/bibliography.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::{CslnNode, ItemType, TemplateCompiler, TemplateComponent};

--- a/crates/citum-migrate/src/template_compiler/compilation.rs
+++ b/crates/citum-migrate/src/template_compiler/compilation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::{

--- a/crates/citum-migrate/src/template_compiler/deduplication.rs
+++ b/crates/citum-migrate/src/template_compiler/deduplication.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::{CslnNode, Rendering, TemplateCompiler, TemplateComponent, TemplateGroup};

--- a/crates/citum-migrate/src/template_compiler/formatting.rs
+++ b/crates/citum-migrate/src/template_compiler/formatting.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::{

--- a/crates/citum-migrate/src/template_compiler/mod.rs
+++ b/crates/citum-migrate/src/template_compiler/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Compiles legacy CslnNode trees into Citum TemplateComponents.

--- a/crates/citum-migrate/src/template_compiler/node_compiler.rs
+++ b/crates/citum-migrate/src/template_compiler/node_compiler.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::{

--- a/crates/citum-migrate/src/template_compiler/sorting.rs
+++ b/crates/citum-migrate/src/template_compiler/sorting.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::{

--- a/crates/citum-migrate/src/template_compiler/types.rs
+++ b/crates/citum-migrate/src/template_compiler/types.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::{CslnNode, ItemType, TemplateCompiler, TemplateComponent};

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Template variant diff computation for bibliography type-variant generation.

--- a/crates/citum-migrate/src/template_resolver.rs
+++ b/crates/citum-migrate/src/template_resolver.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Template resolution for Citum migration.

--- a/crates/citum-migrate/src/upsampler.rs
+++ b/crates/citum-migrate/src/upsampler.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::{self as csln, FormattingOptions, ItemType, Variable};

--- a/crates/citum-migrate/tests/article_journal_no_page_fallback.rs
+++ b/crates/citum-migrate/tests/article_journal_no_page_fallback.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/date_inference.rs
+++ b/crates/citum-migrate/tests/date_inference.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/initialize_with_migration.rs
+++ b/crates/citum-migrate/tests/initialize_with_migration.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/inline_journal_detail_grouping.rs
+++ b/crates/citum-migrate/tests/inline_journal_detail_grouping.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/no_date_fallback_cleanup.rs
+++ b/crates/citum-migrate/tests/no_date_fallback_cleanup.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/patent_number_suppression.rs
+++ b/crates/citum-migrate/tests/patent_number_suppression.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/substitute_extraction.rs
+++ b/crates/citum-migrate/tests/substitute_extraction.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/term_mapping.rs
+++ b/crates/citum-migrate/tests/term_mapping.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-migrate/tests/variable_once.rs
+++ b/crates/citum-migrate/tests/variable_once.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum-pdf/src/lib.rs
+++ b/crates/citum-pdf/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Typst PDF compilation for Citum.

--- a/crates/citum-resolver-api/src/error.rs
+++ b/crates/citum-resolver-api/src/error.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::borrow::Cow;

--- a/crates/citum-resolver-api/src/lib.rs
+++ b/crates/citum-resolver-api/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Canonical style resolution interfaces for the Citum citation engine.

--- a/crates/citum-schema-data/src/abbreviation.rs
+++ b/crates/citum-schema-data/src/abbreviation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Document-level abbreviation map type.

--- a/crates/citum-schema-data/src/citation.rs
+++ b/crates/citum-schema-data/src/citation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citation input model for the Citum processor.

--- a/crates/citum-schema-data/src/lib.rs
+++ b/crates/citum-schema-data/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Data input models for Citum references, citations, and bibliographies.

--- a/crates/citum-schema-data/src/macros.rs
+++ b/crates/citum-schema-data/src/macros.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 /// Generates a string-backed enum that gracefully captures unknown variants.

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Typed read/mutation surface for [`InputReference`].

--- a/crates/citum-schema-data/src/reference/classes.rs
+++ b/crates/citum-schema-data/src/reference/classes.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Reference class discriminator types and shared dispatch helpers.

--- a/crates/citum-schema-data/src/reference/contributor.rs
+++ b/crates/citum-schema-data/src/reference/contributor.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::reference::types::{MultilingualString, Place};

--- a/crates/citum-schema-data/src/reference/conversion/legal.rs
+++ b/crates/citum-schema-data/src/reference/conversion/legal.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Legacy CSL → Citum converters for legal references (case, statute,

--- a/crates/citum-schema-data/src/reference/conversion/media.rs
+++ b/crates/citum-schema-data/src/reference/conversion/media.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Legacy CSL → Citum converters for media references (software, audio-visual).

--- a/crates/citum-schema-data/src/reference/conversion/mod.rs
+++ b/crates/citum-schema-data/src/reference/conversion/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Legacy CSL-JSON → Citum reference conversion.

--- a/crates/citum-schema-data/src/reference/conversion/scholarly.rs
+++ b/crates/citum-schema-data/src/reference/conversion/scholarly.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Legacy CSL → Citum converters for scholarly references (monographs and

--- a/crates/citum-schema-data/src/reference/ctors.rs
+++ b/crates/citum-schema-data/src/reference/ctors.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Construction helpers for [`InputReference`].

--- a/crates/citum-schema-data/src/reference/date.rs
+++ b/crates/citum-schema-data/src/reference/date.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::reference::types::RefDate;

--- a/crates/citum-schema-data/src/reference/discriminator/mod.rs
+++ b/crates/citum-schema-data/src/reference/discriminator/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Layer-1 scaffolding for `csl26-1bdr` / `csl26-odgh`.

--- a/crates/citum-schema-data/src/reference/discriminator_tests.rs
+++ b/crates/citum-schema-data/src/reference/discriminator_tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Behaviour tests for the public class discriminator.

--- a/crates/citum-schema-data/src/reference/input.rs
+++ b/crates/citum-schema-data/src/reference/input.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Public `InputReference` container and unknown-class payload.

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! A reference is a bibliographic item, such as a book, article, or web page.

--- a/crates/citum-schema-data/src/reference/normalize_tests.rs
+++ b/crates/citum-schema-data/src/reference/normalize_tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Behaviour tests for genre/medium normalisation.

--- a/crates/citum-schema-data/src/reference/numbering_tests.rs
+++ b/crates/citum-schema-data/src/reference/numbering_tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Behaviour tests for numbering accessors.

--- a/crates/citum-schema-data/src/reference/serde_impl.rs
+++ b/crates/citum-schema-data/src/reference/serde_impl.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! `Deserialize`/`Serialize`/`JsonSchema` impls for [`InputReference`].

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::*;

--- a/crates/citum-schema-data/src/reference/types/common.rs
+++ b/crates/citum-schema-data/src/reference/types/common.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Shared primitive types used across all reference categories.

--- a/crates/citum-schema-data/src/reference/types/legal.rs
+++ b/crates/citum-schema-data/src/reference/types/legal.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Legal document types: cases, statutes, treaties, hearings, regulations, and briefs.

--- a/crates/citum-schema-data/src/reference/types/mod.rs
+++ b/crates/citum-schema-data/src/reference/types/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Reference data types and structures for citation items.

--- a/crates/citum-schema-data/src/reference/types/specialized.rs
+++ b/crates/citum-schema-data/src/reference/types/specialized.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Specialized work types: classic works, patents, datasets, standards, software, and events.

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Hierarchical work types: monographs, collections, serials, and their components.

--- a/crates/citum-schema-style/benches/formats.rs
+++ b/crates/citum-schema-style/benches/formats.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench/bin crate")]

--- a/crates/citum-schema-style/src/bin/render_demo.rs
+++ b/crates/citum-schema-style/src/bin/render_demo.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(

--- a/crates/citum-schema-style/src/embedded/apa.rs
+++ b/crates/citum-schema-style/src/embedded/apa.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::sync::LazyLock;

--- a/crates/citum-schema-style/src/embedded/chicago.rs
+++ b/crates/citum-schema-style/src/embedded/chicago.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::options::AndOptions;

--- a/crates/citum-schema-style/src/embedded/harvard.rs
+++ b/crates/citum-schema-style/src/embedded/harvard.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::options::AndOptions;

--- a/crates/citum-schema-style/src/embedded/ieee.rs
+++ b/crates/citum-schema-style/src/embedded/ieee.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::options::AndOptions;

--- a/crates/citum-schema-style/src/embedded/locales.rs
+++ b/crates/citum-schema-style/src/embedded/locales.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Embedded locale YAML files for common BCP 47 locales.

--- a/crates/citum-schema-style/src/embedded/mod.rs
+++ b/crates/citum-schema-style/src/embedded/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Embedded priority templates for common citation styles.

--- a/crates/citum-schema-style/src/embedded/numeric.rs
+++ b/crates/citum-schema-style/src/embedded/numeric.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::{tc_number, template::TemplateComponent};

--- a/crates/citum-schema-style/src/embedded/styles.rs
+++ b/crates/citum-schema-style/src/embedded/styles.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Embedded Citum style YAML files for priority citation styles.

--- a/crates/citum-schema-style/src/embedded/vancouver.rs
+++ b/crates/citum-schema-style/src/embedded/vancouver.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::{

--- a/crates/citum-schema-style/src/grouping.rs
+++ b/crates/citum-schema-style/src/grouping.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/legacy.rs
+++ b/crates/citum-schema-style/src/legacy.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::locale::{GeneralTerm, TermForm};

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Public schema types for Citum styles, citations, references, and locales.

--- a/crates/citum-schema-style/src/lint.rs
+++ b/crates/citum-schema-style/src/lint.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Lint helpers for raw locales and styles.

--- a/crates/citum-schema-style/src/locale/embedded/en_us.rs
+++ b/crates/citum-schema-style/src/locale/embedded/en_us.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Hardcoded en-US locale data — role terms, locator terms, archive messages,

--- a/crates/citum-schema-style/src/locale/embedded/mod.rs
+++ b/crates/citum-schema-style/src/locale/embedded/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Embedded baseline locale data.

--- a/crates/citum-schema-style/src/locale/locator.rs
+++ b/crates/citum-schema-style/src/locale/locator.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::citation::LocatorType;

--- a/crates/citum-schema-style/src/locale/message.rs
+++ b/crates/citum-schema-style/src/locale/message.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Message evaluation for parameterized locale strings.

--- a/crates/citum-schema-style/src/locale/message_ids.rs
+++ b/crates/citum-schema-style/src/locale/message_ids.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Canonical message-ID lookups and MF2 message resolution.

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Locale definitions for Citum.

--- a/crates/citum-schema-style/src/locale/raw.rs
+++ b/crates/citum-schema-style/src/locale/raw.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/locale/raw_conversion.rs
+++ b/crates/citum-schema-style/src/locale/raw_conversion.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Conversion from [`raw::RawLocale`] (serde-facing schema) into the runtime

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Locale-specific term types and definitions.
@@ -12,7 +12,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/macros.rs
+++ b/crates/citum-schema-style/src/macros.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Declarative macros for the Citum ecosystem.

--- a/crates/citum-schema-style/src/options/bibliography.rs
+++ b/crates/citum-schema-style/src/options/bibliography.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/contributors.rs
+++ b/crates/citum-schema-style/src/options/contributors.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/dates.rs
+++ b/crates/citum-schema-style/src/options/dates.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::options::localization::MonthFormat;

--- a/crates/citum-schema-style/src/options/integral_names.rs
+++ b/crates/citum-schema-style/src/options/integral_names.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/localization.rs
+++ b/crates/citum-schema-style/src/options/localization.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/locators.rs
+++ b/crates/citum-schema-style/src/options/locators.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Locator rendering configuration.

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style configuration options.

--- a/crates/citum-schema-style/src/options/multilingual.rs
+++ b/crates/citum-schema-style/src/options/multilingual.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/processing.rs
+++ b/crates/citum-schema-style/src/options/processing.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Processing mode and citation/bibliography rendering options.
@@ -11,7 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
 
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/scoped.rs
+++ b/crates/citum-schema-style/src/options/scoped.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Typed scoped options that normalize resolved citation and bibliography specs.

--- a/crates/citum-schema-style/src/options/substitute.rs
+++ b/crates/citum-schema-style/src/options/substitute.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/titles.rs
+++ b/crates/citum-schema-style/src/options/titles.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/presets.rs
+++ b/crates/citum-schema-style/src/presets.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style presets for common formatting patterns.

--- a/crates/citum-schema-style/src/reference_multilingual_tests.rs
+++ b/crates/citum-schema-style/src/reference_multilingual_tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #[cfg(test)]

--- a/crates/citum-schema-style/src/registry.rs
+++ b/crates/citum-schema-style/src/registry.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style registry — discovery and alias resolution for citation styles.

--- a/crates/citum-schema-style/src/renderer.rs
+++ b/crates/citum-schema-style/src/renderer.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Minimal renderer for the legacy Citum (CSL Node) AST.

--- a/crates/citum-schema-style/src/style/diagnostics.rs
+++ b/crates/citum-schema-style/src/style/diagnostics.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Raw YAML diagnostics for template-bearing style surfaces.

--- a/crates/citum-schema-style/src/style/metadata.rs
+++ b/crates/citum-schema-style/src/style/metadata.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style metadata and classification types.

--- a/crates/citum-schema-style/src/style/mod.rs
+++ b/crates/citum-schema-style/src/style/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style model, metadata, validation, and inheritance internals.

--- a/crates/citum-schema-style/src/style/model.rs
+++ b/crates/citum-schema-style/src/style/model.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! The Citum style model.

--- a/crates/citum-schema-style/src/style/overlay.rs
+++ b/crates/citum-schema-style/src/style/overlay.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Null-aware style overlay merging.

--- a/crates/citum-schema-style/src/style/resolution.rs
+++ b/crates/citum-schema-style/src/style/resolution.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style inheritance and resolver integration.

--- a/crates/citum-schema-style/src/style/sections/bibliography.rs
+++ b/crates/citum-schema-style/src/style/sections/bibliography.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Bibliography section specification.

--- a/crates/citum-schema-style/src/style/sections/citation.rs
+++ b/crates/citum-schema-style/src/style/sections/citation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citation section specification.

--- a/crates/citum-schema-style/src/style/sections/mod.rs
+++ b/crates/citum-schema-style/src/style/sections/mod.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citation and bibliography style section specifications.

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style validation and resource-limit checks.

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style base-inheritance mechanism for named compiled-in styles.

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Template components for Citum styles.

--- a/crates/citum-schema-style/src/template/reference.rs
+++ b/crates/citum-schema-style/src/template/reference.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Template presets, references, and locale-scoped template overrides.

--- a/crates/citum-schema-style/src/template/resolution.rs
+++ b/crates/citum-schema-style/src/template/resolution.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Template variant resolution logic.

--- a/crates/citum-schema-style/src/version.rs
+++ b/crates/citum-schema-style/src/version.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Style schema version and resource-limit constants.

--- a/crates/citum-schema-style/tests/bdd_inheritance.rs
+++ b/crates/citum-schema-style/tests/bdd_inheritance.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench/bin crate")]

--- a/crates/citum-schema-style/tests/json_deserialization.rs
+++ b/crates/citum-schema-style/tests/json_deserialization.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench/bin crate")]

--- a/crates/citum-schema-style/tests/parent_reference.rs
+++ b/crates/citum-schema-style/tests/parent_reference.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench/bin crate")]

--- a/crates/citum-schema-style/tests/verify_examples.rs
+++ b/crates/citum-schema-style/tests/verify_examples.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench/bin crate")]

--- a/crates/citum-schema/benches/formats.rs
+++ b/crates/citum-schema/benches/formats.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench")]

--- a/crates/citum-schema/src/lib.rs
+++ b/crates/citum-schema/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Compatibility facade crate for Citum schema models.

--- a/crates/citum-schema/tests/json_deserialization.rs
+++ b/crates/citum-schema/tests/json_deserialization.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench")]

--- a/crates/citum-schema/tests/parent_reference.rs
+++ b/crates/citum-schema/tests/parent_reference.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench/bin crate")]

--- a/crates/citum-schema/tests/verify_examples.rs
+++ b/crates/citum-schema/tests/verify_examples.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test/bench")]

--- a/crates/citum-server/src/error.rs
+++ b/crates/citum-server/src/error.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_engine::ProcessorError;

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::rpc::{RpcRequest, dispatch};

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Citum JSON-RPC Server

--- a/crates/citum-server/src/main.rs
+++ b/crates/citum-server/src/main.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "bin")]

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use crate::error::ServerError;

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 #![allow(missing_docs, reason = "test")]

--- a/crates/citum_store/src/chain.rs
+++ b/crates/citum_store/src/chain.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Standard ChainResolver construction for platform-aware style resolution.

--- a/crates/citum_store/src/cid.rs
+++ b/crates/citum_store/src/cid.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Content-addressed identifiers (CIDv1) for Citum styles.

--- a/crates/citum_store/src/config.rs
+++ b/crates/citum_store/src/config.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Store configuration from `~/.config/citum/config.yaml` or `~/.config/citum/config.toml`.

--- a/crates/citum_store/src/format.rs
+++ b/crates/citum_store/src/format.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Store format detection and serialization.

--- a/crates/citum_store/src/lib.rs
+++ b/crates/citum_store/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Platform-aware store for user-installed Citum styles and locales.

--- a/crates/citum_store/src/paths.rs
+++ b/crates/citum_store/src/paths.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use std::env;

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Store resolver for locating and managing user styles and locales.

--- a/crates/citum_store/src/resolver_tests.rs
+++ b/crates/citum_store/src/resolver_tests.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Integration tests for `StoreResolver`.

--- a/crates/citum_store/tests/resolver_arch.rs
+++ b/crates/citum_store/tests/resolver_arch.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Tests for the resolver architecture.

--- a/crates/csl-legacy/src/bin/main.rs
+++ b/crates/csl-legacy/src/bin/main.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Example binary for parsing a legacy CSL style and printing the JSON form.

--- a/crates/csl-legacy/src/bin/stats.rs
+++ b/crates/csl-legacy/src/bin/stats.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! Utility binary for scanning a style directory and summarizing parse failures.

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! CSL-JSON reference model.

--- a/crates/csl-legacy/src/lib.rs
+++ b/crates/csl-legacy/src/lib.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! CSL 1.0 XML parser for the legacy `.csl` style format.

--- a/crates/csl-legacy/src/model.rs
+++ b/crates/csl-legacy/src/model.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use serde::{Deserialize, Serialize};

--- a/crates/csl-legacy/src/parser.rs
+++ b/crates/csl-legacy/src/parser.rs
@@ -1,6 +1,6 @@
 /*
 SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 //! CSL 1.0 XML → [`model`](crate::model) parser.


### PR DESCRIPTION
This PR shifts the project to the 'Individual + Contributors' model as recommended.

Key changes:
- Created `AUTHORS.md` to lock in historical authorship credit (dating back to 2023).
- Updated root `LICENSE` and `LICENSE-APACHE` files with the new copyright line.
- Bulk updated SPDX headers in all Rust source files to include 'Citum contributors'.

This structure protects original authorship while remaining flexible for future project management handoffs.