### PR TITLE
docs: remove outdated code comment

### DIFF
--- a/crates/citum-schema-data/src/citation.rs
+++ b/crates/citum-schema-data/src/citation.rs
@@ -608,11 +608,6 @@ impl CitationItem {
 }
 
 /// Normalize a textual locator string into the canonical locator model.
-///
-/// # Panics
-///
-/// This function does not panic under normal use; the internal `unwrap` is
-/// guarded by the preceding segment-count match.
 pub fn normalize_locator_text(
     locator: &str,
     aliases: &[(String, LocatorType)],


### PR DESCRIPTION
The function no longer uses unwrap, so ...