### PR TITLE
fix(ci): add citum-refs to publish-crates order

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -90,6 +90,7 @@ CRATES=(
   citum-schema-data
   citum-schema-style
   citum-schema
+  citum-refs
   citum-engine
   citum-io
   citum_store


### PR DESCRIPTION
## Summary

- Adds `citum-refs` to the ordered `CRATES` list in `scripts/publish-crates.sh`, between `citum-schema` (which it depends on) and `citum-engine` (which depends on it)
- Omission caused the `publish-crates` CI job to fail on v0.58.0; `citum-refs` was published manually as a workaround

## Test plan

- [ ] Re-run the failed v0.58.0 `publish-crates` job: `gh run re-run 26534204034 --failed`
- [ ] Verify next release tag publishes all crates in order without error
