### PR TITLE
chore(beans): scrap csl26-tjqn as obsolete

### DIFF
--- a/.beans/archive/csl26-tjqn--auto-minimize-wrapper-by-default-for-proven-candid.md
+++ b/.beans/archive/csl26-tjqn--auto-minimize-wrapper-by-default-for-proven-candid.md
@@ -1,11 +1,11 @@
 ---
 # csl26-tjqn
 title: Auto-minimize wrapper by default for proven candidates
-status: todo
+status: scrapped
 type: feature
 priority: high
 created_at: 2026-05-21T00:10:10Z
-updated_at: 2026-05-21T11:24:18Z
+updated_at: 2026-05-23T12:21:39Z
 parent: csl26-f1u7
 ---
 
@@ -42,3 +42,21 @@ Any future design must be distribution-safe and must not make APA 6 default to a
 Reopened after PR #768 review. A checked YAML manifest loaded by the binary is not an acceptable default-routing mechanism: it is checkout-shaped, distribution-hostile, and risks masking converter bloat. The strict SQI gate now rejects unsafe candidates, but default minimization remains unresolved.
 
 Next work should first reduce known standalone converter bloat (see csl26-kd28) and then revisit any default minimization design with a distribution-safe runtime story.
+
+
+## Reasons for Scrapping
+
+Bean obsoleted by `csl26-kd28` and current strict-gate behavior; see
+`docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md`.
+
+- The cited 5,661-LOC `apa-6th-edition` standalone is now 993 LOC after
+  the converter-bloat reduction in `csl26-kd28` (d0f3a80a).
+- Across the 18-style sentinel + lab corpus, only `apa-6th-edition` is
+  still standalone with a discovered candidate parent; the strict
+  equivalence gate added in PR #768 correctly rejects its `apa-7th`
+  candidate. Every other candidate is already emitted as an
+  ExistingWrapper at lineage time (registry-alias, local-extends).
+- The remaining real compression opportunity (`mdpi` via template-link)
+  is scoped to `csl26-ly8d`. Default-minimize would change zero observable
+  output today and is better revisited as a thin follow-up once
+  `csl26-ly8d` lands.

--- a/.beans/csl26-f1u7--citum-migrate-post-publish-quality-wave.md
+++ b/.beans/csl26-f1u7--citum-migrate-post-publish-quality-wave.md
@@ -5,7 +5,7 @@ status: in-progress
 type: epic
 priority: high
 created_at: 2026-05-20T17:04:36Z
-updated_at: 2026-05-21T00:15:11Z
+updated_at: 2026-05-23T12:22:10Z
 ---
 
 Post-publish converter quality wave. Drive citum-migrate output toward high SQI while preserving 100% fidelity on the established portfolio gate. Strategy in `~/.claude/plans/with-crates-now-published-reflective-snowglobe.md`:
@@ -31,9 +31,9 @@ Each phase is one PR; this epic tracks the wave end-to-end. Sentinels in the PR1
 | PR1 | [[csl26-e7yw]] | completed | [#763](https://github.com/citum/citum-core/pull/763) — scorecard + alias-wrapper + atomic-config diff. Migrated mean SQI `93.57` -> `98.17`. |
 | PR2 | [[csl26-kqji]] | completed | [#766](https://github.com/citum/citum-core/pull/766) — descendant-of-preset-base wrapper rewrite. Adds template-parent routing in `lineage.rs` and `chicago-notes`/`oscola` sentinels. |
 | PR3 | [[csl26-39tm]] | in-progress | Output-driven compression + evidence emission. First target: apa-6th-edition (<1,500 LOC, no APA-7 aliasing). |
-| PR4-pre | [[csl26-dqtx]] | todo | **CRITICAL.** Expand reference corpus to expose APA 6 vs 7 semantic differences (et al. threshold, author cap, ampersand-vs-and, DOI format, publisher city). The 5-LOC apa-6th from PR3 is a corpus artifact — fixtures cannot distinguish APA 6 from APA 7. Blocks PR4 and PR4b. |
+| PR4-pre | [[csl26-dqtx]] | todo | **CRITICAL.** Expand reference corpus to expose APA 6 vs 7 semantic differences (et al. threshold, author cap, ampersand-vs-and, DOI format, publisher city). The 5-LOC apa-6th from PR3 is a corpus artifact — fixtures cannot distinguish APA 6 from APA 7. Blocks PR4. |
 | PR4 | [[csl26-ly8d]] | blocked | Extend `--minimize-wrapper` to template-link / independent-parent-link candidates. |
-| PR4b | [[csl26-tjqn]] | blocked | Make minimization the **default**. Cannot safely land until oracle gate stops false-positiving on insufficient corpora. |
+| PR4b | [[csl26-tjqn]] | scrapped | Obsoleted by csl26-kd28 (standalone bloat reduction) and PR #768 strict gate. Per `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md`, no sentinel candidate would change emitted output today. |
 | PR5 | (not yet filed) | — | Author a Vancouver / numeric-journal preset base and repeat the rewrite pass for the numeric cluster (`american-medical-association`, `karger`, `iop`, `thieme`, `mdpi`). |
 | PR6 | (not yet filed) | — | Auto-derive candidate family bases from cluster fingerprints. |
 


### PR DESCRIPTION
## Summary

Scrap `csl26-tjqn` ("Auto-minimize wrapper by default for proven candidates") as obsolete. The bean's premise is stale post-kd28, and the strict equivalence gate added in PR #768 already enforces the bean's safety acceptance criterion by construction.

## Evidence

From `docs/architecture/2026-05-20_MIGRATE_SQI_BASELINE.md` (commit `7753f82d`, post-`csl26-kd28`):

| Style | Default-emit | Standalone (hypothetical) | Minimize attempt | Strict gate |
|---|---:|---:|---:|---|
| `apa` | 5 LOC | 2481 | – | already ExistingWrapper via registry-alias |
| `apa-6th-edition` | **993** | 993 | 993 → 5 | **✗ rejected** (citations 1/1 → 0/1) |
| `chicago-author-date` | 5 | 8610 | – | already ExistingWrapper via registry-alias |
| `chicago-notes` | 5 | 74 | – | already ExistingWrapper via registry-alias |
| `elsevier-harvard / -with-titles / -vancouver` | 24–67 | 124–324 | – | already ExistingWrapper via local-extends |
| `springer-basic-author-date` | 65 | 231 | – | already ExistingWrapper via local-extends |
| `taylor-and-francis-chicago-author-date` | 50 | 9034 | – | already ExistingWrapper via local-extends |
| `multidisciplinary-digital-publishing-institute` | 237 | 237 | 237 → 237 | **✗** minimize path doesn't fire for template-link (`csl26-ly8d`'s scope) |
| `ieee` / `ama` / `nature` / `cell` / `karger` / `iop` / `thieme` | bloated | — | none | no candidate parent discovered |

Three findings:

1. The bean cites a 5,661-LOC `apa-6th-edition` standalone; post-kd28 (`d0f3a80a`) it's **993 LOC**. The "users running the binary see no compression" complaint has already been substantially answered by converter-bloat reduction.
2. Across the full 18-style sentinel + lab corpus, only `apa-6th-edition` is still standalone with a discovered candidate parent. The strict gate correctly rejects its `apa-7th` candidate because APA 6 ≠ APA 7 on citations.
3. Every other candidate is already emitted as `ExistingWrapper` at lineage time. The remaining real compression opportunity (`mdpi` via template-link) is scoped to `csl26-ly8d` — implementing default-minimize today would change zero observable output and is better revisited as a thin follow-up once `csl26-ly8d` lands.

## Changes

- `.beans/csl26-tjqn--…md` → archived to `.beans/archive/` with `## Reasons for Scrapping` appended.
- `.beans/csl26-f1u7--…md`: PR4b row in epic table changed from `blocked` to `scrapped`; PR4-pre row's trailing "Blocks PR4 and PR4b" dropped to "Blocks PR4".

Docs-only; no Rust, no Cargo, no scripts touched.

## Test plan

- [x] `beans show csl26-tjqn --json | jq '.status, .path'` → `"scrapped"`, under `archive/`
- [x] `beans show csl26-f1u7 --body-only | grep -E "tjqn|PR4b"` → PR4b row marked scrapped
- [x] `./scripts/test-beans-hygiene.sh` → ok
- [x] CI green
