### PR TITLE
ci: add zizmor + actionlint security gate

### DIFF
--- a/.beans/archive/csl26-87vs--add-workflow-security-gate-zizmor-actionlint.md
+++ b/.beans/archive/csl26-87vs--add-workflow-security-gate-zizmor-actionlint.md
@@ -1,0 +1,22 @@
+---
+# csl26-87vs
+title: Add workflow security gate (zizmor + actionlint)
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-30T15:33:46Z
+updated_at: 2026-05-30T15:47:13Z
+---
+
+Add a new .github/workflows/actions-security.yml with zizmor + actionlint jobs, fix any existing findings so CI lands green, then open a PR. See plan at ~/.claude/plans/this-is-for-a-sorted-melody.md
+
+
+## Summary of Changes
+
+- New  with  and  jobs
+- SHA-pinned all action references across all 4 existing workflow files (97 → 18 findings)
+- Fixed High/High template-injection in ci.yml ( → env var ) and release.yml (/ → env vars /)
+- Added  to fidelity.yml (Medium/Medium excessive-permissions)
+- Added  to all checkout steps that don't need credentials for git-push
+- Configured zizmor with  — filters remaining Low-confidence artipacked/cache-poisoning findings while keeping High/High and Medium/Medium gates active
+- 0 blocking findings after remediation

--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,52 @@
+name: Actions Security
+
+permissions: {}
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+
+      - name: Lint workflow files
+        env:
+          ACTIONLINT: ${{ steps.get_actionlint.outputs.executable }}
+        run: $ACTIONLINT -color
+        shell: bash
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload SARIF to code scanning
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
+        with:
+          min-confidence: medium  # skip Low-confidence findings (artipacked, cache-poisoning)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,18 @@ jobs:
       semver: ${{ steps.filter.outputs.semver }}
       release: ${{ steps.filter.outputs.release }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Detect changed paths
         id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD")
           else
             CHANGED=$(git diff --name-only HEAD^ HEAD 2>/dev/null || git diff --name-only HEAD)
           fi
@@ -61,12 +65,13 @@ jobs:
     if: ${{ needs.changes.outputs.docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run repository hygiene (alint)
-        uses: asamarts/alint@v0.9.22
+        uses: asamarts/alint@3c15d45a21884dc39f1f351a85e03297da237b87  # v0.9.22
 
   hygiene-beans:
     name: Hygiene Checks — Beans
@@ -74,9 +79,10 @@ jobs:
     if: ${{ needs.changes.outputs.beans == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install beans CLI
         run: |
@@ -87,7 +93,7 @@ jobs:
           sudo install -m 0755 /tmp/beans /usr/local/bin/beans
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
 
@@ -106,10 +112,12 @@ jobs:
     if: ${{ needs.changes.outputs.scripts == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
 
@@ -132,22 +140,24 @@ jobs:
     if: ${{ needs.changes.outputs.release == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: release-dry-runs
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: wasm-pack
 
@@ -170,10 +180,12 @@ jobs:
     if: ${{ needs.changes.outputs.infra == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
 
@@ -199,12 +211,13 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       CARGO_INCREMENTAL: "0"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt, clippy
 
@@ -212,12 +225,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y mold
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: cargo-nextest
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
@@ -248,18 +261,19 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Set up nightly Rust for fuzzing
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
 
       - name: Install security tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: cargo-audit,cargo-deny,cargo-fuzz
 
@@ -284,21 +298,22 @@ jobs:
           needs.changes.outputs.semver == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: "citum-core-semver"
           cache-workspace-crates: true
 
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: cargo-semver-checks
 

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Configure environment
         run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
           sccache --start-server
 
       - name: Install Node dependencies

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -30,31 +30,32 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Initialize optional corpora
         run: git submodule update --init --depth 1 styles-legacy tests/csl-test-suite
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install mold linker and sccache
         run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: cargo-nextest
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
 
       - name: Cache Rust (dependencies + sccache)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
@@ -84,16 +85,16 @@ jobs:
           cp target/migration-behavior-report.html docs/migration-behavior-report.html
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: ./docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
 
       - name: Display sccache stats
         run: sccache --show-stats

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Configure environment
         run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
           sccache --start-server
 
       - name: Install script dependencies

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -1,5 +1,8 @@
 name: Fidelity
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]
@@ -30,26 +33,27 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_DIR: /home/runner/.cache/sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Initialize optional corpora
         run: git submodule update --init --depth 1 styles-legacy tests/csl-test-suite
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install mold linker and sccache
         run: sudo apt-get update && sudo apt-get install -y mold sccache
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
 
       - name: Cache Rust (dependencies + sccache)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,11 @@ jobs:
         id: config
         run: |
           # All releases flow through a release PR on release/next.
-          echo "branch=release/next" >> "$GITHUB_OUTPUT"
-          echo "create_pr=true" >> "$GITHUB_OUTPUT"
-          echo "push_tags=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "branch=release/next"
+            echo "create_pr=true"
+            echo "push_tags=false"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create release branch
         if: steps.config.outputs.create_pr == 'true'
@@ -157,7 +159,7 @@ jobs:
           print('.'.join(v))
           ")
           RANGE="${LAST_TAG:+${LAST_TAG}..}HEAD"
-          git cliff $RANGE --tag "v${NEW_VERSION}" --prepend CHANGELOG.md
+          git cliff "$RANGE" --tag "v${NEW_VERSION}" --prepend CHANGELOG.md
           git add CHANGELOG.md
           if ! git diff --cached --quiet; then
             git commit \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,10 @@ jobs:
       bump-level: ${{ steps.infer.outputs.level }}
       should-release: ${{ steps.infer.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Infer bump level from commits
         id: infer
@@ -79,15 +80,16 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
+          # persist-credentials: true (default) — needed for git push to release/next
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: cargo-release,cargo-semver-checks,git-cliff
 
@@ -250,15 +252,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
+          # persist-credentials: true (default) — needed for git push tags
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install cargo-release
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: cargo-release
 
@@ -324,13 +327,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: build (${{ matrix.target }})
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: release-${{ matrix.target }}
 
@@ -340,7 +345,7 @@ jobs:
 
       - name: Install cross (when needed)
         if: matrix.use_cross == '1'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: cross
 
@@ -348,9 +353,11 @@ jobs:
         shell: bash
         env:
           USE_CROSS: ${{ matrix.use_cross }}
-        run: bash scripts/release-binary.sh "${{ matrix.target }}" "${{ github.ref_name }}"
+          TARGET: ${{ matrix.target }}
+          REF_NAME: ${{ github.ref_name }}
+        run: bash scripts/release-binary.sh "$TARGET" "$REF_NAME"
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: citum-${{ matrix.target }}
           path: release-out/${{ matrix.target }}/*
@@ -363,9 +370,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
           path: release-artifacts
           pattern: citum-*
@@ -411,11 +420,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: publish-crates
 
@@ -442,22 +453,24 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "22"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: publish-jsr
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@0fd46367812ee04360509b4169d9f659d6892bb2  # v2
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
## Summary

Adds a `Actions Security` workflow (`.github/workflows/actions-security.yml`) that
gates every PR touching workflow files on two tools:

- **actionlint** — structural lint and shellcheck of all `run:` blocks
- **zizmor** — security audit of all workflow files, with SARIF uploaded to GitHub code scanning

Also remediates the existing findings so CI is green from day one.

## What changed

### New workflow
- `actions-security.yml`: two jobs (`actionlint`, `zizmor`), top-level `permissions: {}`
- `zizmor` configured with `min-confidence: medium` — filters Low-confidence advisory
  findings (artipacked, cache-poisoning) into the SARIF dashboard without blocking merges;
  High/High and Medium/Medium findings are blocking

### Remediations across existing workflows

| Finding | Severity/Confidence | Fix |
|---------|-------------------|-----|
| `template-injection` in `ci.yml` (`${{ github.base_ref }}` in `run:`) | High/High | Moved to `env: BASE_REF: ${{ github.base_ref }}` |
| `template-injection` in `release.yml` (`${{ matrix.target }}`, `${{ github.ref_name }}` in `run:`) | High/High | Moved to `env: TARGET:`, `REF_NAME:` |
| `excessive-permissions` on `fidelity.yml` (no top-level permissions block) | Medium/Medium | Added `permissions: contents: read` |
| `unpinned-uses` across all 4 workflow files | High/High | SHA-pinned all action references |
| `artipacked` (credential persistence via checkout) | Low/Low | Added `persist-credentials: false` to all non-push checkouts; push checkouts in `release-pr` / `auto-tag` retain credentials by design |

**Result: 97 findings → 0 blocking findings** (18 Low-confidence advisory findings remain visible in code scanning).

### SHA reference for pinned actions

All tags are preserved as inline comments for maintainability, e.g.:
```yaml
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
```

## Making this un-bypassable (org-level — user action required)

This PR lands the in-repo workflow. To match the Reddit setup (nobody can disable it, even with admin access), configure a **required workflow** at the org level:

> `citum` org Settings → Actions → **Required workflows** → Add `citum-core/.github/workflows/actions-security.yml`

Alternatively, add `actionlint` and `zizmor` as required status checks on the `main` branch protection rule (Settings → Branches → Edit).

## Test plan

- [ ] CI passes: `actionlint` and `zizmor` jobs both green
- [ ] SARIF tab visible under Security → Code scanning with 18 advisory findings
- [ ] (Post-merge) Configure org-level required workflow for `citum` org
