### PR TITLE
feat(engine): add markdown output format

### DIFF
--- a/.beans/archive/csl26-qz8y--featrender-add-commonmarkmarkdown-output-format-fo.md
+++ b/.beans/archive/csl26-qz8y--featrender-add-commonmarkmarkdown-output-format-fo.md
@@ -1,0 +1,21 @@
+---
+# csl26-qz8y
+title: 'feat(render): add CommonMark/Markdown output format for Pandoc interop'
+status: completed
+type: feature
+priority: normal
+created_at: 2026-05-30T19:33:07Z
+updated_at: 2026-05-30T19:43:56Z
+---
+
+Add OutputFormat::Markdown passthrough that renders citations inline (CommonMark emph/strong) and emits body markup verbatim. Enables pipe workflow: citum render doc --format markdown | pandoc.\n\nAlso reverts the grid-table preprocessor from PR #846 (abandoned branch).\n\n## Tasks\n- [x] Switch to main, close PR #846, create new branch\n- [x] Add crates/citum-engine/src/render/markdown.rs (OutputFormat impl)\n- [x] Wire markdown into render/mod.rs\n- [x] Wire CLI: OutputFormat::Markdown in args.rs, to_document_format, dispatch arms\n- [x] Inline tests in markdown.rs\n- [x] Integration test: pipe table + code block passes through, citations rendered\n- [x] Integration test: note style emits [^n] anchors/definitions with CM emphasis\n- [x] Spec note in docs/ documenting passthrough formats and Pandoc interop\n- [x] Pass pre-commit gate
+
+## Summary of Changes
+
+- Added `crates/citum-engine/src/render/markdown.rs`: new `Markdown` renderer implementing `OutputFormat` with CommonMark inline markup (emph `*x*`, strong `**x**`, small-caps/superscript as raw `<span>`/`<sup>` HTML, semantic passthrough).
+- Wired `pub mod markdown` into `render/mod.rs`.
+- Added `OutputFormat::Markdown` to CLI `args.rs` enum and `Display` impl.
+- Wired five match arms in `commands/render/mod.rs`: `to_document_format`, both `DocumentInput` branches in `render_doc_with_output_format`, `render_refs_human`, `render_refs_json`.
+- Two new integration tests in `crates/citum-engine/tests/document.rs`: passthrough of pipe tables/code blocks; note-style footnote syntax emission.
+- Spec doc `docs/specs/PANDOC_MARKDOWN_CITATIONS.md` updated (v1.2) with passthrough vs. converted format classification, Pandoc interop workflow, and footnote-extension caveat.
+- Grid-table preprocessor from PR #846 does not appear on this branch (branched off clean `main`); PR #846 abandoned.

--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -91,6 +91,11 @@ pub(crate) enum OutputFormat {
     Plain,
     Html,
     Djot,
+    /// CommonMark (Markdown) output — citations rendered inline, body markup
+    /// passed through verbatim. Suitable for piping to pandoc or any
+    /// CommonMark-aware formatter. Note styles emit `[^n]` footnote syntax
+    /// (Pandoc/GFM extension — use `pandoc --from commonmark+footnotes`).
+    Markdown,
     Latex,
     Typst,
 }
@@ -101,6 +106,7 @@ impl std::fmt::Display for OutputFormat {
             OutputFormat::Plain => write!(f, "plain"),
             OutputFormat::Html => write!(f, "html"),
             OutputFormat::Djot => write!(f, "djot"),
+            OutputFormat::Markdown => write!(f, "markdown"),
             OutputFormat::Latex => write!(f, "latex"),
             OutputFormat::Typst => write!(f, "typst"),
         }

--- a/crates/citum-cli/src/commands/render/mod.rs
+++ b/crates/citum-cli/src/commands/render/mod.rs
@@ -17,7 +17,9 @@ use crate::output::write_output;
 use crate::style_resolver::{create_processor, load_any_style};
 use crate::typst_pdf;
 use citum_engine::processor::document::{djot::DjotParser, markdown::MarkdownParser};
-use citum_engine::render::{djot::Djot, html::Html, latex::Latex, plain::PlainText, typst::Typst};
+use citum_engine::render::{
+    djot::Djot, html::Html, latex::Latex, markdown::Markdown, plain::PlainText, typst::Typst,
+};
 use citum_engine::{Citation, DocumentFormat, Processor};
 use citum_io::{
     AnnotationFormat, AnnotationStyle, load_annotations, load_merged_bibliography,
@@ -200,6 +202,9 @@ fn render_doc_with_output_format(
                 OutputFormat::Djot => {
                     Ok(processor.process_document::<_, Djot>(content, &parser, doc_format))
                 }
+                OutputFormat::Markdown => {
+                    Ok(processor.process_document::<_, Markdown>(content, &parser, doc_format))
+                }
                 OutputFormat::Latex => {
                     Ok(processor.process_document::<_, Latex>(content, &parser, doc_format))
                 }
@@ -220,6 +225,9 @@ fn render_doc_with_output_format(
                 OutputFormat::Djot => {
                     Ok(processor.process_document::<_, Djot>(content, &parser, doc_format))
                 }
+                OutputFormat::Markdown => {
+                    Ok(processor.process_document::<_, Markdown>(content, &parser, doc_format))
+                }
                 OutputFormat::Latex => {
                     Ok(processor.process_document::<_, Latex>(content, &parser, doc_format))
                 }
@@ -237,6 +245,7 @@ fn to_document_format(output_format: OutputFormat) -> Result<DocumentFormat, Box
         OutputFormat::Plain => Ok(DocumentFormat::Plain),
         OutputFormat::Html => Ok(DocumentFormat::Html),
         OutputFormat::Djot => Ok(DocumentFormat::Djot),
+        OutputFormat::Markdown => Ok(DocumentFormat::Markdown),
         OutputFormat::Latex => Ok(DocumentFormat::Latex),
         OutputFormat::Typst => Ok(DocumentFormat::Typst),
     }
@@ -282,6 +291,10 @@ fn render_refs_human(
             print_human_safe::<Djot>(ctx, show_cite, show_bib, citations, show_keys)
                 .map_err(std::convert::Into::into)
         }
+        OutputFormat::Markdown => {
+            print_human_safe::<Markdown>(ctx, show_cite, show_bib, citations, show_keys)
+                .map_err(std::convert::Into::into)
+        }
         OutputFormat::Latex => {
             print_human_safe::<Latex>(ctx, show_cite, show_bib, citations, show_keys)
                 .map_err(std::convert::Into::into)
@@ -312,6 +325,9 @@ fn render_refs_json(
         }
         OutputFormat::Html => print_json_with_format::<Html>(ctx, show_cite, show_bib, citations),
         OutputFormat::Djot => print_json_with_format::<Djot>(ctx, show_cite, show_bib, citations),
+        OutputFormat::Markdown => {
+            print_json_with_format::<Markdown>(ctx, show_cite, show_bib, citations)
+        }
         OutputFormat::Latex => print_json_with_format::<Latex>(ctx, show_cite, show_bib, citations),
         OutputFormat::Typst => print_json_with_format::<Typst>(ctx, show_cite, show_bib, citations),
     }
@@ -376,6 +392,7 @@ mod tests {
         assert_eq!(OutputFormat::Plain.to_string(), "plain");
         assert_eq!(OutputFormat::Html.to_string(), "html");
         assert_eq!(OutputFormat::Djot.to_string(), "djot");
+        assert_eq!(OutputFormat::Markdown.to_string(), "markdown");
         assert_eq!(OutputFormat::Latex.to_string(), "latex");
         assert_eq!(OutputFormat::Typst.to_string(), "typst");
     }

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -13,6 +13,7 @@ use crate::render::djot::Djot;
 use crate::render::format::OutputFormat;
 use crate::render::html::Html;
 use crate::render::latex::Latex;
+use crate::render::markdown::Markdown;
 use crate::render::plain::PlainText;
 use crate::render::typst::Typst;
 use citum_schema::Style;
@@ -126,6 +127,10 @@ pub fn format_document(
 /// # Errors
 ///
 /// Returns an error if rendering fails.
+#[allow(
+    clippy::too_many_lines,
+    reason = "match arms grow one-to-one with format variants"
+)]
 pub fn format_document_with_style(
     style: Style,
     request: FormatDocumentRequest,
@@ -208,6 +213,7 @@ pub fn format_document_with_style(
         OutputFormatKind::Djot => format_by_kind::<Djot>(&processor, &citations)?,
         OutputFormatKind::Latex => format_by_kind::<Latex>(&processor, &citations)?,
         OutputFormatKind::Typst => format_by_kind::<Typst>(&processor, &citations)?,
+        OutputFormatKind::Markdown => format_by_kind::<Markdown>(&processor, &citations)?,
     };
 
     // Process bibliography
@@ -233,6 +239,11 @@ pub fn format_document_with_style(
             request.document_options.as_ref(),
         )?,
         OutputFormatKind::Typst => format_bibliography::<Typst>(
+            &processor,
+            request.output_format,
+            request.document_options.as_ref(),
+        )?,
+        OutputFormatKind::Markdown => format_bibliography::<Markdown>(
             &processor,
             request.output_format,
             request.document_options.as_ref(),

--- a/crates/citum-engine/src/api/types.rs
+++ b/crates/citum-engine/src/api/types.rs
@@ -53,6 +53,8 @@ pub enum OutputFormatKind {
     Latex,
     /// Typst markup.
     Typst,
+    /// CommonMark/Markdown markup.
+    Markdown,
 }
 
 /// Controls how annotation text is rendered in an annotated bibliography.

--- a/crates/citum-engine/src/ffi/mod.rs
+++ b/crates/citum-engine/src/ffi/mod.rs
@@ -15,6 +15,7 @@ use crate::reference::{Bibliography, Citation, Reference};
 use crate::render::djot::Djot;
 use crate::render::html::Html;
 use crate::render::latex::Latex;
+use crate::render::markdown::Markdown;
 use crate::render::plain::PlainText;
 use crate::render::typst::Typst;
 use citum_schema::Style;
@@ -62,6 +63,7 @@ fn parse_output_format(format: &str) -> Result<&'static str, ()> {
         "djot" => Ok("djot"),
         "typst" => Ok("typst"),
         "plain" => Ok("plain"),
+        "markdown" => Ok("markdown"),
         other => {
             set_error(format!("Unsupported output format: {other}"));
             Err(())
@@ -566,6 +568,7 @@ pub unsafe extern "C" fn citum_render_citations_json(
         "latex" => processor.process_citations_with_format::<Latex>(&citations),
         "djot" => processor.process_citations_with_format::<Djot>(&citations),
         "typst" => processor.process_citations_with_format::<Typst>(&citations),
+        "markdown" => processor.process_citations_with_format::<Markdown>(&citations),
         _ => processor.process_citations_with_format::<PlainText>(&citations),
     };
 

--- a/crates/citum-engine/src/processor/document/markdown.rs
+++ b/crates/citum-engine/src/processor/document/markdown.rs
@@ -7,16 +7,24 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use super::djot::parsing::parse_frontmatter;
 use super::{CitationParser, CitationPlacement, CitationStructure, ParsedCitation, ParsedDocument};
+use crate::processor::document::ManualNoteReference;
 use crate::{Citation, CitationItem};
 use citum_schema::citation::{CitationMode, normalize_locator_text};
 use citum_schema::locale::Locale;
 use std::collections::HashSet;
+use std::ops::Range;
+
+/// Byte range of a manual footnote definition in the document body.
+///
+/// Used to classify citations found inside `[^label]: …` blocks as
+/// [`CitationPlacement::ManualFootnote`] rather than
+/// [`CitationPlacement::InlineProse`].
+struct FootnoteRange {
+    label: String,
+    content: Range<usize>,
+}
 
 /// A parser for Markdown documents with Pandoc-style citation syntax.
-///
-/// This parser currently supports inline prose citations and maps them into the
-/// shared document-processing pipeline. Markdown-specific footnotes, document
-/// metadata, and inline bibliography blocks remain future work.
 pub struct MarkdownParser;
 
 impl Default for MarkdownParser {
@@ -37,7 +45,10 @@ impl CitationParser for MarkdownParser {
         use pulldown_cmark::{Options, html};
 
         let (remapped, token_map) = remap_nul_tokens(rendered);
-        let parser = pulldown_cmark::Parser::new_ext(&remapped, Options::ENABLE_STRIKETHROUGH);
+        let parser = pulldown_cmark::Parser::new_ext(
+            &remapped,
+            Options::ENABLE_STRIKETHROUGH | Options::ENABLE_FOOTNOTES | Options::ENABLE_TABLES,
+        );
         let mut out = String::new();
         html::push_html(&mut out, parser);
 
@@ -84,22 +95,54 @@ impl CitationParser for MarkdownParser {
                     .is_none()
             });
 
+        let (raw_note_refs, manual_note_labels, footnote_ranges) = scan_manual_notes_markdown(body);
+
+        // Adjust footnote reference offsets and build deduped note order.
+        let mut seen_labels = HashSet::new();
+        let mut manual_note_order = Vec::new();
+        let manual_note_references: Vec<ManualNoteReference> = raw_note_refs
+            .into_iter()
+            .map(|r| ManualNoteReference {
+                label: r.label.clone(),
+                start: body_start + r.start,
+            })
+            .inspect(|r| {
+                if seen_labels.insert(r.label.clone()) {
+                    manual_note_order.push(r.label.clone());
+                }
+            })
+            .collect();
+
+        // Adjust footnote definition ranges by the body offset.
+        let adjusted_ranges: Vec<FootnoteRange> = footnote_ranges
+            .into_iter()
+            .map(|fr| FootnoteRange {
+                label: fr.label,
+                content: (body_start + fr.content.start)..(body_start + fr.content.end),
+            })
+            .collect();
+
         let citations = find_citations(body, locale)
             .into_iter()
-            .map(|(start, end, citation)| ParsedCitation {
-                start: body_start + start,
-                end: body_start + end,
-                citation,
-                placement: CitationPlacement::InlineProse,
-                structure: CitationStructure::default(),
+            .map(|(start, end, citation)| {
+                let abs_start = body_start + start;
+                let abs_end = body_start + end;
+                let placement = footnote_placement(abs_start, abs_end, &adjusted_ranges);
+                ParsedCitation {
+                    start: abs_start,
+                    end: abs_end,
+                    citation,
+                    placement,
+                    structure: CitationStructure::default(),
+                }
             })
             .collect();
 
         ParsedDocument {
             citations,
-            manual_note_order: Vec::new(),
-            manual_note_references: Vec::new(),
-            manual_note_labels: HashSet::new(),
+            manual_note_order,
+            manual_note_references,
+            manual_note_labels,
             bibliography_blocks: Vec::new(),
             frontmatter_groups: None,
             frontmatter_integral_name_memory,
@@ -109,6 +152,72 @@ impl CitationParser for MarkdownParser {
             body_start,
         }
     }
+}
+
+/// Scan a Markdown document body for manual footnote references and definitions.
+///
+/// Uses pulldown-cmark with `ENABLE_FOOTNOTES` to find:
+/// - `[^label]` references in prose → [`ManualNoteReference`] entries
+/// - `[^label]: …` definition blocks → [`FootnoteRange`] entries whose byte
+///   ranges cover the entire definition in the source text
+///
+/// The returned triple mirrors the contract of the Djot parser's
+/// `scan_manual_notes`, enabling the shared pipeline to classify citations
+/// found inside footnote definitions as [`CitationPlacement::ManualFootnote`].
+fn scan_manual_notes_markdown(
+    content: &str,
+) -> (
+    Vec<ManualNoteReference>,
+    HashSet<String>,
+    Vec<FootnoteRange>,
+) {
+    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+    let opts = Options::ENABLE_FOOTNOTES | Options::ENABLE_STRIKETHROUGH;
+    let mut manual_note_references = Vec::new();
+    let mut manual_note_labels = HashSet::new();
+    let mut footnote_ranges = Vec::new();
+    let mut footnote_stack: Vec<(String, usize)> = Vec::new();
+
+    for (event, range) in Parser::new_ext(content, opts).into_offset_iter() {
+        match event {
+            Event::FootnoteReference(label) if footnote_stack.is_empty() => {
+                manual_note_references.push(ManualNoteReference {
+                    label: label.to_string(),
+                    start: range.start,
+                });
+                manual_note_labels.insert(label.to_string());
+            }
+            Event::Start(Tag::FootnoteDefinition(label)) => {
+                manual_note_labels.insert(label.to_string());
+                footnote_stack.push((label.to_string(), range.start));
+            }
+            Event::End(TagEnd::FootnoteDefinition) => {
+                if let Some((open_label, content_start)) = footnote_stack.pop() {
+                    footnote_ranges.push(FootnoteRange {
+                        label: open_label,
+                        content: content_start..range.end,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (manual_note_references, manual_note_labels, footnote_ranges)
+}
+
+/// Determine the citation placement given the byte range of a citation
+/// and the set of footnote definition ranges in the document.
+fn footnote_placement(start: usize, end: usize, ranges: &[FootnoteRange]) -> CitationPlacement {
+    ranges
+        .iter()
+        .find(|fr| fr.content.start <= start && end <= fr.content.end)
+        .map_or(CitationPlacement::InlineProse, |fr| {
+            CitationPlacement::ManualFootnote {
+                label: fr.label.clone(),
+            }
+        })
 }
 
 #[allow(
@@ -512,5 +621,89 @@ mod tests {
             output.contains("<em>italic</em>"),
             "expected <em>italic</em> in: {output}"
         );
+    }
+
+    #[test]
+    fn given_markdown_pipe_table_when_finalize_html_output_then_table_element_emitted() {
+        let parser = MarkdownParser;
+        let input = "| A | B |\n|---|---|\n| 1 | 2 |";
+        let output = parser.finalize_html_output(input);
+        assert!(
+            output.contains("<table>"),
+            "pipe table should render as <table>: {output}"
+        );
+    }
+
+    #[test]
+    fn given_markdown_footnote_def_when_finalize_html_output_then_footnote_rendered() {
+        let parser = MarkdownParser;
+        let input = "Text[^1].\n\n[^1]: A note.";
+        let output = parser.finalize_html_output(input);
+        assert!(
+            output.contains("footnote") || output.contains("fn1"),
+            "footnote definition should produce HTML footnote markup: {output}"
+        );
+    }
+
+    #[test]
+    fn given_citation_inside_footnote_def_when_parse_document_then_placement_is_manual_footnote() {
+        let parser = MarkdownParser;
+        // The citation [@kuhn1962] appears inside a footnote definition, not in prose.
+        let doc = "See note[^1].\n\n[^1]: See [@kuhn1962].";
+        let parsed = parser.parse_document(doc, &Locale::en_us());
+
+        assert_eq!(parsed.citations.len(), 1, "one citation expected");
+        assert!(
+            matches!(
+                parsed.citations[0].placement,
+                CitationPlacement::ManualFootnote { .. }
+            ),
+            "citation inside [^n]: block should be ManualFootnote, got: {:?}",
+            parsed.citations[0].placement
+        );
+        assert!(
+            parsed.manual_note_labels.contains("1"),
+            "footnote label '1' should be tracked: {:?}",
+            parsed.manual_note_labels
+        );
+        assert_eq!(parsed.manual_note_order, vec!["1".to_string()]);
+    }
+
+    #[test]
+    fn given_citation_in_prose_when_parse_document_then_placement_is_inline_prose() {
+        let parser = MarkdownParser;
+        let doc = "As shown by [@kuhn1962], the method works.\n\n[^1]: Unrelated note.";
+        let parsed = parser.parse_document(doc, &Locale::en_us());
+
+        assert_eq!(parsed.citations.len(), 1);
+        assert!(
+            matches!(
+                parsed.citations[0].placement,
+                CitationPlacement::InlineProse
+            ),
+            "prose citation should be InlineProse: {:?}",
+            parsed.citations[0].placement
+        );
+    }
+
+    #[test]
+    fn given_multiple_footnotes_when_parse_document_then_note_order_is_first_reference_order() {
+        let parser = MarkdownParser;
+        let doc = "First[^b] then[^a].\n\n[^a]: [@kuhn1962].\n\n[^b]: [@smith2010].";
+        let parsed = parser.parse_document(doc, &Locale::en_us());
+
+        // Note order follows the order references appear in prose, not definition order.
+        assert_eq!(
+            parsed.manual_note_order,
+            vec!["b".to_string(), "a".to_string()]
+        );
+        assert_eq!(parsed.citations.len(), 2);
+        for c in &parsed.citations {
+            assert!(
+                matches!(c.placement, CitationPlacement::ManualFootnote { .. }),
+                "both citations are inside footnote definitions: {:?}",
+                c.placement
+            );
+        }
     }
 }

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -454,14 +454,15 @@ impl Renderer<'_> {
         let mut group_delimiter: Option<String> = None;
         for (index, item) in group.iter().enumerate() {
             let state = self.resolve_item_render_state(item, params.spec)?;
-            let (filtered_template, leading_affix) = filter_author_from_template(&state.template);
+            let (filtered_template, leading_affix, strip_item_delimiter) =
+                filter_author_from_template(&state.template);
             if group_delimiter.is_none() {
                 group_delimiter = leading_affix
                     .as_ref()
                     .filter(|value| !value.is_empty())
                     .cloned();
             }
-            let item_delimiter = if leading_affix.is_some() {
+            let item_delimiter = if strip_item_delimiter {
                 ""
             } else {
                 params.intra_delimiter
@@ -1193,12 +1194,44 @@ pub(super) fn template_uses_first_ref_note_number(template: &[TemplateComponent]
 
 pub(super) fn filter_author_from_template(
     template: &[TemplateComponent],
-) -> (Vec<TemplateComponent>, Option<String>) {
+) -> (Vec<TemplateComponent>, Option<String>, bool) {
     let mut filtered: Vec<TemplateComponent> =
         template.iter().filter_map(strip_author_component).collect();
-    let leading_affix = filtered.first().and_then(leading_group_affix);
+    let stripped_leading_affix = filtered.first().and_then(leading_group_affix);
+    let leading_affix = stripped_leading_affix.clone().or_else(|| {
+        filtered
+            .first()
+            .and_then(|_| template.first().and_then(author_group_delimiter_affix))
+    });
     if let Some(first) = filtered.first_mut() {
         strip_leading_group_affixes(first);
     }
-    (filtered, leading_affix)
+    (filtered, leading_affix, stripped_leading_affix.is_some())
+}
+
+fn author_group_delimiter_affix(component: &TemplateComponent) -> Option<String> {
+    let TemplateComponent::Group(group) = component else {
+        return None;
+    };
+    group
+        .group
+        .first()
+        .is_some_and(component_starts_with_author)
+        .then_some(group.delimiter.as_ref())
+        .flatten()
+        .map(citum_schema::template::DelimiterPunctuation::to_string_with_space)
+        .filter(|delimiter| !delimiter.is_empty())
+}
+
+fn component_starts_with_author(component: &TemplateComponent) -> bool {
+    match component {
+        TemplateComponent::Contributor(contributor) => {
+            contributor.contributor == citum_schema::template::ContributorRole::Author
+        }
+        TemplateComponent::Group(group) => group
+            .group
+            .first()
+            .is_some_and(component_starts_with_author),
+        _ => false,
+    }
 }

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -8,8 +8,8 @@ use crate::Processor;
 use crate::processor::rendering::grouped::group_citation_items_by_author;
 use citum_schema::citation::{Citation, CitationItem, CitationMode, IntegralNameState};
 use citum_schema::options::{
-    Config, IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, Processing,
-    SubsequentNameForm,
+    Config, IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, LocatorPreset,
+    Processing, SubsequentNameForm,
 };
 use citum_schema::template::*;
 use citum_schema::{CitationSpec, Style, StyleInfo};
@@ -64,6 +64,102 @@ fn grouped_author_date_style() -> Style {
                 }),
             ]),
             wrap: Some(WrapPunctuation::Parentheses.into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn explicit_author_year_group_style() -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("Explicit Author Year Group".to_string()),
+            id: Some("explicit-author-year-group".into()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            processing: Some(Processing::AuthorDate),
+            locators: Some(LocatorPreset::Note.config()),
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            template: Some(vec![
+                TemplateComponent::Group(TemplateGroup {
+                    group: vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author,
+                            form: ContributorForm::Short,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: citum_schema::template::DateVariable::Issued,
+                            form: DateForm::Year,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                    ],
+                    delimiter: Some(DelimiterPunctuation::Space),
+                    rendering: Rendering::default(),
+                    custom: None,
+                }),
+                TemplateComponent::Variable(TemplateVariable {
+                    variable: SimpleVariable::Locator,
+                    rendering: Rendering {
+                        prefix: Some(", ".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+            ]),
+            wrap: Some(WrapPunctuation::Parentheses.into()),
+            delimiter: Some("".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn explicit_author_year_group_with_locator_delimiter_style() -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("Explicit Author Year Group With Locator Delimiter".to_string()),
+            id: Some("explicit-author-year-group-with-locator-delimiter".into()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            processing: Some(Processing::AuthorDate),
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            template: Some(vec![
+                TemplateComponent::Group(TemplateGroup {
+                    group: vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author,
+                            form: ContributorForm::Short,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: citum_schema::template::DateVariable::Issued,
+                            form: DateForm::Year,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                    ],
+                    delimiter: Some(DelimiterPunctuation::Space),
+                    rendering: Rendering::default(),
+                    custom: None,
+                }),
+                TemplateComponent::Variable(TemplateVariable {
+                    variable: SimpleVariable::Locator,
+                    rendering: Rendering::default(),
+                    ..Default::default()
+                }),
+            ]),
+            wrap: Some(WrapPunctuation::Parentheses.into()),
+            delimiter: Some(", ".to_string()),
             ..Default::default()
         }),
         ..Default::default()
@@ -411,6 +507,69 @@ fn grouped_author_date_preserves_later_item_prefixes() {
             .process_citation(&citation)
             .expect("grouped citation should preserve later item prefixes"),
         "(Kuhn, 1962, see 1963)"
+    );
+}
+
+#[test]
+fn explicit_author_year_group_uses_group_delimiter_after_author_strip() {
+    let mut bibliography = Bibliography::new();
+    bibliography.insert(
+        "item1".to_string(),
+        make_reference("item1", "book", Some(("Kuhn", "Thomas")), 1962, "Book A"),
+    );
+    let processor = Processor::new(explicit_author_year_group_style(), bibliography);
+
+    let citation = Citation {
+        items: vec![CitationItem {
+            id: "item1".to_string(),
+            locator: Some(citum_schema::citation::CitationLocator::single(
+                citum_schema::citation::LocatorType::Page,
+                "5",
+            )),
+            ..Default::default()
+        }],
+        mode: CitationMode::NonIntegral,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        processor
+            .process_citation(&citation)
+            .expect("explicit author-year group should render"),
+        "(Kuhn 1962, 5)"
+    );
+}
+
+#[test]
+fn explicit_author_year_group_keeps_tail_delimiter_for_locator() {
+    let mut bibliography = Bibliography::new();
+    bibliography.insert(
+        "item1".to_string(),
+        make_reference("item1", "book", Some(("Kuhn", "Thomas")), 1962, "Book A"),
+    );
+    let processor = Processor::new(
+        explicit_author_year_group_with_locator_delimiter_style(),
+        bibliography,
+    );
+
+    let citation = Citation {
+        items: vec![CitationItem {
+            id: "item1".to_string(),
+            locator: Some(citum_schema::citation::CitationLocator::single(
+                citum_schema::citation::LocatorType::Page,
+                "5",
+            )),
+            ..Default::default()
+        }],
+        mode: CitationMode::NonIntegral,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        processor
+            .process_citation(&citation)
+            .expect("explicit author-year group should render locator"),
+        "(Kuhn 1962, p. 5)"
     );
 }
 

--- a/crates/citum-engine/src/render/markdown.rs
+++ b/crates/citum-engine/src/render/markdown.rs
@@ -1,0 +1,261 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! CommonMark (Markdown) output format.
+//!
+//! This renderer is designed for **Pandoc interop**: citum processes citations
+//! inline (replacing `[@key]` markers with rendered text) and emits the document
+//! body verbatim, so the output can be piped directly to `pandoc` or any other
+//! CommonMark-aware formatter. Only citation and bibliography strings are
+//! rendered in CommonMark markup; block-level document markup passes through
+//! unchanged.
+//!
+//! # Note styles
+//!
+//! Note-based styles (Chicago notes, etc.) emit `[^label]` anchors in prose and
+//! `[^label]: …` footnote definitions at the end of the document. These follow
+//! the Pandoc/GFM footnote extension — **not** core CommonMark. Downstream
+//! consumers must enable the extension:
+//! `pandoc --from commonmark+footnotes` (or `--from gfm`).
+
+use super::format::OutputFormat;
+use citum_schema::template::WrapPunctuation;
+
+/// Escape CommonMark-active characters in raw bibliography data text.
+///
+/// Backslash-escapes `\`, `*`, `_`, `[`, `]`, `` ` ``, `<`, `>`, and `&`
+/// so that data fields (titles, author names, etc.) cannot accidentally
+/// activate emphasis, strong, link, code-span, autolink, inline HTML, or
+/// HTML-entity syntax. Style-applied markup (`emph`, `strong`, `link`)
+/// wraps already-escaped text, so intentional markup is unaffected.
+fn escape_commonmark_text(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for ch in s.chars() {
+        match ch {
+            '\\' | '*' | '_' | '[' | ']' | '`' | '<' | '>' | '&' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Renders processed citations and bibliography entries as CommonMark markup.
+#[derive(Default, Clone)]
+pub struct Markdown;
+
+impl OutputFormat for Markdown {
+    type Output = String;
+
+    fn text(&self, s: &str) -> Self::Output {
+        escape_commonmark_text(s)
+    }
+
+    fn join(&self, items: Vec<Self::Output>, delimiter: &str) -> Self::Output {
+        items.join(delimiter)
+    }
+
+    fn finish(&self, output: Self::Output) -> String {
+        output
+    }
+
+    /// Render emphasis as `*content*` (CommonMark italic).
+    fn emph(&self, content: Self::Output) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("*{content}*")
+    }
+
+    /// Render strong emphasis as `**content**` (CommonMark bold).
+    fn strong(&self, content: Self::Output) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("**{content}**")
+    }
+
+    /// Render small caps as raw inline HTML.
+    ///
+    /// CommonMark has no native small-caps syntax. Raw `<span>` HTML is passed
+    /// through by Pandoc's CommonMark reader and most other processors.
+    fn small_caps(&self, content: Self::Output) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("<span style=\"font-variant:small-caps\">{content}</span>")
+    }
+
+    /// Render superscript as raw inline HTML.
+    ///
+    /// CommonMark has no native superscript syntax. Raw `<sup>` HTML is passed
+    /// through by Pandoc and most processors.
+    fn superscript(&self, content: Self::Output) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("<sup>{content}</sup>")
+    }
+
+    fn quote(&self, content: Self::Output) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("\u{201C}{content}\u{201D}")
+    }
+
+    fn affix(&self, prefix: &str, content: Self::Output, suffix: &str) -> Self::Output {
+        format!("{prefix}{content}{suffix}")
+    }
+
+    fn inner_affix(&self, prefix: &str, content: Self::Output, suffix: &str) -> Self::Output {
+        format!("{prefix}{content}{suffix}")
+    }
+
+    fn wrap_punctuation(&self, wrap: &WrapPunctuation, content: Self::Output) -> Self::Output {
+        match wrap {
+            WrapPunctuation::Parentheses => format!("({content})"),
+            WrapPunctuation::Brackets => format!("[{content}]"),
+            WrapPunctuation::Quotes => format!("\u{201C}{content}\u{201D}"),
+        }
+    }
+
+    /// Render a semantic class as a plain passthrough.
+    ///
+    /// CommonMark has no attribute syntax. Content is returned unchanged so
+    /// citations remain readable plain text. Use `--format html` or `--format djot`
+    /// if machine-readable semantic spans are needed.
+    fn semantic(&self, _class: &str, content: Self::Output) -> Self::Output {
+        content
+    }
+
+    fn annotation(&self, content: Self::Output) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("\n\n{content}")
+    }
+
+    fn link(&self, url: &str, content: Self::Output) -> Self::Output {
+        if content.is_empty() {
+            return content;
+        }
+        format!("[{content}]({url})")
+    }
+
+    fn entry(
+        &self,
+        _id: &str,
+        content: Self::Output,
+        url: Option<&str>,
+        _metadata: &super::format::ProcEntryMetadata,
+    ) -> Self::Output {
+        if let Some(u) = url {
+            self.link(u, content)
+        } else {
+            content
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_markdown_emph() {
+        let fmt = Markdown;
+        for (input, expected) in [("", ""), ("text", "*text*")] {
+            assert_eq!(fmt.emph(input.to_string()), expected);
+        }
+    }
+
+    #[test]
+    fn test_markdown_strong() {
+        let fmt = Markdown;
+        for (input, expected) in [("", ""), ("text", "**text**")] {
+            assert_eq!(fmt.strong(input.to_string()), expected);
+        }
+    }
+
+    #[test]
+    fn test_markdown_small_caps() {
+        let fmt = Markdown;
+        assert_eq!(fmt.small_caps(String::new()), "");
+        assert_eq!(
+            fmt.small_caps("Smith".to_string()),
+            "<span style=\"font-variant:small-caps\">Smith</span>"
+        );
+    }
+
+    #[test]
+    fn test_markdown_superscript() {
+        let fmt = Markdown;
+        assert_eq!(fmt.superscript(String::new()), "");
+        assert_eq!(fmt.superscript("2".to_string()), "<sup>2</sup>");
+    }
+
+    #[test]
+    fn test_markdown_quote() {
+        let fmt = Markdown;
+        for (input, expected) in [("", ""), ("text", "\u{201C}text\u{201D}")] {
+            assert_eq!(fmt.quote(input.to_string()), expected);
+        }
+    }
+
+    #[test]
+    fn test_markdown_semantic_passthrough() {
+        let fmt = Markdown;
+        assert_eq!(fmt.semantic("author", "Jane Doe".to_string()), "Jane Doe");
+        assert_eq!(fmt.semantic("title", String::new()), "");
+    }
+
+    #[test]
+    fn test_markdown_link() {
+        let fmt = Markdown;
+        assert_eq!(fmt.link("https://example.com", String::new()), "");
+        assert_eq!(
+            fmt.link("https://example.com", "Example".to_string()),
+            "[Example](https://example.com)"
+        );
+    }
+
+    #[test]
+    fn test_markdown_wrap_punctuation() {
+        let fmt = Markdown;
+        for (wrap, input, expected) in [
+            (WrapPunctuation::Parentheses, "text", "(text)"),
+            (WrapPunctuation::Brackets, "text", "[text]"),
+            (WrapPunctuation::Quotes, "text", "\u{201C}text\u{201D}"),
+        ] {
+            assert_eq!(fmt.wrap_punctuation(&wrap, input.to_string()), expected);
+        }
+    }
+
+    #[test]
+    fn test_markdown_text_escapes_active_chars() {
+        let fmt = Markdown;
+        assert_eq!(fmt.text("plain"), "plain");
+        assert_eq!(fmt.text("A * B"), "A \\* B");
+        assert_eq!(fmt.text("use [x]"), "use \\[x\\]");
+        assert_eq!(fmt.text("code `foo`"), "code \\`foo\\`");
+        assert_eq!(fmt.text("back\\slash"), "back\\\\slash");
+        assert_eq!(fmt.text("under_score"), "under\\_score");
+        // Angle brackets and ampersand: escape to prevent autolinks,
+        // inline HTML, and HTML entity expansion.
+        assert_eq!(fmt.text("<doi:10.1/x>"), "\\<doi:10.1/x\\>");
+        assert_eq!(fmt.text("Smith & Jones"), "Smith \\& Jones");
+        assert_eq!(fmt.text("<em>bold</em>"), "\\<em\\>bold\\</em\\>");
+    }
+}

--- a/crates/citum-engine/src/render/mod.rs
+++ b/crates/citum-engine/src/render/mod.rs
@@ -11,7 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //!
 //! ## Modules
 //! - `format`: Defines the core [`crate::render::format::OutputFormat`] trait.
-//! - `plain`, `html`, `djot`, `latex`, `typst`: Concrete renderer implementations.
+//! - `plain`, `html`, `djot`, `markdown`, `latex`, `typst`: Concrete renderer implementations.
 //! - `component`: Logic for rendering individual template components.
 //! - `citation`: Logic for joining components into full citations.
 //! - `bibliography`: Logic for rendering bibliographies.
@@ -26,6 +26,7 @@ pub mod djot;
 pub mod format;
 pub mod html;
 pub mod latex;
+pub mod markdown;
 pub(crate) mod markup;
 pub mod org;
 pub mod plain;

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -746,6 +746,44 @@ fn given_markdown_integral_note_citation_when_rendered_with_a_note_style_then_a_
     );
 }
 
+fn given_markdown_citation_inside_manual_footnote_when_rendered_with_note_style_then_it_renders_in_place()
+ {
+    // When the user writes their own [^n]: block containing a citation,
+    // the citation should render inline inside that definition (ManualFootnote
+    // placement) rather than generating a second auto-footnote.
+    let processor =
+        example_document_processor("styles/embedded/chicago-shortened-notes-bibliography.yaml");
+    let parser = MarkdownParser;
+    let document = "See note[^1].\n\n[^1]: Early work [@kuhn1962] supports this.";
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        document,
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    // The manual footnote anchor must appear in prose.
+    assert!(
+        output.contains("[^1]"),
+        "manual footnote reference should appear in prose: {output}"
+    );
+    // The rendered citation should appear inside the footnote definition, not
+    // as a separate auto-generated note.
+    assert!(
+        output.contains("[^1]: Early work"),
+        "footnote definition body should be preserved: {output}"
+    );
+    assert!(
+        output.contains("Kuhn") || output.contains("Structure"),
+        "citation inside manual footnote should be rendered in place: {output}"
+    );
+    // No auto-generated note should be created for this citation.
+    assert!(
+        !output.contains("[^citum-auto-"),
+        "no auto-footnote should be generated for a ManualFootnote citation: {output}"
+    );
+}
+
 // --- Grouped Bibliography Scenarios ---
 
 fn given_grouped_primary_and_secondary_sources_when_rendered_then_both_group_headings_and_entries_appear()

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -1207,6 +1207,85 @@ mod markdown_documents {
         );
         super::given_markdown_integral_note_citation_when_rendered_with_a_note_style_then_a_generated_note_is_emitted();
     }
+
+    #[test]
+    fn markdown_output_passes_pipe_table_and_code_block_through_verbatim() {
+        announce_behavior(
+            "Markdown output format must pass block-level markup (pipe tables, fenced code blocks) through verbatim while replacing citation markers with rendered inline text.",
+        );
+        super::given_markdown_document_with_pipe_table_when_rendered_as_markdown_then_body_passes_through_verbatim();
+    }
+
+    #[test]
+    fn note_style_markdown_output_emits_commonmark_footnote_syntax() {
+        announce_behavior(
+            "A note-style document rendered as Markdown output should emit [^n] anchors in prose and [^n]: … definitions, following the CommonMark+footnotes extension used by Pandoc and GFM.",
+        );
+        super::given_note_style_markdown_document_when_rendered_as_markdown_then_commonmark_footnote_syntax_is_emitted();
+    }
+
+    #[test]
+    fn citation_inside_manual_footnote_renders_in_place_not_as_auto_note() {
+        announce_behavior(
+            "A citation found inside a user-authored [^n]: footnote definition should render inline within that definition rather than generating a separate auto-footnote.",
+        );
+        super::given_markdown_citation_inside_manual_footnote_when_rendered_with_note_style_then_it_renders_in_place();
+    }
+
+    #[test]
+    fn chicago_author_date_markdown_citation_has_no_spurious_space() {
+        announce_behavior(
+            "Chicago author-date Markdown citation with locator renders as '(Kuhn 1962, 5)'.",
+        );
+        super::given_chicago_author_date_markdown_citation_when_rendered_then_no_spurious_space_before_locator();
+    }
+
+    #[test]
+    fn chicago_author_date_suppressed_citation_has_no_spurious_space() {
+        announce_behavior(
+            "Suppress-author Chicago author-date Markdown citation with locator renders as '(1962, 5)'.",
+        );
+        super::given_chicago_author_date_markdown_suppressed_citation_when_rendered_then_no_spurious_space();
+    }
+}
+
+// --- Chicago author-date Markdown rendering (#844) ---
+
+fn given_chicago_author_date_markdown_citation_when_rendered_then_no_spurious_space_before_locator()
+{
+    let processor = example_document_processor("styles/embedded/chicago-author-date-18th.yaml");
+    let parser = MarkdownParser;
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        "See [@kuhn1962, p. 5].",
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    // Chicago author-date should render "(Kuhn 1962, 5)" — author, year, locator, no
+    // spurious space before the comma.
+    assert!(
+        output.contains("(Kuhn 1962, 5)"),
+        "expected '(Kuhn 1962, 5)' in parenthetical citation: {output}"
+    );
+}
+
+fn given_chicago_author_date_markdown_suppressed_citation_when_rendered_then_no_spurious_space() {
+    let processor = example_document_processor("styles/embedded/chicago-author-date-18th.yaml");
+    let parser = MarkdownParser;
+
+    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
+        "See [-@kuhn1962, p. 5].",
+        &parser,
+        DocumentFormat::Plain,
+    );
+
+    // Suppress-author form should render "(1962, 5)" — year + locator, no author, no
+    // spurious space before the comma.
+    assert!(
+        output.contains("(1962, 5)"),
+        "expected '(1962, 5)' in suppress-author citation: {output}"
+    );
 }
 
 // --- Djot Adapter & Pipeline Tests ---

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -1055,6 +1055,102 @@ mod note_flow {
     }
 }
 
+fn given_markdown_document_with_pipe_table_when_rendered_as_markdown_then_body_passes_through_verbatim()
+ {
+    // A GFM pipe table, a fenced code block, and a citation in prose — body
+    // markup must survive verbatim; only the [@key] marker is replaced.
+    let processor = example_document_processor("styles/embedded/apa-7th.yaml");
+    let parser = MarkdownParser;
+    let pipe_table = "| Column A | Column B |\n|----------|----------|\n| cell 1   | cell 2   |";
+    let code_block = "```rust\nfn hello() {}\n```";
+    let document =
+        format!("# Introduction\n\nAs argued in [@kuhn1962].\n\n{pipe_table}\n\n{code_block}\n");
+
+    let output = processor.process_document::<_, citum_engine::render::markdown::Markdown>(
+        &document,
+        &parser,
+        DocumentFormat::Markdown,
+    );
+
+    // Pipe table lines must be unchanged.
+    assert!(
+        output.contains("| Column A | Column B |"),
+        "pipe table header missing: {output}"
+    );
+    assert!(
+        output.contains("|----------|----------|"),
+        "pipe table separator missing: {output}"
+    );
+    assert!(
+        output.contains("| cell 1   | cell 2   |"),
+        "pipe table row missing: {output}"
+    );
+
+    // Fenced code block must be unchanged.
+    assert!(
+        output.contains("```rust\nfn hello() {}\n```"),
+        "fenced code block missing or modified: {output}"
+    );
+
+    // Citation marker replaced with rendered inline text.
+    assert!(
+        !output.contains("[@kuhn1962]"),
+        "raw citation marker should be replaced: {output}"
+    );
+    assert!(
+        output.contains("As argued in (Kuhn, 1962)."),
+        "rendered citation should replace the marker with the full APA cite: {output}"
+    );
+
+    // Bibliography heading present.
+    assert!(
+        output.contains("# Bibliography"),
+        "bibliography heading missing: {output}"
+    );
+}
+
+fn given_note_style_markdown_document_when_rendered_as_markdown_then_commonmark_footnote_syntax_is_emitted()
+ {
+    // Note styles emit [^label] anchors in prose and [^label]: … definitions
+    // at the end — the CommonMark+footnotes extension used by Pandoc/GFM.
+    let processor =
+        example_document_processor("styles/embedded/chicago-shortened-notes-bibliography.yaml");
+    let parser = MarkdownParser;
+    let document = "First claim [@kuhn1962]. Second claim [@smith2010].";
+
+    let output = processor.process_document::<_, citum_engine::render::markdown::Markdown>(
+        document,
+        &parser,
+        DocumentFormat::Markdown,
+    );
+
+    // Footnote anchors in prose.
+    assert!(
+        output.contains("[^citum-auto-1]"),
+        "first footnote anchor missing: {output}"
+    );
+    assert!(
+        output.contains("[^citum-auto-2]"),
+        "second footnote anchor missing: {output}"
+    );
+
+    // Footnote definitions with rendered content (CommonMark emphasis).
+    assert!(
+        output.contains("[^citum-auto-1]:"),
+        "first footnote definition missing: {output}"
+    );
+    assert!(
+        output.contains("[^citum-auto-2]:"),
+        "second footnote definition missing: {output}"
+    );
+
+    // No raw citation markers remain.
+    assert!(
+        !output.contains("[@kuhn1962]") && !output.contains("[@smith2010]"),
+        "raw citation markers should be replaced: {output}"
+    );
+}
+
 mod markdown_documents {
     use super::announce_behavior;
 

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -96,19 +96,21 @@ citation:
     - variable: locator
       prefix: ", "
   template:
-  - contributor: author
-    form: short
-    shorten:
-      min: 3
-      use-first: 1
-      and-others: et-al
-  - date: issued
-    form: year
+  - group:
+    - contributor: author
+      form: short
+      shorten:
+        min: 3
+        use-first: 1
+        and-others: et-al
+    - date: issued
+      form: year
+    delimiter: " "
   - variable: locator
     prefix: ", "
   wrap:
     punctuation: parentheses
-  delimiter: " "
+  delimiter: none
   multi-cite-delimiter: "; "
 bibliography:
   options:

--- a/docs/specs/PANDOC_MARKDOWN_CITATIONS.md
+++ b/docs/specs/PANDOC_MARKDOWN_CITATIONS.md
@@ -1,8 +1,8 @@
 # Pandoc Markdown Citations Specification
 
 **Status:** Completed
-**Version:** 1.1
-**Date:** 2026-03-16
+**Version:** 1.2
+**Date:** 2026-05-30
 **Supersedes:** None
 **Related:** `crates/citum-cli/src/main.rs`, `crates/citum-engine/src/processor/document/README.md`
 
@@ -69,10 +69,71 @@ the Markdown parser itself where syntax normalization is non-obvious.
 - [x] Existing Djot document behavior remains unchanged
 - [x] Tests cover the new Markdown citation path
 
+## Passthrough Output Formats and Pandoc Interop
+
+Citum's document pipeline has two distinct classes of output format:
+
+**Converted formats** (`html`, `typst`, `latex`) — citations are spliced in,
+then a second pass converts surrounding block markup to the target format
+(jotdown for Djot→HTML, `render_body_markup` for Djot/Markdown→Typst/LaTeX).
+
+**Passthrough formats** (`plain`, `djot`, `markdown`) — citations are rendered
+and spliced in, but block-level document markup is **emitted verbatim**. The
+output is ready to pipe to any downstream formatter.
+
+### Pandoc interop workflow
+
+The correct direction is always **citum → pandoc**: Citum processes citations
+first, replacing `[@key]` markers with rendered text, then Pandoc receives the
+output and handles block-level formatting and final output conversion.
+
+```bash
+citum render doc input.md --input-format markdown --format markdown \
+  -s apa -b refs.yaml | pandoc --to html
+```
+
+Omitting `--from` lets Pandoc use its native Markdown reader, which handles
+pipe tables, fenced code blocks, and footnote syntax (`[^n]`) — all of which
+citum passes through verbatim. Do not use `--from commonmark`: bare CommonMark
+cannot parse pipe tables or `[^n]` footnotes.
+
+**Do not pre-process with `pandoc --to commonmark`** if the document contains
+Citum citation markers. Pandoc escapes `[` when converting to CommonMark
+(`[@key]` → `\[@key\]`), which Citum's Markdown parser cannot recognise.
+Citations would silently go unrendered (verified with pandoc 3.9.0.2).
+
+### Supported CommonMark surface
+
+Citum supports **CommonMark + GFM extensions** (pipe tables, strikethrough).
+Pandoc-only block syntax (grid tables, definition lists, etc.) is **not**
+handled — documents using such syntax must avoid mixing it with Citum citation
+markers, or convert the block syntax separately by a tool that preserves
+`[@key]` verbatim.
+
+### Note styles and footnote syntax
+
+Note-based styles emit `[^label]` anchors in prose and `[^label]: …`
+definitions at the document end — the Pandoc/GFM footnote extension, not core
+CommonMark. Use `--from gfm+footnotes` or `--from markdown` downstream:
+
+```bash
+citum render doc input.md --input-format markdown --format markdown \
+  -s chicago-notes -b refs.yaml | pandoc --to html
+```
+
+`--format djot` is unaffected — Djot supports footnotes natively.
+
 ## Changelog
 - v1.0 (2026-03-09): Initial version.
 - v1.1 (2026-03-16): All criteria met. `BibliographyBlock` moved to shared
   `types.rs`; `CitationParser::finalize_html_output` default changed to
   pass-through; `DocumentFormat::Markdown` variant added; engine README
   restructured to distinguish document input, output, and field markup concerns.
-
+- v1.2 (2026-05-30): Added `OutputFormat::Markdown` CLI variant and
+  `render::markdown::Markdown` renderer, making `--format markdown` reachable.
+  Documented passthrough vs. converted output formats, Pandoc interop workflow,
+  and footnote-extension caveat for note-based styles. Grid-table preprocessor
+  (PR #846) reverted — Pandoc-only syntax is Pandoc's responsibility. Corrected
+  workflow direction to `citum → pandoc` (primary); removed `pandoc → citum`
+  pre-processing chain (Pandoc escapes `[@key]` to `\[@key\]`, breaking citation
+  parsing). Added `text()` escaping for CommonMark-active punctuation.


### PR DESCRIPTION
## Summary

Closes #844. Supersedes the reverted grid-table preprocessor approach from PR #846.

This PR adds Markdown output as a first-class render target and keeps the supported interop direction explicit: `citum -> pandoc`. Citum processes citation markers and emits Markdown with citation/bibliography text rendered in CommonMark-compatible inline markup, while body-level Markdown is passed through for Pandoc or another downstream Markdown consumer.

It also fixes the Chicago author-date locator regression with the preferred declarative style shape: author and year live in an explicit grouped template with a space delimiter, while the locator owns its comma prefix. The engine now preserves that group delimiter when suppress-author rendering strips the author from the group, instead of relying on a flat year-prefix workaround or a generic spacing heuristic.

## Changes

- Add `--format markdown` support through CLI document/reference rendering.
- Add `render::markdown::Markdown` with CommonMark inline rendering for emphasis, strong, small caps, superscript, quotes, links, and semantic passthrough.
- Escape Markdown-active raw data text, including `*`, `_`, `[`, `]`, backticks, `<`, `>`, and `&`, so bibliography fields do not accidentally become markup or entities downstream.
- Preserve Markdown body blocks verbatim for passthrough output, including pipe tables, fenced code blocks, headings, and footnote syntax.
- Parse Markdown input footnote definitions with `ENABLE_FOOTNOTES`, so citations inside user-authored footnotes render in place as `ManualFootnote` rather than generating duplicate auto-footnotes.
- Enable HTML finalization support for Markdown pipe tables and footnotes.
- Fix grouped author-date citation rendering when author suppression removes the leading grouped child but the remaining year still needs the group delimiter boundary.
- Update Chicago author-date 18th citation layout to use an explicit author/year group and separate locator punctuation.
- Update the Pandoc workflow docs, including the note-style `--input-format markdown` example.

## Pandoc workflow

```bash
citum render doc input.md --input-format markdown --format markdown \
  -s apa -b refs.yaml | pandoc --to html
```

Do not pre-process citation-bearing Markdown with `pandoc --to commonmark`; Pandoc escapes citation marker brackets during that conversion, so Citum can no longer recognize `[@key]` markers.

## Test plan

- [x] Markdown renderer unit tests for inline formatting and text escaping, including `*`, `_`, `[`, `]`, backticks, `<`, `>`, and `&`.
- [x] Markdown parser unit tests for manual footnote citation placement, note order tracking, and multiple footnotes.
- [x] HTML finalization tests for Markdown pipe tables and footnotes.
- [x] Integration coverage for Markdown passthrough with pipe tables, fenced code blocks, citation replacement, and bibliography generation.
- [x] Integration coverage for Chicago notes Markdown footnotes with no duplicate auto-footnotes.
- [x] Chicago author-date parenthetical and suppress-author locator regression tests.
- [x] Engine regression for explicit author+year grouped template with `delimiter: " "`, proving `Author Year` rather than `AuthorYear`.
- [x] Local full gate: `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run` passed, 1455/1455 tests.
- [x] Pre-push hook gate passed before force-push.
