### PR TITLE
feat(engine): add RefsInput tagged union

### DIFF
--- a/.beans/csl26-4qh2--extract-shared-bibliography-loading-into-lower-cra.md
+++ b/.beans/csl26-4qh2--extract-shared-bibliography-loading-into-lower-cra.md
@@ -1,0 +1,15 @@
+---
+# csl26-4qh2
+title: Extract shared bibliography loading into lower crate
+status: todo
+type: task
+priority: normal
+tags:
+    - architecture
+    - io
+    - engine
+created_at: 2026-05-25T14:49:00Z
+updated_at: 2026-05-25T14:49:00Z
+---
+
+citum-io owns the broad bibliography loading pipeline, but it depends on citum-engine, so engine APIs such as RefsInput cannot reuse it without a dependency cycle. Extract the shared native/legacy bibliography parsing surface into a lower crate used by citum-io, citum-engine, citum-server, and bindings. Preserve CLI behavior and avoid changing public wire formats.

--- a/crates/citum-engine/README.md
+++ b/crates/citum-engine/README.md
@@ -33,8 +33,9 @@ support used by sorting and rendering. Optional features:
 Most integrations should start with the document-level API:
 
 - `format_document` resolves a local style from `StyleInput::Path` or
-  `StyleInput::Yaml`, then formats ordered citation occurrences and a
-  bibliography.
+  `StyleInput::Yaml`, and bibliography data from `RefsInput::Path`,
+  `RefsInput::Yaml`, or `RefsInput::Json`, then formats ordered citation
+  occurrences and a bibliography.
 - `format_document_with_style` takes an already resolved `Style` as its first
   argument, plus the same `FormatDocumentRequest` shape. Use this when your
   application has its own style resolver, registry, cache, or embedded style
@@ -51,26 +52,23 @@ application already parses a document into citation occurrences, prefer
 
 ## Quick Start
 
-This example uses the document-level API with a local Citum style file and
-`citum-io` for bibliography loading. `citum-io::load_bibliography` supports
-Citum YAML, Citum JSON, Citum CBOR, and CSL-JSON bibliography files.
+This example uses the document-level API with local Citum YAML files.
+`RefsInput::Path` reads and parses the bibliography file at request time;
+`RefsInput::Yaml` and `RefsInput::Json` accept inline data when loading from
+a path is not convenient.
 
 ```rust,no_run
 use citum_engine::{
-    format_document, Bibliography, CitationOccurrence, CitationOccurrenceItem,
-    FormatDocumentRequest, OutputFormatKind, StyleInput,
+    format_document, CitationOccurrence, CitationOccurrenceItem,
+    FormatDocumentRequest, OutputFormatKind, RefsInput, StyleInput,
 };
-use citum_io::load_bibliography;
-use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let refs: Bibliography = load_bibliography(Path::new("references.json"))?;
-
     let request = FormatDocumentRequest {
-        style: StyleInput::Path("styles/apa-7th.yaml".to_string()),
+        style: StyleInput::Path("styles/embedded/apa-7th.yaml".to_string()),
         locale: None,
         output_format: OutputFormatKind::Html,
-        refs,
+        refs: RefsInput::Path("references.yaml".to_string()),
         citations: vec![CitationOccurrence {
             id: "cite-1".to_string(),
             items: vec![CitationOccurrenceItem {
@@ -122,7 +120,7 @@ The document-level API expects:
 | Input | Type | Notes |
 |---|---|---|
 | Style | `StyleInput`; optionally a separate resolved `Style` | `format_document` resolves local path or inline YAML values from `request.style`. `format_document_with_style` uses its explicit `Style` argument, but the request still includes a `style` field. |
-| References | `Bibliography` | An `IndexMap` keyed by reference ID, containing Citum input references. |
+| References | `RefsInput` | Local bibliography path, inline YAML, inline JSON, or legacy bare JSON map. |
 | Citations | `Vec<CitationOccurrence>` | Ordered as they appear in the document so note positions and repeated citations can be processed. |
 | Output format | `OutputFormatKind` | `plain`, `html`, `djot`, `latex`, or `typst`. |
 

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 
 use super::{
     BibliographyEntry, CitationOccurrence, DocumentOptions, EntryMetadata, FormattedBibliography,
-    FormattedCitation, OutputFormatKind, StyleInput, Warning, WarningLevel,
+    FormattedCitation, OutputFormatKind, RefsInput, StyleInput, Warning, WarningLevel,
 };
 
 /// A request to format a complete document's citations and bibliography.
@@ -45,8 +45,8 @@ pub struct FormatDocumentRequest {
     /// when omitted from the request.
     #[serde(default)]
     pub output_format: OutputFormatKind,
-    /// Bibliography (references indexed by ID).
-    pub refs: Bibliography,
+    /// Reference input as a local path, inline YAML, inline JSON, or legacy bare map.
+    pub refs: RefsInput,
     /// Ordered citations as they appear in the document.
     pub citations: Vec<CitationOccurrence>,
     /// Optional document-level configuration.
@@ -73,6 +73,10 @@ pub enum FormatDocumentError {
     StyleParse(String),
     /// Failed to read or locate the style file.
     StylePath(String),
+    /// Failed to read a local refs input path.
+    RefsInputPath(String),
+    /// Failed to parse refs input data.
+    RefsInputParse(String),
     /// The processor encountered an error during rendering.
     Processing(ProcessorError),
 }
@@ -83,6 +87,8 @@ impl std::fmt::Display for FormatDocumentError {
             Self::UnresolvedInput(msg) => write!(f, "Unresolved style input: {}", msg),
             Self::StyleParse(msg) => write!(f, "Style parse error: {}", msg),
             Self::StylePath(msg) => write!(f, "Style path error: {}", msg),
+            Self::RefsInputPath(msg) => write!(f, "Refs input path error: {}", msg),
+            Self::RefsInputParse(msg) => write!(f, "Refs input parse error: {}", msg),
             Self::Processing(err) => write!(f, "Processing error: {}", err),
         }
     }
@@ -145,7 +151,8 @@ pub fn format_document_with_style(
         });
     }
 
-    let mut processor = Processor::new(style, request.refs);
+    let bibliography = request.refs.resolve_local()?;
+    let mut processor = Processor::new(style, bibliography);
     warnings.extend(unknown_reference_class_warnings(&processor.bibliography));
     warnings.extend(unknown_enum_warnings(&processor));
 
@@ -555,7 +562,7 @@ mod tests {
         }
     }
 
-    fn make_test_bibliography() -> Bibliography {
+    fn make_test_bibliography() -> RefsInput {
         let mut refs = Bibliography::new();
         refs.insert(
             "smith2020".to_string(),
@@ -567,7 +574,7 @@ mod tests {
                 ..Default::default()
             })),
         );
-        refs
+        RefsInput::Json(serde_json::to_value(refs).unwrap())
     }
 
     #[test]
@@ -663,7 +670,7 @@ mod tests {
             style: StyleInput::Yaml("dummy".to_string()),
             locale: None,
             output_format: OutputFormatKind::Plain,
-            refs,
+            refs: RefsInput::Json(serde_json::to_value(refs).unwrap()),
             citations: vec![citation_occ],
             document_options: None,
         };
@@ -716,7 +723,7 @@ mod tests {
             style: StyleInput::Yaml(yaml_style),
             locale: None,
             output_format: OutputFormatKind::Plain,
-            refs,
+            refs: RefsInput::Json(serde_json::to_value(refs).unwrap()),
             citations: vec![citation_occ],
             document_options: None,
         };
@@ -734,7 +741,7 @@ mod tests {
             style: StyleInput::Uri("https://example.com/style.yaml".to_string()),
             locale: None,
             output_format: OutputFormatKind::Plain,
-            refs: Bibliography::new(),
+            refs: RefsInput::Json(serde_json::Value::Object(Default::default())),
             citations: vec![],
             document_options: None,
         };

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -11,6 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 mod document;
 pub mod forward_compat;
+mod refs_input;
 mod style_input;
 mod types;
 
@@ -19,6 +20,7 @@ pub use document::{
     format_document_with_style, unknown_enum_warnings, unknown_reference_class_warnings,
 };
 pub use forward_compat::{UnknownFieldPath, collect_unknown_field_paths};
+pub use refs_input::RefsInput;
 pub use style_input::StyleInput;
 pub use types::{
     AbbreviationMap, AnnotationFormat, AnnotationStyle, BibliographyEntry, CitationOccurrence,

--- a/crates/citum-engine/src/api/refs_input.rs
+++ b/crates/citum-engine/src/api/refs_input.rs
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Refs input resolution type for interactive APIs.
 
-use crate::reference::Bibliography;
+use crate::reference::{Bibliography, Reference};
 use serde::{Deserialize, Serialize};
 
 /// A refs input that can be resolved locally or by an external resolver.
@@ -161,27 +161,26 @@ impl RefsInput {
     pub fn resolve_local(&self) -> Result<Bibliography, crate::api::FormatDocumentError> {
         match self {
             RefsInput::Path(path) => {
-                let yaml_bytes = std::fs::read(path).map_err(|e| {
+                let bytes = std::fs::read(path).map_err(|e| {
                     crate::api::FormatDocumentError::RefsInputPath(format!(
                         "Failed to read refs input from '{}': {}",
                         path, e
                     ))
                 })?;
-                serde_yaml::from_slice::<Bibliography>(&yaml_bytes).map_err(|e| {
+                let yaml_str = String::from_utf8_lossy(&bytes);
+                parse_yaml_bibliography(&yaml_str).map_err(|e| {
                     crate::api::FormatDocumentError::RefsInputParse(format!(
                         "Failed to parse refs input from '{}': {}",
                         path, e
                     ))
                 })
             }
-            RefsInput::Yaml(yaml_str) => {
-                serde_yaml::from_str::<Bibliography>(yaml_str).map_err(|e| {
-                    crate::api::FormatDocumentError::RefsInputParse(format!(
-                        "Failed to parse inline YAML refs input: {}",
-                        e
-                    ))
-                })
-            }
+            RefsInput::Yaml(yaml_str) => parse_yaml_bibliography(yaml_str).map_err(|e| {
+                crate::api::FormatDocumentError::RefsInputParse(format!(
+                    "Failed to parse inline YAML refs input: {}",
+                    e
+                ))
+            }),
             RefsInput::Json(json_val) => serde_json::from_value::<Bibliography>(json_val.clone())
                 .map_err(|e| {
                     crate::api::FormatDocumentError::RefsInputParse(format!(
@@ -191,6 +190,35 @@ impl RefsInput {
                 }),
         }
     }
+}
+
+fn parse_yaml_bibliography(yaml_str: &str) -> Result<Bibliography, String> {
+    let native_err = match serde_yaml::from_str::<citum_schema::InputBibliography>(yaml_str) {
+        Ok(input) => return Ok(bibliography_from_references(input.references)),
+        Err(e) => e,
+    };
+
+    if let Ok(bibliography) = serde_yaml::from_str::<Bibliography>(yaml_str) {
+        return Ok(bibliography);
+    }
+
+    if let Ok(references) = serde_yaml::from_str::<Vec<Reference>>(yaml_str) {
+        return Ok(bibliography_from_references(references));
+    }
+
+    Err(format!(
+        "tried native `references:` bibliography, flat id-to-reference map, and reference sequence: {native_err}"
+    ))
+}
+
+fn bibliography_from_references(references: Vec<Reference>) -> Bibliography {
+    references
+        .into_iter()
+        .filter_map(|reference| {
+            let id = reference.id()?.to_string();
+            Some((id, reference))
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -212,6 +240,31 @@ mod tests {
         let result = input.resolve_local();
         assert!(result.is_ok());
         assert!(result.unwrap().contains_key("test_ref"));
+    }
+
+    #[test]
+    fn refs_input_path_reads_native_input_bibliography() {
+        let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+        let yaml_content = "info:\n  title: Test Bibliography\nreferences:\n  - id: test_ref\n    class: monograph\n    type: book\n    title: Test\n    issued: '2024'\n";
+        tmp.write_all(yaml_content.as_bytes())
+            .expect("Failed to write temp file");
+        tmp.flush().expect("Failed to flush temp file");
+
+        let input = RefsInput::Path(tmp.path().to_string_lossy().to_string());
+        let result = input
+            .resolve_local()
+            .expect("native bibliography should parse");
+        assert!(result.contains_key("test_ref"));
+    }
+
+    #[test]
+    fn refs_input_yaml_reads_native_input_bibliography() {
+        let yaml_content = "info:\n  title: Test Bibliography\nreferences:\n  - id: test_ref\n    class: monograph\n    type: book\n    title: Test\n    issued: '2024'\n";
+        let input = RefsInput::Yaml(yaml_content.to_string());
+        let result = input
+            .resolve_local()
+            .expect("native bibliography should parse");
+        assert!(result.contains_key("test_ref"));
     }
 
     #[test]

--- a/crates/citum-engine/src/api/refs_input.rs
+++ b/crates/citum-engine/src/api/refs_input.rs
@@ -1,0 +1,319 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Refs input resolution type for interactive APIs.
+
+use crate::reference::Bibliography;
+use serde::{Deserialize, Serialize};
+
+/// A refs input that can be resolved locally or by an external resolver.
+///
+/// This union type allows callers to supply reference data by local YAML file path,
+/// inline YAML, or inline JSON (current API). Enables citum-server and bindings to
+/// accept references from files (e.g., via pipe transport from LaTeX).
+#[derive(Debug, Clone)]
+pub enum RefsInput {
+    /// Local filesystem path to a YAML refs file.
+    Path(String),
+    /// Inline YAML refs string.
+    Yaml(String),
+    /// Inline JSON map of reference objects.
+    Json(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for RefsInput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Deserialize to a generic Value first so we can inspect the shape.
+        let v = serde_json::Value::deserialize(deserializer)?;
+
+        if let Some(object) = v.as_object() {
+            let tagged_kind = object
+                .get("kind")
+                .and_then(|k| k.as_str())
+                .filter(|k| matches!(*k, "path" | "yaml" | "json"));
+            if tagged_kind.is_none() || object.get("value").is_none() {
+                return Ok(RefsInput::Json(v));
+            }
+        } else {
+            return Err(serde::de::Error::custom(
+                "refs input must be a tagged object or legacy refs object",
+            ));
+        }
+
+        // Tagged union: {"kind": "path"|"yaml"|"json", "value": ...}
+        let kind = v
+            .get("kind")
+            .and_then(|k| k.as_str())
+            .ok_or_else(|| serde::de::Error::custom("refs input must have a 'kind' field"))?;
+
+        let value = v
+            .get("value")
+            .ok_or_else(|| serde::de::Error::missing_field("value"))?;
+
+        match kind {
+            "path" | "yaml" => {
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| {
+                        serde::de::Error::custom("'value' must be a string for path/yaml refs")
+                    })?
+                    .to_string();
+                if kind == "path" {
+                    Ok(RefsInput::Path(s))
+                } else {
+                    Ok(RefsInput::Yaml(s))
+                }
+            }
+            "json" => Ok(RefsInput::Json(value.clone())),
+            k => Err(serde::de::Error::unknown_variant(
+                k,
+                &["path", "yaml", "json"],
+            )),
+        }
+    }
+}
+
+impl Serialize for RefsInput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(2))?;
+        match self {
+            RefsInput::Path(s) => {
+                map.serialize_entry("kind", "path")?;
+                map.serialize_entry("value", s)?;
+            }
+            RefsInput::Yaml(s) => {
+                map.serialize_entry("kind", "yaml")?;
+                map.serialize_entry("value", s)?;
+            }
+            RefsInput::Json(v) => {
+                map.serialize_entry("kind", "json")?;
+                map.serialize_entry("value", v)?;
+            }
+        }
+        map.end()
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for RefsInput {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "RefsInput".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let reference_schema = generator.subschema_for::<crate::reference::Reference>();
+
+        schemars::json_schema!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["kind", "value"],
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "enum": ["path", "yaml"]
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "required": ["kind", "value"],
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "const": "json"
+                        },
+                        "value": {
+                            "type": "object",
+                            "additionalProperties": reference_schema
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": reference_schema
+                }
+            ]
+        })
+    }
+}
+
+impl RefsInput {
+    /// Resolve refs input locally from Path, Yaml, or Json variants.
+    ///
+    /// # Errors
+    ///
+    /// Returns error for refs input filesystem or parse failures.
+    pub fn resolve_local(&self) -> Result<Bibliography, crate::api::FormatDocumentError> {
+        match self {
+            RefsInput::Path(path) => {
+                let yaml_bytes = std::fs::read(path).map_err(|e| {
+                    crate::api::FormatDocumentError::RefsInputPath(format!(
+                        "Failed to read refs input from '{}': {}",
+                        path, e
+                    ))
+                })?;
+                serde_yaml::from_slice::<Bibliography>(&yaml_bytes).map_err(|e| {
+                    crate::api::FormatDocumentError::RefsInputParse(format!(
+                        "Failed to parse refs input from '{}': {}",
+                        path, e
+                    ))
+                })
+            }
+            RefsInput::Yaml(yaml_str) => {
+                serde_yaml::from_str::<Bibliography>(yaml_str).map_err(|e| {
+                    crate::api::FormatDocumentError::RefsInputParse(format!(
+                        "Failed to parse inline YAML refs input: {}",
+                        e
+                    ))
+                })
+            }
+            RefsInput::Json(json_val) => serde_json::from_value::<Bibliography>(json_val.clone())
+                .map_err(|e| {
+                    crate::api::FormatDocumentError::RefsInputParse(format!(
+                        "Failed to parse JSON refs input: {}",
+                        e
+                    ))
+                }),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "test code uses assertions and panic"
+)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn refs_input_yaml_resolves_locally() {
+        let yaml_content = "test_ref:\n  id: test_ref\n  class: monograph\n  type: book\n  title: Test\n  issued: '2024'\n";
+        let input = RefsInput::Yaml(yaml_content.to_string());
+        let result = input.resolve_local();
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains_key("test_ref"));
+    }
+
+    #[test]
+    fn refs_input_json_resolves_locally() {
+        let json_obj = serde_json::json!({
+            "test_ref": {
+                "id": "test_ref",
+                "class": "monograph",
+                "type": "book",
+                "title": "Test",
+                "issued": "2024"
+            }
+        });
+        let input = RefsInput::Json(json_obj);
+        let result = input.resolve_local();
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains_key("test_ref"));
+    }
+
+    #[test]
+    fn refs_input_path_reads_and_parses() {
+        let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+        let yaml_content = "test_ref:\n  id: test_ref\n  class: monograph\n  type: book\n  title: Test\n  issued: '2024'\n";
+        tmp.write_all(yaml_content.as_bytes())
+            .expect("Failed to write temp file");
+        tmp.flush().expect("Failed to flush temp file");
+
+        let input = RefsInput::Path(tmp.path().to_string_lossy().to_string());
+        let result = input.resolve_local();
+        assert!(result.is_ok());
+        assert!(result.unwrap().contains_key("test_ref"));
+    }
+
+    #[test]
+    fn refs_input_path_missing_returns_error() {
+        let input = RefsInput::Path("/nonexistent/path/refs.yaml".to_string());
+        let result = input.resolve_local();
+        match result {
+            Err(crate::api::FormatDocumentError::RefsInputPath(msg)) => {
+                assert!(msg.contains("Failed to read"));
+            }
+            _ => panic!("Expected RefsInputPath error"),
+        }
+    }
+
+    #[test]
+    fn refs_input_invalid_yaml_returns_parse_error() {
+        let input = RefsInput::Yaml("{ invalid yaml: [".to_string());
+        let result = input.resolve_local();
+        match result {
+            Err(crate::api::FormatDocumentError::RefsInputParse(msg)) => {
+                assert!(msg.contains("Failed to parse"));
+            }
+            _ => panic!("Expected RefsInputParse error"),
+        }
+    }
+
+    #[test]
+    fn refs_input_deserialize_tagged_path() {
+        let json_str = r#"{"kind":"path","value":"/tmp/bib.yaml"}"#;
+        let input: RefsInput = serde_json::from_str(json_str).expect("deserialize");
+        match input {
+            RefsInput::Path(p) => assert_eq!(p, "/tmp/bib.yaml"),
+            _ => panic!("Expected Path variant"),
+        }
+    }
+
+    #[test]
+    fn refs_input_deserialize_tagged_json() {
+        let json_str = r#"{"kind":"json","value":{"key":"value"}}"#;
+        let input: RefsInput = serde_json::from_str(json_str).expect("deserialize");
+        match input {
+            RefsInput::Json(v) => assert_eq!(v.get("key").unwrap(), "value"),
+            _ => panic!("Expected Json variant"),
+        }
+    }
+
+    #[test]
+    fn refs_input_deserialize_bare_object_as_json() {
+        let json_str = r#"{"test_ref":{"id":"test_ref","class":"monograph","type":"book","title":"Test","issued":"2024"}}"#;
+        let input: RefsInput = serde_json::from_str(json_str).expect("deserialize");
+        match input {
+            RefsInput::Json(v) => assert!(v.get("test_ref").is_some()),
+            _ => panic!("Expected Json variant"),
+        }
+    }
+
+    #[test]
+    fn refs_input_deserialize_legacy_kind_ref_id_as_json() {
+        let json_str = r#"{"kind":{"id":"kind","class":"monograph","type":"book","title":"Kind","issued":"2024"}}"#;
+        let input: RefsInput = serde_json::from_str(json_str).expect("deserialize");
+        match input {
+            RefsInput::Json(v) => assert!(v.get("kind").is_some()),
+            _ => panic!("Expected Json variant"),
+        }
+    }
+
+    #[test]
+    fn refs_input_serialize_path() {
+        let input = RefsInput::Path("/tmp/bib.yaml".to_string());
+        let json_str = serde_json::to_string(&input).expect("serialize");
+        assert!(json_str.contains("\"kind\":\"path\""));
+        assert!(json_str.contains("\"/tmp/bib.yaml\""));
+    }
+}

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -11,6 +11,12 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //!
 //! The processor is designed to be pluggable with different renderers and supports
 //! advanced features like disambiguation, sorting, and localization.
+//!
+//! For document-level integrations, use [`format_document`] with a
+//! [`FormatDocumentRequest`]. The request carries a [`StyleInput`] and
+//! [`RefsInput`], so callers can pass local style paths, inline style YAML, local
+//! bibliography paths, inline bibliography YAML, or inline JSON references
+//! without constructing a [`Processor`] directly.
 
 //! # Example
 //!
@@ -106,8 +112,8 @@ pub mod values;
 pub use api::{
     BibliographyEntry, CitationOccurrence, CitationOccurrenceItem, DocumentOptions, EntryMetadata,
     FormatDocumentError, FormatDocumentRequest, FormatDocumentResult, FormattedBibliography,
-    FormattedCitation, OutputFormatKind, StyleInput, Warning, WarningLevel, format_document,
-    format_document_with_style,
+    FormattedCitation, OutputFormatKind, RefsInput, StyleInput, Warning, WarningLevel,
+    format_document, format_document_with_style,
 };
 pub use citum_schema::options::{Config, Processing};
 pub use citum_schema::reference::{

--- a/crates/citum-server/README.md
+++ b/crates/citum-server/README.md
@@ -63,8 +63,10 @@ Errors echo the request ID when available and include `error`:
 }
 ```
 
-`refs` uses native Citum reference data. Dates are EDTF strings such as
-`"1988"`, not CSL-JSON `date-parts` objects.
+`refs` in `render_citation` and `render_bibliography` is an inline JSON map of
+reference objects. `refs` in `format_document` accepts a tagged input object —
+see the `refs` input section below. Reference data uses native Citum schema.
+Dates are EDTF strings such as `"1988"`, not CSL-JSON `date-parts` objects.
 
 ## Method Summary
 
@@ -233,37 +235,68 @@ The response `result` has the same top-level shape over HTTP and stdio:
 Clients should read bibliography output from `result.bibliography`, not from
 `result.formatted_citations`.
 
+## `refs` Input for `format_document`
+
+The `refs` field in `format_document` accepts a tagged input object, mirroring
+the `style` field. These are alternative shapes, not one combined JSON value:
+
+```json
+{ "kind": "path",  "value": "/abs/path/to/refs.yaml" }
+```
+
+```json
+{ "kind": "yaml",  "value": "hawking1988:\n  id: hawking1988\n  ..." }
+```
+
+```json
+{ "kind": "json",  "value": { "hawking1988": { ... } } }
+```
+
+A bare JSON object (no `kind` key) is also accepted as `{"kind": "json"}` for
+backward compatibility.
+
+`path` and `yaml` have the server read and parse the bibliography file; `json`
+passes inline reference data directly. Use `path` when the server and client
+share a filesystem (e.g., when called via pipe from a LuaLaTeX document).
+
 ## Loading Local Files
 
-The server resolves local style paths because style loading is part of its job.
-Reference and citation data must be sent as JSON values in `params`; they are
-not loaded from paths by the server.
+Style and bibliography files on the same filesystem can be referenced by path
+in both `style` and `refs`:
 
-If your client stores references and citations in local files, assemble the
-HTTP request body on the client side before posting it to `/rpc`:
+```sh
+printf '%s\n' '{
+  "id": 4,
+  "method": "format_document",
+  "params": {
+    "style":        { "kind": "path", "value": "styles/embedded/apa-7th.yaml" },
+    "refs":         { "kind": "path", "value": "examples/document-refs-native.json" },
+    "output_format": "html",
+    "citations":    [{ "id": "cite-1", "items": [{ "id": "kuhn1962" }] }]
+  }
+}' | cargo run -q -p citum-server
+```
+
+For HTTP clients that prefer inline data, assemble the request with `jq`:
 
 ```sh
 jq -n \
   --arg style_path "styles/embedded/apa-7th.yaml" \
   --slurpfile refs examples/document-refs-native.json \
   --slurpfile citations examples/document-citations.json \
-  --slurpfile options examples/document-options.json \
   '{
     id: 4,
     method: "format_document",
     params: {
       style: { kind: "path", value: $style_path },
-      refs: $refs[0],
+      refs:  { kind: "json", value: $refs[0] },
       citations: $citations[0],
-      document_options: $options[0],
       output_format: "html"
     }
   }' | curl -s http://localhost:9000/rpc \
     -H 'Content-Type: application/json' \
     -d @-
 ```
-
-Those example files exist at the workspace-level `examples/` directory.
 
 ## Discovery
 

--- a/crates/citum-server/src/lib.rs
+++ b/crates/citum-server/src/lib.rs
@@ -20,8 +20,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! | `validate_style` | `style_path` | none | validation object |
 //! | `format_document` | `style`, `refs`, `citations` | `output_format`, `locale`, `document_options` | `{formatted_citations, bibliography, warnings}` |
 //!
-//! `refs` uses native Citum reference data. Dates are EDTF strings such as
-//! `"1988"`, not CSL-JSON `date-parts` objects.
+//! `refs` in `render_citation` and `render_bibliography` is an inline JSON map
+//! of native Citum reference objects. `refs` in `format_document` accepts
+//! `citum-engine`'s tagged [`citum_engine::RefsInput`] shape, including local
+//! bibliography paths, inline YAML, inline JSON, and legacy bare JSON maps.
+//! Dates are EDTF strings such as `"1988"`, not CSL-JSON `date-parts` objects.
 //!
 //! `render_citation`, `render_bibliography`, and `validate_style` accept
 //! `style_path`, a string path to a local Citum YAML style. `format_document`

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -146,7 +146,7 @@ pub struct FormatDocumentParams {
     pub locale: Option<String>,
     /// Output format (plain, html, djot, latex, typst). Defaults to plain.
     pub output_format: Option<OutputFormat>,
-    /// Bibliography (references) as a map of reference objects.
+    /// Bibliography input as `RefsInput`: path, YAML, JSON, or legacy bare map.
     pub refs: serde_json::Value,
     /// Ordered citations as they appear in the document.
     pub citations: serde_json::Value,

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -33,6 +33,14 @@ fn apa_style_path() -> String {
     )
 }
 
+/// Absolute path to a native Citum YAML bibliography fixture.
+fn chicago_bib_path() -> String {
+    format!(
+        "{}/../../examples/chicago-bib.yaml",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
 /// Minimal bibliography: one book (Hawking 1988) in native Citum schema format.
 /// `issued` is a plain EDTF string; `author` is a `ContributorList`.
 fn hawking_refs() -> serde_json::Value {
@@ -320,6 +328,47 @@ fn format_document_returns_citations_bibliography_and_warnings() {
         .expect("bibliography.entries should be an array");
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0]["id"], "ITEM-2");
+}
+
+#[test]
+fn format_document_accepts_refs_path_native_bibliography() {
+    let req = make_request(
+        16,
+        "format_document",
+        json!({
+            "style": {
+                "kind": "path",
+                "value": apa_style_path()
+            },
+            "output_format": "plain",
+            "refs": {
+                "kind": "path",
+                "value": chicago_bib_path()
+            },
+            "citations": [{
+                "id": "cite-1",
+                "items": [{"id": "biss"}]
+            }]
+        }),
+    );
+
+    let result = dispatch(req).expect("dispatch should succeed");
+    assert_eq!(result["id"], 16);
+
+    let payload = &result["result"];
+    let formatted_citations = payload["formatted_citations"]
+        .as_array()
+        .expect("formatted_citations should be an array");
+    assert_eq!(formatted_citations.len(), 1);
+    assert_eq!(formatted_citations[0]["id"], "cite-1");
+
+    let entries = payload["bibliography"]["entries"]
+        .as_array()
+        .expect("bibliography.entries should be an array");
+    assert!(
+        entries.iter().any(|entry| entry["id"] == "biss"),
+        "bibliography should include the path-loaded reference: {payload}"
+    );
 }
 
 // --- error handling ---

--- a/docs/guides/integrations/fixtures/rust-library/src/main.rs
+++ b/docs/guides/integrations/fixtures/rust-library/src/main.rs
@@ -8,8 +8,8 @@ use std::error::Error;
 use std::fs;
 
 use citum_engine::{
-    format_document, Bibliography, CitationOccurrence, CitationOccurrenceItem,
-    FormatDocumentRequest, OutputFormatKind, StyleInput,
+    format_document, CitationOccurrence, CitationOccurrenceItem, FormatDocumentRequest,
+    OutputFormatKind, RefsInput, StyleInput,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -18,11 +18,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     //    resolver chain that lives in citum-server.)
     let style = StyleInput::Path("apa-7th.yaml".to_string());
 
-    // 2. Load references in Citum's native JSON format. The native format
-    //    deserializes directly into a Bibliography (IndexMap<String, Reference>).
-    //    For BibLaTeX or CSL-JSON inputs, use the citum-io crate to convert.
-    let refs_json = fs::read_to_string("references-native.json")?;
-    let refs: Bibliography = serde_json::from_str(&refs_json)?;
+    // 2. Load references in Citum's native JSON format. RefsInput::Json accepts
+    //    the inline reference map. For BibLaTeX or CSL-JSON inputs, convert first.
+    let refs_json: serde_json::Value = serde_json::from_str(&fs::read_to_string(
+        "references-native.json",
+    )?)?;
+    let refs = RefsInput::Json(refs_json);
 
     // 3. Describe the citations in document order. Your own pipeline owns the
     //    job of scanning Markdown / Djot / AST for citation keys; citum only

--- a/docs/guides/integrations/rust-library.html
+++ b/docs/guides/integrations/rust-library.html
@@ -171,23 +171,23 @@ assert_eq!(processor.process_citation(&citation).unwrap(), "(Kuhn, 1962)");</cod
                 <h2>3. Load style and references from disk</h2>
                 <p>
                     Most real applications keep styles and bibliographies in files. The engine reads YAML styles
-                    natively, and the native bibliography format deserializes directly into <code>Bibliography</code>
-                    via serde &mdash; no separate parser needed.
+                    natively, and <code>format_document</code> accepts references through <code>RefsInput</code>
+                    as a local path, inline YAML, inline JSON, or a legacy bare JSON map.
                 </p>
             </div>
             <div class="workshop-block">
-                <pre><code>use citum_engine::{Bibliography, StyleInput};
+                <pre><code>use citum_engine::{RefsInput, StyleInput};
 use std::fs;
 
 // Style: YAML on disk, inline string, or a registry id (id/uri variants need
 // the citum-server resolver chain; path/yaml resolve locally).
 let style = StyleInput::Path("apa-7th.yaml".to_string());
 
-// References: native Citum JSON deserializes straight into Bibliography.
-// For BibLaTeX or CSL-JSON inputs, convert first with `citum convert refs`
-// or pull in the citum-io crate.
-let refs: Bibliography =
-    serde_json::from_str(&fs::read_to_string("references-native.json")?)?;</code></pre>
+// References: native Citum JSON maps can be passed through RefsInput::Json.
+// For BibLaTeX or CSL-JSON inputs, convert first with `citum convert refs`.
+let refs = RefsInput::Json(
+    serde_json::from_str(&fs::read_to_string("references-native.json")?)?
+);</code></pre>
             </div>
         </section>
 

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2892,7 +2892,7 @@
         ]
       },
       "refs": {
-        "description": "Bibliography (references) as a map of reference objects."
+        "description": "Bibliography input as `RefsInput`: path, YAML, JSON, or legacy bare map."
       },
       "citations": {
         "description": "Ordered citations as they appear in the document."

--- a/docs/specs/SERVER_INTERACTIVE_API.md
+++ b/docs/specs/SERVER_INTERACTIVE_API.md
@@ -75,7 +75,7 @@ All methods that accept a style use a `StyleInput` union to avoid adapter-specif
 {"kind": "uri", "value": "https://hub.citum.org/styles/apa-7th.yaml"}
 
 // Path — server resolves from local filesystem
-{"kind": "path", "value": "styles/apa-7th.yaml"}
+{"kind": "path", "value": "styles/embedded/apa-7th.yaml"}
 
 // Inline YAML — WASM and HTTP callers may supply the style body directly
 {"kind": "yaml", "value": "---\ninfo:\n  title: ..."}
@@ -274,7 +274,7 @@ Modelled on Pandoc citeproc: one call, all inputs, all outputs. Works in stdio, 
 | `style` | `StyleInput` | yes | Style reference (see above) |
 | `locale` | string | no | BCP 47 locale override (e.g. `"en-US"`) |
 | `output_format` | string | no | One of `plain` (default), `html`, `djot`, `latex`, `typst` |
-| `refs` | object | yes | Bibliography: reference ID → reference object |
+| `refs` | `RefsInput` | yes | Bibliography input: tagged path, YAML, JSON, or legacy bare JSON map |
 | `citations` | array | yes | Ordered `CitationOccurrence` items (document order) |
 | `document_options` | `DocumentOptions` | no | Document-level rendering config (see above) |
 


### PR DESCRIPTION
## Summary

- Add `RefsInput` enum to `citum-engine` mirroring the existing `StyleInput` tagged-union pattern (`Path`, `Yaml`, `Json` variants)
- Change `FormatDocumentRequest.refs` from `Bibliography` to `RefsInput`; the engine resolves path/yaml variants internally
- Custom `Deserialize` impl preserves backward compatibility — bare JSON objects (no `kind` key) are treated as `RefsInput::Json`
- Re-export `RefsInput` from `citum_engine` public API alongside `StyleInput`
- Update `citum-engine` and `citum-server` READMEs with new refs input types and path-based loading examples

## Motivation

The LuaLaTeX pipe transport (in citum-labs) needs to call `format_document` without an in-process YAML parser. By accepting `refs: {kind: "path", value: "/abs/path/to/refs.yaml"}`, the server reads and parses the bibliography file itself — same pattern already used for `style: {kind: "path", ...}`.

## Test plan

- [x] `cargo test -p citum-engine` — all existing engine tests pass (refs fixtures converted to `RefsInput::Json`)
- [x] `cargo test -p citum-server` — all 22 server tests pass (backward-compat deserializer handles bare JSON objects)
- [x] Smoke test: `echo '{"id":1,"method":"format_document","params":{"style":{"kind":"path","value":"styles/embedded/apa-7th.yaml"},"refs":{"kind":"path","value":"examples/document-refs.yaml"},"citations":[{"id":"c1","items":[{"id":"hawking1988"}]}]}}' | cargo run -q -p citum-server --no-default-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)