### PR TITLE
fix(engine): add cdylib for FFI library output

### DIFF
--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [lib]
 name = "citum_engine"
-crate-type = ["rlib"]
+crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 citum-schema = { workspace = true, features = ["legacy-convert"] }


### PR DESCRIPTION
## Summary

- `crates/citum-engine/Cargo.toml` declared `crate-type = ["rlib"]` only
- `cargo build --features ffi` compiled the FFI code but produced no shared library — no `.dylib` / `.so` / `.dll` was emitted
- Adding `"cdylib"` causes Cargo to emit `libcitum_engine.{dylib,so,dll}` alongside the existing `rlib`

## Why

The `ffi` feature gate enables the `#[no_mangle]` `citum_processor_*` symbols in `crates/citum-engine/src/ffi/mod.rs`. Without `cdylib`, those symbols are compiled but never exposed as a loadable shared library. Consumers (Lua via `ffi.load`, Python via `ctypes`, etc.) need the `.dylib`/`.so` to call the C API at runtime.

## Notes

- Standard `lualatex` uses Lua 5.3, which has no LuaJIT FFI — the shared library is loaded by `luajittex` or non-TeX consumers (Python, Node.js, etc.)
- RPC mode in `citum-labs` is the LaTeX-compatible path until a `package.loadlib`-based binding is written
- Build command: `cd crates/citum-engine && cargo build --release --features ffi`

## Test plan

- [x] `cargo build --release --features ffi` produces `target/release/libcitum_engine.dylib`
- [x] `texlua` can `ffi.load` the library and call `citum_get_last_error()` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)