### PR TITLE
docs: add demo, citation-modes, and reference data

### DIFF
--- a/docs/architecture/design-principles.html
+++ b/docs/architecture/design-principles.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/architecture/migration-strategy.html
+++ b/docs/architecture/migration-strategy.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/assets/citum-interactive.css
+++ b/docs/assets/citum-interactive.css
@@ -21,6 +21,11 @@
   --citum-transition-speed: 0.3s;
 }
 
+/* Article prose */
+.content p + p {
+  text-indent: 1.5em;
+}
+
 /* Citations */
 .citum-citation {
   color: var(--citum-citation-color);

--- a/docs/citation-modes.html
+++ b/docs/citation-modes.html
@@ -1,0 +1,426 @@
+<!-- PAGE_ID: citation-modes -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <meta name="description" content="Integral and non-integral citation modes across author-date, numeric, note-based, and label citation style classes — illustrated with identical input.">
+    <title>Citation Modes | Citum</title>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="assets/citum-theme.css">
+    <style>
+        .cite-mode-pair {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1rem;
+            margin: 1.25rem 0;
+        }
+        @media (max-width: 680px) {
+            .cite-mode-pair { grid-template-columns: 1fr; }
+        }
+        .cite-mode-block {
+            border: 1px solid var(--citum-border);
+            border-radius: 6px;
+            overflow: hidden;
+        }
+        .cite-mode-block .workshop-label {
+            border-radius: 0;
+            border-bottom: 1px solid var(--citum-border);
+        }
+        .cite-mode-prose {
+            padding: 0.9rem 1rem;
+            font-size: 0.95rem;
+            line-height: 1.65;
+            font-family: 'Newsreader', serif;
+        }
+        .cite-mode-prose .cite {
+            color: var(--citum-blue, #2a94d6);
+            font-style: normal;
+        }
+        .cite-mode-prose .cite-num {
+            vertical-align: super;
+            font-size: 0.75em;
+            color: var(--citum-blue, #2a94d6);
+            font-variant-numeric: tabular-nums;
+        }
+        .cite-mode-prose sup.fn {
+            font-size: 0.7em;
+            vertical-align: super;
+            color: var(--citum-blue, #2a94d6);
+        }
+        .cite-mode-prose .fn-note {
+            margin-top: 0.75rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid var(--citum-border);
+            font-size: 0.8rem;
+            color: var(--citum-muted);
+        }
+        .cite-mode-prose .cite-label {
+            color: var(--citum-blue, #2a94d6);
+            font-variant-numeric: tabular-nums;
+        }
+        .ref-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.88rem;
+            margin: 1rem 0 0.5rem;
+        }
+        .ref-table th {
+            text-align: left;
+            padding: 0.35rem 0.75rem;
+            background: var(--citum-paper-deep, #f5f2eb);
+            border-bottom: 2px solid var(--citum-border);
+            font-weight: 600;
+            white-space: nowrap;
+        }
+        .ref-table td {
+            padding: 0.35rem 0.75rem;
+            border-bottom: 1px solid var(--citum-border);
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.82rem;
+        }
+        .ref-table tr:last-child td { border-bottom: none; }
+        .ref-table .td-label { color: var(--citum-muted); font-family: inherit; font-size: 0.85rem; }
+        .notice {
+            background: var(--citum-blue-soft, #eef6fc);
+            border-left: 3px solid var(--citum-blue, #2a94d6);
+            border-radius: 4px;
+            padding: 0.7rem 1rem;
+            font-size: 0.9rem;
+            color: var(--citum-muted, #555);
+            margin-bottom: 2rem;
+        }
+    </style>
+</head>
+
+<body>
+    <nav class="site-nav" aria-label="Site">
+    <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link active" href="examples.html">Capabilities</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
+                <a class="site-nav-link " href="demo.html">Demo</a>
+                <a class="site-nav-link " href="schemas/">Schemas</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link active" href="examples.html">Capabilities</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
+            <a class="site-nav-link " href="demo.html">Demo</a>
+            <a class="site-nav-link " href="schemas/">Schemas</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+    </nav>
+
+    <main class="doc-shell">
+        <header class="doc-section-header">
+            <span class="citum-kicker">Capabilities</span>
+            <h1>Integral and non-integral citations</h1>
+            <p>
+                Every Citum style declares separate templates for <strong>integral</strong>
+                (narrative) and <strong>non-integral</strong> (parenthetical) citation forms.
+                The same input data renders differently depending on whether the author name
+                is grammatically part of the sentence.
+            </p>
+            <p>
+                This page shows the same two-citation passage rendered by four classes of
+                citation style: author-date, numeric and note-based (combined, since the
+                integral/non-integral logic is identical), and label.
+            </p>
+        </header>
+
+        <div class="notice">
+            <strong>Illustration only.</strong> The passage text and references below are
+            entirely artificial. See <a href="demo.html">the full demo</a> for a richer
+            example with multilingual sources, EDTF dates, and archival references.
+        </div>
+
+        <!-- Shared reference data -->
+        <section class="doc-section" id="shared-references">
+            <div class="doc-section-header">
+                <h2>Input</h2>
+                <p>The same two references are used across all style-class sections below.</p>
+            </div>
+            <table class="ref-table">
+                <thead>
+                    <tr>
+                        <th>Key</th>
+                        <th>Author(s)</th>
+                        <th>Year</th>
+                        <th>Title</th>
+                        <th>Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>chen2017</td>
+                        <td>Chen, M.</td>
+                        <td>2017</td>
+                        <td class="td-label">The Social Life of References</td>
+                        <td class="td-label">book</td>
+                    </tr>
+                    <tr>
+                        <td>okafor2024</td>
+                        <td>Okafor, N.; Ferreira, B.; Park, J.</td>
+                        <td>2024</td>
+                        <td class="td-label">Network Topology of Academic Citation</td>
+                        <td class="td-label">report (preprint)</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p style="margin-top:0.75rem;color:var(--citum-muted);font-size:0.9rem;">
+                Full YAML definition: <a href="demo-refs.yaml"><code>docs/demo-refs.yaml</code></a>
+            </p>
+        </section>
+
+        <!-- 1. Author-date -->
+        <section class="doc-section" id="author-date">
+            <div class="doc-section-header">
+                <h2>Author-date</h2>
+                <p>
+                    Representative style: <strong>APA 7th</strong>.
+                    The in-text citation carries the author surname and year.
+                    Integral form folds the author name into the sentence;
+                    non-integral places author and year in parentheses.
+                </p>
+            </div>
+
+            <div class="cite-mode-pair">
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Integral (narrative)</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        <span class="cite">Chen (2017)</span>
+                        has argued that citation practices encode social hierarchies
+                        as much as intellectual ones. More recently,
+                        <span class="cite">Okafor et al. (2024)</span>
+                        provided computational evidence for this view at scale.
+                    </div>
+                </div>
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Non-integral (parenthetical)</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        Citation practices encode social hierarchies as much as
+                        intellectual ones
+                        <span class="cite">(Chen, 2017)</span>.
+                        Computational evidence for this view has recently been
+                        provided at scale
+                        <span class="cite">(Okafor et al., 2024)</span>.
+                    </div>
+                </div>
+            </div>
+
+            <div class="workshop-block">
+                <div class="workshop-label">Rendered citation forms &mdash; APA 7th</div>
+<pre><code>Integral             Chen (2017)          Okafor et al. (2024)
+Integral + locator   Chen (2017, p. 42)   Okafor et al. (2024, p. 8)
+Non-integral         (Chen, 2017)         (Okafor et al., 2024)
+Non-integral + loc   (Chen, 2017, p. 42)  (Okafor et al., 2024, p. 8)</code></pre>
+            </div>
+        </section>
+
+        <!-- 2. Numeric + Note-based -->
+        <section class="doc-section" id="numeric-note">
+            <div class="doc-section-header">
+                <h2>Numeric and note-based</h2>
+                <p>
+                    These two classes share the same integral/non-integral logic: the citation
+                    marker (a number or a note reference) can appear either adjacent to the
+                    author name (integral) or anchored to the clause end (non-integral).
+                    The difference is purely in marker form: a bracketed integer
+                    <code>[1]</code> for numeric styles, a superscript note reference
+                    <sup>1</sup> for note-based styles.
+                </p>
+                <p>
+                    Representative styles: <strong>IEEE</strong> (numeric),
+                    <strong>Chicago Notes</strong> (note-based).
+                </p>
+            </div>
+
+            <div class="cite-mode-pair">
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Integral — numeric (IEEE)</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        Chen <span class="cite">[1]</span>
+                        has argued that citation practices encode social hierarchies
+                        as much as intellectual ones. More recently,
+                        Okafor et al. <span class="cite">[2]</span>
+                        provided computational evidence for this view at scale.
+                    </div>
+                </div>
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Non-integral — numeric (IEEE)</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        Citation practices encode social hierarchies as much as
+                        intellectual ones <span class="cite">[1]</span>.
+                        Computational evidence for this view has recently been
+                        provided at scale <span class="cite">[2]</span>.
+                    </div>
+                </div>
+            </div>
+
+            <div class="cite-mode-pair">
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Integral — note-based (Chicago)</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        Chen<sup class="fn">1</sup>
+                        has argued that citation practices encode social hierarchies
+                        as much as intellectual ones. More recently,
+                        Okafor et al.<sup class="fn">2</sup>
+                        provided computational evidence for this view at scale.
+                        <div class="fn-note">
+                            <sup>1</sup> Chen Mei, <em>The Social Life of References</em> (MIT Press, 2017), p.&thinsp;12.<br>
+                            <sup>2</sup> Nnamdi Okafor, Beatriz Ferreira, and Jiyeon Park, &#8220;Network Topology of Academic Citation,&#8221; arXiv:2401.05832 (2024).
+                        </div>
+                    </div>
+                </div>
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Non-integral — note-based (Chicago)</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        Citation practices encode social hierarchies as much as
+                        intellectual ones.<sup class="fn">1</sup>
+                        Computational evidence for this view has recently been
+                        provided at scale.<sup class="fn">2</sup>
+                        <div class="fn-note">
+                            <sup>1</sup> Chen, <em>Social Life of References</em>, 12.<br>
+                            <sup>2</sup> Okafor, Ferreira, and Park, &#8220;Network Topology,&#8221; 2401.05832.
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="workshop-block">
+                <div class="workshop-label">Name memory in note styles</div>
+<pre><code>First note:     Chen Mei, The Social Life of References (MIT Press, 2017), p. 12.
+Later note:     Chen, Social Life of References, 42.   ← abbreviated (name memory)</code></pre>
+            </div>
+        </section>
+
+        <!-- 3. Label -->
+        <section class="doc-section" id="label">
+            <div class="doc-section-header">
+                <h2>Label-based</h2>
+                <p>
+                    Representative style: alphanumeric (e.g., <strong>ACM</strong>,
+                    <strong>alpha</strong>). The citation marker is a short mnemonic
+                    derived from author surnames and year rather than an assigned integer.
+                    Integral and non-integral placement follow the same logic as other
+                    classes: either adjacent to the author name or at the clause end.
+                </p>
+            </div>
+
+            <div class="cite-mode-pair">
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Integral</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        Chen <span class="cite">[Che17]</span>
+                        has argued that citation practices encode social hierarchies
+                        as much as intellectual ones. More recently,
+                        Okafor et al. <span class="cite">[OFP24]</span>
+                        provided computational evidence for this view at scale.
+                    </div>
+                </div>
+                <div class="cite-mode-block">
+                    <div class="workshop-label">Non-integral</div>
+                    <div class="cite-mode-prose">
+                        The mechanisms by which academic knowledge is attributed
+                        have attracted renewed scholarly attention.
+                        Citation practices encode social hierarchies as much as
+                        intellectual ones <span class="cite">[Che17]</span>.
+                        Computational evidence for this view has recently been
+                        provided at scale <span class="cite">[OFP24]</span>.
+                    </div>
+                </div>
+            </div>
+
+            <div class="workshop-block">
+                <div class="workshop-label">Rendered citation forms &mdash; label (alpha)</div>
+<pre><code>Integral       Chen [Che17]          Okafor et al. [OFP24]
+Non-integral   [Che17]               [OFP24]</code></pre>
+            </div>
+        </section>
+
+        <!-- See also -->
+        <section class="doc-section" id="see-also">
+            <div class="doc-section-header">
+                <h2>Related</h2>
+            </div>
+            <ul>
+                <li>&rarr; <a href="examples.html#citation-modes">Capabilities &mdash; Citation modes</a>: full feature overview including name memory</li>
+                <li>&rarr; <a href="guides/style-authoring/templates.html#citation-modes">Template reference</a>: how to author <code>integral</code> and <code>non-integral</code> templates in a style file</li>
+                <li>&rarr; <a href="demo.html">Interactive demo</a>: bidirectional linking, sidebar layout, and all demo-refs features together</li>
+            </ul>
+        </section>
+    </main>
+
+    <footer class="py-12 px-6 border-t border-slate-200 bg-white/50">
+        <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="developer.html">Integrate</a>
+                    <a href="schemas/">Schemas</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>
+        <!-- LAYOUT_FOOTER_END -->
+    </footer>
+
+    <script>
+        const navToggle = document.querySelector('[data-nav-toggle]');
+        const mobileMenu = document.querySelector('[data-mobile-menu]');
+        if (navToggle && mobileMenu) {
+            navToggle.addEventListener('click', () => {
+                const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+                navToggle.setAttribute('aria-expanded', String(!expanded));
+                mobileMenu.classList.toggle('hidden', expanded);
+            });
+        }
+    </script>
+</body>
+</html>

--- a/docs/demo-refs.yaml
+++ b/docs/demo-refs.yaml
@@ -1,0 +1,130 @@
+# Demo reference list for docs/demo.html and bindings/latex/demo/citum-example.tex
+# All entries are entirely fabricated for illustration purposes.
+# Exception: harrington1891 is loosely modelled on archival ms. conventions.
+references:
+
+  # Monograph — cited twice (name memory: full → abbreviated in note styles)
+  - id: chen2017
+    class: monograph
+    type: book
+    title: "The Social Life of References: Knowledge-Making in Collaborative Science"
+    author:
+      - family: Chen
+        given: Mei
+    issued: "2017"
+    publisher:
+      name: MIT Press
+      place: Cambridge, MA
+
+  # Second monograph by same author — shows multi-work disambiguation
+  - id: chen2020
+    class: monograph
+    type: book
+    title: "Citation and Authority: Epistemic Practices in the Digital Age"
+    author:
+      - family: Chen
+        given: Mei
+    issued: "2020"
+    publisher:
+      name: MIT Press
+      place: Cambridge, MA
+
+  # Classic monograph — non-integral use
+  - id: webb1968
+    class: monograph
+    type: book
+    title: "The Footnote as Institution: A History of Scholarly Reference"
+    author:
+      - family: Webb
+        given: Margaret L.
+    issued: "1968"
+    publisher:
+      name: Oxford University Press
+      place: Oxford
+
+  # Multilingual — Japanese journal article with English translation
+  - id: tanaka_yuki2019
+    class: serial-component
+    type: article
+    language: ja
+    title: "引用の社会的機能：学術知識の構築における参照実践"
+    title-translated: "The Social Function of Citation: Reference Practices in the Construction of Academic Knowledge"
+    author:
+      - family: 田中
+        given: 由紀
+        family-romanized: Tanaka
+        given-romanized: Yuki
+      - family: 鈴木
+        given: 春人
+        family-romanized: Suzuki
+        given-romanized: Haruto
+    issued: "2019"
+    pages: "45-78"
+    container:
+      class: serial
+      type: academic-journal
+      language: ja
+      title: "科学社会学研究"
+      title-translated: "Studies in Science and Technology"
+      volume: "37"
+      issue: "2"
+
+  # Multilingual — Spanish book chapter; EDTF approximate date
+  - id: garcia2022
+    class: serial-component
+    type: chapter
+    language: es
+    title: "Prácticas de citación en la ciencia latinoamericana"
+    title-translated: "Citation Practices in Latin American Science"
+    author:
+      - family: García-Reyes
+        given: Isabel
+      - family: Montoya
+        given: Claudia P.
+    issued: "2022~"   # EDTF Level 1: approximate date
+    pages: "112-138"
+    container:
+      class: monograph
+      type: book
+      title: "Epistemologías del Sur: Perspectivas desde América Latina"
+      editor:
+        - family: Restrepo
+          given: Eduardo
+      publisher:
+        name: CLACSO
+        place: Buenos Aires
+
+  # Archival manuscript — EDTF uncertain date + archive-info
+  # Primary source in the primary/secondary bibliography split
+  - id: harrington1891
+    class: monograph
+    type: manuscript
+    title: "Notes on Bibliographic Method and the Organisation of Learned References"
+    author:
+      - family: Harrington
+        given: R. L.
+    issued: "1891?"   # EDTF Level 1: uncertain date
+    archive-info:
+      name: "British Library"
+      location: "Manuscripts Reading Room"
+      place: "London"
+      collection: "Harrington Papers"
+      shelfmark: "MS Add. 47903, ff. 12–34"
+
+  # Preprint — eprint with arXiv identifier
+  - id: okafor2024
+    class: monograph
+    type: report
+    title: "Network Topology of Academic Citation: A Large-Scale Computational Analysis"
+    author:
+      - family: Okafor
+        given: Nnamdi
+      - family: Ferreira
+        given: Beatriz
+      - family: Park
+        given: Jiyeon
+    issued: "2024-01"
+    eprint:
+      id: "2401.05832"
+      type: arXiv
+      category: "cs.DL"

--- a/docs/demo.djot
+++ b/docs/demo.djot
@@ -1,0 +1,69 @@
+{.citum-demo-notice}
+**Note**: This is an entirely artificial document created for the purpose of illustrating
+Citum citation rendering features. All arguments, references, and authors are fabricated.
+No scholarly claims are made.
+
+---
+
+**Features illustrated**: integral and non-integral citations; name memory (Chen, cited
+across two works); multilingual sources (Japanese, Spanish); EDTF dates (approximate:
+`2022~`; uncertain: `1891?`); archival reference with `archive-info`; preprint with
+`eprint` identifier. The companion reference file is `docs/demo-refs.yaml`.
+
+Citation syntax below uses `@key` for integral (narrative) form and `[@key]` for
+non-integral (parenthetical) form, as a hypothetical Citum djot preprocessor would
+accept. Actual rendering uses the citum-core API directly.
+
+---
+
+# The Infrastructure of Scholarly Memory
+
+Scholarly citation serves as the primary mechanism through which academic knowledge
+is organized, attributed, and transmitted. As @chen2017 has argued, the practices
+surrounding citation reflect deeper epistemological commitments about what counts
+as knowledge and who produces it. The formal apparatus of bibliographic reference
+— the footnote, the parenthetical, the numbered list — constitutes what Webb
+[@webb1968] called "the footnote as institution," embedding social relations within
+the seemingly neutral mechanics of scholarly communication.
+
+The production of this apparatus is not confined to Anglophone scholarship.
+@tanaka_yuki2019 demonstrate that citation practices in Japanese science studies
+reflect distinct epistemological conventions, including different assumptions about
+authorial authority and collective knowledge-making. Parallel observations emerge
+from Spanish-language scholarship, where the relationship between citation and
+institutional context differs in ways that challenge Anglocentric models of
+attribution [@garcia2022].
+
+These questions have a longer history than recent digital debates might suggest.
+@harrington1891 observed — in manuscript notes preserved at the British Library —
+that bibliographic method was already contested among Victorian scholars of natural
+history, who disagreed fundamentally about whether a citation should indicate
+provenance, priority, or deference. @chen2017 [ch. 3] traces a direct line from
+these Victorian anxieties to contemporary algorithmic citation metrics; the impulse
+to quantify scholarly influence has deep institutional roots.
+
+More recent work challenges the assumption that citation reflects merit rather than
+network position. @chen2020 extends this analysis to the digital transition, arguing
+that platform architectures reproduce and amplify existing hierarchies of credibility.
+@okafor2024 provide large-scale empirical support for this claim, showing through
+computational analysis of citation networks that topological centrality correlates
+more strongly with institutional affiliation than with measured scholarly impact.
+
+Together, this body of evidence suggests that citation is less a neutral epistemic
+tool than a cultural technology whose workings differ across languages, institutions,
+and time periods. Understanding that variability requires attention to both the fine
+structure of individual references — their dates, languages, formats, and archival
+contexts — and the aggregate patterns they produce across documents and disciplines.
+
+## Primary Sources
+
+- @harrington1891
+
+## Secondary Sources
+
+- @chen2017
+- @chen2020
+- @garcia2022
+- @okafor2024
+- @tanaka_yuki2019
+- @webb1968

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -1,0 +1,384 @@
+<!-- PAGE_ID: demo -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Citum | Demo</title>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries,typography"></script>
+  <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@300;400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;700&amp;family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&amp;display=swap"
+      rel="stylesheet" />
+  <script>
+      tailwind.config = {
+          darkMode: "class",
+          theme: {
+              extend: {
+                  colors: {
+                      "primary": "#2a94d6",
+                      "background-light": "#fdfbf7",
+                      "accent-cream": "#f5f2eb",
+                  },
+                  fontFamily: {
+                      "display": ["Libre Franklin", "sans-serif"],
+                      "mono": ["JetBrains Mono", "monospace"]
+                  },
+                  borderRadius: {
+                      "DEFAULT": "0.25rem",
+                      "lg": "0.5rem",
+                      "xl": "0.75rem",
+                      "full": "9999px"
+                  },
+              },
+          },
+      }
+  </script>
+  <style type="text/tailwindcss">
+    .glass-nav {
+        background: rgba(253, 251, 247, 0.85);
+        backdrop-filter: blur(12px);
+        border-bottom: 1px solid rgba(42, 148, 214, 0.1);
+    }
+    body {
+      font-family: 'Libre Franklin', sans-serif;
+      line-height: 1.6;
+      color: var(--citum-ink);
+      background: var(--citum-paper);
+    }
+    .font-mono {
+        font-family: 'JetBrains Mono', monospace;
+    }
+    .container-demo {
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 2rem;
+    }
+    header {
+      border-bottom: 1px solid var(--citum-border);
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+    }
+    .config-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--citum-muted);
+      text-decoration: none;
+      font-size: 0.9rem;
+      padding: 0.4rem 0.8rem;
+      border-radius: 4px;
+      background: var(--citum-blue-soft);
+      transition: all 0.2s;
+    }
+    .config-link:hover {
+      background: var(--citum-paper-deep);
+      color: var(--citum-ink-strong);
+    }
+    .controls {
+      background: var(--citum-paper-deep);
+      padding: 1rem;
+      border-radius: 8px;
+      margin-bottom: 1.5rem;
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+    }
+    .demo-container {
+      transition: all 0.3s ease;
+    }
+    h1 { margin-bottom: 0.5rem; }
+    .subtitle { color: #666; font-size: 1.1rem; }
+
+    /* Layout toggles */
+    .btn {
+      padding: 0.5rem 1rem;
+      border: 1px solid var(--citum-border);
+      background: var(--citum-surface);
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .btn.active {
+      background: var(--citum-blue);
+      color: oklch(0.985 0.008 238);
+      border-color: var(--citum-blue);
+    }
+
+    /* Demo notice */
+    .demo-notice {
+      background: var(--citum-blue-soft, #eef6fc);
+      border-left: 3px solid var(--citum-blue, #2a94d6);
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      font-size: 0.9rem;
+      color: var(--citum-muted, #555);
+      margin-bottom: 2rem;
+    }
+    .demo-notice strong {
+      color: var(--citum-ink, #222);
+    }
+    .feature-tags {
+      margin-top: 0.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+    }
+    .feature-tag {
+      background: white;
+      border: 1px solid var(--citum-border, #ddd);
+      border-radius: 12px;
+      padding: 0.15rem 0.6rem;
+      font-size: 0.8rem;
+      color: var(--citum-muted, #555);
+    }
+  </style>
+    <link rel="stylesheet" href="assets/citum-theme.css">
+  <link rel="stylesheet" href="assets/citum-interactive.css">
+</head>
+<body class="bg-background-light text-slate-700">
+
+  <!-- Navigation -->
+  <!-- LAYOUT_NAV_START -->
+        <div class="site-nav-inner">
+            <div class="site-brand-wrap">
+                <a href="index.html" class="site-brand">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </a>
+            </div>
+            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
+                <a class="site-nav-link " href="index.html">Overview</a>
+                <a class="site-nav-link " href="examples.html">Capabilities</a>
+                <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+                <a class="site-nav-link " href="developer.html">Integrate</a>
+                <a class="site-nav-link active" href="demo.html">Demo</a>
+                <a class="site-nav-link " href="schemas/">Schemas</a>
+                <a class="site-nav-link " href="reports.html">Reports</a>
+                <a class="site-source-link" href="https://github.com/citum/citum-core">
+                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
+                    </svg>
+                    GitHub
+                </a>
+            </div>
+            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            </button>
+        </div>
+        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
+            <a class="site-nav-link " href="index.html">Overview</a>
+            <a class="site-nav-link " href="examples.html">Capabilities</a>
+            <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
+            <a class="site-nav-link " href="developer.html">Integrate</a>
+            <a class="site-nav-link active" href="demo.html">Demo</a>
+            <a class="site-nav-link " href="schemas/">Schemas</a>
+            <a class="site-nav-link " href="reports.html">Reports</a>
+            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        </div>        <!-- LAYOUT_NAV_END -->
+
+  <div class="container-demo pt-24">
+    <div class="flex justify-end mb-4">
+      <a href="developer.html#interactive" class="config-link">
+        <span class="material-icons" style="font-size: 1rem;">settings</span>
+        View Configuration
+      </a>
+    </div>
+
+    <header>
+      <h1>The Infrastructure of Scholarly Memory</h1>
+      <p class="subtitle">How citation practices construct scholarly knowledge across languages, times, and media.</p>
+    </header>
+
+    <div class="demo-notice">
+      <strong>Illustration only.</strong> This is an entirely artificial document created to
+      demonstrate Citum citation rendering. All arguments, references, and authors are
+      fabricated. No scholarly claims are made.
+      <div class="feature-tags">
+        <span class="feature-tag">integral &amp; non-integral</span>
+        <span class="feature-tag">name memory</span>
+        <span class="feature-tag">multilingual (ja, es)</span>
+        <span class="feature-tag">EDTF dates (2022~, 1891?)</span>
+        <span class="feature-tag">archival + archive-info</span>
+        <span class="feature-tag">preprint + eprint</span>
+        <span class="feature-tag">primary / secondary bibliography</span>
+      </div>
+    </div>
+
+    <div class="controls">
+      <span>Layout:</span>
+      <button class="btn active" id="btn-classic">Classic (Bottom)</button>
+      <button class="btn" id="btn-sidebar">Modern Sidebar</button>
+    </div>
+
+  <div id="demo-root" class="demo-container">
+    <article class="content">
+      <p>
+        Scholarly citation serves as the primary mechanism through which academic knowledge
+        is organized, attributed, and transmitted. As
+        <span class="citum-citation" data-ref="chen2017">Chen (2017)</span>
+        has argued, the practices surrounding citation reflect deeper epistemological
+        commitments about what counts as knowledge and who produces it. The formal apparatus
+        of bibliographic reference — the footnote, the parenthetical, the numbered list —
+        constitutes what
+        <span class="citum-citation" data-ref="webb1968">Webb (1968)</span>
+        called &#8220;the footnote as institution,&#8221; embedding social relations within
+        the seemingly neutral mechanics of scholarly communication.
+      </p>
+
+      <p>
+        The production of this apparatus is not confined to Anglophone scholarship.
+        <span class="citum-citation" data-ref="tanaka_yuki2019">Tanaka and Suzuki (2019)</span>
+        demonstrate that citation practices in Japanese science studies reflect distinct
+        epistemological conventions, including different assumptions about authorial authority
+        and collective knowledge-making. Parallel observations emerge from Spanish-language
+        scholarship, where the relationship between citation and institutional context differs
+        in ways that challenge Anglocentric models of attribution
+        <span class="citum-citation" data-ref="garcia2022">(Garc&#237;a-Reyes &amp; Montoya, ca.&thinsp;2022)</span>.
+      </p>
+
+      <p>
+        These questions have a longer history than recent digital debates might suggest.
+        <span class="citum-citation" data-ref="harrington1891">Harrington (1891?)</span>
+        observed — in manuscript notes preserved at the British Library — that bibliographic
+        method was already contested among Victorian scholars of natural history, who
+        disagreed fundamentally about whether a citation should indicate provenance,
+        priority, or deference.
+        <span class="citum-citation" data-ref="chen2017">Chen (2017, ch.&thinsp;3)</span>
+        traces a direct line from these Victorian anxieties to contemporary algorithmic
+        citation metrics; the impulse to quantify scholarly influence has deep institutional
+        roots.
+      </p>
+
+      <p>
+        More recent work challenges the assumption that citation reflects merit rather than
+        network position.
+        <span class="citum-citation" data-ref="chen2020">Chen (2020)</span>
+        extends this analysis to the digital transition, arguing that platform architectures
+        reproduce and amplify existing hierarchies of credibility.
+        <span class="citum-citation" data-ref="okafor2024">Okafor et al. (2024)</span>
+        provide large-scale empirical support for this claim, showing through computational
+        analysis of citation networks that topological centrality correlates more strongly
+        with institutional affiliation than with measured scholarly impact.
+      </p>
+
+      <p>
+        Together, this body of evidence suggests that citation is less a neutral epistemic
+        tool than a cultural technology whose workings differ across languages, institutions,
+        and time periods. Understanding that variability requires attention to both the fine
+        structure of individual references — their dates, languages, formats, and archival
+        contexts — and the aggregate patterns they produce across documents and disciplines.
+      </p>
+    </article>
+
+    <section class="citum-bibliography">
+      <h3>Primary Sources</h3>
+
+      <div class="citum-entry" id="ref-harrington1891"
+           data-author="Harrington, R. L." data-year="1891?" data-title="Notes on Bibliographic Method">
+        <span class="citum-author">Harrington, R. L.</span>
+        <span class="citum-date">(1891?).</span>
+        <span class="citum-title">Notes on bibliographic method and the organisation of learned references</span>
+        [Manuscript]. MS Add.&thinsp;47903, ff.&thinsp;12&#8211;34.
+        British Library, Manuscripts Reading Room, London.
+      </div>
+
+      <h3>Secondary Sources</h3>
+
+      <div class="citum-entry" id="ref-chen2017"
+           data-author="Chen, M." data-year="2017" data-title="The Social Life of References">
+        <span class="citum-author">Chen, M.</span>
+        <span class="citum-date">(2017).</span>
+        <em class="citum-title">The social life of references: Knowledge-making in collaborative science.</em>
+        MIT Press.
+      </div>
+
+      <div class="citum-entry" id="ref-chen2020"
+           data-author="Chen, M." data-year="2020" data-title="Citation and Authority">
+        <span class="citum-author">Chen, M.</span>
+        <span class="citum-date">(2020).</span>
+        <em class="citum-title">Citation and authority: Epistemic practices in the digital age.</em>
+        MIT Press.
+      </div>
+
+      <div class="citum-entry" id="ref-garcia2022"
+           data-author="García-Reyes &amp; Montoya" data-year="ca. 2022" data-title="Prácticas de citación en la ciencia latinoamericana">
+        <span class="citum-author">Garc&#237;a-Reyes, I., &amp; Montoya, C.&thinsp;P.</span>
+        <span class="citum-date">(ca.&thinsp;2022).</span>
+        Pr&#225;cticas de citaci&#243;n en la ciencia latinoamericana
+        [Citation practices in Latin American science].
+        In E. Restrepo (Ed.),
+        <em class="citum-container-title">Epistemolog&#237;as del Sur: Perspectivas desde Am&#233;rica Latina</em>
+        (pp.&thinsp;112&#8211;138). CLACSO.
+      </div>
+
+      <div class="citum-entry" id="ref-okafor2024"
+           data-author="Okafor, Ferreira &amp; Park" data-year="2024" data-title="Network Topology of Academic Citation">
+        <span class="citum-author">Okafor, N., Ferreira, B., &amp; Park, J.</span>
+        <span class="citum-date">(2024, January).</span>
+        <em class="citum-title">Network topology of academic citation: A large-scale computational analysis.</em>
+        arXiv:2401.05832 [cs.DL].
+      </div>
+
+      <div class="citum-entry" id="ref-tanaka_yuki2019"
+           data-author="田中 &amp; 鈴木" data-year="2019" data-title="引用の社会的機能">
+        <span class="citum-author">&#30000;&#20013;, &#30001;&#32000;, &amp; &#40658;&#26408;, &#26149;&#20154;.</span>
+        <span class="citum-date">(2019).</span>
+        &#24341;&#29992;&#12398;&#31038;&#20250;&#30340;&#26178;&#35251;&#65306;&#23398;&#34899;&#30693;&#35672;&#12398;&#27083;&#31689;&#12395;&#12362;&#12369;&#12427;&#21442;&#29031;&#23455;&#36341;
+        [The social function of citation: Reference practices in the construction of academic knowledge].
+        <em class="citum-container-title">&#31185;&#23398;&#31038;&#20250;&#23398;&#30740;&#31350;,</em>
+        <em>37</em>(2), 45&#8211;78.
+      </div>
+
+      <div class="citum-entry" id="ref-webb1968"
+           data-author="Webb, M. L." data-year="1968" data-title="The Footnote as Institution">
+        <span class="citum-author">Webb, M.&thinsp;L.</span>
+        <span class="citum-date">(1968).</span>
+        <em class="citum-title">The footnote as institution: A history of scholarly reference.</em>
+        Oxford University Press.
+      </div>
+    </section>
+  </div>
+  </div>
+
+    <!-- Footer -->
+    <footer class="py-12 px-6 border-t border-slate-200 bg-white/50">
+        <!-- LAYOUT_FOOTER_START -->
+            <div class="site-footer-inner">
+                <div class="site-brand site-brand-small">
+                    <div class="site-brand-mark"><span>C</span></div>
+                    <span class="site-brand-name">Citum</span>
+                </div>
+                <div class="site-footer-links">
+                    <a href="guides/style-authoring/start.html">Style Authoring</a>
+                    <a href="developer.html">Integrate</a>
+                    <a href="schemas/">Schemas</a>
+                    <a href="reports.html">Reports</a>
+                    <a href="operating.html">Contributing</a>
+                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                </div>
+                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
+            </div>
+            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/github.min.css">
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js" defer onload="hljs.highlightAll();"></script>        <!-- LAYOUT_FOOTER_END -->
+    </footer>
+
+  <script src="assets/citum-interactive.js"></script>
+  <script>
+    const root = document.getElementById('demo-root');
+    const btnClassic = document.getElementById('btn-classic');
+    const btnSidebar = document.getElementById('btn-sidebar');
+
+    btnClassic.addEventListener('click', () => {
+      root.classList.remove('citum-with-sidebar');
+      btnClassic.classList.add('active');
+      btnSidebar.classList.remove('active');
+    });
+
+    btnSidebar.addEventListener('click', () => {
+      root.classList.add('citum-with-sidebar');
+      btnSidebar.classList.add('active');
+      btnClassic.classList.remove('active');
+    });
+  </script>
+</body>
+</html>

--- a/docs/developer.html
+++ b/docs/developer.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="developer.html">Integrate</a>
-                <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="developer.html">Integrate</a>
-            <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
@@ -384,7 +384,7 @@ citum-server --http --port 8765       # HTTP JSON-RPC</code></pre>
 &lt;script src="https://docs.citum.org/assets/citum-interactive.js"&gt;&lt;/script&gt;</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                See the <a href="interactive-demo.html">live demo</a> for a runnable page.
+                See the <a href="demo.html">live demo</a> for a runnable page.
                 The assets are MPL-2.0 and free to vendor into your own site.
             </p>
         </section>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -31,7 +31,7 @@
                 <a class="site-nav-link active" href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Integrate</a>
-                <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -50,7 +50,7 @@
             <a class="site-nav-link active" href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Integrate</a>
-            <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
@@ -83,7 +83,9 @@ Integral:      Kuhn and Popper (1962)
 Name memory:   Thomas S. Kuhn (10) … later Smith (12)</code></pre>
             </div>
             <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
-                &rarr; <a href="guides/style-authoring/advanced-examples.html#advanced-citations">Advanced citation examples</a>
+                &rarr; <a href="citation-modes.html">Integral vs non-integral across style classes</a>
+                &nbsp;&middot;&nbsp;
+                <a href="guides/style-authoring/advanced-examples.html#advanced-citations">Advanced citation examples</a>
                 &nbsp;&middot;&nbsp;
                 <a href="guides/style-authoring/templates.html#citation-modes">Template reference</a>
             </p>
@@ -243,7 +245,7 @@ citum render refs -b refs.json -s apa-7th -f plain</code></pre>
 &lt;script src="https://docs.citum.org/assets/citum-interactive.js"&gt;&lt;/script&gt;</code></pre>
             </div>
             <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
-                &rarr; <a href="interactive-demo.html">Live demo</a>
+                &rarr; <a href="demo.html">Live demo</a>
                 &nbsp;&middot;&nbsp;
                 <a href="developer.html#interactive">Developer &rarr; Interactive HTML</a>
             </p>

--- a/docs/guides/integrations/djot.html
+++ b/docs/guides/integrations/djot.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/integrations/editor-plugin.html
+++ b/docs/guides/integrations/editor-plugin.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/integrations/lualatex.html
+++ b/docs/guides/integrations/lualatex.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/integrations/rust-library.html
+++ b/docs/guides/integrations/rust-library.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/integrations/scholar-cli.html
+++ b/docs/guides/integrations/scholar-cli.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/integrations/static-site.html
+++ b/docs/guides/integrations/static-site.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/integrations/typst.html
+++ b/docs/guides/integrations/typst.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link active" href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -88,7 +88,7 @@
                 <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -107,7 +107,7 @@
             <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-author-guide.template.html
+++ b/docs/guides/style-author-guide.template.html
@@ -89,7 +89,7 @@
                 <a class="nav-link" href="https://citum.org">Home</a>
                 <a class="nav-link text-slate-600" href="../index.html">Docs</a>
                 <a class="nav-link text-slate-600" href="../news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
+                <a class="nav-link text-slate-600" href="../demo.html">Demo</a>
                 <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
                 <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
                 <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
@@ -110,7 +110,7 @@
                 <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
                 <a class="nav-link text-slate-600" href="../index.html">Docs</a>
                 <a class="nav-link text-slate-600" href="../news/index.html">News</a>
-                <a class="nav-link text-slate-600" href="../interactive-demo.html">Demo</a>
+                <a class="nav-link text-slate-600" href="../demo.html">Demo</a>
                 <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
                 <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
                 <a class="nav-link text-slate-600" href="../reports.html">Reports</a>

--- a/docs/guides/style-authoring-skill.html
+++ b/docs/guides/style-authoring-skill.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/advanced-examples.html
+++ b/docs/guides/style-authoring/advanced-examples.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/inheritance-and-registries.html
+++ b/docs/guides/style-authoring/inheritance-and-registries.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/locales.html
+++ b/docs/guides/style-authoring/locales.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/options.html
+++ b/docs/guides/style-authoring/options.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/start.html
+++ b/docs/guides/style-authoring/start.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/style-anatomy.html
+++ b/docs/guides/style-authoring/style-anatomy.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/templates.html
+++ b/docs/guides/style-authoring/templates.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/guides/style-authoring/validation.html
+++ b/docs/guides/style-authoring/validation.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../../examples.html">Capabilities</a>
                 <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../../demo.html">Demo</a>
                 <a class="site-nav-link " href="../../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../../examples.html">Capabilities</a>
             <a class="site-nav-link active" href="../../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../../demo.html">Demo</a>
             <a class="site-nav-link " href="../../schemas/">Schemas</a>
             <a class="site-nav-link " href="../../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Integrate</a>
-                <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Integrate</a>
-            <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/operating.html
+++ b/docs/operating.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Integrate</a>
-                <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Integrate</a>
-            <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/policies/type-addition-policy.html
+++ b/docs/policies/type-addition-policy.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../demo.html">Demo</a>
                 <a class="site-nav-link " href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../demo.html">Demo</a>
             <a class="site-nav-link " href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Integrate</a>
-                <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="demo.html">Demo</a>
                 <a class="site-nav-link active" href="schemas/">Schemas</a>
                 <a class="site-nav-link " href="reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Integrate</a>
-            <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="demo.html">Demo</a>
             <a class="site-nav-link active" href="schemas/">Schemas</a>
             <a class="site-nav-link " href="reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/reports.html
+++ b/docs/reports.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="examples.html">Capabilities</a>
                 <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="developer.html">Integrate</a>
-                <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="demo.html">Demo</a>
                 <a class="site-nav-link " href="schemas/">Schemas</a>
                 <a class="site-nav-link active" href="reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="examples.html">Capabilities</a>
             <a class="site-nav-link " href="guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="developer.html">Integrate</a>
-            <a class="site-nav-link " href="interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="demo.html">Demo</a>
             <a class="site-nav-link " href="schemas/">Schemas</a>
             <a class="site-nav-link active" href="reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>

--- a/docs/schemas/index.html
+++ b/docs/schemas/index.html
@@ -24,7 +24,7 @@
                 <a class="site-nav-link " href="../examples.html">Capabilities</a>
                 <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
                 <a class="site-nav-link " href="../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+                <a class="site-nav-link " href="../demo.html">Demo</a>
                 <a class="site-nav-link active" href="../schemas/">Schemas</a>
                 <a class="site-nav-link " href="../reports.html">Reports</a>
                 <a class="site-source-link" href="https://github.com/citum/citum-core">
@@ -43,7 +43,7 @@
             <a class="site-nav-link " href="../examples.html">Capabilities</a>
             <a class="site-nav-link " href="../guides/style-authoring/start.html">Style Authoring</a>
             <a class="site-nav-link " href="../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../interactive-demo.html">Demo</a>
+            <a class="site-nav-link " href="../demo.html">Demo</a>
             <a class="site-nav-link active" href="../schemas/">Schemas</a>
             <a class="site-nav-link " href="../reports.html">Reports</a>
             <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>


### PR DESCRIPTION
## Summary

- Replaces `interactive-demo.html` with `demo.html` — a richer article-style demo document sourced from the new `demo.djot`. The article demonstrates integral/non-integral citations, name memory, multilingual sources (Japanese, Spanish), EDTF uncertain and approximate dates, archival references with `archive-info`, and preprints with `eprint` identifiers. The Classic/Sidebar layout toggle and all interactive JS/CSS are preserved.
- Adds `citation-modes.html` — shows the same two-citation passage rendered across author-date, numeric+note-based, and label style classes, integral vs non-integral side by side.
- Adds `docs/demo-refs.yaml` (shared fabricated reference data) and `docs/demo.djot` (djot source narrative).
- Adds `.content p + p { text-indent: 1.5em }` to `citum-interactive.css` for article prose rendering.
- Updates all nav links across docs from `interactive-demo.html` → `demo.html`.
- Links `citation-modes.html` from the citation modes section of `examples.html`.

## Test plan

- [x] Open `demo.html` in browser — article renders, toggle switches between Classic and Sidebar layout, clicking citations scrolls to bibliography, hover tooltips appear
- [x] Open `citation-modes.html` — three sections render, integral/non-integral pairs display side by side
- [x] Confirm no remaining `interactive-demo.html` hrefs in other pages: `grep -r interactive-demo docs/ --include="*.html"`