### PR TITLE
fix(demo): enlarge bib h1; fix spacing

### DIFF
--- a/docs/assets/citum-interactive.css
+++ b/docs/assets/citum-interactive.css
@@ -69,15 +69,6 @@
   padding-top: 0;
 }
 
-/* "Bibliography" section title */
-#Bibliography > h1 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--citum-ink-strong, #1a1a2e);
-  margin-bottom: 1.5rem;
-}
-
 /* Subsection labels (Primary Sources / Secondary Sources) */
 #Bibliography h2 {
   font-size: 0.75rem;
@@ -85,7 +76,7 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--citum-muted, #888);
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   margin-bottom: 0.5rem;
   padding-bottom: 0.4rem;
   border-bottom: 1px solid #eee;

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -90,6 +90,15 @@
     h1 { margin-bottom: 0.5rem; }
     .subtitle { color: #666; font-size: 1.1rem; }
 
+    /* Bibliography section heading — larger than body, scoped to demo page */
+    #Bibliography > h1 {
+      font-size: 1.4rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      color: var(--citum-ink-strong, #1a1a2e);
+      margin-bottom: 1rem;
+    }
+
     /* Layout toggles */
     .btn {
       padding: 0.5rem 1rem;

--- a/scripts/build-demo-page.js
+++ b/scripts/build-demo-page.js
@@ -190,6 +190,15 @@ const TEMPLATE = `<!-- PAGE_ID: demo -->
     h1 { margin-bottom: 0.5rem; }
     .subtitle { color: #666; font-size: 1.1rem; }
 
+    /* Bibliography section heading — larger than body, scoped to demo page */
+    #Bibliography > h1 {
+      font-size: 1.4rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      color: var(--citum-ink-strong, #1a1a2e);
+      margin-bottom: 1rem;
+    }
+
     /* Layout toggles */
     .btn {
       padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary

Followup to #825. The Bibliography section heading and its spacing still needed work:

- **`#Bibliography > h1`** moved from `citum-interactive.css` into the demo template's inline `<style>` — sizing is context-specific (a sidebar embed would want a different size). Bumped to `1.4rem` so it reads clearly as a section heading.
- **`#Bibliography h2`** `margin-top` reduced from `1.5rem` → `1rem` to fix double-gap: the h1's `margin-bottom` + h2's `margin-top` were stacking to 3rem of whitespace.

## Test plan

- [x] "Bibliography" heading visually reads as a section heading (not body text)
- [x] "Primary Sources" / "Secondary Sources" dividers have comfortable but not excessive spacing below "Bibliography"
- [x] Sidebar mode layout unaffected
