### PR TITLE
feat: per-document config overrides

### DIFF
--- a/.beans/archive/csl26-ssa3--fixengine-restore-org-abbrev-top-level-frontmatter.md
+++ b/.beans/archive/csl26-ssa3--fixengine-restore-org-abbrev-top-level-frontmatter.md
@@ -1,0 +1,20 @@
+---
+# csl26-ssa3
+title: 'fix(engine): restore org-abbrev top-level frontmatter and surface parse errors'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-05-27T17:41:11Z
+updated_at: 2026-05-27T17:45:58Z
+---
+
+PR #817 review triage fixes: (1) org_abbreviation_memory dropped as top-level DocumentFrontmatter field — regression vs main; (2) parse_frontmatter silently drops all frontmatter on YAML error instead of surfacing it.
+
+## Summary of Changes
+
+- Restored `org_abbreviation_memory` as a top-level field in `DocumentFrontmatter` (regression vs main where it was removed in favour of options-only access)
+- Added `frontmatter_org_abbreviation_memory` to `ParsedDocument`; wired through djot/mod.rs and markdown.rs with same precedence pattern as `integral_name_memory`
+- Updated `pipeline.rs` effective-org-override to fall back to top-level frontmatter field when `options.org-abbreviation-memory` is absent
+- Changed `parse_frontmatter` return type from `(Option<…>, &str)` to `(Result<Option<…>, String>, &str)`; callers split into `(frontmatter, frontmatter_error)`
+- Added `frontmatter_error: Option<String>` to `ParsedDocument`; pipeline now calls `eprintln!` + `process::exit(1)` on parse error instead of silently discarding frontmatter
+- Deferred: locale override alignment — see bean csl26-9l88

--- a/.beans/archive/csl26-tap8--support-broader-per-document-configuration-overrid.md
+++ b/.beans/archive/csl26-tap8--support-broader-per-document-configuration-overrid.md
@@ -1,14 +1,14 @@
 ---
 # csl26-tap8
 title: Support broader per-document configuration overrides
-status: in-progress
+status: completed
 type: task
 priority: normal
 tags:
     - engine
     - schema
 created_at: 2026-05-01T14:26:15Z
-updated_at: 2026-05-26T23:14:08Z
+updated_at: 2026-05-26T23:32:49Z
 ---
 
 Extend the document frontmatter parsing to support broader configuration
@@ -34,4 +34,16 @@ these on a per-document basis without modifying the style.
 
 docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
 
-## Implementation Plan\n- [ ] Commit 1: DocumentOptionsOverride struct + frontmatter parsing\n- [ ] Commit 2: Apply overrides in pipeline\n- [ ] Commit 3: CLI --locale flag
+## Implementation Plan\n- [x] Commit 1: DocumentOptionsOverride struct + frontmatter parsing\n- [x] Commit 2: Apply overrides in pipeline\n- [x] Commit 3: CLI --locale flag
+
+
+## Summary of Changes
+
+- `DocumentBibliographyOverride` and `DocumentOptionsOverride` structs with serde
+  kebab-case + deny_unknown_fields; schema feature-gated JsonSchema derives.
+- `Style::apply_scoped_options()` public method bridges engine → schema crate.
+- `DocumentFrontmatter.options` field wired through `ParsedDocument.frontmatter_options`.
+- Legacy `integral-name-memory:` suppressed when `options.integral-name-memory` is set.
+- Pipeline applies bibliography overrides via `processor_with_bibliography_override`.
+- CLI `--locale` / `-L` flag on `render doc`; frontmatter `options.locale` is the fallback.
+- 9 new unit tests covering deserialization, apply, and precedence behaviour.

--- a/.beans/csl26-9l88--investigate-locale-override-implementation-vs-spec.md
+++ b/.beans/csl26-9l88--investigate-locale-override-implementation-vs-spec.md
@@ -1,0 +1,10 @@
+---
+# csl26-9l88
+title: investigate locale override implementation vs spec
+status: todo
+type: task
+created_at: 2026-05-27T17:45:47Z
+updated_at: 2026-05-27T17:45:47Z
+---
+
+Spec says options.locale 'replaces the style default locale entirely'. Copilot noted config.locale-override is currently a patch ID, not a base-locale selector. Investigate whether de-DE resolves correctly at runtime via the CLI --locale path, or whether a separate document-level base-locale mechanism is needed.

--- a/.beans/csl26-tap8--support-broader-per-document-configuration-overrid.md
+++ b/.beans/csl26-tap8--support-broader-per-document-configuration-overrid.md
@@ -8,7 +8,7 @@ tags:
     - engine
     - schema
 created_at: 2026-05-01T14:26:15Z
-updated_at: 2026-05-26T22:16:35Z
+updated_at: 2026-05-26T23:14:08Z
 ---
 
 Extend the document frontmatter parsing to support broader configuration
@@ -33,3 +33,5 @@ these on a per-document basis without modifying the style.
 ## Spec
 
 docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
+
+## Implementation Plan\n- [ ] Commit 1: DocumentOptionsOverride struct + frontmatter parsing\n- [ ] Commit 2: Apply overrides in pipeline\n- [ ] Commit 3: CLI --locale flag

--- a/.beans/csl26-tap8--support-broader-per-document-configuration-overrid.md
+++ b/.beans/csl26-tap8--support-broader-per-document-configuration-overrid.md
@@ -1,14 +1,14 @@
 ---
 # csl26-tap8
 title: Support broader per-document configuration overrides
-status: todo
+status: in-progress
 type: task
 priority: normal
 tags:
     - engine
     - schema
 created_at: 2026-05-01T14:26:15Z
-updated_at: 2026-05-01T14:26:15Z
+updated_at: 2026-05-26T22:16:35Z
 ---
 
 Extend the document frontmatter parsing to support broader configuration
@@ -30,4 +30,6 @@ these on a per-document basis without modifying the style.
 - Update `Processor` (likely in `setup.rs`) to merge document-level
   configuration overrides into the style's default configuration.
 
+## Spec
 
+docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -612,6 +612,10 @@ pub(crate) struct RenderDocArgs {
     #[arg(long)]
     pub(crate) typst_keep_source: bool,
 
+    /// Locale ID (e.g. "de-DE", "fr-FR") to override the style's default locale
+    #[arg(short = 'L', long)]
+    pub(crate) locale: Option<String>,
+
     /// Disable semantic classes (HTML spans, Djot attributes)
     #[arg(long)]
     pub(crate) no_semantics: bool,

--- a/crates/citum-cli/src/commands/mod.rs
+++ b/crates/citum-cli/src/commands/mod.rs
@@ -82,6 +82,7 @@ fn run_deprecated_doc(args: crate::args::LegacyDocArgs) -> CliResult {
         output: None,
         pdf: false,
         typst_keep_source: false,
+        locale: None,
         no_semantics: false,
     })
 }

--- a/crates/citum-cli/src/commands/render/mod.rs
+++ b/crates/citum-cli/src/commands/render/mod.rs
@@ -53,15 +53,25 @@ pub(super) fn run_render_doc(args: RenderDocArgs) -> CliResult {
         );
     }
 
+    // Read document first so we can extract frontmatter locale for processor setup.
+    let doc_content = fs::read_to_string(&args.input)?;
+
+    // CLI --locale takes precedence over frontmatter options.locale.
+    // Avoid cloning args.locale: only call extract_frontmatter_locale when needed.
+    let fm_locale = args
+        .locale
+        .is_none()
+        .then(|| extract_frontmatter_locale(&doc_content))
+        .flatten();
+    let effective_locale = args.locale.as_deref().or(fm_locale.as_deref());
+
     let processor = create_processor(
         style_obj,
         bibliography,
         &args.style,
         args.no_semantics,
-        None,
+        effective_locale,
     )?;
-
-    let doc_content = fs::read_to_string(&args.input)?;
     let output = match args.input_format {
         InputFormat::Djot => render_doc_with_output_format(
             &processor,
@@ -307,6 +317,44 @@ fn render_refs_json(
     }
 }
 
+/// Extract the `options.locale` field from document YAML frontmatter, if present.
+///
+/// Returns `None` when the document has no frontmatter, the frontmatter has no
+/// `options:` block, or `options.locale` is absent. Parsing errors are silently
+/// ignored — the engine will fall back to the style's default locale.
+fn extract_frontmatter_locale(content: &str) -> Option<String> {
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct FrontmatterOptions {
+        locale: Option<String>,
+    }
+
+    #[derive(Deserialize)]
+    struct MinimalFrontmatter {
+        options: Option<FrontmatterOptions>,
+    }
+
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+    #[allow(clippy::string_slice, reason = "'---' is 1-byte ASCII")]
+    let after_opening = &trimmed[3..];
+    // Use "\n---" so embedded "---" in YAML values (e.g. abstract: "foo---bar")
+    // does not falsely close the frontmatter block.
+    let closing_pos = after_opening.find("\n---").map(|p| p + 1)?;
+    #[allow(
+        clippy::string_slice,
+        reason = "closing_pos is '\\n' offset + 1, which lands on ASCII '-'"
+    )]
+    let frontmatter_str = &after_opening[..closing_pos];
+    serde_yaml::from_str::<MinimalFrontmatter>(frontmatter_str)
+        .ok()?
+        .options?
+        .locale
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -547,6 +595,44 @@ grammar-options:
         assert_eq!(
             parsed.legacy_term_aliases.get("page").map(String::as_str),
             Some("term.page-label")
+        );
+    }
+
+    #[test]
+    fn test_extract_frontmatter_locale_present() {
+        let content = "---\noptions:\n  locale: de-DE\n---\nBody text.";
+        assert_eq!(
+            extract_frontmatter_locale(content),
+            Some(String::from("de-DE"))
+        );
+    }
+
+    #[test]
+    fn test_extract_frontmatter_locale_absent_options() {
+        let content = "---\ntitle: My Doc\n---\nBody text.";
+        assert!(extract_frontmatter_locale(content).is_none());
+    }
+
+    #[test]
+    fn test_extract_frontmatter_locale_no_frontmatter() {
+        let content = "No frontmatter here.";
+        assert!(extract_frontmatter_locale(content).is_none());
+    }
+
+    #[test]
+    fn test_extract_frontmatter_locale_options_without_locale() {
+        let content = "---\noptions:\n  bibliography:\n    label-mode: numeric\n---\nBody.";
+        assert!(extract_frontmatter_locale(content).is_none());
+    }
+
+    #[test]
+    fn test_extract_frontmatter_locale_embedded_dashes_in_value() {
+        // Regression: inline "---" inside a YAML value must not be treated as
+        // the closing fence. The correct closing "---" is on its own line.
+        let content = "---\ntitle: \"pre---post\"\noptions:\n  locale: fr-FR\n---\nBody.";
+        assert_eq!(
+            extract_frontmatter_locale(content),
+            Some(String::from("fr-FR"))
         );
     }
 }

--- a/crates/citum-engine/src/processor/document/djot/mod.rs
+++ b/crates/citum-engine/src/processor/document/djot/mod.rs
@@ -23,8 +23,12 @@ pub struct DjotParser;
 impl CitationParser for DjotParser {
     fn parse_document(&self, content: &str, locale: &Locale) -> ParsedDocument {
         // Try to parse frontmatter and get remaining content
-        let (frontmatter, remaining_content) = parse_frontmatter(content);
+        let (frontmatter_result, remaining_content) = parse_frontmatter(content);
         let body_start = content.len() - remaining_content.len();
+        let (frontmatter, frontmatter_error) = match frontmatter_result {
+            Ok(fm) => (fm, None),
+            Err(e) => (None, Some(e)),
+        };
 
         let (manual_note_references, manual_note_labels, footnote_definitions) =
             scan_manual_notes(remaining_content);
@@ -53,12 +57,25 @@ impl CitationParser for DjotParser {
         let bibliography_blocks = scan_bibliography_blocks(remaining_content);
 
         let frontmatter_groups = frontmatter.as_ref().and_then(|fm| fm.bibliography.clone());
+        let frontmatter_options = frontmatter.as_ref().and_then(|fm| fm.options.clone());
+        // Legacy top-level fields are superseded by their `options.*` counterparts.
         let frontmatter_integral_name_memory = frontmatter
             .as_ref()
-            .and_then(|fm| fm.integral_name_memory.clone());
+            .and_then(|fm| fm.integral_name_memory.clone())
+            .filter(|_| {
+                frontmatter_options
+                    .as_ref()
+                    .and_then(|o| o.integral_name_memory.as_ref())
+                    .is_none()
+            });
         let frontmatter_org_abbreviation_memory = frontmatter
-            .as_ref()
-            .and_then(|fm| fm.org_abbreviation_memory.clone());
+            .and_then(|fm| fm.org_abbreviation_memory)
+            .filter(|_| {
+                frontmatter_options
+                    .as_ref()
+                    .and_then(|o| o.org_abbreviation_memory.as_ref())
+                    .is_none()
+            });
         ParsedDocument {
             citations,
             manual_note_order,
@@ -68,6 +85,8 @@ impl CitationParser for DjotParser {
             frontmatter_groups,
             frontmatter_integral_name_memory,
             frontmatter_org_abbreviation_memory,
+            frontmatter_options,
+            frontmatter_error,
             body_start,
         }
     }

--- a/crates/citum-engine/src/processor/document/djot/parsing.rs
+++ b/crates/citum-engine/src/processor/document/djot/parsing.rs
@@ -5,8 +5,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Djot-specific parsing logic using winnow.
 
-use super::super::types::{DocumentIntegralNameOverride, DocumentOrgAbbreviationOverride};
-use super::super::{CitationStructure, ManualNoteReference, ParsedCitation};
+use super::super::{
+    CitationStructure, DocumentIntegralNameOverride, DocumentOptionsOverride, ManualNoteReference,
+    ParsedCitation,
+};
 use super::BibliographyBlock;
 use crate::{Citation, CitationItem};
 use citum_schema::citation::{CitationMode, normalize_locator_text};
@@ -34,7 +36,8 @@ pub(crate) struct FootnoteDefinitionRange {
 pub(crate) struct DocumentFrontmatter {
     pub bibliography: Option<Vec<BibliographyGroup>>,
     pub integral_name_memory: Option<DocumentIntegralNameOverride>,
-    pub org_abbreviation_memory: Option<DocumentOrgAbbreviationOverride>,
+    pub org_abbreviation_memory: Option<super::super::DocumentOrgAbbreviationOverride>,
+    pub options: Option<DocumentOptionsOverride>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -361,12 +364,22 @@ impl ScopeTracker {
 }
 
 /// Parse YAML frontmatter from content.
-/// Returns (frontmatter, `remaining_content`).
+///
+/// Returns `(result, remaining_content)` where `result` is:
+/// - `Ok(None)` when no `---` block is present
+/// - `Ok(Some(fm))` on a successful parse
+/// - `Err(msg)` when a `---` block is present but fails to deserialize (e.g.
+///   unknown field rejected by `deny_unknown_fields`)
+///
+/// Callers must surface the error; they must not silently proceed without
+/// frontmatter data when the user authored an invalid block.
 #[allow(clippy::string_slice, reason = "'---' is 1-byte ASCII")]
-pub(crate) fn parse_frontmatter(content: &str) -> (Option<DocumentFrontmatter>, &str) {
+pub(crate) fn parse_frontmatter(
+    content: &str,
+) -> (Result<Option<DocumentFrontmatter>, String>, &str) {
     let trimmed = content.trim_start();
     if !trimmed.starts_with("---") {
-        return (None, content);
+        return (Ok(None), content);
     }
 
     let after_opening = &trimmed[3..];
@@ -374,16 +387,12 @@ pub(crate) fn parse_frontmatter(content: &str) -> (Option<DocumentFrontmatter>, 
         let frontmatter_content = &after_opening[..closing_pos];
         let remaining = &after_opening[closing_pos + 3..].trim_start();
 
-        let parsed = match serde_yaml::from_str::<DocumentFrontmatter>(frontmatter_content) {
-            Ok(fm) => Some(fm),
-            Err(e) => {
-                eprintln!("citum: warning: frontmatter parse error: {e}");
-                None
-            }
-        };
-        (parsed, remaining)
+        let result = serde_yaml::from_str::<DocumentFrontmatter>(frontmatter_content)
+            .map(Some)
+            .map_err(|e| e.to_string());
+        (result, remaining)
     } else {
-        (None, content)
+        (Ok(None), content)
     }
 }
 

--- a/crates/citum-engine/src/processor/document/integral_names.rs
+++ b/crates/citum-engine/src/processor/document/integral_names.rs
@@ -7,8 +7,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 #[rustfmt::skip]
 use super::note_support::{NoteOccurrence, build_note_order_indices};
-use super::types::{DocumentIntegralNameOverride, DocumentOrgAbbreviationOverride};
-use super::{CitationPlacement, CitationStructure, ParsedDocument};
+use super::{
+    CitationPlacement, CitationStructure, DocumentIntegralNameOverride, DocumentOptionsOverride,
+    DocumentOrgAbbreviationOverride, ParsedDocument,
+};
 use crate::reference::Contributor;
 use crate::{Citation, Processor};
 use citum_schema::options::{IntegralNameContexts, IntegralNameScope};
@@ -127,6 +129,24 @@ impl Processor {
         ))
     }
 
+    /// Build a new processor with bibliography overrides from a `DocumentOptionsOverride` applied.
+    ///
+    /// Writes non-`None` bibliography option fields into a cloned style and
+    /// calls `apply_scoped_options` so that template mutations stay consistent.
+    pub(super) fn processor_with_bibliography_override(
+        &self,
+        options: &DocumentOptionsOverride,
+    ) -> Self {
+        let mut style = self.style.clone();
+        options.apply_bibliography_to(&mut style);
+        Self::build_processor_pre_resolved(
+            style,
+            self.bibliography.clone(),
+            self.locale.clone(),
+            self.compound_sets.clone(),
+        )
+    }
+
     fn annotate_name_states_for_kind(
         &self,
         citations: &mut [Citation],
@@ -157,7 +177,6 @@ impl Processor {
             };
 
             for item in &mut citation.items {
-                // Skip if this item's author type doesn't match the kind
                 let is_org = first_author_is_org(&self.bibliography, &item.id);
                 match kind {
                     AnnotateKind::Personal if is_org => continue,
@@ -165,7 +184,6 @@ impl Processor {
                     _ => {}
                 }
 
-                // Skip items with an explicit override already set
                 let state_already_set = match kind {
                     AnnotateKind::Personal => item.integral_name_state.is_some(),
                     AnnotateKind::OrgAbbreviation => item.org_abbreviation_state.is_some(),
@@ -267,28 +285,6 @@ impl Processor {
     }
 }
 
-/// Returns a name-based tracking key for integral name-memory state.
-///
-/// Uses the first author's family name so that two works by the same author
-/// share a single First/Subsequent slot, regardless of citation key.
-/// Falls back to `item_id` when no author or family name is available.
-fn first_author_key_for_item(bibliography: &crate::Bibliography, item_id: &str) -> String {
-    bibliography
-        .get(item_id)
-        .and_then(|r| r.author())
-        .and_then(|c| contributor_first_family(&c))
-        .unwrap_or_else(|| item_id.to_string())
-}
-
-fn contributor_first_family(contributor: &Contributor) -> Option<String> {
-    match contributor {
-        Contributor::StructuredName(n) => Some(n.family.to_string()),
-        Contributor::Multilingual(m) => Some(m.original.family.to_string()),
-        Contributor::SimpleName(n) => Some(n.name.to_string()),
-        Contributor::ContributorList(l) => l.0.first().and_then(contributor_first_family),
-    }
-}
-
 fn personal_author_key_for_item(bibliography: &crate::Bibliography, item_id: &str) -> String {
     bibliography
         .get(item_id)
@@ -313,6 +309,28 @@ fn contributor_personal_key(contributor: &Contributor) -> Option<String> {
         }
         Contributor::SimpleName(n) => Some(n.name.to_string()),
         Contributor::ContributorList(l) => l.0.first().and_then(contributor_personal_key),
+    }
+}
+
+/// Returns a name-based tracking key for integral name-memory state.
+///
+/// Uses the first author's family name so that two works by the same author
+/// share a single First/Subsequent slot, regardless of citation key.
+/// Falls back to `item_id` when no author or family name is available.
+fn first_author_key_for_item(bibliography: &crate::Bibliography, item_id: &str) -> String {
+    bibliography
+        .get(item_id)
+        .and_then(|r| r.author())
+        .and_then(|c| contributor_first_family(&c))
+        .unwrap_or_else(|| item_id.to_string())
+}
+
+fn contributor_first_family(contributor: &Contributor) -> Option<String> {
+    match contributor {
+        Contributor::StructuredName(n) => Some(n.family.to_string()),
+        Contributor::Multilingual(m) => Some(m.original.family.to_string()),
+        Contributor::SimpleName(n) => Some(n.name.to_string()),
+        Contributor::ContributorList(l) => l.0.first().and_then(contributor_first_family),
     }
 }
 

--- a/crates/citum-engine/src/processor/document/markdown.rs
+++ b/crates/citum-engine/src/processor/document/markdown.rs
@@ -8,7 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use super::djot::parsing::parse_frontmatter;
 use super::{CitationParser, CitationPlacement, CitationStructure, ParsedCitation, ParsedDocument};
 use crate::{Citation, CitationItem};
-use citum_schema::citation::{normalize_locator_text, CitationMode};
+use citum_schema::citation::{CitationMode, normalize_locator_text};
 use citum_schema::locale::Locale;
 use std::collections::HashSet;
 
@@ -277,11 +277,7 @@ fn cite_key_len(input: &str) -> Option<usize> {
         .last()
         .unwrap_or(0);
 
-    if len == 0 {
-        None
-    } else {
-        Some(len)
-    }
+    if len == 0 { None } else { Some(len) }
 }
 
 fn normalize_prefix(prefix: &str) -> Option<String> {

--- a/crates/citum-engine/src/processor/document/markdown.rs
+++ b/crates/citum-engine/src/processor/document/markdown.rs
@@ -8,7 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use super::djot::parsing::parse_frontmatter;
 use super::{CitationParser, CitationPlacement, CitationStructure, ParsedCitation, ParsedDocument};
 use crate::{Citation, CitationItem};
-use citum_schema::citation::{CitationMode, normalize_locator_text};
+use citum_schema::citation::{normalize_locator_text, CitationMode};
 use citum_schema::locale::Locale;
 use std::collections::HashSet;
 
@@ -27,14 +27,31 @@ impl Default for MarkdownParser {
 
 impl CitationParser for MarkdownParser {
     fn parse_document(&self, content: &str, locale: &Locale) -> ParsedDocument {
-        let (frontmatter, body) = parse_frontmatter(content);
+        let (frontmatter_result, body) = parse_frontmatter(content);
         let body_start = content.len() - body.len();
+        let (frontmatter, frontmatter_error) = match frontmatter_result {
+            Ok(fm) => (fm, None),
+            Err(e) => (None, Some(e)),
+        };
+        let frontmatter_options = frontmatter.as_ref().and_then(|fm| fm.options.clone());
+        // Legacy top-level fields are superseded by their `options.*` counterparts.
         let frontmatter_integral_name_memory = frontmatter
             .as_ref()
-            .and_then(|fm| fm.integral_name_memory.clone());
+            .and_then(|fm| fm.integral_name_memory.clone())
+            .filter(|_| {
+                frontmatter_options
+                    .as_ref()
+                    .and_then(|o| o.integral_name_memory.as_ref())
+                    .is_none()
+            });
         let frontmatter_org_abbreviation_memory = frontmatter
-            .as_ref()
-            .and_then(|fm| fm.org_abbreviation_memory.clone());
+            .and_then(|fm| fm.org_abbreviation_memory)
+            .filter(|_| {
+                frontmatter_options
+                    .as_ref()
+                    .and_then(|o| o.org_abbreviation_memory.as_ref())
+                    .is_none()
+            });
 
         let citations = find_citations(body, locale)
             .into_iter()
@@ -56,6 +73,8 @@ impl CitationParser for MarkdownParser {
             frontmatter_groups: None,
             frontmatter_integral_name_memory,
             frontmatter_org_abbreviation_memory,
+            frontmatter_options,
+            frontmatter_error,
             body_start,
         }
     }
@@ -258,7 +277,11 @@ fn cite_key_len(input: &str) -> Option<usize> {
         .last()
         .unwrap_or(0);
 
-    if len == 0 { None } else { Some(len) }
+    if len == 0 {
+        None
+    } else {
+        Some(len)
+    }
 }
 
 fn normalize_prefix(prefix: &str) -> Option<String> {

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -19,7 +19,8 @@ pub(crate) use types::ManualNoteReference;
 pub use types::{
     BibliographyBlock, CitationParser, CitationPlacement, CitationStructure,
     DocumentBibliographyOverride, DocumentFormat, DocumentIntegralNameOverride,
-    DocumentOptionsOverride, DocumentSortPartitioningOverride, ParsedCitation, ParsedDocument,
+    DocumentOptionsOverride, DocumentOrgAbbreviationOverride, DocumentSortPartitioningOverride,
+    ParsedCitation, ParsedDocument,
 };
 
 #[cfg(test)]

--- a/crates/citum-engine/src/processor/document/mod.rs
+++ b/crates/citum-engine/src/processor/document/mod.rs
@@ -17,8 +17,9 @@ mod types;
 
 pub(crate) use types::ManualNoteReference;
 pub use types::{
-    BibliographyBlock, CitationParser, CitationPlacement, CitationStructure, DocumentFormat,
-    DocumentIntegralNameOverride, ParsedCitation, ParsedDocument,
+    BibliographyBlock, CitationParser, CitationPlacement, CitationStructure,
+    DocumentBibliographyOverride, DocumentFormat, DocumentIntegralNameOverride,
+    DocumentOptionsOverride, DocumentSortPartitioningOverride, ParsedCitation, ParsedDocument,
 };
 
 #[cfg(test)]

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -6,10 +6,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! High-level document-processing orchestration.
 
 use super::output::{
-    HtmlPlaceholderRegistry, RenderedDocumentBody, append_document_bibliography,
-    bibliography_block_placeholder, render_document_bibliography_block_replacement,
-    rewrite_document_markup_for_typst, rewrite_group_headings_for_document,
-    stage_document_bibliography_blocks,
+    append_document_bibliography, bibliography_block_placeholder,
+    render_document_bibliography_block_replacement, rewrite_document_markup_for_typst,
+    rewrite_group_headings_for_document, stage_document_bibliography_blocks,
+    HtmlPlaceholderRegistry, RenderedDocumentBody,
 };
 use super::{BibliographyBlock, CitationParser, DocumentFormat, ParsedDocument};
 use crate::processor::Processor;
@@ -19,7 +19,7 @@ impl Processor {
     ///
     /// This is the primary document-level entry point. It:
     /// 1. Parses the source document using the provided adapter.
-    /// 2. Resolves frontmatter overrides for the integral-name policy.
+    /// 2. Resolves frontmatter overrides (integral-name policy, bibliography options).
     /// 3. Chooses a bibliography orchestration path based on frontmatter and document blocks.
     #[allow(
         clippy::string_slice,
@@ -36,14 +36,44 @@ impl Processor {
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let mut parsed = parser.parse_document(content, &self.locale);
-        let owned_integral = self.processor_with_document_integral_name_override(
-            parsed.frontmatter_integral_name_memory.as_ref(),
-        );
-        let base = owned_integral.as_ref().unwrap_or(self);
-        let owned_org = base.processor_with_document_org_abbreviation_override(
-            parsed.frontmatter_org_abbreviation_memory.as_ref(),
-        );
-        let processor = owned_org.as_ref().unwrap_or(base);
+
+        // `options.integral-name-memory` takes precedence over the legacy top-level field.
+        let effective_integral_override = parsed
+            .frontmatter_options
+            .as_ref()
+            .and_then(|o| o.integral_name_memory.as_ref())
+            .or(parsed.frontmatter_integral_name_memory.as_ref());
+        let owned_integral =
+            self.processor_with_document_integral_name_override(effective_integral_override);
+
+        // Apply org-abbreviation-memory override from the options block.
+        let effective_org_override = parsed
+            .frontmatter_options
+            .as_ref()
+            .and_then(|o| o.org_abbreviation_memory.as_ref());
+        let owned_org = {
+            let base = owned_integral.as_ref().unwrap_or(self);
+            base.processor_with_document_org_abbreviation_override(effective_org_override)
+        };
+
+        // Apply bibliography overrides from the options block.
+        let owned_bib = parsed
+            .frontmatter_options
+            .as_ref()
+            .filter(|o| o.bibliography.is_some())
+            .map(|options| {
+                let base = owned_org
+                    .as_ref()
+                    .or(owned_integral.as_ref())
+                    .unwrap_or(self);
+                base.processor_with_bibliography_override(options)
+            });
+
+        let processor = owned_bib
+            .as_ref()
+            .or(owned_org.as_ref())
+            .or(owned_integral.as_ref())
+            .unwrap_or(self);
         let body = &content[parsed.body_start..];
         if let Some(groups) = parsed.frontmatter_groups.take() {
             return processor.process_document_with_frontmatter_groups::<P, F>(

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -6,10 +6,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! High-level document-processing orchestration.
 
 use super::output::{
-    append_document_bibliography, bibliography_block_placeholder,
-    render_document_bibliography_block_replacement, rewrite_document_markup_for_typst,
-    rewrite_group_headings_for_document, stage_document_bibliography_blocks,
-    HtmlPlaceholderRegistry, RenderedDocumentBody,
+    HtmlPlaceholderRegistry, RenderedDocumentBody, append_document_bibliography,
+    bibliography_block_placeholder, render_document_bibliography_block_replacement,
+    rewrite_document_markup_for_typst, rewrite_group_headings_for_document,
+    stage_document_bibliography_blocks,
 };
 use super::{BibliographyBlock, CitationParser, DocumentFormat, ParsedDocument};
 use crate::processor::Processor;
@@ -37,7 +37,12 @@ impl Processor {
     {
         let mut parsed = parser.parse_document(content, &self.locale);
 
-        // `options.integral-name-memory` takes precedence over the legacy top-level field.
+        if let Some(err) = &parsed.frontmatter_error {
+            eprintln!("citum: error: frontmatter parse error: {err}");
+            std::process::exit(1);
+        }
+
+        // `options.*` fields take precedence over the legacy top-level fields.
         let effective_integral_override = parsed
             .frontmatter_options
             .as_ref()
@@ -46,11 +51,12 @@ impl Processor {
         let owned_integral =
             self.processor_with_document_integral_name_override(effective_integral_override);
 
-        // Apply org-abbreviation-memory override from the options block.
+        // `options.org-abbreviation-memory` takes precedence over the legacy top-level field.
         let effective_org_override = parsed
             .frontmatter_options
             .as_ref()
-            .and_then(|o| o.org_abbreviation_memory.as_ref());
+            .and_then(|o| o.org_abbreviation_memory.as_ref())
+            .or(parsed.frontmatter_org_abbreviation_memory.as_ref());
         let owned_org = {
             let base = owned_integral.as_ref().unwrap_or(self);
             base.processor_with_document_org_abbreviation_override(effective_org_override)

--- a/crates/citum-engine/src/processor/document/types.rs
+++ b/crates/citum-engine/src/processor/document/types.rs
@@ -6,6 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! Shared document-processing types and parser contracts.
 
 use crate::Citation;
+use citum_schema::Style;
 use citum_schema::grouping::BibliographyGroup;
 use citum_schema::locale::Locale;
 use citum_schema::options::bibliography::{
@@ -16,7 +17,6 @@ use citum_schema::options::scoped::{
     BibliographyLabelMode, BibliographyLabelWrap, RepeatedAuthorRendering,
 };
 use citum_schema::options::{IntegralNameMemoryConfig, OrgAbbreviationMemoryConfig};
-use citum_schema::Style;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -131,7 +131,7 @@ impl DocumentOrgAbbreviationOverride {
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::DocumentIntegralNameOverride;
-    use citum_schema::options::{IntegralNameMemoryConfig, ShortNameDisplay};
+    use citum_schema::options::IntegralNameMemoryConfig;
 
     #[test]
     fn test_document_integral_name_override_enabled_false_disables_block() {

--- a/crates/citum-engine/src/processor/document/types.rs
+++ b/crates/citum-engine/src/processor/document/types.rs
@@ -8,8 +8,17 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use crate::Citation;
 use citum_schema::grouping::BibliographyGroup;
 use citum_schema::locale::Locale;
+use citum_schema::options::bibliography::{
+    BibliographyPartitionHeading, BibliographyPartitionKind, BibliographyPartitionMode,
+    BibliographySortPartitioning,
+};
+use citum_schema::options::scoped::{
+    BibliographyLabelMode, BibliographyLabelWrap, RepeatedAuthorRendering,
+};
 use citum_schema::options::{IntegralNameMemoryConfig, OrgAbbreviationMemoryConfig};
+use citum_schema::Style;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::collections::HashSet;
 
 /// Describes where a parsed citation appears in the source document.
@@ -82,28 +91,24 @@ impl DocumentIntegralNameOverride {
     }
 }
 
-/// Document-level org-abbreviation override parsed from frontmatter.
+/// Document-level org-abbreviation-memory override parsed from frontmatter.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct DocumentOrgAbbreviationOverride {
-    /// Whether org-abbreviation is enabled for this document.
+    /// Whether org-abbreviation-memory is enabled for this document.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    /// Where the first-mention memory resets.
+    /// Where name-memory resets.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scope: Option<citum_schema::options::IntegralNameScope>,
-    /// Which document contexts participate.
+    /// Which document contexts participate in the policy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contexts: Option<citum_schema::options::IntegralNameContexts>,
-    /// How to display a short name on the first integral mention.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub short_name_display: Option<citum_schema::options::ShortNameDisplay>,
 }
 
 impl DocumentOrgAbbreviationOverride {
-    /// Apply this frontmatter override to a base org-abbreviation configuration.
-    #[allow(dead_code, reason = "Infrastructure for org-abbreviation support")]
+    /// Apply this override to a base org-abbreviation-memory config.
     pub(super) fn apply_to(
         &self,
         base: Option<&OrgAbbreviationMemoryConfig>,
@@ -118,9 +123,6 @@ impl DocumentOrgAbbreviationOverride {
         if self.contexts.is_some() {
             result.contexts = self.contexts;
         }
-        if self.short_name_display.is_some() {
-            result.short_name_display = self.short_name_display;
-        }
         Some(result)
     }
 }
@@ -128,41 +130,8 @@ impl DocumentOrgAbbreviationOverride {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{DocumentIntegralNameOverride, DocumentOrgAbbreviationOverride};
-    use citum_schema::options::{
-        IntegralNameMemoryConfig, OrgAbbreviationMemoryConfig, ShortNameDisplay,
-    };
-
-    #[test]
-    fn test_document_org_abbreviation_override_deserializes_short_name_display() {
-        assert_eq!(
-            serde_yaml::from_str::<DocumentOrgAbbreviationOverride>(
-                "short-name-display: short-then-bracketed"
-            )
-            .ok()
-            .map(|config| config.short_name_display),
-            Some(Some(ShortNameDisplay::ShortThenBracketed))
-        );
-    }
-
-    #[test]
-    fn test_document_org_abbreviation_override_applies_short_name_display() {
-        let base = OrgAbbreviationMemoryConfig {
-            short_name_display: Some(ShortNameDisplay::FullThenParenthetical),
-            ..Default::default()
-        };
-        let override_config = DocumentOrgAbbreviationOverride {
-            short_name_display: Some(ShortNameDisplay::ShortThenBracketed),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            override_config
-                .apply_to(Some(&base))
-                .map(|config| config.short_name_display),
-            Some(Some(ShortNameDisplay::ShortThenBracketed))
-        );
-    }
+    use super::DocumentIntegralNameOverride;
+    use citum_schema::options::{IntegralNameMemoryConfig, ShortNameDisplay};
 
     #[test]
     fn test_document_integral_name_override_enabled_false_disables_block() {
@@ -173,6 +142,194 @@ mod tests {
         };
 
         assert!(override_config.apply_to(Some(&base)).is_none());
+    }
+
+    #[test]
+    fn test_document_bibliography_override_deserializes_label_mode() {
+        use super::DocumentBibliographyOverride;
+        use citum_schema::options::scoped::BibliographyLabelMode;
+
+        let parsed: DocumentBibliographyOverride =
+            serde_yaml::from_str("label-mode: numeric").unwrap();
+        assert_eq!(parsed.label_mode, Some(BibliographyLabelMode::Numeric));
+        assert!(parsed.repeated_author_rendering.is_none());
+        assert!(parsed.sort_partitioning.is_none());
+    }
+
+    #[test]
+    fn test_document_bibliography_override_deserializes_repeated_author() {
+        use super::DocumentBibliographyOverride;
+        use citum_schema::options::scoped::RepeatedAuthorRendering;
+
+        let parsed: DocumentBibliographyOverride =
+            serde_yaml::from_str("repeated-author-rendering: dash").unwrap();
+        assert_eq!(
+            parsed.repeated_author_rendering,
+            Some(RepeatedAuthorRendering::Dash)
+        );
+    }
+
+    #[test]
+    fn test_document_options_override_deserializes_locale_and_bibliography() {
+        use super::{DocumentBibliographyOverride, DocumentOptionsOverride};
+        use citum_schema::options::scoped::BibliographyLabelWrap;
+
+        let yaml = "locale: de-DE\nbibliography:\n  label-wrap: brackets\n";
+        let parsed: DocumentOptionsOverride = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed.locale.as_deref(), Some("de-DE"));
+        assert_eq!(
+            parsed.bibliography,
+            Some(DocumentBibliographyOverride {
+                label_wrap: Some(BibliographyLabelWrap::Brackets),
+                ..Default::default()
+            })
+        );
+        assert!(parsed.integral_name_memory.is_none());
+    }
+
+    #[test]
+    fn test_document_options_override_empty_is_default() {
+        use super::DocumentOptionsOverride;
+
+        let parsed: DocumentOptionsOverride = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(parsed, DocumentOptionsOverride::default());
+    }
+
+    #[test]
+    fn test_document_options_override_unknown_field_errors() {
+        use super::DocumentOptionsOverride;
+
+        assert!(serde_yaml::from_str::<DocumentOptionsOverride>("unknown-field: true").is_err());
+    }
+}
+
+/// Sparse per-document sort-partitioning overlay.
+///
+/// Absent fields inherit the style's existing sort-partitioning values.
+/// When `by` is absent and the style has no sort-partitioning configured,
+/// the override is a no-op.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DocumentSortPartitioningOverride {
+    /// Partition key source. Required when no style-level partitioning exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub by: Option<BibliographyPartitionKind>,
+    /// Whether partitioning affects sorting, visible sections, or both.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<BibliographyPartitionMode>,
+    /// Preferred partition order. Unlisted partitions sort after listed ones.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub order: Vec<String>,
+    /// Optional headings for visible partition sections.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headings: HashMap<String, BibliographyPartitionHeading>,
+}
+
+/// Per-document bibliography presentation overrides.
+///
+/// All fields are optional. Absent fields inherit the style's defaults.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DocumentBibliographyOverride {
+    /// Sparse multilingual bibliography partitioning override.
+    ///
+    /// Non-`None` fields are merged into the style's existing sort-partitioning;
+    /// absent fields are inherited. When `by` is absent and the style has no
+    /// sort-partitioning, the field is a no-op.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_partitioning: Option<DocumentSortPartitioningOverride>,
+    /// Repeated-author rendering mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repeated_author_rendering: Option<RepeatedAuthorRendering>,
+    /// Bibliography label mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_mode: Option<BibliographyLabelMode>,
+    /// Bibliography label wrap punctuation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_wrap: Option<BibliographyLabelWrap>,
+}
+
+/// Per-document presentation overrides parsed from frontmatter `options:` block.
+///
+/// Eligible options are those that control how output looks without requiring the
+/// processor to re-walk citations for disambiguation or sorting. All fields are
+/// optional; absent fields inherit the style's defaults.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DocumentOptionsOverride {
+    /// BCP 47 locale ID to use as the base locale for this document.
+    ///
+    /// Replaces the style's default locale entirely. Handled in the CLI layer;
+    /// `apply_to` does not touch locale.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+    /// Integral-name-memory override. Takes precedence over the legacy top-level
+    /// `integral-name-memory:` frontmatter field when both are present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integral_name_memory: Option<DocumentIntegralNameOverride>,
+    /// Org-abbreviation-memory override.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_abbreviation_memory: Option<DocumentOrgAbbreviationOverride>,
+    /// Bibliography presentation overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bibliography: Option<DocumentBibliographyOverride>,
+}
+
+impl DocumentOptionsOverride {
+    /// Apply bibliography overrides from this override block to a resolved style.
+    ///
+    /// Writes non-`None` bibliography fields into `style.bibliography.options`,
+    /// then calls `apply_scoped_options` to propagate changes into the style's
+    /// templates. Locale and integral-name-memory are handled by the pipeline
+    /// and CLI layers respectively.
+    pub(super) fn apply_bibliography_to(&self, style: &mut Style) {
+        let Some(bib_override) = &self.bibliography else {
+            return;
+        };
+        let bib = style.bibliography.get_or_insert_with(Default::default);
+        let opts = bib.options.get_or_insert_with(Default::default);
+        if let Some(sp_override) = &bib_override.sort_partitioning {
+            match opts.sort_partitioning.as_mut() {
+                Some(existing) => {
+                    if let Some(by) = sp_override.by {
+                        existing.by = by;
+                    }
+                    if let Some(mode) = sp_override.mode {
+                        existing.mode = mode;
+                    }
+                    if !sp_override.order.is_empty() {
+                        existing.order = sp_override.order.clone();
+                    }
+                    if !sp_override.headings.is_empty() {
+                        existing.headings = sp_override.headings.clone();
+                    }
+                }
+                None => {
+                    if let Some(by) = sp_override.by {
+                        opts.sort_partitioning = Some(BibliographySortPartitioning {
+                            by,
+                            mode: sp_override.mode.unwrap_or_default(),
+                            order: sp_override.order.clone(),
+                            headings: sp_override.headings.clone(),
+                            unknown_fields: Default::default(),
+                        });
+                    }
+                }
+            }
+        }
+        if let Some(rar) = bib_override.repeated_author_rendering {
+            opts.repeated_author_rendering = Some(rar);
+        }
+        if let Some(lm) = bib_override.label_mode {
+            opts.label_mode = Some(lm);
+        }
+        if let Some(lw) = bib_override.label_wrap {
+            opts.label_wrap = Some(lw);
+        }
+        style.apply_scoped_options();
     }
 }
 
@@ -227,8 +384,22 @@ pub struct ParsedDocument {
     pub frontmatter_groups: Option<Vec<citum_schema::grouping::BibliographyGroup>>,
     /// Integral-name-memory override from YAML frontmatter (legacy top-level field).
     pub frontmatter_integral_name_memory: Option<DocumentIntegralNameOverride>,
-    /// Org-abbreviation-memory override from YAML frontmatter.
+    /// Org-abbreviation-memory override from YAML frontmatter (legacy top-level field).
+    ///
+    /// Superseded by `options.org_abbreviation_memory` when both are present.
     pub frontmatter_org_abbreviation_memory: Option<DocumentOrgAbbreviationOverride>,
+    /// Full options override from YAML frontmatter `options:` block.
+    ///
+    /// When `options.integral_name_memory` is `Some`, it takes precedence over
+    /// the legacy top-level `frontmatter_integral_name_memory`.
+    /// When `options.org_abbreviation_memory` is `Some`, it takes precedence over
+    /// the legacy top-level `frontmatter_org_abbreviation_memory`.
+    pub frontmatter_options: Option<DocumentOptionsOverride>,
+    /// Non-empty when the frontmatter `---` block failed to deserialize.
+    ///
+    /// The pipeline treats this as a hard error: it prints the message and
+    /// exits rather than proceeding silently without frontmatter data.
+    pub frontmatter_error: Option<String>,
     /// Byte offset where the document body starts (past any frontmatter).
     pub body_start: usize,
 }

--- a/crates/citum-schema-style/src/style/model.rs
+++ b/crates/citum-schema-style/src/style/model.rs
@@ -104,6 +104,17 @@ impl Style {
         Ok(style)
     }
 
+    /// Apply scoped citation and bibliography option overrides to this style.
+    ///
+    /// Translates typed option values (label mode, label wrap, repeated-author
+    /// rendering, date position, title terminator) into concrete template mutations.
+    /// Call this after mutating `bibliography.options` at runtime — e.g. after
+    /// applying per-document overrides — so that template state stays consistent
+    /// with the option values.
+    pub fn apply_scoped_options(&mut self) {
+        crate::options::scoped::apply_scoped_style_options(self);
+    }
+
     /// Parse a Citum style from YAML bytes, preserving raw YAML for
     /// null-aware overlay merging during preset resolution.
     ///

--- a/docs/demo.djot
+++ b/docs/demo.djot
@@ -1,8 +1,9 @@
 ---
-integral-name-memory:
-  enabled: true
-  scope: document
-  contexts: body-and-notes
+options:
+  integral-name-memory:
+    enabled: true
+    scope: document
+    contexts: body-and-notes
 ---
 
 {.citum-demo-notice}
@@ -12,10 +13,11 @@ No scholarly claims are made.
 
 ---
 
-**Features illustrated**: integral and non-integral citations; name memory (Chen, cited
-across two works); multilingual sources (Japanese, Spanish); EDTF dates (approximate:
-`2022~`; uncertain: `1891?`); archival reference with `archive-info`; preprint with
-`eprint` identifier. The companion reference file is `docs/demo-refs.yaml`.
+**Features illustrated**: integral and non-integral citations; per-document integral
+name memory via `options.integral-name-memory` (Chen, cited across two works, rendered
+in short form on repeat); multilingual sources (Japanese, Spanish); EDTF dates
+(approximate: `2022~`; uncertain: `1891?`); archival reference with `archive-info`;
+preprint with `eprint` identifier. The companion reference file is `docs/demo-refs.yaml`.
 
 ---
 

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -211,136 +211,65 @@
     </div>
 
   <div id="demo-root" class="demo-container">
-    <article class="content">
-      <p>
-        Scholarly citation serves as the primary mechanism through which academic knowledge
-        is organized, attributed, and transmitted. As
-        <span class="citum-citation" data-ref="chen2017">Chen (2017)</span>
-        has argued, the practices surrounding citation reflect deeper epistemological
-        commitments about what counts as knowledge and who produces it. The formal apparatus
-        of bibliographic reference — the footnote, the parenthetical, the numbered list —
-        constitutes what
-        <span class="citum-citation" data-ref="webb1968">Webb (1968)</span>
-        called &#8220;the footnote as institution,&#8221; embedding social relations within
-        the seemingly neutral mechanics of scholarly communication.
-      </p>
+<p class="citum-demo-notice"><strong><strong>Note</strong></strong>: This is an entirely artificial document created for the purpose of illustrating
+Citum citation rendering features. All arguments, references, and authors are fabricated.
+No scholarly claims are made.</p>
+<hr>
+<p><strong><strong>Features illustrated</strong></strong>: integral and non-integral citations; per-document integral
+name memory via <code>options.integral-name-memory</code> (Chen, cited across two works, rendered
+in short form on repeat); multilingual sources (Japanese, Spanish); EDTF dates
+(approximate: <code>2022~</code>; uncertain: <code>1891?</code>); archival reference with <code>archive-info</code>;
+preprint with <code>eprint</code> identifier. The companion reference file is <code>docs/demo-refs.yaml</code>.</p>
+<hr>
+<section id="The-Infrastructure-of-Scholarly-Memory">
+<h1>The Infrastructure of Scholarly Memory</h1>
+<p>Scholarly citation serves as the primary mechanism through which academic knowledge
+is organized, attributed, and transmitted. As <span class="citum-citation" data-ref="chen2017"><span class="citum-author">M. Chen</span> (<span class="citum-issued">2017</span>)</span> has argued, the practices
+surrounding citation reflect deeper epistemological commitments about what counts
+as knowledge and who produces it. The formal apparatus of bibliographic reference
+— the footnote, the parenthetical, the numbered list — constitutes what (<span class="citum-citation" data-ref="webb1968">Webb, <span class="citum-issued">1968</span></span>)
+called “the footnote as institution,” embedding social relations within
+the seemingly neutral mechanics of scholarly communication.</p>
+<p>The production of this apparatus is not confined to Anglophone scholarship.
+<span class="citum-citation" data-ref="tanaka_yuki2019"><span class="citum-author">Y. Tanaka & H. Suzuki</span> (<span class="citum-issued">2019</span>)</span> demonstrate that citation practices in Japanese science studies
+reflect distinct epistemological conventions, including different assumptions about
+authorial authority and collective knowledge-making. Parallel observations emerge
+from Spanish-language scholarship, where the relationship between citation and
+institutional context differs in ways that challenge Anglocentric models of
+attribution (<span class="citum-citation" data-ref="garcia2022">García-Reyes & Montoya, <span class="citum-issued">ca. 2022</span></span>).</p>
+<p>These questions have a longer history than recent digital debates might suggest.
+<span class="citum-citation" data-ref="harrington1891"><span class="citum-author">R. L. Harrington</span> (<span class="citum-issued">1891?</span>)</span> observed — in manuscript notes preserved at the British Library —
+that bibliographic method was already contested among Victorian scholars of natural
+history, who disagreed fundamentally about whether a citation should indicate
+provenance, priority, or deference. <span class="citum-citation" data-ref="chen2017"><span class="citum-author">Chen</span> (<span class="citum-issued">2017</span>, <span class="citum-variable">ch. 3</span>)</span> traces a direct line from
+these Victorian anxieties to contemporary algorithmic citation metrics; the impulse
+to quantify scholarly influence has deep institutional roots.</p>
+<p>More recent work challenges the assumption that citation reflects merit rather than
+network position. <span class="citum-citation" data-ref="chen2020"><span class="citum-author">Chen</span> (<span class="citum-issued">2020</span>)</span> extends this analysis to the digital transition, arguing
+that platform architectures reproduce and amplify existing hierarchies of credibility.
+<span class="citum-citation" data-ref="okafor2024"><span class="citum-author">N. Okafor et al.</span> (<span class="citum-issued">2024</span>)</span> provide large-scale empirical support for this claim, showing through
+computational analysis of citation networks that topological centrality correlates
+more strongly with institutional affiliation than with measured scholarly impact.</p>
+<p>Together, this body of evidence suggests that citation is less a neutral epistemic
+tool than a cultural technology whose workings differ across languages, institutions,
+and time periods. Understanding that variability requires attention to both the fine
+structure of individual references — their dates, languages, formats, and archival
+contexts — and the aggregate patterns they produce across documents and disciplines.</p>
+<section id="Primary-Sources" class="citum-bibliography">
+<h2>Primary Sources</h2>
+<div class="citum-entry" id="ref-harrington1891" data-author="Harrington" data-year="1891" data-title="Notes on Bibliographic Method and the Organisation of Learned References"><span class="citum-author">Harrington, R. L.</span><span class="citum-issued"> (1891?)</span>. <span class="citum-title"><em>Notes on Bibliographic Method and the Organisation of Learned References</em></span>. <span class="citum-variable">British Library</span><span class="citum-variable"> (Manuscripts Reading Room)</span></div>
+</section>
+<section id="Secondary-Sources" class="citum-bibliography">
+<h2>Secondary Sources</h2>
+<div class="citum-entry" id="ref-chen2017" data-author="Chen" data-year="2017" data-title="The Social Life of References: Knowledge-Making in Collaborative Science"><span class="citum-author">Chen, M.</span><span class="citum-issued"> (2017)</span>. <span class="citum-title"><em>The Social Life of References: Knowledge-Making in Collaborative Science</em></span><span class="citum-publisher">. MIT Press.</span></div>
+<div class="citum-entry" id="ref-chen2020" data-author="Chen" data-year="2020" data-title="Citation and Authority: Epistemic Practices in the Digital Age"><span class="citum-author">Chen, M.</span><span class="citum-issued"> (2020)</span>. <span class="citum-title"><em>Citation and Authority: Epistemic Practices in the Digital Age</em></span><span class="citum-publisher">. MIT Press.</span></div>
+<div class="citum-entry" id="ref-garcia2022" data-author="García-Reyes, &amp; Montoya" data-year="2022" data-title="Prácticas de citación en la ciencia latinoamericana"><span class="citum-author">García-Reyes, I., & Montoya, C. P.</span><span class="citum-issued"> (ca. 2022)</span>. <span class="citum-title"><em>Prácticas de citación en la ciencia latinoamericana</em></span> (<span class="citum-editor">E. Restrepo, editor</span>). <span class="citum-container-title"><em>Epistemologías del Sur: Perspectivas desde América Latina</em></span><span class="citum-pages">, 112–138.</span></div>
+<div class="citum-entry" id="ref-okafor2024" data-author="Okafor, Ferreira, &amp; Park" data-year="2024" data-title="Network Topology of Academic Citation: A Large-Scale Computational Analysis"><span class="citum-author">Okafor, N., Ferreira, B., & Park, J.</span><span class="citum-issued"> (2024)</span>. <span class="citum-title"><em>Network Topology of Academic Citation: A Large-Scale Computational Analysis</em></span></div>
+<div class="citum-entry" id="ref-webb1968" data-author="Webb" data-year="1968" data-title="The Footnote as Institution: A History of Scholarly Reference"><span class="citum-author">Webb, M. L.</span><span class="citum-issued"> (1968)</span>. <span class="citum-title"><em>The Footnote as Institution: A History of Scholarly Reference</em></span><span class="citum-publisher">. Oxford University Press.</span></div>
+<div class="citum-entry" id="ref-tanaka_yuki2019" data-author="田中, &amp; 鈴木" data-year="2019" data-title="引用の社会的機能：学術知識の構築における参照実践"><span class="citum-author">Tanaka, Y., & Suzuki, H.</span><span class="citum-issued"> (2019)</span>. <span class="citum-title"><em>In’yo no shakaiteki kino: Gakujutsu chishiki no kochiku ni okeru sansho jissen [The Social Function of Citation: Reference Practices in the Construction of Academic Knowledge]</em></span>. <span class="citum-container-title"><em>Kagaku Shakai-gaku Kenkyu</em></span><span class="citum-pages">, 45–78.</span></div>
+</section>
+</section>
 
-      <p>
-        The production of this apparatus is not confined to Anglophone scholarship.
-        <span class="citum-citation" data-ref="tanaka_yuki2019">Tanaka and Suzuki (2019)</span>
-        demonstrate that citation practices in Japanese science studies reflect distinct
-        epistemological conventions, including different assumptions about authorial authority
-        and collective knowledge-making. Parallel observations emerge from Spanish-language
-        scholarship, where the relationship between citation and institutional context differs
-        in ways that challenge Anglocentric models of attribution
-        <span class="citum-citation" data-ref="garcia2022">(Garc&#237;a-Reyes &amp; Montoya, ca.&thinsp;2022)</span>.
-      </p>
-
-      <p>
-        These questions have a longer history than recent digital debates might suggest.
-        <span class="citum-citation" data-ref="harrington1891">Harrington (1891?)</span>
-        observed — in manuscript notes preserved at the British Library — that bibliographic
-        method was already contested among Victorian scholars of natural history, who
-        disagreed fundamentally about whether a citation should indicate provenance,
-        priority, or deference.
-        <span class="citum-citation" data-ref="chen2017">Chen (2017, ch.&thinsp;3)</span>
-        traces a direct line from these Victorian anxieties to contemporary algorithmic
-        citation metrics; the impulse to quantify scholarly influence has deep institutional
-        roots.
-      </p>
-
-      <p>
-        More recent work challenges the assumption that citation reflects merit rather than
-        network position.
-        <span class="citum-citation" data-ref="chen2020">Chen (2020)</span>
-        extends this analysis to the digital transition, arguing that platform architectures
-        reproduce and amplify existing hierarchies of credibility.
-        <span class="citum-citation" data-ref="okafor2024">Okafor et al. (2024)</span>
-        provide large-scale empirical support for this claim, showing through computational
-        analysis of citation networks that topological centrality correlates more strongly
-        with institutional affiliation than with measured scholarly impact.
-      </p>
-
-      <p>
-        Together, this body of evidence suggests that citation is less a neutral epistemic
-        tool than a cultural technology whose workings differ across languages, institutions,
-        and time periods. Understanding that variability requires attention to both the fine
-        structure of individual references — their dates, languages, formats, and archival
-        contexts — and the aggregate patterns they produce across documents and disciplines.
-      </p>
-    </article>
-
-    <section class="citum-bibliography">
-      <h3>Primary Sources</h3>
-
-      <div class="citum-entry" id="ref-harrington1891"
-           data-author="Harrington, R. L." data-year="1891?" data-title="Notes on Bibliographic Method">
-        <span class="citum-author">Harrington, R. L.</span>
-        <span class="citum-date">(1891?).</span>
-        <span class="citum-title">Notes on bibliographic method and the organisation of learned references</span>
-        [Manuscript]. MS Add.&thinsp;47903, ff.&thinsp;12&#8211;34.
-        British Library, Manuscripts Reading Room, London.
-      </div>
-
-      <h3>Secondary Sources</h3>
-
-      <div class="citum-entry" id="ref-chen2017"
-           data-author="Chen, M." data-year="2017" data-title="The Social Life of References">
-        <span class="citum-author">Chen, M.</span>
-        <span class="citum-date">(2017).</span>
-        <em class="citum-title">The social life of references: Knowledge-making in collaborative science.</em>
-        MIT Press.
-      </div>
-
-      <div class="citum-entry" id="ref-chen2020"
-           data-author="Chen, M." data-year="2020" data-title="Citation and Authority">
-        <span class="citum-author">Chen, M.</span>
-        <span class="citum-date">(2020).</span>
-        <em class="citum-title">Citation and authority: Epistemic practices in the digital age.</em>
-        MIT Press.
-      </div>
-
-      <div class="citum-entry" id="ref-garcia2022"
-           data-author="García-Reyes &amp; Montoya" data-year="ca. 2022" data-title="Prácticas de citación en la ciencia latinoamericana">
-        <span class="citum-author">Garc&#237;a-Reyes, I., &amp; Montoya, C.&thinsp;P.</span>
-        <span class="citum-date">(ca.&thinsp;2022).</span>
-        Pr&#225;cticas de citaci&#243;n en la ciencia latinoamericana
-        [Citation practices in Latin American science].
-        In E. Restrepo (Ed.),
-        <em class="citum-container-title">Epistemolog&#237;as del Sur: Perspectivas desde Am&#233;rica Latina</em>
-        (pp.&thinsp;112&#8211;138). CLACSO.
-      </div>
-
-      <div class="citum-entry" id="ref-okafor2024"
-           data-author="Okafor, Ferreira &amp; Park" data-year="2024" data-title="Network Topology of Academic Citation">
-        <span class="citum-author">Okafor, N., Ferreira, B., &amp; Park, J.</span>
-        <span class="citum-date">(2024, January).</span>
-        <em class="citum-title">Network topology of academic citation: A large-scale computational analysis.</em>
-        arXiv:2401.05832 [cs.DL].
-      </div>
-
-      <div class="citum-entry" id="ref-tanaka_yuki2019"
-           data-author="Tanaka &amp; Suzuki" data-year="2019" data-title="In'yo no shakaiteki kino">
-        <span class="citum-author">Tanaka, Y., &amp; Suzuki, H.</span>
-        <span class="citum-date">(2019).</span>
-        <em class="citum-title">In&rsquo;yo no shakaiteki kino: Gakujutsu chishiki no kochiku ni okeru sansho jissen
-        [The Social Function of Citation: Reference Practices in the Construction of Academic Knowledge]</em>.
-        <em class="citum-container-title">Kagaku Shakai-gaku Kenkyu</em>, 45&#8211;78.
-      </div>
-
-      <div class="citum-entry" id="ref-webb1968"
-           data-author="Webb, M. L." data-year="1968" data-title="The Footnote as Institution">
-        <span class="citum-author">Webb, M.&thinsp;L.</span>
-        <span class="citum-date">(1968).</span>
-        <em class="citum-title">The footnote as institution: A history of scholarly reference.</em>
-        Oxford University Press.
-      </div>
-    </section>
-
-    <section class="citum-bibliography">
-      <h3>Reproduce This Rendering</h3>
-      <pre><code>citum render doc -s styles/embedded/apa-7th.yaml -b docs/demo-refs.yaml docs/demo.djot</code></pre>
-    </section>
   </div>
   </div>
 

--- a/docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
+++ b/docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
@@ -1,0 +1,351 @@
+# Per-Document Configuration Overrides Specification
+
+**Status:** Draft
+**Date:** 2026-05-26
+**Related:** bean `csl26-tap8`, `docs/specs/INTEGRAL_NAME_MEMORY.md`, `docs/specs/UNIFIED_SCOPED_OPTIONS.md`
+
+## Purpose
+
+Authors routinely need to adjust how a citation style renders for a specific
+document without forking or modifying a shared style. A thesis submitted to
+a German institution may use an English-default style but require German
+locale terms. A publisher may deliver manuscripts in a style that prohibits
+the 3-em dash convention the house style uses for repeated authors.
+
+This specification defines which style configuration options may be overridden
+at the document level, the criteria that determine eligibility, and the three
+access surfaces: plain-text document frontmatter, the `citum` CLI, and GUI
+consumers such as word-processor plugins.
+
+## Scope
+
+**In scope:**
+
+- Defining the eligible option set and the reasoning behind each inclusion
+- YAML frontmatter syntax (`options:` block in document)
+- CLI surface (`citum render doc` flags)
+- GUI consumer contract (same serde-derived Rust type; YAML/JSON/CBOR share one schema)
+- Implementation pattern (sparse-overlay model)
+- Relationship between per-document `sort-partitioning` and existing bibliography groups
+
+**Out of scope:**
+
+- Entry-spacing and hanging-indent controls — these are layout concerns owned
+  by the rendering target (CSS, LaTeX document class), not the citation
+  engine. The engine's output is semantic; physical spacing belongs to the
+  consuming layer.
+- Disambiguation behavior overrides — disambiguation state is built
+  incrementally as the processor walks all citations in the document.
+  Allowing a per-document policy change would require re-running
+  disambiguation from scratch, and the result would be inconsistent with
+  any pre-rendered or cached citation output. This is a processor concern,
+  not an author-facing override.
+- Any option under `config.processing`, `config.contributors`, `config.dates`,
+  `config.titles`, `config.locators`, `config.substitute`, or
+  `config.multilingual` — these are structural: they change *what gets cited*
+  and *how contributor data is assembled*, not how the output looks. Overriding
+  them per-document would silently produce output that misrepresents the
+  applied style.
+
+## Eligibility Criteria
+
+An option qualifies for per-document override if and only if:
+
+1. **Presentation-layer**: it controls *how output looks* — punctuation,
+   label shape, ordering of pre-assembled elements, locale terms — rather
+   than *what gets cited* or *how contributor data is assembled*.
+2. **No processor side-effects**: applying it at the end of style resolution,
+   after the processor has finished disambiguating and sorting, produces
+   correct and consistent output. Options that require the processor to
+   re-walk citations do not qualify.
+3. **Documented venue variation**: there is evidence from academic publishing
+   practice, style manuals, or community tooling that the option genuinely
+   varies by document type or venue while the underlying citation logic
+   remains the same.
+
+## Eligible Options
+
+### `locale` (top level)
+
+A document may use an English-default style but require output in another
+language. Without a per-document locale, the only recourse is to fork the
+style and change `info.default-locale` — a maintenance burden that breaks
+style updates.
+
+`locale: de-DE` in frontmatter selects the base locale for the document,
+meaning all locale-backed terms, date formats, and punctuation rules are
+drawn from the German locale rather than the style's default. This is
+distinct from the style-internal `config.locale-override`, which is a
+patch ID (e.g. `de-DE-chicago`) that loads a partial diff over the resolved
+base locale. The document-level `locale` field replaces the base entirely.
+
+Implementation note: the resolver will need a new code path for document-level
+base-locale selection, separate from the existing `locale_override` patch
+mechanism in `crates/citum-cli/src/style_resolver.rs`.
+
+### `integral-name-memory` (top level)
+
+Already implemented. See `docs/specs/INTEGRAL_NAME_MEMORY.md`.
+
+This option stays at the top level of the `options:` block for backward
+compatibility: the current `DocumentFrontmatter.integral_name_memory` field
+is a sibling of `bibliography:`, not nested under `options:`. Both locations
+must continue to work. When both are present, `options.integral-name-memory`
+takes precedence. The `options:` placement is the preferred form going forward.
+
+Document overrides support an additional `enabled: false` switch to suppress
+the style's memory policy for that document.
+
+### `bibliography.sort-partitioning`
+
+The style-level `BibliographySortPartitioning` controls automatic grouping of
+a multilingual bibliography by Unicode script (`by: script`) or by item
+language (`by: language`). A document may need to override this policy —
+for example, a multilingual anthology may want script-based sorting disabled
+for a chapter that contains only Western-script sources, or may need to adjust
+the section headings the style provides.
+
+Per-document `sort-partitioning` overrides the style's multilingual
+partitioning policy using the same shape as the style option. All fields are
+optional; absent fields inherit the style's defaults.
+
+Valid `by` values are `script` and `language`. The heading shape follows
+`BibliographyPartitionHeading`: `literal`, `term`, or `localized`.
+
+#### Relationship to bibliography groups
+
+General-purpose bibliography divisions — primary vs. secondary sources, legal
+materials by category (cases / legislation / commentary), print vs. online —
+are **not** sort-partitioning. They are handled by the existing
+`DocumentFrontmatter.bibliography` field, which accepts a list of
+`BibliographyGroup` entries. Each group uses a `GroupSelector` (by type,
+cited status, or field value), an optional heading, an optional per-group
+sort, and an optional per-group template.
+
+OSCOLA's requirement for separate sections for cases, legislation, and
+secondary sources is expressed as bibliography groups with type selectors, not
+as sort-partitioning. Chicago divided bibliographies for large theses are
+likewise bibliography groups. Sort-partitioning is specifically the mechanism
+for script/language-based multilingual reordering.
+
+This distinction resolves the naming confusion between the two features: they
+have different shapes, different selectors, and different purposes.
+
+#### Interaction with numeric `label-mode`
+
+When a bibliography uses numeric labels and is also partitioned by script or
+language, numeric labels must continue across partitions. Each reference
+receives a unique number in document order regardless of which partition it
+falls in; partitions affect only the visual grouping and headings. Restarting
+labels per partition would make cross-referencing ambiguous (the same number
+appearing in multiple sections).
+
+### `bibliography.repeated-author-rendering`
+
+The 3-em dash convention (replacing a repeated author name with ———) varies
+substantially by venue. CMOS 14.67 notes that the convention is a *publisher's
+prerogative*, and explicitly discourages authors from applying it themselves
+in manuscripts submitted for publication — publishers add it in copyediting.
+Some publishers (notably Bloomsbury) prohibit it entirely for XML and eBook
+workflows, where a dash cannot be reliably expanded back to the author name.
+
+Because the same underlying style (e.g., Chicago author-date) may be used
+both by authors preparing manuscripts (where the dash should be suppressed)
+and by publishers rendering final output (where the dash is appropriate),
+this is a clear case for per-document control.
+
+Values: `full` (always render the full contributor list), `dash`, `dash-with-space`.
+
+### `bibliography.label-mode`
+
+The numeric vs. author-date vs. none label distinction is a document-class
+concern. A researcher may use the same style to produce a journal preprint
+(no labels, author-date in-text), a conference proceedings draft (numeric
+labels required by the venue), and a thesis (author-date labels in the
+bibliography matching the in-text key).
+
+Changing label mode does not affect how contributor data is assembled or how
+citation disambiguation works — it affects only whether and how a label
+component is injected into the bibliography template.
+
+### `bibliography.label-wrap`
+
+Label punctuation — whether a numeric label appears as `[1]`, `(1)`, `1.`,
+or as a superscript — varies by venue even within a style family.
+
+**Caveat:** In some style families, the bracket convention is a *defining*
+feature. Overriding `label-wrap` per document can produce output that
+superficially resembles a different named style without declaring it as such,
+which may mislead readers about the citation convention in use. Authors should
+use this with care.
+
+## Future Consideration
+
+The following options are plausible candidates for a future revision but are
+not included in the initial eligible set. Analysis is preserved here to inform
+that decision.
+
+### `bibliography.date-position`
+
+The position of the issued date within a bibliography entry varies by style
+family and publisher. However, in author-date styles, date position carries
+semantic weight: readers expect to find the date immediately after the author
+name so they can match the in-text citation key `(Smith 2020)` to the
+bibliography entry. Overriding this in that context degrades usability without
+changing correctness. Safe exposure requires detecting whether the resolved
+style uses author-date processing — a dependency not yet addressed.
+
+### `bibliography.title-terminator`
+
+Meets the eligibility criteria in isolation but is deferred because its
+interaction with `date-position` is non-trivial: a title ending with a period
+before a repositioned date can produce double punctuation. Address alongside
+`date-position` if both are admitted in a future revision.
+
+### `citation.label-wrap`
+
+Same rationale as `bibliography.label-wrap`. Deferred pending evidence of
+demand for independent control over citation-level vs. bibliography-level
+wrapping, and observation of `bibliography.label-wrap` usage in practice.
+
+### `citation.group-delimiter`
+
+The delimiter between co-cited references in a single citation cluster varies
+by publisher. It does not substitute for style families that differ in other
+ways (numbering scheme, date format, title casing, contributor rendering —
+the delimiter is one small facet). Deferred pending evidence of author demand
+at the document level.
+
+## Access Surfaces
+
+### Plain-text documents (frontmatter)
+
+The primary authoring surface. An `options:` block in document frontmatter
+(Djot or Markdown) is parsed automatically by `citum render doc`. All fields
+are optional; absent fields inherit the style's defaults.
+
+```yaml
+---
+options:
+  locale: de-DE
+  integral-name-memory:
+    enabled: false
+  bibliography:
+    sort-partitioning:
+      by: script
+      mode: sort-and-sections
+      headings:
+        latin:
+          literal: "Latin-script sources"
+        han:
+          localized:
+            zh: "中文文献"
+            en-US: "Chinese-script sources"
+    label-mode: numeric
+    label-wrap: brackets
+    repeated-author-rendering: full
+---
+```
+
+`integral-name-memory` is also accepted at the document top level (sibling
+of `bibliography:`) for backward compatibility:
+
+```yaml
+---
+integral-name-memory:
+  enabled: false
+bibliography:
+  - id: primary
+    ...
+---
+```
+
+### CLI (`citum render doc`)
+
+`citum render doc` reads frontmatter `options:` automatically. No extra flags
+are required for most overrides.
+
+The one exception is locale: authors often need to render a document in a
+different language without modifying the document itself (e.g., batch-rendering
+the same source for different regional audiences, or when the document comes
+from an external source). A `--locale / -L` flag will be added to
+`RenderDocArgs`, matching the existing `-L/--locale` flag on `render refs`:
+
+```
+citum render doc manuscript.djot -s apa-7th -b refs.json --locale de-DE
+```
+
+CLI `--locale` takes precedence over a `locale:` field in frontmatter, which
+takes precedence over the style's default locale.
+
+No other per-document options get dedicated CLI flags in v1. Options that vary
+per document (label mode, repeated-author rendering, etc.) belong in frontmatter
+where they are version-controlled alongside the document.
+
+### GUI consumers (word-processor plugins)
+
+The `DocumentOptionsOverride` Rust struct is the single contract for all
+consumers. Serde derives YAML, JSON, and CBOR representations from one type,
+so plain-text frontmatter, JSON-posting GUI plugins, and binary CBOR protocols
+all share the same schema without a separate wire-format contract.
+
+## Implementation Pattern
+
+The sparse-overlay model used for `integral-name-memory` extends to the full
+`options:` block:
+
+1. **`DocumentOptionsOverride` struct** (new) in
+   `crates/citum-engine/src/processor/document/types.rs` — mirrors the fields
+   in the eligible set, all `Option<T>`. Implements an `apply_to(style)` method
+   that writes non-`None` fields into the resolved style's configuration after
+   normal scoped-options application.
+
+2. **`DocumentFrontmatter` extension** in
+   `crates/citum-engine/src/processor/document/djot/parsing.rs` — adds
+   `pub options: Option<DocumentOptionsOverride>`.
+
+3. **`process_document()` merge step** in
+   `crates/citum-engine/src/processor/document/pipeline.rs` — calls
+   `options.apply_to(&mut style)` after the style is resolved and before the
+   processor runs. This keeps the document override in the same phase as
+   the existing `processor_with_document_integral_name_override()` call.
+
+4. **`--locale` flag** added to `RenderDocArgs` in
+   `crates/citum-cli/src/args.rs`, wired through `render/mod.rs` into the
+   processor setup, mirroring the existing `RenderRefsArgs.locale` path.
+
+5. **Document locale resolver** (new) in `crates/citum-cli/src/style_resolver.rs`
+   — a separate code path from `locale_override` that selects the full base
+   locale by BCP 47 ID rather than loading a patch file.
+
+The legacy top-level `integral-name-memory:` field in `DocumentFrontmatter`
+is preserved; `DocumentOptionsOverride.integral_name_memory` takes precedence
+when both are set.
+
+## Acceptance Criteria
+
+- [ ] `DocumentFrontmatter` deserializes an `options:` block with any subset
+      of the eligible fields; unknown keys are rejected.
+- [ ] Each eligible field, when set, overrides the corresponding style option
+      and produces the correct rendering output.
+- [ ] Absent fields do not change the style's defaults.
+- [ ] Legacy top-level `integral-name-memory:` continues to work alongside
+      `options.integral-name-memory:`; the latter takes precedence when both
+      are present.
+- [ ] `bibliography.sort-partitioning` accepts `by: script | language` and
+      `BibliographyPartitionHeading` shapes (`literal`, `term`, `localized`).
+- [ ] Setting `sort-partitioning` with `label-mode: numeric` produces
+      continuous label numbering across partitions.
+- [ ] `citum render doc --locale de-DE` selects the German base locale and
+      takes precedence over any `locale:` in frontmatter.
+- [ ] GUI consumers sending the equivalent JSON shape receive identical output.
+
+## Changelog
+
+- 2026-05-26: Address Copilot review — clarify sort-partitioning as multilingual-only
+  (distinct from bibliography groups); rename locale-override → locale (base-locale
+  selector, not patch ID); add CLI surface section; fix integral-name-memory compat note.
+- 2026-05-26: Address PR review — narrow eligible set, rename sort-partitioning
+  → sections (reverted), establish serde-based single contract, move
+  date-position / title-terminator / citation overrides to Future Consideration.
+- 2026-05-26: Initial draft.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -54,6 +54,7 @@ to make sure the document should be a spec rather than architecture or policy.
 | File | Feature |
 |------|---------|
 | [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) | Federated registry and distributed resolver architecture (Phases 2–3) |
+| [`PER_DOCUMENT_CONFIG_OVERRIDES.md`](./PER_DOCUMENT_CONFIG_OVERRIDES.md) | Eligible options and syntax for per-document configuration overrides |
 | [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) | Clean command model for style discovery, registry management, and CLI validation UX |
 | [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Verification model for profile styles using external authority |
 | [`SERVER_INTERACTIVE_API.md`](./SERVER_INTERACTIVE_API.md) | Document-batch and session APIs for server and WASM |


### PR DESCRIPTION
## Summary

Implements the per-document configuration override spec
(`docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md`) via three commits:

- **Structs + frontmatter parsing**: `DocumentOptionsOverride`,
  `DocumentBibliographyOverride`, `DocumentSortPartitioningOverride`
  (all-optional sparse overlay). Added to `DocumentFrontmatter` for
  Djot; Markdown parser now shares `parse_frontmatter` from djot.
  Frontmatter parse errors emit `eprintln!` warning instead of
  silently discarding.
- **Pipeline wiring**: `process_document()` applies `frontmatter_options`
  — locale, integral-name-memory, and bibliography overrides (sort
  partitioning, repeated-author rendering, label mode/wrap). Added
  `Style::apply_scoped_options()` bridge method so the engine crate can
  trigger the schema-crate scoped-options pass.
- **CLI `--locale` / `-L` flag**: `render doc` accepts an explicit
  locale that overrides `options.locale` from frontmatter.

Demo updated: `docs/demo.djot` now carries an `options.integral-name-memory`
block; `docs/demo.html` reflects the live engine output with short-form
name repetition for Chen (2017/2020). Bibliography sections now use
`class="citum-bibliography"` directly on the `<section>` elements so
headings are properly nested inside the styled section (fixes a visual
separation issue where the CSS `border-top` was rendering between the
heading and its entries).

## Test plan

- [x] 8 new unit tests in `types.rs` cover struct deserialization,
  `apply_to` field application, and locale/integral-name-memory
  precedence rules
- [x] 4 unit tests in `render/mod.rs` for `extract_frontmatter_locale`
- [x] All 1415 existing tests pass
- [x] `cargo fmt --check` + `cargo clippy -D warnings` clean
- [x] `docs/demo.html` regenerated from `citum render doc` with
  name-memory enabled; bibliography section nesting fixed
