### PR TITLE
fix(engine): document bib restricted to cited refs

### DIFF
--- a/.beans/archive/csl26-vz0t--render-doc-emits-full-bibliography-for-grouped-sty.md
+++ b/.beans/archive/csl26-vz0t--render-doc-emits-full-bibliography-for-grouped-sty.md
@@ -1,0 +1,17 @@
+---
+# csl26-vz0t
+title: render doc emits full bibliography for grouped styles
+status: completed
+type: bug
+priority: high
+created_at: 2026-06-01T15:27:38Z
+updated_at: 2026-06-01T15:32:17Z
+---
+
+## Summary of Changes
+
+- Added  private method to  with a  param — groups and partition branches now intersect with  when true.
+- Added  pub(crate) method that delegates with .
+- Swapped  document path to use the new cited-only method.
+- Added two regression tests in  covering: no citations → no bibliography; one citation → only cited ref in bibliography.
+- All 1466 tests pass.

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -616,6 +616,37 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
+        self.render_grouped_bibliography_inner::<F>(false, annotations, annotation_style)
+    }
+
+    /// Render the trailing document bibliography, restricted to cited references.
+    ///
+    /// Equivalent to [`Self::render_grouped_bibliography_with_format`] but
+    /// intersects every branch's candidate set with `self.cited_ids` so that
+    /// references not cited in the document are excluded — matching
+    /// standard citeproc semantics for document rendering.
+    pub(crate) fn render_grouped_document_bibliography_with_format<F>(&self) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        self.render_grouped_bibliography_inner::<F>(true, None, None)
+    }
+
+    /// Shared implementation for grouped bibliography rendering.
+    ///
+    /// When `restrict_to_cited` is `true`, each branch limits its candidate
+    /// set to references present in `self.cited_ids`. When `false`, all
+    /// loaded references are eligible (the original all-refs behaviour used
+    /// by standalone `render refs`, FFI, and tests).
+    fn render_grouped_bibliography_inner<F>(
+        &self,
+        restrict_to_cited: bool,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
         if let Some(groups) = self
             .style
             .bibliography
@@ -623,10 +654,19 @@ impl Processor {
             .and_then(|bibliography| bibliography.groups.as_ref())
         {
             let id_stubs = self.sorted_id_stubs();
-            let selected = id_stubs
-                .iter()
-                .map(|e| e.id.clone())
-                .collect::<HashSet<_>>();
+            let selected = if restrict_to_cited {
+                let cited = self.cited_ids.borrow();
+                id_stubs
+                    .iter()
+                    .filter(|e| cited.contains(&e.id))
+                    .map(|e| e.id.clone())
+                    .collect::<HashSet<_>>()
+            } else {
+                id_stubs
+                    .iter()
+                    .map(|e| e.id.clone())
+                    .collect::<HashSet<_>>()
+            };
             return self.render_with_custom_groups_filtered::<F>(
                 &id_stubs,
                 groups,
@@ -641,7 +681,12 @@ impl Processor {
             && crate::sort_partitioning::should_render_sections(partitioning)
         {
             self.initialize_numeric_bibliography_numbers();
-            let sorted_refs = self.sort_references(self.bibliography.values().collect());
+            let mut refs: Vec<&Reference> = self.bibliography.values().collect();
+            if restrict_to_cited {
+                let cited = self.cited_ids.borrow();
+                refs.retain(|r| r.id().as_deref().is_some_and(|id| cited.contains(id)));
+            }
+            let sorted_refs = self.sort_references(refs);
             return self.render_with_partition_sections::<F>(
                 sorted_refs,
                 partitioning,

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -162,7 +162,7 @@ impl Processor {
             parsed,
             parser,
             format,
-            super::super::Processor::render_grouped_bibliography_with_format::<F>,
+            super::super::Processor::render_grouped_document_bibliography_with_format::<F>,
         )
     }
 

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -924,3 +924,53 @@ First [+@item1]. Later [+@item1]."#;
         "First John Doe. Later Doe.\n\n# Bibliography\n\n# Cited Works\n\nJohn Doe (2020)\n\nJane Smith (2010)"
     );
 }
+
+/// Build `make_author_date_style` with a catch-all `bibliography.groups` entry so
+/// that document rendering exercises the groups code path.
+fn make_grouped_author_date_style() -> Style {
+    let mut style = make_author_date_style();
+    style.bibliography.as_mut().unwrap().groups =
+        Some(vec![citum_schema::grouping::BibliographyGroup {
+            id: "all".to_string(),
+            heading: None,
+            selector: citum_schema::grouping::GroupSelector::default(),
+            sort: None,
+            template: None,
+            disambiguate: None,
+        }]);
+    style
+}
+
+#[test]
+fn test_grouped_style_document_with_no_citations_omits_bibliography() {
+    // Regression: `render doc` against a style with `bibliography.groups` must
+    // not emit a bibliography when the document contains no citations.
+    let bib = make_test_bib();
+    let processor = Processor::new(make_grouped_author_date_style(), bib);
+    let parser = DjotParser;
+
+    let content = "Some text with no citations.";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert_eq!(result, "Some text with no citations.");
+}
+
+#[test]
+fn test_grouped_style_document_bibliography_contains_only_cited_references() {
+    // Regression: when the document cites only one reference, the trailing
+    // bibliography must contain only that reference — not all loaded references.
+    let bib = make_test_bib();
+    let processor = Processor::new(make_grouped_author_date_style(), bib);
+    let parser = DjotParser;
+
+    // item1 (Doe 2020) is cited; item2 (Smith 2010) must not appear.
+    let content = "Text [@item1].";
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    assert_eq!(
+        result,
+        "Text (Doe, 2020).\n\n# Bibliography\n\nJohn Doe (2020)"
+    );
+}


### PR DESCRIPTION
## Summary

- `render doc` against styles with `bibliography.groups` (e.g. `chicago-author-date`) was emitting the full loaded bibliography regardless of which references the document cited — including outputting `# Bibliography` when nothing was cited at all.
- Root cause: the groups branch of `render_grouped_bibliography_with_format_and_annotations` built its `selected` set from _all_ sorted id-stubs without intersecting `cited_ids`. The partition-sections branch had the same defect. Only the legacy (non-grouped) branch filtered correctly.
- Fix: added a private `render_grouped_bibliography_inner(restrict_to_cited)` that, when `true`, intersects candidates with `cited_ids` in both the groups and partition-sections branches. Document rendering now routes through `render_grouped_document_bibliography_with_format` (`restrict=true`). The existing public all-refs method is untouched — `render refs`, FFI, WASM, and standalone grouped-bib tests are unaffected.

## Test plan

- [x] `citum render doc -s chicago-author-date -b examples/comprehensive.yaml --input-format markdown /tmp/mark.md` (no citations) → body only, no `# Bibliography`
- [x] Same command with `[@kuhn1962]` in the document → only Kuhn 1962 in the bibliography
- [x] Two new engine regression tests: `test_grouped_style_document_with_no_citations_omits_bibliography` and `test_grouped_style_document_bibliography_contains_only_cited_references`
- [x] 1466/1466 tests pass locally; pre-push gate clean

## Notes

The same latent bug exists in the FFI path (`ffi/mod.rs:506` — `render_grouped_bibliography`), which also calls the all-refs public method. That path is used by language bindings, not `render doc`, and is out of scope here. Worth a follow-up.
