### PR TITLE
docs(engine): add doc comments to internal functions

### DIFF
--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -21,6 +21,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 impl Processor {
+    /// Resolve a localized or literal group heading.
     pub(super) fn resolve_group_heading(&self, heading: &GroupHeading) -> Option<String> {
         match heading {
             GroupHeading::Literal { literal } => Some(literal.clone()),
@@ -33,6 +34,14 @@ impl Processor {
         }
     }
 
+    /// Resolve a localized heading map based on the processor locale.
+    ///
+    /// Matches in order:
+    /// 1. Exact locale (e.g., "en-GB")
+    /// 2. Primary language (e.g., "en")
+    /// 3. Style default locale
+    /// 4. en-US fallback
+    /// 5. First alphabetically defined key
     fn resolve_localized_heading(&self, localized: &HashMap<String, String>) -> Option<String> {
         fn language_tag(locale: &str) -> &str {
             locale.split('-').next().unwrap_or(locale)
@@ -69,6 +78,7 @@ impl Processor {
             .map(|(_locale, value)| value.clone())
     }
 
+    /// Resolve a bibliography partition heading.
     fn resolve_partition_heading(&self, heading: &BibliographyPartitionHeading) -> Option<String> {
         match heading {
             BibliographyPartitionHeading::Literal { literal } => Some(literal.clone()),
@@ -83,6 +93,7 @@ impl Processor {
         }
     }
 
+    /// Find unassigned bibliography entries that match a group's selector.
     fn collect_matching_group_refs<'a>(
         &'a self,
         bibliography: &'a [ProcEntry],
@@ -119,6 +130,7 @@ impl Processor {
             .collect()
     }
 
+    /// Mark references as assigned to a bibliography group.
     fn mark_group_members_assigned(assigned: &mut HashSet<String>, references: &[&Reference]) {
         for reference in references {
             if let Some(id) = reference.id() {
@@ -127,6 +139,9 @@ impl Processor {
         }
     }
 
+    /// Calculate disambiguation hints locally within a bibliography group.
+    ///
+    /// Only calculates hints if the group specifies local disambiguation scope.
     fn build_group_local_hints(
         &self,
         sorted_refs: &[&Reference],
@@ -163,6 +178,7 @@ impl Processor {
         Some(disambiguator.calculate_hints())
     }
 
+    /// Resolve the effective style to use for a bibliography group.
     fn effective_group_style<'a>(
         &'a self,
         group: &'a BibliographyGroup,
@@ -178,6 +194,7 @@ impl Processor {
         }
     }
 
+    /// Render bibliography entries for a specific group.
     fn render_group_entries<F>(
         &self,
         _bibliography: &[ProcEntry],
@@ -252,6 +269,7 @@ impl Processor {
         entries
     }
 
+    /// Append a rendered bibliography group to the output string.
     fn append_rendered_group<F>(
         &self,
         result: &mut String,
@@ -283,6 +301,7 @@ impl Processor {
         ));
     }
 
+    /// Append a rendered bibliography partition to the output string.
     fn append_rendered_partition<F>(
         &self,
         result: &mut String,
@@ -310,6 +329,7 @@ impl Processor {
         ));
     }
 
+    /// Orchestrate the rendering of automatic bibliography partitions with headings.
     pub(super) fn render_with_partition_sections<F>(
         &self,
         sorted_refs: Vec<&Reference>,
@@ -347,6 +367,7 @@ impl Processor {
         fmt.finish(result)
     }
 
+    /// Render all entries using custom bibliography grouping.
     pub(super) fn render_with_custom_groups<F>(
         &self,
         all_entries: &[ProcEntry],
@@ -359,6 +380,12 @@ impl Processor {
         self.render_with_custom_groups_filtered::<F>(all_entries, groups, &selected, None, None)
     }
 
+    /// Render a filtered subset of entries using custom bibliography grouping.
+    ///
+    /// This uses a two-pass grouping strategy:
+    /// 1. Collect and render all populated groups.
+    /// 2. Determine if heading suppression applies (only one group populated).
+    /// 3. Append groups and any remaining unassigned entries.
     pub(super) fn render_with_custom_groups_filtered<F>(
         &self,
         all_entries: &[ProcEntry],
@@ -444,6 +471,7 @@ impl Processor {
         fmt.finish(result)
     }
 
+    /// Append unassigned bibliography entries to the output string.
     fn append_unassigned_entries_filtered<F>(
         &self,
         result: &mut String,
@@ -485,6 +513,7 @@ impl Processor {
         ));
     }
 
+    /// Render bibliography using legacy (cited/uncited) grouping.
     fn render_with_legacy_grouping<F>(
         &self,
         bibliography: &[ProcEntry],
@@ -514,6 +543,7 @@ impl Processor {
         fmt.finish(result)
     }
 
+    /// Render a standalone bibliography block for a group.
     fn render_bibliography_for_group<F>(
         &self,
         group: &BibliographyGroup,

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -61,6 +61,9 @@ impl Processor {
     /// Process sorted references and apply subsequent-author substitution.
     ///
     /// Returns bibliography entries with optional author substitution applied.
+    ///
+    /// This is the core iterator for bibliography rendering, handling the choice
+    /// between entry-specific rendering and subsequent-author placeholders.
     fn process_sorted_refs<'a, I, F>(
         &self,
         sorted_refs: I,
@@ -204,6 +207,11 @@ impl Processor {
     }
 
     /// Render a selected bibliography subset to a string with annotations.
+    ///
+    /// Orchestrates the choice between:
+    /// 1. Custom bibliography groups (selectors and headings).
+    /// 2. Automatic sort partitioning with sections (headings only).
+    /// 3. Standard flat rendering.
     pub fn render_selected_bibliography_with_format_and_annotations<F, I>(
         &self,
         item_ids: I,

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -19,6 +19,10 @@ use citum_schema::template::DelimiterPunctuation;
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
+/// Join rendered integral (narrative) groups with localized conjunctions.
+///
+/// Uses the locale's "and" term to join groups according to document grammar
+/// rules (e.g., "A and B" or "A, B, and C" with optional serial comma).
 fn join_integral_groups(rendered_groups: Vec<String>, locale: &Locale) -> String {
     match rendered_groups.len() {
         0 => String::new(),
@@ -47,6 +51,10 @@ fn join_integral_groups(rendered_groups: Vec<String>, locale: &Locale) -> String
 }
 
 impl Processor {
+    /// Determine the text-case policy for a citation at the start of a note.
+    ///
+    /// Only applies for note-based styles when a repeated-citation position (Ibid)
+    /// is at the start of the note and has no user-supplied or spec-defined prefix.
     fn sentence_initial_note_start_text_case(
         &self,
         citation: &Citation,
@@ -74,6 +82,10 @@ impl Processor {
         }
     }
 
+    /// Resolve the citation specification based on the citation's document position.
+    ///
+    /// Delegates to the style's citation spec to handle ibid, subsequent, or first
+    /// position overrides.
     fn resolve_positioned_citation_spec(
         &self,
         citation: &Citation,
@@ -84,6 +96,10 @@ impl Processor {
         )
     }
 
+    /// Register cited reference IDs and ensure numeric labels are initialized.
+    ///
+    /// This maintains the set of all references cited in the document and ensures
+    /// that numeric styles have a stable numbering map.
     fn track_cited_ids_and_init_numbers(&self, citation: &Citation) {
         self.initialize_numeric_citation_numbers();
         let mut cited_ids = self.cited_ids.borrow_mut();
@@ -92,6 +108,7 @@ impl Processor {
         }
     }
 
+    /// Resolve the final effective citation spec for a given mode and position.
     fn resolve_effective_citation_spec(&self, citation: &Citation) -> citum_schema::CitationSpec {
         self.resolve_positioned_citation_spec(citation)
             .into_owned()
@@ -99,6 +116,7 @@ impl Processor {
             .into_owned()
     }
 
+    /// Resolve intra-item and inter-citation delimiters for a citation spec.
     fn resolve_citation_delimiters<'a>(
         &self,
         effective_spec: &'a citum_schema::CitationSpec,
@@ -267,6 +285,10 @@ impl Processor {
         (Some(merged_set), Some(merged_idx), Some(merged_sets))
     }
 
+    /// Render the core content of a citation, handling sorting and grouping.
+    ///
+    /// This is the main orchestration point for template rendering, compound data
+    /// resolution, and mode-specific (integral vs non-integral) formatting.
     fn render_citation_content<F>(
         &self,
         citation: &Citation,
@@ -366,6 +388,10 @@ impl Processor {
         )
     }
 
+    /// Apply user-supplied prefix and suffix from the citation input.
+    ///
+    /// Automatically adds a trailing space to the prefix and a leading space to
+    /// the suffix if they are not already present and not empty.
     fn apply_citation_input_affixes<F>(
         &self,
         citation: &Citation,
@@ -399,6 +425,10 @@ impl Processor {
         fmt.affix(&formatted_prefix, content, &formatted_suffix)
     }
 
+    /// Apply style-defined wrapping and affixes to the rendered citation output.
+    ///
+    /// Handles `wrap` logic (inner prefixes/suffixes and punctuation) based on
+    /// the citation mode and position.
     fn apply_spec_wrap_and_affixes<F>(
         &self,
         citation: &Citation,

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -16,6 +16,11 @@ use crate::processor::Processor;
 
 impl Processor {
     /// Process citations in a document and append a bibliography.
+    ///
+    /// This is the primary document-level entry point. It:
+    /// 1. Parses the source document using the provided adapter.
+    /// 2. Resolves frontmatter overrides for the integral-name policy.
+    /// 3. Chooses a bibliography orchestration path based on frontmatter and document blocks.
     #[allow(
         clippy::string_slice,
         reason = "parser-guaranteed boundaries and indices"
@@ -54,6 +59,7 @@ impl Processor {
         processor.process_document_with_default_bibliography::<P, F>(body, parsed, parser, format)
     }
 
+    /// Orchestrate document processing with custom frontmatter bibliography groups.
     fn process_document_with_frontmatter_groups<P, F>(
         &self,
         body: &str,
@@ -80,6 +86,7 @@ impl Processor {
         )
     }
 
+    /// Orchestrate document processing with explicit bibliography blocks.
     fn process_document_with_bibliography_blocks<P, F>(
         &self,
         body: &str,
@@ -98,6 +105,7 @@ impl Processor {
         self.finalize_document_output(parser, format, rendered)
     }
 
+    /// Orchestrate document processing with the default trailing bibliography.
     fn process_document_with_default_bibliography<P, F>(
         &self,
         body: &str,
@@ -118,6 +126,7 @@ impl Processor {
         )
     }
 
+    /// Generic helper for rendering document body + trailing bibliography.
     fn render_document_with_trailing_bibliography<P, F, B>(
         &self,
         body: &str,
@@ -137,6 +146,10 @@ impl Processor {
         self.finalize_document_output(parser, format, rendered)
     }
 
+    /// Render the citation-annotated document body.
+    ///
+    /// Governs the choice between note-style and inline-style processing,
+    /// and handles HTML placeholder registration for format finalization.
     fn render_document_body<F>(
         &self,
         content: &str,
@@ -171,6 +184,7 @@ impl Processor {
         }
     }
 
+    /// Splice rendered citations into document markup for non-note styles.
     #[allow(
         clippy::string_slice,
         reason = "parser-guaranteed boundaries and indices"
@@ -196,6 +210,7 @@ impl Processor {
         result
     }
 
+    /// Splice HTML-rendered citations into document markup using placeholders.
     #[allow(
         clippy::string_slice,
         reason = "parser-guaranteed boundaries and indices"
@@ -223,6 +238,7 @@ impl Processor {
         result
     }
 
+    /// Replace bibliography block placeholders with rendered content.
     fn replace_document_bibliography_blocks<F>(
         &self,
         rendered: &mut RenderedDocumentBody,
@@ -244,6 +260,7 @@ impl Processor {
         }
     }
 
+    /// Perform final document rewrites and resolve HTML placeholders.
     fn finalize_document_output<P>(
         &self,
         parser: &P,

--- a/crates/citum-engine/src/processor/document/types.rs
+++ b/crates/citum-engine/src/processor/document/types.rs
@@ -58,6 +58,11 @@ pub struct DocumentIntegralNameOverride {
 }
 
 impl DocumentIntegralNameOverride {
+    /// Apply this frontmatter override to a base integral-name configuration.
+    ///
+    /// Returns `None` if the override explicitly disables the policy. Otherwise,
+    /// returns a new configuration where non-null fields from the override
+    /// supersede fields from the base.
     pub(super) fn apply_to(
         &self,
         base: Option<&IntegralNameMemoryConfig>,

--- a/crates/citum-engine/src/processor/rendering/collapse.rs
+++ b/crates/citum-engine/src/processor/rendering/collapse.rs
@@ -9,6 +9,12 @@ use super::Renderer;
 use crate::values::range::{ConsecutiveSegment, consecutive_segments};
 
 impl Renderer<'_> {
+    /// Collapse consecutive numeric citation chunks into ranges (e.g., "1–3").
+    ///
+    /// Only applies when:
+    /// - The chunk contains exactly one reference ID.
+    /// - The chunk content is just the citation number.
+    /// - The citation numbers are consecutive.
     #[allow(clippy::indexing_slicing, reason = "loop-guaranteed indices")]
     pub(super) fn collapse_numeric_citation_chunks(
         &self,
@@ -79,6 +85,12 @@ impl Renderer<'_> {
         collapsed
     }
 
+    /// Collapse consecutive compound sub-labels into ranges (e.g., "1a-c").
+    ///
+    /// Only applies for alphabetic sub-labels when:
+    /// - The chunks belong to the same numeric citation (same number).
+    /// - The chunks belong to the same compound set.
+    /// - The sub-labels are consecutive.
     #[allow(clippy::indexing_slicing, reason = "loop-guaranteed indices")]
     pub(super) fn collapse_compound_citation_chunks(
         &self,

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -202,6 +202,8 @@ impl<'a> Renderer<'a> {
         )
     }
 
+    /// Generate an alphabetic or numeric sub-label (e.g., "a", "1") for a
+    /// reference member of a compound set.
     fn citation_sub_label_for_ref(&self, ref_id: &str) -> Option<String> {
         let compound = self
             .bibliography_config
@@ -251,6 +253,7 @@ impl<'a> Renderer<'a> {
         })
     }
 
+    /// Determine if compound subentries should be collapsed for this citation.
     fn should_collapse_compound_subentries(
         &self,
         mode: &citum_schema::citation::CitationMode,
@@ -265,6 +268,7 @@ impl<'a> Renderer<'a> {
             .is_some_and(|c| c.subentry && c.collapse_subentries)
     }
 
+    /// Determine if citation numbers should be collapsed into ranges.
     fn should_collapse_citation_numbers(
         &self,
         spec: &citum_schema::CitationSpec,
@@ -287,6 +291,7 @@ impl<'a> Renderer<'a> {
             )
     }
 
+    /// Heuristic for ensuring proper spacing after a citation prefix.
     fn normalize_prefix_spacing(prefix: &str) -> String {
         if !prefix.is_empty() && !prefix.ends_with(char::is_whitespace) {
             format!("{prefix} ")
@@ -313,6 +318,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
+    /// Apply prefix and suffix spacing heuristics to a rendered string.
     fn affix_content<F>(
         &self,
         fmt: &F,
@@ -336,6 +342,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
+    /// Pair rendered content with associated reference IDs to form a semantic chunk.
     fn build_citation_chunk<F>(
         &self,
         fmt: &F,
@@ -354,6 +361,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
+    /// Create a template render request for a single citation item.
     fn citation_render_request<'b>(
         &self,
         item: &'b crate::reference::CitationItem,
@@ -376,6 +384,7 @@ impl<'a> Renderer<'a> {
         }
     }
 
+    /// Render a single item to a formatted string using a template.
     fn render_item_from_template_with_format<F>(
         &self,
         reference: &Reference,
@@ -397,6 +406,7 @@ impl<'a> Renderer<'a> {
             })
     }
 
+    /// Initialize render options for a citation.
     fn citation_render_options<'b>(
         &'b self,
         mode: citum_schema::citation::CitationMode,
@@ -421,8 +431,7 @@ impl<'a> Renderer<'a> {
 
     /// Render author + citation number for numeric integral citations.
     ///
-    /// This is used as a default for numeric styles in narrative mode (e.g., "Smith [1]").
-    /// It renders the author's short name followed by the citation number in brackets.
+    /// Default implementation for narrative citations in numeric styles (e.g., "Smith [1]").
     fn render_author_number_for_numeric_integral_with_format<F>(
         &self,
         reference: &Reference,

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -51,6 +51,9 @@ impl Default for Processor {
 }
 
 impl Processor {
+    /// Core internal constructor path.
+    ///
+    /// Resolves the style presets before initializing the processor.
     fn build_processor(
         style: Style,
         bibliography: Bibliography,
@@ -99,6 +102,7 @@ impl Processor {
         processor
     }
 
+    /// Validate compound sets against the bibliography.
     fn try_validate_compound_sets(
         bibliography: &Bibliography,
         compound_sets: IndexMap<String, Vec<String>>,
@@ -107,6 +111,7 @@ impl Processor {
             .map(Option::unwrap_or_default)
     }
 
+    /// Validate compound sets, falling back to an empty map on error.
     fn validate_compound_sets_or_default(
         bibliography: &Bibliography,
         compound_sets: IndexMap<String, Vec<String>>,
@@ -114,6 +119,10 @@ impl Processor {
         Self::try_validate_compound_sets(bibliography, compound_sets).unwrap_or_default()
     }
 
+    /// Build flat reverse-lookup maps for compound sets.
+    ///
+    /// Maps reference IDs to their parent set ID and their 0-based position
+    /// within that set.
     fn build_compound_set_indexes(
         sets: &IndexMap<String, Vec<String>>,
     ) -> (HashMap<String, String>, HashMap<String, usize>) {
@@ -146,6 +155,7 @@ impl Processor {
             })
     }
 
+    /// Check whether the style uses numeric bibliography rendering.
     fn is_numeric_bibliography_style(&self) -> bool {
         self.get_bibliography_config()
             .processing
@@ -155,6 +165,9 @@ impl Processor {
             })
     }
 
+    /// Resolve the effective bibliography sort specification.
+    ///
+    /// Accounts for style overrides and preset defaults.
     fn resolved_bibliography_sort(&self) -> Option<citum_schema::grouping::GroupSort> {
         if let Some(sort_spec) = self
             .style
@@ -198,6 +211,7 @@ impl Processor {
         self.initialize_numeric_numbers(self.sort_bibliography_number_order());
     }
 
+    /// Initialize citation numbers if the map is currently empty.
     fn initialize_numeric_numbers(&self, ordered_ids: Vec<String>) {
         if !self.citation_numbers.borrow().is_empty() {
             return;
@@ -206,6 +220,7 @@ impl Processor {
         self.initialize_numeric_citation_numbers_from_ordered_ids(ordered_ids);
     }
 
+    /// Calculate the document-wide reference order for citation numbering.
     fn sort_citation_number_order(&self) -> Vec<String> {
         self.sort_references(self.bibliography.values().collect())
             .into_iter()
@@ -214,6 +229,7 @@ impl Processor {
             .collect()
     }
 
+    /// Calculate the reference order for bibliography numbering.
     fn sort_bibliography_number_order(&self) -> Vec<String> {
         self.sort_references(self.bibliography.values().collect())
             .into_iter()
@@ -222,7 +238,10 @@ impl Processor {
             .collect()
     }
 
-    /// Assign numeric citation numbers from a pre-resolved reference order.
+    /// Assign stable numeric labels to references based on a document order.
+    ///
+    /// Also populates compound groups for numeric styles that enable compound
+    /// numbering.
     fn initialize_numeric_citation_numbers_from_ordered_ids(&self, ordered_ids: Vec<String>) {
         let mut numbers = self.citation_numbers.borrow_mut();
         if !numbers.is_empty() {


### PR DESCRIPTION
Add /// doc comments to dozens of undocumented or under-documented internal functions, helper methods, and core orchestration loops across the processor codebase.