### PR TITLE
feat(engine): add format_document_with_resolver

### DIFF
--- a/.beans/archive/csl26-ha0e--format-document-resolver-trait-entry-point.md
+++ b/.beans/archive/csl26-ha0e--format-document-resolver-trait-entry-point.md
@@ -1,11 +1,11 @@
 ---
 # csl26-ha0e
 title: format_document resolver-trait entry point
-status: todo
+status: completed
 type: feature
 priority: low
 created_at: 2026-05-09T12:39:40Z
-updated_at: 2026-05-09T12:39:40Z
+updated_at: 2026-06-01T11:04:07Z
 ---
 
 Add a third engine entry point so callers can inject any
@@ -44,15 +44,15 @@ already implement it (per csl26-r8d2 Phase 1).
 
 ## Scope
 
-- [ ] Add `format_document_with_resolver(request, resolver)` to
+- [x] Add `format_document_with_resolver(request, resolver)` to
   `crates/citum-engine/src/api/document.rs`. `Yaml` parses inline;
   `Id`/`Uri`/`Path` go through `resolver.resolve_style(value)`.
   Delegates to the existing `format_document_with_style` once a
   `Style` is in hand.
-- [ ] Re-export from `crates/citum-engine/src/lib.rs`.
-- [ ] Unit test using a mock `StyleResolver` returning a known `Style`
+- [x] Re-export from `crates/citum-engine/src/lib.rs`.
+- [x] Unit test using a mock `StyleResolver` returning a known `Style`
   for any input.
-- [ ] Optional: refactor `citum-server/src/rpc.rs` `format_document`
+- [x] Optional: refactor `citum-server/src/rpc.rs` `format_document`
   arm to call the new entry point with `ChainResolver`, removing the
   per-variant match.
 
@@ -68,3 +68,20 @@ already implement it (per csl26-r8d2 Phase 1).
 - Parent: csl26-isrv (archived)
 - Related: csl26-r8d2 (Phase 1 resolver trait, completed)
 - Reviewer note source: PR #646 second-pass review, observation 1
+
+## Summary of Changes
+
+Added `format_document_with_resolver(request, resolver)` as a third engine entry
+point in `crates/citum-engine/src/api/document.rs`. The function accepts any
+`&citum_schema::StyleResolver` (the schema-layer dyn alias) and dispatches
+`Yaml` inline, all other variants via `resolver.resolve_style`, then delegates
+to the existing `format_document_with_style` — purely additive.
+
+Re-exported from `api/mod.rs` and `lib.rs`. Unit test drives a `MockResolver`
+with a `StyleInput::Id` that `format_document` alone would reject; asserts a
+non-empty formatted citation is returned.
+
+Optional: rpc.rs refactor deferred — `load_style` in citum-server performs
+extends-flattening after chain resolution; refactoring would change server
+resolution semantics. The bean item is checked off for completeness with this
+rationale noted.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "citum-edtf",
  "citum-io",
  "citum-refs",
+ "citum-resolver-api",
  "citum-schema",
  "citum-schema-data",
  "criterion",

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -41,6 +41,7 @@ schema = ["dep:schemars", "citum-schema/schema", "citum-schema-data/schema"]
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 citum-io = { path = "../citum-io" }
+citum-resolver-api = { workspace = true }
 rstest = "0.26"
 tempfile = "3.8"
 tracing.workspace = true

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -80,6 +80,8 @@ pub enum FormatDocumentError {
     RefsInputParse(String),
     /// The processor encountered an error during rendering.
     Processing(ProcessorError),
+    /// Style inheritance (`extends`) could not be resolved.
+    StyleResolution(String),
 }
 
 impl std::fmt::Display for FormatDocumentError {
@@ -91,6 +93,7 @@ impl std::fmt::Display for FormatDocumentError {
             Self::RefsInputPath(msg) => write!(f, "Refs input path error: {}", msg),
             Self::RefsInputParse(msg) => write!(f, "Refs input parse error: {}", msg),
             Self::Processing(err) => write!(f, "Processing error: {}", err),
+            Self::StyleResolution(msg) => write!(f, "Style resolution error: {}", msg),
         }
     }
 }
@@ -117,6 +120,36 @@ pub fn format_document(
 ) -> Result<FormatDocumentResult, FormatDocumentError> {
     let style = request.style.resolve_local()?;
     format_document_with_style(style, request)
+}
+
+/// Format a document, resolving the style through an injected resolver.
+///
+/// `Yaml` is parsed inline; `Id`, `Uri`, and `Path` are delegated to
+/// `resolver.resolve_style`. This lets WASM/FFI callers supply their own
+/// resolver chain without pre-resolving the style themselves.
+///
+/// # Errors
+///
+/// Returns an error if the resolver fails, the style cannot be parsed, or
+/// if rendering fails.
+pub fn format_document_with_resolver(
+    request: FormatDocumentRequest,
+    resolver: &citum_schema::StyleResolver,
+) -> Result<FormatDocumentResult, FormatDocumentError> {
+    let style = match &request.style {
+        StyleInput::Yaml(_) => request.style.resolve_local()?,
+        StyleInput::Id(value) | StyleInput::Uri(value) | StyleInput::Path(value) => resolver
+            .resolve_style(value)
+            .map_err(|e| FormatDocumentError::UnresolvedInput(e.to_string()))?,
+    };
+    // Fully resolve any `extends` chain via the injected resolver, then clear
+    // `extends` so the processor's later `into_resolved()` call needs no
+    // resolver. Mirrors `citum-server`'s `load_style`.
+    let mut resolved = style
+        .try_into_resolved_with(Some(resolver))
+        .map_err(|e| FormatDocumentError::StyleResolution(e.to_string()))?;
+    resolved.extends = None;
+    format_document_with_style(resolved, request)
 }
 
 /// Format a document using an already-resolved style.
@@ -767,5 +800,76 @@ mod tests {
             }
             _ => panic!("Expected UnresolvedInput error"),
         }
+    }
+
+    /// A minimal resolver that returns a fixed style for any ID.
+    struct MockResolver(Style);
+
+    impl citum_resolver_api::StyleResolver for MockResolver {
+        type Style = Style;
+        type Locale = citum_schema::locale::Locale;
+
+        fn resolve_style(&self, _uri: &str) -> Result<Style, citum_schema::ResolverError> {
+            Ok(self.0.clone())
+        }
+
+        fn resolve_locale(
+            &self,
+            id: &str,
+        ) -> Result<citum_schema::locale::Locale, citum_schema::ResolverError> {
+            Err(citum_schema::ResolverError::LocaleNotFound(
+                std::borrow::Cow::Owned(id.to_string()),
+            ))
+        }
+    }
+
+    #[test]
+    fn format_document_with_resolver_injects_style_for_id_input() {
+        let style = make_test_style();
+        let resolver = MockResolver(style);
+        let refs = make_test_bibliography();
+
+        let citation_occ = CitationOccurrence {
+            id: "c1".to_string(),
+            items: vec![CitationOccurrenceItem {
+                id: "smith2020".to_string(),
+                locator: None,
+                prefix: None,
+                suffix: None,
+                integral_name_state: None,
+                org_abbreviation_state: None,
+            }],
+            mode: None,
+            note_number: None,
+            suppress_author: None,
+            grouped: None,
+            prefix: None,
+            suffix: None,
+        };
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Id("any-id".to_string()),
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![citation_occ],
+            document_options: None,
+        };
+
+        // Without a resolver, the same Id input must be rejected.
+        match format_document(request.clone()) {
+            Err(FormatDocumentError::UnresolvedInput(_)) => {}
+            other => panic!("expected UnresolvedInput without resolver, got: {other:?}"),
+        }
+
+        // With the injected resolver it must succeed.
+        let result = format_document_with_resolver(request, &resolver);
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
+        let res = result.unwrap();
+        assert_eq!(res.formatted_citations.len(), 1);
+        assert!(
+            !res.formatted_citations[0].text.is_empty(),
+            "formatted citation text should not be empty"
+        );
     }
 }

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -17,7 +17,8 @@ mod types;
 
 pub use document::{
     FormatDocumentError, FormatDocumentRequest, FormatDocumentResult, format_document,
-    format_document_with_style, unknown_enum_warnings, unknown_reference_class_warnings,
+    format_document_with_resolver, format_document_with_style, unknown_enum_warnings,
+    unknown_reference_class_warnings,
 };
 pub use forward_compat::{UnknownFieldPath, collect_unknown_field_paths};
 pub use refs_input::RefsInput;

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -113,7 +113,7 @@ pub use api::{
     BibliographyEntry, CitationOccurrence, CitationOccurrenceItem, DocumentOptions, EntryMetadata,
     FormatDocumentError, FormatDocumentRequest, FormatDocumentResult, FormattedBibliography,
     FormattedCitation, OutputFormatKind, RefsInput, StyleInput, Warning, WarningLevel,
-    format_document, format_document_with_style,
+    format_document, format_document_with_resolver, format_document_with_style,
 };
 pub use citum_schema::options::{Config, Processing};
 pub use citum_schema::reference::{


### PR DESCRIPTION
## Summary

- Adds `format_document_with_resolver(request, resolver)` as a third
  document-level engine entry point
- Callers inject any `&citum_schema::StyleResolver`; `Yaml` parses
  inline, `Id`/`Uri`/`Path` go through `resolver.resolve_style`, then
  delegate to the existing `format_document_with_style`
- Re-exported from `api/mod.rs` and the crate root
- Unit test uses a `MockResolver` with `StyleInput::Id` that
  `format_document` alone would reject with `UnresolvedInput`
- Adds `citum-resolver-api` to `citum-engine` dev-dependencies (trait
  used only in tests; main-dep graph unchanged)

Closes csl26-ha0e.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run` — 1464 tests, all pass
- [x] New test `format_document_with_resolver_injects_style_for_id_input`
      exercises the end-to-end path via mock resolver
