### PR TITLE
docs(specs): remove effort estimates

### DIFF
--- a/docs/specs/BIBLIOGRAPHY_GROUPING.md
+++ b/docs/specs/BIBLIOGRAPHY_GROUPING.md
@@ -398,43 +398,6 @@ groups:
 
 **Processor precedence:** User-defined groups > Style-defined groups > Flat bibliography
 
-## Implementation Roadmap
-
-1. **Schema Extension** (2 days)
-   - Add types to `citum_schema/src/lib.rs`
-   - Generate JSON schema
-   - Add tests for YAML parsing
-
-2. **Selector Logic** (3 days)
-   - Create `citum_engine/src/grouping/selector.rs`
-   - Implement predicate evaluation
-   - Add unit tests for selector matching
-
-3. **Group Sorting** (4 days)
-   - Extend sorting with type-order and name-order variants
-   - Refactor `sort_references` to accept sort specification
-   - Add integration tests
-
-4. **Processor Integration** (3 days)
-   - Refactor `render_grouped_bibliography_with_format`
-   - Add fallback logic for ungrouped items
-   - Preserve backward compatibility
-
-5. **Legal Use Case** (2 days)
-   - Create `styles/bluebook-legal.yaml`
-   - Test type hierarchy with legal fixtures
-   - Validate against Bluebook manual
-
-6. **Multilingual Use Case** (2 days)
-   - Create `styles/multilingual-academic.yaml`
-   - Test per-group sorting with Vietnamese/English fixtures
-   - Validate collation rules
-
-7. **Documentation** (2 days)
-   - Style authoring guide for grouping
-   - Migration guide from hardcoded logic
-   - Update CLAUDE.md with grouping patterns
-
 ## Prior Art
 
 ### biblatex

--- a/docs/specs/LEGAL_CITATIONS.md
+++ b/docs/specs/LEGAL_CITATIONS.md
@@ -176,7 +176,6 @@ Obergefell v. Hodges, 135 S. Ct. 2584, 2604, 192 L. Ed. 2d 609 (2015).
 ### Phase 1: Core Legal Types (Tier 1)
 
 **Priority:** Medium (Feature Roadmap)
-**Effort:** 2-3 weeks
 
 1. **Add legal reference types to `citum-schema-style/src/reference/types.rs`:**
    ```rust
@@ -237,7 +236,6 @@ Obergefell v. Hodges, 135 S. Ct. 2584, 2604, 192 L. Ed. 2d 609 (2015).
 ### Phase 2: Legal Specialist Features (Tier 2)
 
 **Priority:** Low (after Phase 1 validated)
-**Effort:** 3-4 weeks
 
 1. **Create jurisdiction hierarchy system** (`citum-schema-style/src/legal/jurisdiction.rs`):
    ```rust


### PR DESCRIPTION
## Summary

- Adds MaybeGendered dispatch regression fixtures for the locale feature landed in csl26-y3kj (bean csl26-oyl4).
- Expands `fr-FR.yaml` editor role with masculine/feminine/common variants (editeur/editrice/editeurs/editrices).
- Adds Arabic `page` locator term with `gender: feminine` lexical gender marker to `ar-AR.yaml`.
- New test file `tests/gendered_locale.rs` with three locale-API-level snapshot tests.

## Test plan

- [x] `cargo nextest run --test gendered_locale` — all 3 new tests pass
- [x] `cargo nextest run` — 1462/1462 green, no regressions
- [x] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings` — clean

Closes bean csl26-oyl4 (archived).
