### PR TITLE
fix(ci): legal fixture path after spec dir move

### DIFF
--- a/tests/fixtures/coverage-manifest.json
+++ b/tests/fixtures/coverage-manifest.json
@@ -667,7 +667,7 @@
         "YAML bibliography parsing parity"
       ],
       "used_by": [
-        "docs/architecture/design/LEGAL_CITATIONS.md"
+        "docs/specs/LEGAL_CITATIONS.md"
       ],
       "ci_status": "advisory",
       "notes": "YAML companion fixture retained for schema/examples and manual parity checks."


### PR DESCRIPTION
## Summary

- Corrects the `coverage-manifest.json` pointer for the legal citations
  spec, which still referenced `docs/architecture/design/LEGAL_CITATIONS.md`
  after that directory was dissolved into `docs/specs/` in 2adcda9e.

## Test plan

- [x] CI contract check passes (the path is advisory; this is the only
  file changed).
