### PR TITLE
test(engine): harden disambiguation test soundness

### DIFF
--- a/.beans/archive/csl26-ucs3--harden-disambiguation-test-soundness.md
+++ b/.beans/archive/csl26-ucs3--harden-disambiguation-test-soundness.md
@@ -1,11 +1,11 @@
 ---
 # csl26-ucs3
 title: Harden disambiguation test soundness
-status: in-progress
+status: completed
 type: task
 priority: high
 created_at: 2026-05-31T14:11:38Z
-updated_at: 2026-05-31T14:37:29Z
+updated_at: 2026-05-31T14:41:14Z
 ---
 
 Fix 1 broken + 5 suspicious disambiguation tests, add 2 coverage-gap tests (§4 multilingual key, §2 givenname rule), persist JSON analysis as audit doc, scaffold global skill. Ref docs/specs/DISAMBIGUATION.md.
@@ -18,5 +18,9 @@ Fix 1 broken + 5 suspicious disambiguation tests, add 2 coverage-gap tests (§4 
 - [x] New: §2 positive given-name expansion test (by-cite/all-names rule not in schema; positive collision case covered)
 - [x] Audit doc docs/architecture/audits/2026-05-31_DISAMBIGUATION_TEST_SOUNDNESS.md
 - [x] Pre-commit gate green
-- [ ] Open PR
-- [ ] Scaffold global skill (skill-creator)
+- [x] Open PR (#850)
+- [x] Scaffold global skill (skill-creator) → ~/.claude/skills/test-soundness-review/
+
+## Summary of Changes
+
+Fixed 1 broken test (exact assert_eq! replacing substring checks), renamed/realigned 5 suspicious tests, strengthened the group-local suffix restart assertion in document.rs, added 3 new tests (positive given-name expansion, givenname cascade fallback, multilingual original-name collision). Wrote audit doc to docs/architecture/audits/2026-05-31_DISAMBIGUATION_TEST_SOUNDNESS.md. Corrected DISAMBIGUATION.md §4 acceptance criterion from [x] to [ ] — render_name_for_disambiguation is unimplemented. Scaffolded global skill at ~/.claude/skills/test-soundness-review/. PR #850 open.

--- a/.beans/csl26-ucs3--harden-disambiguation-test-soundness.md
+++ b/.beans/csl26-ucs3--harden-disambiguation-test-soundness.md
@@ -1,0 +1,22 @@
+---
+# csl26-ucs3
+title: Harden disambiguation test soundness
+status: in-progress
+type: task
+priority: high
+created_at: 2026-05-31T14:11:38Z
+updated_at: 2026-05-31T14:37:29Z
+---
+
+Fix 1 broken + 5 suspicious disambiguation tests, add 2 coverage-gap tests (§4 multilingual key, §2 givenname rule), persist JSON analysis as audit doc, scaffold global skill. Ref docs/specs/DISAMBIGUATION.md.
+
+- [x] Branch fix/disambiguation-test-soundness
+- [x] Fix broken: subsequent_et_al_thresholds exact assertions
+- [x] Rename/realign suspicious: duplicate_family_names, initials_collide, conditions_expand, et_al_subsequent_form
+- [x] Strengthen: group-local suffix restart assertions (document.rs:822)
+- [x] New: §4 multilingual-key collision test (original-name form; transliteration path noted as unimplemented)
+- [x] New: §2 positive given-name expansion test (by-cite/all-names rule not in schema; positive collision case covered)
+- [x] Audit doc docs/architecture/audits/2026-05-31_DISAMBIGUATION_TEST_SOUNDNESS.md
+- [x] Pre-commit gate green
+- [ ] Open PR
+- [ ] Scaffold global skill (skill-creator)

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -342,8 +342,11 @@ fn disambiguation_same_year_articles_increment_suffixes() {
     run_test_case_native(&input, &citation_items, expected, "citation");
 }
 
-/// Test given name expansion for authors with duplicate family names.
-fn disambiguation_duplicate_family_names_expand_given_names_only_where_needed() {
+/// Guard against spurious given-name expansion: when all family-name collisions
+/// are already resolved by different issued years, `add_givenname` must not add
+/// initials or given names. The three Asthma refs differ in year (1885 vs 1980)
+/// so they form distinct collision groups; no given-name expansion is triggered.
+fn disambiguation_no_spurious_givenname_expansion_when_years_differ() {
     let input = vec![
         make_book_multi_author(
             "ITEM-1",
@@ -355,13 +358,39 @@ fn disambiguation_duplicate_family_names_expand_given_names_only_where_needed() 
         make_book("ITEM-3", "Asthma", "Albert", 1885, "Book C"),
     ];
     let citation_items = vec![vec!["ITEM-1", "ITEM-2", "ITEM-3"]];
-    // Sorted by author (Asthma, then Bronchitis) and year (1885, then 1980)
+    // Sorted by author (Asthma, then Bronchitis) and year (1885, then 1980).
+    // No given-name expansion: the 1885 and 1980 Asthma groups are distinct.
     let expected = "Asthma, (1885); Asthma, Asthma, (1980); Bronchitis, (1995)";
 
     run_test_case_native_with_options(common::TestCaseOptions {
         input: &input,
         citation_items: &citation_items,
         expected,
+        mode: "citation",
+        disambiguate_year_suffix: false,
+        disambiguate_names: false,
+        disambiguate_givenname: true,
+        et_al_min: None,
+        et_al_use_first: None,
+    });
+}
+
+/// Positive §2 given-name expansion: two same-year books whose authors share a
+/// family name but have different given names must have initials injected only
+/// for the ambiguous pair; a third non-colliding author stays unexpanded.
+fn disambiguation_givenname_expansion_resolves_same_year_family_name_collision() {
+    let input = vec![
+        make_book("ITEM-A", "Smith", "Alice", 2000, "Book A"),
+        make_book("ITEM-B", "Smith", "Bob", 2000, "Book B"),
+        make_book("ITEM-C", "Jones", "Carol", 2000, "Book C"),
+    ];
+    let citation_items = vec![vec!["ITEM-A", "ITEM-B", "ITEM-C"]];
+
+    run_test_case_native_with_options(common::TestCaseOptions {
+        input: &input,
+        citation_items: &citation_items,
+        // Jones is unambiguous — stays bare. Both Smiths expand to initials.
+        expected: "Jones, (2000); A Smith, (2000); B Smith, (2000)",
         mode: "citation",
         disambiguate_year_suffix: false,
         disambiguate_names: false,
@@ -470,6 +499,30 @@ T Smith, (2000); T Smith, (2000)";
     });
 }
 
+/// When given-name expansion cannot resolve a collision (identical given name and
+/// family name, different works), the cascade must fall through to year-suffix.
+fn disambiguation_year_suffix_fallback_when_givenname_expansion_fails() {
+    let input = vec![
+        make_book("ITEM-4", "Smith", "Ted", 2000, "Book D"),
+        make_book("ITEM-5", "Smith", "Ted", 2000, "Book E"),
+    ];
+    let citation_items = vec![vec!["ITEM-4", "ITEM-5"]];
+
+    run_test_case_native_with_options(common::TestCaseOptions {
+        input: &input,
+        citation_items: &citation_items,
+        // Same author/given-name on both items → no initials injected; year suffixes
+        // are still assigned because the family-name collision group is unresolved.
+        expected: "Smith, (2000a), (2000b)",
+        mode: "citation",
+        disambiguate_year_suffix: true,
+        disambiguate_names: false,
+        disambiguate_givenname: true,
+        et_al_min: None,
+        et_al_use_first: None,
+    });
+}
+
 /// Test subsequent et-al: first cite shows full list; repeat cite applies `subsequent_min/use_first`.
 fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
     use citum_schema::options::{Disambiguation, Processing, ProcessingCustom, ShortenListOptions};
@@ -550,32 +603,23 @@ fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
         .expect("citations should render");
 
     // First cite: all 3 authors visible (no et al.)
-    assert!(
-        results[0].contains("Doe") && results[0].contains("Smith") && results[0].contains("Jones"),
-        "First citation should show all authors, got: {}",
-        results[0]
-    );
-    assert!(
-        !results[0].contains("et al"),
-        "First citation should not use et al., got: {}",
-        results[0]
+    assert_eq!(
+        results[0], "Doe, Smith, Jones, (2020)",
+        "First citation should show all three authors without et al."
     );
 
-    // Subsequent cite: only 1 author + et al. (subsequent_use_first=1)
-    assert!(
-        results[1].contains("et al"),
-        "Subsequent citation should use et al., got: {}",
-        results[1]
-    );
-    assert!(
-        !results[1].contains("Smith") && !results[1].contains("Jones"),
-        "Subsequent citation should hide Smith and Jones, got: {}",
-        results[1]
+    // Subsequent cite: abbreviated to 1 author + et al. (subsequent_use_first=1)
+    assert_eq!(
+        results[1], "Doe et al., (2020)",
+        "Subsequent citation should collapse to one author + et al."
     );
 }
 
-/// Test year suffix + et-al with varying author list lengths.
-fn subsequent_et_al_configuration_uses_the_subsequent_form_on_repeat() {
+/// Year-suffix assignment under et-al truncation: when two distinct multi-author
+/// lists are both collapsed to the same et-al prefix, the collision group still
+/// receives distinct suffixes. Non-citation-order suffix assignment is verified
+/// (2000b before 2000a because title B sorts before title A under the sort key).
+fn disambiguation_year_suffix_assigned_when_et_al_truncation_leaves_collision() {
     let input = vec![
         make_article_multi_author(
             "ITEM-1",
@@ -675,8 +719,9 @@ fn citation_scoped_contributor_shorten_applies_without_component_override() {
     );
 }
 
-/// Test conditional disambiguation with identical author-year pairs.
-fn disambiguation_conditions_expand_only_the_marked_items() {
+/// Two works with identical two-author list and same issued year: both receive
+/// year suffixes (a, b) sorted by title. Complements the single-author cases.
+fn disambiguation_identical_two_author_year_pair_receives_year_suffixes() {
     let input = vec![
         make_book_multi_author(
             "ITEM-1",
@@ -862,6 +907,56 @@ fn sorting_empty_dates_pushes_undated_items_to_the_end() {
     assert_eq!(
         result,
         "BookD 1999; BookB 2000; BookA n.d.; BookC n.d.; BookE n.d."
+    );
+}
+
+// --- Multilingual contributor disambiguation (§4) ---
+
+/// Verifies that `Contributor::Multilingual` entries participate in the
+/// collision-key path. Two refs share the same *original* family name and issued
+/// year → both receive a year suffix.
+///
+/// NOTE: The spec §4 specifies that when a style uses a non-`primary` display
+/// mode (transliteration, translation), the key should be built from the
+/// *displayed* name variant so transliteration-level collisions are caught.
+/// That path (`render_name_for_disambiguation`) is not yet implemented —
+/// `to_names_vec()` always reads `original`. A future test should add two refs
+/// whose originals differ but whose transliterations collide and assert they
+/// also receive year suffixes.
+fn disambiguation_multilingual_contributors_collide_on_original_family_name() {
+    let a = common::make_multilingual_book(common::MultilingualBookParams {
+        id: "ml-a",
+        original_family: "김",
+        original_given: "철수",
+        lang: "ko",
+        translit_script: "Latn",
+        translit_family: "Kim",
+        translit_given: "Cheolsu",
+        year: 2020,
+        title: "Book A",
+    });
+    let b = common::make_multilingual_book(common::MultilingualBookParams {
+        id: "ml-b",
+        original_family: "김",
+        original_given: "영희",
+        lang: "ko",
+        translit_script: "Latn",
+        translit_family: "Kim",
+        translit_given: "Yeonghui",
+        year: 2020,
+        title: "Book B",
+    });
+
+    let input = vec![a, b];
+    let citation_items = vec![vec!["ml-a", "ml-b"]];
+
+    // The collision key uses the original Korean family name "김"; both entries
+    // form one group and receive year suffixes.
+    run_test_case_native(
+        &input,
+        &citation_items,
+        "김, (2020a); 김, (2020b)",
+        "citation",
     );
 }
 
@@ -1596,11 +1691,19 @@ mod disambiguation {
     }
 
     #[test]
-    fn duplicate_family_names_expand_given_names_only_where_needed() {
+    fn no_spurious_givenname_expansion_when_years_differ() {
         announce_behavior(
-            "Family-name collisions should expand given names only for the ambiguous items.",
+            "When same-family-name refs already differ by year, add_givenname must not introduce spurious given-name expansion.",
         );
-        super::disambiguation_duplicate_family_names_expand_given_names_only_where_needed();
+        super::disambiguation_no_spurious_givenname_expansion_when_years_differ();
+    }
+
+    #[test]
+    fn givenname_expansion_resolves_same_year_family_name_collision() {
+        announce_behavior(
+            "Two same-year authors with the same family name but different given names must have initials injected for the ambiguous pair; unrelated authors stay unexpanded.",
+        );
+        super::disambiguation_givenname_expansion_resolves_same_year_family_name_collision();
     }
 
     #[test]
@@ -1628,6 +1731,14 @@ mod disambiguation {
     }
 
     #[test]
+    fn year_suffix_fallback_when_givenname_expansion_fails() {
+        announce_behavior(
+            "When given-name expansion cannot resolve a collision (same given name and family name), year-suffix must be applied as the next cascade step.",
+        );
+        super::disambiguation_year_suffix_fallback_when_givenname_expansion_fails();
+    }
+
+    #[test]
     fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
         announce_behavior(
             "Subsequent-citation et al. thresholds should shorten a repeat citation more aggressively than the first cite.",
@@ -1636,19 +1747,19 @@ mod disambiguation {
     }
 
     #[test]
-    fn subsequent_et_al_configuration_uses_the_subsequent_form_on_repeat() {
+    fn year_suffix_assigned_when_et_al_truncation_leaves_collision() {
         announce_behavior(
-            "Repeat citations should honor the subsequent et al. configuration instead of reusing first-citation name expansion.",
+            "When et-al truncation collapses distinct author lists to the same prefix, the resulting collision group should still receive distinct year suffixes in title sort order.",
         );
-        super::subsequent_et_al_configuration_uses_the_subsequent_form_on_repeat();
+        super::disambiguation_year_suffix_assigned_when_et_al_truncation_leaves_collision();
     }
 
     #[test]
-    fn conditions_expand_only_the_marked_items() {
+    fn identical_two_author_year_pair_receives_year_suffixes() {
         announce_behavior(
-            "Conditional disambiguation should expand only the specifically marked citation items.",
+            "Two works sharing the same two-author list and issued year should each receive a year suffix.",
         );
-        super::disambiguation_conditions_expand_only_the_marked_items();
+        super::disambiguation_identical_two_author_year_pair_receives_year_suffixes();
     }
 
     #[test]
@@ -1657,6 +1768,14 @@ mod disambiguation {
             "Year suffix generation should continue past z without resetting or truncating.",
         );
         super::disambiguation_suffixes_continue_past_z();
+    }
+
+    #[test]
+    fn multilingual_contributors_collide_on_original_family_name() {
+        announce_behavior(
+            "Multilingual contributors with matching original family names and the same issued year must form a collision group and receive year suffixes.",
+        );
+        super::disambiguation_multilingual_contributors_collide_on_original_family_name();
     }
 
     #[test]

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -856,24 +856,33 @@ fn given_group_local_disambiguation_when_rendering_multilingual_groups_then_year
         DocumentFormat::Plain,
     );
 
+    // Split on the known group headings to get per-group bibliography text.
+    let vi_block = output
+        .split("# Vietnamese Sources")
+        .nth(1)
+        .and_then(|s| s.split("# Western Sources").next())
+        .unwrap_or_else(|| panic!("Vietnamese Sources section missing: {output}"));
+    let en_block = output
+        .split("# Western Sources")
+        .nth(1)
+        .unwrap_or_else(|| panic!("Western Sources section missing: {output}"));
+
+    // Each group must have both 2020a and 2020b — suffixes restart at 'a' per group.
     assert!(
-        output.contains("# Vietnamese Sources"),
-        "missing vietnamese heading: {output}"
+        vi_block.contains("2020a") && vi_block.contains("2020b"),
+        "Vietnamese group should have both 2020a and 2020b: {vi_block}"
     );
     assert!(
-        output.contains("# Western Sources"),
-        "missing western heading: {output}"
+        en_block.contains("2020a") && en_block.contains("2020b"),
+        "Western group should have both 2020a and 2020b: {en_block}"
     );
 
-    // With per-group local disambiguation, each group should restart at 2020a.
-    // Count only bibliography output because in-text citations can include extra suffixes.
-    let bibliography_only = output
-        .split("# Bibliography")
-        .nth(1)
-        .unwrap_or_default()
-        .to_string();
-    let count_2020a = bibliography_only.matches("2020a").count();
-    assert_eq!(count_2020a, 2, "expected 2020a in both groups: {output}");
+    // Suffixes must not bleed across the boundary: neither group should contain
+    // a suffix that belongs to the other (i.e. no 2020c or 2020d anywhere).
+    assert!(
+        !output.contains("2020c") && !output.contains("2020d"),
+        "No cross-group suffix leakage expected: {output}"
+    );
 }
 
 fn given_juris_m_legal_grouping_when_rendered_then_headings_follow_the_expected_legal_hierarchy() {

--- a/docs/architecture/audits/2026-05-31_DISAMBIGUATION_TEST_SOUNDNESS.md
+++ b/docs/architecture/audits/2026-05-31_DISAMBIGUATION_TEST_SOUNDNESS.md
@@ -1,0 +1,252 @@
+# Disambiguation Test Soundness Audit
+
+**Date:** 2026-05-31
+**Status:** Complete
+**Spec:** [`docs/specs/DISAMBIGUATION.md`](../../specs/DISAMBIGUATION.md)
+**Bean:** csl26-ucs3
+
+## Overview
+
+Full soundness review of automated disambiguation tests in `citum-engine` against
+`docs/specs/DISAMBIGUATION.md`. Checked for unsound, vacuous, or overfit tests.
+Resulted in: 1 broken test fixed, 5 suspicious tests renamed/realigned/strengthened,
+3 new tests added (2 coverage-gap tests, 1 cascade-fallback test), and 1 spec
+acceptance criterion corrected.
+
+## Summary
+
+| Verdict | Count |
+|---------|-------|
+| Good (no change) | 9 |
+| Suspicious (renamed/realigned/strengthened) | 5 |
+| Broken (rewritten) | 1 |
+| New tests added | 3 |
+| Spec corrections | 1 |
+
+**Highest-priority fix:** `subsequent_et_al_thresholds_shorten_the_repeat_citation` — broken
+substring-only assertions replaced with exact `assert_eq!`.
+
+**Notable strengths:** `apa_reprint_year_suffix_attaches_to_issued_year_only` and the
+§6 suppression pair are exact, spec-anchored, and resistant to overfitting.
+
+## Spec correction
+
+`docs/specs/DISAMBIGUATION.md` §4 listed `[x] Multilingual key generation respects
+display mode`, but `render_name_for_disambiguation` does not exist in the codebase.
+`disambiguation.rs` calls `to_names_vec()` which always reads `Contributor::Multilingual.original`,
+ignoring the style's display mode. The acceptance criterion has been corrected to
+`[ ]` pending a future implementation pass. A new test
+(`multilingual_contributors_collide_on_original_family_name`) documents what IS
+currently wired — original-name form drives the collision key — and includes a
+`NOTE` comment describing the future transliteration-aware path.
+
+## Implementation gaps found
+
+| Gap | Status |
+|-----|--------|
+| §4 transliteration-mode collision key | Not implemented; `[ ]` restored in spec |
+| §2 `givenname-disambiguation-rule: by-cite \| all-names` | Not in schema (`add_givenname: bool` only); no parameterized test possible |
+
+## Full JSON analysis
+
+```json
+{
+  "spec": "docs/specs/DISAMBIGUATION.md",
+  "reviewed_files": [
+    "crates/citum-engine/tests/citations.rs",
+    "crates/citum-engine/tests/document.rs",
+    "crates/citum-engine/tests/common/mod.rs"
+  ],
+  "tests": [
+    {
+      "name": "disambiguation_same_author_same_year_titles_follow_title_order",
+      "location": "crates/citum-engine/tests/citations.rs:196",
+      "spec_refs": ["§1 collision key", "§3 suffix ordering by title"],
+      "intended_behavior": "Two works with the same author and issued year form one collision group and receive year suffixes assigned in lowercased-title order.",
+      "what_it_does": "Builds two Smith/2020 books titled 'Alpha' and 'Beta', cites them in one cluster, asserts exact 'Smith, (2020a), (2020b)'.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "disambiguation_two_level_author_collisions_get_distinct_suffixes",
+      "location": "crates/citum-engine/tests/citations.rs:212",
+      "spec_refs": ["§2 cascade (names then year_suffix)"],
+      "intended_behavior": "When et-al truncation collapses distinct author lists into colliding sub-groups, each sub-group is independently year-suffixed.",
+      "what_it_does": "Four 1986 books (two 3-author, two 4-author) with names+year_suffix enabled; asserts exact full string where each truncation level gets its own (1986a)/(1986b).",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "disambiguation_same_year_articles_increment_suffixes",
+      "location": "crates/citum-engine/tests/citations.rs:333",
+      "spec_refs": ["§1", "§3"],
+      "intended_behavior": "Three same-author/same-year works increment suffixes a, b, c in title order.",
+      "what_it_does": "Three Ylinen/1995 articles (titles A/B/C), asserts exact 'Ylinen, (1995a), (1995b), (1995c)'.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "disambiguation_duplicate_family_names_expand_given_names_only_where_needed",
+      "location": "crates/citum-engine/tests/citations.rs:346",
+      "spec_refs": ["§2 given-name expansion"],
+      "intended_behavior": "Given-name expansion is applied only to items whose family names collide across the colliding cites.",
+      "what_it_does": "Three refs with differing years — no collision is ever triggered, so the test asserts the ABSENCE of given-name expansion.",
+      "verdict": "suspicious",
+      "improvement": "Mislabeled: fixture never triggers a collision. Rename to reflect 'no spurious expansion when years differ'; add a positive case where expansion IS triggered.",
+      "action_taken": "Renamed to disambiguation_no_spurious_givenname_expansion_when_years_differ; wrapper announce_behavior updated. New positive test disambiguation_givenname_expansion_resolves_same_year_family_name_collision added."
+    },
+    {
+      "name": "disambiguation_et_al_conflicts_expand_names_when_that_resolves_them",
+      "location": "crates/citum-engine/tests/citations.rs:375",
+      "spec_refs": ["§2 step 1 et-al expansion"],
+      "intended_behavior": "When et-al truncation hides the name that distinguishes two cites, expansion past the et-al threshold resolves the collision before year suffixes are tried.",
+      "what_it_does": "Two 1980 books differing in 2nd author (Brown vs Beefheart), names-only enabled, et-al min3/first1; asserts exact expected string.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "disambiguation_et_al_conflicts_fall_back_to_year_suffixes",
+      "location": "crates/citum-engine/tests/citations.rs:411",
+      "spec_refs": ["§2 cascade early-exit / fallback"],
+      "intended_behavior": "When name expansion cannot split a group (identical author lists), the cascade falls through to year-suffix assignment.",
+      "what_it_does": "Two identical-author 1980 books, names+year_suffix enabled; asserts exact 'Smith et al., (1980a), (1980b)'.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "disambiguation_initials_are_used_when_short_form_family_names_collide",
+      "location": "crates/citum-engine/tests/citations.rs:443",
+      "spec_refs": ["§2 given-name expansion to initials"],
+      "intended_behavior": "Colliding short-form family names expand to initials; non-colliding names stay bare.",
+      "what_it_does": "Five 2000 books; Doe/Doe (John/Aloysius) expand; Roe stays bare; Smith/Smith (Thomas/Ted) left unresolved because year_suffix is off.",
+      "verdict": "suspicious",
+      "improvement": "Freezes the ambiguous T Smith/T Smith output with no fallback enabled. Add sibling with year_suffix enabled to verify cascade resolves the Smith pair.",
+      "action_taken": "New test disambiguation_year_suffix_fallback_when_givenname_expansion_fails added (same given name, year_suffix=true — exact fallback path verified). The engine resolves Thomas/Ted at data level (different given names) so the sibling uses identical given names to force the fallback."
+    },
+    {
+      "name": "subsequent_et_al_thresholds_shorten_the_repeat_citation",
+      "location": "crates/citum-engine/tests/citations.rs:474",
+      "spec_refs": ["§2 (et-al thresholds; subsequent form)"],
+      "intended_behavior": "First cite shows all authors (below min); a repeat cite applies the more aggressive subsequent_min/subsequent_use_first thresholds.",
+      "what_it_does": "One 3-author 2020 book cited twice; assertions used contains()/!contains() on short substrings — never pins year, punctuation, or exact name form.",
+      "verdict": "broken",
+      "improvement": "Replace substring checks with exact assert_eq! on both results.",
+      "action_taken": "Replaced with assert_eq!(results[0], \"Doe, Smith, Jones, (2020)\") and assert_eq!(results[1], \"Doe et al., (2020)\") after capturing actual output."
+    },
+    {
+      "name": "subsequent_et_al_configuration_uses_the_subsequent_form_on_repeat",
+      "location": "crates/citum-engine/tests/citations.rs:578",
+      "spec_refs": ["§2 et-al + §3 year suffix"],
+      "intended_behavior": "(per wrapper) Repeat citations honor the subsequent et al. configuration.",
+      "what_it_does": "Single citation cluster of three 2000 articles with year_suffix+et-al. No Position::Subsequent cite exists — the name and wrapper claim 'repeat' behavior not tested.",
+      "verdict": "suspicious",
+      "improvement": "Rename function and realign announce_behavior to reflect what is actually tested: year-suffix under et-al truncation.",
+      "action_taken": "Renamed to disambiguation_year_suffix_assigned_when_et_al_truncation_leaves_collision; wrapper announce_behavior updated to accurately describe the test."
+    },
+    {
+      "name": "disambiguation_conditions_expand_only_the_marked_items",
+      "location": "crates/citum-engine/tests/citations.rs:679",
+      "spec_refs": ["§1", "§3"],
+      "intended_behavior": "Conditional disambiguation expands only specifically marked citation items.",
+      "what_it_does": "Two identical-author identical-year books; plain year-suffix case with no conditional/marked-item mechanism set up.",
+      "verdict": "suspicious",
+      "improvement": "Name overstates scope and partially duplicates same_author_same_year case. Rename to a plain multi-author duplicate-year description.",
+      "action_taken": "Renamed to disambiguation_identical_two_author_year_pair_receives_year_suffixes; wrapper updated."
+    },
+    {
+      "name": "disambiguation_suffixes_continue_past_z",
+      "location": "crates/citum-engine/tests/citations.rs:701",
+      "spec_refs": ["§3 base-26 wrapping (int_to_letter)"],
+      "intended_behavior": "Suffix sequence continues past z into aa, ab, ... without resetting or truncating.",
+      "what_it_does": "30 Smith/1986 books; asserts the full exact sequence a..z, aa, ab, ac, ad.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "apa_reprint_issued_year_only_suffix",
+      "location": "crates/citum-engine/tests/citations.rs:876",
+      "spec_refs": ["§1 issued-year-only key", "§1 div-009"],
+      "intended_behavior": "Year-suffix collision keying uses only the issued year; three reprints with differing original-dates all form one group and ALL receive a suffix.",
+      "what_it_does": "Three Freud reprints via CSL-JSON with differing original-date, slash-grouped template; asserts exact '(1926/1967a), (1926/1967b), (1927/1967c)'.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "disambiguate_only_title_suppressed_in_note_cross_ref_position",
+      "location": "crates/citum-engine/tests/citations.rs (suppression section)",
+      "spec_refs": ["§6 short-title suppression via first-reference-note-number"],
+      "intended_behavior": "A disambiguate-only short title is suppressed on a subsequent cite when a first-reference-note-number is available.",
+      "what_it_does": "Note style; first cites of Rome/Greece show titles; subsequent Rome cite asserts exact vec.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "disambiguate_only_title_kept_when_template_lacks_note_number",
+      "location": "crates/citum-engine/tests/citations.rs (suppression section)",
+      "spec_refs": ["§6 suppression gated on template_uses_first_ref_note_number"],
+      "intended_behavior": "When the subsequent template does NOT render a first-reference-note-number, the disambiguating title must be retained.",
+      "what_it_does": "Same fixture minus the note-number component; subsequent Rome cite asserts the title is kept.",
+      "verdict": "good",
+      "improvement": null,
+      "action_taken": null
+    },
+    {
+      "name": "given_group_local_disambiguation_when_rendering_multilingual_groups_then_year_suffixes_restart_within_each_group",
+      "location": "crates/citum-engine/tests/document.rs:822",
+      "spec_refs": ["§5 disambiguate: locally (per-group suffix restart)"],
+      "intended_behavior": "With per-group local disambiguation, year-suffix sequences restart at 'a' inside each BibliographyGroup and never leak across group boundaries.",
+      "what_it_does": "Count of '2020a' in bibliography == 2. Does not verify the two occurrences are in different groups, or that each group has both 2020a and 2020b.",
+      "verdict": "suspicious",
+      "improvement": "Split bibliography into per-group blocks; assert each block independently contains 2020a AND 2020b; assert no 2020c/2020d.",
+      "action_taken": "Replaced count assertion with per-group block extraction and independent 2020a/2020b assertions plus leakage guard."
+    }
+  ],
+  "new_tests_added": [
+    {
+      "name": "disambiguation_givenname_expansion_resolves_same_year_family_name_collision",
+      "spec_refs": ["§2 given-name expansion positive path"],
+      "rationale": "Positive complement to the renamed no-spurious-expansion guard. Verifies expansion IS applied to the ambiguous Smith/Smith pair while Jones stays bare.",
+      "expected": "Jones, (2000); A Smith, (2000); B Smith, (2000)"
+    },
+    {
+      "name": "disambiguation_year_suffix_fallback_when_givenname_expansion_fails",
+      "spec_refs": ["§2 cascade fallback"],
+      "rationale": "When given-name expansion cannot resolve (identical given names), cascade falls through to year-suffix.",
+      "expected": "Smith, (2000a), (2000b)"
+    },
+    {
+      "name": "disambiguation_multilingual_contributors_collide_on_original_family_name",
+      "spec_refs": ["§4 (partial — original-name form only)"],
+      "rationale": "Verifies Contributor::Multilingual is wired into the collision-key path via to_names_vec().original. NOTE: transliteration-display-mode path not yet implemented.",
+      "expected": "김, (2020a); 김, (2020b)"
+    }
+  ],
+  "coverage_gaps_remaining": [
+    {
+      "spec_ref": "§4 transliteration-mode collision key",
+      "observation": "render_name_for_disambiguation does not exist. disambiguation.rs calls to_names_vec() which always reads Contributor::Multilingual.original regardless of style display mode. Two refs whose originals differ but transliterations collide will NOT be grouped.",
+      "recommendation": "Implement render_name_for_disambiguation in disambiguation.rs that consults config.multilingual.name_mode and calls resolve_multilingual_name; remove the [x] from DISAMBIGUATION.md acceptance criterion until done."
+    },
+    {
+      "spec_ref": "§2 givenname-disambiguation-rule: by-cite | all-names",
+      "observation": "Schema only has add_givenname: bool. The by-cite/all-names distinction from CSL is not modeled. No parameterized test is possible.",
+      "recommendation": "When the rule enum is added to citum-schema-style, parameterize a test over ByCite and AllNames variants with a three-ref fixture (two colliding, one not) and assert expansion scope differs."
+    }
+  ],
+  "summary": {
+    "good": 9,
+    "suspicious_fixed": 5,
+    "broken_fixed": 1,
+    "new_tests": 3,
+    "spec_corrections": 1
+  }
+}
+```

--- a/docs/specs/DISAMBIGUATION.md
+++ b/docs/specs/DISAMBIGUATION.md
@@ -175,12 +175,16 @@ added to the citation context.
 - [x] Year-suffix collision key uses only `issued` year (no original-date gate)
 - [x] All native disambiguation tests passing
 - [x] Group-aware suffix restart implemented (`disambiguate: locally`)
-- [x] Multilingual key generation respects display mode
+- [ ] Multilingual key generation respects display mode
 - [x] Native fixture asserting `(1926/1967a) (1926/1967b) (1927/1967c)` for the APA §8.15 reprint scenario
 - [x] Short-title suppression via `first-reference-note-number` implemented and tested
 
 ## Changelog
 
+- 2026-05-31: Test soundness audit (csl26-ucs3). Corrected `[x]` → `[ ]` for
+  multilingual key generation — `render_name_for_disambiguation` not yet
+  implemented; `disambiguation.rs` always reads `Contributor::Multilingual.original`.
+  See `docs/architecture/audits/2026-05-31_DISAMBIGUATION_TEST_SOUNDNESS.md`.
 - 2026-05-29: Initial version. Consolidates `DISAMBIGUATION_IMPLEMENTATION_PLAN.md` (now deleted)
   and `DISAMBIGUATION_MULTILINGUAL_GROUPING.md` (now deleted).
 - 2026-05-29: All acceptance criteria implemented; status set to Active.


### PR DESCRIPTION
## Summary

- Fix 1 broken test (`subsequent_et_al_thresholds`): substring assertions replaced with exact `assert_eq!`
- Rename/realign 5 suspicious tests: three had misleading names, one had a false `announce_behavior` claim, one had a weak count-only assertion
- Strengthen group-local suffix restart (document.rs): per-group 2020a/2020b checks + cross-boundary leakage guard
- Add 3 new tests: positive §2 given-name expansion, §2 cascade fallback, §4 multilingual original-name collision
- Audit record: `docs/architecture/audits/2026-05-31_DISAMBIGUATION_TEST_SOUNDNESS.md` with full JSON analysis
- Spec correction: `DISAMBIGUATION.md` §4 criterion reverted `[x]→[ ]` — `render_name_for_disambiguation` is not implemented; the disambiguator always reads `Contributor::Multilingual.original`

## Implementation gaps surfaced (not fixed here)

- **§4 transliteration-mode collision key**: needs `render_name_for_disambiguation` in `disambiguation.rs` consulting `config.multilingual.name_mode`
- **§2 `givenname-disambiguation-rule: by-cite | all-names`**: not in schema (`add_givenname: bool` only); parameterised test blocked until the enum lands

## Test plan

- [x] `cargo nextest run -p citum-engine` — 729/729 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues
- [x] Full workspace `cargo nextest run` — 1458/1458 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
