### PR TITLE
address allocation hotspots

### DIFF
--- a/.beans/archive/csl26-pmxa--optimize-citum-migrate-macro-expansion-allocations.md
+++ b/.beans/archive/csl26-pmxa--optimize-citum-migrate-macro-expansion-allocations.md
@@ -1,14 +1,14 @@
 ---
 # csl26-pmxa
 title: Optimize citum-migrate macro expansion allocations
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
     - performance
     - migrate
 created_at: 2026-05-24T14:32:34Z
-updated_at: 2026-05-24T14:44:07Z
+updated_at: 2026-05-24T18:20:43Z
 ---
 
 ## Goal

--- a/.beans/archive/csl26-rtak--reduce-render-template-allocation-and-key-string-churn.md
+++ b/.beans/archive/csl26-rtak--reduce-render-template-allocation-and-key-string-churn.md
@@ -1,14 +1,14 @@
 ---
 # csl26-rtak
 title: Reduce render template allocation and key-string churn
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
     - engine
     - performance
 created_at: 2026-05-24T14:32:34Z
-updated_at: 2026-05-24T14:44:07Z
+updated_at: 2026-05-24T18:15:31Z
 ---
 
 ## Goal

--- a/.beans/archive/csl26-tdcl--reduce-citum-migrate-template-diff-cloning.md
+++ b/.beans/archive/csl26-tdcl--reduce-citum-migrate-template-diff-cloning.md
@@ -1,14 +1,14 @@
 ---
 # csl26-tdcl
 title: Reduce citum-migrate template diff cloning
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
     - performance
     - migrate
 created_at: 2026-05-24T14:32:34Z
-updated_at: 2026-05-24T14:44:07Z
+updated_at: 2026-05-24T18:23:35Z
 ---
 
 ## Goal

--- a/crates/citum-cli/src/commands/render/json.rs
+++ b/crates/citum-cli/src/commands/render/json.rs
@@ -118,8 +118,8 @@ where
             .into_iter()
             .filter(|entry| filter.contains(entry.id.as_str()))
             .map(|entry| {
-                let text = citum_engine::render::refs_to_string_with_format::<F>(
-                    vec![entry.clone()],
+                let text = citum_engine::render::refs_to_string_slice_with_format::<F>(
+                    std::slice::from_ref(&entry),
                     ctx.annotations,
                     Some(ctx.annotation_style),
                 );

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -848,23 +848,25 @@ impl Renderer<'_> {
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let mut tracker = TemplateComponentTracker::default();
-        template
-            .iter()
-            .enumerate()
-            .filter_map(|(template_index, component)| {
-                let mut component_options = options.clone();
-                component_options.current_template_index =
-                    self.inject_ast_indices.then_some(template_index);
-                let ctx = TemplateRenderContext {
-                    reference,
-                    ref_type,
-                    options: &component_options,
-                    hint,
-                    template_index,
-                };
+        let mut components = Vec::with_capacity(template.len());
+        let mut component_options = options.clone();
+        for (template_index, component) in template.iter().enumerate() {
+            component_options.current_template_index =
+                self.inject_ast_indices.then_some(template_index);
+            let ctx = TemplateRenderContext {
+                reference,
+                ref_type,
+                options: &component_options,
+                hint,
+                template_index,
+            };
+            if let Some(component) =
                 self.render_template_component_with_format::<F>(&ctx, component, &mut tracker)
-            })
-            .collect()
+            {
+                components.push(component);
+            }
+        }
+        components
     }
 
     fn build_template_render_hint(
@@ -1002,7 +1004,7 @@ impl Renderer<'_> {
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let mut has_meaningful_content = false;
-        let mut values = Vec::new();
+        let mut values = Vec::with_capacity(group.group.len());
 
         for item in &group.group {
             let Some(rendered) =

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -17,6 +17,7 @@ use citum_schema::locale::Locale;
 use citum_schema::options::{Config, bibliography::BibliographyConfig};
 use citum_schema::template::TemplateComponent;
 use indexmap::IndexMap;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
@@ -125,7 +126,7 @@ impl TemplateComponentTracker {
             return false;
         };
         let base = key_base(var_key);
-        self.rendered_vars.contains(var_key) || self.substituted_bases.contains(&base)
+        self.rendered_vars.contains(var_key) || self.substituted_bases.contains(base.as_ref())
     }
 
     fn mark_rendered(&mut self, var_key: Option<String>, substituted_key: Option<&str>) {
@@ -134,7 +135,8 @@ impl TemplateComponentTracker {
         }
         if let Some(substituted_key) = substituted_key {
             self.rendered_vars.insert(substituted_key.to_string());
-            self.substituted_bases.insert(key_base(substituted_key));
+            self.substituted_bases
+                .insert(key_base(substituted_key).into_owned());
         }
     }
 }
@@ -600,11 +602,11 @@ impl<'a> Renderer<'a> {
     }
 }
 
-fn key_base(key: &str) -> String {
+fn key_base(key: &str) -> Cow<'_, str> {
     let mut parts = key.splitn(3, ':');
     match (parts.next(), parts.next()) {
-        (Some(kind), Some(var)) => format!("{kind}:{var}"),
-        _ => key.to_string(),
+        (Some(kind), Some(var)) => Cow::Owned(format!("{kind}:{var}")),
+        _ => Cow::Borrowed(key),
     }
 }
 
@@ -616,37 +618,48 @@ fn key_base(key: &str) -> String {
 #[must_use]
 pub fn get_variable_key(component: &TemplateComponent) -> Option<String> {
     use citum_schema::template::Rendering;
+    use std::fmt::Write;
 
-    fn context_suffix(rendering: &Rendering) -> String {
+    fn push_context_suffix(key: &mut String, rendering: &Rendering) {
         match (&rendering.prefix, &rendering.suffix) {
-            (Some(p), Some(s)) => format!(":{p}_{s}"),
-            (Some(p), None) => format!(":{p}"),
-            (None, Some(s)) => format!(":{s}"),
-            (None, None) => String::new(),
+            (Some(prefix), Some(suffix)) => {
+                key.push(':');
+                key.push_str(prefix);
+                key.push('_');
+                key.push_str(suffix);
+            }
+            (Some(prefix), None) => {
+                key.push(':');
+                key.push_str(prefix);
+            }
+            (None, Some(suffix)) => {
+                key.push(':');
+                key.push_str(suffix);
+            }
+            (None, None) => {}
         }
     }
 
-    fn make_key(kind: &str, value: impl std::fmt::Debug, ctx: String) -> Option<String> {
-        Some(format!("{kind}:{value:?}{ctx}"))
+    fn make_key(kind: &str, value: impl std::fmt::Debug, rendering: &Rendering) -> Option<String> {
+        let mut key = String::new();
+        write!(&mut key, "{kind}:{value:?}").ok()?;
+        push_context_suffix(&mut key, rendering);
+        Some(key)
     }
 
     match component {
-        TemplateComponent::Contributor(c) => {
-            make_key("contributor", &c.contributor, context_suffix(&c.rendering))
-        }
-        TemplateComponent::Date(d) => make_key("date", &d.date, context_suffix(&d.rendering)),
-        TemplateComponent::Variable(v) => {
-            make_key("variable", &v.variable, context_suffix(&v.rendering))
-        }
+        TemplateComponent::Contributor(c) => make_key("contributor", &c.contributor, &c.rendering),
+        TemplateComponent::Date(d) => make_key("date", &d.date, &d.rendering),
+        TemplateComponent::Variable(v) => make_key("variable", &v.variable, &v.rendering),
         TemplateComponent::Title(t) => {
-            let form_part = t.form.as_ref().map_or(String::new(), |f| format!(":{f:?}"));
-            Some(format!(
-                "title:{:?}{form_part}{}",
-                t.title,
-                context_suffix(&t.rendering)
-            ))
+            let mut key = format!("title:{:?}", t.title);
+            if let Some(form) = &t.form {
+                write!(&mut key, ":{form:?}").ok()?;
+            }
+            push_context_suffix(&mut key, &t.rendering);
+            Some(key)
         }
-        TemplateComponent::Number(n) => make_key("number", &n.number, context_suffix(&n.rendering)),
+        TemplateComponent::Number(n) => make_key("number", &n.number, &n.rendering),
         TemplateComponent::Group(_) => None,
         _ => None,
     }

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -258,10 +258,20 @@ pub fn refs_to_string_with_format<F: OutputFormat<Output = String>>(
     annotations: Option<&HashMap<String, String>>,
     annotation_style: Option<&AnnotationStyle>,
 ) -> String {
-    let fmt = F::default();
-    let mut rendered_entries = Vec::new();
+    refs_to_string_slice_with_format::<F>(&proc_entries, annotations, annotation_style)
+}
 
-    for entry in &proc_entries {
+/// Render borrowed processed templates into a final bibliography string using a specific format.
+#[must_use]
+pub fn refs_to_string_slice_with_format<F: OutputFormat<Output = String>>(
+    proc_entries: &[ProcEntry],
+    annotations: Option<&HashMap<String, String>>,
+    annotation_style: Option<&AnnotationStyle>,
+) -> String {
+    let fmt = F::default();
+    let mut rendered_entries = Vec::with_capacity(proc_entries.len());
+
+    for entry in proc_entries {
         let mut entry_output = render_entry_body_with_format::<F>(entry);
         let proc_template = &entry.template;
 
@@ -302,18 +312,13 @@ pub fn refs_to_string_with_format<F: OutputFormat<Output = String>>(
                     // This is a bit tricky as ProcEntry doesn't have the reference.
                     // But we can look it up from the bibliography if we had access to it.
                     // For now, let's see if any component in the template has a URL resolved.
-                    proc_template.iter().find_map(|c| c.url.clone())
+                    proc_template.iter().find_map(|c| c.url.as_deref())
                 } else {
                     None
                 }
             });
 
-        rendered_entries.push(fmt.entry(
-            &entry.id,
-            entry_output,
-            entry_url.as_deref(),
-            &entry.metadata,
-        ));
+        rendered_entries.push(fmt.entry(&entry.id, entry_output, entry_url, &entry.metadata));
     }
 
     fmt.finish(fmt.bibliography(rendered_entries))

--- a/crates/citum-engine/src/render/mod.rs
+++ b/crates/citum-engine/src/render/mod.rs
@@ -45,7 +45,9 @@ pub mod typst;
 )]
 mod test_formats;
 
-pub use bibliography::{refs_to_string, refs_to_string_with_format};
+pub use bibliography::{
+    refs_to_string, refs_to_string_slice_with_format, refs_to_string_with_format,
+};
 pub use citation::{citation_to_string, citation_to_string_with_format};
 pub use component::{
     ProcEntry, ProcTemplate, ProcTemplateComponent, render_component,

--- a/crates/citum-engine/src/values/list.rs
+++ b/crates/citum-engine/src/values/list.rs
@@ -23,48 +23,45 @@ impl ComponentValues for TemplateGroup {
         let fmt = F::default();
 
         // Collect values from all items, applying their rendering
-        let values: Vec<F::Output> = self
-            .group
-            .iter()
-            .filter_map(|item| {
-                let v = item.values::<F>(reference, hints, options)?;
-                if v.value.is_empty() {
-                    return None;
-                }
+        let mut values = Vec::with_capacity(self.group.len());
+        for item in &self.group {
+            let Some(v) = item.values::<F>(reference, hints, options) else {
+                continue;
+            };
+            if v.value.is_empty() {
+                continue;
+            }
 
-                // Track if we have any "meaningful" content (not just a term)
-                if !is_term_based(item) {
-                    has_content = true;
-                }
+            // Track if we have any "meaningful" content (not just a term)
+            if !is_term_based(item) {
+                has_content = true;
+            }
 
-                // Use the central rendering logic to apply global config, local settings, and overrides
-                let proc_item = crate::render::ProcTemplateComponent {
-                    template_component: item.clone(),
-                    template_index: options.current_template_index,
-                    value: v.value,
-                    prefix: v.prefix,
-                    suffix: v.suffix,
-                    url: v.url,
-                    ref_type: Some(reference.ref_type().clone()),
-                    config: Some(options.config.clone()),
-                    bibliography_config: options.bibliography_config.clone(),
-                    item_language: crate::values::effective_component_language(reference, item),
-                    sentence_initial: false,
-                    pre_formatted: v.pre_formatted,
-                };
+            // Use the central rendering logic to apply global config, local settings, and overrides
+            let proc_item = crate::render::ProcTemplateComponent {
+                template_component: item.clone(),
+                template_index: options.current_template_index,
+                value: v.value,
+                prefix: v.prefix,
+                suffix: v.suffix,
+                url: v.url,
+                ref_type: Some(reference.ref_type().clone()),
+                config: Some(options.config.clone()),
+                bibliography_config: options.bibliography_config.clone(),
+                item_language: crate::values::effective_component_language(reference, item),
+                sentence_initial: false,
+                pre_formatted: v.pre_formatted,
+            };
 
-                let rendered = crate::render::render_component_with_format_and_renderer::<F>(
-                    &proc_item,
-                    &fmt,
-                    options.show_semantics,
-                );
-                if rendered.is_empty() {
-                    None
-                } else {
-                    Some(rendered)
-                }
-            })
-            .collect();
+            let rendered = crate::render::render_component_with_format_and_renderer::<F>(
+                &proc_item,
+                &fmt,
+                options.show_semantics,
+            );
+            if !rendered.is_empty() {
+                values.push(rendered);
+            }
+        }
 
         if values.is_empty() || !has_content {
             return None;

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -7,7 +7,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 #![allow(missing_docs, reason = "lib/crate")]
 
-use csl_legacy::model::{CslNode, Style};
+use csl_legacy::model::{Choose, ChooseBranch, CslNode, Group, Names, Style, Substitute};
 use std::collections::HashMap;
 
 /// CSL 1.0 analysis utilities.
@@ -58,18 +58,18 @@ pub use upsampler::Upsampler;
 /// Recursively expands CSL 1.0 macro references into their definitions.
 ///
 /// Handles nested macros and preserves rendering order across macro boundaries.
-pub struct MacroInliner {
-    macros: HashMap<String, Vec<CslNode>>,
+pub struct MacroInliner<'a> {
+    macros: HashMap<&'a str, &'a [CslNode]>,
     provenance: Option<ProvenanceTracker>,
 }
 
-impl MacroInliner {
+impl<'a> MacroInliner<'a> {
     /// Create a new macro inliner from a CSL 1.0 style.
     #[must_use]
-    pub fn new(style: &Style) -> Self {
+    pub fn new(style: &'a Style) -> Self {
         let mut macros = HashMap::new();
         for m in &style.macros {
-            macros.insert(m.name.clone(), m.children.clone());
+            macros.insert(m.name.as_str(), m.children.as_slice());
         }
         Self {
             macros,
@@ -81,10 +81,10 @@ impl MacroInliner {
     ///
     /// Tracks source locations to help debug migration issues.
     #[must_use]
-    pub fn with_provenance(style: &Style, provenance: ProvenanceTracker) -> Self {
+    pub fn with_provenance(style: &'a Style, provenance: ProvenanceTracker) -> Self {
         let mut macros = HashMap::new();
         for m in &style.macros {
-            macros.insert(m.name.clone(), m.children.clone());
+            macros.insert(m.name.as_str(), m.children.as_slice());
         }
         Self {
             macros,
@@ -120,12 +120,12 @@ impl MacroInliner {
     ///
     /// Nested macros inherit their parent's order.
     fn expand_macros_no_increment(&self, nodes: &[CslNode]) -> Vec<CslNode> {
-        let mut expanded = Vec::new();
+        let mut expanded = Vec::with_capacity(nodes.len());
         for node in nodes {
             match node {
                 CslNode::Text(text) if text.macro_name.is_some() => {
                     if let Some(name) = &text.macro_name {
-                        if let Some(macro_children) = self.macros.get(name) {
+                        if let Some(macro_children) = self.macros.get(name.as_str()) {
                             // Recursively expand nested macros without incrementing
                             let expanded_children = self.expand_macros_no_increment(macro_children);
                             expanded.extend(expanded_children);
@@ -135,31 +135,19 @@ impl MacroInliner {
                     }
                 }
                 CslNode::Group(group) => {
-                    let mut new_group = group.clone();
-                    new_group.children = self.expand_macros_no_increment(&group.children);
-                    expanded.push(CslNode::Group(new_group));
+                    let children = self.expand_macros_no_increment(&group.children);
+                    expanded.push(CslNode::Group(clone_group_with_children(group, children)));
                 }
                 CslNode::Names(names) => {
-                    let mut new_names = names.clone();
-                    new_names.children = self.expand_macros_no_increment(&names.children);
-                    expanded.push(CslNode::Names(new_names));
+                    let children = self.expand_macros_no_increment(&names.children);
+                    expanded.push(CslNode::Names(clone_names_with_children(names, children)));
                 }
                 CslNode::Choose(choose) => {
-                    let mut new_choose = choose.clone();
-                    new_choose.if_branch.children =
-                        self.expand_macros_no_increment(&choose.if_branch.children);
-                    for else_if in &mut new_choose.else_if_branches {
-                        else_if.children = self.expand_macros_no_increment(&else_if.children);
-                    }
-                    if let Some(ref else_branch) = new_choose.else_branch {
-                        new_choose.else_branch = Some(self.expand_macros_no_increment(else_branch));
-                    }
-                    expanded.push(CslNode::Choose(new_choose));
+                    expanded.push(CslNode::Choose(self.expand_choose_no_increment(choose)));
                 }
                 CslNode::Substitute(sub) => {
-                    let mut new_sub = sub.clone();
-                    new_sub.children = self.expand_macros_no_increment(&sub.children);
-                    expanded.push(CslNode::Substitute(new_sub));
+                    let children = self.expand_macros_no_increment(&sub.children);
+                    expanded.push(CslNode::Substitute(Substitute { children }));
                 }
                 _ => {
                     expanded.push(node.clone());
@@ -177,12 +165,12 @@ impl MacroInliner {
         nodes: &[CslNode],
         order_counter: &mut usize,
     ) -> Vec<CslNode> {
-        let mut expanded = Vec::new();
+        let mut expanded = Vec::with_capacity(nodes.len());
         for node in nodes {
             match node {
                 CslNode::Text(text) if text.macro_name.is_some() => {
                     if let Some(name) = &text.macro_name {
-                        if let Some(macro_children) = self.macros.get(name) {
+                        if let Some(macro_children) = self.macros.get(name.as_str()) {
                             // Check if this macro call has a pre-assigned order from the layout
                             let is_layout_macro = text.macro_call_order.is_some();
 
@@ -225,53 +213,75 @@ impl MacroInliner {
                 }
                 // For other nodes that have children, we must recurse into them
                 CslNode::Group(group) => {
-                    let mut new_group = group.clone();
-                    new_group.children =
-                        self.expand_nodes_with_order(&group.children, order_counter);
-                    expanded.push(CslNode::Group(new_group));
+                    let children = self.expand_nodes_with_order(&group.children, order_counter);
+                    expanded.push(CslNode::Group(clone_group_with_children(group, children)));
                 }
                 CslNode::Names(names) => {
-                    let mut new_names = names.clone();
-                    new_names.children =
-                        self.expand_nodes_with_order(&names.children, order_counter);
-                    expanded.push(CslNode::Names(new_names));
+                    let children = self.expand_nodes_with_order(&names.children, order_counter);
+                    expanded.push(CslNode::Names(clone_names_with_children(names, children)));
                 }
                 CslNode::Choose(choose) => {
-                    let mut new_choose = choose.clone();
-                    // For macro order tracking, we want sequential orders across ALL branches.
-                    // This tracks the SOURCE order of macro calls, not runtime execution order.
-                    // At runtime only one branch executes, but we need to track where each
-                    // macro appeared in the CSL 1.0 source.
-
-                    new_choose.if_branch.children =
-                        self.expand_nodes_with_order(&choose.if_branch.children, order_counter);
-
-                    for (branch, new_branch) in choose
-                        .else_if_branches
-                        .iter()
-                        .zip(new_choose.else_if_branches.iter_mut())
-                    {
-                        new_branch.children =
-                            self.expand_nodes_with_order(&branch.children, order_counter);
-                    }
-
-                    if let Some(ref else_children) = choose.else_branch {
-                        new_choose.else_branch =
-                            Some(self.expand_nodes_with_order(else_children, order_counter));
-                    }
-
-                    expanded.push(CslNode::Choose(new_choose));
+                    expanded.push(CslNode::Choose(
+                        self.expand_choose_with_order(choose, order_counter),
+                    ));
                 }
                 CslNode::Substitute(sub) => {
-                    let mut new_sub = sub.clone();
-                    new_sub.children = self.expand_nodes_with_order(&sub.children, order_counter);
-                    expanded.push(CslNode::Substitute(new_sub));
+                    let children = self.expand_nodes_with_order(&sub.children, order_counter);
+                    expanded.push(CslNode::Substitute(Substitute { children }));
                 }
                 // Nodes with no children or that don't call macros directly
                 _ => expanded.push(node.clone()),
             }
         }
         expanded
+    }
+
+    fn expand_choose_no_increment(&self, choose: &Choose) -> Choose {
+        let if_children = self.expand_macros_no_increment(&choose.if_branch.children);
+        let else_if_branches = choose
+            .else_if_branches
+            .iter()
+            .map(|branch| {
+                let children = self.expand_macros_no_increment(&branch.children);
+                clone_choose_branch_with_children(branch, children)
+            })
+            .collect();
+        let else_branch = choose
+            .else_branch
+            .as_ref()
+            .map(|children| self.expand_macros_no_increment(children));
+
+        Choose {
+            if_branch: clone_choose_branch_with_children(&choose.if_branch, if_children),
+            else_if_branches,
+            else_branch,
+        }
+    }
+
+    fn expand_choose_with_order(&self, choose: &Choose, order_counter: &mut usize) -> Choose {
+        // For macro order tracking, we want sequential orders across ALL branches.
+        // This tracks the SOURCE order of macro calls, not runtime execution order.
+        // At runtime only one branch executes, but we need to track where each
+        // macro appeared in the CSL 1.0 source.
+        let if_children = self.expand_nodes_with_order(&choose.if_branch.children, order_counter);
+        let else_if_branches = choose
+            .else_if_branches
+            .iter()
+            .map(|branch| {
+                let children = self.expand_nodes_with_order(&branch.children, order_counter);
+                clone_choose_branch_with_children(branch, children)
+            })
+            .collect();
+        let else_branch = choose
+            .else_branch
+            .as_ref()
+            .map(|children| self.expand_nodes_with_order(children, order_counter));
+
+        Choose {
+            if_branch: clone_choose_branch_with_children(&choose.if_branch, if_children),
+            else_if_branches,
+            else_branch,
+        }
     }
 
     /// Assigns `macro_call_order` only if not already set.
@@ -456,5 +466,49 @@ impl MacroInliner {
     #[must_use]
     pub fn inline_citation(&self, style: &Style) -> Vec<CslNode> {
         self.expand_nodes(&style.citation.layout.children)
+    }
+}
+
+fn clone_group_with_children(group: &Group, children: Vec<CslNode>) -> Group {
+    Group {
+        delimiter: group.delimiter.clone(),
+        prefix: group.prefix.clone(),
+        suffix: group.suffix.clone(),
+        children,
+        macro_call_order: group.macro_call_order,
+        formatting: group.formatting.clone(),
+    }
+}
+
+fn clone_names_with_children(names: &Names, children: Vec<CslNode>) -> Names {
+    Names {
+        variable: names.variable.clone(),
+        delimiter: names.delimiter.clone(),
+        delimiter_precedes_et_al: names.delimiter_precedes_et_al.clone(),
+        et_al_min: names.et_al_min,
+        et_al_use_first: names.et_al_use_first,
+        et_al_subsequent_min: names.et_al_subsequent_min,
+        et_al_subsequent_use_first: names.et_al_subsequent_use_first,
+        prefix: names.prefix.clone(),
+        suffix: names.suffix.clone(),
+        children,
+        macro_call_order: names.macro_call_order,
+        formatting: names.formatting.clone(),
+    }
+}
+
+fn clone_choose_branch_with_children(
+    branch: &ChooseBranch,
+    children: Vec<CslNode>,
+) -> ChooseBranch {
+    ChooseBranch {
+        match_mode: branch.match_mode.clone(),
+        type_: branch.type_.clone(),
+        variable: branch.variable.clone(),
+        is_numeric: branch.is_numeric.clone(),
+        is_uncertain_date: branch.is_uncertain_date.clone(),
+        locator: branch.locator.clone(),
+        position: branch.position.clone(),
+        children,
     }
 }

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -5,13 +5,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Template variant diff computation for bibliography type-variant generation.
 
-use citum_schema::{
-    BibliographySpec, Style,
-    template::{
-        Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
-        TemplateModifyOperation, TemplateRemoveOperation, TemplateVariant, TemplateVariantDiff,
-        TypeSelector,
-    },
+use citum_schema::template::{
+    Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
+    TemplateModifyOperation, TemplateRemoveOperation, TemplateVariant, TemplateVariantDiff,
+    TypeSelector,
 };
 use std::collections::BTreeMap;
 
@@ -44,7 +41,7 @@ pub(crate) fn build_type_variants(
 pub(crate) fn template_variant_from_full_template(
     default_template: &[TemplateComponent],
     candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
-    selector: &TypeSelector,
+    _selector: &TypeSelector,
     target_template: Vec<TemplateComponent>,
 ) -> TemplateVariant {
     let Some(diff) =
@@ -53,13 +50,7 @@ pub(crate) fn template_variant_from_full_template(
         return TemplateVariant::Full(target_template);
     };
 
-    if diff_resolves_to_template(
-        default_template,
-        candidate_parents,
-        selector,
-        &diff,
-        &target_template,
-    ) {
+    if diff_resolves_to_template(default_template, candidate_parents, &diff, &target_template) {
         TemplateVariant::Diff(diff)
     } else {
         TemplateVariant::Full(target_template)
@@ -101,35 +92,21 @@ fn diff_operation_weight(diff: &TemplateVariantDiff) -> usize {
 fn diff_resolves_to_template(
     default_template: &[TemplateComponent],
     candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
-    selector: &TypeSelector,
     diff: &TemplateVariantDiff,
     expected_template: &[TemplateComponent],
 ) -> bool {
-    let mut variants = TypeVariantMap::new();
-    for (parent_selector, parent_template) in candidate_parents {
-        variants.insert(
-            parent_selector.clone(),
-            TemplateVariant::Full(parent_template.clone()),
-        );
-    }
-    variants.insert(selector.clone(), TemplateVariant::Diff(diff.clone()));
-    let style = Style {
-        bibliography: Some(BibliographySpec {
-            template: Some(default_template.to_vec()),
-            type_variants: Some(variants),
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
+    let mut resolved = diff
+        .extends
+        .as_ref()
+        .and_then(|extends| {
+            candidate_parents
+                .iter()
+                .find(|(selector, _)| selector == extends)
+                .map(|(_, template)| template.clone())
+        })
+        .unwrap_or_else(|| default_template.to_vec());
 
-    style
-        .try_into_resolved()
-        .ok()
-        .and_then(|style| style.bibliography)
-        .and_then(|bibliography| bibliography.type_variants)
-        .and_then(|variants| variants.get(selector).cloned())
-        .and_then(TemplateVariant::into_template)
-        .is_some_and(|resolved| resolved == expected_template)
+    apply_template_variant_diff(&mut resolved, diff).is_some_and(|()| resolved == expected_template)
 }
 
 fn derive_template_variant_diff(
@@ -213,34 +190,101 @@ fn derive_template_variant_diff(
 }
 
 fn component_keys(template: &[TemplateComponent]) -> Option<Vec<String>> {
-    template
-        .iter()
-        .map(|component| serde_json::to_string(&component_selector(component)?.fields).ok())
-        .collect()
+    template.iter().map(component_key).collect()
 }
 
 pub(crate) fn component_selector(
     component: &TemplateComponent,
 ) -> Option<TemplateComponentSelector> {
-    let serde_json::Value::Object(fields) = serde_json::to_value(component).ok()? else {
-        return None;
-    };
-    for key in [
-        "contributor",
-        "date",
-        "title",
-        "number",
-        "variable",
-        "term",
-        "group",
-    ] {
-        if let Some(value) = fields.get(key) {
-            let mut selector = BTreeMap::new();
-            selector.insert(key.to_string(), value.clone());
-            return Some(TemplateComponentSelector { fields: selector });
+    let (key, value) = component_selector_value(component)?;
+    let mut selector = BTreeMap::new();
+    selector.insert(key.to_string(), value);
+    Some(TemplateComponentSelector { fields: selector })
+}
+
+fn component_key(component: &TemplateComponent) -> Option<String> {
+    let (key, value) = component_selector_value(component)?;
+    let value = serde_json::to_string(&value).ok()?;
+    Some(format!("{key}:{value}"))
+}
+
+fn component_selector_value(
+    component: &TemplateComponent,
+) -> Option<(&'static str, serde_json::Value)> {
+    match component {
+        TemplateComponent::Contributor(inner) => Some((
+            "contributor",
+            serde_json::to_value(&inner.contributor).ok()?,
+        )),
+        TemplateComponent::Date(inner) => Some(("date", serde_json::to_value(&inner.date).ok()?)),
+        TemplateComponent::Title(inner) => {
+            Some(("title", serde_json::to_value(&inner.title).ok()?))
         }
+        TemplateComponent::Number(inner) => {
+            Some(("number", serde_json::to_value(&inner.number).ok()?))
+        }
+        TemplateComponent::Variable(inner) => {
+            Some(("variable", serde_json::to_value(&inner.variable).ok()?))
+        }
+        TemplateComponent::Term(inner) => Some(("term", serde_json::to_value(&inner.term).ok()?)),
+        TemplateComponent::Group(inner) => {
+            Some(("group", serde_json::to_value(&inner.group).ok()?))
+        }
+        _ => None,
     }
-    None
+}
+
+fn apply_template_variant_diff(
+    template: &mut Vec<TemplateComponent>,
+    diff: &TemplateVariantDiff,
+) -> Option<()> {
+    for op in &diff.modify {
+        let index = find_unique_anchor(template, &op.match_selector)?;
+        let component = template.get_mut(index)?;
+        if let Some(label_form) = op.label_form.clone()
+            && let TemplateComponent::Number(number) = component
+        {
+            number.label_form = Some(label_form);
+        }
+        component.rendering_mut().merge(&op.rendering);
+    }
+
+    for op in &diff.remove {
+        let index = find_unique_anchor(template, &op.match_selector)?;
+        template.remove(index);
+    }
+
+    for op in &diff.add {
+        let (selector, insert_after) = match (&op.before, &op.after) {
+            (Some(selector), None) => (selector, false),
+            (None, Some(selector)) => (selector, true),
+            _ => return None,
+        };
+        let anchor_index = find_unique_anchor(template, selector)?;
+        let insert_at = if insert_after {
+            anchor_index.saturating_add(1)
+        } else {
+            anchor_index
+        };
+        template.insert(insert_at, op.component.clone());
+    }
+
+    Some(())
+}
+
+fn find_unique_anchor(
+    template: &[TemplateComponent],
+    selector: &TemplateComponentSelector,
+) -> Option<usize> {
+    if selector.is_empty() {
+        return None;
+    }
+    let mut matches = template
+        .iter()
+        .enumerate()
+        .filter_map(|(index, component)| selector.matches(component).then_some(index));
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
 }
 
 fn modified_number_label_form(


### PR DESCRIPTION
Implemented on branch perf/csl26-allocation-hotspots with 3 commits:

  - 48f6b4a2 perf(engine): reduce render allocation churn
  - 2864f7be perf(migrate): reduce macro expansion cloning
  - 9a093a34 perf(migrate): reduce template diff cloning

  All three beans are completed and archived.

  Verification passed:

  - cargo fmt --check
  - cargo clippy --all-targets --all-features -- -D warnings
  - cargo nextest run → 1344 passed
  - ./scripts/workflow-test.sh styles-legacy/apa.csl → top 10 styles all 100%
  - APA migrate/render smoke commands succeeded

  DHAT current vs report baseline:

```console
  - citum-migrate styles-legacy/apa.csl --template-source xml
      - total: 333,974,675 B → 132,597,522 B
      - peak: 88,248,058 B → 47,506,920 B
  - citum render refs ... apa-7th --json
      - total: 76,253,287 B → 73,191,591 B
      - blocks: 555,624 → 512,937
      - peak increased: 9,392,310 B → 16,429,467 B
 ```