### PR TITLE
ci: always report actions security checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -7,10 +7,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-    paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
-      - "zizmor.yml"
 
 jobs:
   actionlint:


### PR DESCRIPTION
## Summary

Fix required `actionlint` and `zizmor` checks getting stuck at `Expected — Waiting for status to be reported` on PRs that do not touch workflow files.

The Actions Security workflow was path-filtered at the workflow trigger level. When branch protection expects those job contexts on every PR, GitHub must create the workflow run on every PR; otherwise the required check contexts are never reported.

## Change

- Remove the top-level `pull_request.paths` filter from `.github/workflows/actions-security.yml`.
- Keep the existing `actionlint` and `zizmor` jobs unchanged.

## Test plan

- [x] `git diff --check`
- [ ] PR Actions Security run reports both `actionlint` and `zizmor`
