### PR TITLE
Record performance profiling baseline

### DIFF
--- a/.beans/csl26-pmxa--optimize-citum-migrate-macro-expansion-allocations.md
+++ b/.beans/csl26-pmxa--optimize-citum-migrate-macro-expansion-allocations.md
@@ -1,0 +1,35 @@
+---
+# csl26-pmxa
+title: Optimize citum-migrate macro expansion allocations
+status: todo
+type: task
+priority: normal
+tags:
+    - performance
+    - migrate
+created_at: 2026-05-24T14:32:34Z
+updated_at: 2026-05-24T14:44:07Z
+---
+
+## Goal
+
+Reduce peak heap and total allocation in `citum-migrate` macro expansion.
+
+## Evidence
+
+The profiling report at
+`docs/architecture/2026-05-24_PERFORMANCE_PROFILE_REPORT.md` measured
+`citum-migrate styles-legacy/apa.csl --template-source xml` at 142.0 ms and
+333,974,675 bytes allocated. DHAT showed large peak allocations in
+`MacroInliner::expand_macros_no_increment`, especially cloned CSL node subtrees
+around `crates/citum-migrate/src/lib.rs:122`.
+
+## Acceptance Criteria
+
+- Macro expansion avoids cloning whole `CslNode` trees when only child vectors
+  need to change.
+- A focused benchmark, profiling fixture, or before/after DHAT comparison shows
+  reduced peak heap on `styles-legacy/apa.csl`.
+- Existing migration output fidelity stays unchanged for the measured APA path.
+- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  and `cargo nextest run` pass.

--- a/.beans/csl26-rtak--reduce-render-template-allocation-and-key-string-churn.md
+++ b/.beans/csl26-rtak--reduce-render-template-allocation-and-key-string-churn.md
@@ -1,0 +1,38 @@
+---
+# csl26-rtak
+title: Reduce render template allocation and key-string churn
+status: todo
+type: task
+priority: normal
+tags:
+    - engine
+    - performance
+created_at: 2026-05-24T14:32:34Z
+updated_at: 2026-05-24T14:44:07Z
+---
+
+## Goal
+
+Reduce allocation in large bibliography rendering without changing rendered
+output.
+
+## Evidence
+
+The profiling report at
+`docs/architecture/2026-05-24_PERFORMANCE_PROFILE_REPORT.md` measured large APA
+rendering at 46.2 ms and 76,253,287 bytes allocated. DHAT and flamegraph data
+pointed at `render_template_components` collection, `ProcEntry` cloning, cloned
+citation/bibliography options, and high-frequency small allocations in
+`key_base` / `get_variable_key`.
+
+## Acceptance Criteria
+
+- Rendering avoids per-template-component `RenderOptions` clones where a
+  lightweight overlay or borrowed context is sufficient.
+- Rendered component vectors are pre-sized, streamed, or otherwise allocated
+  less aggressively.
+- Key-base handling avoids avoidable `String` allocation in hot paths.
+- A large-reference render comparison shows lower total allocation while keeping
+  output unchanged.
+- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  and `cargo nextest run` pass.

--- a/.beans/csl26-tdcl--reduce-citum-migrate-template-diff-cloning.md
+++ b/.beans/csl26-tdcl--reduce-citum-migrate-template-diff-cloning.md
@@ -1,0 +1,38 @@
+---
+# csl26-tdcl
+title: Reduce citum-migrate template diff cloning
+status: todo
+type: task
+priority: normal
+tags:
+    - performance
+    - migrate
+created_at: 2026-05-24T14:32:34Z
+updated_at: 2026-05-24T14:44:07Z
+---
+
+## Goal
+
+Reduce repeated cloning in `citum-migrate` template diff selection and
+equivalence checks.
+
+## Evidence
+
+The profiling report at
+`docs/architecture/2026-05-24_PERFORMANCE_PROFILE_REPORT.md` identifies
+`template_diff::component_selector` and `diff_resolves_to_template` as hot
+allocation sites. DHAT attributed repeated allocation to cloned
+`serde_json::Value` selector fields at `template_diff.rs:239`, cloned parent
+templates in `TemplateVariant::Full`, and temporary style construction for diff
+resolution.
+
+## Acceptance Criteria
+
+- Selector construction avoids unnecessary `serde_json::Value` clones or uses a
+  smaller selector representation.
+- Diff equivalence checks avoid cloning full parent templates where borrowed or
+  cached resolution can be used safely.
+- A profiling comparison shows lower total allocation for
+  `citum-migrate styles-legacy/apa.csl --template-source xml`.
+- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+  and `cargo nextest run` pass.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +241,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,7 +325,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn",
 ]
@@ -605,6 +629,7 @@ dependencies = [
  "clap_complete",
  "comfy-table",
  "crossterm",
+ "dhat",
  "ratatui",
  "schemars",
  "serde",
@@ -704,6 +729,7 @@ dependencies = [
  "clap",
  "csl-legacy",
  "deno_core",
+ "dhat",
  "indexmap 2.14.0",
  "roxmltree 0.21.1",
  "serde",
@@ -942,7 +968,7 @@ checksum = "3c963350b2b08aa4b725d7802593245380ab53dacfedcaa971385fc33306c0d4"
 dependencies = [
  "comemo-macros",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "siphasher",
  "slab",
 ]
@@ -1454,6 +1480,22 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1986,6 +2028,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gix"
@@ -3050,7 +3098,7 @@ dependencies = [
  "log",
  "moxcms 0.7.11",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "siphasher",
  "skrifa",
  "smallvec",
@@ -3080,7 +3128,7 @@ dependencies = [
  "flate2",
  "kurbo 0.12.0",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "smallvec",
  "zune-jpeg 0.4.21",
 ]
@@ -3926,7 +3974,7 @@ dependencies = [
  "pdf-writer",
  "png 0.17.16",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustybuzz",
  "siphasher",
  "skrifa",
@@ -4179,6 +4227,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -4739,7 +4793,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror",
@@ -4760,7 +4814,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5222,6 +5276,18 @@ dependencies = [
  "arrayvec",
  "num-traits",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5770,7 +5836,7 @@ dependencies = [
  "data-encoding",
  "debugid",
  "if_chain",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "unicode-id-start",
@@ -5911,7 +5977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb6895a12ac5599bb6057362f00e8a3cf1daab4df33f553a55690a44e4fed8d0"
 dependencies = [
  "kurbo 0.12.0",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "skrifa",
  "write-fonts",
 ]
@@ -6093,6 +6159,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"
@@ -6479,7 +6551,7 @@ checksum = "1f6511ee598476f4f322b4d13891083d96dbacb8f9c2b908604c7094ba390653"
 dependencies = [
  "comemo",
  "ecow",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "typst-eval",
  "typst-html",
  "typst-layout",
@@ -6506,7 +6578,7 @@ dependencies = [
  "comemo",
  "ecow",
  "indexmap 2.14.0",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "stacker",
  "toml 0.8.23",
  "typst-library",
@@ -6527,7 +6599,7 @@ dependencies = [
  "comemo",
  "ecow",
  "palette",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "time",
  "typst-assets",
  "typst-library",
@@ -6576,7 +6648,7 @@ dependencies = [
  "icu_segmenter",
  "kurbo 0.12.0",
  "memchr",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustybuzz",
  "smallvec",
  "ttf-parser",
@@ -6630,7 +6702,7 @@ dependencies = [
  "regex-syntax",
  "roxmltree 0.20.0",
  "rust_decimal",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustybuzz",
  "serde",
  "serde_json",
@@ -6685,7 +6757,7 @@ dependencies = [
  "infer",
  "krilla",
  "krilla-svg",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "typst-assets",
@@ -6727,7 +6799,7 @@ dependencies = [
  "hayro",
  "hayro-svg",
  "image",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "ttf-parser",
  "typst-assets",
  "typst-library",
@@ -6745,7 +6817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a95d9192060e23b1e491b0b94dff676acddc92a4d672aeb8ca3890a5a734e879"
 dependencies = [
  "ecow",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "toml 0.8.23",
  "typst-timing",
@@ -6777,7 +6849,7 @@ dependencies = [
  "once_cell",
  "portable-atomic",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "siphasher",
  "thin-vec",
  "unicode-math-class",

--- a/crates/citum-cli/Cargo.toml
+++ b/crates/citum-cli/Cargo.toml
@@ -34,6 +34,7 @@ citum_store = { workspace = true, features = ["http"] }
 citum-resolver-api = { workspace = true }
 citum-server = { workspace = true, optional = true }
 url = { version = "2.5", features = ["serde"] }
+dhat = { version = "0.3", optional = true }
 
 # Features intentionally removed for the v1 crates.io publish: `typescript`
 # depended on the unpublished `citum-bindings` crate. Its cfg-gated code path
@@ -42,6 +43,7 @@ url = { version = "2.5", features = ["serde"] }
 [features]
 default = []
 schema = ["dep:schemars", "citum-schema/schema", "dep:citum-server", "citum-server/schema-types"]
+dhat-heap = ["dep:dhat"]
 
 [lints]
 workspace = true

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -13,7 +13,14 @@ mod style_resolver;
 mod table;
 mod typst_pdf;
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     if let Err(e) = commands::run() {
         eprintln!("\nError: {e}");
         std::process::exit(1);

--- a/crates/citum-migrate/Cargo.toml
+++ b/crates/citum-migrate/Cargo.toml
@@ -22,6 +22,11 @@ roxmltree = "0.21"
 serde_json = "1.0"
 serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 serde = { version = "1.0", features = ["derive"] }
+dhat = { version = "0.3", optional = true }
+
+[features]
+default = []
+dhat-heap = ["dep:dhat"]
 
 [lints]
 workspace = true

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -46,6 +46,10 @@ use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 /// All compiled template and option data needed to build the final Style.
 struct CompiledOutput {
     options: citum_schema::options::Config,
@@ -159,6 +163,9 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     let cli = Args::parse();
     let path = &cli.path;
     let family_candidate = FamilyCandidateMode::from_arg(cli.family_candidate.as_deref());

--- a/docs/architecture/2026-05-24_PERFORMANCE_PROFILE_REPORT.md
+++ b/docs/architecture/2026-05-24_PERFORMANCE_PROFILE_REPORT.md
@@ -1,0 +1,164 @@
+# Performance Profile Report
+
+- Date: 2026-05-24
+- Branch: `perf/analysis`
+- Scope: Citum CLI rendering, reference conversion, validation, and CSL migration
+- Follow-up beans: `csl26-pmxa`, `csl26-tdcl`, `csl26-rtak`
+
+## Summary
+
+This pass bootstrapped the optional CSL corpora, captured a release-mode timing
+baseline with `hyperfine`, generated CPU flamegraphs with `perf`/`flamegraph`,
+and added an optional `dhat-heap` feature so heap profiling can be repeated
+without ad-hoc source edits.
+
+The slowest measured CLI path is CSL migration. `citum-migrate` spent most of
+its time and heap traffic in allocation-heavy CSL node expansion, template diff
+selection, and large temporary clone/drop chains. Large bibliography rendering is
+fast enough for current CLI use, but still allocates heavily while collecting
+rendered template components and building JSON output.
+
+## Setup
+
+The local checkout was bootstrapped with:
+
+```bash
+./scripts/bootstrap.sh full
+```
+
+That installed script dependencies and shallow-initialized:
+
+- `styles-legacy`
+- `tests/csl-test-suite`
+
+Large CSL-JSON fixture wrappers were converted to temporary top-level arrays for
+CLI conversion benchmarks:
+
+```bash
+jq '.items' tests/fixtures/test-items-library/apa-7th.json > /tmp/apa-7th-items.json
+jq '.items' tests/fixtures/test-items-library/chicago-18th.json > /tmp/chicago-18th-items.json
+target/release/citum convert refs /tmp/apa-7th-items.json --from csl-json --to citum-json -o /tmp/apa-7th-citum.json
+target/release/citum convert refs /tmp/chicago-18th-items.json --from csl-json --to citum-json -o /tmp/chicago-18th-citum.json
+```
+
+CPU flamegraphs were captured from release binaries rebuilt with debug symbols
+and no stripping:
+
+```bash
+env CARGO_PROFILE_RELEASE_DEBUG=1 CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --release -p citum -p citum-migrate --no-default-features
+```
+
+Heap profiles were captured with:
+
+```bash
+env CARGO_PROFILE_RELEASE_DEBUG=1 CARGO_PROFILE_RELEASE_STRIP=false \
+  cargo build --release -p citum -p citum-migrate --features dhat-heap
+```
+
+## Timing Baseline
+
+| Workload | Mean | Stddev |
+|---|---:|---:|
+| `citum convert refs /tmp/apa-7th-items.json --from csl-json --to citum-json` | 6.2 ms | 1.2 ms |
+| `citum check -s apa-7th -b tests/fixtures/references-expanded.json -c tests/fixtures/citations-expanded.json --json` | 7.5 ms | 0.6 ms |
+| `citum render refs -b tests/fixtures/references-expanded.json -c tests/fixtures/citations-expanded.json -s apa-7th --json` | 10.2 ms | 1.7 ms |
+| `citum render refs -b /tmp/chicago-18th-citum.json -s chicago-author-date-18th --json` | 44.3 ms | 6.8 ms |
+| `citum render refs -b /tmp/apa-7th-citum.json -s apa-7th --json` | 46.2 ms | 4.4 ms |
+| `citum-migrate styles-legacy/apa.csl --template-source xml` | 142.0 ms | 1.4 ms |
+
+The exported `hyperfine` result for this run was
+`/tmp/citum-hyperfine.json`.
+
+## CPU Findings
+
+Symbolized flamegraphs:
+
+- `/tmp/citum-migrate-apa-xml.symbolized.svg`
+- `/tmp/citum-render-apa-large.symbolized.svg`
+
+Migration hotspots:
+
+- `csl_legacy::model::CslNode` and `Choose` drop chains consumed a large part
+  of sampled time, indicating substantial temporary tree construction.
+- `citum_migrate::template_diff::component_selector` repeatedly cloned
+  `serde_json::Value` into selector maps.
+- `citum_migrate::template_diff::diff_resolves_to_template` cloned parent
+  templates into temporary `TemplateVariant::Full` values.
+
+Rendering hotspots:
+
+- `render_refs_json` and `print_json_with_format` were the dominant CLI frames
+  for the large APA workload.
+- `render_template_components` collected per-entry `ProcTemplateComponent`
+  vectors and cloned component options.
+- JSON value construction/drop was visible in the output path.
+
+## Heap Findings
+
+DHAT artifacts:
+
+- `/tmp/citum-migrate-apa-xml.dhat-heap.json`
+- `/tmp/citum-render-apa-large.dhat-heap.json`
+
+| Workload | Total allocated | Allocation blocks | Peak heap | End heap |
+|---|---:|---:|---:|---:|
+| `citum-migrate styles-legacy/apa.csl --template-source xml` | 333,974,675 B | 1,576,462 | 88,248,058 B | 112,385 B |
+| `citum render refs -b /tmp/apa-7th-citum.json -s apa-7th --json` | 76,253,287 B | 555,624 | 9,392,310 B | 117,045 B |
+
+Largest migration allocation sites:
+
+- `template_diff::component_selector` at `template_diff.rs:239`.
+- `TemplateVariant::clone`, `diff_resolves_to_template`, and
+  `resolve_template_variant` around type-variant resolution.
+- `MacroInliner::expand_macros_no_increment` at `lib.rs:122`, with peak
+  allocations from cloned CSL node subtrees.
+
+Largest render allocation sites:
+
+- `render_template_components` at `grouped/core.rs:867`, collecting rendered
+  components.
+- `ProcEntry::clone` in JSON output assembly.
+- `BibliographySpec::resolve_template` and cloned citation/bibliography
+  options.
+- High-frequency small allocations in `key_base` and `get_variable_key`.
+
+## Improvement Plan
+
+1. Reduce `citum-migrate` macro expansion cloning.
+   Track in `csl26-pmxa`. Rewrite macro expansion to avoid cloning whole
+   `CslNode` trees when only child vectors change, and add a benchmark or
+   profiling fixture proving reduced peak heap.
+
+2. Reduce `citum-migrate` template diff cloning.
+   Track in `csl26-tdcl`. Avoid cloning `serde_json::Value` selector fields and
+   full parent templates in diff equivalence checks.
+
+3. Reduce render hot-path allocation.
+   Track in `csl26-rtak`. Avoid per-component `RenderOptions` clones where
+   possible, pre-size or stream rendered component output, and remove avoidable
+   `String` allocation from key-base handling.
+
+## Reproduction Commands
+
+```bash
+cargo build --release --bins
+
+hyperfine --warmup 5 --min-runs 20 --export-json /tmp/citum-hyperfine.json \
+  'target/release/citum render refs -b tests/fixtures/references-expanded.json -c tests/fixtures/citations-expanded.json -s apa-7th --json -o /tmp/citum-render-expanded.json' \
+  'target/release/citum render refs -b /tmp/apa-7th-citum.json -s apa-7th --json -o /tmp/citum-render-apa-large.json' \
+  'target/release/citum render refs -b /tmp/chicago-18th-citum.json -s chicago-author-date-18th --json -o /tmp/citum-render-chicago-large.json' \
+  'target/release/citum check -s apa-7th -b tests/fixtures/references-expanded.json -c tests/fixtures/citations-expanded.json --json > /tmp/citum-check-expanded.json' \
+  'target/release/citum convert refs /tmp/apa-7th-items.json --from csl-json --to citum-json -o /tmp/citum-convert-apa-large.json' \
+  'target/release/citum-migrate styles-legacy/apa.csl --template-source xml > /tmp/citum-migrate-apa-xml.yaml'
+
+flamegraph -o /tmp/citum-migrate-apa-xml.symbolized.svg -- \
+  target/release/citum-migrate styles-legacy/apa.csl --template-source xml
+
+flamegraph -o /tmp/citum-render-apa-large.symbolized.svg -- \
+  target/release/citum render refs -b /tmp/apa-7th-citum.json -s apa-7th --json \
+  -o /tmp/citum-render-apa-large-symbolized.json
+```
+
+For heap profiling, run the target binary from `/tmp` so `dhat-heap.json` does
+not land in the repository root, then rename the generated file.


### PR DESCRIPTION
## Summary

- Add a dated performance profile report covering hyperfine, flamegraph, and DHAT findings.
- Add optional `dhat-heap` features to `citum` and `citum-migrate` so heap profiling can be repeated without ad-hoc source edits.
- Add three follow-up beans for migration macro expansion allocations, migration template diff cloning, and render allocation/key-string churn.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
