### PR TITLE
docs(server): refine docs.rs module pages

### DIFF
--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -3,6 +3,11 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
+//! Entry point for the `citum` command-line interface.
+//!
+//! This binary wires the top-level CLI commands and delegates their work to
+//! the library crates.
+
 #![allow(missing_docs, reason = "bin")]
 
 mod args;

--- a/crates/citum-cli/src/typst_pdf.rs
+++ b/crates/citum-cli/src/typst_pdf.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 ///
 /// Returns an error in the v1 published build: bundled PDF compilation
 /// requires the `citum-pdf` crate, which is not yet on crates.io. Users
-/// can install Typst separately (https://typst.app/docs/) and run
+/// can install Typst separately (<https://typst.app/docs/>) and run
 /// `typst compile <source.typ>` on the output of
 /// `citum render doc … -f typst`.
 pub fn compile_document_to_pdf(

--- a/crates/citum-migrate/src/bin/migrate_all.rs
+++ b/crates/citum-migrate/src/bin/migrate_all.rs
@@ -3,6 +3,8 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
+//! Bulk migration tool for converting legacy CSL styles into Citum YAML.
+
 #![allow(missing_docs, reason = "bin")]
 
 use citum_migrate::{MacroInliner, Upsampler};

--- a/crates/citum-migrate/src/bin/update_style_info.rs
+++ b/crates/citum-migrate/src/bin/update_style_info.rs
@@ -3,6 +3,8 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
+//! Bulk maintenance tool for refreshing migrated style metadata.
+
 #![allow(missing_docs, reason = "bin")]
 
 use citum_migrate::InfoExtractor;

--- a/crates/citum-schema-data/src/reference/conversion/mod.rs
+++ b/crates/citum-schema-data/src/reference/conversion/mod.rs
@@ -9,12 +9,12 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! impl dispatches by `ref_type` to a per-category converter in one of the
 //! submodules:
 //!
-//! - [`legal`] — `legal-case`, `statute`, `regulation`, `treaty`, `standard`,
+//! - `legal` — `legal-case`, `statute`, `regulation`, `treaty`, `standard`,
 //!   `patent`, `bill`, `hearing`
-//! - [`scholarly`] — `book`, `chapter`, `article-journal`, `article`,
+//! - `scholarly` — `book`, `chapter`, `article-journal`, `article`,
 //!   `paper-conference`, `dataset`, `event`, etc.; plus the standalone
 //!   `input_reference_from_legacy_edited_book` re-exported below
-//! - [`media`] — `software`, `motion_picture`, `song`
+//! - `media` — `software`, `motion_picture`, `song`
 //!
 //! Shared helpers (`legacy_*`, `relation_*`, `build_title`, …) and the
 //! `RefContext` struct that bundles the fields every converter pre-extracts

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -3,6 +3,31 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
+//! Optional HTTP transport for the JSON-RPC server.
+//!
+//! The HTTP server exposes `POST /rpc` for JSON-RPC requests, `GET /rpc` as a
+//! method hint, and `GET /rpc/methods` as a static descriptor list. When the
+//! `schema` feature is enabled, `GET /rpc/schema` also exposes the schema
+//! mirror used by the HTTP API.
+//!
+//! Responses follow the same JSON-RPC shape as the stdio transport, including
+//! the document-level `format_document` result with `formatted_citations`,
+//! `bibliography`, and `warnings`.
+//!
+//! The server binds to `127.0.0.1` and is intended for local use. If you need
+//! to expose it beyond the local machine, put it behind authentication and
+//! transport security.
+//!
+//! ## Example
+//!
+//! ```text
+//! cargo run -q -p citum-server -- --http --port 9000
+//!
+//! curl -s http://localhost:9000/rpc \
+//!   -H 'Content-Type: application/json' \
+//!   -d '{"id":2,"method":"format_document","params":{"style":{"kind":"path","value":"styles/embedded/apa-7th.yaml"},"output_format":"html","refs":{"smith2010":{"id":"smith2010","class":"monograph","type":"book","title":"Nationalism: Theory, Ideology, History","author":[{"family":"Smith","given":"Anthony D."}],"issued":"2010","publisher":{"name":"Polity"}}},"citations":[{"id":"cite-1","items":[{"id":"smith2010","locator":{"label":"page","value":"10"}}]}],"document_options":{"show_semantics":true}}}'
+//! ```
+
 use crate::rpc::{RpcRequest, dispatch};
 use axum::{
     Json, Router,

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -3,7 +3,9 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-//! Optional HTTP transport for the JSON-RPC server.
+//! Default HTTP transport for the JSON-RPC server.
+//!
+//! This module is compiled when the default-on `http` feature is enabled.
 //!
 //! The HTTP server exposes `POST /rpc` for JSON-RPC requests, `GET /rpc` as a
 //! method hint, and `GET /rpc/methods` as a static descriptor list. When the

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -7,19 +7,32 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //!
 //! `citum-server` runs `citum-engine` behind a process boundary for clients
 //! that need a standalone renderer instead of linking the engine directly.
-//! The crate supports stdio JSON-RPC in every build and an optional axum HTTP
-//! transport behind the `http` feature. Both transports expose the same
+//! The crate supports stdio JSON-RPC in every build and an axum HTTP transport
+//! through the default-on `http` feature. Both transports expose the same
 //! JSON-RPC method surface; only the framing changes.
 //!
-//! See [`rpc`] for the request envelope, method surface, and stdio transport
-//! details.
-#![cfg_attr(
-    feature = "http",
-    doc = "See [`http`] for the feature-gated HTTP transport."
-)]
+//! ## Methods
+//!
+//! | Method | Required params | Optional params | Result |
+//! |---|---|---|---|
+//! | `render_citation` | `style_path`, `refs`, `citation` | `output_format`, `inject_ast_indices` | rendered citation string |
+//! | `render_bibliography` | `style_path`, `refs` | `output_format`, `inject_ast_indices` | rendered bibliography object |
+//! | `validate_style` | `style_path` | none | validation object |
+//! | `format_document` | `style`, `refs`, `citations` | `output_format`, `locale`, `document_options` | `{formatted_citations, bibliography, warnings}` |
+//!
+//! `refs` uses native Citum reference data. Dates are EDTF strings such as
+//! `"1988"`, not CSL-JSON `date-parts` objects.
+//!
+//! `render_citation`, `render_bibliography`, and `validate_style` accept
+//! `style_path`, a string path to a local Citum YAML style. `format_document`
+//! accepts the richer `style` object, for example
+//! `{ "kind": "path", "value": "styles/embedded/apa-7th.yaml" }`.
+//!
+//! See [`rpc`] for the request envelope and stdio transport details.
+#![cfg_attr(feature = "http", doc = "See [`http`] for the default HTTP transport.")]
 #![cfg_attr(
     not(feature = "http"),
-    doc = "The `http` module documents the optional HTTP transport when the feature is enabled."
+    doc = "The HTTP transport is unavailable in this build because the `http` feature is disabled."
 )]
 //!
 //! ## Features
@@ -35,7 +48,7 @@ pub mod error;
 pub mod rpc;
 
 #[cfg(feature = "http")]
-/// Optional HTTP transport built on axum.
+/// Default HTTP transport built on axum.
 pub mod http;
 
 pub use error::ServerError;

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -3,111 +3,30 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-//! JSON-RPC server for Citum citation rendering.
+//! Citum JSON-RPC server.
 //!
-//! `citum-server` wraps `citum-engine` in a process boundary for clients that
-//! should not link the Rust engine directly. It supports lightweight
-//! single-citation workflows and full-document rendering through the
-//! `format_document` RPC method.
+//! `citum-server` runs `citum-engine` behind a process boundary for clients
+//! that need a standalone renderer instead of linking the engine directly.
+//! The crate supports stdio JSON-RPC in every build and an optional axum HTTP
+//! transport behind the `http` feature.
 //!
-//! ## Transports
-//!
-//! - **stdio**: newline-delimited JSON-RPC on stdin/stdout. This transport is
-//!   available in every build and is the default runtime mode.
-//! - **HTTP**: `POST /rpc` using axum. This transport is enabled by the default
-//!   `http` feature and is selected with `citum-server --http`.
-//!
-//! ## JSON-RPC envelope
-//!
-//! Requests use `{ "id", "method", "params" }`. Successful responses echo the
-//! request ID and include `result`; failures echo the request ID when available
-//! and include `error`.
-//!
-//! ## Methods
-//!
-//! | Method | Required params | Optional params | Result |
-//! |---|---|---|---|
-//! | `render_citation` | `style_path`, `refs`, `citation` | `output_format`, `inject_ast_indices` | rendered citation string |
-//! | `render_bibliography` | `style_path`, `refs` | `output_format`, `inject_ast_indices` | rendered bibliography object |
-//! | `validate_style` | `style_path` | none | validation object |
-//! | `format_document` | `style`, `refs`, `citations` | `output_format`, `locale`, `document_options` | `{formatted_citations, bibliography, warnings}` |
-//!
-//! `refs` uses native Citum reference data. Dates are EDTF strings such as
-//! `"1988"`, not CSL-JSON `date-parts` objects.
-//!
-//! `render_citation`, `render_bibliography`, and `validate_style` accept
-//! `style_path`, a string path to a local Citum YAML style. `format_document`
-//! accepts the richer `style` object, for example
-//! `{ "kind": "path", "value": "styles/embedded/apa-7th.yaml" }`.
-//!
-//! ## `format_document` result
-//!
-//! `format_document` returns one document-level result object with three
-//! top-level fields:
-//!
-//! - `formatted_citations`: one rendered citation object per input citation.
-//! - `bibliography`: the rendered bibliography object, including `format`,
-//!   `content`, and `entries`.
-//! - `warnings`: non-fatal diagnostics produced while evaluating the style.
-//!
-//! Clients should read bibliography output from `result.bibliography`, not from
-//! `result.formatted_citations`.
-//!
-//! ## Stdio example
-//!
-//! From the Citum repository root:
-//!
-//! ```text
-//! printf '%s\n' '{"id":1,"method":"render_citation","params":{"style_path":"styles/embedded/apa-7th.yaml","refs":{"hawking1988":{"id":"hawking1988","class":"monograph","type":"book","title":"A Brief History of Time","author":[{"family":"Hawking","given":"Stephen"}],"issued":"1988"}},"citation":{"id":"cite-1","items":[{"id":"hawking1988"}]}}}' \
-//!   | cargo run -q -p citum-server
-//! ```
-//!
-//! ## HTTP example
-//!
-//! Start the server:
-//!
-//! ```text
-//! cargo run -q -p citum-server -- --http --port 9000
-//! ```
-//!
-//! Then send a request:
-//!
-//! ```text
-//! curl -s http://localhost:9000/rpc \
-//!   -H 'Content-Type: application/json' \
-//!   -d '{"id":2,"method":"format_document","params":{"style":{"kind":"path","value":"styles/embedded/apa-7th.yaml"},"output_format":"html","refs":{"smith2010":{"id":"smith2010","class":"monograph","type":"book","title":"Nationalism: Theory, Ideology, History","author":[{"family":"Smith","given":"Anthony D."}],"issued":"2010","publisher":{"name":"Polity"}}},"citations":[{"id":"cite-1","items":[{"id":"smith2010","locator":{"label":"page","value":"10"}}]}],"document_options":{"show_semantics":true}}}'
-//! ```
-//!
-//! `format_document` returns a document-level result object. Read formatted
-//! citations from `result.formatted_citations`, bibliography output from
-//! `result.bibliography`, and diagnostics from `result.warnings`.
-//!
-//! ```json
-//! {
-//!   "id": 2,
-//!   "result": {
-//!     "formatted_citations": [
-//!       { "id": "cite-1", "text": "...", "ref_ids": ["smith2010"] }
-//!     ],
-//!     "bibliography": {
-//!       "format": "html",
-//!       "content": "<div class=\"citum-bibliography\">...</div>",
-//!       "entries": [
-//!         { "id": "smith2010", "text": "...", "metadata": { "author": "Smith", "year": "2010", "title": "Nationalism: Theory, Ideology, History" } }
-//!       ]
-//!     },
-//!     "warnings": []
-//!   }
-//! }
-//! ```
+//! See [`rpc`] for the request envelope, method surface, and stdio transport
+//! details.
+#![cfg_attr(
+    feature = "http",
+    doc = "See [`http`] for the feature-gated HTTP transport."
+)]
+#![cfg_attr(
+    not(feature = "http"),
+    doc = "The `http` module documents the optional HTTP transport when the feature is enabled."
+)]
 //!
 //! ## Features
 //!
-//! - `async`: enable the Tokio runtime dependency used by HTTP transport.
-//! - `http`: enable the axum HTTP server; implies `async` and is enabled by
-//!   default.
-//! - `schema`: enable the `/rpc/schema` endpoint and schema derivations.
-//! - `schema-types`: enable schema derivations without the HTTP schema endpoint.
+//! - `async`: Tokio runtime support used by HTTP transport.
+//! - `http`: axum HTTP transport; enabled by default and implies `async`.
+//! - `schema`: `/rpc/schema` plus schema derivations.
+//! - `schema-types`: schema derivations without the HTTP schema endpoint.
 
 /// Server error types and conversions.
 pub mod error;

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -8,7 +8,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! `citum-server` runs `citum-engine` behind a process boundary for clients
 //! that need a standalone renderer instead of linking the engine directly.
 //! The crate supports stdio JSON-RPC in every build and an optional axum HTTP
-//! transport behind the `http` feature.
+//! transport behind the `http` feature. Both transports expose the same
+//! JSON-RPC method surface; only the framing changes.
 //!
 //! See [`rpc`] for the request envelope, method surface, and stdio transport
 //! details.

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -3,6 +3,57 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
+//! JSON-RPC request handling for the stdio transport.
+//!
+//! This module defines the request envelope shared by the stdio entrypoint
+//! and the HTTP handler, plus the dispatcher that maps method names to the
+//! renderer and validator operations.
+//!
+//! ## JSON-RPC envelope
+//!
+//! Requests use `{ "id", "method", "params" }`. Successful responses echo
+//! the request ID and include `result`; failures echo the request ID when
+//! available and include `error`.
+//!
+//! ## Methods
+//!
+//! | Method | Required params | Optional params | Result |
+//! |---|---|---|---|
+//! | `render_citation` | `style_path`, `refs`, `citation` | `output_format`, `inject_ast_indices` | rendered citation string |
+//! | `render_bibliography` | `style_path`, `refs` | `output_format`, `inject_ast_indices` | rendered bibliography object |
+//! | `validate_style` | `style_path` | none | validation object |
+//! | `format_document` | `style`, `refs`, `citations` | `output_format`, `locale`, `document_options` | `{formatted_citations, bibliography, warnings}` |
+//!
+//! `refs` uses native Citum reference data. Dates are EDTF strings such as
+//! `"1988"`, not CSL-JSON `date-parts` objects.
+//!
+//! `render_citation`, `render_bibliography`, and `validate_style` accept
+//! `style_path`, a string path to a local Citum YAML style. `format_document`
+//! accepts the richer `style` object, for example
+//! `{ "kind": "path", "value": "styles/embedded/apa-7th.yaml" }`.
+//!
+//! ## `format_document` result
+//!
+//! `format_document` returns one document-level result object with three
+//! top-level fields:
+//!
+//! - `formatted_citations`: one rendered citation object per input citation.
+//! - `bibliography`: the rendered bibliography object, including `format`,
+//!   `content`, and `entries`.
+//! - `warnings`: non-fatal diagnostics produced while evaluating the style.
+//!
+//! Clients should read bibliography output from `result.bibliography`, not
+//! from `result.formatted_citations`.
+//!
+//! ## Stdio example
+//!
+//! From the Citum repository root:
+//!
+//! ```text
+//! printf '%s\n' '{"id":1,"method":"render_citation","params":{"style_path":"styles/embedded/apa-7th.yaml","refs":{"hawking1988":{"id":"hawking1988","class":"monograph","type":"book","title":"A Brief History of Time","author":[{"family":"Hawking","given":"Stephen"}],"issued":"1988"}},"citation":{"id":"cite-1","items":[{"id":"hawking1988"}]}}}' \
+//!   | cargo run -q -p citum-server
+//! ```
+
 use crate::error::ServerError;
 use citum_engine::{
     Bibliography, Citation, DocumentOptions, Processor, StyleInput,

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -15,22 +15,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! the request ID and include `result`; failures echo the request ID when
 //! available and include `error`.
 //!
-//! ## Methods
-//!
-//! | Method | Required params | Optional params | Result |
-//! |---|---|---|---|
-//! | `render_citation` | `style_path`, `refs`, `citation` | `output_format`, `inject_ast_indices` | rendered citation string |
-//! | `render_bibliography` | `style_path`, `refs` | `output_format`, `inject_ast_indices` | rendered bibliography object |
-//! | `validate_style` | `style_path` | none | validation object |
-//! | `format_document` | `style`, `refs`, `citations` | `output_format`, `locale`, `document_options` | `{formatted_citations, bibliography, warnings}` |
-//!
-//! `refs` uses native Citum reference data. Dates are EDTF strings such as
-//! `"1988"`, not CSL-JSON `date-parts` objects.
-//!
-//! `render_citation`, `render_bibliography`, and `validate_style` accept
-//! `style_path`, a string path to a local Citum YAML style. `format_document`
-//! accepts the richer `style` object, for example
-//! `{ "kind": "path", "value": "styles/embedded/apa-7th.yaml" }`.
+//! See the crate-level documentation for the shared method table exposed by
+//! both transports.
 //!
 //! ## `format_document` result
 //!


### PR DESCRIPTION
## Summary
- Move detailed citum-server RPC and HTTP transport docs onto the relevant module pages.
- Keep the crate root as the shared API contract, including transport parity and the method table.
- Fix rustdoc warnings from `cargo doc --no-deps`.

## Validation
- `cargo fmt --check`
- `cargo doc --no-deps`
- `cargo doc -p citum-server --no-default-features --no-deps`
- pre-push hook: `cargo clippy --all-targets --all-features -- -D warnings`
- pre-push hook: `cargo nextest run`
