### PR TITLE
fix(demo): style bibliography section headings

### DIFF
--- a/.beans/archive/csl26-334l--fix-bibliography-heading-rendering-in-demo.md
+++ b/.beans/archive/csl26-334l--fix-bibliography-heading-rendering-in-demo.md
@@ -1,0 +1,13 @@
+---
+# csl26-334l
+title: Fix bibliography heading rendering in demo
+status: completed
+type: bug
+priority: normal
+created_at: 2026-05-28T12:20:32Z
+updated_at: 2026-05-28T12:20:36Z
+---
+
+Bibliography h1 and h2 headings in demo.html were unstyled/oversized. Add explicit font-size/weight rules for #Bibliography > h1 (1.1rem) and compact uppercase styling for #Bibliography h2 (0.75rem).
+
+## Summary of Changes\n\nAdded  rule (1.1rem, weight 600) and updated  to compact uppercase treatment (0.75rem, uppercase, weight 700, border-bottom separator). Verified via computed styles in browser preview.

--- a/docs/assets/citum-interactive.css
+++ b/docs/assets/citum-interactive.css
@@ -69,15 +69,26 @@
   padding-top: 0;
 }
 
+/* "Bibliography" section title */
+#Bibliography > h1 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--citum-ink-strong, #1a1a2e);
+  margin-bottom: 1.5rem;
+}
+
 /* Subsection labels (Primary Sources / Secondary Sources) */
 #Bibliography h2 {
-  font-size: 0.85rem;
-  font-weight: 600;
+  font-size: 0.75rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--citum-muted, #666);
+  letter-spacing: 0.08em;
+  color: var(--citum-muted, #888);
   margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid #eee;
 }
 
 /* "Reproduce This Rendering" block (outside #demo-root) */


### PR DESCRIPTION
## Summary

- `#Bibliography > h1` was inheriting body font-size (16px), making "Bibliography" look like plain body text — added explicit 1.1rem / weight-600 rule
- `#Bibliography h2` ("Primary Sources" / "Secondary Sources") lacked the compact uppercase treatment — added 0.75rem uppercase / weight-700 with a thin border-bottom separator

## Test plan

- [x] Open demo.html; confirm "Bibliography" heading renders at ~18px, slightly larger than body, with readable weight
- [x] Confirm "Primary Sources" / "Secondary Sources" labels render as small-caps dividers, not oversized headings
- [x] Confirm sidebar mode still lays out correctly (grid unchanged)
