### PR TITLE
refactor: split citum-io lib.rs into formats/ submodules

### DIFF
--- a/.beans/csl26-rfct--refactor-priorities-modularization.md
+++ b/.beans/csl26-rfct--refactor-priorities-modularization.md
@@ -5,7 +5,7 @@ status: in-progress
 type: milestone
 priority: normal
 created_at: 2026-05-16T14:30:00Z
-updated_at: 2026-05-18T11:22:45Z
+updated_at: 2026-05-24T00:17:28Z
 ---
 
 Analysis of Rust source files (excluding tests) exceeding 800 lines, ranked by refactor priority and grouped by modularization strategy.
@@ -37,7 +37,7 @@ Analysis of Rust source files (excluding tests) exceeding 800 lines, ranked by r
    - **Target:** Extract `CitationPositionAnalysis` to `src/upsampler/position.rs`.
 7. [ ] **`citum-engine/src/processor/rendering/grouped/core.rs` (1708 lines)**
    - **Issues:** Highly specific rendering logic and classification helpers.
-8. [ ] **`citum-io/src/lib.rs` (1622 lines)**
+8. [x] **`citum-io/src/lib.rs` (1622 lines)**
    - **Issues:** Multiple format handlers (BibLaTeX, RIS, JSON).
    - **Target:** Move format-specific logic to `src/formats/`.
 
@@ -69,3 +69,16 @@ Analysis of Rust source files (excluding tests) exceeding 800 lines, ranked by r
 ## Strategic Recommendation
 
 Prioritize Tier 1 and Tier 2 refactors, specifically focusing on `citum-schema-style/src/lib.rs` and `citum-cli/src/commands.rs`, as these are the primary entry points and experience the most frequent changes, leading to high friction in PR reviews and local development.
+
+## Summary of Changes (2026-05-23)
+
+### Item 8 — citum-io/src/lib.rs
+- Extracted four format-specific submodules under src/formats/:
+  native.rs, csl_json.rs, ris.rs, output.rs
+- lib.rs reduced from 1622 to ~345 non-test lines (-79%)
+- DRY: unified duplicate load_hybrid_json_reference into
+  parse_hybrid_json_reference
+- Performance: eliminated two String allocations per call in
+  hybrid JSON class/type routing (now uses &str comparison)
+- Idiom: moved validate_compound_sets import to module level;
+  replaced verbose if/else with .then_some() in merge path

--- a/crates/citum-io/src/formats/biblatex.rs
+++ b/crates/citum-io/src/formats/biblatex.rs
@@ -1,0 +1,31 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! BibLaTeX bibliography loading helpers.
+
+use std::fs;
+use std::path::Path;
+
+use citum_engine::ProcessorError;
+use citum_schema::InputBibliography;
+
+/// Load a BibLaTeX bibliography from a file path.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read or parsed as BibLaTeX.
+pub(crate) fn load_biblatex_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
+    let src = fs::read_to_string(path)?;
+    let bibliography = ::biblatex::Bibliography::parse(&src)
+        .map_err(|e| ProcessorError::ParseError("BibLaTeX".to_string(), e.to_string()))?;
+    let references = bibliography
+        .iter()
+        .map(crate::biblatex::input_reference_from_biblatex)
+        .collect();
+    Ok(InputBibliography {
+        references,
+        ..Default::default()
+    })
+}

--- a/crates/citum-io/src/formats/csl_json.rs
+++ b/crates/citum-io/src/formats/csl_json.rs
@@ -1,0 +1,114 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! CSL-JSON bibliography load and write helpers.
+
+use std::fs;
+use std::path::Path;
+
+use citum_engine::ProcessorError;
+use citum_schema::InputBibliography;
+use citum_schema::reference::{ClassExtension, InputReference};
+use csl_legacy::csl_json::{DateVariable, Name, Reference as LegacyReference, StringOrNumber};
+
+/// Load a CSL-JSON bibliography file.
+pub(crate) fn load_csl_json_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
+    let bytes = fs::read(path)?;
+    let refs: Vec<LegacyReference> = serde_json::from_slice(&bytes)
+        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+    let references = refs.into_iter().map(InputReference::from).collect();
+    Ok(InputBibliography {
+        references,
+        ..Default::default()
+    })
+}
+
+/// Convert an [`InputReference`] to a CSL-JSON [`LegacyReference`].
+pub(crate) fn input_reference_to_csl_json(reference: &InputReference) -> LegacyReference {
+    let id = reference.id().unwrap_or_else(|| "item".into());
+    let mut r = LegacyReference {
+        id: id.to_string(),
+        ..Default::default()
+    };
+
+    r.title = reference.title().map(|t| t.to_string());
+    r.language = reference.language().map(|lang| lang.to_string());
+    r.note = reference.note().map(|rt| rt.raw().to_string());
+    r.doi = reference.doi();
+    r.issued = reference.csl_issued_date().and_then(|d| {
+        let year = d.0.get(0..4)?.parse::<i32>().ok()?;
+        Some(DateVariable::year(year))
+    });
+    r.author = reference.author().map(contributor_to_csl_names);
+    r.editor = reference.editor().map(contributor_to_csl_names);
+    r.translator = reference.translator().map(contributor_to_csl_names);
+    r.publisher = reference.publisher().map(|p| p.name.to_string());
+
+    match reference.extension() {
+        ClassExtension::Monograph(m) => {
+            r.ref_type = "book".to_string();
+            r.isbn.clone_from(&m.isbn);
+            r.url = m.url.as_ref().map(std::string::ToString::to_string);
+            r.edition = reference.edition().map(StringOrNumber::String);
+        }
+        ClassExtension::SerialComponent(s) => {
+            r.ref_type = "article-journal".to_string();
+            r.container_title = reference.container_title().map(|t| t.to_string());
+            r.page.clone_from(&s.pages);
+            r.volume = reference
+                .volume()
+                .map(|v| StringOrNumber::String(v.to_string()));
+            r.issue = reference
+                .issue()
+                .map(|v| StringOrNumber::String(v.to_string()));
+            r.url = s.url.as_ref().map(std::string::ToString::to_string);
+        }
+        ClassExtension::CollectionComponent(c) => {
+            r.ref_type = "chapter".to_string();
+            r.container_title = reference.container_title().map(|t| t.to_string());
+            r.page = c.pages.as_ref().map(std::string::ToString::to_string);
+        }
+        _ => {
+            r.ref_type = "book".to_string();
+        }
+    }
+
+    r
+}
+
+fn contributor_to_csl_names(contributor: citum_schema::reference::Contributor) -> Vec<Name> {
+    let mut names = Vec::new();
+    match contributor {
+        citum_schema::reference::Contributor::SimpleName(n) => {
+            names.push(Name::literal(&n.name.to_string()));
+        }
+        citum_schema::reference::Contributor::StructuredName(n) => {
+            names.push(Name {
+                family: Some(n.family.to_string()),
+                given: Some(n.given.to_string()),
+                suffix: n.suffix,
+                dropping_particle: n.dropping_particle,
+                non_dropping_particle: n.non_dropping_particle,
+                literal: None,
+            });
+        }
+        citum_schema::reference::Contributor::Multilingual(n) => {
+            names.push(Name {
+                family: Some(n.original.family.to_string()),
+                given: Some(n.original.given.to_string()),
+                suffix: n.original.suffix,
+                dropping_particle: n.original.dropping_particle,
+                non_dropping_particle: n.original.non_dropping_particle,
+                literal: None,
+            });
+        }
+        citum_schema::reference::Contributor::ContributorList(list) => {
+            for member in list.0 {
+                names.extend(contributor_to_csl_names(member));
+            }
+        }
+    }
+    names
+}

--- a/crates/citum-io/src/formats/mod.rs
+++ b/crates/citum-io/src/formats/mod.rs
@@ -1,0 +1,23 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Format-specific bibliography parsing and rendering helpers.
+
+pub(crate) mod biblatex;
+pub(crate) mod csl_json;
+pub(crate) mod native;
+pub(crate) mod output;
+pub(crate) mod ris;
+
+pub(crate) use biblatex::load_biblatex_bibliography;
+pub(crate) use csl_json::{input_reference_to_csl_json, load_csl_json_bibliography};
+#[cfg(test)]
+pub(crate) use native::loaded_from_input_bibliography;
+pub(crate) use native::{
+    deserialize_any, load_citum_json_bibliography, parse_cbor_bibliography,
+    parse_json_bibliography, parse_yaml_bibliography, serialize_any,
+};
+pub(crate) use output::{render_biblatex, render_ris};
+pub(crate) use ris::load_ris_bibliography;

--- a/crates/citum-io/src/formats/native.rs
+++ b/crates/citum-io/src/formats/native.rs
@@ -1,0 +1,391 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Citum-native (YAML / JSON / CBOR) bibliography parsing and serialization helpers.
+
+use std::io::Cursor;
+
+use citum_engine::processor::validate_compound_sets;
+use citum_engine::{ProcessorError, Reference};
+use citum_schema::InputBibliography;
+use citum_schema::reference::conversion::input_reference_from_legacy_edited_book;
+use citum_schema::reference::types::{ArchiveInfo, EprintInfo};
+use citum_schema::reference::{ClassExtension, InputReference};
+use csl_legacy::csl_json::Reference as LegacyReference;
+use indexmap::IndexMap;
+
+use crate::LoadedBibliography;
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct LegacyBibliographyWrapper {
+    pub(crate) references: Vec<LegacyReference>,
+    #[serde(default)]
+    pub(crate) sets: Option<IndexMap<String, Vec<String>>>,
+}
+
+pub(crate) fn loaded_from_input_bibliography(
+    input_bib: InputBibliography,
+) -> Result<LoadedBibliography, ProcessorError> {
+    let mut references = IndexMap::new();
+    for r in input_bib.references {
+        if let Some(id) = r.id() {
+            references.insert(id.to_string(), r);
+        }
+    }
+    let sets = validate_compound_sets(input_bib.sets, &references)?;
+    Ok(LoadedBibliography { references, sets })
+}
+
+pub(crate) fn parse_cbor_bibliography(bytes: &[u8]) -> Result<LoadedBibliography, ProcessorError> {
+    let input_bib = ciborium::de::from_reader::<InputBibliography, _>(Cursor::new(bytes))
+        .map_err(|e| ProcessorError::ParseError("CBOR".to_string(), e.to_string()))?;
+    loaded_from_input_bibliography(input_bib)
+}
+
+fn loaded_from_hybrid_json_array(
+    references: &[serde_json::Value],
+    sets: Option<IndexMap<String, Vec<String>>>,
+) -> Result<LoadedBibliography, ProcessorError> {
+    let mut bib = IndexMap::new();
+    for value in references.iter().cloned() {
+        let reference = parse_hybrid_json_reference(value)?;
+        if let Some(id) = reference.id() {
+            bib.insert(id.to_string(), reference);
+        }
+    }
+    let sets = validate_compound_sets(sets, &bib)?;
+    Ok(LoadedBibliography {
+        references: bib,
+        sets,
+    })
+}
+
+fn apply_hybrid_json_extensions(
+    mut reference: InputReference,
+    value: &serde_json::Value,
+) -> Result<InputReference, ProcessorError> {
+    let archive_info = value
+        .get("archive-info")
+        .filter(|raw| !raw.is_null())
+        .cloned()
+        .map(serde_json::from_value::<ArchiveInfo>)
+        .transpose()
+        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+    let eprint = value
+        .get("eprint")
+        .filter(|raw| !raw.is_null())
+        .cloned()
+        .map(serde_json::from_value::<EprintInfo>)
+        .transpose()
+        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+
+    match reference.extension_mut() {
+        ClassExtension::Monograph(record) => {
+            if let Some(info) = archive_info.clone() {
+                record.archive_info = Some(info);
+            }
+            if let Some(info) = eprint.clone() {
+                record.eprint = Some(info);
+            }
+        }
+        ClassExtension::CollectionComponent(record) => {
+            if let Some(info) = archive_info.clone() {
+                record.archive_info = Some(info);
+            }
+            if let Some(info) = eprint.clone() {
+                record.eprint = Some(info);
+            }
+        }
+        ClassExtension::SerialComponent(record) => {
+            if let Some(info) = archive_info {
+                record.archive_info = Some(info);
+            }
+            if let Some(info) = eprint {
+                record.eprint = Some(info);
+            }
+        }
+        _ => {}
+    }
+    Ok(reference)
+}
+
+/// Parse a JSON value into an [`InputReference`] with class/type routing and
+/// optional archive-info / eprint extension fields.
+///
+/// Unified from the former `parse_hybrid_json_reference` and
+/// `load_hybrid_json_reference` — the extension pass is a no-op when neither
+/// `archive-info` nor `eprint` keys are present.
+fn parse_hybrid_json_reference(value: serde_json::Value) -> Result<InputReference, ProcessorError> {
+    if let Ok(reference) = serde_json::from_value::<InputReference>(value.clone()) {
+        return Ok(reference);
+    }
+
+    let class = value
+        .get("class")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let ref_type = value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let legacy = serde_json::from_value::<LegacyReference>(value.clone())
+        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+
+    let reference = if class == "collection" && ref_type == "edited-book" {
+        input_reference_from_legacy_edited_book(legacy)
+    } else {
+        InputReference::from(legacy)
+    };
+
+    apply_hybrid_json_extensions(reference, &value)
+}
+
+fn load_hybrid_json_references(
+    references: &[serde_json::Value],
+) -> Result<Vec<InputReference>, ProcessorError> {
+    references
+        .iter()
+        .cloned()
+        .map(parse_hybrid_json_reference)
+        .collect()
+}
+
+/// Parse JSON bytes into a [`LoadedBibliography`].
+///
+/// Accepts Citum JSON, CSL-JSON arrays, wrapped legacy objects, and `IndexMap`
+/// keyed-by-id objects.
+pub(crate) fn parse_json_bibliography(bytes: &[u8]) -> Result<LoadedBibliography, ProcessorError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+
+    if let Some(references) = value.as_array() {
+        return loaded_from_hybrid_json_array(references, None);
+    }
+
+    if let Some(object) = value.as_object()
+        && let Some(references) = object
+            .get("references")
+            .and_then(serde_json::Value::as_array)
+    {
+        let sets = object
+            .get("sets")
+            .filter(|v| !v.is_null())
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+        return loaded_from_hybrid_json_array(references, sets);
+    }
+
+    let mut bib = IndexMap::new();
+
+    if let Ok(legacy_bib) = serde_json::from_slice::<Vec<LegacyReference>>(bytes) {
+        for ref_item in legacy_bib {
+            bib.insert(ref_item.id.clone(), Reference::from(ref_item));
+        }
+        return Ok(LoadedBibliography {
+            references: bib,
+            sets: None,
+        });
+    }
+    if let Ok(input_bib) = serde_json::from_slice::<InputBibliography>(bytes) {
+        return loaded_from_input_bibliography(input_bib);
+    }
+
+    if let Ok(wrapper) = serde_json::from_slice::<LegacyBibliographyWrapper>(bytes) {
+        for ref_item in wrapper.references {
+            bib.insert(ref_item.id.clone(), Reference::from(ref_item));
+        }
+        let sets = validate_compound_sets(wrapper.sets, &bib)?;
+        return Ok(LoadedBibliography {
+            references: bib,
+            sets,
+        });
+    }
+
+    if let Ok(map) = serde_json::from_slice::<IndexMap<String, serde_json::Value>>(bytes) {
+        let mut found = false;
+        for (id, val) in map {
+            if let Ok(ref_item) = serde_json::from_value::<LegacyReference>(val) {
+                let mut r = Reference::from(ref_item);
+                if r.id().is_none() {
+                    r.set_id(id.clone());
+                }
+                bib.insert(id.clone(), r);
+                found = true;
+            }
+        }
+        if found {
+            return Ok(LoadedBibliography {
+                references: bib,
+                sets: None,
+            });
+        }
+    }
+
+    match serde_json::from_slice::<InputBibliography>(bytes) {
+        #[allow(clippy::unreachable, reason = "Primary format must have failed")]
+        Ok(_) => unreachable!(),
+        Err(e) => Err(ProcessorError::ParseError(
+            "JSON".to_string(),
+            e.to_string(),
+        )),
+    }
+}
+
+/// Parse a YAML string into a [`LoadedBibliography`].
+///
+/// Accepts Citum YAML, wrapped legacy format, `IndexMap`, and sequence variants.
+pub(crate) fn parse_yaml_bibliography(content: &str) -> Result<LoadedBibliography, ProcessorError> {
+    let _: serde_yaml::Value = serde_yaml::from_str(content)
+        .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
+
+    let mut bib = IndexMap::new();
+
+    if let Ok(input_bib) = serde_yaml::from_str::<InputBibliography>(content) {
+        return loaded_from_input_bibliography(input_bib);
+    }
+
+    if let Ok(wrapper) = serde_yaml::from_str::<LegacyBibliographyWrapper>(content) {
+        for ref_item in wrapper.references {
+            bib.insert(ref_item.id.clone(), Reference::from(ref_item));
+        }
+        let sets = validate_compound_sets(wrapper.sets, &bib)?;
+        return Ok(LoadedBibliography {
+            references: bib,
+            sets,
+        });
+    }
+
+    if let Ok(map) = serde_yaml::from_str::<IndexMap<String, serde_yaml::Value>>(content) {
+        let mut found = false;
+        for (key, val) in map {
+            if let Ok(mut r) = serde_yaml::from_value::<InputReference>(val.clone()) {
+                if r.id().is_none() {
+                    r.set_id(key.clone());
+                }
+                bib.insert(key, r);
+                found = true;
+            } else if let Ok(ref_item) = serde_yaml::from_value::<LegacyReference>(val) {
+                let mut r = Reference::from(ref_item);
+                if r.id().is_none() {
+                    r.set_id(key.clone());
+                }
+                bib.insert(key, r);
+                found = true;
+            }
+        }
+        if found {
+            return Ok(LoadedBibliography {
+                references: bib,
+                sets: None,
+            });
+        }
+    }
+
+    if let Ok(refs) = serde_yaml::from_str::<Vec<InputReference>>(content) {
+        for r in refs {
+            if let Some(id) = r.id() {
+                bib.insert(id.to_string(), r);
+            }
+        }
+        return Ok(LoadedBibliography {
+            references: bib,
+            sets: None,
+        });
+    }
+
+    match serde_yaml::from_str::<InputBibliography>(content) {
+        #[allow(clippy::unreachable, reason = "Primary format must have failed")]
+        Ok(_) => unreachable!(),
+        Err(e) => Err(ProcessorError::ParseError(
+            "YAML".to_string(),
+            e.to_string(),
+        )),
+    }
+}
+
+/// Deserialize bytes into any serde-compatible type based on the file extension.
+pub(crate) fn deserialize_any<T: serde::de::DeserializeOwned>(
+    bytes: &[u8],
+    ext: &str,
+) -> Result<T, ProcessorError> {
+    match ext {
+        "yaml" | "yml" => serde_yaml::from_slice(bytes)
+            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
+        "json" => serde_json::from_slice(bytes)
+            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string())),
+        "cbor" => ciborium::de::from_reader(Cursor::new(bytes))
+            .map_err(|e| ProcessorError::ParseError("CBOR".to_string(), e.to_string())),
+        _ => serde_yaml::from_slice(bytes)
+            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
+    }
+}
+
+/// Serialize a value to bytes in the format identified by the file extension.
+pub(crate) fn serialize_any<T: serde::Serialize>(
+    obj: &T,
+    ext: &str,
+) -> Result<Vec<u8>, ProcessorError> {
+    match ext {
+        "yaml" | "yml" => serde_yaml::to_string(obj)
+            .map(String::into_bytes)
+            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
+        "json" => serde_json::to_string_pretty(obj)
+            .map(String::into_bytes)
+            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string())),
+        "cbor" => {
+            let mut buf = Vec::new();
+            ciborium::ser::into_writer(obj, &mut buf)
+                .map_err(|e| ProcessorError::ParseError("CBOR".to_string(), e.to_string()))?;
+            Ok(buf)
+        }
+        _ => serde_yaml::to_string(obj)
+            .map(String::into_bytes)
+            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
+    }
+}
+
+/// Load a Citum JSON bibliography from raw bytes.
+///
+/// Tries native `InputBibliography` first, then falls back to hybrid
+/// JSON array / wrapped-object formats.
+pub(crate) fn load_citum_json_bibliography(
+    bytes: &[u8],
+) -> Result<InputBibliography, ProcessorError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+
+    if let Ok(input) = serde_json::from_value::<InputBibliography>(value.clone()) {
+        return Ok(input);
+    }
+
+    if let Some(references) = value.as_array() {
+        return Ok(InputBibliography {
+            references: load_hybrid_json_references(references)?,
+            ..Default::default()
+        });
+    }
+
+    if let Some(object) = value.as_object()
+        && let Some(references) = object
+            .get("references")
+            .and_then(serde_json::Value::as_array)
+    {
+        return Ok(InputBibliography {
+            references: load_hybrid_json_references(references)?,
+            sets: object
+                .get("sets")
+                .filter(|v| !v.is_null())
+                .cloned()
+                .map(serde_json::from_value)
+                .transpose()
+                .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?,
+            ..Default::default()
+        });
+    }
+
+    deserialize_any(bytes, "json")
+}

--- a/crates/citum-io/src/formats/output.rs
+++ b/crates/citum-io/src/formats/output.rs
@@ -1,0 +1,94 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! BibLaTeX and RIS bibliography rendering helpers.
+
+use std::fmt::Write as _;
+
+use citum_schema::InputBibliography;
+use citum_schema::reference::{ClassExtension, Contributor};
+
+/// Convert a contributor to a list of plain name strings ("Family, Given").
+fn contributor_name_strings(contributor: Contributor) -> Vec<String> {
+    match contributor {
+        Contributor::SimpleName(n) => vec![n.name.to_string()],
+        Contributor::StructuredName(n) => vec![format!("{}, {}", n.family, n.given)],
+        Contributor::Multilingual(n) => {
+            vec![format!("{}, {}", n.original.family, n.original.given)]
+        }
+        Contributor::ContributorList(list) => list
+            .0
+            .into_iter()
+            .flat_map(contributor_name_strings)
+            .collect(),
+    }
+}
+
+/// Render a bibliography as a BibLaTeX `.bib` string.
+pub(crate) fn render_biblatex(input: &InputBibliography) -> String {
+    let mut out = String::new();
+    for reference in &input.references {
+        let id = reference.id().unwrap_or_else(|| "item".into());
+        let entry_type = match reference.extension() {
+            ClassExtension::SerialComponent(_) => "article",
+            ClassExtension::CollectionComponent(_) => "incollection",
+            _ => "book",
+        };
+        let _ = writeln!(&mut out, "@{entry_type}{{{id},");
+        if let Some(title) = reference.title() {
+            let _ = writeln!(&mut out, "  title = {{{title}}},");
+        }
+        if let Some(contributor) = reference.author() {
+            let names = contributor_name_strings(contributor);
+            if !names.is_empty() {
+                let _ = writeln!(&mut out, "  author = {{{}}},", names.join(" and "));
+            }
+        }
+        if let Some(issued) = reference.csl_issued_date()
+            && let Some(year) = issued.0.get(0..4)
+        {
+            let _ = writeln!(&mut out, "  year = {{{year}}},");
+        }
+        if let Some(doi) = reference.doi() {
+            let _ = writeln!(&mut out, "  doi = {{{doi}}},");
+        }
+        let _ = writeln!(&mut out, "}}\n");
+    }
+    out
+}
+
+/// Render a bibliography as a RIS string.
+pub(crate) fn render_ris(input: &InputBibliography) -> String {
+    let mut out = String::new();
+    for reference in &input.references {
+        let ty = match reference.extension() {
+            ClassExtension::SerialComponent(_) => "JOUR",
+            ClassExtension::CollectionComponent(_) => "CHAP",
+            _ => "BOOK",
+        };
+        let _ = writeln!(&mut out, "TY  - {ty}");
+        if let Some(id) = reference.id() {
+            let _ = writeln!(&mut out, "ID  - {id}");
+        }
+        if let Some(title) = reference.title() {
+            let _ = writeln!(&mut out, "TI  - {title}");
+        }
+        if let Some(contributor) = reference.author() {
+            for name in contributor_name_strings(contributor) {
+                let _ = writeln!(&mut out, "AU  - {name}");
+            }
+        }
+        if let Some(issued) = reference.csl_issued_date()
+            && let Some(year) = issued.0.get(0..4)
+        {
+            let _ = writeln!(&mut out, "PY  - {year}");
+        }
+        if let Some(doi) = reference.doi() {
+            let _ = writeln!(&mut out, "DO  - {doi}");
+        }
+        let _ = writeln!(&mut out, "ER  -\n");
+    }
+    out
+}

--- a/crates/citum-io/src/formats/ris.rs
+++ b/crates/citum-io/src/formats/ris.rs
@@ -1,0 +1,129 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! RIS bibliography parsing helpers.
+
+use std::path::Path;
+
+use citum_engine::ProcessorError;
+use citum_schema::InputBibliography;
+use citum_schema::reference::InputReference;
+use csl_legacy::csl_json::{DateVariable, Name, Reference as LegacyReference, StringOrNumber};
+
+/// Load a RIS bibliography from a file path.
+pub(crate) fn load_ris_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
+    let src = std::fs::read_to_string(path)?;
+    parse_ris(&src)
+}
+
+fn parse_ris(input: &str) -> Result<InputBibliography, ProcessorError> {
+    let mut references = Vec::<InputReference>::new();
+    let mut current = Vec::<(String, String)>::new();
+
+    for line in input.lines() {
+        let line = line.strip_prefix('\u{feff}').unwrap_or(line);
+        let Some((tag, value)) = line.split_once("  - ") else {
+            continue;
+        };
+        let tag = tag.trim();
+        if tag.len() != 2 || !tag.is_ascii() {
+            continue;
+        }
+        let tag = tag.to_string();
+        let value = value.trim().to_string();
+        if tag == "ER" {
+            if !current.is_empty() {
+                references.push(InputReference::from(ris_record_to_reference(&current)));
+            }
+            current.clear();
+            continue;
+        }
+        current.push((tag, value));
+    }
+
+    if !current.is_empty() {
+        references.push(InputReference::from(ris_record_to_reference(&current)));
+    }
+
+    Ok(InputBibliography {
+        references,
+        ..Default::default()
+    })
+}
+
+fn ris_record_to_reference(fields: &[(String, String)]) -> LegacyReference {
+    let get = |tag: &str| -> Option<String> {
+        fields
+            .iter()
+            .find_map(|(k, v)| (k == tag).then(|| v.clone()))
+    };
+    let get_all = |tag: &str| -> Vec<String> {
+        fields
+            .iter()
+            .filter(|(k, _)| k == tag)
+            .map(|(_, v)| v.clone())
+            .collect()
+    };
+
+    let id = get("ID")
+        .or_else(|| get("L1"))
+        .or_else(|| get("M1"))
+        .unwrap_or_else(|| "item".to_string());
+    let title = get("TI").or_else(|| get("T1"));
+    let ty = get("TY").unwrap_or_else(|| "BOOK".to_string());
+    let author = {
+        let authors = get_all("AU")
+            .into_iter()
+            .map(|n| {
+                let parts: Vec<_> = n.split(',').map(str::trim).collect();
+                if parts.len() >= 2 {
+                    #[allow(clippy::indexing_slicing, reason = "parts.len() >= 2")]
+                    Name::new(parts[0], parts[1])
+                } else {
+                    Name::literal(parts.first().copied().unwrap_or(""))
+                }
+            })
+            .collect::<Vec<_>>();
+        (!authors.is_empty()).then_some(authors)
+    };
+    let issued = get("PY").or_else(|| get("Y1")).and_then(|s| {
+        let year = s.chars().take(4).collect::<String>().parse::<i32>().ok()?;
+        Some(DateVariable::year(year))
+    });
+    let doi = get("DO");
+    let note = get("N1");
+    let page = match (get("SP"), get("EP")) {
+        (Some(sp), Some(ep)) => Some(format!("{sp}-{ep}")),
+        (Some(sp), None) => Some(sp),
+        _ => None,
+    };
+    let ref_type = if ty == "JOUR" || ty == "JFULL" {
+        "article-journal".to_string()
+    } else if ty == "CHAP" {
+        "chapter".to_string()
+    } else {
+        "book".to_string()
+    };
+
+    LegacyReference {
+        id,
+        ref_type,
+        author,
+        title,
+        container_title: get("JO").or_else(|| get("JF")),
+        issued,
+        volume: get("VL").map(StringOrNumber::String),
+        issue: get("IS").map(StringOrNumber::String),
+        page,
+        doi,
+        url: get("UR"),
+        isbn: get("SN"),
+        publisher: get("PB"),
+        publisher_place: get("CY"),
+        language: get("LA"),
+        note,
+        ..Default::default()
+    }
+}

--- a/crates/citum-io/src/lib.rs
+++ b/crates/citum-io/src/lib.rs
@@ -9,24 +9,27 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! (Citum YAML/JSON/CBOR, CSL-JSON, BibLaTeX, RIS) into Citum's internal types.
 
 use std::collections::HashMap;
-use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use citum_engine::processor::validate_compound_sets;
 use citum_schema::InputBibliography;
-use citum_schema::reference::conversion::input_reference_from_legacy_edited_book;
-use citum_schema::reference::types::{ArchiveInfo, EprintInfo};
-use citum_schema::reference::{ClassExtension, InputReference};
 use csl_legacy::csl_json::Reference as LegacyReference;
 use indexmap::IndexMap;
 
 pub use citum_engine::api::{AnnotationFormat, AnnotationStyle};
-use citum_engine::processor::validate_compound_sets;
 use citum_engine::render::format::OutputFormat;
 use citum_engine::render::rich_text::render_djot_inline;
-use citum_engine::{Bibliography, Citation, ProcessorError, Reference};
+use citum_engine::{Bibliography, Citation, ProcessorError};
 
 pub mod biblatex;
+pub(crate) mod formats;
+
+// Re-export private format helpers so the inline test module can reach them via `use super::*`.
+#[cfg(test)]
+pub(crate) use formats::{
+    loaded_from_input_bibliography, parse_json_bibliography, parse_yaml_bibliography,
+};
 
 /// Bibliography formats supported by reusable reference conversion helpers.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -54,43 +57,27 @@ pub struct LoadedBibliography {
     pub sets: Option<IndexMap<String, Vec<String>>>,
 }
 
-#[derive(Debug, serde::Deserialize)]
-struct LegacyBibliographyWrapper {
-    references: Vec<LegacyReference>,
-    #[serde(default)]
-    sets: Option<IndexMap<String, Vec<String>>>,
-}
-
 /// Render a free-text reference field with djot inline markup.
 ///
-/// Applies `render_djot_inline` to the source text, using the provided
-/// `OutputFormat` to handle emphasis, links, and other inline markup.
-/// This is the render-time hook for processing note, abstract, and other
-/// free-text reference fields that may contain djot markup.
-///
-/// # Arguments
-/// * `src` - Input string with optional djot inline markup
-/// * `fmt` - `OutputFormat` implementation for rendering
-///
-/// # Returns
-/// Rendered string with markup applied
+/// Applies `render_djot_inline` to the source text using the provided
+/// `OutputFormat` for emphasis, links, and other inline markup.
 pub fn render_rich_text_field<F: OutputFormat<Output = String>>(src: &str, fmt: &F) -> String {
     render_djot_inline(src, fmt)
 }
 
 /// Load a list of citations from a file.
+///
 /// Supports Citum YAML/JSON.
 ///
 /// # Errors
 ///
-/// Returns an error when the file cannot be read or when its contents are not
-/// valid citation data in a supported format.
+/// Returns an error when the file cannot be read or its contents are not valid
+/// citation data.
 pub fn load_citations(path: &Path) -> Result<Vec<Citation>, ProcessorError> {
     let bytes = fs::read(path)?;
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
 
     if ext == "json" {
-        // Check for syntax errors first
         let _: serde_json::Value = serde_json::from_slice(&bytes)
             .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
 
@@ -106,7 +93,6 @@ pub fn load_citations(path: &Path) -> Result<Vec<Citation>, ProcessorError> {
         }
     } else {
         let content = String::from_utf8_lossy(&bytes);
-        // Check for syntax errors first
         let _: serde_yaml::Value = serde_yaml::from_str(&content)
             .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
 
@@ -124,12 +110,13 @@ pub fn load_citations(path: &Path) -> Result<Vec<Citation>, ProcessorError> {
 }
 
 /// Load annotations from a file (YAML or JSON).
+///
 /// Returns a mapping from reference ID to annotation text.
 ///
 /// # Errors
 ///
-/// Returns an error when the file cannot be read or when its contents are not
-/// valid annotation data in a supported format.
+/// Returns an error when the file cannot be read or its contents are not valid
+/// annotation data.
 pub fn load_annotations(path: &Path) -> Result<HashMap<String, String>, ProcessorError> {
     let bytes = fs::read(path)?;
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
@@ -150,317 +137,36 @@ pub fn load_annotations(path: &Path) -> Result<HashMap<String, String>, Processo
     }
 }
 
-fn loaded_from_input_bibliography(
-    input_bib: InputBibliography,
-) -> Result<LoadedBibliography, ProcessorError> {
-    let mut references = IndexMap::new();
-    for r in input_bib.references {
-        if let Some(id) = r.id() {
-            references.insert(id.to_string(), r);
-        }
-    }
-    let sets = validate_compound_sets(input_bib.sets, &references)?;
-    Ok(LoadedBibliography { references, sets })
-}
-
-fn loaded_from_hybrid_json_array(
-    references: &[serde_json::Value],
-    sets: Option<IndexMap<String, Vec<String>>>,
-) -> Result<LoadedBibliography, ProcessorError> {
-    let mut bib = IndexMap::new();
-    for value in references.iter().cloned() {
-        let reference = parse_hybrid_json_reference(value)?;
-        if let Some(id) = reference.id() {
-            bib.insert(id.to_string(), reference);
-        }
-    }
-    let sets = validate_compound_sets(sets, &bib)?;
-    Ok(LoadedBibliography {
-        references: bib,
-        sets,
-    })
-}
-
-fn apply_hybrid_json_extensions(
-    mut reference: InputReference,
-    value: &serde_json::Value,
-) -> Result<InputReference, ProcessorError> {
-    let archive_info = value
-        .get("archive-info")
-        .filter(|raw| !raw.is_null())
-        .cloned()
-        .map(serde_json::from_value::<ArchiveInfo>)
-        .transpose()
-        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-    let eprint = value
-        .get("eprint")
-        .filter(|raw| !raw.is_null())
-        .cloned()
-        .map(serde_json::from_value::<EprintInfo>)
-        .transpose()
-        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-
-    match reference.extension_mut() {
-        ClassExtension::Monograph(record) => {
-            if let Some(info) = archive_info.clone() {
-                record.archive_info = Some(info);
-            }
-            if let Some(info) = eprint.clone() {
-                record.eprint = Some(info);
-            }
-        }
-        ClassExtension::CollectionComponent(record) => {
-            if let Some(info) = archive_info.clone() {
-                record.archive_info = Some(info);
-            }
-            if let Some(info) = eprint.clone() {
-                record.eprint = Some(info);
-            }
-        }
-        ClassExtension::SerialComponent(record) => {
-            if let Some(info) = archive_info {
-                record.archive_info = Some(info);
-            }
-            if let Some(info) = eprint {
-                record.eprint = Some(info);
-            }
-        }
-        _ => {}
-    }
-
-    Ok(reference)
-}
-
-fn parse_hybrid_json_reference(value: serde_json::Value) -> Result<InputReference, ProcessorError> {
-    if let Ok(reference) = serde_json::from_value::<InputReference>(value.clone()) {
-        return Ok(reference);
-    }
-
-    let class = value
-        .get("class")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let ref_type = value
-        .get("type")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let legacy = serde_json::from_value::<LegacyReference>(value.clone())
-        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-
-    let reference = if class == "collection" && ref_type == "edited-book" {
-        input_reference_from_legacy_edited_book(legacy)
-    } else {
-        InputReference::from(legacy)
-    };
-
-    apply_hybrid_json_extensions(reference, &value)
-}
-
-/// Parse JSON bibliography bytes into a `LoadedBibliography`.
+/// Load bibliography data from a file, including optional compound sets.
 ///
-/// Supports CSL-JSON, Citum JSON, wrapped legacy format, and `IndexMap` variants.
-fn parse_json_bibliography(bytes: &[u8]) -> Result<LoadedBibliography, ProcessorError> {
-    // Check for syntax errors first
-    let value: serde_json::Value = serde_json::from_slice(bytes)
-        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-
-    if let Some(references) = value.as_array() {
-        return loaded_from_hybrid_json_array(references, None);
-    }
-
-    if let Some(object) = value.as_object()
-        && let Some(references) = object
-            .get("references")
-            .and_then(serde_json::Value::as_array)
-    {
-        let sets = object
-            .get("sets")
-            .filter(|value| !value.is_null())
-            .cloned()
-            .map(serde_json::from_value)
-            .transpose()
-            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-        return loaded_from_hybrid_json_array(references, sets);
-    }
-
-    let mut bib = IndexMap::new();
-
-    // Try CSL-JSON (Vec<LegacyReference>)
-    if let Ok(legacy_bib) = serde_json::from_slice::<Vec<LegacyReference>>(bytes) {
-        for ref_item in legacy_bib {
-            bib.insert(ref_item.id.clone(), Reference::from(ref_item));
-        }
-        return Ok(LoadedBibliography {
-            references: bib,
-            sets: None,
-        });
-    }
-    // Try Citum JSON (InputBibliography)
-    if let Ok(input_bib) = serde_json::from_slice::<InputBibliography>(bytes) {
-        return loaded_from_input_bibliography(input_bib);
-    }
-
-    // Try wrapped legacy JSON ({ references: [...], sets: {...} })
-    if let Ok(wrapper) = serde_json::from_slice::<LegacyBibliographyWrapper>(bytes) {
-        for ref_item in wrapper.references {
-            bib.insert(ref_item.id.clone(), Reference::from(ref_item));
-        }
-        let sets = validate_compound_sets(wrapper.sets, &bib)?;
-        return Ok(LoadedBibliography {
-            references: bib,
-            sets,
-        });
-    }
-
-    // Try IndexMap of LegacyReference (preserves insertion order from JSON)
-    if let Ok(map) = serde_json::from_slice::<IndexMap<String, serde_json::Value>>(bytes) {
-        let mut found = false;
-        for (id, val) in map {
-            if let Ok(ref_item) = serde_json::from_value::<LegacyReference>(val) {
-                let mut r = Reference::from(ref_item);
-                if r.id().is_none() {
-                    r.set_id(id.clone());
-                }
-                bib.insert(id.clone(), r);
-                found = true;
-            }
-        }
-        if found {
-            return Ok(LoadedBibliography {
-                references: bib,
-                sets: None,
-            });
-        }
-    }
-
-    // If all failed, return the error from the most likely format (Citum JSON)
-    match serde_json::from_slice::<InputBibliography>(bytes) {
-        #[allow(clippy::unreachable, reason = "Primary format must have failed")]
-        Ok(_) => unreachable!(),
-        Err(e) => Err(ProcessorError::ParseError(
-            "JSON".to_string(),
-            e.to_string(),
-        )),
-    }
-}
-
-/// Parse YAML bibliography string into a `LoadedBibliography`.
-///
-/// Supports Citum YAML, wrapped legacy format, `IndexMap`, and Vec variants.
-fn parse_yaml_bibliography(content: &str) -> Result<LoadedBibliography, ProcessorError> {
-    // Check for syntax errors first
-    let _: serde_yaml::Value = serde_yaml::from_str(content)
-        .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
-
-    let mut bib = IndexMap::new();
-
-    if let Ok(input_bib) = serde_yaml::from_str::<InputBibliography>(content) {
-        return loaded_from_input_bibliography(input_bib);
-    }
-
-    // Try wrapped legacy YAML/JSON ({ references: [...], sets: {...} })
-    if let Ok(wrapper) = serde_yaml::from_str::<LegacyBibliographyWrapper>(content) {
-        for ref_item in wrapper.references {
-            bib.insert(ref_item.id.clone(), Reference::from(ref_item));
-        }
-        let sets = validate_compound_sets(wrapper.sets, &bib)?;
-        return Ok(LoadedBibliography {
-            references: bib,
-            sets,
-        });
-    }
-
-    // Try parsing as IndexMap<String, serde_yaml::Value> (YAML/JSON, preserves order)
-    if let Ok(map) = serde_yaml::from_str::<IndexMap<String, serde_yaml::Value>>(content) {
-        let mut found = false;
-        for (key, val) in map {
-            if let Ok(mut r) = serde_yaml::from_value::<InputReference>(val.clone()) {
-                if r.id().is_none() {
-                    r.set_id(key.clone());
-                }
-                bib.insert(key, r);
-                found = true;
-            } else if let Ok(ref_item) = serde_yaml::from_value::<LegacyReference>(val) {
-                let mut r = Reference::from(ref_item);
-                if r.id().is_none() {
-                    r.set_id(key.clone());
-                }
-                bib.insert(key, r);
-                found = true;
-            }
-        }
-        if found {
-            return Ok(LoadedBibliography {
-                references: bib,
-                sets: None,
-            });
-        }
-    }
-
-    // Try parsing as Vec<InputReference> (YAML/JSON)
-    if let Ok(refs) = serde_yaml::from_str::<Vec<InputReference>>(content) {
-        for r in refs {
-            if let Some(id) = r.id() {
-                bib.insert(id.to_string(), r);
-            }
-        }
-        return Ok(LoadedBibliography {
-            references: bib,
-            sets: None,
-        });
-    }
-
-    // If all failed, return error from Citum YAML
-    match serde_yaml::from_str::<InputBibliography>(content) {
-        #[allow(clippy::unreachable, reason = "Primary format must have failed")]
-        Ok(_) => unreachable!(),
-        Err(e) => Err(ProcessorError::ParseError(
-            "YAML".to_string(),
-            e.to_string(),
-        )),
-    }
-}
-
-/// Load bibliography data from a file path, including optional compound sets.
 /// Supports Citum YAML/JSON/CBOR and CSL-JSON.
 ///
 /// # Errors
 ///
-/// Returns an error when the file cannot be read, when its contents do not
-/// match a supported bibliography format, or when compound sets are invalid.
+/// Returns an error when the file cannot be read, cannot be parsed, or
+/// compound sets are invalid.
 pub fn load_bibliography_with_sets(path: &Path) -> Result<LoadedBibliography, ProcessorError> {
     let bytes = fs::read(path)?;
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
 
-    // Try parsing as Citum formats
     match ext {
-        "cbor" => {
-            match ciborium::de::from_reader::<InputBibliography, _>(std::io::Cursor::new(&bytes)) {
-                Ok(input_bib) => loaded_from_input_bibliography(input_bib),
-                Err(e) => Err(ProcessorError::ParseError(
-                    "CBOR".to_string(),
-                    e.to_string(),
-                )),
-            }
-        }
-        "json" => parse_json_bibliography(&bytes),
+        "cbor" => formats::parse_cbor_bibliography(&bytes),
+        "json" => formats::parse_json_bibliography(&bytes),
         _ => {
-            // YAML/Fallback
             let content = String::from_utf8_lossy(&bytes);
-            parse_yaml_bibliography(&content)
+            formats::parse_yaml_bibliography(&content)
         }
     }
 }
 
 /// Load a bibliography from a file given its path.
+///
 /// Supports Citum YAML/JSON/CBOR and CSL-JSON.
 ///
 /// # Errors
 ///
-/// Returns an error when the file cannot be read, its contents cannot be
-/// parsed, or embedded compound-set metadata is invalid.
+/// Returns an error when the file cannot be read, cannot be parsed, or
+/// embedded compound-set metadata is invalid.
 pub fn load_bibliography(path: &Path) -> Result<Bibliography, ProcessorError> {
     Ok(load_bibliography_with_sets(path)?.references)
 }
@@ -502,14 +208,8 @@ pub fn load_merged_bibliography(paths: &[PathBuf]) -> Result<LoadedBibliography,
         }
     }
 
-    let validated_sets = validate_compound_sets(
-        if merged_sets.is_empty() {
-            None
-        } else {
-            Some(merged_sets)
-        },
-        &merged,
-    )?;
+    let validated_sets =
+        validate_compound_sets((!merged_sets.is_empty()).then_some(merged_sets), &merged)?;
 
     Ok(LoadedBibliography {
         references: merged,
@@ -525,16 +225,14 @@ pub fn load_merged_bibliography(paths: &[PathBuf]) -> Result<LoadedBibliography,
 pub fn load_merged_citations(paths: &[PathBuf]) -> Result<Vec<Citation>, ProcessorError> {
     let mut merged = Vec::new();
     for path in paths {
-        let loaded = load_citations(path)?;
-        merged.extend(loaded);
+        merged.extend(load_citations(path)?);
     }
     Ok(merged)
 }
 
 /// Infer a bibliography input format from a path.
 ///
-/// JSON inputs are content-sniffed to distinguish native Citum JSON from
-/// CSL-JSON.
+/// JSON inputs are content-sniffed to distinguish native Citum JSON from CSL-JSON.
 ///
 /// # Errors
 ///
@@ -601,478 +299,54 @@ pub fn load_input_bibliography(
     match format {
         RefsFormat::CitumYaml => {
             let bytes = fs::read(path)?;
-            deserialize_any(&bytes, "yaml")
+            formats::deserialize_any(&bytes, "yaml")
         }
         RefsFormat::CitumJson => {
             let bytes = fs::read(path)?;
-            load_citum_json_bibliography(&bytes)
+            formats::load_citum_json_bibliography(&bytes)
         }
         RefsFormat::CitumCbor => {
             let bytes = fs::read(path)?;
-            deserialize_any(&bytes, "cbor")
+            formats::deserialize_any(&bytes, "cbor")
         }
-        RefsFormat::CslJson => load_csl_json_bibliography(path),
-        RefsFormat::Biblatex => load_biblatex_bibliography(path),
-        RefsFormat::Ris => load_ris_bibliography(path),
+        RefsFormat::CslJson => formats::load_csl_json_bibliography(path),
+        RefsFormat::Biblatex => formats::load_biblatex_bibliography(path),
+        RefsFormat::Ris => formats::load_ris_bibliography(path),
     }
-}
-
-fn deserialize_any<T: serde::de::DeserializeOwned>(
-    bytes: &[u8],
-    ext: &str,
-) -> Result<T, ProcessorError> {
-    match ext {
-        "yaml" | "yml" => serde_yaml::from_slice(bytes)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
-        "json" => serde_json::from_slice(bytes)
-            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string())),
-        "cbor" => ciborium::de::from_reader(std::io::Cursor::new(bytes))
-            .map_err(|e| ProcessorError::ParseError("CBOR".to_string(), e.to_string())),
-        _ => serde_yaml::from_slice(bytes)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
-    }
-}
-
-fn serialize_any<T: serde::Serialize>(obj: &T, ext: &str) -> Result<Vec<u8>, ProcessorError> {
-    match ext {
-        "yaml" | "yml" => serde_yaml::to_string(obj)
-            .map(String::into_bytes)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
-        "json" => serde_json::to_string_pretty(obj)
-            .map(String::into_bytes)
-            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string())),
-        "cbor" => {
-            let mut buf = Vec::new();
-            ciborium::ser::into_writer(obj, &mut buf)
-                .map_err(|e| ProcessorError::ParseError("CBOR".to_string(), e.to_string()))?;
-            Ok(buf)
-        }
-        _ => serde_yaml::to_string(obj)
-            .map(String::into_bytes)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
-    }
-}
-
-fn load_citum_json_bibliography(bytes: &[u8]) -> Result<InputBibliography, ProcessorError> {
-    let value: serde_json::Value = serde_json::from_slice(bytes)
-        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-
-    if let Ok(input) = serde_json::from_value::<InputBibliography>(value.clone()) {
-        return Ok(input);
-    }
-
-    if let Some(references) = value.as_array() {
-        return Ok(InputBibliography {
-            references: load_hybrid_json_references(references)?,
-            ..Default::default()
-        });
-    }
-
-    if let Some(object) = value.as_object()
-        && let Some(references) = object
-            .get("references")
-            .and_then(serde_json::Value::as_array)
-    {
-        return Ok(InputBibliography {
-            references: load_hybrid_json_references(references)?,
-            sets: object
-                .get("sets")
-                .filter(|value| !value.is_null())
-                .cloned()
-                .map(serde_json::from_value)
-                .transpose()
-                .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?,
-            ..Default::default()
-        });
-    }
-
-    deserialize_any(bytes, "json")
-}
-
-fn load_hybrid_json_references(
-    references: &[serde_json::Value],
-) -> Result<Vec<InputReference>, ProcessorError> {
-    references
-        .iter()
-        .cloned()
-        .map(load_hybrid_json_reference)
-        .collect()
-}
-
-fn load_hybrid_json_reference(value: serde_json::Value) -> Result<InputReference, ProcessorError> {
-    if let Ok(reference) = serde_json::from_value::<InputReference>(value.clone()) {
-        return Ok(reference);
-    }
-
-    let class = value
-        .get("class")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let ref_type = value
-        .get("type")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    let legacy = serde_json::from_value::<LegacyReference>(value)
-        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-
-    if class == "collection" && ref_type == "edited-book" {
-        return Ok(input_reference_from_legacy_edited_book(legacy));
-    }
-
-    Ok(InputReference::from(legacy))
 }
 
 /// Write bibliography input to a specified native or legacy reference format.
 ///
 /// # Errors
 ///
-/// Returns an error when serialization fails or the output file cannot be
-/// written.
+/// Returns an error when serialization fails or the output file cannot be written.
 pub fn write_output_bibliography(
     input: &InputBibliography,
     path: &Path,
     format: RefsFormat,
 ) -> Result<(), ProcessorError> {
     match format {
-        RefsFormat::CitumYaml => fs::write(path, serialize_any(input, "yaml")?)?,
-        RefsFormat::CitumJson => fs::write(path, serialize_any(input, "json")?)?,
-        RefsFormat::CitumCbor => fs::write(path, serialize_any(input, "cbor")?)?,
+        RefsFormat::CitumYaml => fs::write(path, formats::serialize_any(input, "yaml")?)?,
+        RefsFormat::CitumJson => fs::write(path, formats::serialize_any(input, "json")?)?,
+        RefsFormat::CitumCbor => fs::write(path, formats::serialize_any(input, "cbor")?)?,
         RefsFormat::CslJson => {
             let refs: Vec<LegacyReference> = input
                 .references
                 .iter()
-                .map(input_reference_to_csl_json)
+                .map(formats::input_reference_to_csl_json)
                 .collect();
             let json = serde_json::to_string_pretty(&refs)
                 .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
             fs::write(path, json)?;
         }
         RefsFormat::Biblatex => {
-            fs::write(path, render_biblatex(input))?;
+            fs::write(path, formats::render_biblatex(input))?;
         }
         RefsFormat::Ris => {
-            fs::write(path, render_ris(input))?;
+            fs::write(path, formats::render_ris(input))?;
         }
     }
     Ok(())
-}
-
-fn load_csl_json_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
-    let bytes = fs::read(path)?;
-    let refs: Vec<LegacyReference> = serde_json::from_slice(&bytes)
-        .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
-    let references = refs.into_iter().map(InputReference::from).collect();
-    Ok(InputBibliography {
-        references,
-        ..Default::default()
-    })
-}
-
-fn load_biblatex_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
-    let src = fs::read_to_string(path)?;
-    let bibliography = ::biblatex::Bibliography::parse(&src)
-        .map_err(|e| ProcessorError::ParseError("BibLaTeX".to_string(), e.to_string()))?;
-    let references = bibliography
-        .iter()
-        .map(biblatex::input_reference_from_biblatex)
-        .collect();
-    Ok(InputBibliography {
-        references,
-        ..Default::default()
-    })
-}
-
-fn load_ris_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
-    let src = fs::read_to_string(path)?;
-    parse_ris(&src)
-}
-
-fn input_reference_to_csl_json(reference: &InputReference) -> LegacyReference {
-    use csl_legacy::csl_json::{DateVariable, StringOrNumber};
-
-    let id = reference.id().unwrap_or_else(|| "item".into());
-    let mut r = LegacyReference {
-        id: id.to_string(),
-        ..Default::default()
-    };
-
-    r.title = reference.title().map(|t| t.to_string());
-    r.language = reference.language().map(|lang| lang.to_string());
-    r.note = reference.note().map(|rt| rt.raw().to_string());
-    r.doi = reference.doi();
-    r.issued = reference.csl_issued_date().and_then(|d| {
-        let s = d.0;
-        let year = s.get(0..4)?.parse::<i32>().ok()?;
-        Some(DateVariable::year(year))
-    });
-    r.author = reference.author().map(contributor_to_csl_names);
-    r.editor = reference.editor().map(contributor_to_csl_names);
-    r.translator = reference.translator().map(contributor_to_csl_names);
-    r.publisher = reference.publisher().map(|p| p.name.to_string());
-
-    match reference.extension() {
-        ClassExtension::Monograph(m) => {
-            r.ref_type = "book".to_string();
-            r.isbn.clone_from(&m.isbn);
-            r.url = m.url.as_ref().map(std::string::ToString::to_string);
-            r.edition = reference.edition().map(StringOrNumber::String);
-        }
-        ClassExtension::SerialComponent(s) => {
-            r.ref_type = "article-journal".to_string();
-            r.container_title = reference.container_title().map(|t| t.to_string());
-            r.page.clone_from(&s.pages);
-            r.volume = reference
-                .volume()
-                .map(|v| StringOrNumber::String(v.to_string()));
-            r.issue = reference
-                .issue()
-                .map(|v| StringOrNumber::String(v.to_string()));
-            r.url = s.url.as_ref().map(std::string::ToString::to_string);
-        }
-        ClassExtension::CollectionComponent(c) => {
-            r.ref_type = "chapter".to_string();
-            r.container_title = reference.container_title().map(|t| t.to_string());
-            r.page = c.pages.as_ref().map(std::string::ToString::to_string);
-        }
-        _ => {
-            r.ref_type = "book".to_string();
-        }
-    }
-
-    r
-}
-
-fn contributor_to_csl_names(
-    contributor: citum_schema::reference::Contributor,
-) -> Vec<csl_legacy::csl_json::Name> {
-    let mut names = Vec::new();
-    match contributor {
-        citum_schema::reference::Contributor::SimpleName(n) => {
-            names.push(csl_legacy::csl_json::Name::literal(&n.name.to_string()));
-        }
-        citum_schema::reference::Contributor::StructuredName(n) => {
-            names.push(csl_legacy::csl_json::Name {
-                family: Some(n.family.to_string()),
-                given: Some(n.given.to_string()),
-                suffix: n.suffix,
-                dropping_particle: n.dropping_particle,
-                non_dropping_particle: n.non_dropping_particle,
-                literal: None,
-            });
-        }
-        citum_schema::reference::Contributor::Multilingual(n) => {
-            names.push(csl_legacy::csl_json::Name {
-                family: Some(n.original.family.to_string()),
-                given: Some(n.original.given.to_string()),
-                suffix: n.original.suffix,
-                dropping_particle: n.original.dropping_particle,
-                non_dropping_particle: n.original.non_dropping_particle,
-                literal: None,
-            });
-        }
-        citum_schema::reference::Contributor::ContributorList(list) => {
-            for member in list.0 {
-                names.extend(contributor_to_csl_names(member));
-            }
-        }
-    }
-    names
-}
-
-fn render_biblatex(input: &InputBibliography) -> String {
-    let mut out = String::new();
-    for reference in &input.references {
-        let id = reference.id().unwrap_or_else(|| "item".into());
-        let entry_type = match reference.extension() {
-            ClassExtension::SerialComponent(_) => "article",
-            ClassExtension::CollectionComponent(_) => "incollection",
-            _ => "book",
-        };
-        let _ = writeln!(&mut out, "@{entry_type}{{{id},");
-        if let Some(title) = reference.title() {
-            let _ = writeln!(&mut out, "  title = {{{title}}},");
-        }
-        if let Some(contributor) = reference.author() {
-            let names: Vec<String> = contributor_to_biblatex_names(contributor);
-            if !names.is_empty() {
-                let _ = writeln!(&mut out, "  author = {{{}}},", names.join(" and "));
-            }
-        }
-        if let Some(issued) = reference.csl_issued_date()
-            && let Some(year) = issued.0.get(0..4)
-        {
-            let _ = writeln!(&mut out, "  year = {{{year}}},");
-        }
-        if let Some(doi) = reference.doi() {
-            let _ = writeln!(&mut out, "  doi = {{{doi}}},");
-        }
-        let _ = writeln!(&mut out, "}}\n");
-    }
-    out
-}
-
-fn contributor_to_biblatex_names(contributor: citum_schema::reference::Contributor) -> Vec<String> {
-    match contributor {
-        citum_schema::reference::Contributor::SimpleName(n) => vec![n.name.to_string()],
-        citum_schema::reference::Contributor::StructuredName(n) => {
-            vec![format!("{}, {}", n.family, n.given)]
-        }
-        citum_schema::reference::Contributor::Multilingual(n) => {
-            vec![format!("{}, {}", n.original.family, n.original.given)]
-        }
-        citum_schema::reference::Contributor::ContributorList(list) => list
-            .0
-            .into_iter()
-            .flat_map(contributor_to_biblatex_names)
-            .collect(),
-    }
-}
-
-fn parse_ris(input: &str) -> Result<InputBibliography, ProcessorError> {
-    let mut references = Vec::<InputReference>::new();
-    let mut current = Vec::<(String, String)>::new();
-
-    for line in input.lines() {
-        let line = line.strip_prefix('\u{feff}').unwrap_or(line);
-        let Some((tag, value)) = line.split_once("  - ") else {
-            continue;
-        };
-        let tag = tag.trim();
-        if tag.len() != 2 || !tag.is_ascii() {
-            continue;
-        }
-        let tag = tag.to_string();
-        let value = value.trim().to_string();
-        if tag == "ER" {
-            if !current.is_empty() {
-                references.push(InputReference::from(ris_record_to_reference(&current)));
-            }
-            current.clear();
-            continue;
-        }
-        current.push((tag, value));
-    }
-
-    if !current.is_empty() {
-        references.push(InputReference::from(ris_record_to_reference(&current)));
-    }
-
-    Ok(InputBibliography {
-        references,
-        ..Default::default()
-    })
-}
-
-fn ris_record_to_reference(fields: &[(String, String)]) -> LegacyReference {
-    use csl_legacy::csl_json::{DateVariable, Name, StringOrNumber};
-
-    let get = |tag: &str| -> Option<String> {
-        fields
-            .iter()
-            .find_map(|(k, v)| (k == tag).then(|| v.clone()))
-    };
-    let get_all = |tag: &str| -> Vec<String> {
-        fields
-            .iter()
-            .filter(|(k, _)| k == tag)
-            .map(|(_, v)| v.clone())
-            .collect()
-    };
-
-    let id = get("ID")
-        .or_else(|| get("L1"))
-        .or_else(|| get("M1"))
-        .unwrap_or_else(|| "item".to_string());
-    let title = get("TI").or_else(|| get("T1"));
-    let ty = get("TY").unwrap_or_else(|| "BOOK".to_string());
-    let author = {
-        let authors = get_all("AU")
-            .into_iter()
-            .map(|n| {
-                let parts: Vec<_> = n.split(',').map(str::trim).collect();
-                if parts.len() >= 2 {
-                    #[allow(clippy::indexing_slicing, reason = "parts.len() >= 2")]
-                    Name::new(parts[0], parts[1])
-                } else {
-                    Name::literal(parts.first().copied().unwrap_or(""))
-                }
-            })
-            .collect::<Vec<_>>();
-        (!authors.is_empty()).then_some(authors)
-    };
-    let issued = get("PY").or_else(|| get("Y1")).and_then(|s| {
-        let year = s.chars().take(4).collect::<String>().parse::<i32>().ok()?;
-        Some(DateVariable::year(year))
-    });
-    let doi = get("DO");
-    let note = get("N1");
-    let page = match (get("SP"), get("EP")) {
-        (Some(sp), Some(ep)) => Some(format!("{sp}-{ep}")),
-        (Some(sp), None) => Some(sp),
-        _ => None,
-    };
-    let ref_type = if ty == "JOUR" || ty == "JFULL" {
-        "article-journal".to_string()
-    } else if ty == "CHAP" {
-        "chapter".to_string()
-    } else {
-        "book".to_string()
-    };
-
-    LegacyReference {
-        id,
-        ref_type,
-        author,
-        title,
-        container_title: get("JO").or_else(|| get("JF")),
-        issued,
-        volume: get("VL").map(StringOrNumber::String),
-        issue: get("IS").map(StringOrNumber::String),
-        page,
-        doi,
-        url: get("UR"),
-        isbn: get("SN"),
-        publisher: get("PB"),
-        publisher_place: get("CY"),
-        language: get("LA"),
-        note,
-        ..Default::default()
-    }
-}
-
-fn render_ris(input: &InputBibliography) -> String {
-    let mut out = String::new();
-    for reference in &input.references {
-        let ty = match reference.extension() {
-            ClassExtension::SerialComponent(_) => "JOUR",
-            ClassExtension::CollectionComponent(_) => "CHAP",
-            _ => "BOOK",
-        };
-        let _ = writeln!(&mut out, "TY  - {ty}");
-        if let Some(id) = reference.id() {
-            let _ = writeln!(&mut out, "ID  - {id}");
-        }
-        if let Some(title) = reference.title() {
-            let _ = writeln!(&mut out, "TI  - {title}");
-        }
-        if let Some(contributor) = reference.author() {
-            for name in contributor_to_biblatex_names(contributor) {
-                let _ = writeln!(&mut out, "AU  - {name}");
-            }
-        }
-        if let Some(issued) = reference.csl_issued_date()
-            && let Some(year) = issued.0.get(0..4)
-        {
-            let _ = writeln!(&mut out, "PY  - {year}");
-        }
-        if let Some(doi) = reference.doi() {
-            let _ = writeln!(&mut out, "DO  - {doi}");
-        }
-        let _ = writeln!(&mut out, "ER  -\n");
-    }
-    out
 }
 
 #[cfg(test)]
@@ -1090,6 +364,7 @@ fn render_ris(input: &InputBibliography) -> String {
 mod tests {
     use super::*;
     use citum_engine::render::plain::PlainText;
+    use citum_schema::reference::{ClassExtension, InputReference};
     use indexmap::IndexMap;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1531,8 +806,6 @@ issued: "2020"
     #[test]
     /// Parse an `IndexMap` of CSL-JSON objects keyed by id from JSON.
     fn parse_json_indexmap() {
-        // IndexMap format: object with entries having no "references" key,
-        // where each value can be parsed as a LegacyReference.
         let json = r#"{
   "book-1": {"type": "book", "title": "First Book", "id": "book-1"},
   "article-2": {"type": "journal-article", "title": "First Article", "id": "article-2"}
@@ -1579,10 +852,6 @@ sets: null
     #[test]
     /// Parse an `IndexMap` of legacy references keyed by id from YAML.
     fn parse_yaml_indexmap() {
-        // IndexMap format: plain object with reference-id keys mapping to legacy ref objects.
-        // Structure: { id1: {type, title}, id2: {type, title} }
-        // Must use legacy CSL-JSON field names (not InputReference class tags)
-        // to avoid matching InputBibliography or Vec<InputReference>.
         let yaml = r"ref-yaml-1:
   id: ref-yaml-1
   type: book


### PR DESCRIPTION
## Summary

- Extracts all format-specific private helpers from `crates/citum-io/src/lib.rs`
  into focused submodules under `src/formats/`: `native.rs`, `csl_json.rs`,
  `ris.rs`, and `output.rs`
- `lib.rs` is now a thin facade (public API + dispatch); non-test code reduced
  from ~1622 lines to ~345 lines (-79%)
- DRY: removed the near-identical `load_hybrid_json_reference` duplicate;
  unified into `parse_hybrid_json_reference` (with `apply_hybrid_json_extensions`
  as a no-op when `archive-info`/`eprint` are absent)
- Performance: eliminated two `String` allocations per call in the hybrid JSON
  class/type routing path (now uses `&str` comparison via `.as_str()`)
- Idiom: moved `validate_compound_sets` import to module level; replaced verbose
  `if/else` `None`/`Some` with `.then_some()` in the merge path
- Checks off item 8 (`citum-io/src/lib.rs`) in bean `csl26-rfct`

## Test plan

- [x] `cargo nextest run -p citum-io` — all 29 tests pass
- [x] `wc -l crates/citum-io/src/lib.rs` — ~885 total (≤350 non-test lines)
- [x] `wc -l crates/citum-io/src/formats/*.rs` — each submodule ≤400 lines
- [x] Bean `csl26-rfct` item 8 shows `[x]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
