### PR TITLE
chore(tooling): mark repo gate authoritative over global verify

### DIFF
--- a/.beans/archive/csl26-lm1h--resolve-global-verify-rule-vs-project-pre-commit-g.md
+++ b/.beans/archive/csl26-lm1h--resolve-global-verify-rule-vs-project-pre-commit-g.md
@@ -1,0 +1,18 @@
+---
+# csl26-lm1h
+title: Resolve global verify rule vs project pre-commit gate conflict
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-28T22:56:30Z
+updated_at: 2026-05-28T22:56:49Z
+---
+
+Global kernel (~/.claude/CLAUDE.md) says never call cargo directly, use verify.sh. But the global rust adapter is strictly weaker than this repo's pre-commit gate (swallows clippy failures, no fmt --check, cargo test not nextest, no schema regen). Add a project-override line in citum-core/CLAUDE.md Pre-Commit Gate section so the repo gate is authoritative. Doc-only.
+
+- [x] Add override line to citum-core/CLAUDE.md Pre-Commit Gate section
+- [x] Confirm it reads cleanly and does not contradict the gate command
+
+## Summary of Changes
+
+Added a project-override paragraph to the `## Pre-Commit Gate (Rust)` section of `citum-core/CLAUDE.md` declaring the repo gate authoritative and exempting it from the global `verify.sh` rule (which uses a weaker adapter). Doc-only; no behavior code touched.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings &&
 ```
 Run `cargo fmt` first if needed, then re-check. **Do not commit if any check fails.** Docs (`.md`) and styles (`.yaml`) skip checks.
 
+This command is the authoritative gate for this repo. The global "never call `cargo` directly — use `~/.claude/scripts/verify.sh`" rule does **not** apply here: the generic adapter is weaker (it swallows clippy warnings, skips `cargo fmt --check`, and runs `cargo test` instead of `nextest`). Run the gate above verbatim.
+
 If `crates/citum-cli/` or `crates/citum-schema*/` changed, regenerate schemas in the same commit:
 ```bash
 cargo run --bin citum --features schema -- schema --out-dir docs/schemas && git add docs/schemas/
@@ -110,6 +112,8 @@ Style tasks: `/style-evolve` (`upgrade`, `migrate`, `create`). Rust quality: `/r
 ## Git Workflow
 
 Branch protection on `main` — all changes via PR. Branch **before** committing when a PR is planned. Pre-commit gate above is required for Rust.
+
+**First action in any fresh clone:** run `scripts/install-hooks.sh` (sets `core.hooksPath .githooks`). The tracked hooks enforce the commit-msg 50/72 + conventional format, bean hygiene, and the pre-push Rust gate *locally* — without them, those checks fail only in CI.
 
 **After every push on a PR branch:** `gh pr checks <PR> --watch`. If failing, `gh run view <run-id> --log-failed`. Task is not done until CI passes.
 


### PR DESCRIPTION
## Summary

The global agent kernel (`~/.claude/CLAUDE.md`) instructs sessions to run `~/.claude/scripts/verify.sh` instead of calling `cargo` directly. But that generic rust adapter is strictly weaker than this repo's documented pre-commit gate:

- swallows clippy failures (`cargo clippy 2>/dev/null || true`, no `-D warnings`)
- skips `cargo fmt --check`
- runs `cargo test` instead of `cargo nextest run`
- omits schema regeneration

A session that follows the global rule would pass a looser check and could commit code that fails the real gate or CI.

This adds a one-paragraph project override to the `## Pre-Commit Gate (Rust)` section declaring the repo command authoritative and exempting it from the global verify rule — mirroring the existing override pattern in the Code Search Tool Priority block. Doc-only; no behavior code touched.

## Test plan

- [x] `.md`-only change — skips the Rust pre-commit gate per repo rules
- [x] Override line reads cleanly and does not contradict the gate command above it
