### PR TITLE
fix(server): enable http transport by default

### DIFF
--- a/crates/citum-server/Cargo.toml
+++ b/crates/citum-server/Cargo.toml
@@ -38,9 +38,9 @@ schemars = { version = "1.2.1", features = ["derive"], optional = true }
 tower = { version = "0.5", features = ["util"] }
 
 [features]
-default = []
-async = ["tokio"]
-http = ["async", "axum"]
+default = ["http"]
+async = ["dep:tokio"]
+http = ["async", "dep:axum"]
 schema-types = ["dep:schemars", "citum-engine/schema"]
 schema = ["http", "schema-types"]
 

--- a/crates/citum-server/README.md
+++ b/crates/citum-server/README.md
@@ -1,8 +1,8 @@
 # citum-server
 
 Long-running server process for real-time citation formatting. Wraps
-`citum-engine` behind a newline-delimited JSON-RPC interface, with an optional
-HTTP mode for web app integrations.
+`citum-engine` behind a newline-delimited JSON-RPC interface, with HTTP mode
+for web app integrations.
 
 ## Transports
 
@@ -19,13 +19,15 @@ echo '{"id":1,"method":"render_citation","params":{"style_path":"styles/embedded
 # {"id":1,"result":"(Hawking, 1988)"}
 ```
 
-### HTTP (feature-gated)
+### HTTP (default-enabled feature)
 
-Build with `--features http` to expose the same methods over HTTP via
-`axum`. Useful for the citum-hub live preview panel.
+Default builds expose the same methods over HTTP via `axum`. Useful for the
+citum-hub live preview panel. Install with
+`cargo install citum-server --no-default-features` only when you need a
+stdio-only binary.
 
 ```sh
-cargo run -p citum-server --features http -- --http --port 9000
+cargo run -p citum-server -- --http --port 9000
 ```
 
 ```sh
@@ -145,8 +147,8 @@ However, the `refs` and `citations` parameters always expect data objects, not p
 
 | Feature | Default | Description |
 |---|---|---|
-| `async` | off | Required for non-blocking I/O. Wraps `Processor` in `tokio::task::spawn_blocking` |
-| `http` | off | Enables axum HTTP server; **requires and automatically enables `async`** |
+| `async` | on | Enables the Tokio runtime dependency used by HTTP transport |
+| `http` | on | Enables axum HTTP server; **requires and automatically enables `async`** |
 | `schema` | off | Enables `/rpc/schema` endpoint; **requires and automatically enables `http` and `async`** |
 
 ## Usage
@@ -156,7 +158,11 @@ However, the `refs` and `citations` parameters always expect data objects, not p
 citum-server
 
 # HTTP mode
-cargo build --features http && citum-server --http --port 9000
+citum-server --http --port 9000
+
+# stdio-only binary
+cargo build -p citum-server --no-default-features
+cargo install citum-server --no-default-features
 
 # Options
 citum-server --help

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -13,8 +13,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //!
 //! The server supports two transport modes:
 //!
-//! - **stdio (default)**: Newline-delimited JSON-RPC on stdin/stdout. No runtime overhead.
-//! - **HTTP (optional, requires `http` feature)**: Exposes `/rpc` endpoint via axum.
+//! - **stdio (default)**: Newline-delimited JSON-RPC on stdin/stdout. No HTTP listener or Tokio runtime is created.
+//! - **HTTP (default feature)**: Exposes `/rpc` endpoint via axum.
 //!
 //! ## Example (stdio mode)
 //!
@@ -25,8 +25,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //!
 //! ## Features
 //!
-//! - `async`: Enable tokio runtime (required for HTTP)
-//! - `http`: Enable HTTP server (implies async)
+//! - `async`: Enable the Tokio runtime dependency used by HTTP transport
+//! - `http`: Enable HTTP server (implies async; enabled by default)
 
 /// Server error types and conversions.
 pub mod error;

--- a/crates/citum-server/src/main.rs
+++ b/crates/citum-server/src/main.rs
@@ -17,62 +17,70 @@ const CLAP_STYLES: Styles = Styles::styled()
     .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
     .placeholder(AnsiColor::Cyan.on_default());
 
+#[cfg(feature = "http")]
+const ABOUT: &str = "JSON-RPC and HTTP server for citation, bibliography, and document processing";
+
+#[cfg(not(feature = "http"))]
+const ABOUT: &str = "JSON-RPC server for citation, bibliography, and document processing";
+
+#[cfg(feature = "http")]
+const LONG_ABOUT: &str = "citum-server provides a programmable interface for citation
+processing.
+
+It supports both a persistent JSON-RPC mode via stdin/stdout
+and HTTP server mode for remote processing.
+
+EXAMPLES:
+  Run in default JSON-RPC mode (stdin/stdout):
+    citum-server
+
+  Run as an HTTP server on a specific port:
+    citum-server --http --port 8081";
+
+#[cfg(not(feature = "http"))]
+const LONG_ABOUT: &str = "citum-server provides a programmable interface for citation
+processing.
+
+This build supports persistent JSON-RPC mode via stdin/stdout.
+
+EXAMPLES:
+  Run in JSON-RPC mode (stdin/stdout):
+    citum-server";
+
 #[derive(Parser)]
 #[command(
     name = "citum-server",
     author,
     version,
-    about = "JSON-RPC and HTTP server for citation, bibliography, and document processing",
-    long_about = "citum-server provides a programmable interface for citation\n\
-                  processing.\n\n\
-                  It supports both a persistent JSON-RPC mode via stdin/stdout\n\
-                  and an optional HTTP server mode for remote processing.\n\n\
-                  EXAMPLES:\n  \
-                  Run in default JSON-RPC mode (stdin/stdout):\n    \
-                  citum-server\n\n  \
-                  Run as an HTTP server on a specific port:\n    \
-                  citum-server --http --port 8081",
+    about = ABOUT,
+    long_about = LONG_ABOUT,
     styles = CLAP_STYLES,
 )]
 struct Cli {
-    /// Enable HTTP server mode (requires 'http' feature)
+    /// Enable HTTP server mode (default build includes the 'http' feature)
+    #[cfg(feature = "http")]
     #[arg(long)]
     http: bool,
 
     /// HTTP port to listen on
+    #[cfg(feature = "http")]
     #[arg(short, long, default_value_t = 8080)]
     port: u16,
 }
 
-#[cfg(feature = "async")]
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cli = Cli::parse();
-
-    if cli.http {
-        #[cfg(feature = "http")]
-        {
-            http::run_http(cli.port).await
-        }
-        #[cfg(not(feature = "http"))]
-        {
-            eprintln!("Error: --http requires the 'http' feature to be enabled");
-            eprintln!("Build with: cargo build --features http");
-            std::process::exit(1);
-        }
-    } else {
-        rpc::run_stdio().map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
-    }
-}
-
-#[cfg(not(feature = "async"))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(not(feature = "http"))]
+    let _cli = Cli::parse();
+
+    #[cfg(feature = "http")]
     let cli = Cli::parse();
 
+    #[cfg(feature = "http")]
     if cli.http {
-        eprintln!("Error: --http requires the 'http' feature to be enabled");
-        eprintln!("Build with: cargo build --features http");
-        std::process::exit(1);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        return runtime.block_on(http::run_http(cli.port));
     }
 
     rpc::run_stdio().map_err(|e| Box::new(e) as Box<dyn std::error::Error>)

--- a/docs/architecture/CITUM_MODULARIZATION.md
+++ b/docs/architecture/CITUM_MODULARIZATION.md
@@ -91,7 +91,7 @@ See [CITUM_SERVER_MODE.md](./CITUM_SERVER_MODE.md) for the full server mode plan
 | `csln-edtf`      | `csln-edtf`      | Yes        | Potentially standalone         |
 | `citum_analyze`   | `citum-analyze`  | No         | Internal tooling               |
 | `csln` (bin)     | `citum`          | Yes (bin)  | CLI binary (from `citum-cli`) |
-| *(new)*          | `citum-server`   | Yes (bin)  | JSON-RPC + optional HTTP server; see [CITUM_SERVER_MODE.md](./CITUM_SERVER_MODE.md) |
+| *(new)*          | `citum-server`   | Yes (bin)  | JSON-RPC + default-enabled HTTP server; see [CITUM_SERVER_MODE.md](./CITUM_SERVER_MODE.md) |
 
 ### Target Workspace Layout
 
@@ -290,4 +290,4 @@ point a `citum/docs` repo fed by CI from `citum-core` becomes viable.
 | `csl26-p2lb` | Phase 2: Create citum/citum-labs repository        | 2      |
 | `csl26-srvr` | Phase 2: citum-server mode (epic)            | 2      |
 | `csl26-srpc` | Phase 2: Implement JSON-RPC stdin/stdout     | 2      |
-| `csl26-shtp` | Phase 2: HTTP feature (axum, feature-gated)  | 2      |
+| `csl26-shtp` | Phase 2: HTTP feature (axum, default-enabled) | 2      |

--- a/docs/architecture/CITUM_SERVER_MODE.md
+++ b/docs/architecture/CITUM_SERVER_MODE.md
@@ -30,10 +30,10 @@ The server mode is implemented as a dedicated `citum-server` binary crate in the
 
 | Component | Status | Purpose |
 |-----------|--------|---------|
-| `crates/citum-server/Cargo.toml` | DONE | Crate manifest; deps on engine + schema only; optional async/http features |
+| `crates/citum-server/Cargo.toml` | DONE | Crate manifest; deps on engine + schema only; default-enabled async/http features |
 | `crates/citum-server/src/main.rs` | DONE | Entry point; arg parsing (mode flag: `--http`, `--port`) |
 | `crates/citum-server/src/rpc.rs` | DONE | JSON-RPC stdin/stdout handler |
-| `crates/citum-server/src/http.rs` | DONE | HTTP handler (feature-gated behind `http`) |
+| `crates/citum-server/src/http.rs` | DONE | HTTP handler (behind the default-enabled `http` feature) |
 
 ---
 
@@ -136,6 +136,5 @@ different deployment targets:
 |---------------|----------------------------------------------------|-------|
 | `csl26-srvr`  | citum-server mode (epic)                           | 2     |
 | `csl26-srpc`  | Implement JSON-RPC stdin/stdout handler            | 2     |
-| `csl26-shtp`  | Implement HTTP feature (axum, feature-gated)       | 2     |
+| `csl26-shtp`  | Implement HTTP feature (axum, default-enabled)     | 2     |
 | `csl26-stat`  | Consider optional stateful mode for citum-server   | 3     |
-

--- a/docs/architecture/DESIGN_PRINCIPLES.md
+++ b/docs/architecture/DESIGN_PRINCIPLES.md
@@ -178,7 +178,7 @@ reached through several product surfaces.
 
 - **Batch and interactive modes are both first-class.** The CLI supports
   document and reference workflows; `citum-server` provides long-running
-  JSON-RPC over stdio and optional HTTP for low-latency clients.
+  JSON-RPC over stdio and default-enabled HTTP for low-latency clients.
 - **Rendering targets share semantics.** Plain text, HTML, Djot, LaTeX, and
   Typst renderers should differ in markup representation, not in citation
   logic.

--- a/docs/developer.html
+++ b/docs/developer.html
@@ -349,14 +349,16 @@ cargo build --release
                 <div class="workshop-label">Install and start</div>
                 <pre><code>cargo install citum-server
 citum-server                          # stdin/stdout JSON-RPC
-citum-server --http --port 8765       # HTTP mode (http feature)</code></pre>
+citum-server --http --port 8765       # HTTP JSON-RPC</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
                 Methods: <code>format_document</code>, <code>render_citation</code>, <code>render_bibliography</code>,
                 <code>validate_style</code>. See the
                 <a href="guides/integrations/editor-plugin.html">editor / plugin recipe</a> for a working request,
-                response, and Node client. The HTTP server is behind the <code>citum-server/http</code> feature
-                flag (axum). For the full schema, see
+                response, and Node client. The HTTP server is included in the default
+                <code>citum-server</code> build through the <code>citum-server/http</code> feature (axum);
+                use <code>cargo install citum-server --no-default-features</code> only for a stdio-only binary.
+                For the full schema, see
                 <a href="reference.html">Reference &rarr; JSON Schemas</a> or browse
                 <a href="schemas/">docs/schemas/</a> directly.
             </p>

--- a/docs/guides/integrations/editor-plugin.html
+++ b/docs/guides/integrations/editor-plugin.html
@@ -83,8 +83,10 @@
 citum-server      # reads JSON-RPC from stdin, writes responses to stdout</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                Use <code>citum-server --http --port 8765</code> to enable HTTP mode (requires the <code>http</code>
-                feature). For editor plugins, stdin/stdout is the simpler integration; it sidesteps port
+                Use <code>citum-server --http --port 8765</code> to enable HTTP mode. Default
+                <code>citum-server</code> builds include the <code>http</code> feature; use
+                <code>cargo install citum-server --no-default-features</code> only for a stdio-only binary. For editor plugins,
+                stdin/stdout is the simpler integration; it sidesteps port
                 allocation, CORS, and process discovery.
             </p>
         </section>


### PR DESCRIPTION
## Summary

- Enable `citum-server/http` by default so `cargo install citum-server` includes HTTP mode.
- Keep `--no-default-features` as the stdio-only build path.
- Run stdio mode directly; only construct a Tokio runtime when `--http` is selected.
- Hide `--http` and `--port` from stdio-only builds.
- Update server docs, architecture notes, and committed static-site HTML to match the default build behavior.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run`
- `cargo check -p citum-server --no-default-features`
- `cargo run -q -p citum-server -- --help` shows `--http` and `--port`.
- `cargo run -q -p citum-server --no-default-features -- --help` omits `--http` and `--port`.
- `cargo run -q -p citum-server --no-default-features -- --http` reports Clap’s expected unknown-argument error.
