### PR TITLE
fix(engine): primary-name falls to suffix on tie

### DIFF
--- a/.beans/archive/csl26-wu1l--primary-name-rule-does-not-fall-back-to-year-suffi.md
+++ b/.beans/archive/csl26-wu1l--primary-name-rule-does-not-fall-back-to-year-suffi.md
@@ -1,11 +1,11 @@
 ---
 # csl26-wu1l
 title: primary-name givenname rule does not fall back to year-suffix when primary names are identical
-status: todo
+status: completed
 type: bug
 priority: normal
 created_at: 2026-06-02T18:52:04Z
-updated_at: 2026-06-02T18:52:36Z
+updated_at: 2026-06-02T19:27:10Z
 ---
 
 When givenname-disambiguation-rule: primary-name is active and expanding the first author's given name does not resolve a collision (both works share an identical primary author), the engine does not fall back to year-suffix as the next cascade step. The two ambiguous citations render identically instead of receiving year suffixes.
@@ -15,3 +15,11 @@ Discovered during test soundness review of csl26-lvib (by-cite givenname expansi
 Expected: 'A Asthma, Bronchitis, et al., (1990a)' and 'A Asthma, Bronchitis, et al., (1990b)'.
 
 Spec ref: docs/specs/DISAMBIGUATION.md section 2 -- givenname expansion is one step in the cascade; year-suffix must be applied when the expansion step does not uniquely identify each work.
+
+## Summary of Changes
+
+Fixed try_apply_combined_resolution (and the subgroup path in try_apply_name_partitions) in crates/citum-engine/src/processor/disambiguation.rs. Added primary_only: bool to check_givenname_resolution / append_givenname_resolution_key. When primary_givenname_only is active and full-expansion check reports resolution but primary-only check does not, the engine now calls apply_year_suffix_for_group with expand_given_names=true and min_names_to_show retained rather than skipping suffix entirely.
+
+Updated integration test disambiguation_primary_name_givenname_expansion to assert the corrected output. Added unit test test_primary_name_identical_primary_falls_back_to_year_suffix (hints-level). Added integration test disambiguation_primary_name_givenname_expansion_resolves_distinct_primary_authors (success path, no suffix -- test-soundness coverage gap).
+
+Updated docs/specs/DISAMBIGUATION.md acceptance criteria and changelog.

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -360,9 +360,34 @@ impl<'a> Disambiguator<'a> {
             }
 
             if context.flags.add_givenname
-                && self.check_givenname_resolution(subgroup, context.cache, Some(min_names_to_show))
+                && self.check_givenname_resolution(
+                    subgroup,
+                    context.cache,
+                    Some(min_names_to_show),
+                    false,
+                )
             {
-                self.apply_resolution(hints, subgroup, context, true, Some(min_names_to_show));
+                // Under primary-name rules, secondary given names are not rendered.
+                // If the full-expansion check passes but primary-only does not, the
+                // subgroup must fall back to year-suffix (with expansion retained).
+                if context.flags.primary_givenname_only
+                    && !self.check_givenname_resolution(
+                        subgroup,
+                        context.cache,
+                        Some(min_names_to_show),
+                        true,
+                    )
+                {
+                    self.apply_year_suffix_for_group(
+                        hints,
+                        subgroup,
+                        context,
+                        true,
+                        Some(min_names_to_show),
+                    );
+                } else {
+                    self.apply_resolution(hints, subgroup, context, true, Some(min_names_to_show));
+                }
                 continue;
             }
 
@@ -384,8 +409,11 @@ impl<'a> Disambiguator<'a> {
         hints: &mut HashMap<String, ProcHints>,
         context: &GroupDisambiguationContext<'_>,
     ) -> bool {
+        // Use full-expansion keys to determine whether givenname expansion can help at all.
+        // (With n=1, the full and primary-only keys are equivalent — both inspect only the
+        // primary author — so no separate primary-only check is needed here.)
         if !(context.flags.add_givenname
-            && self.check_givenname_resolution(context.group, context.cache, None))
+            && self.check_givenname_resolution(context.group, context.cache, None, false))
         {
             return false;
         }
@@ -395,6 +423,13 @@ impl<'a> Disambiguator<'a> {
     }
 
     /// Attempts to resolve collisions by using both more names AND given name expansion.
+    ///
+    /// When `primary_givenname_only` is active, the renderer only shows given names for
+    /// the first author. `find_combined_resolution` uses full-expansion keys to find the
+    /// minimum name count that would work in theory; this function then verifies whether
+    /// that resolution also holds under the restricted primary-only rendering.  If not,
+    /// the group cannot be resolved by expansion alone and falls back to year-suffix while
+    /// retaining the et-al expansion that was found.
     fn try_apply_combined_resolution(
         &self,
         hints: &mut HashMap<String, ProcHints>,
@@ -408,6 +443,27 @@ impl<'a> Disambiguator<'a> {
         else {
             return false;
         };
+
+        // When primary-name expansion is active, confirm the resolution still holds when
+        // only the first author's given name is rendered.  If it does not, the expansion
+        // alone is insufficient; emit year-suffix while preserving the et-al expansion.
+        if context.flags.primary_givenname_only
+            && !self.check_givenname_resolution(
+                context.group,
+                context.cache,
+                Some(min_names_to_show),
+                true,
+            )
+        {
+            self.apply_year_suffix_for_group(
+                hints,
+                context.group,
+                context,
+                true,
+                Some(min_names_to_show),
+            );
+            return true;
+        }
 
         self.apply_resolution(hints, context.group, context, true, Some(min_names_to_show));
         true
@@ -426,7 +482,10 @@ impl<'a> Disambiguator<'a> {
             .max()
             .unwrap_or(0);
 
-        (2..=max_authors).find(|&n| self.check_givenname_resolution(group, cache, Some(n)))
+        // Use full-expansion keys (primary_only: false) to find the minimum name count.
+        // The caller is responsible for verifying the result under primary-only rendering
+        // when primary_givenname_only is active.
+        (2..=max_authors).find(|&n| self.check_givenname_resolution(group, cache, Some(n), false))
     }
 
     /// Finalizes a successful disambiguation strategy by inserting the calculated hints into the map.
@@ -674,12 +733,19 @@ impl<'a> Disambiguator<'a> {
     }
 
     /// Check if expanding to full names resolves ambiguity in the group.
-    /// If `min_names` is Some(n), it checks resolution when showing n names.
+    ///
+    /// If `min_names` is `Some(n)`, it checks resolution when showing `n` names.
+    ///
+    /// When `primary_only` is `true`, only the first author's given name is included
+    /// in the resolution key — mirroring what `primary-name` and
+    /// `primary-name-with-initials` actually render.  Use this to validate that a
+    /// candidate expansion still works under restricted rendering before committing.
     fn check_givenname_resolution(
         &self,
         group: &[&Reference],
         cache: &ReferenceCache,
         min_names: Option<usize>,
+        primary_only: bool,
     ) -> bool {
         let mut seen = HashSet::new();
         let mut buf = String::new();
@@ -687,7 +753,7 @@ impl<'a> Disambiguator<'a> {
         for reference in group {
             let names = &self.reference_data(reference, cache).names;
             buf.clear();
-            self.append_givenname_resolution_key(&mut buf, names, n);
+            self.append_givenname_resolution_key(&mut buf, names, n, primary_only);
             if !seen.insert(buf.clone()) {
                 return false;
             }
@@ -823,17 +889,27 @@ impl<'a> Disambiguator<'a> {
     }
 
     /// Creates a key including full name parts (given names, particles) for exact resolution.
+    ///
+    /// When `primary_only` is `true`, only the first author (index 0) receives full
+    /// given-name/particle parts; subsequent authors contribute only their family name.
+    /// This mirrors what `primary-name` and `primary-name-with-initials` actually render,
+    /// allowing resolution checks to validate against the real rendered surface form.
     fn append_givenname_resolution_key(
         &self,
         key: &mut String,
         names: &[crate::reference::FlatName],
         n: usize,
+        primary_only: bool,
     ) {
         for (idx, name) in names.iter().take(n).enumerate() {
             if idx > 0 {
                 key.push_str("||");
             }
             Self::append_optional_part(key, name.family.as_deref());
+            if primary_only && idx > 0 {
+                // Secondary authors: family name only under primary-name rules.
+                continue;
+            }
             key.push('|');
             Self::append_optional_part(key, name.given.as_deref());
             key.push('|');
@@ -1168,6 +1244,111 @@ mod tests {
         assert!(
             rendered_r2.contains("A. Smith"),
             "expected expanded given name for r2: {rendered_r2}"
+        );
+    }
+
+    /// When `primary-name` is active and expanding the first author's given name does
+    /// not resolve the collision (both works share an identical primary author), the
+    /// disambiguator must fall back to year-suffix while retaining the et-al expansion
+    /// that was found.  Concretely: hints must have `expand_given_names: true`,
+    /// `expand_given_names_primary_only: true`, `min_names_to_show: Some(2)`, and
+    /// `disamb_condition: true` (year-suffix), with distinct `group_index` values.
+    #[test]
+    fn test_primary_name_identical_primary_falls_back_to_year_suffix() {
+        use citum_schema::options::{
+            Disambiguation, Processing, ProcessingCustom, ShortenListOptions,
+        };
+
+        // Primary author ("Asthma/Albert") is identical; secondary authors differ only
+        // in given name ("Brandon" vs "Edward") — identical families.
+        let r1 = make_multi_author_ref(
+            "r1",
+            &[
+                ("Asthma", "Albert"),
+                ("Bronchitis", "Brandon"),
+                ("Cold", "Crispin"),
+            ],
+            1990,
+        );
+        let r2 = make_multi_author_ref(
+            "r2",
+            &[
+                ("Asthma", "Albert"),
+                ("Bronchitis", "Edward"),
+                ("Cold", "Crispin"),
+            ],
+            1990,
+        );
+
+        let mut bib = Bibliography::new();
+        bib.insert("r1".to_string(), r1);
+        bib.insert("r2".to_string(), r2);
+
+        let config = Config {
+            processing: Some(Processing::Custom(ProcessingCustom {
+                disambiguate: Some(Disambiguation {
+                    names: true,
+                    add_givenname: true,
+                    givenname_rule: GivennameRule::PrimaryName,
+                    year_suffix: true,
+                }),
+                ..Default::default()
+            })),
+            contributors: Some(ContributorConfig {
+                shorten: Some(ShortenListOptions {
+                    min: 3,
+                    use_first: 1,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let locale = Locale::en_us();
+
+        let hints = Disambiguator::new(&bib, &config, &locale).calculate_hints();
+
+        let h1 = hints.get("r1").expect("r1 must have a hint");
+        let h2 = hints.get("r2").expect("r2 must have a hint");
+
+        // Et-al expansion to two names must be retained.
+        assert_eq!(
+            h1.min_names_to_show,
+            Some(2),
+            "r1: expected min_names_to_show=2"
+        );
+        assert_eq!(
+            h2.min_names_to_show,
+            Some(2),
+            "r2: expected min_names_to_show=2"
+        );
+
+        // Given-name expansion must be active (primary author initial shown).
+        assert!(h1.expand_given_names, "r1: expected expand_given_names");
+        assert!(h2.expand_given_names, "r2: expected expand_given_names");
+
+        // Primary-only flag must be propagated.
+        assert!(
+            h1.expand_given_names_primary_only,
+            "r1: expected primary-only"
+        );
+        assert!(
+            h2.expand_given_names_primary_only,
+            "r2: expected primary-only"
+        );
+
+        // Year-suffix must be assigned (disamb_condition true, distinct indices).
+        assert!(
+            h1.disamb_condition,
+            "r1: expected disamb_condition (year-suffix)"
+        );
+        assert!(
+            h2.disamb_condition,
+            "r2: expected disamb_condition (year-suffix)"
+        );
+        assert_ne!(
+            h1.group_index, h2.group_index,
+            "r1 and r2 must receive distinct year-suffix positions"
         );
     }
 

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -546,13 +546,38 @@ fn disambiguation_all_names_co_citation() {
 fn disambiguation_primary_name_givenname_expansion() {
     let processor = processor_for_givenname_rule(GivennameRule::PrimaryName);
 
-    // primary-name must expand the first author's given name and leave non-primary authors unexpanded.
+    // ASTHMA-A and ASTHMA-B share the same primary author (A Asthma).  Expanding the
+    // first author's given name cannot resolve the collision, so the cascade must fall
+    // through to year-suffix.  The et-al expansion to two names is retained alongside
+    // the suffix — the name form must not collapse back to one-name et-al.
     let asthma = process_citation_ids(&processor, &["ASTHMA-A", "ASTHMA-B"]);
 
     assert_eq!(
         asthma,
-        "A Asthma, Bronchitis, et al., (1990); A Asthma, Bronchitis, et al., (1990)"
+        "A Asthma, Bronchitis, et al., (1990a); A Asthma, Bronchitis, et al., (1990b)"
     );
+}
+
+/// §2.1 primary-name *success* path: when the primary authors' given names differ,
+/// expansion resolves the collision and year-suffix must NOT be applied.
+fn disambiguation_primary_name_givenname_expansion_resolves_distinct_primary_authors() {
+    let mut bibliography = indexmap::IndexMap::new();
+    for reference in [
+        make_book("ALICE", "Smith", "Alice", 2000, "Book A"),
+        make_book("BOB", "Smith", "Bob", 2000, "Book B"),
+    ] {
+        let id = reference.id().expect("fixture reference id").to_string();
+        bibliography.insert(id, reference);
+    }
+
+    let processor = Processor::new(
+        build_author_date_style_with_givenname_rule(GivennameRule::PrimaryName),
+        bibliography,
+    );
+
+    let result = process_citation_ids(&processor, &["ALICE", "BOB"]);
+
+    assert_eq!(result, "A Smith, (2000); B Smith, (2000)");
 }
 
 /// Test et-al expansion success: Name expansion disambiguates conflicting references.
@@ -1908,6 +1933,14 @@ mod disambiguation {
             "primary-name rule must expand the first author's given name; when that does not resolve the collision, year-suffix must be applied.",
         );
         super::disambiguation_primary_name_givenname_expansion();
+    }
+
+    #[test]
+    fn primary_name_givenname_expansion_resolves_when_primary_authors_differ() {
+        announce_behavior(
+            "primary-name rule must resolve the collision via given-name expansion alone when the primary authors' given names differ, with no year-suffix applied.",
+        );
+        super::disambiguation_primary_name_givenname_expansion_resolves_distinct_primary_authors();
     }
 
     #[test]

--- a/docs/specs/DISAMBIGUATION.md
+++ b/docs/specs/DISAMBIGUATION.md
@@ -219,6 +219,8 @@ added to the citation context.
 - [x] Short-title suppression via `first-reference-note-number` implemented and tested
 - [x] `givenname-disambiguation-rule` field exists on `Disambiguation`; `primary-name` and
   `primary-name-with-initials` restrict expansion to the first author only (csl26-4ada)
+- [x] `primary-name` falls back to year-suffix when primary-author expansion cannot resolve
+  the collision (identical primary authors); et-al expansion retained alongside suffix (csl26-wu1l)
 - [x] `by-cite` given-name expansion is citation-local and distinguishable from
   `all-names` global expansion (csl26-lvib)
 - [x] Upstream CSL disambiguation fixtures that distinguish `by-cite` and
@@ -226,6 +228,15 @@ added to the citation context.
 
 ## Changelog
 
+- 2026-06-02: Fixed `primary-name` cascade fallback (csl26-wu1l). When the primary
+  author's given name cannot resolve a collision (identical primary authors), the engine
+  now falls back to year-suffix while retaining the et-al expansion that was found.
+  Fixed `try_apply_combined_resolution` and the `try_apply_name_partitions` subgroup path
+  in `processor/disambiguation.rs` to validate expansion under primary-only rendering
+  before committing; added a new `primary_only` flag to `check_givenname_resolution` /
+  `append_givenname_resolution_key`. Added unit test
+  `test_primary_name_identical_primary_falls_back_to_year_suffix` and integration tests
+  for both the fallback and success paths.
 - 2026-06-02: Implemented `by-cite` citation-local given-name expansion
   (csl26-lvib). Citation rendering now overlays current-citation name-expansion
   hints for `GivennameRule::ByCite`, while `all-names` keeps global expansion.


### PR DESCRIPTION
## Summary

- Fixed `try_apply_combined_resolution` and the `try_apply_name_partitions` subgroup path in `processor/disambiguation.rs`: when `primary_givenname_only` is active, the engine now validates a candidate expansion against primary-only rendering before committing, falling through to year-suffix (with expansion retained) when the check fails.
- Added `primary_only: bool` to `check_givenname_resolution` / `append_givenname_resolution_key` so resolution keys can mirror what `primary-name` actually renders (first author full, others family-only).
- Corrected the pinning test assertion; added unit test for the fallback hints and integration test for the success path (test-soundness coverage gap).

## Root cause

`find_combined_resolution` uses full given-name keys across all author positions, which correctly found `min_names_to_show=2` for the ASTHMA fixture. However `try_apply_combined_resolution` then called `apply_resolution` unconditionally — even under `primary-name`, where position 1's given name is never rendered. The two works remained identical but the processor believed it had resolved them.

## Test plan

- [x] `cargo nextest run -p citum-engine --filter-expr 'test(primary_name)'` — 3 tests, all green
- [x] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run` — 1484/1484 pre-push
- [x] Portfolio quality gate `check-core-quality.js` — 154 styles, fidelity=1.0, warnings=0
- [x] Test-soundness review of `docs/specs/DISAMBIGUATION.md` — all existing tests good; one coverage gap resolved (primary-name success path)
