### PR TITLE
chore(beans): close and archive five stale beans

### DIFF
--- a/.beans/archive/csl26-1vq0--redistribute-exampleshtml-capability-showcase-reci.md
+++ b/.beans/archive/csl26-1vq0--redistribute-exampleshtml-capability-showcase-reci.md
@@ -1,10 +1,15 @@
 ---
 # csl26-1vq0
 title: 'Redistribute examples.html: capability showcase + recipe pages'
-status: in-progress
+status: completed
 type: task
+priority: normal
 created_at: 2026-05-19T17:30:38Z
-updated_at: 2026-05-19T17:30:38Z
+updated_at: 2026-05-28T23:53:28Z
 ---
 
 Slim examples.html to a capability showcase (~300 lines). Add 3 new pages: typst.html, lualatex.html (corrected to two-pass, experimental), advanced-examples.html for style authors. Update 5 inbound-link pages. Fixes inaccuracies in Typst (no embedded crates, external CLI) and LuaLaTeX (two-pass, citum-labs, CITUM_LIB_PATH).
+
+## Summary of Changes
+
+Work landed in commit `39be5733 docs: redistribute examples.html to targeted pages` on main. examples.html slimmed to a capability showcase; three new pages created: guides/integrations/typst.html, guides/integrations/lualatex.html, guides/style-authoring/advanced-examples.html. developer.html updated with Typst card and corrected LuaLaTeX info.

--- a/.beans/archive/csl26-fn4e--modularize-citum-cli-commandsrs.md
+++ b/.beans/archive/csl26-fn4e--modularize-citum-cli-commandsrs.md
@@ -1,11 +1,11 @@
 ---
 # csl26-fn4e
 title: Modularize citum-cli commands.rs
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-05-16T23:15:04Z
-updated_at: 2026-05-16T23:34:12Z
+updated_at: 2026-05-28T23:53:22Z
 parent: csl26-rfct
 ---
 
@@ -40,7 +40,7 @@ Closes item #3 on parent bean csl26-rfct.
 - [x] Smoke: --help, style list, doctor all work
 - [x] Regenerate docs/schemas/ (no diff)
 - [x] Check off item #3 on parent csl26-rfct
-- [ ] Open PR, watch CI to green
+- [x] Open PR, watch CI to green (went direct to main — no PR needed)
 
 
 ## Summary of Changes
@@ -54,3 +54,7 @@ Closes item #3 on parent bean csl26-rfct.
 - Net delta: 17 files changed, +3220 / -2923 (≈+297 lines from module headers + dispatch shims); zero behavior change.
 - 1298/1298 workspace tests pass; clippy clean under `--workspace --all-targets`.
 - `docs/schemas/` unchanged (regenerated and identical).
+
+## Summary of Changes (addendum)
+
+Work landed in commit `5c61049e refactor(cli): split commands.rs into modules` on main. The `commands/` subdir exists with 15+ sibling files; `commands.rs` is gone. The earlier summary above covers the full scope.

--- a/.beans/archive/csl26-rfct--refactor-priorities-modularization.md
+++ b/.beans/archive/csl26-rfct--refactor-priorities-modularization.md
@@ -1,11 +1,11 @@
 ---
 # csl26-rfct
 title: Codebase Modularization and Refactor Priorities
-status: in-progress
+status: completed
 type: milestone
 priority: normal
 created_at: 2026-05-16T14:30:00Z
-updated_at: 2026-05-28T23:33:00Z
+updated_at: 2026-05-28T23:54:53Z
 ---
 
 Analysis of Rust source files (excluding tests) exceeding 800 lines, ranked by refactor priority and grouped by modularization strategy.
@@ -35,8 +35,7 @@ Analysis of Rust source files (excluding tests) exceeding 800 lines, ranked by r
 6. [x] **`citum-migrate/src/upsampler.rs` (2064 lines → facade + upsampler/ modules)**
    - **Issues:** Complex citation position analysis intertwined with upsampling logic.
    - **Done:** Extracted citation position analysis/rewrite logic to `src/upsampler/position.rs`, node mapping and scalar conversion helpers to `src/upsampler/mapping.rs`, and inline tests to `src/upsampler/tests.rs`; `upsampler.rs` is now a small facade with stable re-exports and Citum-facing node aliasing.
-7. [ ] **`citum-engine/src/processor/rendering/grouped/core.rs` (1708 lines)**
-   - **Issues:** Highly specific rendering logic and classification helpers.
+7. [x] **`citum-engine/src/processor/rendering/grouped/core.rs` (1708 lines → 1154 lines, extracted to 3 modules) — done via csl26-9f7g**
 8. [x] **`citum-io/src/lib.rs` (1622 lines)**
    - **Issues:** Multiple format handlers (BibLaTeX, RIS, JSON).
    - **Target:** Move format-specific logic to `src/formats/`.
@@ -82,3 +81,7 @@ Prioritize Tier 1 and Tier 2 refactors, specifically focusing on `citum-schema-s
   hybrid JSON class/type routing (now uses &str comparison)
 - Idiom: moved validate_compound_sets import to module level;
   replaced verbose if/else with .then_some() in merge path
+
+## Summary of Changes
+
+Tiers 1 and 2 (items 1–8) are all complete — each tracked as a separate bean. Item 7 (grouped/core.rs) was done in csl26-9f7g but not formally linked. Tier 3/4 items (10–25) remain as informal backlog; they will be addressed on-demand via new beans when prioritized.

--- a/.beans/archive/csl26-rjpo--fix-release-ci-exclude-citum-migrate-from-musl-bui.md
+++ b/.beans/archive/csl26-rjpo--fix-release-ci-exclude-citum-migrate-from-musl-bui.md
@@ -1,11 +1,15 @@
 ---
 # csl26-rjpo
 title: 'Fix release CI: exclude citum-migrate from musl builds + upgrade actions to Node.js 24'
-status: in-progress
+status: completed
 type: bug
 priority: high
 created_at: 2026-05-22T13:49:04Z
-updated_at: 2026-05-22T13:49:04Z
+updated_at: 2026-05-28T23:53:16Z
 ---
 
 Linux musl build jobs failing (404 for rusty_v8 simdutf prebuilt). Fix: exclude citum-migrate from musl release builds in release-binary.sh + update install.sh to gracefully skip it + upgrade all workflow actions to Node.js 24 versions.
+
+## Summary of Changes
+
+Work landed in commit `a23d5d5c fix(ci): musl build + upgrade actions to Node 24` on main. Excluded citum-migrate from musl release builds, updated install.sh to skip gracefully, and upgraded all workflow actions to Node.js 24 versions.

--- a/.beans/archive/csl26-zlvp--external-style-authoring-agent-skill-hub-ui-wizard.md
+++ b/.beans/archive/csl26-zlvp--external-style-authoring-agent-skill-hub-ui-wizard.md
@@ -1,14 +1,14 @@
 ---
 # csl26-zlvp
 title: 'External style authoring: agent skill + hub UI wizard'
-status: todo
+status: completed
 type: feature
 priority: deferred
 tags:
     - style
     - dx
 created_at: 2026-03-16T20:11:54Z
-updated_at: 2026-04-25T20:20:07Z
+updated_at: 2026-05-28T23:53:33Z
 blocked_by:
     - csl26-fuw7
 ---
@@ -54,3 +54,7 @@ The external skill should use `docs/schemas/style.json` (hosted URL) as its prim
 For multi-agent compatibility: skill body should be pure Markdown instructions with no Claude-specific tool assumptions. Inline examples are better than tool-call sequences.
 
 The hub wizard idea is the highest user-value item but also the most work (needs API + frontend + LLM plumbing). Phase 2 (standalone skill) is the right first step and is independently useful.
+
+## Summary of Changes
+
+Phase 2 (external agent skill) shipped in the `citum/skills` repo — the standalone skill is live. Phase 3 (citum-hub UI wizard) is a separate future effort that belongs in citum-hub, not this repo. This bean is closed; a follow-up bean should be opened in citum-hub for the wizard work when that repo is ready.


### PR DESCRIPTION
Close five beans that were confirmed stale against git history.

## Beans closed

| Bean | Title | Landing commit |
|------|-------|----------------|
| csl26-rjpo | Fix release CI: musl + Node 24 | `a23d5d5c` |
| csl26-fn4e | Modularize citum-cli commands.rs | `5c61049e` |
| csl26-1vq0 | Redistribute examples.html | `39be5733` |
| csl26-zlvp | External style authoring agent skill | Shipped in `citum/skills`; hub wizard deferred to citum-hub |
| csl26-rfct | Codebase Modularization milestone | Tier 1/2 all done; Tier 3/4 informal backlog |

## No code changes

Bean files only — all work was already on `main`.
