### PR TITLE
chore(hooks): add demo scope; sync io to pre-push

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -10,7 +10,7 @@ if [[ "$header" =~ ^(Merge|Revert|fixup!|squash!) ]]; then
   exit 0
 fi
 
-header_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((engine|schema|migrate|store|io|cli|server|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security)\))?(!)?: [a-z].+$'
+header_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\((engine|schema|migrate|store|io|cli|server|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security|demo)\))?(!)?: [a-z].+$'
 
 if [[ ! "$header" =~ $header_regex ]]; then
   cat <<'EOF' >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -37,8 +37,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   # Internal commits may use any scope, but everything pushed must be clean.
   # Validate scopes against the canonical allowlist.
   # Use sed to extract scope (avoids bash =~ ERE paren ambiguity).
-  VALID_SCOPES_RE='^(engine|schema|migrate|store|cli|server|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security)$'
-  VALID_SCOPES_LIST="engine, schema, migrate, store, cli, server, styles, locale, i18n, ci, hooks, beans, scripts, tooling, spec, docs, release, report, examples, bindings, security"
+  VALID_SCOPES_RE='^(engine|schema|migrate|store|io|cli|server|styles|locale|i18n|ci|hooks|beans|scripts|tooling|spec|docs|release|report|examples|bindings|security|demo)$'
+  VALID_SCOPES_LIST="engine, schema, migrate, store, io, cli, server, styles, locale, i18n, ci, hooks, beans, scripts, tooling, spec, docs, release, report, examples, bindings, security, demo"
   scope_errors=()
   while IFS= read -r subject; do
     # Extract scope: "type(scope)[!]: ..." -> scope, empty if unscoped.


### PR DESCRIPTION
## Summary

- Adds `demo` to both hook allowlists (`pre-push` and `commit-msg`) to unblock pushes containing recently-merged `fix(demo):` commits
- Syncs `io` scope into `pre-push` (it was already in `commit-msg` but missing from the push-time check)

## Test plan

- [x] CI passes
- [x] `git push tangled main` no longer fails on `demo`-scoped commits
