### PR TITLE
fix(engine): apply mode-specific options to Renderer config for integral citations

### DIFF
--- a/.beans/archive/csl26-5cma--fix-apa-integral-citation-conjunction-and-vs.md
+++ b/.beans/archive/csl26-5cma--fix-apa-integral-citation-conjunction-and-vs.md
@@ -1,0 +1,23 @@
+---
+# csl26-5cma
+title: Fix APA integral citation conjunction (and vs &)
+status: completed
+type: bug
+priority: high
+created_at: 2026-05-27T21:49:48Z
+updated_at: 2026-05-27T21:55:35Z
+---
+
+APA integral/narrative citations should use 'and' but both modes render '&'. Two bugs: (1) mode-specific options never applied to Renderer config in render_citation_content(); (2) resolve_for_mode() replaces options instead of merging. Missing test coverage for this core requirement.
+
+## Summary of Changes
+
+Fixed two bugs causing APA integral citations to render '&' instead of 'and':
+
+1. **Bug 1 (primary):** `render_citation_content()` in `citation.rs` now merges `effective_spec.options` over the mode-agnostic `citation_config` before creating the Renderer, so integral-specific `contributors.and: text` is applied.
+
+2. **Bug 2 (secondary):** `resolve_for_mode()` and `resolve_for_position()` in `sections/citation.rs` now properly merge mode/position options into base citation options instead of replacing them.
+
+3. **New `CitationOptions::merge()`** method in `options/mod.rs` mirrors `Config::merge` for field-by-field override including deep `ContributorConfig::merge`.
+
+4. **Test:** `test_integral_vs_non_integral_conjunction` asserts integral renders 'and' and non-integral renders '&'. All 1419 tests pass.

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -318,6 +318,14 @@ impl Processor {
         let effective_compound_sets = dyn_sets_owned.as_ref().unwrap_or(&self.compound_sets);
 
         let citation_config = self.get_citation_config();
+        let citation_config = match effective_spec.options.as_ref() {
+            Some(mode_options) => {
+                let mut config = citation_config.into_owned();
+                config.merge(&mode_options.to_config());
+                std::borrow::Cow::Owned(config)
+            }
+            None => citation_config,
+        };
         let renderer = Renderer::new(
             RendererResources {
                 style: &self.style,

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -5063,3 +5063,84 @@ fn test_dynamic_group_no_op_for_author_date_style() {
         "author-date should not produce compound sub-labels, got: {rendered}"
     );
 }
+
+/// Integral citations must use "and" (text) while non-integral must use "&" (symbol).
+///
+/// APA style defines `and: symbol` globally and `citation.integral.options.contributors.and: text`.
+/// Both modes were rendering "&" before the fix because mode-specific options were not applied
+/// to the Renderer's config.
+#[test]
+fn test_integral_vs_non_integral_conjunction() {
+    use citum_schema::citation::CitationMode;
+    use citum_schema::options::CitationOptions;
+
+    let mut style = make_style();
+    // Global options already have `and: Symbol` from make_style().
+    // Add integral-specific override: `and: Text`.
+    if let Some(citation) = style.citation.as_mut() {
+        citation.integral = Some(Box::new(CitationSpec {
+            options: Some(CitationOptions {
+                contributors: Some(ContributorConfig {
+                    and: Some(AndOptions::Text),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+    }
+
+    let mut bib = make_bibliography();
+    // Add a two-author book so the conjunction is exercised.
+    bib.insert(
+        "smith2020".to_string(),
+        Reference::from(LegacyReference {
+            id: "smith2020".to_string(),
+            ref_type: "book".to_string(),
+            author: Some(vec![
+                Name::new("Smith", "John"),
+                Name::new("Jones", "Alice"),
+            ]),
+            title: Some("A Two-Author Book".to_string()),
+            issued: Some(DateVariable::year(2020)),
+            ..Default::default()
+        }),
+    );
+
+    let processor = Processor::new(style, bib);
+    let item = CitationItem {
+        id: "smith2020".to_string(),
+        ..Default::default()
+    };
+
+    let integral_cit = Citation {
+        mode: CitationMode::Integral,
+        items: vec![item.clone()],
+        ..Default::default()
+    };
+    let non_integral_cit = Citation {
+        mode: CitationMode::NonIntegral,
+        items: vec![item],
+        ..Default::default()
+    };
+
+    let integral = processor.process_citation(&integral_cit).unwrap();
+    let non_integral = processor.process_citation(&non_integral_cit).unwrap();
+
+    assert!(
+        integral.contains(" and "),
+        "integral citation must use 'and', got: {integral}"
+    );
+    assert!(
+        !integral.contains(" & "),
+        "integral citation must not use '&', got: {integral}"
+    );
+    assert!(
+        non_integral.contains(" & "),
+        "non-integral citation must use '&', got: {non_integral}"
+    );
+    assert!(
+        !non_integral.contains(" and "),
+        "non-integral citation must not use 'and', got: {non_integral}"
+    );
+}

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -593,6 +593,50 @@ impl CitationOptions {
     pub fn merged_with(&self, base: &Config) -> Config {
         Config::merged(base, &self.to_config())
     }
+
+    /// Merge `other` into `self`, with `other` taking precedence for each field.
+    pub fn merge(&mut self, other: &CitationOptions) {
+        crate::merge_options!(
+            self,
+            other,
+            processing,
+            localize,
+            multilingual,
+            dates,
+            titles,
+            locators,
+            page_range_format,
+            links,
+            volume_pages_delimiter,
+            strip_periods,
+            notes,
+            integral_name_memory,
+            org_abbreviation_memory,
+            label_wrap,
+            group_delimiter,
+            custom,
+        );
+
+        if let Some(other_substitute) = &other.substitute {
+            if let Some(this_substitute) = &self.substitute {
+                self.substitute = Some(SubstituteConfig::merged(this_substitute, other_substitute));
+            } else {
+                self.substitute = Some(other_substitute.clone());
+            }
+        }
+
+        if let Some(other_contributors) = &other.contributors {
+            if let Some(this_contributors) = &mut self.contributors {
+                this_contributors.merge(other_contributors);
+            } else {
+                self.contributors = Some(other_contributors.clone());
+            }
+        }
+
+        if other.punctuation_in_quote {
+            self.punctuation_in_quote = true;
+        }
+    }
 }
 
 impl BibliographyOptions {

--- a/crates/citum-schema-style/src/style/sections/citation.rs
+++ b/crates/citum-schema-style/src/style/sections/citation.rs
@@ -208,8 +208,10 @@ impl CitationSpec {
                 merged.integral = None;
                 merged.non_integral = None;
 
-                if spec.options.is_some() {
-                    merged.options = spec.options.clone();
+                match (&mut merged.options, &spec.options) {
+                    (Some(base), Some(mode)) => base.merge(mode),
+                    (None, Some(mode)) => merged.options = Some(mode.clone()),
+                    _ => {}
                 }
                 if spec.template_ref.is_some() {
                     merged.template_ref = spec.template_ref.clone();
@@ -283,8 +285,10 @@ impl CitationSpec {
                 merged.subsequent = None;
                 merged.ibid = None;
 
-                if spec.options.is_some() {
-                    merged.options = spec.options.clone();
+                match (&mut merged.options, &spec.options) {
+                    (Some(base), Some(mode)) => base.merge(mode),
+                    (None, Some(mode)) => merged.options = Some(mode.clone()),
+                    _ => {}
                 }
                 if spec.template_ref.is_some() {
                     merged.template_ref = spec.template_ref.clone();

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -231,7 +231,7 @@ as knowledge and who produces it. The formal apparatus of bibliographic referenc
 called “the footnote as institution,” embedding social relations within
 the seemingly neutral mechanics of scholarly communication.</p>
 <p>The production of this apparatus is not confined to Anglophone scholarship.
-<span class="citum-citation" data-ref="tanaka_yuki2019"><span class="citum-author">Y. Tanaka & H. Suzuki</span> (<span class="citum-issued">2019</span>)</span> demonstrate that citation practices in Japanese science studies
+<span class="citum-citation" data-ref="tanaka_yuki2019"><span class="citum-author">Y. Tanaka and H. Suzuki</span> (<span class="citum-issued">2019</span>)</span> demonstrate that citation practices in Japanese science studies
 reflect distinct epistemological conventions, including different assumptions about
 authorial authority and collective knowledge-making. Parallel observations emerge
 from Spanish-language scholarship, where the relationship between citation and


### PR DESCRIPTION
## Summary

- `CitationOptions::merge()` added to `citum-schema-style/src/options/mod.rs` — field-by-field override with deep `ContributorConfig::merge`, mirroring `Config::merge`
- `resolve_for_mode()` and `resolve_for_position()` in `sections/citation.rs` now merge mode/position `options` into base citation options instead of replacing them wholesale
- `render_citation_content()` in `processor/citation.rs` now layers `effective_spec.options` over the base `citation_config` before building the Renderer, so mode-specific overrides reach the name formatter
- `docs/demo.html` updated: Tanaka & Suzuki integral citation corrected to "and"

## Root cause

APA defines `contributors.and: symbol` globally and `citation.integral.options.contributors.and: text`. The Renderer was built with `get_citation_config()` (mode-agnostic), so the integral override never reached the name formatter. Both modes rendered "&".

## Test plan

- [x] `test_integral_vs_non_integral_conjunction` — asserts integral → "and", non-integral → "&"
- [x] All 1419 tests pass
- [x] APA oracle: 18/18 citations, 33/33 bibliography (no regressions)
