### PR TITLE
feat(engine): multilingual disambiguation key

### DIFF
--- a/.beans/archive/csl26-54jn--display-mode-aware-multilingual-disambiguation-key.md
+++ b/.beans/archive/csl26-54jn--display-mode-aware-multilingual-disambiguation-key.md
@@ -1,7 +1,7 @@
 ---
 # csl26-54jn
 title: Display-mode-aware multilingual disambiguation keys
-status: todo
+status: completed
 type: feature
 priority: normal
 tags:
@@ -10,7 +10,23 @@ tags:
     - disambiguation
     - spec
 created_at: 2026-05-31T20:36:49Z
-updated_at: 2026-05-31T20:36:49Z
+updated_at: 2026-05-31T21:25:28Z
 ---
 
 DISAMBIGUATION.md §4 requires the author collision key to reflect the same multilingual surface form the style renders (transliteration/translation/original) when display mode != primary. build_author_key in crates/citum-engine/src/processor/disambiguation.rs calls append_lowercased_families on raw family names without selecting the appropriate multilingual variant, so colliding transliterations are treated as distinct authors rather than a collision. Acceptance criterion 'Multilingual key generation respects display mode' in docs/specs/DISAMBIGUATION.md is open with no covering bean. Implement render_name_for_disambiguation to select the variant matching the active display mode before building the collision key. Spec: docs/specs/DISAMBIGUATION.md §4.
+
+## Summary of Changes
+
+Implemented `render_name_for_disambiguation` in `crates/citum-engine/src/processor/disambiguation.rs`.
+This private helper wraps the existing `resolve_multilingual_name` function,
+pulling `name_mode`, `preferred_transliteration`, and `preferred_script` from
+`self.config.multilingual`. `build_reference_cache` now calls it instead of
+`Contributor::to_names_vec()`, so the author collision key always reflects the
+same surface form the style renders.
+
+Added unit test `test_multilingual_key_generation_respects_display_mode`:
+- Transliterated mode + shared romanisation → same author key (collision detected)
+- Primary mode + distinct originals → different author keys (no spurious collision)
+
+Updated `docs/specs/DISAMBIGUATION.md` §4 acceptance criterion and Changelog.
+All 1459 tests pass.

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -216,9 +216,9 @@ impl<'a> Disambiguator<'a> {
         let mut cache = HashMap::with_capacity(refs.len());
 
         for reference in refs {
-            let names = reference
-                .author()
-                .map_or_else(Vec::new, |authors| authors.to_names_vec());
+            let names = reference.author().map_or_else(Vec::new, |authors| {
+                self.render_name_for_disambiguation(&authors)
+            });
             let author_key = self.build_author_key(&names);
             let group_key = self.build_group_key(reference, &author_key);
             let title_key = needs_title_key.then(|| {
@@ -698,6 +698,23 @@ impl<'a> Disambiguator<'a> {
         }
 
         groups
+    }
+
+    /// Flattens a contributor to names using the style's active multilingual display
+    /// mode, so the collision key reflects the same surface form the style renders
+    /// (DISAMBIGUATION.md §4). Monolingual contributors fall through to the original.
+    fn render_name_for_disambiguation(
+        &self,
+        contributor: &citum_schema::reference::Contributor,
+    ) -> Vec<crate::reference::FlatName> {
+        let ml = self.config.multilingual.as_ref();
+        crate::values::resolve_multilingual_name(
+            contributor,
+            ml.and_then(|m| m.name_mode.as_ref()),
+            ml.and_then(|m| m.preferred_transliteration.as_deref()),
+            ml.and_then(|m| m.preferred_script.as_ref()),
+            &self.locale.locale,
+        )
     }
 
     /// Generates a normalized author string used for grouping and et-al detection.
@@ -1322,5 +1339,106 @@ mod tests {
         assert_eq!(first.group_key, second.group_key);
         assert!(!first.group_key.contains(':'));
         assert_ne!(first.group_index, second.group_index);
+    }
+
+    /// Build a reference whose author is `Contributor::Multilingual` with distinct
+    /// `original` but a shared `transliterations` entry keyed by `translit_tag`.
+    fn make_multilingual_ref(
+        id: &str,
+        original_family: &str,
+        translit_family: &str,
+        translit_tag: &str,
+        year: i32,
+    ) -> Reference {
+        use citum_schema::reference::contributor::MultilingualName;
+        use std::collections::HashMap;
+
+        let mut transliterations = HashMap::new();
+        transliterations.insert(
+            translit_tag.to_string(),
+            StructuredName {
+                family: MultilingualString::Simple(translit_family.to_string()),
+                given: MultilingualString::Simple("A.".to_string()),
+                ..Default::default()
+            },
+        );
+        Reference::Monograph(Box::new(Monograph {
+            id: Some(id.into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single(format!("Title {id}"))),
+            author: Some(Contributor::Multilingual(MultilingualName {
+                original: StructuredName {
+                    family: MultilingualString::Simple(original_family.to_string()),
+                    given: MultilingualString::Simple("A.".to_string()),
+                    ..Default::default()
+                },
+                lang: Some("ja".into()),
+                transliterations,
+                translations: HashMap::new(),
+            })),
+            issued: EdtfString(year.to_string()),
+            ..Default::default()
+        }))
+    }
+
+    /// DISAMBIGUATION.md §4: when display mode is `Transliterated`, two references
+    /// whose transliterations collide must produce the same author key (→ one
+    /// collision group). When mode is `Primary` (distinct originals), keys must differ.
+    #[test]
+    fn test_multilingual_key_generation_respects_display_mode() {
+        use citum_schema::options::MultilingualConfig;
+        use citum_schema::options::MultilingualMode;
+
+        // Two distinct Japanese authors that share the same romanisation.
+        // Original families differ ("田中" vs "谷中"), but transliteration is "Tanaka".
+        let r1 = make_multilingual_ref("r1", "田中", "Tanaka", "ja-Latn", 2020);
+        let r2 = make_multilingual_ref("r2", "谷中", "Tanaka", "ja-Latn", 2020);
+
+        let mut bib = Bibliography::new();
+        bib.insert("r1".to_string(), r1);
+        bib.insert("r2".to_string(), r2);
+
+        let locale = Locale::en_us();
+
+        // --- case 1: Transliterated mode → same key (collision) ---
+        let config_translit = Config {
+            multilingual: Some(MultilingualConfig {
+                name_mode: Some(MultilingualMode::Transliterated),
+                preferred_transliteration: Some(vec!["ja-Latn".to_string()]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let cache_translit = Disambiguator::new(&bib, &config_translit, &locale)
+            .build_reference_cache(&[bib.get("r1").unwrap(), bib.get("r2").unwrap()], false);
+
+        let ck_r1 = Disambiguator::reference_cache_key(bib.get("r1").unwrap());
+        let ck_r2 = Disambiguator::reference_cache_key(bib.get("r2").unwrap());
+        let ak_r1 = &cache_translit[&ck_r1].author_key;
+        let ak_r2 = &cache_translit[&ck_r2].author_key;
+
+        assert_eq!(
+            ak_r1, ak_r2,
+            "transliterated mode: colliding transliterations must produce the same author key"
+        );
+        assert_eq!(
+            ak_r1, "tanaka",
+            "key should be the lowercased transliteration"
+        );
+
+        // --- case 2: Primary mode → distinct keys (no collision) ---
+        let config_primary = Config::default(); // multilingual: None → falls through to original
+
+        let cache_primary = Disambiguator::new(&bib, &config_primary, &locale)
+            .build_reference_cache(&[bib.get("r1").unwrap(), bib.get("r2").unwrap()], false);
+
+        let ak_r1_primary = &cache_primary[&ck_r1].author_key;
+        let ak_r2_primary = &cache_primary[&ck_r2].author_key;
+
+        assert_ne!(
+            ak_r1_primary, ak_r2_primary,
+            "primary mode: distinct originals must produce different author keys"
+        );
     }
 }

--- a/docs/specs/DISAMBIGUATION.md
+++ b/docs/specs/DISAMBIGUATION.md
@@ -175,12 +175,17 @@ added to the citation context.
 - [x] Year-suffix collision key uses only `issued` year (no original-date gate)
 - [x] All native disambiguation tests passing
 - [x] Group-aware suffix restart implemented (`disambiguate: locally`)
-- [ ] Multilingual key generation respects display mode
+- [x] Multilingual key generation respects display mode
 - [x] Native fixture asserting `(1926/1967a) (1926/1967b) (1927/1967c)` for the APA §8.15 reprint scenario
 - [x] Short-title suppression via `first-reference-note-number` implemented and tested
 
 ## Changelog
 
+- 2026-05-31: Implemented `render_name_for_disambiguation` (csl26-54jn). Flattens
+  contributors via `resolve_multilingual_name` so the collision key matches the style's
+  active display mode (transliterated/translated/primary). Covered by
+  `test_multilingual_key_generation_respects_display_mode` in
+  `crates/citum-engine/src/processor/disambiguation.rs`. All acceptance criteria now met.
 - 2026-05-31: Test soundness audit (csl26-ucs3). Corrected `[x]` → `[ ]` for
   multilingual key generation — `render_name_for_disambiguation` not yet
   implemented; `disambiguation.rs` always reads `Contributor::Multilingual.original`.


### PR DESCRIPTION
## Summary

- Implements `render_name_for_disambiguation` in `crates/citum-engine/src/processor/disambiguation.rs`, satisfying the last open acceptance criterion in `docs/specs/DISAMBIGUATION.md` §4
- The author collision key now calls `resolve_multilingual_name` (same helper used by the renderer and bibliography grouper) so it reflects the style's active multilingual display mode instead of always reading `Contributor::Multilingual.original`
- Two references whose transliterations collide now correctly form a single collision group when the style is set to `Transliterated` mode, triggering year-suffix disambiguation (2020a / 2020b) as expected

## Test plan

- [x] New unit test `test_multilingual_key_generation_respects_display_mode` in `processor::disambiguation::tests`:
  - **Transliterated mode + shared romanisation** → same `author_key` (collision detected)
  - **Primary mode + distinct originals** → different `author_key` (no spurious collision)
- [x] All 1459 existing tests continue to pass (monolingual paths unchanged: `resolve_multilingual_name` delegates to `to_names_vec()` for `SimpleName`/`StructuredName`)
- [x] `docs/specs/DISAMBIGUATION.md` acceptance criterion flipped to `[x]`; changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
