### PR TITLE
fix(ci): replace dorny/paths-filter with git

### DIFF
--- a/.beans/archive/csl26-wtwi--fix-changelog-generation-in-release-workflow.md
+++ b/.beans/archive/csl26-wtwi--fix-changelog-generation-in-release-workflow.md
@@ -1,10 +1,15 @@
 ---
 # csl26-wtwi
 title: Fix changelog generation in release workflow
-status: in-progress
+status: completed
 type: bug
+priority: normal
 created_at: 2026-05-26T12:11:34Z
-updated_at: 2026-05-26T12:11:34Z
+updated_at: 2026-05-26T12:12:57Z
 ---
 
 git-cliff runs inside cargo-release pre-release-hook with ambiguous commit range; changelog entries are missing or just rename the version number. Fix: move git-cliff call to explicit workflow step before cargo-release, use --prepend with explicit LAST_TAG..HEAD range.
+
+## Summary of Changes
+
+Moved git-cliff call from cargo-release pre-release-hook into an explicit workflow step. Now uses LAST_TAG..HEAD range with --prepend. PR #810.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,58 +34,26 @@ jobs:
       release: ${{ steps.filter.outputs.release }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            rust:
-              - 'crates/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-              - 'styles/**'
-            docs:
-              - '**.md'
-              - 'docs/**'
-              - 'CONTRIBUTING.md'
-              - 'examples/**'
-              - '.github/**'
-            scripts:
-              - 'scripts/**'
-              - 'examples/**'
-            beans:
-              - 'registry/**'
-              - 'locales/**'
-              - 'templates/**'
-              - '.beans.yml'
-              - '.beans/**'
-            infra:
-              - 'scripts/**'
-              - 'crates/**'
-            semver:
-              - 'crates/csl-legacy/**'
-              - 'crates/citum-schema-data/**'
-              - 'crates/citum-schema-style/**'
-              - 'crates/citum-schema/**'
-              - 'crates/citum-migrate/**'
-              - 'crates/citum-engine/**'
-              - 'crates/citum-cli/**'
-              - 'crates/citum-bindings/**'
-            release:
-              - '.github/workflows/ci.yml'
-              - '.github/workflows/release.yml'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'RELEASING.md'
-              - 'scripts/build-jsr-package.sh'
-              - 'scripts/install.sh'
-              - 'scripts/publish-crates.sh'
-              - 'scripts/release-binary.sh'
-              # Any publishable crate change can break `cargo publish` (e.g.
-              # `include_bytes!` paths that escape the crate dir, README
-              # paths outside the package, missing `description`). Trigger
-              # the dry-run job on any change inside crates/.
-              - 'crates/**'
+          fetch-depth: 0
+      - name: Detect changed paths
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          else
+            CHANGED=$(git diff --name-only HEAD^ HEAD 2>/dev/null || git diff --name-only HEAD)
+          fi
+          has() { echo "$CHANGED" | grep -qE "$1" && echo "true" || echo "false"; }
+          {
+            echo "rust=$(has '^(crates/|Cargo\.toml$|Cargo\.lock$|rust-toolchain\.toml$|styles/)')"
+            echo "docs=$(has '\.md$|^(docs/|CONTRIBUTING\.md$|examples/|\.github/)')"
+            echo "scripts=$(has '^(scripts/|examples/)')"
+            echo "beans=$(has '^(registry/|locales/|templates/|\.beans\.yml$|\.beans/)')"
+            echo "infra=$(has '^(scripts/|crates/)')"
+            echo "semver=$(has '^crates/(csl-legacy|citum-schema-data|citum-schema-style|citum-schema|citum-migrate|citum-engine|citum-cli|citum-bindings)/')"
+            echo "release=$(has '^(\.github/workflows/(ci|release)\.yml$|Cargo\.toml$|Cargo\.lock$|RELEASING\.md$|scripts/(build-jsr-package|install|publish-crates|release-binary)\.sh$|crates/)')"
+          } >> "$GITHUB_OUTPUT"
 
   hygiene-docs:
     name: Hygiene Checks — Docs

--- a/docs/guides/TEST_STRATEGY.md
+++ b/docs/guides/TEST_STRATEGY.md
@@ -45,7 +45,7 @@ cargo nextest run --test citations
 6. **Structured name particles** - More nuanced than CSL JSON
 
 **Implementation plan** (deferred):
-1. Create `tests/fixtures/csln-native-references.yaml` (or .json - serde supports both)
+1. Create a native references fixture file under `tests/fixtures/` (yaml or json — serde supports both)
 2. Build separate test harness (no oracle comparison - we ARE the reference)
 3. Test Citum-specific rendering against expected outputs
 4. Document intentional divergences from CSL 1.0

--- a/docs/specs/TITLE_TEXT_CASE.md
+++ b/docs/specs/TITLE_TEXT_CASE.md
@@ -4,7 +4,7 @@
 **Version:** 1.0
 **Date:** 2026-03-11
 **Supersedes:** none
-**Related:** `csl26-wv5o`, `csl26-suz3`, `docs/architecture/DJOT_RICH_TEXT.md`
+**Related:** `csl26-wv5o`, `csl26-suz3`, `docs/specs/DJOT_RICH_TEXT.md`
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

- Replaces `dorny/paths-filter` (unavailable on GitHub's CDN for both v3 and v4) with a native `git diff` step that produces identical `true`/`false` outputs per filter
- Fixes two broken backtick path references caught by alint: `TITLE_TEXT_CASE.md` (DJOT spec moved from `docs/architecture/` to `docs/specs/`) and `TEST_STRATEGY.md` (future fixture path reworded so alint doesn't treat it as an existing file)
- Archives bean `csl26-wtwi` (changelog fix shipped in #810)
