### PR TITLE
fix(schema): add ShortOnly to IntegralNameRule; remove from MLA

### DIFF
--- a/.beans/archive/csl26-yzmc--remove-incorrect-fullthenshort-from-mla-add-shorto.md
+++ b/.beans/archive/csl26-yzmc--remove-incorrect-fullthenshort-from-mla-add-shorto.md
@@ -1,0 +1,17 @@
+---
+# csl26-yzmc
+title: Remove incorrect FullThenShort from MLA; add ShortOnly to IntegralNameRule
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-22T23:17:39Z
+updated_at: 2026-05-22T23:21:22Z
+---
+
+MLA's integral-names config incorrectly applied name-memory (FullThenShort). Research shows ShortOnly is correct for all major styles including MLA. Fix: remove integral-names block from MLA YAML, add ShortOnly variant to IntegralNameRule enum for future explicitness.
+
+## Summary of Changes
+
+- Added `ShortOnly` variant to `IntegralNameRule` in `citum-schema-style/src/options/integral_names.rs`
+- Removed the incorrect `integral-names` block from MLA's embedded style YAML; research confirmed FullThenShort name-memory doesn't match how any major style (including MLA) works in practice
+- Replaced the MLA-specific schema config test with a behavioral test for `ShortOnly`: verifies that a Subsequent state is ignored (full name rendered) when the rule is `short-only`

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -164,24 +164,39 @@ fn integral_name_state_overrides_processor_memory() {
     );
 }
 
-fn embedded_mla_enables_integral_name_memory() {
-    let style = citum_schema::embedded::get_embedded_style("mla")
-        .expect("mla style should be embedded")
-        .expect("mla style should parse");
-    let integral_names = style
-        .options
-        .and_then(|options| options.integral_names)
-        .expect("mla should enable integral-names");
-
-    assert_eq!(integral_names.rule, Some(IntegralNameRule::FullThenShort));
-    assert_eq!(integral_names.scope, Some(IntegralNameScope::Document));
-    assert_eq!(
-        integral_names.contexts,
-        Some(IntegralNameContexts::BodyAndNotes)
+fn short_only_rule_ignores_subsequent_name_state() {
+    let mut bibliography = indexmap::IndexMap::new();
+    bibliography.insert(
+        "item1".to_string(),
+        make_book("item1", "Smith", "John", 2020, "Book A"),
     );
+    let mut style = build_integral_name_style();
+    style
+        .options
+        .as_mut()
+        .unwrap()
+        .integral_names
+        .as_mut()
+        .unwrap()
+        .rule = Some(IntegralNameRule::ShortOnly);
+    let processor = Processor::new(style, bibliography);
+
+    let subsequent = Citation {
+        mode: CitationMode::Integral,
+        items: vec![CitationItem {
+            id: "item1".to_string(),
+            integral_name_state: Some(IntegralNameState::Subsequent),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // ShortOnly disables form rewriting — full name rendered regardless of state.
     assert_eq!(
-        integral_names.subsequent_form,
-        Some(IntegralNameForm::Short)
+        processor
+            .process_citation(&subsequent)
+            .expect("should render"),
+        "John Smith"
     );
 }
 
@@ -1461,11 +1476,11 @@ mod integral_name_memory {
     }
 
     #[test]
-    fn embedded_mla_enables_integral_name_memory() {
+    fn short_only_rule_ignores_subsequent_name_state() {
         announce_behavior(
-            "The embedded MLA style should enable document-scoped integral-name memory with full-then-short behavior.",
+            "A style with rule: short-only should render the full name even when the citation carries a Subsequent state.",
         );
-        super::embedded_mla_enables_integral_name_memory();
+        super::short_only_rule_ignores_subsequent_name_state();
     }
 }
 

--- a/crates/citum-schema-style/embedded/styles/modern-language-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/modern-language-association.yaml
@@ -24,11 +24,6 @@ options:
   locators: note
   processing: author-date
   substitute: standard
-  integral-names:
-    rule: full-then-short
-    scope: document
-    contexts: body-and-notes
-    subsequent-form: short
   contributors: chicago
   dates: long
   titles: chicago

--- a/crates/citum-schema-style/src/options/integral_names.rs
+++ b/crates/citum-schema-style/src/options/integral_names.rs
@@ -79,6 +79,9 @@ pub enum IntegralNameRule {
     /// Render the first integral mention in scope in full, then shorten later mentions.
     #[default]
     FullThenShort,
+    /// Opt out of name-memory tracking; no first/subsequent distinction is applied and the
+    /// template's own contributor form is used unchanged for every integral citation.
+    ShortOnly,
 }
 
 /// The scope where integral citation name-memory resets.

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2694,6 +2694,11 @@
           "description": "Render the first integral mention in scope in full, then shorten later mentions.",
           "type": "string",
           "const": "full-then-short"
+        },
+        {
+          "description": "Opt out of name-memory tracking; no first/subsequent distinction is applied and the\ntemplate's own contributor form is used unchanged for every integral citation.",
+          "type": "string",
+          "const": "short-only"
         }
       ]
     },

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -4216,6 +4216,11 @@
           "description": "Render the first integral mention in scope in full, then shorten later mentions.",
           "type": "string",
           "const": "full-then-short"
+        },
+        {
+          "description": "Opt out of name-memory tracking; no first/subsequent distinction is applied and the\ntemplate's own contributor form is used unchanged for every integral citation.",
+          "type": "string",
+          "const": "short-only"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Adds `ShortOnly` to `IntegralNameRule` as an explicit opt-out for styles that always use the short contributor form
- Removes the `integral-names` block from the embedded MLA style — research confirms `FullThenShort` name-memory doesn't reflect real-world practice for any major embedded style, including MLA
- Replaces the MLA-specific config assertion test with a behavioral test verifying `ShortOnly` suppresses subsequent-form rewriting

## Motivation

`IntegralNameRule::FullThenShort` was the only variant and required explicit `integral-names` opt-in. MLA was the sole embedded style that enabled it. Investigation showed this was a misapplication — the feature remains in the engine for potential future use but should not be active for any current embedded style.

## Test plan

- [x] `cargo nextest run -p citum-engine -- integral_name` — all 16 pass
- [x] Full suite clean
- [x] Clippy clean