### PR TITLE
feat(report): components for biblatex authority

### DIFF
--- a/.beans/archive/csl26-8kod--components-column-coverage-for-biblatex-authority.md
+++ b/.beans/archive/csl26-8kod--components-column-coverage-for-biblatex-authority.md
@@ -1,14 +1,14 @@
 ---
 # csl26-8kod
 title: Components column coverage for biblatex-authority styles
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
     - testing
     - migrate
 created_at: 2026-03-07T19:25:01Z
-updated_at: 2026-04-25T20:20:07Z
+updated_at: 2026-05-23T18:17:10Z
 ---
 
 The five compound-numeric styles (numeric-comp, chem-acs, angewandte-chemie, chem-rsc, chem-biochem) use biblatex as their benchmark authority. The biblatex oracle in report-core.js builds entries as { expected, actual, match } with no component-level breakdown, so computeComponentMatchRate() always returns null and the Components column in compat.html is empty for these styles.
@@ -30,3 +30,27 @@ Add a separate oracle pass for biblatex styles using the Citum JSON render outpu
 
 **Option D — Bibliography pass-rate proxy (rejected)**
 Fall back to treating entry.match as 1/1 per entry. Rejected: this duplicates the fidelity score and gives no additional signal about which components are passing or failing.
+
+
+
+## Summary of Changes
+
+Implemented **Option A** (post-hoc `parseComponents` on biblatex output strings) — the symmetric heuristic diff already used for citeproc-js-authority styles, applied to biblatex-authority styles. This makes the Components column apples-to-apples comparable across all benchmark sources.
+
+### Changes
+
+- `scripts/oracle-utils.js` — moved `compareComponents` here (from `oracle.js`) and exported it, so both oracle paths share a single source.
+- `scripts/oracle.js` — now imports `compareComponents` from `./oracle-utils` instead of defining it locally; re-export preserved.
+- `scripts/report-core.js` — `runBiblatexSnapshotOracle` now populates `entry.components` with `{matches, differences}` for mismatched entries, using fixture-aligned `refData`. `computeComponentMatchRate` is now exported.
+- `scripts/report-core.test.js` — added two focused tests covering populated-components scoring and the pre-fix null-baseline behaviour.
+
+### Verification
+
+- All 51 `report-core.test.js` tests pass; all 25 `oracle.test.js` tests pass.
+- All 5 biblatex-authority styles now produce a numeric `componentMatchRate` (previously `null`):
+  `angewandte-chemie`, `chem-acs`, `chem-biochem`, `chem-rsc`, `numeric-comp` → all 1.000 at current fidelity.
+- Quality gate green: 154 styles, fidelity=1.0, warnings=0.
+
+### Followup
+
+Filed [[csl26-hb8v]] — biblatex → Citum scaffold script (scaffold-only path; cf. independent-alternative analysis of a full converter).

--- a/.beans/csl26-hb8v--biblatex-citum-scaffold-script-for-hand-authoring.md
+++ b/.beans/csl26-hb8v--biblatex-citum-scaffold-script-for-hand-authoring.md
@@ -1,0 +1,49 @@
+---
+# csl26-hb8v
+title: biblatex → Citum scaffold script for hand-authoring biblatex-benchmarked styles
+status: todo
+type: task
+priority: low
+created_at: 2026-05-23T18:16:57Z
+updated_at: 2026-05-23T18:16:57Z
+---
+
+Followup from csl26-8kod. Investigates a low-cost path to accelerate authoring of biblatex-benchmarked Citum styles without taking on a full biblatex .bbx/.cbx → Citum converter.
+
+## Why a full converter is impractical
+
+- biblatex style files (.bbx/.cbx) are LaTeX macro code: Turing-complete, no clean AST, conditional control flow, and depend on biblatex's runtime field schema. A general converter is a multi-quarter project.
+- The audience is narrow: most biblatex users already have working LaTeX. Citum's current 5 biblatex-benchmarked styles (numeric-comp, chem-acs, angewandte-chemie, chem-rsc, chem-biochem) are already hand-authored and benchmarked, so the marginal benefit is small.
+
+## Why citum-migrate is not the right home
+
+citum-migrate is structured around CSL 1.0 XML parsing (csl-legacy → Citum YAML). biblatex has no structural analogue to that pipeline — there is no XML-shaped style tree to walk. Trying to fit biblatex into the migrate crate would balloon its scope and dilute its CSL 1.0 focus.
+
+## Proposed alternative — scaffold-only script
+
+A Node script under `scripts/` (e.g. `scripts/scaffold-biblatex.js`) that consumes the rendered output already produced by `scripts/gen-biblatex-snapshot.js` (and existing snapshots in `tests/snapshots/biblatex/`) and emits a Citum YAML scaffold.
+
+What it can plausibly infer from rendered snapshot text alone:
+- bibliography sort order (compare rendered order against the fixture ref ordering).
+- bibliography layout pattern (numeric prefix `(1)` vs alphabetic, em-dash separators, etc.).
+- name-form / contributor-form (initials vs full names, `and` vs `&`, comma vs semicolon).
+- title casing and quoting style.
+- year placement heuristic (after authors vs at end).
+
+What it cannot infer (and must be hand-completed):
+- citation-side macros (biblatex snapshots only carry bibliography output).
+- type-variants and per-type formatting rules.
+- conditional / fallback logic.
+
+The scaffold output should be a partially-complete YAML stub that the author finishes by hand — mirroring the existing workflow for the 5 chem styles, but with the boilerplate (sort, layout, name-form) pre-filled.
+
+## Independent alternative (compared, not chosen)
+
+Add biblatex conversion to citum-migrate. Rejected for the reasons above (LaTeX macro parsing complexity, dilutes crate scope, narrow audience).
+
+## Acceptance criteria for the scaffold-only path
+
+- [ ] Script reads a biblatex snapshot JSON + the fixture and emits a Citum YAML stub.
+- [ ] Stub renders without errors via the Citum engine even if fidelity is low.
+- [ ] Documentation in `docs/guides/` (or amendment to existing authoring guide) explains the scaffold → hand-finish workflow.
+- [ ] Out of scope: any change to `crates/citum-migrate`.

--- a/scripts/oracle-utils.js
+++ b/scripts/oracle-utils.js
@@ -586,11 +586,66 @@ function loadLocale(lang) {
   throw new Error(`Locale not found: ${lang}`);
 }
 
+/**
+ * Compare two component sets and identify differences.
+ *
+ * Symmetric heuristic diff: matches indicate components present and equal in
+ * both renderings; differences flag value mismatches, missing components, or
+ * extra components.
+ */
+function compareComponents(oracleComp, citumComp, _refData) {
+  const differences = [];
+  const matches = [];
+
+  const keys = ['contributors', 'year', 'title', 'containerTitle', 'volume',
+    'issue', 'pages', 'publisher', 'doi', 'edition', 'editors',
+    'translators', 'interviewers', 'recipients'];
+
+  for (const key of keys) {
+    const oracle = oracleComp[key];
+    const citum = citumComp[key];
+
+    if (!oracle.found && !citum.found) continue;
+
+    if (oracle.found && citum.found) {
+      if (oracle.value === citum.value ||
+        (typeof oracle.value === 'boolean' && oracle.value === citum.value)) {
+        matches.push({ component: key, status: 'match' });
+      } else {
+        differences.push({
+          component: key,
+          issue: 'value_mismatch',
+          expected: oracle.value,
+          found: citum.value,
+          detail: 'Value differs between oracle and Citum',
+        });
+      }
+    } else if (oracle.found && !citum.found) {
+      differences.push({
+        component: key,
+        issue: 'missing',
+        expected: oracle.value,
+        detail: `Missing in Citum output`
+      });
+    } else if (!oracle.found && citum.found) {
+      differences.push({
+        component: key,
+        issue: 'extra',
+        found: citum.value,
+        detail: `Extra in Citum output (not in oracle)`
+      });
+    }
+  }
+
+  return { differences, matches };
+}
+
 module.exports = {
   compareText,
   normalizeText,
   isCaseOnlyMismatch,
   parseComponents,
+  compareComponents,
   analyzeOrdering,
   findRefMatchForEntry,
   hasPrimaryNames,

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -30,6 +30,7 @@ const {
   compareText,
   normalizeText,
   parseComponents,
+  compareComponents,
   analyzeOrdering,
   findRefDataForEntry,
   loadLocale,
@@ -216,59 +217,6 @@ function createOracleTempWorkspace() {
 function cleanupOracleTempWorkspace(workspace) {
   if (!workspace?.dir) return;
   fs.rmSync(workspace.dir, { recursive: true, force: true });
-}
-
-/**
- * Compare two component sets and identify differences.
- */
-function compareComponents(oracleComp, citumComp, refData) {
-  const differences = [];
-  const matches = [];
-
-  const keys = ['contributors', 'year', 'title', 'containerTitle', 'volume',
-    'issue', 'pages', 'publisher', 'doi', 'edition', 'editors',
-    'translators', 'interviewers', 'recipients'];
-
-  for (const key of keys) {
-    const oracle = oracleComp[key];
-    const citum = citumComp[key];
-
-    // Skip if neither has this component
-    if (!oracle.found && !citum.found) continue;
-
-    if (oracle.found && citum.found) {
-      // Both have it - check if values match
-      if (oracle.value === citum.value ||
-        (typeof oracle.value === 'boolean' && oracle.value === citum.value)) {
-        matches.push({ component: key, status: 'match' });
-      } else {
-        // Values differ
-        differences.push({
-          component: key,
-          issue: 'value_mismatch',
-          expected: oracle.value,
-          found: citum.value,
-          detail: 'Value differs between oracle and Citum',
-        });
-      }
-    } else if (oracle.found && !citum.found) {
-      differences.push({
-        component: key,
-        issue: 'missing',
-        expected: oracle.value,
-        detail: `Missing in Citum output`
-      });
-    } else if (!oracle.found && citum.found) {
-      differences.push({
-        component: key,
-        issue: 'extra',
-        found: citum.value,
-        detail: `Extra in Citum output (not in oracle)`
-      });
-    }
-  }
-
-  return { differences, matches };
 }
 
 /**

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -49,6 +49,8 @@ const {
   compareText,
   normalizeText,
   textSimilarity,
+  parseComponents,
+  compareComponents,
 } = require('./oracle-utils');
 const { maybeDatasetErrorForFile } = require('./lib/dataset-guard');
 
@@ -1126,12 +1128,14 @@ async function runBiblatexSnapshotOracle(runtime, styleName, styleYamlPath, auth
       }
 
       try {
-        // Build ordered type list from the fixture so we can track per-type pass rates.
-        // The biblatex snapshot entries correspond positionally to fixture entries.
+        // Build ordered ref list from the fixture so we can track per-type pass
+        // rates and run per-position component diffs. The biblatex snapshot
+        // entries correspond positionally to fixture entries after expansion of
+        // compound blocks.
         const fixtureData = JSON.parse(fs.readFileSync(DEFAULT_REFS_FIXTURE, 'utf8'));
-        const fixtureTypes = Object.entries(fixtureData)
+        const fixtureRefs = Object.entries(fixtureData)
           .filter(([key]) => key !== 'comment')
-          .map(([, ref]) => (typeof ref === 'object' && ref !== null ? ref.type : null) || 'unknown');
+          .map(([, ref]) => (typeof ref === 'object' && ref !== null ? ref : null));
 
         const rendered = await renderCitumJson(runtime, styleYamlPath, DEFAULT_REFS_FIXTURE, 'bib');
         const actualEntries = rendered?.bibliography?.entries?.map((entry) => entry.text) || [];
@@ -1149,15 +1153,31 @@ async function runBiblatexSnapshotOracle(runtime, styleName, styleYamlPath, auth
           });
           const match = comparison.match;
           if (match) passed += 1;
-          entries.push({
+          const entryResult = {
             expected: comparison.expected,
             actual: comparison.actual,
             match,
             caseMismatch: comparison.caseMismatch,
-          });
+          };
+
+          // On mismatch, run the same symmetric component-diff heuristic used
+          // for citeproc-js styles so the Components column gets a comparable
+          // signal for biblatex-authority styles.
+          if (!match) {
+            const refData = fixtureRefs[i];
+            if (refData) {
+              const expectedComp = parseComponents(comparison.expected, refData);
+              const actualComp = parseComponents(comparison.actual, refData);
+              const { differences, matches } =
+                compareComponents(expectedComp, actualComp, refData);
+              entryResult.components = { matches, differences };
+            }
+          }
+
+          entries.push(entryResult);
 
           // Track per-type stats using the fixture entry at this position.
-          const refType = fixtureTypes[i] || 'unknown';
+          const refType = (fixtureRefs[i] && fixtureRefs[i].type) || 'unknown';
           const typeStats = citationsByType[refType] || { passed: 0, total: 0 };
           typeStats.total += 1;
           if (match) typeStats.passed += 1;
@@ -3739,6 +3759,7 @@ if (require.main === module) {
 module.exports = {
   buildNoteStyleLookup,
   collectTemplateScopes,
+  computeComponentMatchRate,
   computeConcisionScore,
   computeFallbackRobustness,
   computePresetUsageScore,

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -17,6 +17,7 @@ const { loadReportProvenance } = require('./lib/report-metadata');
 const {
   buildNoteStyleLookup,
   collectTemplateScopes,
+  computeComponentMatchRate,
   computeConcisionScore,
   computeFallbackRobustness,
   computePresetUsageScore,
@@ -1004,6 +1005,56 @@ test('expandCompoundBibEntries splits merged biblatex compound blocks', () => {
     '(3) Third entry.',
     '(4) Standalone entry.',
   ]);
+});
+
+test('computeComponentMatchRate scores biblatex entries with populated components', () => {
+  // Entry 1: text matches (counts as 11/11).
+  // Entry 2: text mismatch but components.{matches,differences} populated by
+  // the same heuristic used for citeproc-js styles — yields 3 matches / 4 total.
+  const oracleResult = {
+    bibliography: {
+      entries: [
+        { match: true },
+        {
+          match: false,
+          components: {
+            matches: [
+              { component: 'contributors', status: 'match' },
+              { component: 'title', status: 'match' },
+              { component: 'year', status: 'match' },
+            ],
+            differences: [
+              {
+                component: 'doi',
+                issue: 'missing',
+                expected: '10.1234/foo',
+                detail: 'Missing in Citum output',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  const rate = computeComponentMatchRate(oracleResult);
+  // (11 + 3) / (11 + 4) = 14/15 ≈ 0.933
+  assert.equal(rate, 0.933);
+});
+
+test('computeComponentMatchRate returns null when no components are populated', () => {
+  // Mirrors the pre-fix biblatex behaviour: mismatched entries without
+  // entry.components produce no signal, total stays 0, result is null.
+  const oracleResult = {
+    bibliography: {
+      entries: [
+        { match: false },
+        { match: false },
+      ],
+    },
+  };
+
+  assert.equal(computeComponentMatchRate(oracleResult), null);
 });
 
 test('equivalentText tolerates near-match snapshot formatting without masking drift', () => {


### PR DESCRIPTION
## Summary

Closes csl26-8kod. The Components column in compat reports was empty for the five biblatex-authority styles (`numeric-comp`, `chem-acs`, `angewandte-chemie`, `chem-rsc`, `chem-biochem`) because `runBiblatexSnapshotOracle` never populated `entry.components`. `computeComponentMatchRate()` therefore returned `null` for any biblatex-authority style.

This PR applies the **same symmetric `parseComponents` / `compareComponents` heuristic** already used for citeproc-js styles to biblatex output strings, so biblatex styles get a Components score that is apples-to-apples comparable to citeproc-js styles.

## Why this approach (Option A) and not a "structured-diff" rewrite

The citeproc-js Components score is itself a *heuristic* — `parseComponents` finds substring positions of refData fields (author, year, title, doi, etc.) in rendered text. There is no structured ground-truth reference; the signal is the symmetric heuristic diff between expected and actual.

That reframes the trade-offs in the bean's candidate list:

- **Option A (chosen)** — reuses the exact same heuristic and gives biblatex styles a Components signal *directly comparable* to citeproc-js styles. ~50 lines, no new infrastructure.
- **Option C (structured render diff)** — sounds cleaner but requires hand-authored structured biblatex reference data (biber --tool only normalizes `.bib` input, it doesn't render per-style structured output). Worse, the resulting Components score would *not* be apples-to-apples with citeproc-js styles, since those are still measured by the heuristic. Cleanliness argument cuts the other way.
- **Option B (structured snapshots)** — middle cost, marginal gain over A.

Discussion captured in commit message.

## Changes

- `scripts/oracle-utils.js` — move `compareComponents` here from `oracle.js` and export it. Both oracle paths now share a single source.
- `scripts/oracle.js` — import `compareComponents` from `./oracle-utils` instead of defining it locally. Re-export preserved so the public surface is unchanged.
- `scripts/report-core.js` — `runBiblatexSnapshotOracle` retains the full `refData` per fixture position (was already keeping `type` only) and populates `entry.components = { matches, differences }` for mismatched entries. `computeComponentMatchRate` is now exported.
- `scripts/report-core.test.js` — two focused tests: populated-components scoring and the pre-fix null-baseline behaviour.

## Verification

- [x] `node --test scripts/report-core.test.js` — 51 pass, 0 fail
- [x] `node --test scripts/oracle.test.js` — 25 pass, 0 fail (includes `compareComponents reports differing component values as mismatches`, exercising the moved function via `oracle.js`'s re-export)
- [x] All 5 biblatex styles now produce a numeric `componentMatchRate` (previously `null`): `angewandte-chemie`, `chem-acs`, `chem-biochem`, `chem-rsc`, `numeric-comp` — all 1.000 at current fidelity.
- [x] Quality gate green: 154 styles, fidelity=1.0, warnings=0.
- [x] No Rust files touched; Rust pre-commit gate not required.

## Follow-up

Filed csl26-hb8v — "biblatex → Citum scaffold script for hand-authoring biblatex-benchmarked styles". It captures both the feasibility analysis for a full converter (rejected: LaTeX macro complexity, narrow audience, citum-migrate scope mismatch) and a proposed alternative: a Node script that consumes existing biblatex snapshot output and emits a Citum YAML scaffold for hand-completion. Mirrors the existing authoring workflow for the 5 chem styles.

## Test plan

- [ ] CI green
- [ ] Reviewer sanity-check: render compat report locally, confirm Components column shows numeric values for the 5 biblatex styles
