### PR TITLE
docs: add self-improvement directive to project skills

### DIFF
--- a/.skills/migrate-research/SKILL.md
+++ b/.skills/migrate-research/SKILL.md
@@ -42,3 +42,11 @@ Read first:
 Report the chosen cluster, semantic class, implementation form, selected parent if any,
 classification, before/after evidence, exact change made if any, and whether the pass
 should continue, stop, or escalate.
+
+## Self-Improvement
+
+When you reach a dead end not covered by the operating rules — a cluster pattern that
+doesn't fit the four classifications, a stop condition missing from the guides, or a
+migration artifact the evidence ladder doesn't anticipate — record the insight as a
+concrete bullet here and include the file update in the same commit or PR. Future
+research passes start with a richer surface.

--- a/.skills/rust-simplify/SKILL.md
+++ b/.skills/rust-simplify/SKILL.md
@@ -41,3 +41,17 @@ Read first:
   passes and review the advisory findings.
 - Regenerate schemas if the touched files require it.
 - Report the exact checks you ran and the result.
+
+## Self-Improvement
+
+When you hit a recurring Rust smell not already caught by the audit script:
+
+1. If it can be expressed as a regex rule, add it to `scripts/audit-rust-review-smells.py`
+   as a new `Rule` entry in the `RULES` tuple — the script is the canonical home for
+   automatable patterns.
+2. If it's too contextual for a regex, add a short bullet to the Quality Pass section
+   above instead.
+
+For verification failure modes or jcodemunch quirks, add a bullet to the Verification
+section above. Include any file updates in the same commit. One concrete rule per
+observation — keep the scope tight.

--- a/.skills/style-evolve/SKILL.md
+++ b/.skills/style-evolve/SKILL.md
@@ -41,3 +41,11 @@ Read first:
 - Keep waves bounded to one family or one clearly related cohort per PR.
 - Do not duplicate the shared decision rules or evidence ladder here.
 - Keep this skill focused on routing and host-facing behavior.
+
+## Self-Improvement
+
+When you encounter a routing case, semantic class, or implementation form not covered
+by the existing operating rules or the shared workflow docs, record the pattern here as
+a new bullet under "Operating Rules" and include the file update in the same commit.
+The goal is that each time style-evolve handles an edge case it couldn't resolve
+cleanly, that edge case becomes a covered case going forward.


### PR DESCRIPTION
## Summary

- Adds a `## Self-Improvement` section to the three substantive project skills in `.skills/`: `style-evolve`, `migrate-research`, and `rust-simplify`
- Wording is tailored to each skill's specific failure modes rather than copy-pasted
- `styleauthor` is left untouched (thin alias — any learning belongs in `style-evolve`)

## Motivation

Based on a recommendation from an Anthropic employee: skills should be self-improving. When an agent hits a gap or blocker that isn't covered by the skill's operating rules, it should resolve it *and* record the fix in the skill itself. This prevents future sessions from re-discovering the same edge case from scratch — the skill file acts as lightweight in-repo memory that grows with use.

## Per-skill rationale

| Skill | What kinds of things get recorded |
|---|---|
| `style-evolve` | Routing edge cases: new semantic classes, implementation forms, or workflow patterns not covered by the existing guides |
| `migrate-research` | Research dead ends: cluster patterns outside the four classifications, missing stop conditions, unanticipated migration artifacts |
| `rust-simplify` | Recurring smells, verification failure modes, or jcodemunch quirks not yet in the quality-pass rules |

## Test plan

- [x] Review diff for correct section placement in each file
- [x] Confirm `styleauthor` is unchanged
- [ ] Confirm wording is skill-specific (not generic copy-paste)
