### PR TITLE
docs(spec): add capability index + SORTING.md

### DIFF
--- a/.beans/archive/csl26-epvd--reorganize-docsspecs-readme-by-capability-add-sort.md
+++ b/.beans/archive/csl26-epvd--reorganize-docsspecs-readme-by-capability-add-sort.md
@@ -1,0 +1,17 @@
+---
+# csl26-epvd
+title: Reorganize docs/specs/ README by capability + add SORTING.md
+status: completed
+type: task
+priority: normal
+created_at: 2026-05-31T20:08:57Z
+updated_at: 2026-05-31T20:13:23Z
+---
+
+Rewrite docs/specs/README.md index with capability-grouped tables (columns: Spec | Status | Tests) so specs and tests are co-navigable by area (Citations, Bibliography, Sorting, Localization, Data Model, Text/Rendering, Document/Input, Migration, Style System, Platform). Add new SORTING.md umbrella spec documenting current sort behavior. Deliver via PR.
+
+## Summary of Changes
+
+- Rewrote  index: replaced status-grouped tables with 10 capability areas (Citations, Bibliography, Note Styles, Sorting, Localization, Data Model, Text/Rendering, Document/Input, Migration, Style System, Platform). Each row now includes Spec | Status | Tests columns for direct spec↔test traceability.
+- Added new  umbrella spec documenting end-to-end sort behavior (bibliography vs citation separation, sort keys, presets, collation, tiebreaking). References narrower sub-specs.
+- Fixed: added  and  which were present in the directory but missing from the old index.

--- a/.beans/csl26-54jn--display-mode-aware-multilingual-disambiguation-key.md
+++ b/.beans/csl26-54jn--display-mode-aware-multilingual-disambiguation-key.md
@@ -1,0 +1,16 @@
+---
+# csl26-54jn
+title: Display-mode-aware multilingual disambiguation keys
+status: todo
+type: feature
+priority: normal
+tags:
+    - engine
+    - multilingual
+    - disambiguation
+    - spec
+created_at: 2026-05-31T20:36:49Z
+updated_at: 2026-05-31T20:36:49Z
+---
+
+DISAMBIGUATION.md §4 requires the author collision key to reflect the same multilingual surface form the style renders (transliteration/translation/original) when display mode != primary. build_author_key in crates/citum-engine/src/processor/disambiguation.rs calls append_lowercased_families on raw family names without selecting the appropriate multilingual variant, so colliding transliterations are treated as distinct authors rather than a collision. Acceptance criterion 'Multilingual key generation respects display mode' in docs/specs/DISAMBIGUATION.md is open with no covering bean. Implement render_name_for_disambiguation to select the variant matching the active display mode before building the collision key. Spec: docs/specs/DISAMBIGUATION.md §4.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@ are marked explicitly.
 | Channel | Format | Audience |
 |---|---|---|
 | **crates.io** | 12 published crates (see list below) | Rust developers (`cargo install citum`, library users) |
-| **JSR** | `@citum/citum` WASM + TypeScript package | JavaScript, TypeScript, Deno, and browser integrations |
+| **JSR** | `@citum/engine` WASM + TypeScript package | JavaScript, TypeScript, Deno, and browser integrations |
 | **GitHub Releases** | Cross-platform tarballs + `SHA256SUMS` + `install.sh` | End-users (`curl ... \| sh`), distro packagers |
 
 Out of scope for now (deliberately): Homebrew tap, npm wrapper, Docker
@@ -60,7 +60,7 @@ The release is automated end-to-end. Day-to-day, the work is:
    - `publish-crates` (~5 min, gated on `build`) — runs
      `scripts/publish-crates.sh` against `CARGO_REGISTRY_TOKEN`
    - `publish-jsr` (~5 min, gated on `build`) — builds the WASM/TypeScript
-     package and publishes `@citum/citum` to JSR using GitHub OIDC
+     package and publishes `@citum/engine` to JSR using GitHub OIDC
 
 4. **Verify** (described in [§ Post-release verification](#post-release-verification)).
 
@@ -94,7 +94,7 @@ citum --version
 citum-server --version
 
 # JavaScript/WASM package:
-# Verify https://jsr.io/@citum/citum shows the new version.
+# Verify https://jsr.io/@citum/engine shows the new version.
 ```
 
 The install script verifies the SHA256 of the downloaded tarball
@@ -165,7 +165,7 @@ cargo install citum-server --locked
    open https://jsr.io/new. JSR creates scopes from the package-publish
    form: in the **Scope** selector, choose the existing `citum` scope if
    it is listed, or choose the create-new-scope option and enter `citum`.
-   Then set the package name to `citum`, producing `@citum/citum`.
+   Then set the package name to `engine`, producing `@citum/engine`.
    This is not a token setup step.
 
 2. **Trusted publishing.** In the JSR package settings, link the package

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -68,7 +68,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 
 | Spec | Status | Tests |
 |------|--------|-------|
-| [`DISAMBIGUATION.md`](./DISAMBIGUATION.md) — collision-key model, strategy cascade, multilingual/group disambiguation, APA §8.15 reprint keying | Draft | `citations.rs::disambiguation` |
+| [`DISAMBIGUATION.md`](./DISAMBIGUATION.md) — collision-key model, strategy cascade, multilingual/group disambiguation, APA §8.15 reprint keying | Active | `citations.rs::disambiguation` |
 | [`CITE_SITE_COMPOUND_GROUPING.md`](./CITE_SITE_COMPOUND_GROUPING.md) — cite-site compound grouping and position-aware overrides | Active | `citations.rs::sorting_and_grouping` |
 | [`INTEGRAL_NAME_MEMORY.md`](./INTEGRAL_NAME_MEMORY.md) — durable author-display state across citation clusters | Active | `citations.rs::integral_name_memory` |
 | [`PERSONAL_COMMUNICATION_CITATION.md`](./PERSONAL_COMMUNICATION_CITATION.md) — rendering of personal communications across style families | Active | `citations.rs::contributor_scoping` |
@@ -124,7 +124,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | Spec | Status | Tests |
 |------|--------|-------|
 | [`TYPE_REFACTOR_v3.md`](./TYPE_REFACTOR_v3.md) — unified type system refactor for high-fidelity work modeling | Active | `metadata.rs`, `domain_fixtures.rs` |
-| [`TYPE_SYSTEM_ARCHITECTURE.md`](./TYPE_SYSTEM_ARCHITECTURE.md) — overall type system architecture and classification hierarchy | Active | `crates/citum-schema/tests/` |
+| [`TYPE_SYSTEM_ARCHITECTURE.md`](./TYPE_SYSTEM_ARCHITECTURE.md) — overall type system architecture and classification hierarchy | Draft | `crates/citum-schema/tests/` |
 | [`INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`](./INPUT_REFERENCE_CLASS_DISCRIMINATOR.md) — discriminated union for reference-class dispatch | Active | `crates/citum-schema/tests/` |
 | [`GENERALIZED_RELATIONAL_CONTAINER_MODEL.md`](./GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) — recursive relational container model replacing flat variables | Active | `metadata.rs` |
 | [`DATE_MODEL.md`](./DATE_MODEL.md) — refined date model for created vs. issued distinction | Active | `metadata.rs` |
@@ -138,10 +138,10 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | Spec | Status | Tests |
 |------|--------|-------|
 | [`TEMPLATE_V2.md`](./TEMPLATE_V2.md) — simplified Template Schema v2 with group-first composition | Active | `bibliography.rs`, `citations.rs` |
-| [`TEMPLATE_V3.md`](./TEMPLATE_V3.md) — Template Schema v3 extensions | Active | `bibliography.rs`, `citations.rs` |
+| [`TEMPLATE_V3.md`](./TEMPLATE_V3.md) — Template Schema v3 extensions | Draft | `bibliography.rs`, `citations.rs` |
 | [`TITLE_TEXT_CASE.md`](./TITLE_TEXT_CASE.md) — modeling and applying title-like text-case transformations | Active | `bibliography.rs` |
 | [`TITLE_NAME_INFLECTION.md`](./TITLE_NAME_INFLECTION.md) — grammatical inflection of title-adjacent names | Active | `bibliography.rs` |
-| [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md) — normalization of punctuation at rendered output boundaries | Active | `bibliography.rs`, `citations.rs` |
+| [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md) — normalization of punctuation at rendered output boundaries | Draft | `bibliography.rs`, `citations.rs` |
 | [`DJOT_RICH_TEXT.md`](./DJOT_RICH_TEXT.md) — Djot as the rich-text markup substrate for note/abstract fields | Active | `document.rs::djot_adapter` |
 | [`SHORT_NAME.md`](./SHORT_NAME.md) — short-name rendering for abbreviated contributor identifiers | Active | `bibliography.rs::title_short_resolution` |
 | [`ABBREVIATION_MAP.md`](./ABBREVIATION_MAP.md) — abbreviation lookup map for journal and publisher names | Active | `bibliography.rs` |
@@ -190,8 +190,8 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | Spec | Status | Tests |
 |------|--------|-------|
 | [`LANGUAGE_BINDINGS.md`](./LANGUAGE_BINDINGS.md) — multi-language type bindings for canonical data shapes | Active | `crates/citum-bindings/tests/` |
-| [`WASM_SUPPORT.md`](./WASM_SUPPORT.md) — WASM build targets and embedding model | Active | — |
-| [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) — federated registry and distributed resolver architecture (Phases 2–3) | Draft | — |
-| [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) — clean command model for style discovery, registry management, and CLI validation UX | Draft | — |
+| [`WASM_SUPPORT.md`](./WASM_SUPPORT.md) — WASM build targets and embedding model | Draft | — |
+| [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) — federated registry and distributed resolver architecture (Phases 2–3) | Active | — |
+| [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) — clean command model for style discovery, registry management, and CLI validation UX | Active | — |
 | [`AUTHORING_AGENT_SKILL.md`](./AUTHORING_AGENT_SKILL.md) — Citum Authoring Agent Skill specification for AI-assisted style authoring | Active | — |
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -151,6 +151,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | Spec | Status | Tests |
 |------|--------|-------|
 | [`DOCUMENT_INPUT_PARSER_BOUNDARY.md`](./DOCUMENT_INPUT_PARSER_BOUNDARY.md) — boundary between format parsers and shared processing pipeline | Active | `document.rs`, `io.rs` |
+| [`PANDOC_MARKDOWN_CITATIONS.md`](./PANDOC_MARKDOWN_CITATIONS.md) — Pandoc-style citation marker support for Markdown documents | Completed | `document.rs::markdown_documents` |
 | [`FIDELITY_RICH_INPUTS.md`](./FIDELITY_RICH_INPUTS.md) — fidelity pipeline support for relational benchmark inputs | Active | `document.rs`, `io.rs` |
 | [`FORWARD_COMPATIBILITY.md`](./FORWARD_COMPATIBILITY.md) — forward-compatibility guarantees across schema versions | Active | `forward_compatibility.rs` |
 | [`SERVER_INTERACTIVE_API.md`](./SERVER_INTERACTIVE_API.md) — document-batch and session APIs for server and WASM | Draft | `crates/citum-server/tests/rpc.rs` |
@@ -181,6 +182,8 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`PER_DOCUMENT_CONFIG_OVERRIDES.md`](./PER_DOCUMENT_CONFIG_OVERRIDES.md) — eligible options and syntax for per-document configuration overrides | Draft | `bibliography.rs::local_overrides` |
 | [`SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md`](./SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md) — crate-level schema split and CLI conversion namespace | Active | `crates/citum-schema/tests/` |
 | [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) — verification model for profile styles using external authority | Draft | — |
+| [`JOURNAL_PROFILE_TAXONOMY_AUDIT.md`](./JOURNAL_PROFILE_TAXONOMY_AUDIT.md) — audit of journal-profile taxonomy and authority rules | Completed | — |
+| [`CONFIG_ONLY_PROFILE_OVERRIDES.md`](./CONFIG_ONLY_PROFILE_OVERRIDES.md) — alternative configuration-only profile override model | Superseded | — |
 
 ### Platform & Infra
 
@@ -192,17 +195,3 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) — clean command model for style discovery, registry management, and CLI validation UX | Draft | — |
 | [`AUTHORING_AGENT_SKILL.md`](./AUTHORING_AGENT_SKILL.md) — Citum Authoring Agent Skill specification for AI-assisted style authoring | Active | — |
 
----
-
-### Completed
-
-| Spec | Feature |
-|------|---------|
-| [`JOURNAL_PROFILE_TAXONOMY_AUDIT.md`](./JOURNAL_PROFILE_TAXONOMY_AUDIT.md) | Audit of journal-profile taxonomy and authority rules |
-| [`PANDOC_MARKDOWN_CITATIONS.md`](./PANDOC_MARKDOWN_CITATIONS.md) | Pandoc-style citation marker support for Markdown documents |
-
-### Superseded
-
-| Spec | Feature |
-|------|---------|
-| [`CONFIG_ONLY_PROFILE_OVERRIDES.md`](./CONFIG_ONLY_PROFILE_OVERRIDES.md) | Alternative configuration-only profile override model |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -47,83 +47,162 @@ to make sure the document should be a spec rather than architecture or policy.
 3. Set Status to `Active` in the same commit as the first implementation.
 4. Reference the spec path in the bean description.
 
+## Using This Index
+
+The **Specs** section below is organized by capability area. Each row includes:
+
+- **Spec** — links directly to the spec file.
+- **Status** — `Draft` / `Active` / `Completed` / `Superseded`.
+- **Tests** — the test file or `file::module` that exercises this capability. Use
+  these anchors to direct an agent: *"review `citations.rs::disambiguation` against
+  `DISAMBIGUATION.md`"*.
+
+Specs covering multiple areas are listed under their primary area with a *see also*
+note. The `—` marker in the Tests column means no targeted test exists yet.
+
+---
+
 ## Specs
 
-### Draft
+### Citations
 
-| File | Feature |
-|------|---------|
-| [`DISAMBIGUATION.md`](./DISAMBIGUATION.md) | Collision-key model, strategy cascade, multilingual/group disambiguation, and APA §8.15 reprint keying |
-| [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) | Federated registry and distributed resolver architecture (Phases 2–3) |
-| [`PER_DOCUMENT_CONFIG_OVERRIDES.md`](./PER_DOCUMENT_CONFIG_OVERRIDES.md) | Eligible options and syntax for per-document configuration overrides |
-| [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) | Clean command model for style discovery, registry management, and CLI validation UX |
-| [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) | Verification model for profile styles using external authority |
-| [`SERVER_INTERACTIVE_API.md`](./SERVER_INTERACTIVE_API.md) | Document-batch and session APIs for server and WASM |
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`DISAMBIGUATION.md`](./DISAMBIGUATION.md) — collision-key model, strategy cascade, multilingual/group disambiguation, APA §8.15 reprint keying | Draft | `citations.rs::disambiguation` |
+| [`CITE_SITE_COMPOUND_GROUPING.md`](./CITE_SITE_COMPOUND_GROUPING.md) — cite-site compound grouping and position-aware overrides | Active | `citations.rs::sorting_and_grouping` |
+| [`INTEGRAL_NAME_MEMORY.md`](./INTEGRAL_NAME_MEMORY.md) — durable author-display state across citation clusters | Active | `citations.rs::integral_name_memory` |
+| [`PERSONAL_COMMUNICATION_CITATION.md`](./PERSONAL_COMMUNICATION_CITATION.md) — rendering of personal communications across style families | Active | `citations.rs::contributor_scoping` |
+| [`LEGAL_CITATIONS.md`](./LEGAL_CITATIONS.md) — legal-case type support and jurisdiction-aware rendering | Draft | — |
+| [`LOCATOR_RENDERING.md`](./LOCATOR_RENDERING.md) — style-level LocatorConfig replacing per-template locator fields | Active | `citations.rs` |
+| [`NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md`](./NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md) — domain-specific numbering and locator labels | Active | `citations.rs` |
 
-### Active
+### Bibliography
 
-| File | Feature |
-|------|---------|
-| [`ANNOTATED_BIBLIOGRAPHY.md`](./ANNOTATED_BIBLIOGRAPHY.md) | Document-scoped annotation overlay for bibliography rendering |
-| [`AUTHORING_AGENT_SKILL.md`](./AUTHORING_AGENT_SKILL.md) | Citum Authoring Agent Skill specification for AI-assisted style authoring |
-| [`APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md`](./APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md) | APA SQI alignment and preset-first cleanup |
-| [`ARCHIVAL_UNPUBLISHED_SUPPORT.md`](./ARCHIVAL_UNPUBLISHED_SUPPORT.md) | ArchiveInfo and EprintInfo first-class source support |
-| [`ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md`](./ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md) | External bibliography parameter for article-journal page fallback |
-| [`CHICAGO_18_COVERAGE.md`](./CHICAGO_18_COVERAGE.md) | Chicago 18th and APA 8th high-fidelity coverage enhancement |
-| [`CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md`](./CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md) | Strict schema split for citation and bibliography option scopes |
-| [`CITE_SITE_COMPOUND_GROUPING.md`](./CITE_SITE_COMPOUND_GROUPING.md) | Cite-site compound grouping and position-aware overrides |
-| [`DATE_MODEL.md`](./DATE_MODEL.md) | Refined date model for created vs. issued distinction |
-| [`DOCUMENT_INPUT_PARSER_BOUNDARY.md`](./DOCUMENT_INPUT_PARSER_BOUNDARY.md) | Boundary between format parsers and shared processing pipeline |
-| [`EDTF_ERA_LABEL_PROFILES.md`](./EDTF_ERA_LABEL_PROFILES.md) | Era label profiles and unspecified historical-year display |
-| [`EDTF_HISTORICAL_ERA_RENDERING.md`](./EDTF_HISTORICAL_ERA_RENDERING.md) | Locale-backed rendering of valid historical EDTF years |
-| [`EMBEDDED_JS_TEMPLATE_INFERENCE.md`](./EMBEDDED_JS_TEMPLATE_INFERENCE.md) | Embedded JS runtime for live template inference in migrator |
-| [`EMBEDDED_ROOT_WRAPPER_MIGRATION.md`](./EMBEDDED_ROOT_WRAPPER_MIGRATION.md) | Proof-gated embedded roots plus thin public wrappers for style migration |
-| [`ENGINE_MIGRATE_COEVOLUTION_WAVE.md`](./ENGINE_MIGRATE_COEVOLUTION_WAVE.md) | Engine-first co-evolution wave for style-fidelity fixes |
-| [`FIDELITY_RICH_INPUTS.md`](./FIDELITY_RICH_INPUTS.md) | Fidelity pipeline support for relational benchmark inputs |
-| [`GENDERED_LOCALE_TERMS.md`](./GENDERED_LOCALE_TERMS.md) | Multi-dimensional locale terms with grammatical gender support |
-| [`GENERALIZED_RELATIONAL_CONTAINER_MODEL.md`](./GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) | Recursive relational container model replacing flat variables |
-| [`INLINE_JOURNAL_DETAIL_GROUPING.md`](./INLINE_JOURNAL_DETAIL_GROUPING.md) | Inline article-journal detail blocks with mixed delimiters |
-| [`LANGUAGE_BINDINGS.md`](./LANGUAGE_BINDINGS.md) | Multi-language type bindings for canonical data shapes |
-| [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md) | ICU MF2 parameterized message system replacing flat YAML terms |
-| [`LOCATOR_RENDERING.md`](./LOCATOR_RENDERING.md) | Style-level LocatorConfig replacing per-template locator fields |
-| [`MIGRATION_TAXONOMY_AWARE_WRAPPERS.md`](./MIGRATION_TAXONOMY_AWARE_WRAPPERS.md) | Taxonomy-aware wrapper derivation during style migration |
-| [`MULTILINGUAL.md`](./MULTILINGUAL.md) | Multilingual support design: data model, processor logic, sorting, disambiguation |
-| [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | Sort and section multilingual bibliographies by script or language |
-| [`MIGRATE_RESEARCH_RICH_INPUTS.md`](./MIGRATE_RESEARCH_RICH_INPUTS.md) | Bounded rich-input workflow for migrate-research passes |
-| [`MIXED_CONDITION_NOTE_POSITION_TREES.md`](./MIXED_CONDITION_NOTE_POSITION_TREES.md) | Migration of legacy choose trees with mixed position predicates |
-| [`MULTILINGUAL_NAMES.md`](./MULTILINGUAL_NAMES.md) | Script-specific contributor name assembly |
-| [`NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md`](./NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md) | Representation of domain-specific numbering and locator labels |
-| [`NOTE_POSITION_AUDIT.md`](./NOTE_POSITION_AUDIT.md) | Audit layer for note-style repeated-citation behavior |
-| [`NOTE_SHORTENING_POLICY.md`](./NOTE_SHORTENING_POLICY.md) | Normative contract for repeated-note and shortened-note behavior |
-| [`NOTE_START_REPEATED_NOTE_POLICY.md`](./NOTE_START_REPEATED_NOTE_POLICY.md) | Repeated-note behavior at note start vs. internal positions |
-| [`NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md`](./NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md) | Document-level note processing and note-in-note participating |
-| [`NUMBERING_SEMANTICS.md`](./NUMBERING_SEMANTICS.md) | Canonical semantics for numbering, report, and part fields |
-| [`ORIGINAL_PUBLICATION_RELATION_SUPPORT.md`](./ORIGINAL_PUBLICATION_RELATION_SUPPORT.md) | Universal original publication metadata support across all types |
-| [`PERSONAL_COMMUNICATION_CITATION.md`](./PERSONAL_COMMUNICATION_CITATION.md) | Rendering of personal communications across style families |
-| [`REPEATED_NOTE_CITATION_STATE_MODEL.md`](./REPEATED_NOTE_CITATION_STATE_MODEL.md) | Style-driven repeated-citation model for note processing |
-| [`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md) | Normative behavior for role-aware contributor fallback chains |
-| [`SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md`](./SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md) | Crate-level schema split and CLI conversion namespace |
-| [`SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md`](./SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md) | Consistent rendering and verification for secondary contributor roles |
-| [`SENTENCE_INITIAL_LABELS.md`](./SENTENCE_INITIAL_LABELS.md) | Sentence-initial capitalization for localized labels |
-| [`STRONG_DOMAIN_TYPES_PHASE1.md`](./STRONG_DOMAIN_TYPES_PHASE1.md) | Replacing primitive String aliases with dedicated domain types |
-| [`STYLE_PRESET_ARCHITECTURE.md`](./STYLE_PRESET_ARCHITECTURE.md) | Two-level configuration reuse for bases and profiles |
-| [`STYLE_REGISTRY.md`](./STYLE_REGISTRY.md) | Serde-driven StyleRegistry replacing hardcoded slices |
-| [`STYLE_TAXONOMY.md`](./STYLE_TAXONOMY.md) | Citum style taxonomy based on semantic class and implementation |
-| [`TEMPLATE_V2.md`](./TEMPLATE_V2.md) | Simplified Template Schema v2 with group-first composition |
-| [`TITLE_TEXT_CASE.md`](./TITLE_TEXT_CASE.md) | Modeling and applying title-like text-case transformations |
-| [`TYPE_REFACTOR_v3.md`](./TYPE_REFACTOR_v3.md) | Unified type system refactor for high-fidelity work modeling |
-| [`UNICODE_BIBLIOGRAPHY_SORTING.md`](./UNICODE_BIBLIOGRAPHY_SORTING.md) | Locale-aware Unicode collation for bibliography sorting |
-| [`UNIFIED_SCOPED_OPTIONS.md`](./UNIFIED_SCOPED_OPTIONS.md) | Typed scoped options replacing flat author-facing contracts |
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`ANNOTATED_BIBLIOGRAPHY.md`](./ANNOTATED_BIBLIOGRAPHY.md) — document-scoped annotation overlay for bibliography rendering | Active | `bibliography.rs::annotated_html_preview`, `document.rs` |
+| [`BIBLIOGRAPHY_GROUPING.md`](./BIBLIOGRAPHY_GROUPING.md) — grouped bibliography architecture: group specs, heading generation, nested groups | Draft | `document.rs::grouped_bibliography` |
+| [`ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md`](./ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md) — external bibliography parameter for article-journal page fallback | Active | `bibliography.rs::article_journal_no_page_fallback` |
+| [`CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md`](./CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md) — strict schema split for citation and bibliography option scopes | Active | `bibliography.rs`, `citations.rs` |
+| [`INLINE_JOURNAL_DETAIL_GROUPING.md`](./INLINE_JOURNAL_DETAIL_GROUPING.md) — inline article-journal detail blocks with mixed delimiters | Active | `bibliography.rs` |
+| [`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md) — normative behavior for role-aware contributor fallback chains | Active | `bibliography.rs::substitution` |
+| [`SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md`](./SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md) — consistent rendering and verification for secondary contributor roles | Active | `bibliography.rs` |
+
+### Note Styles & Repeated Citations
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`NOTE_SHORTENING_POLICY.md`](./NOTE_SHORTENING_POLICY.md) — normative contract for repeated-note and shortened-note behavior | Active | `citations.rs::note_style_positions` |
+| [`NOTE_START_REPEATED_NOTE_POLICY.md`](./NOTE_START_REPEATED_NOTE_POLICY.md) — repeated-note behavior at note start vs. internal positions | Active | `citations.rs::note_style_positions` |
+| [`NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md`](./NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md) — document-level note processing and note-in-note participating | Active | `document.rs::note_flow` |
+| [`REPEATED_NOTE_CITATION_STATE_MODEL.md`](./REPEATED_NOTE_CITATION_STATE_MODEL.md) — style-driven repeated-citation model for note processing | Active | `citations.rs::note_style_positions` |
+| [`NOTE_POSITION_AUDIT.md`](./NOTE_POSITION_AUDIT.md) — audit layer for note-style repeated-citation behavior | Active | `citations.rs::note_style_positions` |
+
+### Sorting
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`SORTING.md`](./SORTING.md) — end-to-end sort semantics: citation vs bibliography, sort keys, presets, collation, tiebreaking | Active | `sort_oracle.rs`, `bibliography.rs::sorting` |
+| [`EXPLICIT_DEFAULT_SORTING.md`](./EXPLICIT_DEFAULT_SORTING.md) — processing-family bibliography defaults; `citation.sort` explicit-only policy | Draft | `sort_oracle.rs` |
+| [`UNICODE_BIBLIOGRAPHY_SORTING.md`](./UNICODE_BIBLIOGRAPHY_SORTING.md) — locale-aware UCA/CLDR collation for bibliography sort keys | Active | `sort_oracle.rs` |
+| [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) — sort and section multilingual bibliographies by script or language | Active | `sort_oracle.rs`, `multilingual.rs` |
+
+### Localization & Multilingual
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`MULTILINGUAL.md`](./MULTILINGUAL.md) — multilingual data model, processor logic, sorting, disambiguation *(umbrella)* | Active | `multilingual.rs`, `i18n.rs::multilingual_rendering` |
+| [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md) — ICU MF2 parameterized message system replacing flat YAML terms | Active | `i18n.rs::string_resolution`, `i18n.rs::config` |
+| [`GENDERED_LOCALE_TERMS.md`](./GENDERED_LOCALE_TERMS.md) — multi-dimensional locale terms with grammatical gender support | Active | `i18n.rs::string_resolution` |
+| [`MULTILINGUAL_NAMES.md`](./MULTILINGUAL_NAMES.md) — script-specific contributor name assembly | Active | `multilingual_names.rs`, `i18n.rs::name_resolution` |
+| [`SENTENCE_INITIAL_LABELS.md`](./SENTENCE_INITIAL_LABELS.md) — sentence-initial capitalization for localized labels | Active | `i18n.rs` |
+| [`EDTF_ERA_LABEL_PROFILES.md`](./EDTF_ERA_LABEL_PROFILES.md) — era label profiles and unspecified historical-year display | Active | `metadata.rs` |
+| [`EDTF_HISTORICAL_ERA_RENDERING.md`](./EDTF_HISTORICAL_ERA_RENDERING.md) — locale-backed rendering of valid historical EDTF years | Active | `metadata.rs` |
+
+### Data Model & Types
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`TYPE_REFACTOR_v3.md`](./TYPE_REFACTOR_v3.md) — unified type system refactor for high-fidelity work modeling | Active | `metadata.rs`, `domain_fixtures.rs` |
+| [`TYPE_SYSTEM_ARCHITECTURE.md`](./TYPE_SYSTEM_ARCHITECTURE.md) — overall type system architecture and classification hierarchy | Active | `crates/citum-schema/tests/` |
+| [`INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`](./INPUT_REFERENCE_CLASS_DISCRIMINATOR.md) — discriminated union for reference-class dispatch | Active | `crates/citum-schema/tests/` |
+| [`GENERALIZED_RELATIONAL_CONTAINER_MODEL.md`](./GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) — recursive relational container model replacing flat variables | Active | `metadata.rs` |
+| [`DATE_MODEL.md`](./DATE_MODEL.md) — refined date model for created vs. issued distinction | Active | `metadata.rs` |
+| [`NUMBERING_SEMANTICS.md`](./NUMBERING_SEMANTICS.md) — canonical semantics for numbering, report, and part fields | Active | `metadata.rs` |
+| [`ARCHIVAL_UNPUBLISHED_SUPPORT.md`](./ARCHIVAL_UNPUBLISHED_SUPPORT.md) — ArchiveInfo and EprintInfo first-class source support | Active | `metadata.rs` |
+| [`ORIGINAL_PUBLICATION_RELATION_SUPPORT.md`](./ORIGINAL_PUBLICATION_RELATION_SUPPORT.md) — universal original publication metadata support across all types | Active | `metadata.rs` |
+| [`STRONG_DOMAIN_TYPES_PHASE1.md`](./STRONG_DOMAIN_TYPES_PHASE1.md) — replacing primitive String aliases with dedicated domain types | Active | `crates/citum-schema/tests/` |
+
+### Text & Rendering
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`TEMPLATE_V2.md`](./TEMPLATE_V2.md) — simplified Template Schema v2 with group-first composition | Active | `bibliography.rs`, `citations.rs` |
+| [`TEMPLATE_V3.md`](./TEMPLATE_V3.md) — Template Schema v3 extensions | Active | `bibliography.rs`, `citations.rs` |
+| [`TITLE_TEXT_CASE.md`](./TITLE_TEXT_CASE.md) — modeling and applying title-like text-case transformations | Active | `bibliography.rs` |
+| [`TITLE_NAME_INFLECTION.md`](./TITLE_NAME_INFLECTION.md) — grammatical inflection of title-adjacent names | Active | `bibliography.rs` |
+| [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md) — normalization of punctuation at rendered output boundaries | Active | `bibliography.rs`, `citations.rs` |
+| [`DJOT_RICH_TEXT.md`](./DJOT_RICH_TEXT.md) — Djot as the rich-text markup substrate for note/abstract fields | Active | `document.rs::djot_adapter` |
+| [`SHORT_NAME.md`](./SHORT_NAME.md) — short-name rendering for abbreviated contributor identifiers | Active | `bibliography.rs::title_short_resolution` |
+| [`ABBREVIATION_MAP.md`](./ABBREVIATION_MAP.md) — abbreviation lookup map for journal and publisher names | Active | `bibliography.rs` |
+
+### Document & Input
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`DOCUMENT_INPUT_PARSER_BOUNDARY.md`](./DOCUMENT_INPUT_PARSER_BOUNDARY.md) — boundary between format parsers and shared processing pipeline | Active | `document.rs`, `io.rs` |
+| [`FIDELITY_RICH_INPUTS.md`](./FIDELITY_RICH_INPUTS.md) — fidelity pipeline support for relational benchmark inputs | Active | `document.rs`, `io.rs` |
+| [`FORWARD_COMPATIBILITY.md`](./FORWARD_COMPATIBILITY.md) — forward-compatibility guarantees across schema versions | Active | `forward_compatibility.rs` |
+| [`SERVER_INTERACTIVE_API.md`](./SERVER_INTERACTIVE_API.md) — document-batch and session APIs for server and WASM | Draft | `crates/citum-server/tests/rpc.rs` |
+
+### Migration (CSL → Citum)
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`MIGRATE_RESEARCH_RICH_INPUTS.md`](./MIGRATE_RESEARCH_RICH_INPUTS.md) — bounded rich-input workflow for migrate-research passes | Active | `crates/citum-migrate/tests/` |
+| [`MIGRATION_TAXONOMY_AWARE_WRAPPERS.md`](./MIGRATION_TAXONOMY_AWARE_WRAPPERS.md) — taxonomy-aware wrapper derivation during style migration | Active | `crates/citum-migrate/tests/` |
+| [`EMBEDDED_ROOT_WRAPPER_MIGRATION.md`](./EMBEDDED_ROOT_WRAPPER_MIGRATION.md) — proof-gated embedded roots plus thin public wrappers for style migration | Active | `crates/citum-migrate/tests/` |
+| [`MIXED_CONDITION_NOTE_POSITION_TREES.md`](./MIXED_CONDITION_NOTE_POSITION_TREES.md) — migration of legacy choose trees with mixed position predicates | Active | `crates/citum-migrate/tests/` |
+| [`EMBEDDED_JS_TEMPLATE_INFERENCE.md`](./EMBEDDED_JS_TEMPLATE_INFERENCE.md) — embedded JS runtime for live template inference in migrator | Active | `crates/citum-migrate/tests/` |
+| [`ENGINE_MIGRATE_COEVOLUTION_WAVE.md`](./ENGINE_MIGRATE_COEVOLUTION_WAVE.md) — engine-first co-evolution wave for style-fidelity fixes | Active | — |
+
+### Style System & Configuration
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`STYLE_PRESET_ARCHITECTURE.md`](./STYLE_PRESET_ARCHITECTURE.md) — two-level configuration reuse for bases and profiles | Active | `crates/citum-schema-style/tests/` |
+| [`STYLE_REGISTRY.md`](./STYLE_REGISTRY.md) — serde-driven StyleRegistry replacing hardcoded slices | Active | `crates/citum-schema-style/tests/` |
+| [`STYLE_TAXONOMY.md`](./STYLE_TAXONOMY.md) — Citum style taxonomy based on semantic class and implementation | Active | `crates/citum-schema-style/tests/` |
+| [`STYLE_EDITIONS_AND_FAMILIES.md`](./STYLE_EDITIONS_AND_FAMILIES.md) — style edition and family versioning model | Active | `crates/citum-schema-style/tests/` |
+| [`STYLE_ALIASING.md`](./STYLE_ALIASING.md) — alias/discovery layer for style identity resolution | Active | `crates/citum-schema-style/tests/` |
+| [`APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md`](./APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md) — APA SQI alignment and preset-first cleanup | Active | `bibliography.rs`, `citations.rs` |
+| [`CHICAGO_18_COVERAGE.md`](./CHICAGO_18_COVERAGE.md) — Chicago 18th and APA 8th high-fidelity coverage enhancement | Active | `bibliography.rs`, `citations.rs` |
+| [`UNIFIED_SCOPED_OPTIONS.md`](./UNIFIED_SCOPED_OPTIONS.md) — typed scoped options replacing flat author-facing contracts | Active | `crates/citum-schema-style/tests/` |
+| [`PER_DOCUMENT_CONFIG_OVERRIDES.md`](./PER_DOCUMENT_CONFIG_OVERRIDES.md) — eligible options and syntax for per-document configuration overrides | Draft | `bibliography.rs::local_overrides` |
+| [`SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md`](./SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md) — crate-level schema split and CLI conversion namespace | Active | `crates/citum-schema/tests/` |
+| [`PROFILE_DOCUMENTARY_VERIFICATION.md`](./PROFILE_DOCUMENTARY_VERIFICATION.md) — verification model for profile styles using external authority | Draft | — |
+
+### Platform & Infra
+
+| Spec | Status | Tests |
+|------|--------|-------|
+| [`LANGUAGE_BINDINGS.md`](./LANGUAGE_BINDINGS.md) — multi-language type bindings for canonical data shapes | Active | `crates/citum-bindings/tests/` |
+| [`WASM_SUPPORT.md`](./WASM_SUPPORT.md) — WASM build targets and embedding model | Active | — |
+| [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) — federated registry and distributed resolver architecture (Phases 2–3) | Draft | — |
+| [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) — clean command model for style discovery, registry management, and CLI validation UX | Draft | — |
+| [`AUTHORING_AGENT_SKILL.md`](./AUTHORING_AGENT_SKILL.md) — Citum Authoring Agent Skill specification for AI-assisted style authoring | Active | — |
+
+---
 
 ### Completed
 
-| File | Feature |
+| Spec | Feature |
 |------|---------|
 | [`JOURNAL_PROFILE_TAXONOMY_AUDIT.md`](./JOURNAL_PROFILE_TAXONOMY_AUDIT.md) | Audit of journal-profile taxonomy and authority rules |
 | [`PANDOC_MARKDOWN_CITATIONS.md`](./PANDOC_MARKDOWN_CITATIONS.md) | Pandoc-style citation marker support for Markdown documents |
 
 ### Superseded
 
-| File | Feature |
+| Spec | Feature |
 |------|---------|
 | [`CONFIG_ONLY_PROFILE_OVERRIDES.md`](./CONFIG_ONLY_PROFILE_OVERRIDES.md) | Alternative configuration-only profile override model |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -138,7 +138,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | Spec | Status | Tests |
 |------|--------|-------|
 | [`TEMPLATE_V2.md`](./TEMPLATE_V2.md) — simplified Template Schema v2 with group-first composition | Active | `bibliography.rs`, `citations.rs` |
-| [`TEMPLATE_V3.md`](./TEMPLATE_V3.md) — Template Schema v3 extensions | Draft | `bibliography.rs`, `citations.rs` |
+| [`TEMPLATE_V3.md`](./TEMPLATE_V3.md) — Template Schema v3 extensions | Active | `bibliography.rs`, `citations.rs` |
 | [`TITLE_TEXT_CASE.md`](./TITLE_TEXT_CASE.md) — modeling and applying title-like text-case transformations | Active | `bibliography.rs` |
 | [`TITLE_NAME_INFLECTION.md`](./TITLE_NAME_INFLECTION.md) — grammatical inflection of title-adjacent names | Active | `bibliography.rs` |
 | [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md) — normalization of punctuation at rendered output boundaries | Draft | `bibliography.rs`, `citations.rs` |
@@ -190,7 +190,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | Spec | Status | Tests |
 |------|--------|-------|
 | [`LANGUAGE_BINDINGS.md`](./LANGUAGE_BINDINGS.md) — multi-language type bindings for canonical data shapes | Active | `crates/citum-bindings/tests/` |
-| [`WASM_SUPPORT.md`](./WASM_SUPPORT.md) — WASM build targets and embedding model | Draft | — |
+| [`WASM_SUPPORT.md`](./WASM_SUPPORT.md) — WASM build targets and embedding model | Active | — |
 | [`DISTRIBUTED_RESOLVER.md`](./DISTRIBUTED_RESOLVER.md) — federated registry and distributed resolver architecture (Phases 2–3) | Active | — |
 | [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) — clean command model for style discovery, registry management, and CLI validation UX | Active | — |
 | [`AUTHORING_AGENT_SKILL.md`](./AUTHORING_AGENT_SKILL.md) — Citum Authoring Agent Skill specification for AI-assisted style authoring | Active | — |

--- a/docs/specs/SORTING.md
+++ b/docs/specs/SORTING.md
@@ -142,9 +142,10 @@ behavior. Bibliography-specific sort tests: `mod sorting` in
 
 ## Open Work
 
-- `EXPLICIT_DEFAULT_SORTING.md` tracks the implementation of `Processing::default_citation_sort_policy()`
-  and the formalization of `CitationSortPolicy::ExplicitOnly` as a public API (currently
-  behavior-only, not an enum value).
+- `EXPLICIT_DEFAULT_SORTING.md` tracks any remaining cleanup around
+  `Processing::default_citation_sort_policy()` and `CitationSortPolicy::ExplicitOnly`.
+  Both are already public (`processing.rs:162`, `processing.rs:207`) and re-exported
+  from `options/mod.rs`; the spec's implementation steps are effectively complete.
 - Per-script partitioning (`sort-partitioning`) acceptance criteria are tracked in
   `MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`.
 

--- a/docs/specs/SORTING.md
+++ b/docs/specs/SORTING.md
@@ -137,7 +137,8 @@ input order if their IDs are also equal.
 ## Test Anchor
 
 `crates/citum-engine/tests/sort_oracle.rs` — end-to-end bibliography and citation sort
-behavior. Bibliography sort sub-module: `crates/citum-engine/tests/bibliography.rs::sorting`.
+behavior. Bibliography-specific sort tests: `mod sorting` in
+`crates/citum-engine/tests/bibliography.rs`.
 
 ## Open Work
 

--- a/docs/specs/SORTING.md
+++ b/docs/specs/SORTING.md
@@ -1,0 +1,152 @@
+# Sorting Specification
+
+**Status:** Active
+**Date:** 2026-05-31
+**Related:** [`EXPLICIT_DEFAULT_SORTING.md`](./EXPLICIT_DEFAULT_SORTING.md),
+  [`UNICODE_BIBLIOGRAPHY_SORTING.md`](./UNICODE_BIBLIOGRAPHY_SORTING.md),
+  [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md),
+  sorting sections of [`MULTILINGUAL.md`](./MULTILINGUAL.md)
+
+## Purpose
+
+Canonical end-to-end specification for bibliography and citation sorting in Citum.
+Sorting predates the spec-driven-development policy, so this document captures shipped
+behavior and design intent, and references narrower specs that extend or constrain it.
+
+## Scope
+
+**In scope:** bibliography sort resolution, citation-cluster sort policy, sort keys and
+presets, collation, secondary/tiebreak rules, grouping interplay.
+
+**Out of scope:** script/language partitioning (see
+[`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md)),
+transliteration-aware sort keys, per-entry sort overrides.
+
+## Core Separation of Concerns
+
+Following biblatex's design, Citum separates sorting into two independent concerns:
+
+| Concern | Schema location | Who may set it |
+|---|---|---|
+| Bibliography ordering | `bibliography.sort` | Style author; falls back to processing-family default |
+| Citation-cluster ordering | `citation.sort` | Style author only; no family default |
+
+These two sort specifications are fully independent. A style may have a `citation.sort`
+without any `bibliography.sort`, or vice versa.
+
+## Bibliography Sort Resolution
+
+Resolution is applied at bibliography-render time, in priority order:
+
+1. Explicit `bibliography.sort` in the style YAML.
+2. Processing-family default (`Processing::default_bibliography_sort()`).
+3. No sort — preserve insertion order.
+
+### Processing-Family Bibliography Defaults
+
+| Processing class | Default bibliography sort preset |
+|---|---|
+| `author-date` | `author-date-title` |
+| `note` | `author-title-date` |
+| `label` | `author-date-title` |
+| `numeric` | None (insertion order) |
+
+These defaults exist because author-date and note families have strong conventional
+ordering, while numeric styles depend on their own numbering logic.
+
+**Implementation:** `crates/citum-schema-style/src/options/processing.rs` →
+`Processing::default_bibliography_sort()` and `Processing::config()`.
+
+## Citation-Cluster Sort Policy
+
+Citation-cluster ordering is explicit-only in the current implementation:
+
+- If `citation.sort` is present, apply it.
+- Otherwise preserve citation input order.
+
+No processing family provides an implicit citation-list sort. This mirrors
+biblatex's `sortcites` opt-in philosophy.
+
+## Sort Keys
+
+Sort keys are defined by `SortKey` (non-exhaustive) in
+`crates/citum-schema-style/src/options/processing.rs`:
+
+| Key | Semantics |
+|---|---|
+| `Author` | Primary author name (family-first); falls back to editor, then title if no contributor |
+| `Year` | Issued date year; year-bearing entries precede year-less entries |
+| `Title` | Title text with locale article stripping (see `Locale::strip_sort_articles`) |
+| `CitationNumber` | Numeric citation order (used internally; always equal in sort comparisons) |
+
+Each key has an `ascending` flag (default `true`).
+
+## Sort Presets
+
+Named `SortPreset` values resolve to fixed `SortKey` chains:
+
+| Preset | Key chain |
+|---|---|
+| `author-date-title` | `Author → Year → Title` |
+| `author-title-date` | `Author → Title → Year` |
+
+Styles may also supply a custom `SortSpec` template instead of a named preset.
+
+## Collation
+
+All text comparisons (author, title keys) use a locale-aware `TextCollator`
+(`crates/citum-engine/src/sort_support.rs`), backed by ICU4X when the `icu`
+feature is enabled.
+
+Configuration:
+- **Strength:** Secondary — base letters and diacritics distinguished; case is not.
+- **Case level:** Off — case-insensitive via collator configuration, not lowercasing.
+- **Alternate handling:** Shifted — punctuation and whitespace ignorable at primary/secondary
+  levels (leading "al-", "O'", etc. do not break alphabetical ordering).
+- **Locale fallback:** Progressively strips subtags (`de-DE-x` → `de-DE` → `de`) until a
+  recognized locale is found; falls back to `en-US`.
+
+Full collation semantics are specified in
+[`UNICODE_BIBLIOGRAPHY_SORTING.md`](./UNICODE_BIBLIOGRAPHY_SORTING.md).
+
+## Deterministic Tiebreaking
+
+When all sort-key comparisons produce `Equal`, entries are ordered by citation-key
+string comparison (`id.0.as_str()`). Entries without an ID sort last. The underlying
+sort is stable, so entries that are collator-equal through all steps retain their original
+input order if their IDs are also equal.
+
+## Grouping Interplay
+
+- Numeric citation-number initialization and year-suffix/disambiguation ordering both
+  consume the resolved bibliography sort; they must be applied after sort resolution.
+- Grouped bibliographies (`bibliography.groups`) apply their own per-group sort independently.
+  Partition-aware sorting (`sort-partitioning`) runs as a pre-pass before the normal key
+  chain; see [`MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`](./MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md).
+
+## Key Implementation Files
+
+| File | Role |
+|---|---|
+| `crates/citum-engine/src/processor/sorting.rs` | `Sorter` struct; multi-key sort dispatch |
+| `crates/citum-engine/src/sort_support.rs` | `TextCollator`, `author_sort_key_opt`, `title_sort_key` |
+| `crates/citum-engine/src/grouping/sorting.rs` | Grouped bibliography sort integration |
+| `crates/citum-engine/src/sort_partitioning.rs` | Script/language partition pre-pass |
+| `crates/citum-schema-style/src/options/processing.rs` | `SortKey`, `SortSpec`, `SortEntry`, `SortPreset`, `Processing::default_bibliography_sort()` |
+
+## Test Anchor
+
+`crates/citum-engine/tests/sort_oracle.rs` — end-to-end bibliography and citation sort
+behavior. Bibliography sort sub-module: `crates/citum-engine/tests/bibliography.rs::sorting`.
+
+## Open Work
+
+- `EXPLICIT_DEFAULT_SORTING.md` tracks the implementation of `Processing::default_citation_sort_policy()`
+  and the formalization of `CitationSortPolicy::ExplicitOnly` as a public API (currently
+  behavior-only, not an enum value).
+- Per-script partitioning (`sort-partitioning`) acceptance criteria are tracked in
+  `MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md`.
+
+## Changelog
+
+- 2026-05-31: Initial version — documents shipped behavior; references narrow sub-specs.

--- a/docs/specs/TEMPLATE_V3.md
+++ b/docs/specs/TEMPLATE_V3.md
@@ -1,6 +1,6 @@
 # Template Schema v3 Specification
 
-**Status:** Draft
+**Status:** Active
 **Version:** 0.3
 **Date:** 2026-05-05
 **Supersedes:** `docs/specs/TEMPLATE_V2.md`

--- a/docs/specs/WASM_SUPPORT.md
+++ b/docs/specs/WASM_SUPPORT.md
@@ -1,339 +1,122 @@
-# WebAssembly Support Architecture
+# WebAssembly Support Specification
 
-**Status:** Design Phase (Deferred)
-**Bean:** csl26-qf4k
-**Author:** Deep architecture analysis
-**Date:** 2026-02-15
+**Status:** Active
+**Date:** 2026-05-31
+**Supersedes:** previous "Design Phase (Deferred)" architecture document
+**Related:** `crates/citum-bindings/`, `scripts/build-jsr-package.sh`,
+  `.github/workflows/release.yml`, `RELEASING.md`
 
-## Problem Statement
+## Purpose
 
-Citum processor is a pure Rust citation engine with no I/O dependencies, making it an ideal candidate for WebAssembly compilation. However, WASM support requires:
+Document Citum's shipped WebAssembly and TypeScript publication strategy. Citum
+exposes its citation engine to JavaScript/TypeScript consumers via a wasm-bindgen
+build of `crates/citum-bindings`, published as `@citum/engine` on JSR. This spec
+is the design authority for the public JS/TS API surface, the build pipeline, and
+the downstream integration point in citum-hub.
 
-1. **Browser integration** - JavaScript bindings for web-based citation processing
-2. **Cross-platform deployment** - Desktop/mobile plugins without native compilation
-3. **Serverless edge** - Cloudflare Workers, Deno Deploy, AWS Lambda with WASM runtime
-4. **Bundle size optimization** - Target <250 KB gzipped for fast browser loading
+## Scope
 
-The challenge: How do we expose Citum's synchronous, type-safe API to JavaScript ecosystems while maintaining zero-cost abstractions and deterministic performance?
+**In scope:** the `citum-bindings` wasm feature set, exported JS API, build
+pipeline (`build-jsr-package.sh`), JSR publication, and the citum-hub wasm-bridge
+as a downstream reference consumer.
 
-## Key Insight: WASM Beyond Browsers
+**Out of scope:** native FFI bindings (citum-labs), WASM runtimes other than the
+web target, bundle-size optimizations not yet implemented, and browser integration
+testing infrastructure.
 
-WASM is not just a browser technology—it's a universal compilation target for sandboxed execution:
+## Design
 
-**Desktop Contexts:**
-- Plugin systems (VS Code extensions, Obsidian plugins, Zotero plugins)
-- Cross-platform apps (Tauri/Electron) wanting embedded citation processing
-- Any app embedding citation engine without per-platform native compilation
+### Feature flags
 
-**Mobile Contexts:**
-- React Native apps (hermes-wasm)
-- Flutter apps (wasm_interop)
-- Hybrid mobile frameworks (Ionic, Capacitor)
+`crates/citum-bindings/Cargo.toml` exposes three composable WASM feature flags:
 
-**Serverless/Edge:**
-- Cloudflare Workers, Deno Deploy (WASM-native)
-- AWS Lambda with WASM runtime
-- Python/Node.js apps wanting sandboxed execution
+| Feature | Contents |
+|---|---|
+| `wasm` | wasm-bindgen bindings only; minimal bundle |
+| `small-wasm` | alias for `wasm` |
+| `full-wasm` | `wasm` + `icu` (locale-aware collation via ICU4X) |
 
-**Key Benefit:** Compile once, run anywhere with WASM runtime—avoids native compilation complexity.
+The JSR release build uses `full-wasm` for correct Unicode collation. Consumers
+wanting a smaller bundle can use `small-wasm` and accept ASCII-only collation
+fallback.
 
-## Design Solution: Three-Tier WASM Strategy
+### Exported JavaScript API
 
-### Tier 1: Core WASM Compatibility
+All public functions are feature-gated with
+`#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "..."))]`
+in `crates/citum-bindings/src/lib.rs`:
 
-**Purpose:** Ensure citum_engine compiles to wasm32-unknown-unknown without code changes.
+| JS name | Rust fn | Description |
+|---|---|---|
+| `getStyleMetadata` | `get_style_metadata` | Parse a YAML style and return metadata as JSON |
+| `materializeStyle` | `materialize_style` | Resolve inheritance and return a fully-materialized style JSON |
+| `renderCitation` | `render_citation` | Render a citation cluster from style YAML + refs JSON |
+| `renderBibliography` | `render_bibliography` | Render a bibliography from style YAML + refs JSON |
+| `validateStyle` | `validate_style` | Validate a YAML style; returns `Ok(())` or an error string |
+| `formatDocument` | `format_document` | Full document-batch rendering from a JSON request |
 
-**Approach:**
-1. Add `crate-type = ["cdylib", "rlib"]` to citum_engine Cargo.toml
-2. Feature-gate filesystem I/O (already minimal—only in CLI crates)
-3. Audit dependencies for no_std/WASM support
-4. Add wasm32-unknown-unknown to CI build matrix
+`export_typescript` is native-only (used by the schema generation toolchain).
 
-**Dependency Validation:**
-- ✅ winnow - Pure parser, no I/O
-- ✅ serde/serde_json/serde_yaml - WASM-compatible
-- ✅ indexmap - no_std support
-- ✅ jotdown - Renderer trait abstraction (PRIOR_ART.md #105)
-- ⚠️ regex - Works in WASM but large binary size (needs size optimization)
+### Build pipeline
 
-**Success Criteria:**
-- `cargo build --target wasm32-unknown-unknown` succeeds
-- All tests pass in WASM environment (wasm-pack test)
+`scripts/build-jsr-package.sh` is the authoritative build script:
 
-### Tier 2: JavaScript Bindings
+1. Runs `wasm-pack build crates/citum-bindings --target web --features full-wasm`.
+2. Stages output under `target/jsr/citum/` alongside `README-JSR.md` (renamed
+   to `README.md`) and a generated `jsr.json`.
+3. `jsr.json` sets `"name": "@citum/engine"` and lists the four wasm-bindgen
+   artefacts: `citum_bindings.js`, `citum_bindings.d.ts`,
+   `citum_bindings_bg.wasm`, `citum_bindings_bg.wasm.d.ts`.
 
-**Purpose:** Expose type-safe, ergonomic JavaScript API for citation processing.
+The `target/jsr/` directory is gitignored; the package is built fresh on every
+release tag.
 
-**Approach:** Create `csln_wasm` crate with wasm-bindgen bindings.
+### Publication
 
-**API Design (Synchronous Only):**
-```rust
-use wasm_bindgen::prelude::*;
+`@citum/engine` is published to `jsr.io/@citum/engine` via GitHub OIDC trusted
+publishing in the `publish-jsr` job of `.github/workflows/release.yml`. No JSR
+token is stored in CI secrets; publication is gated on a successful `build` job.
 
-#[wasm_bindgen]
-pub struct WasmProcessor {
-    style: Style,
-    references: Vec<Reference>,
-}
-
-#[wasm_bindgen]
-impl WasmProcessor {
-    /// Create processor from style YAML and references JSON
-    #[wasm_bindgen(constructor)]
-    pub fn new(style_yaml: &str, refs_json: &str) -> Result<WasmProcessor, JsValue>;
-
-    /// Process a single citation
-    #[wasm_bindgen(js_name = processCitation)]
-    pub fn process_citation(&self, citation_json: &str) -> Result<String, JsValue>;
-
-    /// Generate bibliography
-    #[wasm_bindgen(js_name = processBibliography)]
-    pub fn process_bibliography(&self) -> Result<String, JsValue>;
-
-    /// Get available reference types
-    #[wasm_bindgen(js_name = referenceTypes)]
-    pub fn reference_types() -> Vec<String>;
-}
+```bash
+# Install
+deno add jsr:@citum/engine
 ```
 
-**Error Handling:**
-```rust
-#[wasm_bindgen]
-pub enum WasmErrorKind {
-    ParseError,          // YAML/JSON parse failure
-    ReferenceError,      // Invalid reference structure
-    TemplateError,       // Style template issue
-}
+### citum-hub wasm-bridge (downstream reference)
 
-impl From<ProcessorError> for JsValue {
-    fn from(err: ProcessorError) -> Self {
-        // Structured error translation for JavaScript
-        let obj = js_sys::Object::new();
-        js_sys::Reflect::set(&obj, &"kind".into(), &err.kind().to_string().into());
-        js_sys::Reflect::set(&obj, &"message".into(), &err.to_string().into());
-        obj.into()
-    }
-}
-```
+`citum-hub/server/crates/wasm-bridge` is a Hub-specific adapter crate that
+depends on `citum-bindings` (with `wasm` + `legacy-convert` features) and the
+Hub's `intent-engine`. It is built with `wasm-pack --target nodejs` for the Hub
+server and exposes three additional Hub-specific functions: `decide`,
+`generate_style`, `render_intent_citation`. It is **not** part of the public
+`@citum/engine` API.
 
-**TypeScript Definitions:**
-```typescript
-// Generated by wasm-bindgen
-export class WasmProcessor {
-  constructor(style_yaml: string, refs_json: string);
-  processCitation(citation_json: string): string;
-  processBibliography(): string;
-  static referenceTypes(): string[];
-}
+## Implementation Notes
 
-export enum WasmErrorKind {
-  ParseError = "ParseError",
-  ReferenceError = "ReferenceError",
-  TemplateError = "TemplateError",
-}
-```
+- `wasm-opt` is disabled in the citum-hub wasm-bridge release profile but
+  enabled with size flags in `citum-bindings`
+  (`-Oz --enable-bulk-memory --enable-simd --strip-debug`).
+- TypeScript definitions are generated automatically by wasm-bindgen and
+  included in the JSR package.
+- `full-wasm` includes ICU4X for locale-aware bibliography sorting; `small-wasm`
+  falls back to bytewise comparison.
 
-**Rationale for Synchronous API:**
-- Citation processing is fast (<10ms per reference)
-- No I/O, network, or blocking operations
-- Matches native Citum API design
-- Avoids async overhead in JavaScript
+## Acceptance Criteria
 
-**Success Criteria:**
-- TypeScript definitions validated (tsc --noEmit)
-- Browser integration tests pass (Playwright)
-- Error messages clear and actionable
+- [x] `crates/citum-bindings` compiles to `wasm32-unknown-unknown` with
+      `full-wasm` feature.
+- [x] All six JS API functions exported with correct camelCase JS names.
+- [x] TypeScript definitions generated and included in the JSR package.
+- [x] `@citum/engine` published to JSR via trusted publishing (no stored token).
+- [x] `deno add jsr:@citum/engine` installs successfully.
+- [ ] End-to-end integration test: `formatDocument` called from Deno with a real
+      style + bibliography returns correct output.
+- [ ] Browser integration tests (Chrome, Firefox, Safari) via web target.
 
-### Tier 3: Bundle Optimization
+## Changelog
 
-**Purpose:** Minimize WASM bundle size for fast browser loading.
-
-**Approach:**
-1. **Cargo.toml optimization:**
-   ```toml
-   [profile.release]
-   opt-level = "z"           # Optimize for size
-   lto = true                # Link-time optimization
-   codegen-units = 1         # Single codegen unit for smaller binary
-   strip = true              # Strip debug symbols
-   panic = "abort"           # Smaller panic handling
-   ```
-
-2. **wasm-opt post-processing:**
-   ```bash
-   wasm-opt -Oz -o output.wasm input.wasm
-   ```
-
-3. **Feature flags for optional locales:**
-   ```toml
-   [features]
-   default = ["locale-en"]
-   locale-en = []
-   locale-de = []
-   locale-fr = []
-   # ... other locales
-   ```
-
-4. **Lazy loading for large data:**
-   - Load locales on-demand via JavaScript fetch
-   - Cache in IndexedDB for subsequent loads
-
-**Size Targets:**
-- Minimal (en-US only): <150 KB gzipped
-- Standard (5 locales): <250 KB gzipped
-- Full (all locales): <500 KB gzipped
-
-**Success Criteria:**
-- Bundle size meets targets
-- Lazy locale loading works
-- No runtime performance regression vs native
-
-## Implementation Roadmap
-
-### Phase 1: WASM Compatibility (1 week)
-1. Add `crate-type = ["cdylib", "rlib"]` to citum_engine
-2. Create csln_wasm crate with basic wasm-bindgen setup
-3. Add wasm32-unknown-unknown to CI (.github/workflows/ci.yml)
-4. Validate all dependencies compile to WASM
-5. Run test suite in WASM environment
-
-### Phase 2: JavaScript Bindings (2 weeks)
-1. Implement WasmProcessor with new(), process_citation(), process_bibliography()
-2. Add error translation (ProcessorError → JsValue)
-3. Generate TypeScript definitions
-4. Create browser integration tests (Playwright)
-5. Write example HTML demo page
-
-### Phase 3: Bundle Optimization (1 week)
-1. Enable LTO + opt-level="z" in release profile
-2. Add wasm-opt post-processing to build script
-3. Implement feature flags for locales
-4. Benchmark bundle sizes (minimal/standard/full)
-5. Add lazy locale loading example
-
-### Phase 4: npm Package (1 week)
-1. Create @csln/processor-wasm package structure
-2. Add package.json with TypeScript types
-3. Set up automated publishing (GitHub Actions)
-4. Write integration guide (../../WASM_INTEGRATION.md)
-5. Publish to npm registry
-
-### Phase 5: Verification (1 week)
-1. Port oracle.js verification to browser
-2. Run APA 7th test suite in WASM
-3. Benchmark native vs WASM performance
-4. Test in multiple browsers (Chrome, Firefox, Safari)
-5. Update STYLE_EDITOR_VISION.md with implementation status
-
-**Total Effort:** 6 weeks (deferred until API stable)
-
-## Compliance with Project Principles
-
-### 1. Explicit Over Magic
-- WASM API mirrors native Rust API design
-- No hidden browser-specific optimizations
-- Error handling explicit and structured
-
-### 2. Declarative Templates
-- WASM processor uses same style YAML as native
-- No WASM-specific template syntax
-- Portable styles between native and WASM
-
-### 3. Code-as-Schema
-- wasm-bindgen generates TypeScript definitions from Rust types
-- Single source of truth for API surface
-- Type safety preserved across language boundary
-
-### 4. Graceful Degradation
-- Locale loading fails gracefully (fallback to en-US)
-- Large bundle sizes degrade to lazy loading
-- WASM-unsupported browsers fall back to native or polyfill
-
-### 5. No Configuration Burden
-- Single new() constructor, minimal API surface
-- Same YAML/JSON inputs as native
-- No WASM-specific configuration
-
-## Persona Evaluation
-
-### Style Author
-- WASM deployment transparent (same YAML styles)
-- Browser preview uses WASM backend
-- No WASM-specific authoring required
-
-### Web Developer
-- Clean JavaScript API with TypeScript definitions
-- npm package with zero-config setup
-- Error messages clear and actionable
-
-### Systems Architect
-- Pure Rust implementation, zero-cost abstractions
-- Deterministic performance (no GC pauses)
-- Well-documented WASM compilation process
-
-### Domain Expert
-- WASM backend invisible (same citation output)
-- Browser-based tools "just work"
-- No installation required for web demos
-
-## Trigger Conditions for Implementation
-
-WASM support should be implemented when **any** of these conditions are met:
-
-1. **API Stability:** 10+ parent styles fully working (validates API design)
-2. **Feature Completeness:** Core features stable (disambiguation, page ranges, locales)
-3. **Integration Need:** Style editor work begins (STYLE_EDITOR_VISION.md #159)
-4. **External Request:** Zotero web, Obsidian plugin, or other integration request
-5. **Web Demo:** Need browser-based demonstration for project visibility
-
-**Current Status:** DEFERRED—blocked by Bean csl26-m3lb (hybrid migration strategy)
-
-## References
-
-- **citeproc-rs WASM** - PRIOR_ART.md Section 5.5 (WASM-first architecture)
-- **jotdown renderer** - PRIOR_ART.md #105 (trait-based output abstraction)
-- **STYLE_EDITOR_VISION.md** - Requires /preview/citation and /preview/bibliography endpoints (#159)
-- **wasm-bindgen Guide** - https://rustwasm.github.io/../../wasm-bindgen/
-- **wasm-pack** - https://rustwasm.github.io/../../wasm-pack/
-
-## Open Questions
-
-1. **Async API?** Should we provide optional async API for large bibliographies (>1000 refs)? Rationale: blocking main thread for long operations.
-2. **Streaming Output?** For large bibliographies, should we stream results incrementally? Rationale: progressive rendering in UI.
-3. **Multi-threading?** Should we support multi-threaded WASM via rayon + web workers? Rationale: parallel citation processing.
-4. **Locale CDN?** Should we host locales on CDN for lazy loading? Rationale: avoid bundling all locales in every app.
-
-## Success Metrics
-
-**Tier 1 (WASM Compatibility):**
-- [ ] citum_engine compiles to wasm32-unknown-unknown
-- [ ] All tests pass in WASM environment
-- [ ] Zero code changes to core processor
-
-**Tier 2 (JavaScript Bindings):**
-- [ ] TypeScript definitions validated
-- [ ] Browser integration tests pass (Chrome, Firefox, Safari)
-- [ ] Error messages clear and actionable
-- [ ] Example HTML demo page works
-
-**Tier 3 (Bundle Optimization):**
-- [ ] Minimal bundle <150 KB gzipped
-- [ ] Standard bundle <250 KB gzipped
-- [ ] Lazy locale loading works
-- [ ] Performance within 3x native
-
-**Tier 4 (npm Package):**
-- [ ] @csln/processor-wasm published to npm
-- [ ] Integration guide complete (../../WASM_INTEGRATION.md)
-- [ ] Automated publishing via GitHub Actions
-
-**Tier 5 (Verification):**
-- [x] APA 7th oracle tests pass in WASM
-- [x] Performance benchmark report (native vs WASM) — see [WASM_BENCHMARK_REPORT.md](./WASM_BENCHMARK_REPORT.md)
-- [ ] STYLE_EDITOR_VISION.md updated with implementation status
-
-## Conclusion
-
-WASM support extends Citum processor to browser, desktop, mobile, and serverless contexts without code duplication or native compilation complexity. By deferring implementation until API stability (10+ parent styles working), we avoid premature optimization while preserving WASM-compatible design patterns.
-
-The three-tier strategy (compatibility → bindings → optimization) provides clear milestones and allows incremental deployment. When trigger conditions are met, implementation follows a well-defined 6-week roadmap with measurable success criteria.
+- 2026-05-31: Rewrite. Supersedes the "Design Phase (Deferred)" document that
+  proposed `csln_wasm` crate, `@csln/processor-wasm` on npm, and a three-tier
+  future roadmap. Documents the shipped `@citum/engine` on JSR, the
+  `citum-bindings` feature-flag model, and citum-hub wasm-bridge as a downstream
+  consumer.


### PR DESCRIPTION
## Summary

- Reorganizes `docs/specs/README.md` from status-grouped tables into **10 capability areas** (Citations, Bibliography, Note Styles, Sorting, Localization & Multilingual, Data Model & Types, Text & Rendering, Document & Input, Migration, Style System & Config, Platform & Infra).
- Each row now carries `Spec | Status | Tests` columns so an agent or human can navigate "review `citations.rs::disambiguation` against `DISAMBIGUATION.md`" directly.
- Adds `SORTING.md` — an umbrella spec documenting shipped sort behavior (bibliography vs citation separation, processing-family defaults, sort keys/presets, UCA/CLDR collation, tiebreaking). References `EXPLICIT_DEFAULT_SORTING`, `UNICODE_BIBLIOGRAPHY_SORTING`, `MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING`. Anchors: `sort_oracle.rs`, `bibliography.rs::sorting`.
- Fixes two specs that were on disk but absent from the old index: `BIBLIOGRAPHY_GROUPING.md` and `LEGAL_CITATIONS.md`.

## Coverage check

All 76 spec files are listed exactly once (75 pre-existing + 1 new). Verified by `comm -23` and `uniq -d`.

## Test plan

- [x] All spec links in README resolve to existing files (`grep -oE ... | xargs`)
- [x] All test anchors named in the Tests column are real module paths
- [x] No specs were dropped or duplicated
