### PR TITLE
feat(engine): support script name separators

### DIFF
--- a/crates/citum-engine/src/values/contributor/names.rs
+++ b/crates/citum-engine/src/values/contributor/names.rs
@@ -11,6 +11,7 @@ use citum_schema::options::{
     AndOptions, AndOtherOptions, DemoteNonDroppingParticle, DisplayAsSort, ShortenListOptions,
 };
 use citum_schema::template::{ContributorForm, NameOrder};
+use unicode_script::{Script, UnicodeScript};
 
 /// Configuration for formatting a single name.
 pub(crate) struct NameFormatContext<'a> {
@@ -21,6 +22,9 @@ pub(crate) struct NameFormatContext<'a> {
     pub(crate) name_form: Option<NameForm>,
     pub(crate) demote_ndp: Option<&'a DemoteNonDroppingParticle>,
     pub(crate) sort_separator: Option<&'a String>,
+    pub(crate) component_sort_separator: Option<&'a String>,
+    pub(crate) script_configs:
+        Option<&'a std::collections::HashMap<String, citum_schema::options::ScriptConfig>>,
     pub(crate) integral_name_state: Option<citum_schema::citation::IntegralNameState>,
     pub(crate) use_integral_short_name: bool,
     pub(crate) short_name_display: Option<citum_schema::options::ShortNameDisplay>,
@@ -296,6 +300,12 @@ pub fn format_names(
         sort_separator: overrides
             .sort_separator
             .or_else(|| config.and_then(|c| c.sort_separator.as_ref())),
+        component_sort_separator: overrides.sort_separator,
+        script_configs: options
+            .config
+            .multilingual
+            .as_ref()
+            .map(|multilingual| &multilingual.scripts),
         integral_name_state: hints.integral_name_state,
         use_integral_short_name: matches!(
             options.mode,
@@ -433,67 +443,221 @@ fn initialize_given_name(
     result.trim().to_string()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NameAssemblyOrder {
+    GivenFirst,
+    NativeFamilyFirst,
+    Inverted,
+}
+
+#[derive(Debug, Default)]
+struct NameScriptFlags {
+    has_han: bool,
+    has_hiragana: bool,
+    has_katakana: bool,
+    has_hangul: bool,
+}
+
+impl NameScriptFlags {
+    fn record(&mut self, value: &str) {
+        for ch in value.chars() {
+            match ch.script() {
+                Script::Han => self.has_han = true,
+                Script::Hiragana => self.has_hiragana = true,
+                Script::Katakana => self.has_katakana = true,
+                Script::Hangul => self.has_hangul = true,
+                _ => {}
+            }
+        }
+    }
+
+    fn cjk_script_count(&self) -> usize {
+        usize::from(self.has_han)
+            + usize::from(self.has_hiragana)
+            + usize::from(self.has_katakana)
+            + usize::from(self.has_hangul)
+    }
+
+    fn candidate_keys(&self) -> Vec<&'static str> {
+        let count = self.cjk_script_count();
+        if count == 0 {
+            return Vec::new();
+        }
+        // Mixed kana (Hiragana + Katakana, no Han/Hangul) matches "kana" before "cjk".
+        if count > 1
+            && !self.has_han
+            && !self.has_hangul
+            && (self.has_hiragana || self.has_katakana)
+        {
+            return vec!["kana", "Hrkt", "cjk"];
+        }
+        if count > 1 {
+            return vec!["cjk"];
+        }
+        if self.has_katakana {
+            return vec!["katakana", "Kana", "Hrkt", "kana", "cjk"];
+        }
+        if self.has_hiragana {
+            return vec!["hiragana", "Hira", "Hrkt", "kana", "cjk"];
+        }
+        if self.has_han {
+            return vec!["han", "Hani", "cjk"];
+        }
+        if self.has_hangul {
+            return vec!["hangul", "Hang", "cjk"];
+        }
+        Vec::new()
+    }
+}
+
+fn script_config_for_name<'a>(
+    name: &crate::reference::FlatName,
+    ctx: &'a NameFormatContext<'a>,
+) -> Option<&'a citum_schema::options::ScriptConfig> {
+    let configs = ctx.script_configs?;
+    if configs.is_empty() {
+        return None;
+    }
+
+    let mut flags = NameScriptFlags::default();
+    for part in [
+        name.family.as_deref(),
+        name.given.as_deref(),
+        name.dropping_particle.as_deref(),
+        name.non_dropping_particle.as_deref(),
+        name.suffix.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        flags.record(part);
+    }
+
+    flags
+        .candidate_keys()
+        .into_iter()
+        .find_map(|key| configs.get(key))
+}
+
 /// Assemble a long-form name from its computed parts.
 ///
-/// When `inverted` is true uses "Family, Given" order; otherwise "Given Family".
+/// Inverted order uses "Family, Given"; native family-first uses family-first
+/// display order without sort punctuation.
 fn assemble_long_name(
     family_part: String,
     given_part: String,
     particle_part: String,
     suffix: &str,
-    inverted: bool,
+    order: NameAssemblyOrder,
+    name_part_delimiter: &str,
     sort_separator: &str,
 ) -> String {
-    if inverted {
-        // "Family, Given" format
-        // Family Part + sort_separator + Given Part + Particle Part + Suffix
-        let mut suffix_part = String::new();
-        if !given_part.is_empty() {
-            suffix_part.push_str(&given_part);
-        }
-        if !particle_part.is_empty() {
-            if !suffix_part.is_empty() {
-                suffix_part.push(' ');
-            }
-            suffix_part.push_str(&particle_part);
-        }
-        if !suffix.is_empty() {
-            if !suffix_part.is_empty() {
-                suffix_part.push(' ');
-            }
-            suffix_part.push_str(suffix);
-        }
-
-        if suffix_part.is_empty() {
-            family_part
-        } else {
-            format!("{family_part}{sort_separator}{suffix_part}")
-        }
-    } else {
-        // "Given Family" format
-        // Given Part + Particle Part + Family Part + Suffix
-        let mut parts = Vec::new();
-        if !given_part.is_empty() {
-            parts.push(given_part);
-        }
-        if !particle_part.is_empty() {
-            parts.push(particle_part);
-        }
-        if !family_part.is_empty() {
-            if let Some(last) = parts.last_mut()
-                && last.ends_with('-')
-            {
-                last.push_str(&family_part);
-            } else {
-                parts.push(family_part);
-            }
-        }
-        if !suffix.is_empty() {
-            parts.push(suffix.to_string());
-        }
-
-        parts.join(" ")
+    match order {
+        NameAssemblyOrder::Inverted => assemble_inverted_long_name(
+            family_part,
+            given_part,
+            particle_part,
+            suffix,
+            sort_separator,
+        ),
+        NameAssemblyOrder::NativeFamilyFirst => assemble_native_family_first_long_name(
+            family_part,
+            given_part,
+            particle_part,
+            suffix,
+            name_part_delimiter,
+        ),
+        NameAssemblyOrder::GivenFirst => assemble_given_first_long_name(
+            family_part,
+            given_part,
+            particle_part,
+            suffix,
+            name_part_delimiter,
+        ),
     }
+}
+
+fn assemble_inverted_long_name(
+    family_part: String,
+    given_part: String,
+    particle_part: String,
+    suffix: &str,
+    sort_separator: &str,
+) -> String {
+    let mut suffix_part = String::new();
+    if !given_part.is_empty() {
+        suffix_part.push_str(&given_part);
+    }
+    if !particle_part.is_empty() {
+        if !suffix_part.is_empty() {
+            suffix_part.push(' ');
+        }
+        suffix_part.push_str(&particle_part);
+    }
+    if !suffix.is_empty() {
+        if !suffix_part.is_empty() {
+            suffix_part.push(' ');
+        }
+        suffix_part.push_str(suffix);
+    }
+
+    if suffix_part.is_empty() {
+        family_part
+    } else {
+        format!("{family_part}{sort_separator}{suffix_part}")
+    }
+}
+
+fn assemble_native_family_first_long_name(
+    family_part: String,
+    given_part: String,
+    particle_part: String,
+    suffix: &str,
+    name_part_delimiter: &str,
+) -> String {
+    let mut parts = Vec::new();
+    if !family_part.is_empty() {
+        parts.push(family_part);
+    }
+    if !particle_part.is_empty() {
+        parts.push(particle_part);
+    }
+    if !given_part.is_empty() {
+        parts.push(given_part);
+    }
+    if !suffix.is_empty() {
+        parts.push(suffix.to_string());
+    }
+    parts.join(name_part_delimiter)
+}
+
+fn assemble_given_first_long_name(
+    family_part: String,
+    given_part: String,
+    particle_part: String,
+    suffix: &str,
+    name_part_delimiter: &str,
+) -> String {
+    let mut parts = Vec::new();
+    if !given_part.is_empty() {
+        parts.push(given_part);
+    }
+    if !particle_part.is_empty() {
+        parts.push(particle_part);
+    }
+    if !family_part.is_empty() {
+        if let Some(last) = parts.last_mut()
+            && last.ends_with('-')
+        {
+            last.push_str(&family_part);
+        } else {
+            parts.push(family_part);
+        }
+    }
+    if !suffix.is_empty() {
+        parts.push(suffix.to_string());
+    }
+    parts.join(name_part_delimiter)
 }
 
 fn format_literal_name(literal: &str, short: Option<&str>, ctx: &NameFormatContext) -> String {
@@ -516,6 +680,55 @@ fn format_literal_name(literal: &str, short: Option<&str>, ctx: &NameFormatConte
         }
     }
     literal.to_string()
+}
+
+fn is_inverted_name_order(index: usize, ctx: &NameFormatContext) -> bool {
+    match ctx.name_order {
+        Some(NameOrder::GivenFirst) => false,
+        Some(NameOrder::FamilyFirst) => match ctx.display_as_sort {
+            Some(DisplayAsSort::First) => index == 0,
+            _ => true,
+        },
+        Some(NameOrder::FamilyFirstOnly) => index == 0,
+        None => match ctx.display_as_sort {
+            Some(DisplayAsSort::All) => true,
+            Some(DisplayAsSort::First) => index == 0,
+            _ => false,
+        },
+    }
+}
+
+fn name_assembly_order(
+    inverted: bool,
+    script_config: Option<&citum_schema::options::ScriptConfig>,
+    ctx: &NameFormatContext,
+) -> NameAssemblyOrder {
+    if inverted {
+        return NameAssemblyOrder::Inverted;
+    }
+    let native_family_first =
+        ctx.name_order.is_none() && script_config.is_some_and(|config| config.use_native_ordering);
+    if native_family_first {
+        NameAssemblyOrder::NativeFamilyFirst
+    } else {
+        NameAssemblyOrder::GivenFirst
+    }
+}
+
+fn sort_separator_for_name<'a>(
+    script_config: Option<&'a citum_schema::options::ScriptConfig>,
+    ctx: &'a NameFormatContext<'a>,
+) -> &'a str {
+    ctx.component_sort_separator
+        .map_or_else(
+            || {
+                script_config
+                    .and_then(|config| config.sort_separator.as_deref())
+                    .or_else(|| ctx.sort_separator.map(std::string::String::as_str))
+            },
+            |separator| Some(separator.as_str()),
+        )
+        .unwrap_or(", ")
 }
 
 /// Format a single name.
@@ -544,23 +757,13 @@ pub(crate) fn format_single_name(
     let dp = name.dropping_particle.as_deref().unwrap_or("");
     let ndp = name.non_dropping_particle.as_deref().unwrap_or("");
     let suffix = name.suffix.as_deref().unwrap_or("");
+    let script_config = script_config_for_name(name, ctx);
 
     // Determine if we should invert (Family, Given).
     // `display-as-sort: first` in the config limits inversion to the first name
     // even when the template requests `name-order: family-first` for all names.
-    let inverted = match ctx.name_order {
-        Some(NameOrder::GivenFirst) => false,
-        Some(NameOrder::FamilyFirst) => match ctx.display_as_sort {
-            Some(DisplayAsSort::First) => index == 0,
-            _ => true,
-        },
-        Some(NameOrder::FamilyFirstOnly) => index == 0,
-        None => match ctx.display_as_sort {
-            Some(DisplayAsSort::All) => true,
-            Some(DisplayAsSort::First) => index == 0,
-            _ => false,
-        },
-    };
+    let inverted = is_inverted_name_order(index, ctx);
+    let assembly_order = name_assembly_order(inverted, script_config, ctx);
 
     // Determine effective form
     let effective_form = if expand_given_names && matches!(form, ContributorForm::Short) {
@@ -627,13 +830,17 @@ pub(crate) fn format_single_name(
                 particle_part.push_str(ndp);
             }
 
-            let sep = ctx.sort_separator.map_or(", ", std::string::String::as_str);
+            let name_part_delimiter = script_config
+                .and_then(|config| config.delimiter.as_deref())
+                .unwrap_or(" ");
+            let sep = sort_separator_for_name(script_config, ctx);
             assemble_long_name(
                 family_part,
                 given_part,
                 particle_part,
                 suffix,
-                inverted,
+                assembly_order,
+                name_part_delimiter,
                 sep,
             )
         }

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -154,6 +154,8 @@ fn make_name_format_context<'a>(
         name_form,
         demote_ndp,
         sort_separator,
+        component_sort_separator: None,
+        script_configs: None,
         integral_name_state: None,
         use_integral_short_name: true,
         short_name_display: None,
@@ -2969,6 +2971,275 @@ fn test_sort_separator_space() {
     let result_default =
         contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
     assert_eq!(result_default, "Smith, J");
+}
+
+#[test]
+fn katakana_names_use_script_delimiter_in_original_order() {
+    let name = FlatName {
+        family: Some("ジャクソン".to_string()),
+        given: Some("マイケル".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "katakana".to_string(),
+        ScriptConfig {
+            delimiter: Some("・".to_string()),
+            ..Default::default()
+        },
+    )]);
+    let mut ctx =
+        make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
+    ctx.script_configs = Some(&scripts);
+
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+
+    assert_eq!(result, "マイケル・ジャクソン");
+}
+
+#[test]
+fn katakana_names_use_script_sort_separator_when_inverted() {
+    let name = FlatName {
+        family: Some("ジャクソン".to_string()),
+        given: Some("マイケル".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "katakana".to_string(),
+        ScriptConfig {
+            delimiter: Some("・".to_string()),
+            sort_separator: Some("、".to_string()),
+            ..Default::default()
+        },
+    )]);
+    let mut ctx = make_name_format_context(
+        Some(DisplayAsSort::All),
+        None,
+        None,
+        None,
+        Some(NameForm::Full),
+        None,
+        None,
+    );
+    ctx.script_configs = Some(&scripts);
+
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+
+    assert_eq!(result, "ジャクソン、マイケル");
+}
+
+/// Reproduces the forum use-case verbatim:
+///   マイケル・ジャクソン  (original order)
+///   ジャクソン、マイケル  (inverted order)
+/// Both outputs come from the same style config with one `katakana` entry.
+#[test]
+fn katakana_name_renders_correctly_in_both_orders() {
+    let name = FlatName {
+        family: Some("ジャクソン".to_string()),
+        given: Some("マイケル".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "katakana".to_string(),
+        ScriptConfig {
+            delimiter: Some("・".to_string()),
+            sort_separator: Some("、".to_string()),
+            ..Default::default()
+        },
+    )]);
+
+    let mut ctx_original =
+        make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
+    ctx_original.script_configs = Some(&scripts);
+    let original =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx_original, false);
+
+    let mut ctx_inverted = make_name_format_context(
+        Some(DisplayAsSort::All),
+        None,
+        None,
+        None,
+        Some(NameForm::Full),
+        None,
+        None,
+    );
+    ctx_inverted.script_configs = Some(&scripts);
+    let inverted =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx_inverted, false);
+
+    assert_eq!(original, "マイケル・ジャクソン");
+    assert_eq!(inverted, "ジャクソン、マイケル");
+}
+
+#[test]
+fn native_cjk_names_use_native_ordering_without_space() {
+    let name = FlatName {
+        family: Some("北川".to_string()),
+        given: Some("善太郎".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "cjk".to_string(),
+        ScriptConfig {
+            use_native_ordering: true,
+            delimiter: Some(String::new()),
+            ..Default::default()
+        },
+    )]);
+    let mut ctx =
+        make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
+    ctx.script_configs = Some(&scripts);
+
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+
+    assert_eq!(result, "北川善太郎");
+}
+
+#[test]
+fn latin_names_ignore_unmatched_script_separators() {
+    let name = FlatName {
+        family: Some("Jackson".to_string()),
+        given: Some("Michael".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "katakana".to_string(),
+        ScriptConfig {
+            delimiter: Some("・".to_string()),
+            sort_separator: Some("、".to_string()),
+            ..Default::default()
+        },
+    )]);
+    let mut ctx =
+        make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
+    ctx.script_configs = Some(&scripts);
+
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+
+    assert_eq!(result, "Michael Jackson");
+}
+
+#[test]
+fn component_sort_separator_overrides_script_sort_separator() {
+    let name = FlatName {
+        family: Some("ジャクソン".to_string()),
+        given: Some("マイケル".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "katakana".to_string(),
+        ScriptConfig {
+            sort_separator: Some("、".to_string()),
+            ..Default::default()
+        },
+    )]);
+    let component_separator = " / ".to_string();
+    let mut ctx = make_name_format_context(
+        Some(DisplayAsSort::All),
+        None,
+        None,
+        None,
+        Some(NameForm::Full),
+        None,
+        None,
+    );
+    ctx.script_configs = Some(&scripts);
+    ctx.component_sort_separator = Some(&component_separator);
+
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+
+    assert_eq!(result, "ジャクソン / マイケル");
+}
+
+#[test]
+fn mixed_kana_names_match_kana_config() {
+    // Family in Hiragana, given in Katakana — mixed kana should resolve to "kana" key.
+    let name = FlatName {
+        family: Some("やまだ".to_string()), // hiragana
+        given: Some("タロウ".to_string()),  // katakana
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "kana".to_string(),
+        ScriptConfig {
+            delimiter: Some("・".to_string()),
+            ..Default::default()
+        },
+    )]);
+    let mut ctx =
+        make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
+    ctx.script_configs = Some(&scripts);
+
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+
+    assert_eq!(result, "タロウ・やまだ");
+}
+
+#[test]
+fn explicit_name_order_overrides_use_native_ordering() {
+    let name = FlatName {
+        family: Some("北川".to_string()),
+        given: Some("善太郎".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "cjk".to_string(),
+        ScriptConfig {
+            use_native_ordering: true,
+            delimiter: Some(String::new()),
+            ..Default::default()
+        },
+    )]);
+    let order = NameOrder::GivenFirst;
+    let mut ctx = make_name_format_context(
+        None,
+        Some(&order),
+        None,
+        None,
+        Some(NameForm::Full),
+        None,
+        None,
+    );
+    ctx.script_configs = Some(&scripts);
+
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+
+    // Explicit given-first order wins over script use-native-ordering.
+    assert_eq!(result, "善太郎北川");
+}
+
+#[test]
+fn native_ordering_applies_when_display_as_sort_is_set() {
+    // display-as-sort: first inverts only the first name (index 0).
+    // For a subsequent name (index 1) that is not inverted, use-native-ordering must
+    // still apply — the global display_as_sort setting must not suppress it.
+    let name = FlatName {
+        family: Some("北川".to_string()),
+        given: Some("善太郎".to_string()),
+        ..Default::default()
+    };
+    let scripts = std::collections::HashMap::from([(
+        "cjk".to_string(),
+        ScriptConfig {
+            use_native_ordering: true,
+            delimiter: Some(String::new()),
+            ..Default::default()
+        },
+    )]);
+    let mut ctx = make_name_format_context(
+        Some(DisplayAsSort::First),
+        None,
+        None,
+        None,
+        Some(NameForm::Full),
+        None,
+        None,
+    );
+    ctx.script_configs = Some(&scripts);
+
+    // Index 1 — not inverted by display-as-sort:first; native ordering must apply.
+    let result = contributor::format_single_name(&name, &ContributorForm::Long, 1, &ctx, false);
+
+    assert_eq!(result, "北川善太郎");
 }
 
 /// Tests the behavior of `preferred_transliteration_exact_match`.

--- a/crates/citum-schema-style/src/options/multilingual.rs
+++ b/crates/citum-schema-style/src/options/multilingual.rs
@@ -55,7 +55,10 @@ pub struct ScriptConfig {
     /// Whether to use native ordering for this script (e.g., FamilyGiven for CJK).
     #[serde(default)]
     pub use_native_ordering: bool,
-    /// Custom delimiter for this script.
+    /// Custom delimiter between name parts for this script.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delimiter: Option<String>,
+    /// Custom delimiter between family and given name when this script is inverted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_separator: Option<String>,
 }

--- a/crates/citum-schema-style/src/reference_multilingual_tests.rs
+++ b/crates/citum-schema-style/src/reference_multilingual_tests.rs
@@ -69,12 +69,21 @@ multilingual:
     cjk:
       use-native-ordering: true
       delimiter: ""
+    katakana:
+      delimiter: "・"
+      sort-separator: "、"
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         let mlt = config.multilingual.unwrap();
         assert_eq!(mlt.title_mode, Some(MultilingualMode::Transliterated));
         assert_eq!(mlt.name_mode, Some(MultilingualMode::Combined));
         assert!(mlt.scripts.get("cjk").unwrap().use_native_ordering);
+        assert_eq!(
+            mlt.scripts
+                .get("katakana")
+                .and_then(|script| script.sort_separator.as_deref()),
+            Some("、")
+        );
     }
 
     #[test]

--- a/docs/architecture/DISAMBIGUATION_MULTILINGUAL_GROUPING.md
+++ b/docs/architecture/DISAMBIGUATION_MULTILINGUAL_GROUPING.md
@@ -2,7 +2,7 @@
 
 **Status:** Planning phase
 **Created:** 2026-02-16
-**Related:** ../reference/DISAMBIGUATION.md, ./MULTILINGUAL.md, ./design/BIBLIOGRAPHY_GROUPING.md
+**Related:** ../reference/DISAMBIGUATION.md, ../specs/MULTILINGUAL.md, ./design/BIBLIOGRAPHY_GROUPING.md
 
 ## Executive Summary
 
@@ -278,7 +278,7 @@ for group in &grouped_refs {
 
 **Files:**
 - `../reference/DISAMBIGUATION.md`
-- `./MULTILINGUAL.md`
+- `../specs/MULTILINGUAL.md`
 - `./design/BIBLIOGRAPHY_GROUPING.md`
 
 **Updates:**
@@ -326,6 +326,6 @@ for group in &grouped_refs {
 ## References
 
 - [DISAMBIGUATION.md](../reference/DISAMBIGUATION.md) - Current disambiguation implementation
-- [MULTILINGUAL.md](MULTILINGUAL.md) - Multilingual data model
+- [MULTILINGUAL.md](../specs/MULTILINGUAL.md) - Multilingual data model
 - [BIBLIOGRAPHY_GROUPING.md](design/BIBLIOGRAPHY_GROUPING.md) - Grouping architecture
 - CSL 1.0 Specification - Disambiguation section

--- a/docs/architecture/MULTILINGUAL.md
+++ b/docs/architecture/MULTILINGUAL.md
@@ -4,6 +4,9 @@
 **Authors**: @dstyleplan
 **Date**: 2026-02-11
 
+**Normative specs:** [`../specs/MULTILINGUAL_NAMES.md`](../specs/MULTILINGUAL_NAMES.md),
+[`../specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](../specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md)
+
 ## Overview
 
 This document outlines the architectural design for adding "elegant" multilingual support to Citum. The goal is to move away from procedural macros and toward a declarative, type-safe system that handles parallel metadata for high-fidelity citations.

--- a/docs/architecture/MULTILINGUAL_GROUPING_STYLE_TARGETS.md
+++ b/docs/architecture/MULTILINGUAL_GROUPING_STYLE_TARGETS.md
@@ -360,7 +360,7 @@ csl26-group (COMPLETED)
 
 ## References
 
-- `/Users/brucedarcus/Code/csl26/docs/architecture/MULTILINGUAL.md`
+- `../specs/MULTILINGUAL.md`
 - `/Users/brucedarcus/Code/citum/citum-core/docs/specs/BIBLIOGRAPHY_GROUPING.md`
 - `/Users/brucedarcus/Code/csl26/docs/architecture/DISAMBIGUATION_MULTILINGUAL_GROUPING.md`
 - `/Users/brucedarcus/Code/csl26/crates/citum-schema-style/src/options/multilingual.rs`

--- a/docs/guides/DOCUMENT_CLASSIFICATION.md
+++ b/docs/guides/DOCUMENT_CLASSIFICATION.md
@@ -86,7 +86,7 @@ conversion:
 |---------|------------------------|-----|
 | `docs/specs/TYPE_SYSTEM_ARCHITECTURE.md` | Moved to specs (2026-05-26) | Rationale + option analysis for the type model |
 | `docs/specs/LEGAL_CITATIONS.md` | Moved to specs (2026-05-26) | De facto contract for legal-reference behavior |
-| `docs/architecture/MULTILINGUAL.md` | Likely split | It appears broad enough to separate rationale from implementable behavior |
+| `docs/specs/MULTILINGUAL.md` | Moved to specs (2026-05-26) | Normative design spec; now co-located with MULTILINGUAL_NAMES.md |
 | `docs/specs/BIBLIOGRAPHY_GROUPING.md` | Moved to specs (2026-05-26) | Describes processor behavior that should be testable |
 | `docs/architecture/CITUM_STORE_PLAN.md` | Likely spec candidate | It appears feature-oriented if the store remains active roadmap work |
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -3014,7 +3014,14 @@
           "default": false
         },
         "delimiter": {
-          "description": "Custom delimiter for this script.",
+          "description": "Custom delimiter between name parts for this script.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sort-separator": {
+          "description": "Custom delimiter between family and given name when this script is inverted.",
           "type": [
             "string",
             "null"

--- a/docs/specs/MULTILINGUAL.md
+++ b/docs/specs/MULTILINGUAL.md
@@ -1,17 +1,17 @@
 # Citum Multilingual Support Design
 
-**Status**: Draft
+**Status**: Active
 **Authors**: @dstyleplan
-**Date**: 2026-02-11
+**Date**: 2026-05-26
 
-**Normative specs:** [`../specs/MULTILINGUAL_NAMES.md`](../specs/MULTILINGUAL_NAMES.md),
-[`../specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](../specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md)
+**Normative specs:** [`MULTILINGUAL_NAMES.md`](./MULTILINGUAL_NAMES.md),
+[`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md)
 
 ## Overview
 
 This document outlines the architectural design for adding "elegant" multilingual support to Citum. The goal is to move away from procedural macros and toward a declarative, type-safe system that handles parallel metadata for high-fidelity citations.
 
-## core Principles
+## Core Principles
 
 1.  **High-Fidelity Data**: Store original, transliterated, and translated versions of metadata fields side-by-side.
 2.  **Declarative Style**: Styles request a specific "view" of the data (e.g., "transliterated [translated]") rather than implementing complex logic.
@@ -162,7 +162,6 @@ Transliteration keys use BCP 47 language tags with script and variant subtags to
 3. Fallback to `original` field
 
 Future: `preferred-transliteration` style option will allow explicit method selection.
-```
 
 ## 2. Style Configuration
 
@@ -171,15 +170,13 @@ A new global configuration section `multilingual` will be added to the Citum sty
 ```yaml
 options:
   multilingual:
-    # Preferred view for titles:
-    # - primary: Use original script
-    # - transliterated: Prefer transliteration
-    # - translated: Use translation matching style locale
-    # - combined: "original [translation]" pattern
+    # Preferred view for titles.
+    # The value is a mode key or a combined pattern such as "transliterated [translated]".
+    # See the style schema for the authoritative grammar.
     title-mode: "transliterated [translated]"
 
-    # Preferred view for names:
-    # - primary, transliterated, translated, combined
+    # Preferred view for names.
+    # See the style schema for the authoritative value set.
     name-mode: "transliterated"
 
     # Preferred script for transliterations (e.g., "Latn", "Cyrl")
@@ -198,17 +195,21 @@ options:
 
 ... [existing resolution logic] ...
 
-### 3.2 Script-Aware Ordering
+### 3.2 Script-Aware Name Rendering
 
-For contributors, the processor must be script-aware to handle ordering (Given Family vs Family Given) and delimiters.
+For contributors, the processor inspects the rendered given/family name parts to determine the active script, then applies script-specific ordering and separators from `options.multilingual.scripts`.
 
-1.  **Detection**: Determine the script of the resolved name (e.g., Latin vs CJK).
-2.  **Ordering**:
-    *   If CJK and `use-native-ordering` is true, use `FamilyGiven`.
-    *   If Latin, use `Given Family` (unless `sort-order` is requested).
-3.  **Delimiters**: Use script-appropriate delimiters for contributor lists (e.g., "・" for Japanese lists).
+**Detection** uses the `unicode_script` crate, which covers all Unicode planes including CJK Unified Ideographs Extension B+ (U+20000 and above). Common or inherited punctuation does not force a script match. The supported script key set and matching order (exact key → ISO 15924 alias → group key → `cjk` umbrella) is specified in [`MULTILINGUAL_NAMES.md`](./MULTILINGUAL_NAMES.md).
 
-### 3.2 Locale Separation
+**Ordering**: `use-native-ordering: true` on a matched script config renders family-first when the template has not explicitly requested another order. Template-level `name-order` and contributor sort settings remain authoritative and override `use-native-ordering`.
+
+**Separators**: `delimiter` joins visible name parts in non-inverted rendering. `sort-separator` joins family and given when the name is inverted; it is a distinct field and is overridden by any component-level `sort-separator` attribute. The style config block example at the top of §2 shows `cjk: delimiter: ""` (no inter-part space) — per-script keys such as `katakana` can add a `・` delimiter and `、` sort-separator for that specific script.
+
+Mixed-script names (e.g., family in Han, given in Katakana) collapse to the `cjk` umbrella unless the mix is purely Hiragana + Katakana, which resolves to `kana`. Dominance-based selection for other mixes is deferred.
+
+If no matching script config exists, existing behavior is preserved: non-inverted names use spaces and inverted names use the normal contributor `sort-separator` fallback.
+
+### 3.3 Locale Separation
 
 The processor must distinguish between:
 *   **Data Language**: The language of the source metadata (e.g., Russian).

--- a/docs/specs/MULTILINGUAL_NAMES.md
+++ b/docs/specs/MULTILINGUAL_NAMES.md
@@ -1,0 +1,187 @@
+# Multilingual Names Specification
+
+**Status:** Active
+**Date:** 2026-05-26
+**Related:** [`../architecture/MULTILINGUAL.md`](../architecture/MULTILINGUAL.md), [`../architecture/NAME_FORMATTING.md`](../architecture/NAME_FORMATTING.md), [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md)
+
+## Purpose
+
+Define how Citum renders contributor names whose selected surface form carries
+script-specific ordering and separator requirements. The first implementation
+is motivated by Japanese Katakana names that need `・` in original order and
+`、` in inverted order, but the contract is script-configured and not
+Japanese-specific.
+
+## Scope
+
+In scope: selected multilingual name variants, script detection from rendered
+name parts, script-specific native ordering, intra-name separators, inverted
+sort separators, and precedence between template contributor options and
+script options.
+
+Out of scope: generating transliterations, locale-invented default separators,
+CSL `name-part` affixes as a general formatting model, automatic behavior with
+no style opt-in, and bibliography partitioning or collation rules.
+
+## Design
+
+Contributor name rendering is the composition of:
+
+- the selected name variant, controlled by `options.multilingual.name-mode`
+  and transliteration preferences;
+- the detected script of the rendered given/family name parts;
+- the effective name order from template contributor options, contributor
+  config, and script-native ordering;
+- the intra-name separator used for non-inverted names;
+- the sort separator used for inverted names.
+
+Styles opt in through `options.multilingual.scripts`:
+
+```yaml
+options:
+  multilingual:
+    name-mode: primary
+    scripts:
+      katakana:
+        delimiter: "・"
+        sort-separator: "、"
+      cjk:
+        use-native-ordering: true
+        delimiter: ""
+```
+
+`delimiter` joins visible name parts in non-inverted order. For a Katakana
+given/family pair, `delimiter: "・"` renders:
+
+```text
+マイケル・ジャクソン
+```
+
+`sort-separator` joins family and given parts when the effective contributor
+rendering is inverted. For the same pair, `sort-separator: "、"` renders:
+
+```text
+ジャクソン、マイケル
+```
+
+`use-native-ordering: true` renders a matched script in family-first order when
+the template has not explicitly requested another order. It is display order,
+not CSL sort inversion. For native CJK names, `delimiter: ""` supports output
+such as:
+
+```text
+北川善太郎
+```
+
+Script matching is deterministic. Exact script/category keys are preferred
+over broader groups. The supported key set is:
+
+| Key | Matches |
+|---|---|
+| `katakana` / `Kana` | All-Katakana name parts |
+| `hiragana` / `Hira` | All-Hiragana name parts |
+| `kana` / `Hrkt` | All-Hiragana, all-Katakana, or mixed Hiragana+Katakana |
+| `han` / `Hani` | All-Han name parts |
+| `hangul` / `Hang` | All-Hangul name parts |
+| `cjk` | Any of the above, or mixes that don't resolve to a more specific key |
+
+For a single-script name, the engine tries exact keys first (`katakana`,
+`hiragana`, `han`, `hangul`), then ISO 15924 aliases, then the `kana` group
+key, then `cjk`. For mixed-script names, the kana group (`Hiragana +
+Katakana`, no Han or Hangul present) resolves to `kana`/`Hrkt`/`cjk`.
+All other mixed CJK combinations resolve directly to `cjk`. Dominance-based
+selection for Han+kana or other non-kana mixes is not implemented in this
+version and is deferred to a future enhancement.
+
+Template contributor options remain authoritative. A component-level
+`sort-separator` overrides script-level `sort-separator`. Explicit
+`name-order` or configured sort display still controls inversion before
+script-native ordering is considered.
+
+If no matching script config exists, Citum preserves existing behavior:
+non-inverted names use spaces between name parts and inverted names use the
+normal contributor `sort-separator` fallback.
+
+## Implementation Notes
+
+Script detection inspects the rendered `given`, `family`, particles, and
+suffix after multilingual variant selection. Common or inherited punctuation
+does not force a script match. The public contract is expressed in terms of
+script categories, not codepoint ranges.
+
+The rendering path should keep script-aware decisions local to contributor
+assembly. Multilingual variant selection, bibliography partitioning, and
+Unicode collation remain separate mechanisms.
+
+The implementation uses the `unicode_script` crate for script classification,
+which covers all Unicode planes including CJK Unified Ideographs Extension B+
+(U+20000 and above). The public contract is defined in terms of script
+categories, not codepoint ranges.
+
+## Examples
+
+### Latin name — no script config matches
+
+```yaml
+# style has no options.multilingual.scripts entry
+```
+
+```text
+input : given="Jane", family="Smith"
+output: Jane Smith          # given-first (default)
+output: Smith, Jane         # inverted, uses normal ", " sort separator
+```
+
+Latin names fall through script detection with no match and preserve existing
+behavior regardless of what script configs the style defines.
+
+### Katakana name — with the example config above
+
+```text
+input : given="マイケル", family="ジャクソン"
+output: マイケル・ジャクソン   # non-inverted, delimiter "・"
+output: ジャクソン、マイケル   # inverted, sort-separator "、"
+```
+
+### Native CJK name — with use-native-ordering
+
+```text
+input : given="善太郎", family="北川"
+output: 北川善太郎            # family-first, delimiter "" (no space)
+```
+
+## Precedence
+
+`sort-separator` on a script config applies **only** when the engine renders
+the name in inverted order. It is distinct from `delimiter`, which applies to
+non-inverted rendering. Template contributor options always win:
+
+- A component-level `sort-separator` attribute overrides the script-level
+  `sort-separator`.
+- An explicit template `name-order="given-family"` overrides
+  `use-native-ordering: true` in the matched script config.
+
+Mixed-script names (e.g., a family name in Han and a given name in Katakana)
+fall through to `cjk` unless the mix is purely kana (Hiragana + Katakana),
+which resolves to `kana`. Dominance-based selection for other mixes is not
+implemented. Per-field or per-person overrides are out of scope for this
+specification.
+
+## Acceptance Criteria
+
+- [ ] Existing styles preserve current name rendering unless they opt in with
+      `options.multilingual.scripts`.
+- [ ] Katakana non-inverted names can render with `・` between given and family
+      parts.
+- [ ] Katakana inverted names can render with `、` between family and given
+      parts.
+- [ ] Native CJK names can render in native family-first order without an
+      inserted space.
+- [ ] Template-level `sort-separator` overrides script-level `sort-separator`.
+- [ ] Explicit template `name-order` overrides script `use-native-ordering`.
+- [ ] Generated schemas expose script-level `sort-separator`.
+
+## Changelog
+
+- 2026-05-26: Initial draft.
+- 2026-05-26: Marked active for the initial script-specific separator implementation.

--- a/docs/specs/MULTILINGUAL_NAMES.md
+++ b/docs/specs/MULTILINGUAL_NAMES.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Date:** 2026-05-26
-**Related:** [`../architecture/MULTILINGUAL.md`](../architecture/MULTILINGUAL.md), [`../architecture/NAME_FORMATTING.md`](../architecture/NAME_FORMATTING.md), [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md)
+**Related:** [`MULTILINGUAL.md`](./MULTILINGUAL.md), [`../architecture/NAME_FORMATTING.md`](../architecture/NAME_FORMATTING.md), [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md)
 
 ## Purpose
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -53,6 +53,7 @@ to make sure the document should be a spec rather than architecture or policy.
 
 | File | Feature |
 |------|---------|
+| [`MULTILINGUAL_NAMES.md`](./MULTILINGUAL_NAMES.md) | Script-specific contributor name assembly |
 | [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) | Federated registry and distributed resolver architecture (Phases 2–3) |
 | [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) | Clean command model for style discovery, registry management, and CLI validation UX |
 | [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Verification model for profile styles using external authority |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -85,6 +85,7 @@ to make sure the document should be a spec rather than architecture or policy.
 | [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md) | ICU MF2 parameterized message system replacing flat YAML terms |
 | [`LOCATOR_RENDERING.md`](./LOCATOR_RENDERING.md) | Style-level LocatorConfig replacing per-template locator fields |
 | [`MIGRATION_TAXONOMY_AWARE_WRAPPERS.md`](./MIGRATION_TAXONOMY_AWARE_WRAPPERS.md) | Taxonomy-aware wrapper derivation during style migration |
+| [`MULTILINGUAL.md`](./MULTILINGUAL.md) | Multilingual support design: data model, processor logic, sorting, disambiguation |
 | [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | Sort and section multilingual bibliographies by script or language |
 | [`MIGRATE_RESEARCH_RICH_INPUTS.md`](./MIGRATE_RESEARCH_RICH_INPUTS.md) | Bounded rich-input workflow for migrate-research passes |
 | [`MIXED_CONDITION_NOTE_POSITION_TREES.md`](./MIXED_CONDITION_NOTE_POSITION_TREES.md) | Migration of legacy choose trees with mixed position predicates |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -53,7 +53,6 @@ to make sure the document should be a spec rather than architecture or policy.
 
 | File | Feature |
 |------|---------|
-| [`MULTILINGUAL_NAMES.md`](./MULTILINGUAL_NAMES.md) | Script-specific contributor name assembly |
 | [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) | Federated registry and distributed resolver architecture (Phases 2–3) |
 | [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) | Clean command model for style discovery, registry management, and CLI validation UX |
 | [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Verification model for profile styles using external authority |
@@ -89,6 +88,7 @@ to make sure the document should be a spec rather than architecture or policy.
 | [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | Sort and section multilingual bibliographies by script or language |
 | [`MIGRATE_RESEARCH_RICH_INPUTS.md`](./MIGRATE_RESEARCH_RICH_INPUTS.md) | Bounded rich-input workflow for migrate-research passes |
 | [`MIXED_CONDITION_NOTE_POSITION_TREES.md`](./MIXED_CONDITION_NOTE_POSITION_TREES.md) | Migration of legacy choose trees with mixed position predicates |
+| [`MULTILINGUAL_NAMES.md`](./MULTILINGUAL_NAMES.md) | Script-specific contributor name assembly |
 | [`NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md`](./NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md) | Representation of domain-specific numbering and locator labels |
 | [`NOTE_POSITION_AUDIT.md`](./NOTE_POSITION_AUDIT.md) | Audit layer for note-style repeated-citation behavior |
 | [`NOTE_SHORTENING_POLICY.md`](./NOTE_SHORTENING_POLICY.md) | Normative contract for repeated-note and shortened-note behavior |


### PR DESCRIPTION
## Summary
- Adds `docs/specs/MULTILINGUAL_NAMES.md` as the normative contract for script-specific contributor name assembly.
- Wires opt-in `options.multilingual.scripts` behavior into contributor rendering for native order, intra-name separators, and script-level sort separators.
- Extends `ScriptConfig` with `sort-separator`, regenerates `docs/schemas/style.json`, and adds focused Katakana/CJK regression tests.

## Context
Motivated by the CSL discussion on Japanese name-part separators:
- https://discourse.citationstyles.org/t/is-it-possible-to-render-name-part-affixes-in-japanese-author-names/1828/2
- https://discourse.citationstyles.org/t/is-it-possible-to-render-name-part-affixes-in-japanese-author-names/1828/3

The implementation keeps behavior opt-in: existing styles preserve current name rendering unless they configure matching `options.multilingual.scripts` rules.

## Validation
- `cargo test -p citum-engine katakana -- --nocapture`
- `cargo test -p citum-engine native_cjk_names_use_native_ordering_without_space -- --nocapture`
- `cargo test -p citum-engine latin_names_ignore_unmatched_script_separators -- --nocapture`
- `cargo test -p citum-engine component_sort_separator_overrides_script_sort_separator -- --nocapture`
- `cargo test -p citum-schema-style test_multilingual_style_options -- --nocapture`
- `cargo run --bin citum --features schema -- schema --out-dir docs/schemas`
- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`
- `bash .githooks/commit-msg` for both commit messages
- `bash .githooks/pre-push`
