### PR TITLE
fix(styles): align oscola bibliography name-form

### DIFF
--- a/.beans/archive/csl26-gfx5--fix-oscolayaml-bibliography-name-form-to-match-no.md
+++ b/.beans/archive/csl26-gfx5--fix-oscolayaml-bibliography-name-form-to-match-no.md
@@ -1,0 +1,15 @@
+---
+# csl26-gfx5
+title: Fix oscola.yaml bibliography name-form to match no-ibid variant
+status: scrapped
+type: task
+priority: normal
+created_at: 2026-05-23T13:02:26Z
+updated_at: 2026-05-23T13:06:39Z
+---
+
+oscola.yaml bibliography options use name-form: full but should use name-form: initials + initialize-with: "" (matching oscola-no-ibid.yaml). This causes 3/34 bibliography failures (entries 32, 33, 34) in the oracle. Fix: copy the two fields from oscola-no-ibid bibliography options.
+
+## Reasons for Scrapping
+
+Duplicate of csl26-y9xu which completed the same work.

--- a/.beans/archive/csl26-y9xu--fix-oscolayaml-bibliography-name-form-to-match-no.md
+++ b/.beans/archive/csl26-y9xu--fix-oscolayaml-bibliography-name-form-to-match-no.md
@@ -1,0 +1,17 @@
+---
+# csl26-y9xu
+title: Fix oscola.yaml bibliography name-form to match no-ibid variant
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-23T13:02:29Z
+updated_at: 2026-05-23T13:06:10Z
+---
+
+oscola.yaml bibliography options use name-form: full but should use name-form: initials + initialize-with: '' (matching oscola-no-ibid.yaml). This causes 3/34 bibliography failures.
+
+## Summary of Changes
+
+Changed  from  to  and added  in . This matches the existing  configuration, which already passed 34/34.
+
+**Fidelity:** bibliography 31/34 → 34/34 (100%). Citations remain 18/18. Core quality gate: 154 styles, all pass.

--- a/styles/oscola.yaml
+++ b/styles/oscola.yaml
@@ -122,7 +122,8 @@ bibliography:
   options:
     contributors:
       display-as-sort: all
-      name-form: full
+      name-form: initials
+      initialize-with: ""
       shorten:
         min: 4
         use-first: 1


### PR DESCRIPTION
## Summary

- Fix bibliography contributor name format in `styles/oscola.yaml`: change `name-form: full` → `name-form: initials` and add `initialize-with: ""` to match the already-correct `oscola-no-ibid.yaml` configuration
- Bibliography fidelity: **31/34 → 34/34 (100%)**; citations unchanged at 18/18
- Core quality gate: 154 styles, all pass

## Root cause

The three failing entries (32–34) were multi-author items where the oracle's structured-diff parser uses contributor text as an anchor to locate subsequent components. With full given names (`Weinberg Gerald M., Freedman Daniel P.`) the component boundaries shifted, causing cascading false failures on year, title, publisher, and edition. The `oscola-no-ibid` variant already had the correct settings and passed 34/34.

## Test plan

- [x] `node scripts/oracle.js styles-legacy/oscola.csl` → 18/18 citations, 34/34 bibliography
- [x] `node scripts/oracle.js styles-legacy/oscola-no-ibid.csl` → unchanged, still 34/34
- [x] `node scripts/check-core-quality.js` → core quality gate passes (154 styles)
- [x] `~/.claude/scripts/verify.sh` → all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
