### PR TITLE
fix(ci): explicit changelog generation step

### DIFF
--- a/.beans/csl26-wtwi--fix-changelog-generation-in-release-workflow.md
+++ b/.beans/csl26-wtwi--fix-changelog-generation-in-release-workflow.md
@@ -1,0 +1,10 @@
+---
+# csl26-wtwi
+title: Fix changelog generation in release workflow
+status: in-progress
+type: bug
+created_at: 2026-05-26T12:11:34Z
+updated_at: 2026-05-26T12:11:34Z
+---
+
+git-cliff runs inside cargo-release pre-release-hook with ambiguous commit range; changelog entries are missing or just rename the version number. Fix: move git-cliff call to explicit workflow step before cargo-release, use --prepend with explicit LAST_TAG..HEAD range.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,36 @@ jobs:
         if: steps.config.outputs.create_pr == 'true'
         run: git checkout -B "${{ steps.config.outputs.branch }}"
 
+      - name: Generate changelog
+        run: |
+          LAST_TAG=$(git tag --sort=-version:refname -l 'v*' | head -1)
+          CURRENT=$(python3 - <<'PY'
+          import re, pathlib
+          text = pathlib.Path("Cargo.toml").read_text()
+          m = re.search(r'^\[workspace\.package\].*?^version\s*=\s*"([^"]+)"', text, re.DOTALL|re.MULTILINE)
+          if not m:
+              raise SystemExit("workspace package version not found")
+          print(m.group(1))
+          PY
+          )
+          LEVEL="${{ steps.resolve.outputs.level }}"
+          NEW_VERSION=$(python3 -c "
+          v = '$CURRENT'.split('.')
+          if '$LEVEL' == 'major':
+              v[0] = str(int(v[0]) + 1); v[1] = '0'; v[2] = '0'
+          elif '$LEVEL' == 'minor':
+              v[1] = str(int(v[1]) + 1); v[2] = '0'
+          else:
+              v[2] = str(int(v[2]) + 1)
+          print('.'.join(v))
+          ")
+          RANGE="${LAST_TAG:+${LAST_TAG}..}HEAD"
+          git cliff $RANGE --tag "v${NEW_VERSION}" --prepend CHANGELOG.md
+          git add CHANGELOG.md
+          if ! git diff --cached --quiet; then
+            git commit -m "docs: update changelog for v${NEW_VERSION}"
+          fi
+
       - name: Bump schema version (if schema changed)
         if: needs.detect.outputs.schema-changed == 'true'
         run: |

--- a/release.toml
+++ b/release.toml
@@ -4,10 +4,3 @@ dependent-version = "upgrade"
 tag-prefix = "v"
 tag-message = "v{{version}}"
 pre-release-commit-message = "chore: release v{{version}}\n\nAutomated workspace version bump for v{{version}}."
-pre-release-hook = [
-  "bash",
-  "-c",
-  "repo=$(git rev-parse --show-toplevel) && git-cliff --config \"$repo/cliff.toml\" -o \"$repo/CHANGELOG.md\" --tag \"$1\"",
-  "update-root-changelog",
-  "v{{version}}",
-]


### PR DESCRIPTION
## Summary

- Moves `git-cliff` out of the `cargo-release` `pre-release-hook` and into an explicit `Generate changelog` step in the `release-pr` workflow job
- Uses an explicit `LAST_TAG..HEAD` range so all commits since the last version tag are captured
- Switches from `-o` (full overwrite) to `--prepend` so existing changelog history is preserved
- Commits `CHANGELOG.md` separately before the version bump commit, which eliminates the ambiguous context that caused the hook to see wrong commit ranges

## Root cause

The `pre-release-hook` ran git-cliff *after* cargo-release had already added the version bump commit to `release/next`. git-cliff resolved the commit range from that narrow context, missing the actual feature/fix commits that landed on `main` since the last tag. Result: release PRs (e.g. #808) showed changelogs that were either empty or just renamed the previous version number.

## Test plan

- [ ] Merge this PR first, then let any subsequent fix/feat PR trigger the release workflow
- [ ] Verify the updated `release/next` PR shows a `CHANGELOG.md` diff with a new `## [vX.Y.Z]` section containing actual `feat:`/`fix:` entries
- [ ] Confirm the existing changelog history is preserved below the new section
