### PR TITLE
feat(engine): add biblatex refs input variant

### DIFF
--- a/crates/citum-engine/src/api/refs_input.rs
+++ b/crates/citum-engine/src/api/refs_input.rs
@@ -10,17 +10,33 @@ use serde::{Deserialize, Serialize};
 
 /// A refs input that can be resolved locally or by an external resolver.
 ///
-/// This union type allows callers to supply reference data by local YAML file path,
-/// inline YAML, or inline JSON (current API). Enables citum-server and bindings to
-/// accept references from files (e.g., via pipe transport from LaTeX).
+/// This union type allows callers to supply reference data by local file path,
+/// inline YAML, inline JSON, or inline BibLaTeX. Enables citum-server and
+/// bindings to accept references from files (e.g., via pipe transport from
+/// LaTeX or Emacs).
+///
+/// Supported tagged-object shapes over JSON/RPC:
+///
+/// ```json
+/// {"kind": "path",     "value": "/abs/path/refs.yaml"}
+/// {"kind": "path",     "value": "/abs/path/refs.bib"}  // .bib detected by extension
+/// {"kind": "yaml",     "value": "references:\n  - id: …"}
+/// {"kind": "json",     "value": {"id": { … }}}
+/// {"kind": "biblatex", "value": "@book{key, title={…}, …}"}
+/// ```
 #[derive(Debug, Clone)]
 pub enum RefsInput {
-    /// Local filesystem path to a YAML refs file.
+    /// Local filesystem path to a refs file.
+    ///
+    /// YAML/JSON/CBOR extensions are loaded as native Citum refs; `.bib`
+    /// extensions are parsed as BibLaTeX.
     Path(String),
     /// Inline YAML refs string.
     Yaml(String),
     /// Inline JSON map of reference objects.
     Json(serde_json::Value),
+    /// Inline BibLaTeX (`.bib`) content.
+    Biblatex(String),
 }
 
 impl<'de> Deserialize<'de> for RefsInput {
@@ -35,7 +51,7 @@ impl<'de> Deserialize<'de> for RefsInput {
             let tagged_kind = object
                 .get("kind")
                 .and_then(|k| k.as_str())
-                .filter(|k| matches!(*k, "path" | "yaml" | "json"));
+                .filter(|k| matches!(*k, "path" | "yaml" | "json" | "biblatex"));
             if tagged_kind.is_none() || object.get("value").is_none() {
                 return Ok(RefsInput::Json(v));
             }
@@ -45,7 +61,7 @@ impl<'de> Deserialize<'de> for RefsInput {
             ));
         }
 
-        // Tagged union: {"kind": "path"|"yaml"|"json", "value": ...}
+        // Tagged union: {"kind": "path"|"yaml"|"json"|"biblatex", "value": ...}
         let kind = v
             .get("kind")
             .and_then(|k| k.as_str())
@@ -56,23 +72,25 @@ impl<'de> Deserialize<'de> for RefsInput {
             .ok_or_else(|| serde::de::Error::missing_field("value"))?;
 
         match kind {
-            "path" | "yaml" => {
+            "path" | "yaml" | "biblatex" => {
                 let s = value
                     .as_str()
                     .ok_or_else(|| {
-                        serde::de::Error::custom("'value' must be a string for path/yaml refs")
+                        serde::de::Error::custom(
+                            "'value' must be a string for path/yaml/biblatex refs",
+                        )
                     })?
                     .to_string();
-                if kind == "path" {
-                    Ok(RefsInput::Path(s))
-                } else {
-                    Ok(RefsInput::Yaml(s))
+                match kind {
+                    "path" => Ok(RefsInput::Path(s)),
+                    "yaml" => Ok(RefsInput::Yaml(s)),
+                    _ => Ok(RefsInput::Biblatex(s)),
                 }
             }
             "json" => Ok(RefsInput::Json(value.clone())),
             k => Err(serde::de::Error::unknown_variant(
                 k,
-                &["path", "yaml", "json"],
+                &["path", "yaml", "json", "biblatex"],
             )),
         }
     }
@@ -98,6 +116,10 @@ impl Serialize for RefsInput {
                 map.serialize_entry("kind", "json")?;
                 map.serialize_entry("value", v)?;
             }
+            RefsInput::Biblatex(s) => {
+                map.serialize_entry("kind", "biblatex")?;
+                map.serialize_entry("value", s)?;
+            }
         }
         map.end()
     }
@@ -120,7 +142,7 @@ impl schemars::JsonSchema for RefsInput {
                     "properties": {
                         "kind": {
                             "type": "string",
-                            "enum": ["path", "yaml"]
+                            "enum": ["path", "yaml", "biblatex"]
                         },
                         "value": {
                             "type": "string"
@@ -153,7 +175,10 @@ impl schemars::JsonSchema for RefsInput {
 }
 
 impl RefsInput {
-    /// Resolve refs input locally from Path, Yaml, or Json variants.
+    /// Resolve refs input locally from Path, Yaml, Json, or Biblatex variants.
+    ///
+    /// For `Path` inputs, `.bib` files are parsed as BibLaTeX; all other
+    /// extensions are parsed as native Citum YAML/JSON/CBOR.
     ///
     /// # Errors
     ///
@@ -161,6 +186,18 @@ impl RefsInput {
     pub fn resolve_local(&self) -> Result<Bibliography, crate::api::FormatDocumentError> {
         match self {
             RefsInput::Path(path) => {
+                let p = std::path::Path::new(path);
+                if p.extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("bib"))
+                {
+                    let input = citum_refs::formats::biblatex::load_biblatex(p).map_err(|e| {
+                        crate::api::FormatDocumentError::RefsInputParse(format!(
+                            "Failed to parse BibLaTeX refs from '{}': {}",
+                            path, e
+                        ))
+                    })?;
+                    return Ok(bibliography_from_references(input.references));
+                }
                 let bytes = std::fs::read(path).map_err(|e| {
                     crate::api::FormatDocumentError::RefsInputPath(format!(
                         "Failed to read refs input from '{}': {}",
@@ -188,6 +225,16 @@ impl RefsInput {
                         e
                     ))
                 }),
+            RefsInput::Biblatex(src) => {
+                let input =
+                    citum_refs::formats::biblatex::parse_biblatex_str(src).map_err(|e| {
+                        crate::api::FormatDocumentError::RefsInputParse(format!(
+                            "Failed to parse inline BibLaTeX refs input: {}",
+                            e
+                        ))
+                    })?;
+                Ok(bibliography_from_references(input.references))
+            }
         }
     }
 }
@@ -368,5 +415,51 @@ mod tests {
         let json_str = serde_json::to_string(&input).expect("serialize");
         assert!(json_str.contains("\"kind\":\"path\""));
         assert!(json_str.contains("\"/tmp/bib.yaml\""));
+    }
+
+    #[test]
+    fn refs_input_deserialize_tagged_biblatex() {
+        let bib_src = "@book{hawking1988, title = {A Brief History of Time}, author = {Hawking, Stephen}, date = {1988}}";
+        let json_str = format!(
+            r#"{{"kind":"biblatex","value":{}}}"#,
+            serde_json::to_string(bib_src).unwrap()
+        );
+        let input: RefsInput = serde_json::from_str(&json_str).expect("deserialize biblatex");
+        match input {
+            RefsInput::Biblatex(s) => assert!(s.contains("hawking1988")),
+            _ => panic!("Expected Biblatex variant"),
+        }
+    }
+
+    #[test]
+    fn refs_input_biblatex_resolves_locally() {
+        let bib_src = "@book{hawking1988, title = {A Brief History of Time}, author = {Hawking, Stephen}, date = {1988}}";
+        let input = RefsInput::Biblatex(bib_src.to_string());
+        let result = input.resolve_local().expect("biblatex should parse");
+        assert!(result.contains_key("hawking1988"));
+    }
+
+    #[test]
+    fn refs_input_path_bib_extension_parses_biblatex() {
+        let bib_content = "@article{doe2024, title = {Test Article}, author = {Doe, Jane}, journaltitle = {Journal of Tests}, date = {2024}}";
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".bib")
+            .tempfile()
+            .expect("Failed to create temp .bib file");
+        tmp.write_all(bib_content.as_bytes())
+            .expect("Failed to write temp file");
+        tmp.flush().expect("Failed to flush temp file");
+
+        let input = RefsInput::Path(tmp.path().to_string_lossy().to_string());
+        let result = input.resolve_local().expect(".bib path should parse");
+        assert!(result.contains_key("doe2024"));
+    }
+
+    #[test]
+    fn refs_input_serialize_biblatex() {
+        let input = RefsInput::Biblatex("@book{key, title = {T}}".to_string());
+        let json_str = serde_json::to_string(&input).expect("serialize");
+        assert!(json_str.contains("\"kind\":\"biblatex\""));
+        assert!(json_str.contains("@book{key"));
     }
 }

--- a/crates/citum-engine/src/api/refs_input.rs
+++ b/crates/citum-engine/src/api/refs_input.rs
@@ -48,12 +48,24 @@ impl<'de> Deserialize<'de> for RefsInput {
         let v = serde_json::Value::deserialize(deserializer)?;
 
         if let Some(object) = v.as_object() {
-            let tagged_kind = object
-                .get("kind")
-                .and_then(|k| k.as_str())
-                .filter(|k| matches!(*k, "path" | "yaml" | "json" | "biblatex"));
-            if tagged_kind.is_none() || object.get("value").is_none() {
-                return Ok(RefsInput::Json(v));
+            // If the object has a string "kind" and a "value" field it is a
+            // tagged-union wrapper — validate the kind rather than silently
+            // treating an unrecognised kind as a legacy bare-map, which would
+            // produce a confusing downstream parse error.
+            let kind_str = object.get("kind").and_then(|k| k.as_str());
+            let has_value = object.contains_key("value");
+            match (kind_str, has_value) {
+                (Some(k), true) => {
+                    if !matches!(k, "path" | "yaml" | "json" | "biblatex") {
+                        return Err(serde::de::Error::unknown_variant(
+                            k,
+                            &["path", "yaml", "json", "biblatex"],
+                        ));
+                    }
+                    // Recognised kind — fall through to dispatch below.
+                }
+                // No string kind, or no value field: legacy bare refs map.
+                _ => return Ok(RefsInput::Json(v)),
             }
         } else {
             return Err(serde::de::Error::custom(
@@ -461,5 +473,17 @@ mod tests {
         let json_str = serde_json::to_string(&input).expect("serialize");
         assert!(json_str.contains("\"kind\":\"biblatex\""));
         assert!(json_str.contains("@book{key"));
+    }
+
+    #[test]
+    fn refs_input_deserialize_unknown_kind_returns_error() {
+        let json_str = r#"{"kind":"csl-json","value":"..."}"#;
+        let result = serde_json::from_str::<RefsInput>(json_str);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("csl-json"),
+            "error should name the unknown variant: {msg}"
+        );
     }
 }

--- a/crates/citum-refs/src/formats/biblatex.rs
+++ b/crates/citum-refs/src/formats/biblatex.rs
@@ -12,14 +12,16 @@ use citum_schema::InputBibliography;
 
 use crate::RefsError;
 
-/// Load a BibLaTeX bibliography from a file path.
+/// Parse BibLaTeX bibliography content from an in-memory string.
+///
+/// This is the core parsing primitive; [`load_biblatex`] delegates to it after
+/// reading the file.
 ///
 /// # Errors
 ///
-/// Returns an error when the file cannot be read or parsed as BibLaTeX.
-pub fn load_biblatex(path: &Path) -> Result<InputBibliography, RefsError> {
-    let src = fs::read_to_string(path)?;
-    let bibliography = ::biblatex::Bibliography::parse(&src)
+/// Returns an error when `src` cannot be parsed as valid BibLaTeX.
+pub fn parse_biblatex_str(src: &str) -> Result<InputBibliography, RefsError> {
+    let bibliography = ::biblatex::Bibliography::parse(src)
         .map_err(|e| RefsError::ParseError("BibLaTeX".to_string(), e.to_string()))?;
     let references = bibliography
         .iter()
@@ -29,4 +31,14 @@ pub fn load_biblatex(path: &Path) -> Result<InputBibliography, RefsError> {
         references,
         ..Default::default()
     })
+}
+
+/// Load a BibLaTeX bibliography from a file path.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read or parsed as BibLaTeX.
+pub fn load_biblatex(path: &Path) -> Result<InputBibliography, RefsError> {
+    let src = fs::read_to_string(path)?;
+    parse_biblatex_str(&src)
 }

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -146,7 +146,8 @@ pub struct FormatDocumentParams {
     pub locale: Option<String>,
     /// Output format (plain, html, djot, latex, typst). Defaults to plain.
     pub output_format: Option<OutputFormat>,
-    /// Bibliography input as `RefsInput`: path, YAML, JSON, or legacy bare map.
+    /// Bibliography input as `RefsInput`: path (YAML/JSON/CBOR or `.bib`), inline YAML,
+    /// inline JSON, inline BibLaTeX (`{"kind":"biblatex","value":"@book{…}"}`) or legacy bare map.
     pub refs: serde_json::Value,
     /// Ordered citations as they appear in the document.
     pub citations: serde_json::Value,

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2866,7 +2866,7 @@
         ]
       },
       "refs": {
-        "description": "Bibliography input as `RefsInput`: path, YAML, JSON, or legacy bare map."
+        "description": "Bibliography input as `RefsInput`: path (YAML/JSON/CBOR or `.bib`), inline YAML,\ninline JSON, inline BibLaTeX (`{\"kind\":\"biblatex\",\"value\":\"@book{…}\"}`) or legacy bare map."
       },
       "citations": {
         "description": "Ordered citations as they appear in the document."


### PR DESCRIPTION
## Summary

- Extracts `parse_biblatex_str(src: &str)` in `citum-refs` as a string-based parsing primitive; `load_biblatex` now delegates to it
- Adds `RefsInput::Biblatex(String)` variant to the engine, accepting inline `.bib` content via `{"kind":"biblatex","value":"@book{…}"}`
- Adds `.bib` extension detection on `RefsInput::Path` so `{"kind":"path","value":"x.bib"}` dispatches to the biblatex parser
- Updates all three `RefsInput` impls: `Deserialize`, `Serialize`, `JsonSchema`
- Updates `rpc.rs` doc comment for the new variant

No new crate dependencies — `citum-engine` already depends on `citum-refs`, and `citum-refs` already depends on the `biblatex` crate.

## Motivation

Enables language bindings (e.g. the new Emacs `oc-citum` processor in citum-labs) to send a `.bib` file directly to `format_document` without an intermediate conversion step on the client side.

## Test plan

- [x] `refs_input_deserialize_tagged_biblatex` — deserialises `{"kind":"biblatex","value":"..."}` to `Biblatex` variant
- [x] `refs_input_biblatex_resolves_locally` — parses inline BibLaTeX and finds the key
- [x] `refs_input_path_bib_extension_parses_biblatex` — `Path("x.bib")` dispatches to biblatex parser
- [x] `refs_input_serialize_biblatex` — round-trips through `Serialize`
- [x] All 1470 existing tests still pass
- [x] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings` clean
