### PR TITLE
perf(schema): typed merge_style_overlay, drop yaml round-trips

### DIFF
--- a/.beans/archive/csl26-mrg3--optimize-merge-style-overlay-serialization.md
+++ b/.beans/archive/csl26-mrg3--optimize-merge-style-overlay-serialization.md
@@ -1,11 +1,11 @@
 ---
 # csl26-mrg3
 title: Optimize merge_style_overlay to avoid serialization round-trips
-status: todo
+status: completed
 type: task
 priority: low
 created_at: 2026-05-09T00:00:00Z
-updated_at: 2026-05-09T00:00:00Z
+updated_at: 2026-05-29T00:27:23Z
 ---
 
 The current implementation of `merge_style_overlay` in `citum-schema-style` relies
@@ -23,6 +23,27 @@ process.
   the recursive merging of templates and variants.
 - Baseline the performance of the current serialization-based approach against
   the new implementation to verify gains.
+
+## Summary of Changes
+
+Replaced all serde_yaml round-trips in `merge_style_overlay` with typed field merges:
+
+- `merge_info`: uses `merge_options!` macro over StyleInfo Option fields
+- `merge_citation_spec` / `merge_bibliography_spec`: per-field Option merge, per-key
+  merge for `type_variants` (IndexMap) and `templates`/`custom` (HashMap)
+- `CitationOptions::merge` (already existed) and new `BibliographyOptions::merge` wired up
+- Null-aware clearing (e.g. `ibid: ~`) preserved via targeted raw_yaml inspection
+- Removed `merge_serialized`, `merge_serialized_value`, `merge_yaml_value` and all
+  associated `#[allow(unwrap_used/expect_used)]` escape hatches
+- Added regression test for per-key type_variants preservation (fixed silent bug)
+- Added Criterion bench: `Style Resolution/merge_style_overlay`
+
+**Bench results (Apple M-series, optimized build):**
+- Before (serde round-trip): 36.5 µs
+- After (typed merge): 31.3 µs
+- Gain: ~14% faster
+
+**Portfolio quality gate:** 154 styles, fidelity=1.0 (no regressions)
 
 ## Rationale
 

--- a/crates/citum-schema-style/benches/formats.rs
+++ b/crates/citum-schema-style/benches/formats.rs
@@ -89,5 +89,76 @@ fn bench_formats(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_formats);
+fn bench_style_resolution(c: &mut Criterion) {
+    use citum_resolver_api::StyleResolver;
+    use citum_schema_style::ResolverError;
+    use citum_schema_style::locale::Locale;
+
+    // Mirror the BDD test fixture: known-good template components only.
+    let base_yaml = r#"
+version: "0.44.0"
+info:
+  id: base-style
+  title: Base Style
+bibliography:
+  template:
+    - title: primary
+    - variable: doi
+    - variable: url
+  type-variants:
+    book:
+      - title: primary
+      - variable: publisher
+      - variable: url
+    article-journal:
+      - title: primary
+      - variable: doi
+"#;
+
+    let overlay_yaml = r#"
+extends: base-style
+info:
+  id: overlay-style
+  title: Overlay Style
+bibliography:
+  type-variants:
+    book:
+      modify:
+        - match: { title: primary }
+          emph: true
+"#;
+
+    let base = Style::from_yaml_str(base_yaml).expect("valid base");
+    let overlay = Style::from_yaml_str(overlay_yaml).expect("valid overlay");
+
+    struct MockResolver(Style);
+    impl StyleResolver for MockResolver {
+        type Style = Style;
+        type Locale = Locale;
+        fn resolve_style(&self, _uri: &str) -> Result<Style, ResolverError> {
+            Ok(self.0.clone())
+        }
+        fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
+            Err(ResolverError::LocaleNotFound(std::borrow::Cow::Owned(
+                id.to_string(),
+            )))
+        }
+    }
+
+    let resolver = MockResolver(base);
+
+    let mut group = c.benchmark_group("Style Resolution");
+    group.bench_function("merge_style_overlay", |b| {
+        b.iter(|| {
+            let style = black_box(overlay.clone());
+            let mut visited = std::collections::HashSet::new();
+            style
+                .try_into_resolved_recursive_with(Some(&resolver), &mut visited)
+                .unwrap()
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_formats, bench_style_resolution);
 criterion_main!(benches);

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -689,6 +689,68 @@ impl BibliographyOptions {
     pub fn merged_with(&self, base: &Config) -> Config {
         Config::merged(base, &self.to_config())
     }
+
+    /// Merge `other` into `self`, with `other` taking precedence for each field.
+    pub fn merge(&mut self, other: &BibliographyOptions) {
+        crate::merge_options!(
+            self,
+            other,
+            processing,
+            localize,
+            multilingual,
+            dates,
+            titles,
+            page_range_format,
+            links,
+            volume_pages_delimiter,
+            strip_periods,
+            article_journal,
+            subsequent_author_substitute,
+            subsequent_author_substitute_rule,
+            hanging_indent,
+            entry_suffix,
+            separator,
+            compound_numeric,
+            sort_partitioning,
+            label_mode,
+            label_wrap,
+            date_position,
+            title_terminator,
+            repeated_author_rendering,
+            custom,
+        );
+
+        self.merge_shared_fields(other);
+    }
+
+    fn merge_shared_fields(&mut self, other: &BibliographyOptions) {
+        if let Some(other_substitute) = &other.substitute {
+            if let Some(this_substitute) = &self.substitute {
+                self.substitute = Some(SubstituteConfig::merged(this_substitute, other_substitute));
+            } else {
+                self.substitute = Some(other_substitute.clone());
+            }
+        }
+
+        if let Some(other_contributors) = &other.contributors {
+            if let Some(this_contributors) = &mut self.contributors {
+                this_contributors.merge(other_contributors);
+            } else {
+                self.contributors = Some(other_contributors.clone());
+            }
+        }
+
+        if other.punctuation_in_quote {
+            self.punctuation_in_quote = true;
+        }
+        if other.suppress_period_after_url {
+            self.suppress_period_after_url = true;
+        }
+
+        for (key, value) in &other.unknown_fields {
+            self.unknown_fields.insert(key.clone(), value.clone());
+        }
+    }
 }
 
 /// Deserialize contributor config from either a preset name or explicit config.

--- a/crates/citum-schema-style/src/style/overlay.rs
+++ b/crates/citum-schema-style/src/style/overlay.rs
@@ -5,105 +5,446 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Null-aware style overlay merging.
 
-use serde::Serialize;
-use serde::de::DeserializeOwned;
+use super::{BibliographySpec, CitationSpec, Style};
 
-use super::Style;
+/// Clear base `Option` fields whose raw YAML key is explicitly null in the overlay.
+///
+/// Invocation: `clear_raw_nulls!(base, raw_val, field => "yaml-key", ...)`.
+/// Only call from a `Some(raw_val)` branch; `raw_val` is `&serde_yaml::Value`.
+macro_rules! clear_raw_nulls {
+    ($base:expr, $raw:expr, $( $field:ident => $key:literal ),+ $(,)?) => {
+        if let Some(m) = ($raw).as_mapping() {
+            $(
+                if m.get(serde_yaml::Value::String($key.into()))
+                    .is_some_and(serde_yaml::Value::is_null)
+                {
+                    $base.$field = None;
+                }
+            )+
+        }
+    };
+}
 
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "Internal merging logic ensures presence of re-parsed values"
-)]
+/// Merge an overlay style into a base style, with the overlay taking precedence.
+///
+/// Uses typed field merges throughout, preserving null-aware semantics for
+/// citation/bibliography sub-specs (e.g., `ibid: ~` clears inherited values).
 pub(crate) fn merge_style_overlay(base: &mut Style, overlay: &Style) {
-    if !overlay.info.is_empty() {
-        base.info = merge_serialized(base.info.clone(), &overlay.info);
-    }
+    // Merge StyleInfo: per-field Option merge, fields vec replaces if non-empty
+    merge_info(&mut base.info, &overlay.info);
 
-    if let Some(templates) = &overlay.templates {
-        base.templates = Some(match &base.templates {
-            Some(existing) => merge_serialized(existing.clone(), templates),
-            None => templates.clone(),
-        });
-    }
-
-    if let Some(options) = &overlay.options {
-        match &mut base.options {
-            Some(existing) => existing.merge(options),
-            None => base.options = Some(options.clone()),
+    // Merge templates: per-key merge
+    if let Some(overlay_templates) = &overlay.templates {
+        match &mut base.templates {
+            Some(base_templates) => {
+                for (key, overlay_template) in overlay_templates {
+                    base_templates.insert(key.clone(), overlay_template.clone());
+                }
+            }
+            None => base.templates = Some(overlay_templates.clone()),
         }
     }
 
-    let raw_citation = overlay.raw_yaml.as_ref().and_then(|v| v.get("citation"));
-    if raw_citation.is_some() || overlay.citation.is_some() {
-        base.citation = Some(match (&base.citation, raw_citation) {
-            (Some(existing), Some(raw)) => merge_serialized_value(existing.clone(), raw),
-            (Some(existing), None) => {
-                merge_serialized(existing.clone(), overlay.citation.as_ref().unwrap())
-            }
-            (None, Some(raw)) => serde_yaml::from_value(raw.clone()).expect("citation parses"),
-            (None, None) => overlay.citation.clone().unwrap(),
-        });
+    // Merge options: use Config::merge (already typed)
+    if let Some(overlay_options) = &overlay.options {
+        match &mut base.options {
+            Some(existing) => existing.merge(overlay_options),
+            None => base.options = Some(overlay_options.clone()),
+        }
     }
 
+    // Merge citation spec with raw_yaml for null-aware semantics
+    let raw_citation = overlay.raw_yaml.as_ref().and_then(|v| v.get("citation"));
+    if raw_citation.is_some() || overlay.citation.is_some() {
+        let merged = match (&base.citation, &overlay.citation, raw_citation) {
+            (Some(existing), Some(overlay_spec), Some(raw)) => {
+                merge_citation_spec(existing.clone(), overlay_spec, Some(raw))
+            }
+            (Some(existing), Some(overlay_spec), None) => {
+                merge_citation_spec(existing.clone(), overlay_spec, None)
+            }
+            (Some(existing), None, Some(raw)) => {
+                apply_raw_null_clears_citation(existing.clone(), raw)
+            }
+            (Some(existing), None, None) => existing.clone(),
+            (None, Some(overlay_spec), _) => overlay_spec.clone(),
+            (None, None, _) => return, // Impossible due to outer if guard
+        };
+        base.citation = Some(merged);
+    }
+
+    // Merge bibliography spec with raw_yaml for null-aware semantics
     let raw_bibliography = overlay
         .raw_yaml
         .as_ref()
         .and_then(|v| v.get("bibliography"));
     if raw_bibliography.is_some() || overlay.bibliography.is_some() {
-        base.bibliography = Some(match (&base.bibliography, raw_bibliography) {
-            (Some(existing), Some(raw)) => merge_serialized_value(existing.clone(), raw),
-            (Some(existing), None) => {
-                merge_serialized(existing.clone(), overlay.bibliography.as_ref().unwrap())
+        let merged = match (&base.bibliography, &overlay.bibliography, raw_bibliography) {
+            (Some(existing), Some(overlay_spec), Some(raw)) => {
+                merge_bibliography_spec(existing.clone(), overlay_spec, Some(raw))
             }
-            (None, Some(raw)) => serde_yaml::from_value(raw.clone()).expect("bibliography parses"),
-            (None, None) => overlay.bibliography.clone().unwrap(),
-        });
+            (Some(existing), Some(overlay_spec), None) => {
+                merge_bibliography_spec(existing.clone(), overlay_spec, None)
+            }
+            (Some(existing), None, Some(raw)) => {
+                apply_raw_null_clears_bibliography(existing.clone(), raw)
+            }
+            (Some(existing), None, None) => existing.clone(),
+            (None, Some(overlay_spec), _) => overlay_spec.clone(),
+            (None, None, _) => return, // Impossible due to outer if guard
+        };
+        base.bibliography = Some(merged);
     }
 
-    if let Some(custom) = &overlay.custom {
-        base.custom = Some(match &base.custom {
-            Some(existing) => merge_serialized(existing.clone(), custom),
-            None => custom.clone(),
-        });
+    // Merge custom fields: per-key, overlay wins
+    if let Some(overlay_custom) = &overlay.custom {
+        match &mut base.custom {
+            Some(base_custom) => {
+                for (key, overlay_value) in overlay_custom {
+                    base_custom.insert(key.clone(), overlay_value.clone());
+                }
+            }
+            None => base.custom = Some(overlay_custom.clone()),
+        }
     }
 }
 
-#[allow(clippy::expect_used, reason = "T must be serializable to YAML")]
-pub(crate) fn merge_serialized<T>(base: T, overlay: &T) -> T
-where
-    T: Clone + DeserializeOwned + Serialize,
-{
-    let overlay_value = serde_yaml::to_value(overlay).expect("serializable overlay");
-    merge_serialized_value(base, &overlay_value)
+/// Merge StyleInfo fields: per-field Option merge, fields vec replaces if non-empty.
+fn merge_info(base: &mut crate::StyleInfo, overlay: &crate::StyleInfo) {
+    crate::merge_options!(
+        base,
+        overlay,
+        title,
+        id,
+        description,
+        default_locale,
+        source,
+        short_name,
+        edition,
+        citum_version
+    );
+
+    // fields: Vec replaces if overlay is non-empty
+    if !overlay.fields.is_empty() {
+        base.fields = overlay.fields.clone();
+    }
 }
 
-#[allow(
-    clippy::expect_used,
-    reason = "T must be serializable and merged values must match schema"
-)]
-pub(crate) fn merge_serialized_value<T>(base: T, overlay: &serde_yaml::Value) -> T
-where
-    T: Clone + DeserializeOwned + Serialize,
-{
-    let mut base_value = serde_yaml::to_value(base).expect("serializable base");
-    merge_yaml_value(&mut base_value, overlay);
-    serde_yaml::from_value(base_value).expect("merged value matches schema")
-}
+/// Merge two CitationSpec values with optional raw YAML for null-aware clearing.
+fn merge_citation_spec(
+    mut base: CitationSpec,
+    overlay: &CitationSpec,
+    raw: Option<&serde_yaml::Value>,
+) -> CitationSpec {
+    // Merge per-field Options (except type_variants, which needs null-aware logic)
+    crate::merge_options!(
+        base,
+        overlay,
+        template_ref,
+        template,
+        locales,
+        wrap,
+        prefix,
+        suffix,
+        delimiter,
+        multi_cite_delimiter,
+        collapse,
+        sort,
+        note_start_text_case,
+        custom
+    );
 
-pub(crate) fn merge_yaml_value(base: &mut serde_yaml::Value, overlay: &serde_yaml::Value) {
-    match (base, overlay) {
-        (serde_yaml::Value::Mapping(base_map), serde_yaml::Value::Mapping(overlay_map)) => {
-            for (key, overlay_value) in overlay_map {
-                if let Some(base_value) = base_map.get_mut(key) {
-                    merge_yaml_value(base_value, overlay_value);
-                } else {
-                    base_map.insert(key.clone(), overlay_value.clone());
+    // Restore explicit-null clearing: raw `field: ~` must clear the inherited Option.
+    // merge_options! above only writes when overlay is Some; null deserializes to None,
+    // so without this pass an explicit null would silently preserve the base value.
+    if let Some(raw_val) = raw {
+        clear_citation_raw_nulls(&mut base, raw_val);
+    }
+
+    // Handle type_variants: per-key merge (base keys not in overlay are preserved)
+    if let Some(raw_val) = raw {
+        if let Some(mapping) = raw_val.as_mapping() {
+            if mapping
+                .get(serde_yaml::Value::String("type-variants".to_string()))
+                .is_some_and(|v| v.is_null())
+            {
+                base.type_variants = None;
+            } else if let Some(overlay_variants) = &overlay.type_variants {
+                let base_variants = base.type_variants.get_or_insert_with(Default::default);
+                for (key, variant) in overlay_variants {
+                    base_variants.insert(key.clone(), variant.clone());
                 }
             }
         }
-        (base_value, overlay_value) => {
-            *base_value = overlay_value.clone();
+    } else if let Some(overlay_variants) = &overlay.type_variants {
+        let base_variants = base.type_variants.get_or_insert_with(Default::default);
+        for (key, variant) in overlay_variants {
+            base_variants.insert(key.clone(), variant.clone());
         }
     }
+
+    // Merge options: CitationOptions has .merge()
+    match (&mut base.options, &overlay.options) {
+        (Some(existing), Some(other)) => existing.merge(other),
+        (None, Some(other)) => base.options = Some(other.clone()),
+        _ => {}
+    }
+
+    merge_citation_sub_specs(&mut base, overlay, raw);
+
+    for (key, overlay_value) in &overlay.unknown_fields {
+        base.unknown_fields
+            .insert(key.clone(), overlay_value.clone());
+    }
+
+    base
+}
+
+/// Merge the four Box<CitationSpec> sub-specs with null-aware clearing.
+fn merge_citation_sub_specs(
+    base: &mut CitationSpec,
+    overlay: &CitationSpec,
+    raw: Option<&serde_yaml::Value>,
+) {
+    if let Some(raw_val) = raw {
+        base.integral = merge_opt_box_spec(&base.integral, &overlay.integral, raw_val, "integral");
+        base.non_integral = merge_opt_box_spec(
+            &base.non_integral,
+            &overlay.non_integral,
+            raw_val,
+            "non-integral",
+        );
+        base.subsequent =
+            merge_opt_box_spec(&base.subsequent, &overlay.subsequent, raw_val, "subsequent");
+        base.ibid = merge_opt_box_spec(&base.ibid, &overlay.ibid, raw_val, "ibid");
+    } else {
+        merge_opt_box_spec_typed(&mut base.integral, &overlay.integral);
+        merge_opt_box_spec_typed(&mut base.non_integral, &overlay.non_integral);
+        merge_opt_box_spec_typed(&mut base.subsequent, &overlay.subsequent);
+        merge_opt_box_spec_typed(&mut base.ibid, &overlay.ibid);
+    }
+}
+
+/// Typed-only (no raw) merge for an `Option<Box<CitationSpec>>` sub-spec.
+fn merge_opt_box_spec_typed(
+    base: &mut Option<Box<CitationSpec>>,
+    overlay: &Option<Box<CitationSpec>>,
+) {
+    if let Some(overlay_spec) = overlay {
+        let base_spec = base.take().map(|b| *b).unwrap_or_default();
+        *base = Some(Box::new(merge_citation_spec(base_spec, overlay_spec, None)));
+    }
+}
+
+/// Merge two BibliographySpec values with optional raw YAML for null-aware clearing.
+fn merge_bibliography_spec(
+    mut base: BibliographySpec,
+    overlay: &BibliographySpec,
+    raw: Option<&serde_yaml::Value>,
+) -> BibliographySpec {
+    // Merge per-field Options (except type_variants and groups, which need null-aware logic)
+    crate::merge_options!(base, overlay, template_ref, template, locales, sort, custom);
+
+    // Restore explicit-null clearing for bibliography flat Option fields (mirrors citation).
+    if let Some(raw_val) = raw {
+        clear_bibliography_raw_nulls(&mut base, raw_val);
+    }
+
+    // Handle type_variants: per-key merge (base keys not in overlay are preserved)
+    if let Some(raw_val) = raw {
+        if let Some(mapping) = raw_val.as_mapping() {
+            if mapping
+                .get(serde_yaml::Value::String("type-variants".to_string()))
+                .is_some_and(|v| v.is_null())
+            {
+                base.type_variants = None;
+            } else if let Some(overlay_variants) = &overlay.type_variants {
+                let base_variants = base.type_variants.get_or_insert_with(Default::default);
+                for (key, variant) in overlay_variants {
+                    base_variants.insert(key.clone(), variant.clone());
+                }
+            }
+        }
+    } else if let Some(overlay_variants) = &overlay.type_variants {
+        let base_variants = base.type_variants.get_or_insert_with(Default::default);
+        for (key, variant) in overlay_variants {
+            base_variants.insert(key.clone(), variant.clone());
+        }
+    }
+
+    // Handle groups with null-aware semantics
+    if let Some(raw_val) = raw {
+        if let Some(mapping) = raw_val.as_mapping() {
+            if mapping
+                .get(serde_yaml::Value::String("groups".to_string()))
+                .is_some_and(|v| v.is_null())
+            {
+                // Explicit null in raw: clear the field
+                base.groups = None;
+            } else if overlay.groups.is_some() {
+                // Not explicitly null and overlay has value: use overlay
+                base.groups = overlay.groups.clone();
+            }
+        }
+    } else if overlay.groups.is_some() {
+        // No raw YAML: standard Option merge
+        base.groups = overlay.groups.clone();
+    }
+
+    // Merge options: BibliographyOptions has .merge()
+    match (&mut base.options, &overlay.options) {
+        (Some(existing), Some(other)) => existing.merge(other),
+        (None, Some(other)) => base.options = Some(other.clone()),
+        _ => {}
+    }
+
+    // groups_enabled: only override if present in raw_yaml
+    if let Some(raw_val) = raw
+        && let Some(bib_mapping) = raw_val.as_mapping()
+        && bib_mapping.contains_key(serde_yaml::Value::String("groups-enabled".to_string()))
+    {
+        // If explicitly set in raw, use overlay's value
+        base.groups_enabled = overlay.groups_enabled;
+    } else if overlay.groups_enabled != BibliographySpec::default().groups_enabled {
+        // If no raw but overlay differs from default, use overlay
+        base.groups_enabled = overlay.groups_enabled;
+    }
+
+    // Merge unknown fields: per-key, overlay wins
+    for (key, overlay_value) in &overlay.unknown_fields {
+        base.unknown_fields
+            .insert(key.clone(), overlay_value.clone());
+    }
+
+    base
+}
+
+/// Merge a Box<CitationSpec> with null-aware clearing via raw YAML.
+///
+/// If raw_yaml has the key as explicit null, clear the field (set to None).
+/// Otherwise, standard Option merge.
+fn merge_opt_box_spec(
+    base: &Option<Box<CitationSpec>>,
+    overlay: &Option<Box<CitationSpec>>,
+    raw: &serde_yaml::Value,
+    key: &str,
+) -> Option<Box<CitationSpec>> {
+    let is_explicitly_null = raw
+        .as_mapping()
+        .and_then(|m| {
+            m.get(serde_yaml::Value::String(key.to_string()))
+                .map(|v| v.is_null())
+        })
+        .unwrap_or(false);
+
+    if is_explicitly_null {
+        // Explicit null in raw YAML: clear the field
+        None
+    } else if let Some(overlay_spec) = overlay {
+        // overlay is Some: merge and keep
+        let base_spec = base.as_ref().map(|b| (**b).clone()).unwrap_or_default();
+        Some(Box::new(merge_citation_spec(base_spec, overlay_spec, None)))
+    } else {
+        // overlay is None: keep base
+        base.clone()
+    }
+}
+
+/// Apply null-clearing for citation fields based on raw YAML.
+///
+/// Called when `overlay.citation` is None but raw citation section exists.
+/// Clears any fields that are explicitly null in the raw value.
+fn apply_raw_null_clears_citation(mut base: CitationSpec, raw: &serde_yaml::Value) -> CitationSpec {
+    if let Some(mapping) = raw.as_mapping() {
+        // Check for explicit nulls in sub-specs
+        if mapping
+            .get(serde_yaml::Value::String("integral".to_string()))
+            .is_some_and(|v| v.is_null())
+        {
+            base.integral = None;
+        }
+        if mapping
+            .get(serde_yaml::Value::String("non-integral".to_string()))
+            .is_some_and(|v| v.is_null())
+        {
+            base.non_integral = None;
+        }
+        if mapping
+            .get(serde_yaml::Value::String("subsequent".to_string()))
+            .is_some_and(|v| v.is_null())
+        {
+            base.subsequent = None;
+        }
+        if mapping
+            .get(serde_yaml::Value::String("ibid".to_string()))
+            .is_some_and(|v| v.is_null())
+        {
+            base.ibid = None;
+        }
+    }
+    base
+}
+
+/// Apply null-clearing for bibliography fields based on raw YAML.
+///
+/// Called when `overlay.bibliography` is None but raw bibliography section exists.
+/// Clears any fields that are explicitly null in the raw value.
+fn apply_raw_null_clears_bibliography(
+    mut base: BibliographySpec,
+    raw: &serde_yaml::Value,
+) -> BibliographySpec {
+    if let Some(mapping) = raw.as_mapping() {
+        // Check for explicit nulls in optional fields
+        if mapping
+            .get(serde_yaml::Value::String("options".to_string()))
+            .is_some_and(|v| v.is_null())
+        {
+            base.options = None;
+        }
+        if mapping
+            .get(serde_yaml::Value::String("groups".to_string()))
+            .is_some_and(|v| v.is_null())
+        {
+            base.groups = None;
+        }
+    }
+    base
+}
+
+/// Clear `CitationSpec` Option fields that are explicitly null in raw YAML.
+///
+/// Extracted so the complexity budget is counted against this function, not
+/// the already-complex `merge_citation_spec`.
+fn clear_citation_raw_nulls(base: &mut CitationSpec, raw: &serde_yaml::Value) {
+    clear_raw_nulls!(
+        base,
+        raw,
+        template_ref => "template-ref",
+        template => "template",
+        locales => "locales",
+        wrap => "wrap",
+        prefix => "prefix",
+        suffix => "suffix",
+        delimiter => "delimiter",
+        multi_cite_delimiter => "multi-cite-delimiter",
+        collapse => "collapse",
+        sort => "sort",
+        note_start_text_case => "note-start-text-case",
+        custom => "custom",
+        options => "options",
+    );
+}
+
+/// Clear `BibliographySpec` Option fields that are explicitly null in raw YAML.
+fn clear_bibliography_raw_nulls(base: &mut BibliographySpec, raw: &serde_yaml::Value) {
+    clear_raw_nulls!(
+        base,
+        raw,
+        template_ref => "template-ref",
+        template => "template",
+        locales => "locales",
+        sort => "sort",
+        custom => "custom",
+        options => "options",
+    );
 }

--- a/crates/citum-schema-style/tests/bdd_inheritance.rs
+++ b/crates/citum-schema-style/tests/bdd_inheritance.rs
@@ -276,3 +276,231 @@ bibliography:
     // Component 1: doi (strong: true from top)
     assert_eq!(template[1].rendering().strong, Some(true));
 }
+
+#[test]
+fn test_overlay_preserves_base_type_variant_keys_not_in_overlay() {
+    // Regression guard: overlay with only one type-variant key must not drop
+    // base type-variant keys that are absent from the overlay.
+    let base_yaml = r#"
+version: "0.44.0"
+info: { id: base }
+bibliography:
+  template:
+    - title: primary
+  type-variants:
+    book:
+      - title: primary
+      - variable: publisher
+    article-journal:
+      - title: primary
+      - variable: doi
+"#;
+    let overlay_yaml = r#"
+extends: base
+info: { id: overlay }
+bibliography:
+  type-variants:
+    book:
+      modify:
+        - match: { title: primary }
+          emph: true
+"#;
+
+    let base = Style::from_yaml_str(base_yaml).unwrap();
+    let overlay = Style::from_yaml_str(overlay_yaml).unwrap();
+
+    struct R(Style);
+    impl citum_resolver_api::StyleResolver for R {
+        type Style = Style;
+        type Locale = citum_schema_style::locale::Locale;
+        fn resolve_style(&self, _: &str) -> Result<Style, citum_schema_style::ResolverError> {
+            Ok(self.0.clone())
+        }
+        fn resolve_locale(
+            &self,
+            id: &str,
+        ) -> Result<Self::Locale, citum_schema_style::ResolverError> {
+            Err(citum_schema_style::ResolverError::LocaleNotFound(
+                std::borrow::Cow::Owned(id.to_string()),
+            ))
+        }
+    }
+
+    let mut visited = HashSet::new();
+    let resolved = overlay
+        .try_into_resolved_recursive_with(Some(&R(base)), &mut visited)
+        .unwrap();
+
+    let variants = resolved
+        .bibliography
+        .as_ref()
+        .unwrap()
+        .type_variants
+        .as_ref()
+        .unwrap();
+
+    // The overlay only touched `book` — `article-journal` from base must survive.
+    assert!(
+        variants.contains_key(&TypeSelector::Single("article-journal".into())),
+        "base article-journal variant dropped by overlay"
+    );
+    assert!(
+        variants.contains_key(&TypeSelector::Single("book".into())),
+        "book variant missing after overlay"
+    );
+}
+
+// Regression tests: explicit `field: ~` in overlay must clear the inherited Option value.
+// The typed merge_options! treats None as "absent"; these tests guard that raw_yaml
+// null-inspection clears the base before merge_options! runs.
+
+fn make_resolver(
+    base: Style,
+) -> impl citum_resolver_api::StyleResolver<Style = Style, Locale = citum_schema_style::locale::Locale>
+{
+    struct R(Style);
+    impl citum_resolver_api::StyleResolver for R {
+        type Style = Style;
+        type Locale = citum_schema_style::locale::Locale;
+        fn resolve_style(&self, _: &str) -> Result<Style, citum_schema_style::ResolverError> {
+            Ok(self.0.clone())
+        }
+        fn resolve_locale(
+            &self,
+            id: &str,
+        ) -> Result<Self::Locale, citum_schema_style::ResolverError> {
+            Err(citum_schema_style::ResolverError::LocaleNotFound(
+                std::borrow::Cow::Owned(id.to_string()),
+            ))
+        }
+    }
+    R(base)
+}
+
+#[test]
+fn test_explicit_null_clears_citation_flat_field() {
+    let base_yaml = r#"
+version: "0.44.0"
+info: { id: base }
+citation:
+  prefix: "("
+  suffix: ")"
+"#;
+    let overlay_yaml = r#"
+extends: base
+info: { id: overlay }
+citation:
+  prefix: ~
+"#;
+    let base = Style::from_yaml_str(base_yaml).unwrap();
+    let overlay = Style::from_yaml_str(overlay_yaml).unwrap();
+    let mut visited = HashSet::new();
+    let resolved = overlay
+        .try_into_resolved_recursive_with(Some(&make_resolver(base)), &mut visited)
+        .unwrap();
+
+    let cit = resolved.citation.as_ref().unwrap();
+    assert!(
+        cit.prefix.is_none(),
+        "explicit `prefix: ~` did not clear inherited prefix"
+    );
+    assert_eq!(
+        cit.suffix.as_deref(),
+        Some(")"),
+        "suffix not in overlay must survive"
+    );
+}
+
+#[test]
+fn test_explicit_null_clears_citation_options() {
+    let base_yaml = r#"
+version: "0.44.0"
+info: { id: base }
+citation:
+  options: {}
+"#;
+    let overlay_yaml = r#"
+extends: base
+info: { id: overlay }
+citation:
+  options: ~
+"#;
+    let base = Style::from_yaml_str(base_yaml).unwrap();
+    // Verify base has non-None options before resolution.
+    assert!(
+        base.citation.as_ref().unwrap().options.is_some(),
+        "base must have citation.options for this test"
+    );
+
+    let overlay = Style::from_yaml_str(overlay_yaml).unwrap();
+    let mut visited = HashSet::new();
+    let resolved = overlay
+        .try_into_resolved_recursive_with(Some(&make_resolver(base)), &mut visited)
+        .unwrap();
+
+    assert!(
+        resolved.citation.as_ref().unwrap().options.is_none(),
+        "explicit `citation.options: ~` did not clear inherited options"
+    );
+}
+
+#[test]
+fn test_explicit_null_clears_bibliography_template() {
+    let base_yaml = r#"
+version: "0.44.0"
+info: { id: base }
+bibliography:
+  template:
+    - title: primary
+    - variable: doi
+"#;
+    let overlay_yaml = r#"
+extends: base
+info: { id: overlay }
+bibliography:
+  template: ~
+"#;
+    let base = Style::from_yaml_str(base_yaml).unwrap();
+    let overlay = Style::from_yaml_str(overlay_yaml).unwrap();
+    let mut visited = HashSet::new();
+    let resolved = overlay
+        .try_into_resolved_recursive_with(Some(&make_resolver(base)), &mut visited)
+        .unwrap();
+
+    assert!(
+        resolved.bibliography.as_ref().unwrap().template.is_none(),
+        "explicit `bibliography.template: ~` did not clear inherited template"
+    );
+}
+
+#[test]
+fn test_explicit_null_clears_bibliography_options() {
+    let base_yaml = r#"
+version: "0.44.0"
+info: { id: base }
+bibliography:
+  options: {}
+"#;
+    let overlay_yaml = r#"
+extends: base
+info: { id: overlay }
+bibliography:
+  options: ~
+"#;
+    let base = Style::from_yaml_str(base_yaml).unwrap();
+    assert!(
+        base.bibliography.as_ref().unwrap().options.is_some(),
+        "base must have bibliography.options for this test"
+    );
+
+    let overlay = Style::from_yaml_str(overlay_yaml).unwrap();
+    let mut visited = HashSet::new();
+    let resolved = overlay
+        .try_into_resolved_recursive_with(Some(&make_resolver(base)), &mut visited)
+        .unwrap();
+
+    assert!(
+        resolved.bibliography.as_ref().unwrap().options.is_none(),
+        "explicit `bibliography.options: ~` did not clear inherited options"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace three `serde_yaml` serialization round-trips in `merge_style_overlay` with typed per-field merges, removing the `#[allow(unwrap_used/expect_used)]` escape hatches they required
- Add `BibliographyOptions::merge` mirroring the existing `CitationOptions::merge`
- Add a Criterion bench for the style resolution path; baseline 36.5 µs → 31.3 µs (~14% gain on a one-hop `extends`)
- Add regression test `test_overlay_preserves_base_type_variant_keys_not_in_overlay` guarding per-key type-variant merge semantics

Null-aware `raw_yaml` semantics (`ibid: ~` clearing an inherited preset) are preserved through targeted raw inspection. The non-Option `groups_enabled` bool is only overridden when its key is explicitly present in raw YAML.

## Test plan

- [x] `cargo nextest run -p citum-schema-style` — all 269 tests pass, including `bdd_inheritance`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Portfolio fidelity gate — 154 styles, fidelity=1.0, no regressions
- [x] `cargo bench -p citum-schema-style` — before 36.5 µs, after 31.3 µs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
