### PR TITLE
clarify citum-server JSON-RPC docs

### DIFF
--- a/crates/citum-server/README.md
+++ b/crates/citum-server/README.md
@@ -1,40 +1,119 @@
 # citum-server
 
-Long-running server process for real-time citation formatting. Wraps
-`citum-engine` behind a newline-delimited JSON-RPC interface, with HTTP mode
-for web app integrations.
+`citum-server` exposes Citum citation rendering through JSON-RPC. Use it when a
+client should talk to a long-running process instead of linking
+`citum-engine` directly.
 
-## Transports
+The same dispatcher is available over two transports:
 
-### stdin/stdout (default)
+- stdin/stdout: newline-delimited JSON-RPC, enabled in every build
+- HTTP: `POST /rpc`, enabled by the default `http` feature
 
-The default mode reads JSON-RPC requests from stdin and writes responses to
-stdout, one object per line. This matches the protocol used by citeproc-rs and
-works cleanly inside word-processor plugins (Zotero, Pandoc pipelines) with no
-port management.
+The document-level RPC method is `format_document`. The single-citation and
+bibliography methods are convenience methods for smaller workflows.
+
+## Run It
+
+From the workspace root:
 
 ```sh
-echo '{"id":1,"method":"render_citation","params":{"style_path":"styles/embedded/apa-7th.yaml","refs":{"hawking1988":{"id":"hawking1988","class":"monograph","type":"book","title":"A Brief History of Time","author":[{"family":"Hawking","given":"Stephen"}],"issued":"1988"}},"citation":{"id":"cite-1","items":[{"id":"hawking1988"}]}}}' \
-  | citum-server
-# {"id":1,"result":"(Hawking, 1988)"}
+cargo run -p citum-server
 ```
 
-### HTTP (default-enabled feature)
+That starts stdio mode. It reads one JSON object per line from stdin and writes
+one JSON object per line to stdout.
 
-Default builds expose the same methods over HTTP via `axum`. Useful for the
-citum-hub live preview panel. Install with
-`cargo install citum-server --no-default-features` only when you need a
-stdio-only binary.
+For HTTP mode:
 
 ```sh
 cargo run -p citum-server -- --http --port 9000
 ```
 
+The examples below assume they are run from the Citum repository root so the
+relative style path `styles/embedded/apa-7th.yaml` resolves. Outside the
+repository, replace that value with an absolute path to a Citum YAML style.
+
+## JSON-RPC Envelope
+
+Every request has this shape:
+
+```json
+{
+  "id": 1,
+  "method": "render_citation",
+  "params": {}
+}
+```
+
+Successful responses echo the request ID and include `result`:
+
+```json
+{
+  "id": 1,
+  "result": "..."
+}
+```
+
+Errors echo the request ID when available and include `error`:
+
+```json
+{
+  "id": 1,
+  "error": "missing required field: style_path"
+}
+```
+
+`refs` uses native Citum reference data. Dates are EDTF strings such as
+`"1988"`, not CSL-JSON `date-parts` objects.
+
+## Method Summary
+
+| Method | Required params | Optional params | Result |
+|---|---|---|---|
+| `render_citation` | `style_path`, `refs`, `citation` | `output_format`, `inject_ast_indices` | rendered citation string |
+| `render_bibliography` | `style_path`, `refs` | `output_format`, `inject_ast_indices` | `{format, content, entries}` |
+| `validate_style` | `style_path` | none | `{valid, warnings}` |
+| `format_document` | `style`, `refs`, `citations` | `output_format`, `locale`, `document_options` | `{formatted_citations, bibliography, warnings}` |
+
+Supported `output_format` values are `plain` (default), `html`, `djot`,
+`latex`, and `typst`.
+
+`render_citation`, `render_bibliography`, and `validate_style` use
+`style_path`, a string path to a local Citum YAML style. `format_document` uses
+the richer `style` object:
+
+```json
+{ "kind": "path", "value": "styles/embedded/apa-7th.yaml" }
+```
+
+Other `style.kind` values are `id`, `uri`, and `yaml`.
+
+## Stdio Example: `render_citation`
+
+The stdio transport expects each request on a single line:
+
+```sh
+printf '%s\n' '{"id":1,"method":"render_citation","params":{"style_path":"styles/embedded/apa-7th.yaml","refs":{"hawking1988":{"id":"hawking1988","class":"monograph","type":"book","title":"A Brief History of Time","author":[{"family":"Hawking","given":"Stephen"}],"issued":"1988"}},"citation":{"id":"cite-1","items":[{"id":"hawking1988"}]}}}' \
+  | cargo run -q -p citum-server
+```
+
+The response is a JSON object whose `result` is the rendered citation string.
+
+## HTTP Example: `render_bibliography`
+
+Start the server in another terminal:
+
+```sh
+cargo run -q -p citum-server -- --http --port 9000
+```
+
+Then send a request:
+
 ```sh
 curl -s http://localhost:9000/rpc \
   -H 'Content-Type: application/json' \
   -d '{
-    "id": 1,
+    "id": 2,
     "method": "render_bibliography",
     "params": {
       "style_path": "styles/embedded/apa-7th.yaml",
@@ -45,85 +124,132 @@ curl -s http://localhost:9000/rpc \
           "class": "monograph",
           "type": "book",
           "title": "A Brief History of Time",
-          "author": [{"family": "Hawking", "given": "Stephen"}],
+          "author": [{ "family": "Hawking", "given": "Stephen" }],
           "issued": "1988"
         }
       }
     }
   }'
-# {"id":1,"result":{"format":"html","content":"<div class=\"csln-bibliography\">...","entries":null}}
 ```
 
-> **Note:** `refs` uses native Citum schema format. `issued` is an EDTF string
-> (`"1988"`), not a CSL-JSON `{"date-parts": [[1988]]}` object.
+The response `result` contains:
 
-## Performance
+- `format`: the selected output format
+- `content`: the rendered bibliography
+- `entries`: optional plain-text entry strings when the renderer supplies them
 
-A simulation script is available to benchmark the server under a simulated word processor workflow (large bibliography, sequential citation insertion, and periodic bibliography refreshes).
+## Full Document Example: `format_document`
+
+Use `format_document` when the client has the whole document citation order.
+This is the preferred editor and word-processor integration method because it
+lets the engine render document-sensitive citation state and bibliography output
+in one call.
+
+### HTTP `format_document`
+
+Use this form when the server is running with `--http`:
 
 ```sh
-# Ensure the server is built in release mode first
-cargo build --release -p citum-server
-
-# Run the simulation
-node scripts/benchmark-rpc-workflow.js
+curl -s http://localhost:9000/rpc \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": 3,
+    "method": "format_document",
+    "params": {
+      "style": { "kind": "path", "value": "styles/embedded/apa-7th.yaml" },
+      "output_format": "html",
+      "refs": {
+        "smith2010": {
+          "id": "smith2010",
+          "class": "monograph",
+          "type": "book",
+          "title": "Nationalism: Theory, Ideology, History",
+          "author": [{ "family": "Smith", "given": "Anthony D." }],
+          "issued": "2010",
+          "publisher": { "name": "Polity" }
+        }
+      },
+      "citations": [
+        {
+          "id": "cite-1",
+          "items": [
+            {
+              "id": "smith2010",
+              "locator": { "label": "page", "value": "10" }
+            }
+          ]
+        }
+      ],
+      "document_options": {
+        "show_semantics": true
+      }
+    }
+  }'
 ```
 
-## Methods
+### Stdio JSON-RPC `format_document`
 
-| Method | Params | Result |
-|---|---|---|
-| `render_citation` | `style_path`, `refs`, `citation`, `output_format?`, `inject_ast_indices?` | `String` |
-| `render_bibliography` | `style_path`, `refs`, `output_format?`, `inject_ast_indices?` | `{format, content, entries?}` |
-| `validate_style` | `style_path` | `{valid, warnings}` |
-| `format_document` | `style`, `refs`, `citations`, `document_options?`, `output_format?`, `locale?` | `{formatted_citations, bibliography, warnings}` |
+Use this form when the server is running in its default stdin/stdout mode. The
+request must be one JSON object on one line:
 
-Supported `output_format` values:
+```sh
+printf '%s\n' '{"id":3,"method":"format_document","params":{"style":{"kind":"path","value":"styles/embedded/apa-7th.yaml"},"output_format":"html","refs":{"smith2010":{"id":"smith2010","class":"monograph","type":"book","title":"Nationalism: Theory, Ideology, History","author":[{"family":"Smith","given":"Anthony D."}],"issued":"2010","publisher":{"name":"Polity"}}},"citations":[{"id":"cite-1","items":[{"id":"smith2010","locator":{"label":"page","value":"10"}}]}],"document_options":{"show_semantics":true}}}' \
+  | cargo run -q -p citum-server
+```
 
-- `plain` (default)
-- `html`
-- `djot`
-- `latex`
-- `typst`
-
-**Debug Parameters:** The `inject_ast_indices` parameter (optional, default `false`) is accepted by `render_citation` and `render_bibliography` for debug use. When enabled, AST node indices are embedded in the output.
-
-### Request / response envelope
+The response `result` has the same top-level shape over HTTP and stdio:
 
 ```json
-{"id": 1, "method": "render_citation", "params": {"style_path": "styles/embedded/apa-7th.yaml", "refs": [...], "citation": {...}, "output_format": "html"}}
-{"id": 1, "result": "Smith (2024)"}
-
-{"id": 2, "error": "style not found: missing.yaml"}
+{
+  "id": 3,
+  "result": {
+    "formatted_citations": [
+      {
+        "id": "cite-1",
+        "text": "(<span class=\"citum-citation\" data-ref=\"smith2010\">Smith, <span class=\"citum-issued\">2010</span>, <span class=\"citum-variable\">p. 10</span></span>)",
+        "ref_ids": ["smith2010"]
+      }
+    ],
+    "bibliography": {
+      "format": "html",
+      "content": "<div class=\"citum-bibliography\">...</div>",
+      "entries": [
+        {
+          "id": "smith2010",
+          "text": "<div class=\"citum-bibliography\">...</div>",
+          "metadata": {
+            "author": "Smith",
+            "year": "2010",
+            "title": "Nationalism: Theory, Ideology, History"
+          }
+        }
+      ]
+    },
+    "warnings": []
+  }
+}
 ```
 
-## Discovery
+Clients should read bibliography output from `result.bibliography`, not from
+`result.formatted_citations`.
 
-When running in HTTP mode, two read-only discovery endpoints are available:
+## Loading Local Files
 
-```sh
-# List all supported methods
-curl http://localhost:9000/rpc/methods
+The server resolves local style paths because style loading is part of its job.
+Reference and citation data must be sent as JSON values in `params`; they are
+not loaded from paths by the server.
 
-# JSON Schema for method parameters (requires --features schema build)
-curl http://localhost:9000/rpc/schema
-```
-
-Sending a `GET` request to `/rpc` returns a `405 Method Not Allowed` response with a JSON hint explaining POST usage.
-
-## Batch Document Formatting
-
-The `format_document` method is designed for processing a full document in one request. For practical workflows where data is stored in local files, you can use `jq` to assemble the JSON-RPC payload.
+If your client stores references and citations in local files, assemble the
+HTTP request body on the client side before posting it to `/rpc`:
 
 ```sh
-# Assemble and send a document formatting request using local JSON files
 jq -n \
   --arg style_path "styles/embedded/apa-7th.yaml" \
   --slurpfile refs examples/document-refs-native.json \
   --slurpfile citations examples/document-citations.json \
   --slurpfile options examples/document-options.json \
   '{
-    id: 1,
+    id: 4,
     method: "format_document",
     params: {
       style: { kind: "path", value: $style_path },
@@ -137,39 +263,54 @@ jq -n \
     -d @-
 ```
 
-## Working with Local Files
+Those example files exist at the workspace-level `examples/` directory.
 
-When running `citum-server` locally, the `style_path` (or `style`) parameter accepts relative or absolute paths to Citum YAML files.
+## Discovery
 
-However, the `refs` and `citations` parameters always expect data objects, not paths. This allows the server to remain transport-agnostic and simplifies its security model (preventing arbitrary file reads by the server process). To use local files for these parameters, load them into the request payload on the client side as shown in the example above.
+HTTP mode exposes read-only discovery endpoints:
+
+```sh
+curl http://localhost:9000/rpc/methods
+```
+
+`GET /rpc/methods` returns supported methods, required fields, and optional
+fields.
+
+```sh
+curl http://localhost:9000/rpc/schema
+```
+
+`GET /rpc/schema` returns JSON Schemas for method parameters when the binary is
+built with the `schema` feature. Sending `GET /rpc` returns `405 Method Not
+Allowed` with a JSON hint explaining that `/rpc` expects `POST`.
 
 ## Features
 
 | Feature | Default | Description |
 |---|---|---|
-| `async` | on | Enables the Tokio runtime dependency used by HTTP transport |
-| `http` | on | Enables axum HTTP server; **requires and automatically enables `async`** |
-| `schema` | off | Enables `/rpc/schema` endpoint; **requires and automatically enables `http` and `async`** |
+| `async` | on through `http` | Enables the Tokio runtime dependency used by HTTP transport |
+| `http` | on | Enables the axum HTTP server and implies `async` |
+| `schema` | off | Enables `/rpc/schema` and implies `http` plus schema type support |
+| `schema-types` | off | Enables schema derivations without the HTTP schema endpoint |
 
-## Usage
+Build a stdio-only binary with:
 
 ```sh
-# stdio mode (default)
-citum-server
-
-# HTTP mode
-citum-server --http --port 9000
-
-# stdio-only binary
 cargo build -p citum-server --no-default-features
 cargo install citum-server --no-default-features
+```
 
-# Options
-citum-server --help
-citum-server --version
+## Performance
+
+A simulation script benchmarks a server-backed word-processor workflow:
+
+```sh
+cargo build --release -p citum-server
+node scripts/benchmark-rpc-workflow.js
 ```
 
 ## Dependencies
 
-Depends on `citum-engine`, `citum-schema`, and `citum_store` for the standard
-resolver chain. No migrate crate is pulled in.
+`citum-server` depends on `citum-engine`, `citum-schema`, and `citum_store` for
+rendering and the standard resolver chain. It does not depend on
+`citum-migrate`.

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -71,7 +71,7 @@ async fn rpc_methods() -> impl IntoResponse {
             "method": "format_document",
             "description": "Format all citations and bibliography in a document.",
             "required": ["style", "refs", "citations"],
-            "optional": ["output_format"]
+            "optional": ["output_format", "locale", "document_options"]
         }
     ]))
 }
@@ -364,5 +364,16 @@ mod tests {
         assert!(methods.contains(&"render_bibliography"));
         assert!(methods.contains(&"validate_style"));
         assert!(methods.contains(&"format_document"));
+
+        let format_document = body
+            .as_array()
+            .expect("should be array")
+            .iter()
+            .find(|method| method["method"] == "format_document")
+            .expect("format_document descriptor should exist");
+        assert_eq!(
+            format_document["optional"],
+            serde_json::json!(["output_format", "locale", "document_options"])
+        );
     }
 }

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -3,30 +3,111 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-//! Citum JSON-RPC Server
+//! JSON-RPC server for Citum citation rendering.
 //!
-//! This crate provides a JSON-RPC server for citation and bibliography processing.
-//! It wraps the `citum-engine` functionality in a request-response protocol suitable
-//! for use with word processors, web applications, and other clients.
+//! `citum-server` wraps `citum-engine` in a process boundary for clients that
+//! should not link the Rust engine directly. It supports lightweight
+//! single-citation workflows and full-document rendering through the
+//! `format_document` RPC method.
 //!
-//! ## Modes
+//! ## Transports
 //!
-//! The server supports two transport modes:
+//! - **stdio**: newline-delimited JSON-RPC on stdin/stdout. This transport is
+//!   available in every build and is the default runtime mode.
+//! - **HTTP**: `POST /rpc` using axum. This transport is enabled by the default
+//!   `http` feature and is selected with `citum-server --http`.
 //!
-//! - **stdio (default)**: Newline-delimited JSON-RPC on stdin/stdout. No HTTP listener or Tokio runtime is created.
-//! - **HTTP (default feature)**: Exposes `/rpc` endpoint via axum.
+//! ## JSON-RPC envelope
 //!
-//! ## Example (stdio mode)
+//! Requests use `{ "id", "method", "params" }`. Successful responses echo the
+//! request ID and include `result`; failures echo the request ID when available
+//! and include `error`.
 //!
-//! ```bash
-//! echo '{"id": 1, "method": "validate_style", "params": {"style_path": "path/to/style.yaml"}}' \
-//!   | citum-server
+//! ## Methods
+//!
+//! | Method | Required params | Optional params | Result |
+//! |---|---|---|---|
+//! | `render_citation` | `style_path`, `refs`, `citation` | `output_format`, `inject_ast_indices` | rendered citation string |
+//! | `render_bibliography` | `style_path`, `refs` | `output_format`, `inject_ast_indices` | rendered bibliography object |
+//! | `validate_style` | `style_path` | none | validation object |
+//! | `format_document` | `style`, `refs`, `citations` | `output_format`, `locale`, `document_options` | `{formatted_citations, bibliography, warnings}` |
+//!
+//! `refs` uses native Citum reference data. Dates are EDTF strings such as
+//! `"1988"`, not CSL-JSON `date-parts` objects.
+//!
+//! `render_citation`, `render_bibliography`, and `validate_style` accept
+//! `style_path`, a string path to a local Citum YAML style. `format_document`
+//! accepts the richer `style` object, for example
+//! `{ "kind": "path", "value": "styles/embedded/apa-7th.yaml" }`.
+//!
+//! ## `format_document` result
+//!
+//! `format_document` returns one document-level result object with three
+//! top-level fields:
+//!
+//! - `formatted_citations`: one rendered citation object per input citation.
+//! - `bibliography`: the rendered bibliography object, including `format`,
+//!   `content`, and `entries`.
+//! - `warnings`: non-fatal diagnostics produced while evaluating the style.
+//!
+//! Clients should read bibliography output from `result.bibliography`, not from
+//! `result.formatted_citations`.
+//!
+//! ## Stdio example
+//!
+//! From the Citum repository root:
+//!
+//! ```text
+//! printf '%s\n' '{"id":1,"method":"render_citation","params":{"style_path":"styles/embedded/apa-7th.yaml","refs":{"hawking1988":{"id":"hawking1988","class":"monograph","type":"book","title":"A Brief History of Time","author":[{"family":"Hawking","given":"Stephen"}],"issued":"1988"}},"citation":{"id":"cite-1","items":[{"id":"hawking1988"}]}}}' \
+//!   | cargo run -q -p citum-server
+//! ```
+//!
+//! ## HTTP example
+//!
+//! Start the server:
+//!
+//! ```text
+//! cargo run -q -p citum-server -- --http --port 9000
+//! ```
+//!
+//! Then send a request:
+//!
+//! ```text
+//! curl -s http://localhost:9000/rpc \
+//!   -H 'Content-Type: application/json' \
+//!   -d '{"id":2,"method":"format_document","params":{"style":{"kind":"path","value":"styles/embedded/apa-7th.yaml"},"output_format":"html","refs":{"smith2010":{"id":"smith2010","class":"monograph","type":"book","title":"Nationalism: Theory, Ideology, History","author":[{"family":"Smith","given":"Anthony D."}],"issued":"2010","publisher":{"name":"Polity"}}},"citations":[{"id":"cite-1","items":[{"id":"smith2010","locator":{"label":"page","value":"10"}}]}],"document_options":{"show_semantics":true}}}'
+//! ```
+//!
+//! `format_document` returns a document-level result object. Read formatted
+//! citations from `result.formatted_citations`, bibliography output from
+//! `result.bibliography`, and diagnostics from `result.warnings`.
+//!
+//! ```json
+//! {
+//!   "id": 2,
+//!   "result": {
+//!     "formatted_citations": [
+//!       { "id": "cite-1", "text": "...", "ref_ids": ["smith2010"] }
+//!     ],
+//!     "bibliography": {
+//!       "format": "html",
+//!       "content": "<div class=\"citum-bibliography\">...</div>",
+//!       "entries": [
+//!         { "id": "smith2010", "text": "...", "metadata": { "author": "Smith", "year": "2010", "title": "Nationalism: Theory, Ideology, History" } }
+//!       ]
+//!     },
+//!     "warnings": []
+//!   }
+//! }
 //! ```
 //!
 //! ## Features
 //!
-//! - `async`: Enable the Tokio runtime dependency used by HTTP transport
-//! - `http`: Enable HTTP server (implies async; enabled by default)
+//! - `async`: enable the Tokio runtime dependency used by HTTP transport.
+//! - `http`: enable the axum HTTP server; implies `async` and is enabled by
+//!   default.
+//! - `schema`: enable the `/rpc/schema` endpoint and schema derivations.
+//! - `schema-types`: enable schema derivations without the HTTP schema endpoint.
 
 /// Server error types and conversions.
 pub mod error;

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -19,7 +19,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! Integration tests for the JSON-RPC dispatcher.
 //!
 //! Uses a real Citum style (apa-7th.yaml) and minimal inline reference data
-//! to exercise all three methods without touching stdin/stdout.
+//! to exercise all four methods without touching stdin/stdout.
 
 use citum_server::rpc::{RpcRequest, dispatch};
 use serde_json::json;
@@ -256,6 +256,70 @@ fn render_citation_typst_returns_internal_link_markup() {
         citation.contains("#link(<ref-ITEM-2>)"),
         "typst citation should contain an internal link: {citation}"
     );
+}
+
+// --- format_document ---
+
+#[test]
+fn format_document_returns_citations_bibliography_and_warnings() {
+    let req = make_request(
+        15,
+        "format_document",
+        json!({
+            "style": {
+                "kind": "path",
+                "value": apa_style_path()
+            },
+            "output_format": "html",
+            "refs": hawking_refs(),
+            "citations": [{
+                "id": "cite-1",
+                "items": [{"id": "ITEM-2"}]
+            }],
+            "document_options": {
+                "show_semantics": true
+            }
+        }),
+    );
+
+    let result = dispatch(req).expect("dispatch should succeed");
+    assert_eq!(result["id"], 15);
+
+    let payload = &result["result"];
+    assert!(
+        payload["formatted_citations"].is_array(),
+        "document result should include formatted_citations: {payload}"
+    );
+    assert!(
+        payload["bibliography"].is_object(),
+        "document result should include bibliography: {payload}"
+    );
+    assert!(
+        payload["warnings"].is_array(),
+        "document result should include warnings: {payload}"
+    );
+
+    let formatted_citations = payload["formatted_citations"]
+        .as_array()
+        .expect("formatted_citations should be an array");
+    assert_eq!(formatted_citations.len(), 1);
+    assert_eq!(formatted_citations[0]["id"], "cite-1");
+
+    let bibliography = &payload["bibliography"];
+    assert_eq!(bibliography["format"], "html");
+    let content = bibliography["content"]
+        .as_str()
+        .expect("bibliography.content should be a string");
+    assert!(
+        content.contains(r#"<div class="citum-bibliography">"#),
+        "bibliography.content should contain rendered bibliography markup: {content}"
+    );
+
+    let entries = bibliography["entries"]
+        .as_array()
+        .expect("bibliography.entries should be an array");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["id"], "ITEM-2");
 }
 
 // --- error handling ---

--- a/docs/guides/integrations/editor-plugin.html
+++ b/docs/guides/integrations/editor-plugin.html
@@ -99,7 +99,8 @@ citum-server      # reads JSON-RPC from stdin, writes responses to stdout</code>
                     <code>{ "id", "method", "params" }</code>; responses echo the <code>id</code> and carry either
                     <code>result</code> or <code>error</code>. The most useful method for editor integration is
                     <code>format_document</code>, which renders an entire document's citations and bibliography in
-                    one round-trip.
+                    one round-trip. This example uses the embedded APA 7th style id, so it does not depend on the
+                    client's working directory.
                 </p>
             </div>
             <div class="workshop-block">
@@ -128,7 +129,10 @@ citum-server      # reads JSON-RPC from stdin, writes responses to stdout</code>
           { "id": "smith2010", "locator": { "label": "page", "value": "10" } }
         ]
       }
-    ]
+    ],
+    "document_options": {
+      "show_semantics": true
+    }
   }
 }</code></pre>
             </div>
@@ -150,8 +154,8 @@ citum-server      # reads JSON-RPC from stdin, writes responses to stdout</code>
 }</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                <code>style</code> is a tagged union: <code>{"kind":"id","value":"apa-7th"}</code> for a registry
-                id, <code>{"kind":"path","value":"/abs/style.yaml"}</code> for a local file,
+                <code>style</code> is a tagged union: <code>{"kind":"id","value":"apa-7th"}</code> for an
+                embedded or installed style id, <code>{"kind":"path","value":"/abs/style.yaml"}</code> for a local file,
                 <code>{"kind":"yaml","value":"..."}</code> for inline YAML, or
                 <code>{"kind":"uri","value":"https://..."}</code> for a remote URL.
                 Reference objects use the native Citum schema with a <code>class</code> discriminator. To send

--- a/docs/guides/integrations/fixtures/format-document-request.json
+++ b/docs/guides/integrations/fixtures/format-document-request.json
@@ -22,6 +22,9 @@
           { "id": "smith2010", "locator": { "label": "page", "value": "10" } }
         ]
       }
-    ]
+    ],
+    "document_options": {
+      "show_semantics": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Rewrite the citum-server README around stdio, HTTP, and full-document format_document workflows.
- Expand docs.rs crate-level rustdoc with the same JSON-RPC contract, method table, and runnable examples.
- Align /rpc/methods metadata with format_document optional fields and sync the duplicated editor-plugin fixture.

## Why

The previous crate docs made the server surface difficult to use directly. Some examples were transport-ambiguous or not copy-paste runnable, and /rpc/methods omitted format_document optional fields that are accepted by the actual parameter type.

## Validation

- cargo fmt --check
- cargo test -p citum-server --test rpc
- manual stdio render_citation example
- manual HTTP render_bibliography example
- manual HTTP and stdio format_document examples
- manual /rpc/methods check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo nextest run: 1351 passed, 0 skipped

The pre-push hook reran the Rust gate successfully before pushing the branch.