### PR TITLE
feat(schema): multilingual presets + pattern mode

### DIFF
--- a/.beans/archive/csl26-dzzr--resolve-copilot-review-comments-on-pr-870-multilin.md
+++ b/.beans/archive/csl26-dzzr--resolve-copilot-review-comments-on-pr-870-multilin.md
@@ -1,0 +1,26 @@
+---
+# csl26-dzzr
+title: 'Resolve Copilot review comments on PR #870 (multilingual presets)'
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-02T23:25:44Z
+updated_at: 2026-06-02T23:29:38Z
+---
+
+Fix all Copilot review comments from both review rounds on PR #870:
+1. Fix doc comments in options/mod.rs + presets.rs (old preset names 'apa'/'chicago')
+2. Add Pattern roundtrip test in options/mod.rs
+3. Remove redundant CJK char assertion in i18n.rs (already has assert_eq! above)
+4. Fix function signature formatting in i18n.rs (cargo fmt)
+5. Convert contains() assertions at lines 1830/1851 to assert_eq!
+
+## Summary of Changes
+
+- Fixed 3× multilingual doc comments in options/mod.rs (lines 82, 184, 284): replaced stale preset examples , with , 
+- Fixed presets.rs line 867 doc comment: same stale preset names
+- Added  test in options/mod.rs exercising the  YAML path that the existing test missed
+- Renamed  →  (now accurately scoped)
+- Removed redundant CJK unicode range assertion in i18n.rs (redundant with preceding assert_eq!)
+- Converted  to full  in two German locale tests (lines 1822, 1839)
+- cargo fmt applied to fix long-function-name brace placement

--- a/.beans/archive/csl26-fvlx--multilingual-style-presets-pattern-mode.md
+++ b/.beans/archive/csl26-fvlx--multilingual-style-presets-pattern-mode.md
@@ -1,0 +1,35 @@
+---
+# csl26-fvlx
+title: Multilingual style presets + Pattern mode
+status: completed
+type: feature
+priority: normal
+created_at: 2026-06-02T21:53:36Z
+updated_at: 2026-06-02T22:15:17Z
+---
+
+Add MultilingualPreset enum (apa/mla/chicago/ieee), a Pattern engine mode for 3-way CJK views (original+romanized+[translated]), and wire the preset into all embedded core styles.
+
+## Todos
+
+- [x] Engine: add Pattern mode + segment types to multilingual.rs
+- [x] Engine: implement Pattern arm in resolve_multilingual_string / resolve_multilingual_name
+- [x] Schema: add MultilingualPreset enum to presets.rs
+- [x] Schema: add MultilingualConfigEntry + deserialize_multilingual_config in options/mod.rs
+- [x] Styles: wire preset into all embedded core files
+- [x] Optionally migrate apa-7th.yaml + modern-language-association.yaml to preset form
+- [x] Tests: schema unit test (preset parses + resolves)
+- [x] Tests: engine unit tests (Pattern mode: dedup, 3-way, wrapping)
+- [x] Tests: end-to-end tests (Chicago + MLA Japanese reference)
+- [x] Docs: update MULTILINGUAL.md spec
+- [x] Gate: cargo fmt/clippy/nextest
+- [x] Schema regen
+
+## Summary of Changes
+
+Engine, schema, preset, and style changes to extend multilingual romanization/translation to all embedded core styles.
+
+Pattern mode added: ordered segment list with dedup; powers Chicago (3-way) and MLA (original+translation) presets.
+MultilingualPreset enum added: apa/mla/chicago/ieee, each resolving to a concrete MultilingualConfig.
+14 embedded styles gained multilingual preset annotations. APA migrated to preset form.
+11 new tests added (schema unit + engine unit + end-to-end). Portfolio quality gate: 154 styles passing.

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -184,9 +184,72 @@ pub fn resolve_multilingual_string(
                         (None, None) => complex.original.clone(),
                     }
                 }
+
+                MultilingualMode::Pattern(segments) => resolve_multilingual_pattern(
+                    segments,
+                    &complex.original,
+                    &complex.transliterations,
+                    &complex.translations,
+                    preferred_transliteration,
+                    preferred_script,
+                    style_locale,
+                ),
             }
         }
     }
+}
+
+/// Render a [`MultilingualMode::Pattern`] against a complex multilingual string.
+///
+/// Each segment is resolved to its text; segments that are empty or identical to
+/// the previous non-empty segment are skipped (dedup).  The surviving segments are
+/// joined by a single space.
+fn resolve_multilingual_pattern(
+    segments: &[citum_schema::options::MultilingualSegment],
+    original: &str,
+    transliterations: &std::collections::HashMap<String, String>,
+    translations: &std::collections::HashMap<citum_schema::reference::types::LangID, String>,
+    preferred_transliteration: Option<&[String]>,
+    preferred_script: Option<&String>,
+    style_locale: &str,
+) -> String {
+    use citum_schema::options::{MultilingualView, SegmentWrap};
+    let mut parts: Vec<String> = Vec::with_capacity(segments.len());
+    let mut last_text: Option<String> = None;
+
+    for seg in segments {
+        let text: Option<String> = match &seg.view {
+            MultilingualView::Original => Some(original.to_string()),
+            MultilingualView::Transliterated => resolve_transliteration(
+                transliterations,
+                preferred_transliteration,
+                preferred_script,
+            )
+            .map(ToString::to_string),
+            MultilingualView::Translated => {
+                resolve_translation(translations, style_locale).map(ToString::to_string)
+            }
+        };
+
+        let Some(text) = text else { continue };
+        if text.is_empty() {
+            continue;
+        }
+        // Skip duplicate: if this text is identical to the previous segment (e.g. when
+        // transliteration falls back to the same value as original).
+        if last_text.as_deref() == Some(text.as_str()) {
+            continue;
+        }
+
+        let wrapped = match &seg.wrap {
+            SegmentWrap::None => text.clone(),
+            other => other.apply(&text),
+        };
+        last_text = Some(text);
+        parts.push(wrapped);
+    }
+
+    parts.join(" ")
 }
 
 /// Resolve the effective language for one logical field scope on a reference.
@@ -329,6 +392,12 @@ pub fn resolve_multilingual_name(
                 }
                 // Combined mode for names defaults to transliterated (parenthetical combo not common for names)
                 MultilingualMode::Combined => {
+                    select_by_transliteration(m, preferred_transliteration, preferred_script)
+                }
+                // Pattern mode for names: use the first non-original view (romanized).
+                // Names are always shown in a single script; multi-view name strings are
+                // not idiomatic in any major style guide.
+                MultilingualMode::Pattern(_) => {
                     select_by_transliteration(m, preferred_transliteration, preferred_script)
                 }
             };

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -1144,12 +1144,335 @@ fn given_apa_multilingual_title_mode_when_rendering_a_japanese_article_then_titl
         rendered,
         "In’yo no shakaiteki kino: Gakujutsu chishiki no kochiku ni okeru sansho jissen [The Social Function of Citation: Reference Practices in the Construction of Academic Knowledge]. Kagaku Shakai-gaku Kenkyu"
     );
-    assert!(
-        !rendered.chars().any(|c| {
-            ('\u{3040}'..='\u{30ff}').contains(&c) || ('\u{4e00}'..='\u{9fff}').contains(&c)
+}
+
+// ── End-to-end: Chicago + MLA multilingual rendering ─────────────────────────
+
+/// Pattern mode: 3-way Japanese title (romanized + original + [translation]).
+///
+/// Verifies that `Transliterated` → `Original` → `Translated(brackets)` segment order
+/// produces `romanized 原文 [translation]` and that the smart-quote transform is applied
+/// to the transliterated text (ASCII `'` → U+2019 RIGHT SINGLE QUOTATION MARK).
+fn chicago_pattern_renders_three_way_japanese_title() {
+    use citum_schema::options::{
+        MultilingualMode, MultilingualSegment, MultilingualView, SegmentWrap,
+    };
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Chicago Pattern Test".to_string()),
+            default_locale: Some("en-US".to_string()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            multilingual: Some(MultilingualConfig {
+                title_mode: Some(MultilingualMode::Pattern(vec![
+                    MultilingualSegment {
+                        view: MultilingualView::Transliterated,
+                        wrap: SegmentWrap::None,
+                    },
+                    MultilingualSegment {
+                        view: MultilingualView::Original,
+                        wrap: SegmentWrap::None,
+                    },
+                    MultilingualSegment {
+                        view: MultilingualView::Translated,
+                        wrap: SegmentWrap::Brackets,
+                    },
+                ])),
+                name_mode: Some(MultilingualMode::Transliterated),
+                preferred_script: Some("Latn".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
         }),
-        "rendered bibliography should not contain Japanese scripts: {rendered}"
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![citum_schema::template::TemplateComponent::Title(
+                TemplateTitle {
+                    title: TitleType::Primary,
+                    rendering: Rendering {
+                        suffix: Some(". ".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let reference = InputReference::SerialComponent(Box::new(SerialComponent {
+        id: Some("suzuki2020".into()),
+        r#type: SerialComponentType::Article,
+        title: Some(Title::Multilingual(MultilingualComplex {
+            original: "引用の社会的機能".to_string(),
+            lang: Some("ja".into()),
+            transliterations: HashMap::from([(
+                "ja-Latn".to_string(),
+                "In'yo no shakaiteki kino".to_string(),
+            )]),
+            translations: HashMap::from([(
+                "en".into(),
+                "The Social Function of Citation".to_string(),
+            )]),
+        })),
+        issued: EdtfString("2020".to_string()),
+        language: Some("ja".into()),
+        ..Default::default()
+    }));
+
+    let bibliography = indexmap::IndexMap::from([("suzuki2020".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor.render_bibliography();
+
+    // Smart-quote: ASCII `'` between alphabetic chars → U+2019 (curly apostrophe).
+    assert_eq!(
+        rendered,
+        "In\u{2019}yo no shakaiteki kino 引用の社会的機能 [The Social Function of Citation]. "
     );
+}
+
+/// Pattern mode: 2-segment Chinese title (original + [translation]), no romanization.
+///
+/// Verifies that a `Original` → `Translated(brackets)` pattern renders `原文 [translation]`
+/// and that no romanized form leaks through (transliteration data is present in the
+/// fixture but the pattern does not request it).
+fn mla_pattern_renders_original_and_translation_chinese_title() {
+    use citum_schema::options::{
+        MultilingualMode, MultilingualSegment, MultilingualView, SegmentWrap,
+    };
+    let style = Style {
+        info: StyleInfo {
+            title: Some("MLA Pattern Test".to_string()),
+            default_locale: Some("en-US".to_string()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            multilingual: Some(MultilingualConfig {
+                title_mode: Some(MultilingualMode::Pattern(vec![
+                    MultilingualSegment {
+                        view: MultilingualView::Original,
+                        wrap: SegmentWrap::None,
+                    },
+                    MultilingualSegment {
+                        view: MultilingualView::Translated,
+                        wrap: SegmentWrap::Brackets,
+                    },
+                ])),
+                name_mode: Some(MultilingualMode::Transliterated),
+                preferred_script: Some("Latn".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![citum_schema::template::TemplateComponent::Title(
+                TemplateTitle {
+                    title: TitleType::Primary,
+                    rendering: Rendering {
+                        suffix: Some(". ".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let reference = InputReference::SerialComponent(Box::new(SerialComponent {
+        id: Some("wang2021".into()),
+        r#type: SerialComponentType::Article,
+        title: Some(Title::Multilingual(MultilingualComplex {
+            original: "战争与和平".to_string(),
+            lang: Some("zh".into()),
+            transliterations: HashMap::from([(
+                "zh-Latn-pinyin".to_string(),
+                "Zhànzhēng yǔ Hépíng".to_string(),
+            )]),
+            translations: HashMap::from([("en".into(), "War and Peace".to_string())]),
+        })),
+        issued: EdtfString("2021".to_string()),
+        language: Some("zh".into()),
+        ..Default::default()
+    }));
+
+    let bibliography = indexmap::IndexMap::from([("wang2021".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor.render_bibliography();
+
+    // No romanized segment in this pattern — the transliteration is present in the
+    // fixture data but must not appear in the output.
+    assert_eq!(rendered, "战争与和平 [War and Peace]. ");
+}
+
+// ── Pattern mode helpers ──────────────────────────────────────────────────────
+
+fn given_mla_pattern_mode_when_original_and_translation_exist_then_original_precedes_bracketed_translation()
+ {
+    use citum_schema::options::{
+        MultilingualMode, MultilingualSegment, MultilingualView, SegmentWrap,
+    };
+    let complex = MultilingualComplex {
+        original: "战争与和平".to_string(),
+        lang: Some("zh".into()),
+        transliterations: HashMap::new(), // MLA may omit transliteration
+        translations: {
+            let mut map = HashMap::new();
+            map.insert("en".into(), "War and Peace".to_string());
+            map
+        },
+    };
+    let ml_string = MultilingualString::Complex(complex);
+    let mode = MultilingualMode::Pattern(vec![
+        MultilingualSegment {
+            view: MultilingualView::Original,
+            wrap: SegmentWrap::None,
+        },
+        MultilingualSegment {
+            view: MultilingualView::Translated,
+            wrap: SegmentWrap::Brackets,
+        },
+    ]);
+    let result = resolve_multilingual_string(&ml_string, Some(&mode), None, None, "en");
+    assert_eq!(result, "战争与和平 [War and Peace]");
+}
+
+fn given_chicago_pattern_mode_when_all_three_views_exist_then_romanized_original_translation_are_joined()
+ {
+    use citum_schema::options::{
+        MultilingualMode, MultilingualSegment, MultilingualView, SegmentWrap,
+    };
+    let complex = MultilingualComplex {
+        original: "战争与和平".to_string(),
+        lang: Some("zh".into()),
+        transliterations: {
+            let mut map = HashMap::new();
+            map.insert(
+                "zh-Latn-pinyin".to_string(),
+                "Zhànzhēng yǔ Hépíng".to_string(),
+            );
+            map
+        },
+        translations: {
+            let mut map = HashMap::new();
+            map.insert("en".into(), "War and Peace".to_string());
+            map
+        },
+    };
+    let ml_string = MultilingualString::Complex(complex);
+    let mode = MultilingualMode::Pattern(vec![
+        MultilingualSegment {
+            view: MultilingualView::Transliterated,
+            wrap: SegmentWrap::None,
+        },
+        MultilingualSegment {
+            view: MultilingualView::Original,
+            wrap: SegmentWrap::None,
+        },
+        MultilingualSegment {
+            view: MultilingualView::Translated,
+            wrap: SegmentWrap::Brackets,
+        },
+    ]);
+    let result = resolve_multilingual_string(
+        &ml_string,
+        Some(&mode),
+        Some(&["zh-Latn-pinyin".to_string()]),
+        None,
+        "en",
+    );
+    assert_eq!(result, "Zhànzhēng yǔ Hépíng 战争与和平 [War and Peace]");
+}
+
+fn given_pattern_mode_when_transliteration_equals_original_then_duplicate_is_suppressed() {
+    use citum_schema::options::{
+        MultilingualMode, MultilingualSegment, MultilingualView, SegmentWrap,
+    };
+    // When the transliteration falls back to or happens to match the original,
+    // the dedup logic should suppress the second occurrence.
+    let complex = MultilingualComplex {
+        original: "Tokyo".to_string(),
+        lang: Some("ja".into()),
+        transliterations: {
+            let mut map = HashMap::new();
+            map.insert("ja-Latn".to_string(), "Tokyo".to_string()); // same as original
+            map
+        },
+        translations: {
+            let mut map = HashMap::new();
+            map.insert("en".into(), "Tokyo (East Capital)".to_string());
+            map
+        },
+    };
+    let ml_string = MultilingualString::Complex(complex);
+    let mode = MultilingualMode::Pattern(vec![
+        MultilingualSegment {
+            view: MultilingualView::Transliterated,
+            wrap: SegmentWrap::None,
+        },
+        MultilingualSegment {
+            view: MultilingualView::Original,
+            wrap: SegmentWrap::None,
+        },
+        MultilingualSegment {
+            view: MultilingualView::Translated,
+            wrap: SegmentWrap::Brackets,
+        },
+    ]);
+    let result = resolve_multilingual_string(
+        &ml_string,
+        Some(&mode),
+        Some(&["ja-Latn".to_string()]),
+        None,
+        "en",
+    );
+    // "Tokyo" appears once (dedup suppresses original); translation is still shown
+    assert_eq!(result, "Tokyo [Tokyo (East Capital)]");
+}
+
+fn given_pattern_mode_when_translation_is_missing_then_missing_segment_is_skipped() {
+    use citum_schema::options::{
+        MultilingualMode, MultilingualSegment, MultilingualView, SegmentWrap,
+    };
+    let complex = MultilingualComplex {
+        original: "引用の社会的機能".to_string(),
+        lang: Some("ja".into()),
+        transliterations: {
+            let mut map = HashMap::new();
+            map.insert(
+                "ja-Latn".to_string(),
+                "In'yo no shakaiteki kino".to_string(),
+            );
+            map
+        },
+        translations: HashMap::new(), // no English translation available
+    };
+    let ml_string = MultilingualString::Complex(complex);
+    let mode = MultilingualMode::Pattern(vec![
+        MultilingualSegment {
+            view: MultilingualView::Transliterated,
+            wrap: SegmentWrap::None,
+        },
+        MultilingualSegment {
+            view: MultilingualView::Original,
+            wrap: SegmentWrap::None,
+        },
+        MultilingualSegment {
+            view: MultilingualView::Translated,
+            wrap: SegmentWrap::Brackets,
+        },
+    ]);
+    let result = resolve_multilingual_string(
+        &ml_string,
+        Some(&mode),
+        None,
+        Some(&"Latn".to_string()),
+        "en",
+    );
+    // Translation segment is absent → only romanized + original
+    assert_eq!(result, "In'yo no shakaiteki kino 引用の社会的機能");
 }
 
 mod string_resolution {
@@ -1233,6 +1556,39 @@ mod string_resolution {
             "Combined mode should fall back to original text plus translation when no transliteration exists.",
         );
         super::given_combined_mode_without_transliteration_when_resolving_then_original_and_translation_are_combined();
+    }
+
+    #[test]
+    fn mla_pattern_mode_shows_original_then_bracketed_translation() {
+        announce_behavior(
+            "MLA Pattern mode should render the original CJK title followed by the English translation in brackets.",
+        );
+        super::given_mla_pattern_mode_when_original_and_translation_exist_then_original_precedes_bracketed_translation();
+    }
+
+    #[test]
+    fn chicago_pattern_mode_shows_three_way_romanized_original_translation() {
+        announce_behavior(
+            "Chicago Pattern mode should render romanized + original CJK + [English translation] in that order.",
+        );
+        super::given_chicago_pattern_mode_when_all_three_views_exist_then_romanized_original_translation_are_joined();
+    }
+
+    #[test]
+    fn pattern_mode_deduplicates_segments_with_identical_text() {
+        announce_behavior(
+            "Pattern mode should suppress a segment whose text is identical to the immediately preceding segment.",
+        );
+        super::given_pattern_mode_when_transliteration_equals_original_then_duplicate_is_suppressed(
+        );
+    }
+
+    #[test]
+    fn pattern_mode_skips_missing_segment_without_error() {
+        announce_behavior(
+            "Pattern mode should silently skip segments for which no text is available.",
+        );
+        super::given_pattern_mode_when_translation_is_missing_then_missing_segment_is_skipped();
     }
 }
 
@@ -1329,6 +1685,24 @@ mod multilingual_rendering {
             "APA combined title mode should romanize Japanese article and journal titles while adding the article-title translation.",
         );
         super::given_apa_multilingual_title_mode_when_rendering_a_japanese_article_then_titles_are_romanized();
+    }
+
+    #[test]
+    fn chicago_pattern_renders_three_way_japanese_title() {
+        announce_behavior(
+            "Pattern mode [Transliterated, Original, Translated(brackets)] renders \
+             'romanized original [translation]' for a Japanese title, with smart-quote applied to the transliteration.",
+        );
+        super::chicago_pattern_renders_three_way_japanese_title();
+    }
+
+    #[test]
+    fn mla_pattern_renders_original_and_translation_chinese_title() {
+        announce_behavior(
+            "Pattern mode [Original, Translated(brackets)] renders 'original [translation]' \
+             for a Chinese title; the transliteration present in the fixture must not appear.",
+        );
+        super::mla_pattern_renders_original_and_translation_chinese_title();
     }
 }
 
@@ -1445,11 +1819,9 @@ fn chicago_german_override_localizes_editor_verb() {
     let processor = Processor::with_locale(style, bib, locale);
     let output = processor.render_bibliography();
 
-    // In de-DE-chicago, role.editor.verb is "hg. von"
-    assert!(
-        output.contains("hg. von Editor Name"),
-        "Output should contain localized editor verb: {}",
-        output
+    assert_eq!(
+        output,
+        "Name, Autor. 2024. \u{201c}Kapitel.\u{201d} hg. von Editor Name, _Sammelband_."
     );
 }
 
@@ -1467,10 +1839,9 @@ fn german_override_localizes_translator_verb_when_role_preset_requests_it() {
     let processor = Processor::with_locale(style, bib, locale);
     let output = processor.render_bibliography();
 
-    assert!(
-        output.contains("übers. von Ubersetzer Name"),
-        "Output should contain localized translator verb: {}",
-        output
+    assert_eq!(
+        output,
+        "Autor Name. 2024. _Das Buch_. übers. von Ubersetzer Name"
     );
 }
 

--- a/crates/citum-schema-style/docs/schemas/abbrev-map.json
+++ b/crates/citum-schema-style/docs/schemas/abbrev-map.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": {
+    "type": "string"
+  },
+  "description": "Document-level map from full rendered strings to their abbreviations.\n\nKeys are the full rendered string (exact, case-sensitive). Values are the\nreplacement abbreviation. Applied after value extraction, before output.\n\nAccepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.",
+  "title": "AbbreviationMap",
+  "type": "object"
+}

--- a/crates/citum-schema-style/docs/schemas/bib.json
+++ b/crates/citum-schema-style/docs/schemas/bib.json
@@ -1,0 +1,4122 @@
+{
+  "$defs": {
+    "ArchiveInfo": {
+      "description": "Structured archival location metadata for unpublished and archival material.\n\nModels the hierarchical location of an item within an archive, following\ncommon archival description standards (DACS, ISAD(G), EAD).",
+      "properties": {
+        "box": {
+          "description": "Box number within the collection.\n\nUses raw identifier syntax `r#box`, which serde serializes as `\"box\"` transparently.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "collection": {
+          "description": "Name of the collection within the archive.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "collection-id": {
+          "description": "Identifier for the collection (call number, accession number, etc.).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "folder": {
+          "description": "Folder number within the box.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "item": {
+          "description": "Item identifier within the folder.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "location": {
+          "description": "Display override for the archival location (shelfmark, call number, or complex location string).\n\nWhen present, overrides the structured fields for display. Acts as the legacy\n`archive_location` fallback for complex shelfmarks that don't fit the structured model.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultilingualString"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Name of the archive or repository holding the material.\n\nUses `MultilingualString` to support international institution names\n(e.g., 国立国会図書館 / National Diet Library)."
+        },
+        "place": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Place"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Geographic location (city/country) of the archive.\n\nParallel to `SimpleName.location`; both carry geographic-place semantics."
+        },
+        "series": {
+          "description": "Name of the series within the collection.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "description": "URL for the archival item (e.g. digitized finding aid or item page).",
+          "format": "uri",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "AudioVisualType": {
+      "description": "Discriminates audio-visual subtypes for style-directed formatting.",
+      "oneOf": [
+        {
+          "const": "film",
+          "description": "A film or motion picture (default).",
+          "type": "string"
+        },
+        {
+          "const": "episode",
+          "description": "A single episode of a TV series, podcast, or web series.",
+          "type": "string"
+        },
+        {
+          "const": "recording",
+          "description": "A recording (music video, concert, etc.).",
+          "type": "string"
+        },
+        {
+          "const": "broadcast",
+          "description": "A broadcast program.",
+          "type": "string"
+        }
+      ]
+    },
+    "CollectionType": {
+      "description": "Discriminates collection subtypes for style-directed formatting.",
+      "oneOf": [
+        {
+          "const": "anthology",
+          "description": "A curated anthology of independent works (e.g., short stories, essays).",
+          "type": "string"
+        },
+        {
+          "const": "proceedings",
+          "description": "Published proceedings of a conference or symposium.",
+          "type": "string"
+        },
+        {
+          "const": "edited-book",
+          "description": "A book assembled from contributions by multiple authors under an editor.",
+          "type": "string"
+        },
+        {
+          "const": "edited-volume",
+          "description": "An edited volume that may span multiple books or a series.",
+          "type": "string"
+        }
+      ]
+    },
+    "Contributor": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SimpleName"
+        },
+        {
+          "$ref": "#/$defs/StructuredName"
+        },
+        {
+          "$ref": "#/$defs/MultilingualName"
+        },
+        {
+          "$ref": "#/$defs/ContributorList"
+        }
+      ],
+      "description": "A contributor can be a single string, a structured name, or a list of contributors."
+    },
+    "ContributorEntry": {
+      "description": "A single entry in a reference's contributors list.",
+      "properties": {
+        "contributor": {
+          "$ref": "#/$defs/Contributor",
+          "description": "The contributor (name, organization, or list)."
+        },
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The grammatical gender used for role-label agreement."
+        },
+        "role": {
+          "$ref": "#/$defs/ContributorRole",
+          "description": "The role this contributor plays in relation to the work."
+        }
+      },
+      "required": [
+        "role",
+        "contributor"
+      ],
+      "type": "object"
+    },
+    "ContributorGender": {
+      "description": "Grammatical gender carried on contributor records for role-label agreement.",
+      "oneOf": [
+        {
+          "const": "masculine",
+          "description": "Masculine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "feminine",
+          "description": "Feminine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "neuter",
+          "description": "Neuter grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "common",
+          "description": "Common or shared grammatical gender.",
+          "type": "string"
+        }
+      ]
+    },
+    "ContributorList": {
+      "description": "A list of contributors.",
+      "items": {
+        "$ref": "#/$defs/Contributor"
+      },
+      "type": "array"
+    },
+    "ContributorRole": {
+      "description": "A contributor role for use in the unified contributors list.",
+      "oneOf": [
+        {
+          "enum": [
+            "author",
+            "editor",
+            "translator",
+            "director",
+            "performer",
+            "composer",
+            "illustrator",
+            "narrator",
+            "host",
+            "guest",
+            "interviewer",
+            "recipient",
+            "compiler",
+            "producer",
+            "writer"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "EdtfString": {
+      "description": "An EDTF string.",
+      "type": "string"
+    },
+    "EprintInfo": {
+      "description": "Preprint server identifier following the biblatex eprint model.\n\nUsed on all three reference classes (Monograph, CollectionComponent, SerialComponent)\nbecause journal articles routinely carry arXiv or similar identifiers.",
+      "properties": {
+        "class": {
+          "description": "Subject class or category used by the server (e.g. \"cs.CL\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "The identifier on the preprint server (e.g. \"2301.00001\").",
+          "type": "string"
+        },
+        "server": {
+          "description": "The preprint server name in canonical lowercase form.\n\nProducers may supply mixed-case values such as \"arXiv\" or \"SSRN\";\nimplementations should treat the field case-insensitively and compare\nor normalize on the lowercase form.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "server"
+      ],
+      "type": "object"
+    },
+    "InputBibliographyInfo": {
+      "description": "Metadata for an input bibliography.",
+      "properties": {
+        "author": {
+          "description": "Creator or maintainer of the bibliography dataset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Human-readable title for the bibliography dataset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "InputReference": {
+      "oneOf": [
+        {
+          "description": "A monograph, such as a book or a report, is a monolithic work published or produced as a complete entity.",
+          "properties": {
+            "abstract-text": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ads-bibcode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive-info": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ArchiveInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "archive-location": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "available-date": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "class": {
+              "const": "monograph",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              },
+              "type": "array"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "duration": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "eprint": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EprintInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "type": "object"
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "isbn": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "keywords": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              },
+              "type": "array"
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "references": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scale": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "size": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/MonographType"
+            },
+            "url": {
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A component of a larger monograph, such as a chapter in a book.",
+          "properties": {
+            "abstract-text": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "archive-info": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ArchiveInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "class": {
+              "const": "collection-component",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              },
+              "type": "array"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "eprint": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EprintInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "type": "object"
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "keywords": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              },
+              "type": "array"
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "pages": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/NumOrStr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/MonographComponentType"
+            },
+            "url": {
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A component of a larger serial publication; for example a journal or newspaper article.\nThe parent serial is referenced by its ID.",
+          "properties": {
+            "abstract-text": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ads-bibcode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "archive-info": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ArchiveInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "available-date": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "class": {
+              "const": "serial-component",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              },
+              "type": "array"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "eprint": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EprintInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "type": "object"
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "keywords": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              },
+              "type": "array"
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "pages": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reviewed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "section": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/SerialComponentType"
+            },
+            "url": {
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A collection of works, such as an anthology or proceedings.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "class": {
+              "const": "collection",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              },
+              "type": "array"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "event": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "isbn": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "keywords": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              },
+              "type": "array"
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/CollectionType"
+            },
+            "url": {
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A serial publication (journal, magazine, etc.).",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "class": {
+              "const": "serial",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              },
+              "type": "array"
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "issn": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/SerialType"
+            },
+            "url": {
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A legal case (court decision).",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "authority": {
+              "description": "Court or authority (e.g., \"U.S. Supreme Court\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "const": "legal-case",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the legal work."
+            },
+            "doi": {
+              "description": "DOI identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Decision date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this case record derives."
+            },
+            "page": {
+              "description": "First page of case in reporter",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reporter": {
+              "description": "Reporter abbreviation (e.g., \"U.S.\", \"F.2d\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Case name (e.g., \"Brown v. Board of Education\")"
+            },
+            "url": {
+              "description": "URL for the case.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "description": "Reporter volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A statute or legislative act.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "authority": {
+              "description": "Legislative body (e.g., \"U.S. Congress\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "chapter-number": {
+              "description": "Optional chapter or session identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "const": "statute",
+              "type": "string"
+            },
+            "code": {
+              "description": "Code abbreviation (e.g., \"U.S.C.\", \"Pub. L.\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the statute."
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Enactment or publication date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "number": {
+              "description": "Statute or public-law number when present.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this statute derives."
+            },
+            "page": {
+              "description": "Page or entry locator for session laws and registers.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "section": {
+              "description": "Section or page number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Statute name (e.g., \"Civil Rights Act of 1964\")"
+            },
+            "url": {
+              "description": "URL for the statute.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "description": "Code volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "An international treaty or agreement.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Parties to the treaty"
+            },
+            "class": {
+              "const": "treaty",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the treaty text."
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Signing or ratification date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this treaty derives."
+            },
+            "page": {
+              "description": "Page or treaty number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reporter": {
+              "description": "Treaty series abbreviation (e.g., \"U.N.T.S.\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Treaty name (e.g., \"Treaty of Versailles\")"
+            },
+            "url": {
+              "description": "URL for the treaty.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "description": "Treaty series volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A legislative or administrative hearing.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "authority": {
+              "description": "Legislative body conducting the hearing (e.g., \"U.S. Senate Committee on Finance\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "const": "hearing",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the hearing record."
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Hearing date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this hearing record derives."
+            },
+            "session-number": {
+              "description": "Session or congress number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hearing title"
+            },
+            "url": {
+              "description": "URL for the hearing record.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "An administrative regulation.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "authority": {
+              "description": "Regulatory authority (e.g., \"EPA\", \"Federal Register\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "const": "regulation",
+              "type": "string"
+            },
+            "code": {
+              "description": "Code abbreviation (e.g., \"C.F.R.\", \"Fed. Reg.\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the regulation text."
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Publication or effective date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this regulation derives."
+            },
+            "section": {
+              "description": "Section or page number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Regulation title"
+            },
+            "url": {
+              "description": "URL for the regulation.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "description": "Code volume",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A legal brief or filing.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Author/filer of the brief"
+            },
+            "authority": {
+              "description": "Court (e.g., \"U.S. Supreme Court\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "const": "brief",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the brief."
+            },
+            "docket-number": {
+              "description": "Docket number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Filing date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this brief derives."
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Brief title or case name"
+            },
+            "url": {
+              "description": "URL for the brief.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A classic work (Aristotle, Bible, etc.) with standard citation forms.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "class": {
+              "const": "classic",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "edition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "editor": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "issue": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "keywords": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              },
+              "type": "array"
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "part-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "printing-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "supplement-number": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "translator": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "url": {
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "volume": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A patent.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "application-number": {
+              "description": "Application number",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "assignee": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Assignee (patent holder)"
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inventor(s)"
+            },
+            "authority": {
+              "description": "Patent office (e.g., \"U.S. Patent and Trademark Office\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "const": "patent",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the patented work."
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "filing-date": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filing date"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Issue/grant date"
+            },
+            "jurisdiction": {
+              "description": "Jurisdiction (e.g., \"US\", \"EP\", \"JP\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this patent derives."
+            },
+            "patent-number": {
+              "description": "Patent number (e.g., \"U.S. Patent No. 7,347,809\")",
+              "type": "string"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Patent title"
+            },
+            "url": {
+              "description": "URL for the patent.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "patent-number",
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A research dataset.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Dataset author(s)/creator(s)"
+            },
+            "class": {
+              "const": "dataset",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the dataset."
+            },
+            "doi": {
+              "description": "DOI identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "format": {
+              "description": "File format. Prefer IANA media types (e.g., `\"text/csv\"`) or common\nabbreviations (e.g., `\"NetCDF\"`, `\"HDF5\"`) where no IANA type exists.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Publication/release date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the dataset."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this dataset derives."
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Publisher or repository (e.g., \"Zenodo\", \"Dryad\")"
+            },
+            "repository": {
+              "description": "Repository or archive name",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "size": {
+              "description": "Dataset size (e.g., \"2.4 GB\", \"150,000 records\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Dataset title"
+            },
+            "url": {
+              "description": "URL for the dataset.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version": {
+              "description": "Version number",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "A technical standard or specification.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "authority": {
+              "description": "Standards organization (e.g., \"ISO\", \"ANSI\", \"IEEE\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "const": "standard",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the standard."
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Publication date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the document."
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this standard derives."
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Publisher (usually same as authority)"
+            },
+            "standard-number": {
+              "description": "Standard number (e.g., \"ISO 8601\", \"IEEE 754-2008\")",
+              "type": "string"
+            },
+            "status": {
+              "description": "Publication status. Canonical controlled-vocabulary values: `\"published\"`, `\"draft\"`, `\"withdrawn\"`.\nSee `docs/policies/ENUM_VOCABULARY_POLICY.md` for matching rules.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Standard title"
+            },
+            "url": {
+              "description": "URL for the standard.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "standard-number",
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "Software or source code.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "author": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Contributor"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Author(s)/developer(s)"
+            },
+            "class": {
+              "const": "software",
+              "type": "string"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Creation or origination date of the software work."
+            },
+            "doi": {
+              "description": "DOI identifier.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "description": "Release date"
+            },
+            "keywords": {
+              "description": "Keywords or subject tags.",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the software documentation."
+            },
+            "license": {
+              "description": "SPDX license identifier preferred (e.g., `\"MIT\"`, `\"GPL-3.0-only\"`, `\"Apache-2.0\"`).\nSee <https://spdx.org/licenses/> for the authoritative identifier list.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this software derives."
+            },
+            "platform": {
+              "description": "Platform (e.g., \"Windows\", \"macOS\", \"Linux\", \"cross-platform\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Publisher or repository (e.g., \"GitHub\", \"Zenodo\")"
+            },
+            "repository": {
+              "description": "Repository URL",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Software title"
+            },
+            "url": {
+              "description": "URL for the software.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version": {
+              "description": "Version number (e.g., \"4.1.0\", \"v2.3.1\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "Event metadata for conferences, performances, broadcasts, and recordings.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the URL was accessed."
+            },
+            "available-date": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Date the event became or will become publicly available."
+            },
+            "class": {
+              "const": "event",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Immediate container (e.g., broadcast program, proceedings volume)."
+            },
+            "contributors": {
+              "description": "Unified contributor list with explicit role tags.",
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              },
+              "type": "array"
+            },
+            "date": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Event date."
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "description": "Per-field language overrides.",
+              "type": "object"
+            },
+            "genre": {
+              "description": "Event genre (e.g., `\"conference\"`, `\"performance\"`, `\"broadcast\"`, `\"talk\"`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for this reference."
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCP 47 language of the event."
+            },
+            "location": {
+              "description": "Event location (city, venue).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "network": {
+              "description": "Broadcaster, network, or streaming platform.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Freeform note."
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Original work or publication from which this event derives."
+            },
+            "series": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Recurring event series (e.g., annual conference series)."
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Event name (e.g., conference title, performance name)."
+            },
+            "url": {
+              "description": "URL for the event.",
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        },
+        {
+          "description": "An audio-visual work: film, TV episode, recording, or broadcast.\n\nThis is a work-like reference class. It represents the creative work\nwhen that work is the citee, not a fully modeled release hierarchy.",
+          "properties": {
+            "accessed": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "class": {
+              "const": "audio-visual",
+              "type": "string"
+            },
+            "container": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "contributors": {
+              "items": {
+                "$ref": "#/$defs/ContributorEntry"
+              },
+              "type": "array"
+            },
+            "created": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "field-languages": {
+              "additionalProperties": {
+                "$ref": "#/$defs/LangID"
+              },
+              "type": "object"
+            },
+            "genre": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RefID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "issued": {
+              "$ref": "#/$defs/EdtfString",
+              "default": ""
+            },
+            "language": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LangID"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "note": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RichText"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "number": {
+              "description": "Catalog or episode number shorthand (normalized into `numbering`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering": {
+              "items": {
+                "$ref": "#/$defs/Numbering"
+              },
+              "type": "array"
+            },
+            "original": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "platform": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "publisher": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Publisher"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "short-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Title"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "$ref": "#/$defs/AudioVisualType",
+              "default": "film"
+            },
+            "url": {
+              "format": "uri",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "class"
+          ],
+          "type": "object",
+          "unevaluatedProperties": false
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "LangID": {
+      "description": "BCP 47 language tag (e.g., `\"en\"`, `\"de\"`, `\"ja\"`).",
+      "type": "string"
+    },
+    "MonographComponentType": {
+      "description": "Discriminates monograph-component subtypes for style-directed formatting.",
+      "oneOf": [
+        {
+          "const": "chapter",
+          "description": "A chapter within a book or edited volume.",
+          "type": "string"
+        },
+        {
+          "const": "document",
+          "description": "A document component that does not fit a more specific subtype.",
+          "type": "string"
+        }
+      ]
+    },
+    "MonographType": {
+      "description": "Discriminates monograph subtypes for style-directed formatting.",
+      "oneOf": [
+        {
+          "const": "book",
+          "description": "A book or monograph (default).",
+          "type": "string"
+        },
+        {
+          "const": "manual",
+          "description": "A technical manual or user guide.",
+          "type": "string"
+        },
+        {
+          "const": "report",
+          "description": "A technical or institutional report.",
+          "type": "string"
+        },
+        {
+          "const": "thesis",
+          "description": "An academic thesis or dissertation.",
+          "type": "string"
+        },
+        {
+          "const": "webpage",
+          "description": "A webpage or standalone web document.",
+          "type": "string"
+        },
+        {
+          "const": "post",
+          "description": "A standalone post (e.g., social media, forum).",
+          "type": "string"
+        },
+        {
+          "const": "interview",
+          "description": "An interview treated as a standalone monographic source.",
+          "type": "string"
+        },
+        {
+          "const": "manuscript",
+          "description": "An unpublished manuscript or archival document.",
+          "type": "string"
+        },
+        {
+          "const": "preprint",
+          "description": "A preprint hosted on a preprint server (arXiv, bioRxiv, SSRN, etc.).\n\nThe preprint server has a custodial relationship with the work (hosting and\npreservation), not an editorial one. This parallels an archived manuscript\nheld by a repository.",
+          "type": "string"
+        },
+        {
+          "const": "personal-communication",
+          "description": "A letter, email, or other personal communication.",
+          "type": "string"
+        },
+        {
+          "const": "document",
+          "description": "A generic standalone document that does not fit a more specific subtype.",
+          "type": "string"
+        }
+      ]
+    },
+    "MultilingualComplex": {
+      "description": "Complex multilingual representation with original, transliterations, and translations.\n\nAllows capturing the original text in its native script, along with transliterations\n(phonetic representations in different scripts) and translations (semantic equivalents\nin different languages). This is essential for accurately rendering bibliographies in\nmultilingual and non-Latin-script contexts.",
+      "properties": {
+        "lang": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "ISO 639/BCP 47 language code for the original text."
+        },
+        "original": {
+          "description": "The text in its original script and language.",
+          "type": "string"
+        },
+        "translations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Translations of the text into other languages.\n\nKeys are ISO 639/BCP 47 language codes (e.g., \"en\" for English, \"fr\" for French).\nValues are the translated text.",
+          "type": "object"
+        },
+        "transliterations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Transliterations/Transcriptions of the original text into other scripts.\n\nKeys are typically script codes (e.g., \"Latn\" for Latin) or full BCP 47 tags.\nValues are the transliterated or transcribed text.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "original"
+      ],
+      "type": "object"
+    },
+    "MultilingualName": {
+      "description": "Holistic multilingual name representation.",
+      "properties": {
+        "lang": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LangID"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "ISO 639/BCP 47 language code for the original name."
+        },
+        "original": {
+          "$ref": "#/$defs/StructuredName",
+          "description": "The name in its original script."
+        },
+        "translations": {
+          "additionalProperties": {
+            "$ref": "#/$defs/StructuredName"
+          },
+          "description": "Translations of the name.",
+          "type": "object"
+        },
+        "transliterations": {
+          "additionalProperties": {
+            "$ref": "#/$defs/StructuredName"
+          },
+          "description": "Transliterations/Transcriptions of the name.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "original"
+      ],
+      "type": "object"
+    },
+    "MultilingualString": {
+      "anyOf": [
+        {
+          "description": "A simple string in a single language.",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/MultilingualComplex",
+          "description": "A complex multilingual string with original, transliterations, and translations."
+        }
+      ],
+      "description": "A string that can be represented in multiple languages and scripts.\n\nThis is an enum that supports both simple strings and complex multilingual representations.\nUse `Simple` for basic strings and `Complex` when you need to track original language,\ntransliterations, and translations."
+    },
+    "NumOrStr": {
+      "anyOf": [
+        {
+          "description": "A numeric value.",
+          "format": "int64",
+          "type": "integer"
+        },
+        {
+          "description": "A string value.",
+          "type": "string"
+        }
+      ],
+      "description": "A value that could be either a number or a string.\n\nUsed for fields that may contain numeric or string values, such as issue numbers,\nvolume numbers, or similar identifiers that can be formatted as either type.\nThe `Display` implementation shows the value in its appropriate form."
+    },
+    "Numbering": {
+      "description": "A numbering identifier for a work (e.g., volume, issue, number).",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/NumberingType",
+          "description": "The type of the numbering."
+        },
+        "value": {
+          "description": "The value of the numbering (e.g., \"4\", \"B\").",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "type": "object"
+    },
+    "NumberingType": {
+      "description": "Known numbering kind keyword or custom kebab-case identifier.",
+      "type": "string"
+    },
+    "Place": {
+      "description": "Geographic place name used for publication and archive locations.",
+      "type": "string"
+    },
+    "Publisher": {
+      "anyOf": [
+        {
+          "properties": {
+            "name": {
+              "$ref": "#/$defs/MultilingualString"
+            },
+            "place": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Place"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/$defs/Contributor"
+        },
+        {
+          "$ref": "#/$defs/MultilingualString"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "A publisher or production company.\n\nPublisher is always a corporate entity — a person is never a publisher\nin the bibliographic sense."
+    },
+    "RefID": {
+      "description": "Unique identifier for a reference item.",
+      "type": "string"
+    },
+    "RichText": {
+      "anyOf": [
+        {
+          "description": "Plain text with no inline markup.",
+          "type": "string"
+        },
+        {
+          "description": "Djot inline markup.",
+          "properties": {
+            "djot": {
+              "description": "Djot inline markup source.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "djot"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Inline markup for freeform text fields (note, abstract).\n\nSerializes from a plain string or a `{ djot: \"...\" }` object."
+    },
+    "SerialComponentType": {
+      "description": "Discriminates serial-component subtypes for style-directed formatting.",
+      "oneOf": [
+        {
+          "const": "article",
+          "description": "A peer-reviewed or editorial article in a journal, magazine, or newspaper.",
+          "type": "string"
+        },
+        {
+          "const": "post",
+          "description": "A post within an online serial (blog, news site, social feed).",
+          "type": "string"
+        },
+        {
+          "const": "review",
+          "description": "A review published in a serial (book review, film review, etc.).",
+          "type": "string"
+        }
+      ]
+    },
+    "SerialType": {
+      "description": "Types of serial publications.",
+      "oneOf": [
+        {
+          "const": "academic-journal",
+          "description": "An academic peer-reviewed journal.",
+          "type": "string"
+        },
+        {
+          "const": "blog",
+          "description": "A blog or personal website updated periodically.",
+          "type": "string"
+        },
+        {
+          "const": "magazine",
+          "description": "A general-interest magazine.",
+          "type": "string"
+        },
+        {
+          "const": "newspaper",
+          "description": "A newspaper.",
+          "type": "string"
+        },
+        {
+          "const": "newsletter",
+          "description": "A newsletter.",
+          "type": "string"
+        },
+        {
+          "const": "proceedings",
+          "description": "A conference proceedings serial.",
+          "type": "string"
+        },
+        {
+          "const": "podcast",
+          "description": "A podcast.",
+          "type": "string"
+        },
+        {
+          "const": "broadcast-program",
+          "description": "A broadcast program (radio, television).",
+          "type": "string"
+        }
+      ]
+    },
+    "SimpleName": {
+      "description": "A simple name is just a string, with an optional location.",
+      "properties": {
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Place"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Geographic place associated with the name."
+        },
+        "name": {
+          "$ref": "#/$defs/MultilingualString",
+          "description": "Institutional or organization name."
+        },
+        "short-name": {
+          "description": "Short form of the name (e.g., abbreviation or shortened form).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "StructuredName": {
+      "description": "A structured name is a name broken down into its constituent parts.",
+      "properties": {
+        "dropping-particle": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "family": {
+          "$ref": "#/$defs/MultilingualString"
+        },
+        "given": {
+          "$ref": "#/$defs/MultilingualString"
+        },
+        "non-dropping-particle": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "given",
+        "family"
+      ],
+      "type": "object"
+    },
+    "StructuredTitle": {
+      "description": "Where title parts are meaningful, use this struct; Citum processors will not parse title strings.",
+      "properties": {
+        "full": {
+          "description": "Full rendered title string (optional override).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "main": {
+          "description": "Main title component.",
+          "type": "string"
+        },
+        "sub": {
+          "$ref": "#/$defs/Subtitle",
+          "description": "Subtitle component."
+        }
+      },
+      "required": [
+        "main",
+        "sub"
+      ],
+      "type": "object"
+    },
+    "Subtitle": {
+      "anyOf": [
+        {
+          "description": "A single subtitle string.",
+          "type": "string"
+        },
+        {
+          "description": "Multiple subtitle strings.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "The subtitle can either be a string, as is the common case, or a vector of strings."
+    },
+    "Title": {
+      "anyOf": [
+        {
+          "description": "A title in a single language.",
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/StructuredTitle",
+          "description": "A structured title."
+        },
+        {
+          "$ref": "#/$defs/MultilingualComplex",
+          "description": "A complex multilingual title."
+        },
+        {
+          "description": "A title in multiple languages.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "$ref": "#/$defs/LangID"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        },
+        {
+          "description": "A structured title in multiple languages.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "$ref": "#/$defs/LangID"
+              },
+              {
+                "$ref": "#/$defs/StructuredTitle"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        },
+        {
+          "description": "An abbreviated title (shorthand, full).",
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "type": "array"
+        }
+      ],
+      "description": "A title can be a single string, a structured title, or a multilingual title."
+    },
+    "WorkRelation": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RefID",
+          "description": "The target work is referenced by its ID (resolved at render time)."
+        },
+        {
+          "$ref": "#/$defs/InputReference",
+          "description": "The target work is embedded inline."
+        }
+      ],
+      "description": "A relation to another bibliographic entity.\n\nUntagged in serde to allow either an inline object or a string ID reference.\nUsed for both hierarchical (`container`) and associative (`original`, `reviewed`, `series`) links."
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A collection of bibliographic references with optional metadata.",
+  "properties": {
+    "custom": {
+      "additionalProperties": true,
+      "description": "Custom user-defined fields for extensions.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "info": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/InputBibliographyInfo"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Bibliography metadata."
+    },
+    "references": {
+      "description": "The list of references.",
+      "items": {
+        "$ref": "#/$defs/InputReference"
+      },
+      "type": "array"
+    },
+    "sets": {
+      "additionalProperties": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "description": "Optional compound entry sets keyed by set id.\n\nEach set id maps to an ordered list of reference ids that should be treated\nas one compound numeric group when `compound-numeric` is enabled by style.",
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "references"
+  ],
+  "title": "InputBibliography",
+  "type": "object"
+}

--- a/crates/citum-schema-style/docs/schemas/citation.json
+++ b/crates/citum-schema-style/docs/schemas/citation.json
@@ -1,0 +1,264 @@
+{
+  "$defs": {
+    "Citation": {
+      "description": "A citation containing one or more references.",
+      "properties": {
+        "grouped": {
+          "description": "If true, the entire citation is a single dynamic compound set.\n\nThe first item acts as the head and subsequent items are merged as tails\nin the bibliography. Ignored for non-numeric (compound-numeric) styles.\nItem order is preserved and sorting is suppressed when this flag is set.",
+          "type": "boolean"
+        },
+        "id": {
+          "description": "The citation ID (optional, for tracking).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "items": {
+          "description": "The citation items (references being cited).",
+          "items": {
+            "$ref": "#/$defs/CitationItem"
+          },
+          "type": "array"
+        },
+        "mode": {
+          "$ref": "#/$defs/CitationMode",
+          "description": "Citation mode: integral (narrative) vs non-integral (parenthetical).\nOnly relevant for author-date styles."
+        },
+        "note-number": {
+          "description": "Note number for footnote/endnote styles.\nAssigned by the document processor, not the citation processor.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "position": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Position"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Position of this citation in the document flow.\nDetected automatically by the processor or set explicitly by the caller."
+        },
+        "prefix": {
+          "description": "Prefix text before all citation items.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Suffix text after all citation items.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress-author": {
+          "description": "Suppress the author name across all items in this citation.\nUsed when the author is already named in the prose: \"Smith argues (2020)\".\nApplies uniformly to all items — per-item suppression is not supported\nbecause mixed-visibility citations are typographically incoherent.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object"
+    },
+    "CitationItem": {
+      "description": "A single citation item referencing a bibliography entry.",
+      "properties": {
+        "id": {
+          "description": "The reference ID (citekey).",
+          "type": "string"
+        },
+        "integral-name-state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit integral name-memory state override for this item."
+        },
+        "locator": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationLocator"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Canonical locator value for pinpoint citations."
+        },
+        "org-abbreviation-state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit org-abbreviation state override for this item."
+        },
+        "prefix": {
+          "description": "Prefix text before this item",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Suffix text after this item",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "CitationLocator": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LocatorSegment"
+        },
+        {
+          "properties": {
+            "segments": {
+              "items": {
+                "$ref": "#/$defs/LocatorSegment"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "segments"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "CitationMode": {
+      "description": "Citation mode for author-date styles.\n\nDetermines how the author name is rendered relative to the citation.",
+      "oneOf": [
+        {
+          "const": "integral",
+          "description": "Author inline in text: \"Smith (2020) argues...\"\nAlso known as \"narrative\" or \"in-text\" citations.",
+          "type": "string"
+        },
+        {
+          "const": "non-integral",
+          "description": "Author in parentheses: \"(Smith, 2020)\"\nThe default mode for most citations.",
+          "type": "string"
+        }
+      ]
+    },
+    "IntegralNameState": {
+      "description": "Explicit integral citation name-memory state for one citation item.",
+      "oneOf": [
+        {
+          "const": "first",
+          "description": "Render this item as the first integral mention in scope.",
+          "type": "string"
+        },
+        {
+          "const": "subsequent",
+          "description": "Render this item as a subsequent integral mention in scope.",
+          "type": "string"
+        }
+      ]
+    },
+    "LocatorSegment": {
+      "description": "A single segment of a compound locator.\n\nPairs a locator type with its value, e.g. `{ label: chapter, value: \"3\" }`.",
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/LocatorType",
+          "description": "The locator type for this segment."
+        },
+        "value": {
+          "$ref": "#/$defs/LocatorValue",
+          "description": "The locator value (e.g., \"3\", \"42-45\")."
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ],
+      "type": "object"
+    },
+    "LocatorType": {
+      "description": "Known locator label keyword or custom kebab-case identifier.",
+      "type": "string"
+    },
+    "LocatorValue": {
+      "anyOf": [
+        {
+          "description": "Plain string value with heuristic plural detection.",
+          "type": "string"
+        },
+        {
+          "description": "Explicit value with manual plural override.",
+          "properties": {
+            "plural": {
+              "description": "Whether this locator is plural.",
+              "type": "boolean"
+            },
+            "value": {
+              "description": "The locator value string.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "plural"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A locator value that supports both plain strings and explicit plurality.\n\nPlain strings use heuristic plural detection (checking for `-`, `–`, `,`, `&`).\nUse the explicit form to override when the heuristic fails (e.g., \"figure A-3\"\nshould be singular despite containing a hyphen)."
+    },
+    "Position": {
+      "description": "Position of a citation in the document flow.\n\nIndicates where this citation appears relative to previous citations\nof the same item(s). Used for note-based styles to detect ibid and\nsubsequent citations, and for author-date styles to apply position-specific\nformatting rules (e.g., short forms after first citation).",
+      "oneOf": [
+        {
+          "const": "first",
+          "description": "First citation of an item.",
+          "type": "string"
+        },
+        {
+          "const": "subsequent",
+          "description": "Subsequent citation of an item (non-consecutive).",
+          "type": "string"
+        },
+        {
+          "const": "ibid",
+          "description": "Same item cited immediately before, no locator on either.",
+          "type": "string"
+        },
+        {
+          "const": "ibid-with-locator",
+          "description": "Same item cited immediately before, with different locator.",
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "$ref": "#/$defs/Citation"
+  },
+  "title": "Array_of_Citation",
+  "type": "array"
+}

--- a/crates/citum-schema-style/docs/schemas/locale.json
+++ b/crates/citum-schema-style/docs/schemas/locale.json
@@ -1,0 +1,613 @@
+{
+  "$defs": {
+    "EvaluationConfig": {
+      "description": "Runtime evaluation options for a locale.\n\nDeclares which message syntax the `messages` map uses and controls\nevaluator selection. May grow with additional fields (custom function\ndeclarations, evaluator hints) without breaking existing locale files.",
+      "properties": {
+        "message-syntax": {
+          "$ref": "#/$defs/MessageSyntax",
+          "default": "static",
+          "description": "Message syntax used in this locale's `messages` map."
+        }
+      },
+      "type": "object"
+    },
+    "GrammarOptions": {
+      "description": "Grammar options that vary by language or regional convention.",
+      "properties": {
+        "close-inner-quote": {
+          "default": "’",
+          "description": "Closing inner (nested) quotation mark character.",
+          "type": "string"
+        },
+        "close-quote": {
+          "default": "”",
+          "description": "Closing outer quotation mark character.",
+          "type": "string"
+        },
+        "nbsp-before-colon": {
+          "default": false,
+          "description": "Whether to use a non-breaking space before colon/question mark (French style).",
+          "type": "boolean"
+        },
+        "open-inner-quote": {
+          "default": "‘",
+          "description": "Opening inner (nested) quotation mark character.",
+          "type": "string"
+        },
+        "open-quote": {
+          "default": "“",
+          "description": "Opening outer quotation mark character.",
+          "type": "string"
+        },
+        "page-range-delimiter": {
+          "default": "–",
+          "description": "Delimiter between page range endpoints.",
+          "type": "string"
+        },
+        "punctuation-in-quote": {
+          "default": false,
+          "description": "Whether to place periods/commas inside closing quotation marks (American style).",
+          "type": "boolean"
+        },
+        "serial-comma": {
+          "default": false,
+          "description": "Whether to use a serial (Oxford) comma before the final list item.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "GrammaticalGender": {
+      "description": "Grammatical gender used for locale agreement and term selection.",
+      "oneOf": [
+        {
+          "const": "masculine",
+          "description": "Masculine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "feminine",
+          "description": "Feminine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "neuter",
+          "description": "Neuter grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "common",
+          "description": "Common or shared grammatical gender.",
+          "type": "string"
+        }
+      ]
+    },
+    "MessageSyntax": {
+      "description": "Message syntax variant active in a locale file.\n\nControls which `MessageEvaluator` implementation the engine selects at\nlocale-load time.",
+      "oneOf": [
+        {
+          "const": "static",
+          "description": "Plain text only; parameterized messages are not evaluated.",
+          "type": "string"
+        },
+        {
+          "const": "mf2",
+          "description": "ICU Message Format 2 evaluation (requires `Mf2MessageEvaluator`).",
+          "type": "string"
+        }
+      ]
+    },
+    "NumberFormats": {
+      "description": "Number formatting options for a locale.",
+      "properties": {
+        "decimal-separator": {
+          "default": ".",
+          "description": "Decimal separator (e.g., \".\" for en-US, \",\" for de-DE).",
+          "type": "string"
+        },
+        "minimum-digits": {
+          "default": 1,
+          "description": "Minimum digits to display.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "thousands-separator": {
+          "default": ",",
+          "description": "Thousands separator (e.g., \",\" for en-US, \".\" for de-DE).",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "RawDateTerms": {
+      "description": "Raw date terms for YAML parsing.",
+      "properties": {
+        "ad": {
+          "default": null,
+          "description": "Localized era suffix for positive years in BC/AD profile (e.g., \"AD\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "am": {
+          "default": null,
+          "description": "Localized ante meridiem marker.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bc": {
+          "default": null,
+          "description": "Localized era suffix for negative years in BC/AD profile (e.g., \"BC\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bce": {
+          "default": null,
+          "description": "Localized era suffix for negative years in BCE/CE profile (e.g., \"BCE\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "before-era": {
+          "default": null,
+          "description": "Localized era suffix for year zero and negative years.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ce": {
+          "default": null,
+          "description": "Localized era suffix for positive years in BCE/CE profile (e.g., \"CE\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "months": {
+          "$ref": "#/$defs/RawMonthNames",
+          "default": {
+            "long": [],
+            "short": []
+          },
+          "description": "Localized month names."
+        },
+        "open-ended-term": {
+          "default": null,
+          "description": "Localized term for open-ended date ranges.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pm": {
+          "default": null,
+          "description": "Localized post meridiem marker.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "seasons": {
+          "default": [],
+          "description": "Localized season names in display order.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "timezone-utc": {
+          "default": null,
+          "description": "Localized label for UTC.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uncertainty-term": {
+          "default": null,
+          "description": "Localized term for uncertain dates.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RawGenderedString": {
+      "anyOf": [
+        {
+          "description": "Plain string value.",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Gender-specific values.",
+          "minProperties": 1,
+          "properties": {
+            "common": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "feminine": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "masculine": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "neuter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "description": "A raw string that may include gender-specific variants."
+    },
+    "RawLocatorTerm": {
+      "description": "Raw locator term with optional lexical gender.",
+      "properties": {
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Lexical gender used for noun agreement."
+        },
+        "long": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Long-form locator term."
+        },
+        "short": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Short-form locator term."
+        },
+        "symbol": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Symbol-form locator term."
+        }
+      },
+      "type": "object"
+    },
+    "RawMonthNames": {
+      "description": "Raw month names for YAML parsing.",
+      "properties": {
+        "long": {
+          "default": [],
+          "description": "Full month names.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "short": {
+          "default": [],
+          "description": "Abbreviated month names.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "RawRoleTerm": {
+      "description": "Raw role term with form-keyed values.",
+      "properties": {
+        "long": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Long-form role term."
+        },
+        "short": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Short-form role term."
+        },
+        "verb": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Verb-form role term."
+        },
+        "verb-short": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawTermValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Short verb-form role term."
+        }
+      },
+      "type": "object"
+    },
+    "RawTermValue": {
+      "anyOf": [
+        {
+          "description": "Simple string value.",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Singular/plural forms.",
+          "properties": {
+            "plural": {
+              "$ref": "#/$defs/RawGenderedString"
+            },
+            "singular": {
+              "$ref": "#/$defs/RawGenderedString"
+            }
+          },
+          "required": [
+            "singular",
+            "plural"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Gender-specific values.",
+          "minProperties": 1,
+          "properties": {
+            "common": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "feminine": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "masculine": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "neuter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        {
+          "additionalProperties": {
+            "$ref": "#/$defs/RawTermValue"
+          },
+          "description": "Form-keyed value (for terms with long/short or nested forms).",
+          "type": "object"
+        }
+      ],
+      "description": "A term value that can be a simple string or have singular/plural forms."
+    },
+    "RawVocab": {
+      "description": "Raw vocab maps for genre and medium display text.",
+      "properties": {
+        "genre": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Genre canonical key → display string.",
+          "type": "object"
+        },
+        "medium": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Medium canonical key → display string.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Raw locale format for YAML parsing.\nThis is a simpler format that uses string keys for terms.",
+  "properties": {
+    "date-formats": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Named date format presets: symbolic name → CLDR date pattern (v2 locales only).",
+      "type": "object"
+    },
+    "dates": {
+      "$ref": "#/$defs/RawDateTerms",
+      "default": {
+        "ad": null,
+        "am": null,
+        "bc": null,
+        "bce": null,
+        "before-era": null,
+        "ce": null,
+        "months": {
+          "long": [],
+          "short": []
+        },
+        "open-ended-term": null,
+        "pm": null,
+        "seasons": [],
+        "timezone-utc": null,
+        "uncertainty-term": null
+      },
+      "description": "Date-related terms."
+    },
+    "evaluation": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EvaluationConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Runtime evaluation options (message syntax, evaluator hints)."
+    },
+    "grammar-options": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GrammarOptions"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Grammar toggles that vary by language."
+    },
+    "legacy-term-aliases": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Backwards-compatibility aliases: old CSL term key → new message ID.",
+      "type": "object"
+    },
+    "locale": {
+      "description": "The locale identifier (e.g., \"en-US\", \"de-DE\").",
+      "type": "string"
+    },
+    "locale-schema-version": {
+      "description": "Schema version. Absent or \"1\" uses the legacy term-map path.\n\"2\" activates the new messages/dateFormats/grammarOptions path.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "locators": {
+      "additionalProperties": {
+        "$ref": "#/$defs/RawLocatorTerm"
+      },
+      "default": {},
+      "description": "Locator terms keyed by locator name.",
+      "type": "object"
+    },
+    "messages": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "ICU Message Format 1 messages keyed by message ID (v2 locales only).",
+      "type": "object"
+    },
+    "number-formats": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/NumberFormats"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Locale-level number formatting options."
+    },
+    "roles": {
+      "additionalProperties": {
+        "$ref": "#/$defs/RawRoleTerm"
+      },
+      "default": {},
+      "description": "Role terms keyed by role name.",
+      "type": "object"
+    },
+    "terms": {
+      "additionalProperties": {
+        "$ref": "#/$defs/RawTermValue"
+      },
+      "default": {},
+      "description": "General terms keyed by term name.",
+      "type": "object"
+    },
+    "vocab": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RawVocab"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Vocabulary maps for genre and medium display text."
+    }
+  },
+  "required": [
+    "locale"
+  ],
+  "title": "RawLocale",
+  "type": "object"
+}

--- a/crates/citum-schema-style/docs/schemas/registry.json
+++ b/crates/citum-schema-style/docs/schemas/registry.json
@@ -1,0 +1,125 @@
+{
+  "$defs": {
+    "RegistryEntry": {
+      "description": "A single entry in a style registry.",
+      "properties": {
+        "aliases": {
+          "default": [],
+          "description": "Short aliases that resolve to this entry (default empty).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "builtin": {
+          "description": "Name of an embedded style (present for the default registry).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "Human-readable description.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fields": {
+          "default": [],
+          "description": "Subject/domain classification tags (default empty).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "Canonical style ID, must match the key used in `get_embedded_style`.",
+          "type": "string"
+        },
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StyleKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Tier classification (base, profile, journal, independent)."
+        },
+        "path": {
+          "description": "Relative path to a YAML file (used in local registries).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "description": "Human-readable title from the style metadata.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "description": "HTTP URL to a YAML style file.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "StyleKind": {
+      "description": "Tier classification for a style in the registry.",
+      "oneOf": [
+        {
+          "const": "base",
+          "description": "Complete style that serves as an inheritance root.",
+          "type": "string"
+        },
+        {
+          "const": "profile",
+          "description": "Organizational adaptation of a base style (publisher, society, standards body).",
+          "type": "string"
+        },
+        {
+          "const": "journal",
+          "description": "Pure alias pointing to a profile or base style.",
+          "type": "string"
+        },
+        {
+          "const": "independent",
+          "description": "Standalone style with no aliases and no inheritance role.",
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A registry of citation styles with alias resolution.",
+  "properties": {
+    "styles": {
+      "description": "List of style entries in the registry.",
+      "items": {
+        "$ref": "#/$defs/RegistryEntry"
+      },
+      "type": "array"
+    },
+    "version": {
+      "description": "Version identifier for the registry format.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "version",
+    "styles"
+  ],
+  "title": "StyleRegistry",
+  "type": "object"
+}

--- a/crates/citum-schema-style/docs/schemas/server.json
+++ b/crates/citum-schema-style/docs/schemas/server.json
@@ -1,0 +1,2887 @@
+{
+  "$defs": {
+    "AbbreviationMap": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Document-level map from full rendered strings to their abbreviations.\n\nKeys are the full rendered string (exact, case-sensitive). Values are the\nreplacement abbreviation. Applied after value extraction, before output.\n\nAccepts both `abbreviation-map` (YAML frontmatter) and `abbreviation_map` forms.",
+      "type": "object"
+    },
+    "AndOptions": {
+      "description": "Conjunction options between contributors.",
+      "oneOf": [
+        {
+          "const": "text",
+          "description": "Use the localized term for \"and\" (e.g., \"and\" in English).",
+          "type": "string"
+        },
+        {
+          "const": "symbol",
+          "description": "Use the localized symbol for \"and\" (e.g., \"&\" in English).",
+          "type": "string"
+        },
+        {
+          "const": "none",
+          "description": "No conjunction (e.g., \"Smith, Jones\").",
+          "type": "string"
+        }
+      ]
+    },
+    "AndOtherOptions": {
+      "description": "How to render \"and others\" / et al.",
+      "enum": [
+        "et-al",
+        "text"
+      ],
+      "type": "string"
+    },
+    "AnnotationFormat": {
+      "description": "Markup format for annotation text.",
+      "oneOf": [
+        {
+          "const": "djot",
+          "description": "Parse annotation as djot inline markup (default).",
+          "type": "string"
+        },
+        {
+          "const": "plain",
+          "description": "Treat annotation as plain text with no markup interpretation.",
+          "type": "string"
+        },
+        {
+          "const": "org",
+          "description": "Parse annotation as org-mode markup.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographyGroup": {
+      "description": "A bibliography group with selector, optional heading, and per-group sorting.\n\nGroups allow styles to divide bibliographies into labeled sections with\ndistinct sorting rules. Items match the first group whose selector evaluates\nto true (first-match semantics).\n\n# Examples\n\n```yaml\ngroups:\n  - id: vietnamese\n    heading:\n      localized:\n        vi: \"Tài liệu tiếng Việt\"\n        en-US: \"Vietnamese Sources\"\n    selector:\n      field:\n        language: vi\n    sort:\n      template:\n        - key: author\n          sort-order: given-family\n```",
+      "properties": {
+        "disambiguate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DisambiguationScope"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional disambiguation scope.\n- `globally` (default): Year suffixes are assigned across the whole bibliography.\n- `locally`: Year suffixes are assigned independently within this group."
+        },
+        "heading": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupHeading"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional heading to display above this group.\nOmit for no heading (e.g., fallback group)."
+        },
+        "id": {
+          "description": "Unique identifier for this group.",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/$defs/GroupSelector",
+          "description": "Selector predicate to match references."
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSortEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional per-group sorting specification.\nFalls back to global bibliography sort if omitted."
+        },
+        "template": {
+          "description": "Optional per-group template override.\nFalls back to global bibliography template if omitted.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "selector"
+      ],
+      "type": "object"
+    },
+    "BibliographyPartitionHeading": {
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "properties": {
+            "form": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional term form (defaults to long)."
+            },
+            "term": {
+              "$ref": "#/$defs/GeneralTerm",
+              "description": "Locale general term key."
+            }
+          },
+          "required": [
+            "term"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "properties": {
+            "localized": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "localized"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Localizable heading source for automatic bibliography partition sections."
+    },
+    "BibliographyPartitionKind": {
+      "description": "Partition key source for bibliography partitioning.",
+      "oneOf": [
+        {
+          "const": "script",
+          "description": "Partition by Unicode script detected from author/editor/title sort text.",
+          "type": "string"
+        },
+        {
+          "const": "language",
+          "description": "Partition by the reference's effective item language.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographyPartitionMode": {
+      "description": "Rendering mode for bibliography partitioning.",
+      "oneOf": [
+        {
+          "const": "sort-only",
+          "description": "Sort a flat bibliography by partition before normal sort keys.",
+          "type": "string"
+        },
+        {
+          "const": "sections",
+          "description": "Render visible sections for grouped bibliography output only.",
+          "type": "string"
+        },
+        {
+          "const": "sort-and-sections",
+          "description": "Sort flat output by partition and render visible sections for grouped output.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographySortPartitioning": {
+      "description": "Bibliography partitioning policy for multilingual sort order and sections.",
+      "properties": {
+        "by": {
+          "$ref": "#/$defs/BibliographyPartitionKind",
+          "description": "Source used to derive each reference's partition key."
+        },
+        "headings": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BibliographyPartitionHeading"
+          },
+          "description": "Optional headings for visible partition sections.",
+          "type": "object"
+        },
+        "mode": {
+          "$ref": "#/$defs/BibliographyPartitionMode",
+          "default": "sort-only",
+          "description": "Whether partitioning affects flat sorting, visible sections, or both."
+        },
+        "order": {
+          "description": "Preferred partition order. Unlisted partitions sort after listed ones.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "by"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "CitedStatus": {
+      "description": "Citation status filter.",
+      "oneOf": [
+        {
+          "const": "visible",
+          "description": "Match only references cited in the document.",
+          "type": "string"
+        },
+        {
+          "const": "any",
+          "description": "Match all references regardless of citation status.",
+          "type": "string"
+        }
+      ]
+    },
+    "ContributorForm": {
+      "description": "How to render contributor names.",
+      "enum": [
+        "long",
+        "short",
+        "family-only",
+        "verb",
+        "verb-short"
+      ],
+      "type": "string"
+    },
+    "ContributorRole": {
+      "description": "Contributor roles.",
+      "oneOf": [
+        {
+          "enum": [
+            "author",
+            "chair",
+            "editor",
+            "translator",
+            "director",
+            "publisher",
+            "recipient",
+            "interviewer",
+            "interviewee",
+            "guest",
+            "inventor",
+            "counsel",
+            "composer",
+            "collection-editor",
+            "container-author",
+            "editorial-director",
+            "textual-editor",
+            "illustrator",
+            "original-author",
+            "reviewed-author"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "DateForm": {
+      "description": "Date rendering forms.",
+      "oneOf": [
+        {
+          "enum": [
+            "year",
+            "year-month",
+            "full",
+            "month-day",
+            "year-month-day",
+            "day-month-abbr-year"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "month-abbr-day-year",
+          "description": "Abbreviated month + day + year in US order: \"Jan 15, 2024\".",
+          "type": "string"
+        }
+      ]
+    },
+    "DateVariable": {
+      "description": "Date variables.",
+      "enum": [
+        "issued",
+        "accessed",
+        "original-published",
+        "submitted",
+        "event-date"
+      ],
+      "type": "string"
+    },
+    "DelimiterPrecedesLast": {
+      "description": "When to use delimiter before last contributor.",
+      "enum": [
+        "after-inverted-name",
+        "always",
+        "never",
+        "contextual"
+      ],
+      "type": "string"
+    },
+    "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
+      "type": "string"
+    },
+    "DisambiguationScope": {
+      "description": "Scope for disambiguation (e.g., year suffix assignment).",
+      "oneOf": [
+        {
+          "const": "globally",
+          "description": "Disambiguate across all items in the bibliography.",
+          "type": "string"
+        },
+        {
+          "const": "locally",
+          "description": "Disambiguate only within the current group.",
+          "type": "string"
+        }
+      ]
+    },
+    "DocumentIntegralNameOverride": {
+      "additionalProperties": false,
+      "description": "Document-level integral-name override parsed from frontmatter.",
+      "properties": {
+        "contexts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameContexts"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Which document contexts participate in the policy."
+        },
+        "enabled": {
+          "description": "Whether the integral-name policy is enabled for this document.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameScope"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Where name-memory resets."
+        },
+        "subsequent-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubsequentNameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The contributor form used after the first mention."
+        }
+      },
+      "type": "object"
+    },
+    "DocumentOptions": {
+      "description": "Document-level configuration for rendering.\n\nControls rendering behavior that belongs to the document rather than the style.",
+      "properties": {
+        "abbreviation_map": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbbreviationMap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Map from full rendered strings to their abbreviations."
+        },
+        "annotation_format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnnotationFormat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Format for annotation text (djot, plain, org)."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Reference ID to annotation text mapping.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "bibliography_groups": {
+          "description": "Override or replace style-defined bibliography grouping.",
+          "items": {
+            "$ref": "#/$defs/BibliographyGroup"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "inject_ast_indices": {
+          "description": "Whether to annotate semantic wrappers with source template indices.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "integral_name_memory": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DocumentIntegralNameOverride"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Document-level narrative citation rules."
+        },
+        "show_semantics": {
+          "description": "Whether to output semantic markup (HTML spans, Djot attributes).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "sort_partitioning": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BibliographySortPartitioning"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Automatic bibliography partitioning by script or language."
+        }
+      },
+      "type": "object"
+    },
+    "FieldMatcher": {
+      "anyOf": [
+        {
+          "description": "Match exact field value.",
+          "type": "string"
+        },
+        {
+          "description": "Match any of multiple values.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "Field value matcher."
+    },
+    "GeneralTerm": {
+      "description": "A list of general terms for citation formatting.\n\nThese are the standard terms that appear in bibliographies and citations,\nincluding prepositions (in, at, from, by), punctuation terms (and, et al),\ndate-related terms (accessed, no-date, circa), locator terms (page, chapter, volume),\nand special phrases (ibid, forthcoming, available-at).",
+      "oneOf": [
+        {
+          "const": "in",
+          "description": "The preposition \"in\" (e.g., \"in Smith, 2020\").",
+          "type": "string"
+        },
+        {
+          "const": "accessed",
+          "description": "The term used for access dates (e.g., \"accessed May 1\").",
+          "type": "string"
+        },
+        {
+          "const": "retrieved",
+          "description": "The term used for retrieval statements (e.g., \"retrieved from URL\").",
+          "type": "string"
+        },
+        {
+          "const": "at",
+          "description": "The preposition \"at\" (e.g., \"at the conference\").",
+          "type": "string"
+        },
+        {
+          "const": "from",
+          "description": "The preposition \"from\" (e.g., \"from the publisher\").",
+          "type": "string"
+        },
+        {
+          "const": "of",
+          "description": "The preposition \"of\" (e.g., \"special issue of\").",
+          "type": "string"
+        },
+        {
+          "const": "to",
+          "description": "The preposition \"to\" (e.g., \"from x to y\").",
+          "type": "string"
+        },
+        {
+          "const": "by",
+          "description": "The preposition \"by\" (e.g., \"by John Smith\").",
+          "type": "string"
+        },
+        {
+          "const": "no-date",
+          "description": "The term used when no date is available (e.g., \"n.d.\").",
+          "type": "string"
+        },
+        {
+          "const": "anonymous",
+          "description": "The term used for anonymous authorship (e.g., \"anonymous\").",
+          "type": "string"
+        },
+        {
+          "const": "circa",
+          "description": "The term used for approximate dates (e.g., \"circa\").",
+          "type": "string"
+        },
+        {
+          "const": "available-at",
+          "description": "The phrase used for availability statements (e.g., \"available at URL\").",
+          "type": "string"
+        },
+        {
+          "const": "ibid",
+          "description": "The term used for immediately repeated citations (e.g., \"ibid.\").",
+          "type": "string"
+        },
+        {
+          "const": "and",
+          "description": "The conjunction \"and\" (e.g., \"Smith and Jones\").",
+          "type": "string"
+        },
+        {
+          "const": "et-al",
+          "description": "The abbreviation for omitted additional names (e.g., \"et al.\").",
+          "type": "string"
+        },
+        {
+          "const": "and-others",
+          "description": "The phrase \"and others\" (generic use).",
+          "type": "string"
+        },
+        {
+          "const": "forthcoming",
+          "description": "The term used for forthcoming works (e.g., \"forthcoming\").",
+          "type": "string"
+        },
+        {
+          "const": "online",
+          "description": "The term used for online resources (e.g., \"online\").",
+          "type": "string"
+        },
+        {
+          "const": "here",
+          "description": "The adverb \"here\".",
+          "type": "string"
+        },
+        {
+          "const": "deposited",
+          "description": "The term used for deposited materials.",
+          "type": "string"
+        },
+        {
+          "const": "review-of",
+          "description": "The phrase used to introduce reviewed works (e.g., \"review of\").",
+          "type": "string"
+        },
+        {
+          "const": "original-work-published",
+          "description": "The phrase used for original publication references (e.g., \"originally published\").",
+          "type": "string"
+        },
+        {
+          "const": "patent",
+          "description": "The term used for patents (e.g., \"patent\").",
+          "type": "string"
+        },
+        {
+          "const": "volume",
+          "description": "The general term for volume locators (e.g., \"volume\", \"vol.\").",
+          "type": "string"
+        },
+        {
+          "const": "issue",
+          "description": "The general term for issue locators (e.g., \"issue\", \"no.\").",
+          "type": "string"
+        },
+        {
+          "const": "page",
+          "description": "The general term for page locators (e.g., \"page\", \"p.\", \"pp.\").",
+          "type": "string"
+        },
+        {
+          "const": "chapter",
+          "description": "The general term for chapter locators (e.g., \"chapter\", \"ch.\").",
+          "type": "string"
+        },
+        {
+          "const": "edition",
+          "description": "The general term for editions (e.g., \"edition\", \"ed.\").",
+          "type": "string"
+        },
+        {
+          "const": "section",
+          "description": "The general term for section locators (e.g., \"section\", \"§\").",
+          "type": "string"
+        },
+        {
+          "const": "personal-communication",
+          "description": "The label for personal communications (e.g., \"personal communication\").",
+          "type": "string"
+        }
+      ]
+    },
+    "GrammaticalGender": {
+      "description": "Grammatical gender used for locale agreement and term selection.",
+      "oneOf": [
+        {
+          "const": "masculine",
+          "description": "Masculine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "feminine",
+          "description": "Feminine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "neuter",
+          "description": "Neuter grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "common",
+          "description": "Common or shared grammatical gender.",
+          "type": "string"
+        }
+      ]
+    },
+    "GroupHeading": {
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "properties": {
+            "form": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional term form (defaults to long)."
+            },
+            "term": {
+              "$ref": "#/$defs/GeneralTerm",
+              "description": "Locale general term key."
+            }
+          },
+          "required": [
+            "term"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "properties": {
+            "localized": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "localized"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Localizable heading source for bibliography groups."
+    },
+    "GroupSelector": {
+      "description": "Selector predicate for matching references to groups.\n\nAll specified conditions must match (AND logic).\nUse the `not` field for negation-based fallback groups.",
+      "properties": {
+        "cited": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitedStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Match references by citation status."
+        },
+        "field": {
+          "additionalProperties": {
+            "$ref": "#/$defs/FieldMatcher"
+          },
+          "description": "Match references by field values (e.g., language, keywords).",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "not": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Negation for fallback groups.\nMatches references that do NOT match the nested selector."
+        },
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Match references by type."
+        }
+      },
+      "type": "object"
+    },
+    "GroupSort": {
+      "description": "Per-group sorting specification.\n\nSorting follows a template of sort keys, applied in order.\nThe first key is the primary sort, second is the tiebreaker, etc.",
+      "properties": {
+        "template": {
+          "description": "Ordered list of sort keys to apply.",
+          "items": {
+            "$ref": "#/$defs/GroupSortKey"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "GroupSortEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SortPreset",
+          "description": "A named sort preset (e.g., \"author-date-title\")."
+        },
+        {
+          "$ref": "#/$defs/GroupSort",
+          "description": "Explicit sort configuration."
+        }
+      ],
+      "description": "Citation sort configuration: either a preset name or explicit configuration."
+    },
+    "GroupSortKey": {
+      "description": "A single sort key in a group sorting template.",
+      "properties": {
+        "ascending": {
+          "default": true,
+          "description": "Sort order direction.",
+          "type": "boolean"
+        },
+        "key": {
+          "$ref": "#/$defs/SortKey",
+          "description": "The field or variable to sort by."
+        },
+        "order": {
+          "description": "For type-based ordering: explicit type sequence.\n\nExample: `[\"legal-case\", \"statute\", \"treaty\"]` for Bluebook hierarchy.\nItems appear in this order regardless of alphabetical content.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "sort-order": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameSortOrder"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "For name-based sorting: culturally appropriate name order.\n\nExample: `given-family` for Vietnamese, `family-given` for Western."
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "IntegralNameContexts": {
+      "description": "Which document contexts participate in integral citation name memory.",
+      "oneOf": [
+        {
+          "const": "body-only",
+          "description": "Only body-text integral citations participate.",
+          "type": "string"
+        },
+        {
+          "const": "body-and-notes",
+          "description": "Body text and note citations both participate.",
+          "type": "string"
+        }
+      ]
+    },
+    "IntegralNameScope": {
+      "description": "The scope where integral citation name-memory resets.",
+      "oneOf": [
+        {
+          "const": "document",
+          "description": "Keep one name-memory scope for the whole document.",
+          "type": "string"
+        },
+        {
+          "const": "chapter",
+          "description": "Reset name memory at chapter boundaries.",
+          "type": "string"
+        },
+        {
+          "const": "section",
+          "description": "Reset name memory at section boundaries.",
+          "type": "string"
+        }
+      ]
+    },
+    "LabelForm": {
+      "description": "Label rendering forms.",
+      "enum": [
+        "long",
+        "short",
+        "symbol"
+      ],
+      "type": "string"
+    },
+    "LabelPlacement": {
+      "description": "Label placement relative to contributor names.",
+      "enum": [
+        "prefix",
+        "suffix"
+      ],
+      "type": "string"
+    },
+    "LinkAnchor": {
+      "description": "Link anchor options.",
+      "oneOf": [
+        {
+          "const": "title",
+          "description": "Link the title component.",
+          "type": "string"
+        },
+        {
+          "const": "url",
+          "description": "Link the URL component itself.",
+          "type": "string"
+        },
+        {
+          "const": "doi",
+          "description": "Link the DOI component itself.",
+          "type": "string"
+        },
+        {
+          "const": "component",
+          "description": "Link the specific component this config is attached to.",
+          "type": "string"
+        },
+        {
+          "const": "entry",
+          "description": "Link the entire bibliography entry.",
+          "type": "string"
+        }
+      ]
+    },
+    "LinkTarget": {
+      "description": "Link target options.",
+      "enum": [
+        "url",
+        "doi",
+        "url-or-doi",
+        "pubmed",
+        "pmcid"
+      ],
+      "type": "string"
+    },
+    "LinksConfig": {
+      "description": "Structured link options.",
+      "properties": {
+        "anchor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinkAnchor"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "What text should be hyperlinked (title, url, etc.)."
+        },
+        "doi": {
+          "description": "Link value to the item's DOI.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "target": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinkTarget"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The target for the link (url, doi, etc.)."
+        },
+        "url": {
+          "description": "Link value to the item's URL.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "NameForm": {
+      "description": "How to render the given-name component of a contributor name.\n\nControls whether full given names, family name only, or initialized\ngiven names are rendered. Used to express first/subsequent mention\ndifferences (Chicago) and integral/non-integral differences.\n\nInitialization formatting details (`initialize_with`, `initialize_with_hyphen`)\nare separate fields and only take effect when `NameForm::Initials` is active.",
+      "oneOf": [
+        {
+          "const": "full",
+          "description": "Render full given names: \"John D. Smith\".",
+          "type": "string"
+        },
+        {
+          "const": "family-only",
+          "description": "Render family name only, suppressing given names: \"Smith\".\nUsed for subsequent mentions in Chicago/Turabian note styles.",
+          "type": "string"
+        },
+        {
+          "const": "initials",
+          "description": "Render initialized given names using `initialize_with` separator.\nIf `initialize_with` is None, defaults to \". \" (e.g., \"J. Smith\").\nEmpty string gives compact initials: \"JD Smith\".",
+          "type": "string"
+        }
+      ]
+    },
+    "NameOrder": {
+      "description": "Name display order.",
+      "oneOf": [
+        {
+          "const": "given-first",
+          "description": "Display as \"Given Family\" (e.g., \"John Smith\").",
+          "type": "string"
+        },
+        {
+          "const": "family-first",
+          "description": "Display as \"Family, Given\" (e.g., \"Smith, John\").",
+          "type": "string"
+        },
+        {
+          "const": "family-first-only",
+          "description": "First contributor inverted (\"Family, Given\"); subsequent contributors given-first.",
+          "type": "string"
+        }
+      ]
+    },
+    "NameSortOrder": {
+      "description": "Name sorting order for culturally appropriate collation.",
+      "oneOf": [
+        {
+          "const": "family-given",
+          "description": "Family name first (Western convention).\nExample: \"Smith, John\" → \"S\" sorts before \"T\"",
+          "type": "string"
+        },
+        {
+          "const": "given-family",
+          "description": "Given name first (Vietnamese convention).\nExample: \"Nguyễn Văn A\" → \"Nguyễn\" sorts before \"Trần\"",
+          "type": "string"
+        }
+      ]
+    },
+    "NumberForm": {
+      "description": "Number rendering forms.",
+      "enum": [
+        "numeric",
+        "ordinal",
+        "roman"
+      ],
+      "type": "string"
+    },
+    "NumberVariable": {
+      "description": "Known number variable keyword or custom kebab-case identifier.",
+      "type": "string"
+    },
+    "OutputFormat": {
+      "description": "Output format for rendered citations and bibliographies.",
+      "oneOf": [
+        {
+          "const": "plain",
+          "description": "Plain text output.",
+          "type": "string"
+        },
+        {
+          "const": "html",
+          "description": "HTML output.",
+          "type": "string"
+        },
+        {
+          "const": "djot",
+          "description": "Djot markup output.",
+          "type": "string"
+        },
+        {
+          "const": "latex",
+          "description": "LaTeX output.",
+          "type": "string"
+        },
+        {
+          "const": "typst",
+          "description": "Typst output.",
+          "type": "string"
+        }
+      ]
+    },
+    "RoleLabel": {
+      "description": "Configuration for role labels (e.g., \"eds.\", \"trans.\").",
+      "properties": {
+        "form": {
+          "$ref": "#/$defs/RoleLabelForm",
+          "default": "short",
+          "description": "Term form: short (\"eds.\") or long (\"editors\")."
+        },
+        "placement": {
+          "$ref": "#/$defs/LabelPlacement",
+          "default": "suffix",
+          "description": "Where to place the label relative to names."
+        },
+        "term": {
+          "description": "Locale term key for the role (e.g., \"editor\", \"translator\").",
+          "type": "string"
+        }
+      },
+      "required": [
+        "term"
+      ],
+      "type": "object"
+    },
+    "RoleLabelForm": {
+      "description": "Term form for role labels.",
+      "enum": [
+        "short",
+        "long"
+      ],
+      "type": "string"
+    },
+    "ShortenListOptions": {
+      "description": "Et al. / list shortening options.",
+      "properties": {
+        "and-others": {
+          "$ref": "#/$defs/AndOtherOptions",
+          "default": "et-al",
+          "description": "How to render \"and others\"."
+        },
+        "delimiter-precedes-last": {
+          "$ref": "#/$defs/DelimiterPrecedesLast",
+          "default": "contextual",
+          "description": "When to use delimiter before last name."
+        },
+        "min": {
+          "description": "Minimum number of names to trigger shortening.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "subsequent-min": {
+          "description": "Minimum number of names to trigger shortening on subsequent cites.\nDefaults to `min` if not set.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "subsequent-use-first": {
+          "description": "Number of names to show when shortened on subsequent cites.\nDefaults to `use_first` if not set.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "use-first": {
+          "description": "Number of names to show when shortened.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "use-last": {
+          "description": "Number of names to show after the ellipsis (et-al-use-last).",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "min",
+        "use-first"
+      ],
+      "type": "object"
+    },
+    "SimpleVariable": {
+      "description": "Simple string variables.\n\nUse `variable:` for string passthrough fields, even when the field name is\nalso present in [`NumberVariable`]. For example, `variable: volume` keeps the\nsource value as plain text, while `number: volume` opts into numeric\nformatting behavior.",
+      "enum": [
+        "doi",
+        "isbn",
+        "issn",
+        "url",
+        "pmid",
+        "pmcid",
+        "abstract",
+        "note",
+        "annote",
+        "keyword",
+        "genre",
+        "medium",
+        "source",
+        "status",
+        "archive",
+        "archive-location",
+        "archive-name",
+        "archive-place",
+        "archive-collection",
+        "archive-collection-id",
+        "archive-series",
+        "archive-box",
+        "archive-folder",
+        "archive-item",
+        "archive-url",
+        "eprint-id",
+        "eprint-server",
+        "eprint-class",
+        "publisher",
+        "publisher-place",
+        "original-publisher",
+        "original-publisher-place",
+        "event-place",
+        "dimensions",
+        "scale",
+        "version",
+        "locator",
+        "container-title-short",
+        "authority",
+        "code",
+        "reporter",
+        "page",
+        "section",
+        "volume",
+        "number",
+        "docket-number",
+        "patent-number",
+        "standard-number",
+        "report-number",
+        "ads-bibcode"
+      ],
+      "type": "string"
+    },
+    "SortKey": {
+      "description": "Sort key selector.",
+      "oneOf": [
+        {
+          "const": "type",
+          "description": "Sort by reference type.",
+          "type": "string"
+        },
+        {
+          "const": "author",
+          "description": "Sort by author/contributor.",
+          "type": "string"
+        },
+        {
+          "const": "title",
+          "description": "Sort by title.",
+          "type": "string"
+        },
+        {
+          "const": "issued",
+          "description": "Sort by issued date.",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Sort by custom field.",
+          "properties": {
+            "field": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "field"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SortPreset": {
+      "description": "Sort order presets for bibliography entries.\n\nEach preset encodes the sort key sequence for a citation style family.\nUse for the `bibliography.sort` field to avoid repeating boilerplate key lists.",
+      "oneOf": [
+        {
+          "const": "author-date-title",
+          "description": "Author → year → title. Standard for author-date styles (APA, Chicago, Harvard).",
+          "type": "string"
+        },
+        {
+          "const": "author-title-date",
+          "description": "Author → title → year. Used in some footnote and note styles.",
+          "type": "string"
+        },
+        {
+          "const": "citation-number",
+          "description": "Citation number only. Used in numeric styles (Vancouver, IEEE).",
+          "type": "string"
+        }
+      ]
+    },
+    "StyleInput": {
+      "description": "A style reference that can be resolved locally or by an external resolver.\n\nThis union type allows callers to supply a style by local path, inline YAML,\nor as an identifier that requires a remote resolver. Only `Path` and `Yaml`\ncan be resolved locally; `Id` and `Uri` require the citum-server resolver chain.",
+      "oneOf": [
+        {
+          "description": "A style identifier to be resolved from registries (builtin, store, remote).\nRequires external resolver chain — local resolution returns UnresolvedInput error.",
+          "properties": {
+            "kind": {
+              "const": "id",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A remote URI to be resolved (requires HTTP access).\nRequires external resolver chain — local resolution returns UnresolvedInput error.",
+          "properties": {
+            "kind": {
+              "const": "uri",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A local filesystem path to a YAML style file.",
+          "properties": {
+            "kind": {
+              "const": "path",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Inline YAML style definition.",
+          "properties": {
+            "kind": {
+              "const": "yaml",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SubsequentNameForm": {
+      "description": "The contributor form used after the first integral mention in scope.\n\n`Short` preserves non-dropping particles (\"van Beethoven\"); `FamilyOnly`\nstrips them (\"Beethoven\"). MLA-style narrative memory uses `Short`.",
+      "oneOf": [
+        {
+          "const": "short",
+          "description": "Use the short contributor form for subsequent mentions.",
+          "type": "string"
+        },
+        {
+          "const": "family-only",
+          "description": "Use family name only (without non-dropping particles) for subsequent mentions.",
+          "type": "string"
+        }
+      ]
+    },
+    "TemplateComponent": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TemplateContributor"
+        },
+        {
+          "$ref": "#/$defs/TemplateDate"
+        },
+        {
+          "$ref": "#/$defs/TemplateTitle"
+        },
+        {
+          "$ref": "#/$defs/TemplateNumber"
+        },
+        {
+          "$ref": "#/$defs/TemplateVariable"
+        },
+        {
+          "$ref": "#/$defs/TemplateGroup"
+        },
+        {
+          "$ref": "#/$defs/TemplateTerm"
+        }
+      ],
+      "description": "A template component - the building blocks of citation/bibliography templates.\n\nEach variant handles a specific data type with appropriate formatting options."
+    },
+    "TemplateContributor": {
+      "additionalProperties": false,
+      "description": "A contributor component for rendering names.",
+      "properties": {
+        "and": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AndOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the conjunction between the last two names.\nUse `none` for bibliography when citation uses `text` or `symbol`."
+        },
+        "contributor": {
+          "$ref": "#/$defs/ContributorRole",
+          "description": "Which contributor role to render (author, editor, etc.)."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "delimiter": {
+          "description": "Custom delimiter between names (overrides global setting).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "$ref": "#/$defs/ContributorForm",
+          "description": "How to display the contributor (long names, short, with label, etc.)."
+        },
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit grammatical gender override for role-label agreement."
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional role label configuration (e.g., \"eds.\" for editors)."
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "name-order": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameOrder"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the global name order for this specific component.\nUse to show editors as \"Given Family\" even when global setting is \"Family, Given\"."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "shorten": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShortenListOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Shorten the list of names (et al. configuration)."
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "sort-separator": {
+          "description": "Delimiter between family and given name when inverted (overrides global setting).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "contributor",
+        "form"
+      ],
+      "type": "object"
+    },
+    "TemplateDate": {
+      "additionalProperties": false,
+      "description": "A date component for rendering dates.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "date": {
+          "$ref": "#/$defs/DateVariable"
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fallback": {
+          "description": "Fallback components if the primary date is missing.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "form": {
+          "$ref": "#/$defs/DateForm"
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "date",
+        "form"
+      ],
+      "type": "object"
+    },
+    "TemplateGroup": {
+      "additionalProperties": false,
+      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "group": {
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": "array"
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "group"
+      ],
+      "type": "object"
+    },
+    "TemplateNumber": {
+      "additionalProperties": false,
+      "description": "A number component (volume, issue, pages, etc.).",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NumberForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit grammatical gender override for number/ordinal agreement."
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LabelForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "number": {
+          "$ref": "#/$defs/NumberVariable"
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "show-with-locator": {
+          "description": "When `true`, show this pages component even when a locator is present in a note-style citation.\nBy default, pages are suppressed in note-style citations when a locator is present.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "number"
+      ],
+      "type": "object"
+    },
+    "TemplateTerm": {
+      "additionalProperties": false,
+      "description": "A term component for rendering locale-specific text.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TermForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Form: long (default), short, or symbol."
+        },
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit grammatical gender override for term selection."
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "term": {
+          "$ref": "#/$defs/GeneralTerm",
+          "description": "Which term to render."
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "term"
+      ],
+      "type": "object"
+    },
+    "TemplateTitle": {
+      "additionalProperties": false,
+      "description": "A title component.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "disambiguate-only": {
+          "description": "When true, suppress this title component unless the reference needs\ndisambiguation (i.e. multiple works by the same author appear in the\ndocument). Used by author-class styles (e.g. MLA) where the title\nappears in citations only to resolve same-author ambiguity.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "title": {
+          "$ref": "#/$defs/TitleType"
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "type": "object"
+    },
+    "TemplateVariable": {
+      "additionalProperties": false,
+      "description": "A simple variable component (DOI, ISBN, URL, etc.).",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "variable": {
+          "$ref": "#/$defs/SimpleVariable"
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "variable"
+      ],
+      "type": "object"
+    },
+    "TermForm": {
+      "description": "Form for term lookup.\n\nSpecifies which form variant of a term should be used in citation output.",
+      "oneOf": [
+        {
+          "const": "long",
+          "description": "Long form of a term (e.g., \"page\" vs \"p.\").",
+          "type": "string"
+        },
+        {
+          "const": "short",
+          "description": "Short form of a term (e.g., \"p.\" vs \"page\").",
+          "type": "string"
+        },
+        {
+          "const": "verb",
+          "description": "Verb form of a term (e.g., \"edited by\").",
+          "type": "string"
+        },
+        {
+          "const": "verb-short",
+          "description": "Short verb form of a term (e.g., \"ed.\" vs \"edited by\").",
+          "type": "string"
+        },
+        {
+          "const": "symbol",
+          "description": "Symbol form of a term (e.g., \"§\" for section).",
+          "type": "string"
+        }
+      ]
+    },
+    "TextCase": {
+      "description": "Text-case transform applied to title-like fields.\n\nStyles select which transform applies to which field category.\nThe engine provides the generic primitives; styles own the selection.",
+      "oneOf": [
+        {
+          "const": "title",
+          "description": "English headline-style title case (capitalize principal words).",
+          "type": "string"
+        },
+        {
+          "const": "sentence",
+          "description": "Generic sentence case (capitalize first word only).",
+          "type": "string"
+        },
+        {
+          "const": "sentence-apa",
+          "description": "APA-style sentence case: capitalize first word of main title\nand first word after each subtitle boundary.",
+          "type": "string"
+        },
+        {
+          "const": "sentence-nlm",
+          "description": "NLM-style sentence case: capitalize first word of main title only;\nsubtitles preserve only explicit/protected capitals.",
+          "type": "string"
+        },
+        {
+          "const": "capitalize-first",
+          "description": "Capitalize the first letter of the value.",
+          "type": "string"
+        },
+        {
+          "const": "lowercase",
+          "description": "Transform the entire value to lowercase.",
+          "type": "string"
+        },
+        {
+          "const": "uppercase",
+          "description": "Transform the entire value to uppercase.",
+          "type": "string"
+        },
+        {
+          "const": "as-is",
+          "description": "No transformation; render the value exactly as stored.",
+          "type": "string"
+        }
+      ]
+    },
+    "TitleForm": {
+      "description": "Title rendering forms.",
+      "enum": [
+        "short",
+        "long"
+      ],
+      "type": "string"
+    },
+    "TitleType": {
+      "description": "Types of titles.",
+      "oneOf": [
+        {
+          "const": "primary",
+          "description": "The primary title of the cited work.",
+          "type": "string"
+        },
+        {
+          "const": "parent-monograph",
+          "description": "Title of a book/monograph containing the cited work.",
+          "type": "string"
+        },
+        {
+          "const": "parent-serial",
+          "description": "Title of a periodical/serial containing the cited work.",
+          "type": "string"
+        }
+      ]
+    },
+    "TypeSelector": {
+      "description": "Selector for reference types in overrides.\nCan be a single type string or a list of types.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "Single": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Single"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "Multiple": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "Multiple"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "VerticalAlign": {
+      "description": "Vertical text alignment relative to the baseline.",
+      "oneOf": [
+        {
+          "const": "baseline",
+          "description": "Render at the baseline (default).",
+          "type": "string"
+        },
+        {
+          "const": "superscript",
+          "description": "Render as superscript.",
+          "type": "string"
+        },
+        {
+          "const": "subscript",
+          "description": "Render as subscript.",
+          "type": "string"
+        }
+      ]
+    },
+    "WrapConfig": {
+      "description": "Wrapping punctuation and optional inner affixes applied around a rendered value.\n\nCombines the wrap punctuation with optional text that appears inside the wrap\n(between the wrap character and the rendered content).",
+      "properties": {
+        "inner-prefix": {
+          "description": "Text inserted after the opening wrap character but before the content.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inner-suffix": {
+          "description": "Text inserted after the content but before the closing wrap character.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "punctuation": {
+          "$ref": "#/$defs/WrapPunctuation",
+          "description": "The wrapping punctuation style."
+        }
+      },
+      "required": [
+        "punctuation"
+      ],
+      "type": "object"
+    },
+    "WrapPunctuation": {
+      "description": "Punctuation to wrap a component in.",
+      "enum": [
+        "parentheses",
+        "brackets",
+        "quotes"
+      ],
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Parameter schemas for all Citum JSON-RPC methods.",
+  "format_document": {
+    "description": "Parameters for the `format_document` method (schema mirror of `FormatDocumentRequest`).",
+    "properties": {
+      "citations": {
+        "description": "Ordered citations as they appear in the document."
+      },
+      "document_options": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/DocumentOptions"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Optional document-level configuration."
+      },
+      "locale": {
+        "description": "Optional BCP 47 locale override.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "output_format": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/OutputFormat"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Output format (plain, html, djot, latex, typst). Defaults to plain."
+      },
+      "refs": {
+        "description": "Bibliography input as `RefsInput`: path (YAML/JSON/CBOR or `.bib`), inline YAML,\ninline JSON, inline BibLaTeX (`{\"kind\":\"biblatex\",\"value\":\"@book{…}\"}`) or legacy bare map."
+      },
+      "style": {
+        "$ref": "#/$defs/StyleInput",
+        "description": "Style identifier, path, URI, or inline YAML."
+      }
+    },
+    "required": [
+      "style",
+      "refs",
+      "citations"
+    ],
+    "title": "FormatDocumentParams",
+    "type": "object"
+  },
+  "render_bibliography": {
+    "description": "Parameters for the `render_bibliography` method.",
+    "properties": {
+      "inject_ast_indices": {
+        "description": "Debug: embed AST node indices in output.",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "output_format": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/OutputFormat"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Output format for the rendered bibliography."
+      },
+      "refs": {
+        "description": "Bibliography (references) as a map of reference objects."
+      },
+      "style_path": {
+        "description": "Path to the Citum YAML style file.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "style_path",
+      "refs"
+    ],
+    "title": "RenderBibliographyParams",
+    "type": "object"
+  },
+  "render_citation": {
+    "description": "Parameters for the `render_citation` method.",
+    "properties": {
+      "citation": {
+        "description": "Citation object specifying which references to cite."
+      },
+      "inject_ast_indices": {
+        "description": "Debug: embed AST node indices in output.",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "output_format": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/OutputFormat"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Output format for the rendered citation."
+      },
+      "refs": {
+        "description": "Bibliography (references) as a map of reference objects."
+      },
+      "style_path": {
+        "description": "Path to the Citum YAML style file.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "style_path",
+      "refs",
+      "citation"
+    ],
+    "title": "RenderCitationParams",
+    "type": "object"
+  },
+  "title": "Citum Server RPC",
+  "validate_style": {
+    "description": "Parameters for the `validate_style` method.",
+    "properties": {
+      "style_path": {
+        "description": "Path to the Citum YAML style file to validate.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "style_path"
+    ],
+    "title": "ValidateStyleParams",
+    "type": "object"
+  }
+}

--- a/crates/citum-schema-style/docs/schemas/style.json
+++ b/crates/citum-schema-style/docs/schemas/style.json
@@ -1,0 +1,6450 @@
+{
+  "$defs": {
+    "AndOptions": {
+      "description": "Conjunction options between contributors.",
+      "oneOf": [
+        {
+          "const": "text",
+          "description": "Use the localized term for \"and\" (e.g., \"and\" in English).",
+          "type": "string"
+        },
+        {
+          "const": "symbol",
+          "description": "Use the localized symbol for \"and\" (e.g., \"&\" in English).",
+          "type": "string"
+        },
+        {
+          "const": "none",
+          "description": "No conjunction (e.g., \"Smith, Jones\").",
+          "type": "string"
+        }
+      ]
+    },
+    "AndOtherOptions": {
+      "description": "How to render \"and others\" / et al.",
+      "enum": [
+        "et-al",
+        "text"
+      ],
+      "type": "string"
+    },
+    "ArticleJournalBibliographyConfig": {
+      "description": "Article-journal-specific bibliography configuration.",
+      "properties": {
+        "no-page-fallback": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArticleJournalNoPageFallback"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Fallback policy used when page data is absent from an article-journal reference."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ArticleJournalNoPageFallback": {
+      "description": "Named fallback policies for page-less article-journal bibliography entries.",
+      "oneOf": [
+        {
+          "const": "doi",
+          "description": "Replace the standard article detail block with the DOI component.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographyGroup": {
+      "description": "A bibliography group with selector, optional heading, and per-group sorting.\n\nGroups allow styles to divide bibliographies into labeled sections with\ndistinct sorting rules. Items match the first group whose selector evaluates\nto true (first-match semantics).\n\n# Examples\n\n```yaml\ngroups:\n  - id: vietnamese\n    heading:\n      localized:\n        vi: \"Tài liệu tiếng Việt\"\n        en-US: \"Vietnamese Sources\"\n    selector:\n      field:\n        language: vi\n    sort:\n      template:\n        - key: author\n          sort-order: given-family\n```",
+      "properties": {
+        "disambiguate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DisambiguationScope"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional disambiguation scope.\n- `globally` (default): Year suffixes are assigned across the whole bibliography.\n- `locally`: Year suffixes are assigned independently within this group."
+        },
+        "heading": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupHeading"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional heading to display above this group.\nOmit for no heading (e.g., fallback group)."
+        },
+        "id": {
+          "description": "Unique identifier for this group.",
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/$defs/GroupSelector",
+          "description": "Selector predicate to match references."
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSortEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional per-group sorting specification.\nFalls back to global bibliography sort if omitted."
+        },
+        "template": {
+          "description": "Optional per-group template override.\nFalls back to global bibliography template if omitted.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "selector"
+      ],
+      "type": "object"
+    },
+    "BibliographyLabelMode": {
+      "description": "Bibliography label modes supported by scoped bibliography options.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No explicit label component.",
+          "type": "string"
+        },
+        {
+          "const": "numeric",
+          "description": "Numeric bibliography labels.",
+          "type": "string"
+        },
+        {
+          "const": "author-date",
+          "description": "Author-date bibliography labels.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographyLabelWrap": {
+      "description": "Wrapper punctuation supported by bibliography label options.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No outer punctuation.",
+          "type": "string"
+        },
+        {
+          "const": "parentheses",
+          "description": "Parentheses.",
+          "type": "string"
+        },
+        {
+          "const": "brackets",
+          "description": "Brackets.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographyOptions": {
+      "description": "Bibliography-local option overrides.",
+      "properties": {
+        "article-journal": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArticleJournalBibliographyConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Article-journal-specific bibliography policies."
+        },
+        "compound-numeric": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompoundNumericConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Configuration for compound numeric bibliography entries."
+        },
+        "contributors": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Contributor formatting defaults."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "date-position": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DatePosition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Placement of issued dates within bibliography entries."
+        },
+        "dates": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Date formatting defaults."
+        },
+        "entry-suffix": {
+          "description": "Suffix appended to each bibliography entry.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hanging-indent": {
+          "description": "Whether to use a hanging indent.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "label-mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BibliographyLabelMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Bibliography label mode for label-bearing styles."
+        },
+        "label-wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BibliographyLabelWrap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Label wrap policy applied to bibliography labels."
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hyperlink configuration."
+        },
+        "localize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Localize"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Localization settings."
+        },
+        "multilingual": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultilingualConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Multilingual rendering defaults. Accepts a preset name (e.g., `\"apa\"`, `\"chicago\"`)\nor an explicit configuration block."
+        },
+        "page-range-format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PageRangeFormat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Page range formatting (expanded, minimal, chicago)."
+        },
+        "processing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Processing"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Processing mode (author-date, numeric, etc.)."
+        },
+        "punctuation-in-quote": {
+          "description": "Whether to place periods/commas inside quotation marks.",
+          "type": "boolean"
+        },
+        "repeated-author-rendering": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RepeatedAuthorRendering"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Repeated-author rendering mode for bibliography entries."
+        },
+        "separator": {
+          "description": "Separator between bibliography components.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sort-partitioning": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BibliographySortPartitioning"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Partitioning policy for multilingual bibliography sorting and sections."
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from terms, labels, and abbreviated dates.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "subsequent-author-substitute": {
+          "description": "String to substitute for repeating authors.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subsequent-author-substitute-rule": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubsequentAuthorSubstituteRule"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Rule for when to apply the substitute."
+        },
+        "substitute": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubstituteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Substitution rules for missing data."
+        },
+        "suppress-period-after-url": {
+          "description": "Whether to suppress the trailing period after URLs/DOIs.",
+          "type": "boolean"
+        },
+        "title-terminator": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleTerminator"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Terminator applied to primary-title bibliography components."
+        },
+        "titles": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitlesConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Title formatting defaults."
+        },
+        "volume-pages-delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Delimiter between volume/issue and pages for serial sources."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "BibliographyPartitionHeading": {
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "properties": {
+            "form": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional term form (defaults to long)."
+            },
+            "term": {
+              "$ref": "#/$defs/GeneralTerm",
+              "description": "Locale general term key."
+            }
+          },
+          "required": [
+            "term"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "properties": {
+            "localized": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "localized"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Localizable heading source for automatic bibliography partition sections."
+    },
+    "BibliographyPartitionKind": {
+      "description": "Partition key source for bibliography partitioning.",
+      "oneOf": [
+        {
+          "const": "script",
+          "description": "Partition by Unicode script detected from author/editor/title sort text.",
+          "type": "string"
+        },
+        {
+          "const": "language",
+          "description": "Partition by the reference's effective item language.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographyPartitionMode": {
+      "description": "Rendering mode for bibliography partitioning.",
+      "oneOf": [
+        {
+          "const": "sort-only",
+          "description": "Sort a flat bibliography by partition before normal sort keys.",
+          "type": "string"
+        },
+        {
+          "const": "sections",
+          "description": "Render visible sections for grouped bibliography output only.",
+          "type": "string"
+        },
+        {
+          "const": "sort-and-sections",
+          "description": "Sort flat output by partition and render visible sections for grouped output.",
+          "type": "string"
+        }
+      ]
+    },
+    "BibliographySortPartitioning": {
+      "description": "Bibliography partitioning policy for multilingual sort order and sections.",
+      "properties": {
+        "by": {
+          "$ref": "#/$defs/BibliographyPartitionKind",
+          "description": "Source used to derive each reference's partition key."
+        },
+        "headings": {
+          "additionalProperties": {
+            "$ref": "#/$defs/BibliographyPartitionHeading"
+          },
+          "description": "Optional headings for visible partition sections.",
+          "type": "object"
+        },
+        "mode": {
+          "$ref": "#/$defs/BibliographyPartitionMode",
+          "default": "sort-only",
+          "description": "Whether partitioning affects flat sorting, visible sections, or both."
+        },
+        "order": {
+          "description": "Preferred partition order. Unlisted partitions sort after listed ones.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "by"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "BibliographySpec": {
+      "description": "Bibliography specification.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "groups": {
+          "description": "Optional bibliography grouping specification.\n\nWhen present, divides the bibliography into labeled sections with\noptional per-group sorting. Items match the first group whose selector\nevaluates to true (first-match semantics). Omit for flat bibliography.\n\nSee `BibliographyGroup` for examples.",
+          "items": {
+            "$ref": "#/$defs/BibliographyGroup"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "groups-enabled": {
+          "default": true,
+          "description": "Whether to apply manual `groups:` bibliography grouping.\n\nDefaults to `true`. Set to `false` to disable the `groups:` configuration\nand render a flat bibliography instead. Automatic sort-partition sections\nare unaffected by this toggle.",
+          "type": "boolean"
+        },
+        "locales": {
+          "description": "Locale-specific template overrides checked before the default template.",
+          "items": {
+            "$ref": "#/$defs/LocalizedTemplateSpec"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BibliographyOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Bibliography-specific option overrides merged over the style config."
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSortEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional global bibliography sorting specification.\n\nWhen present, used for sorting the flat bibliography or as default\nfor groups that don't specify their own sort."
+        },
+        "template": {
+          "description": "The default template for bibliography entries.\nDefault template for entries when no localized override is selected.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "template-ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Reference to an embedded template preset or external template.\n\nIf both `template-ref` and `template` are present, `template` takes precedence."
+        },
+        "type-variants": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TemplateVariant"
+          },
+          "description": "Type-specific template overrides. When present, replaces the default\ntemplate for entries of the specified types. Keys are reference type\nnames (e.g., \"chapter\", \"article-journal\").",
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "CitationCollapse": {
+      "description": "Citation collapse behavior for multi-item citations.",
+      "oneOf": [
+        {
+          "const": "citation-number",
+          "description": "Collapse adjacent citation numbers into a numeric range such as `1–3`.",
+          "type": "string"
+        }
+      ]
+    },
+    "CitationField": {
+      "description": "Discipline/field classification for a citation style.\n\nValues correspond to the CSL 1.0 `<category field=\"...\"/>` attribute,\n`generic-base` is silently ignored during migration.",
+      "oneOf": [
+        {
+          "const": "anthropology",
+          "description": "Anthropology styles.",
+          "type": "string"
+        },
+        {
+          "const": "biology",
+          "description": "Biology styles.",
+          "type": "string"
+        },
+        {
+          "const": "botany",
+          "description": "Botany styles.",
+          "type": "string"
+        },
+        {
+          "const": "chemistry",
+          "description": "Chemistry styles.",
+          "type": "string"
+        },
+        {
+          "const": "communications",
+          "description": "Communications studies styles.",
+          "type": "string"
+        },
+        {
+          "const": "engineering",
+          "description": "Engineering styles.",
+          "type": "string"
+        },
+        {
+          "const": "geography",
+          "description": "Geography styles.",
+          "type": "string"
+        },
+        {
+          "const": "geology",
+          "description": "Geology styles.",
+          "type": "string"
+        },
+        {
+          "const": "history",
+          "description": "History styles.",
+          "type": "string"
+        },
+        {
+          "const": "humanities",
+          "description": "Humanities styles.",
+          "type": "string"
+        },
+        {
+          "const": "law",
+          "description": "Law styles.",
+          "type": "string"
+        },
+        {
+          "const": "linguistics",
+          "description": "Linguistics styles.",
+          "type": "string"
+        },
+        {
+          "const": "literature",
+          "description": "Literature styles.",
+          "type": "string"
+        },
+        {
+          "const": "math",
+          "description": "Mathematics styles.",
+          "type": "string"
+        },
+        {
+          "const": "medicine",
+          "description": "Medicine styles.",
+          "type": "string"
+        },
+        {
+          "const": "philosophy",
+          "description": "Philosophy styles.",
+          "type": "string"
+        },
+        {
+          "const": "physics",
+          "description": "Physics styles.",
+          "type": "string"
+        },
+        {
+          "const": "political-science",
+          "description": "Political science styles.",
+          "type": "string"
+        },
+        {
+          "const": "psychology",
+          "description": "Psychology styles.",
+          "type": "string"
+        },
+        {
+          "const": "science",
+          "description": "General science styles.",
+          "type": "string"
+        },
+        {
+          "const": "social-science",
+          "description": "Social science styles.",
+          "type": "string"
+        },
+        {
+          "const": "sociology",
+          "description": "Sociology styles.",
+          "type": "string"
+        },
+        {
+          "const": "theology",
+          "description": "Theology styles.",
+          "type": "string"
+        },
+        {
+          "const": "zoology",
+          "description": "Zoology styles.",
+          "type": "string"
+        }
+      ]
+    },
+    "CitationGroupDelimiter": {
+      "description": "Delimiters between grouped citations.",
+      "oneOf": [
+        {
+          "const": "comma",
+          "description": "`, `",
+          "type": "string"
+        },
+        {
+          "const": "semicolon",
+          "description": "`; `",
+          "type": "string"
+        },
+        {
+          "const": "space",
+          "description": "` `",
+          "type": "string"
+        }
+      ]
+    },
+    "CitationOptions": {
+      "description": "Citation-local option overrides.",
+      "properties": {
+        "contributors": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Contributor formatting defaults."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "dates": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Date formatting defaults."
+        },
+        "group-delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationGroupDelimiter"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Delimiter between grouped citation items."
+        },
+        "integral-name-memory": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameMemoryConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Integral citation name-memory behavior."
+        },
+        "label-wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LabelWrap"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Label wrap policy applied to citation labels."
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hyperlink configuration."
+        },
+        "localize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Localize"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Localization settings."
+        },
+        "locators": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocatorConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Locator rendering configuration."
+        },
+        "multilingual": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultilingualConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Multilingual rendering defaults. Accepts a preset name (e.g., `\"apa\"`, `\"chicago\"`)\nor an explicit configuration block."
+        },
+        "notes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NoteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Document-level note marker placement and punctuation movement rules."
+        },
+        "org-abbreviation-memory": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OrgAbbreviationMemoryConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Organizational name abbreviation expansion policy."
+        },
+        "page-range-format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PageRangeFormat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Page range formatting (expanded, minimal, chicago)."
+        },
+        "processing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Processing"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Processing mode (author-date, numeric, etc.)."
+        },
+        "punctuation-in-quote": {
+          "description": "Whether to place periods/commas inside quotation marks.",
+          "type": "boolean"
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from terms, labels, and abbreviated dates.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "substitute": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubstituteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Substitution rules for missing data."
+        },
+        "titles": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitlesConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Title formatting defaults."
+        },
+        "volume-pages-delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Delimiter between volume/issue and pages for serial sources."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "CitationSpec": {
+      "description": "Citation specification.",
+      "properties": {
+        "collapse": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationCollapse"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional collapse behavior for adjacent multi-item citations."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "delimiter": {
+          "description": "Delimiter between components within a single citation item (e.g., \", \" or \" \").\nDefaults to \", \".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ibid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Configuration for ibid citations (ibid or ibid with locator).\nOverrides fields from the main citation spec when position is Ibid or IbidWithLocator.\nIf present, takes precedence over `subsequent` for these positions.\nAllows compact rendering like \"ibid.\" or \"ibid., p. 45\"."
+        },
+        "integral": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Configuration for integral (narrative) citations (e.g., \"Smith (2020)\").\nOverrides fields from the main citation spec when mode is Integral."
+        },
+        "locales": {
+          "description": "Locale-specific template overrides checked before the default template.",
+          "items": {
+            "$ref": "#/$defs/LocalizedTemplateSpec"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "multi-cite-delimiter": {
+          "description": "Delimiter between multiple citation items (e.g., \"; \").\nDefaults to \"; \".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "non-integral": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Configuration for non-integral (parenthetical) citations (e.g., \"(Smith, 2020)\").\nOverrides fields from the main citation spec when mode is NonIntegral."
+        },
+        "note-start-text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NoteStartTextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional text-case transform for standalone note-start citation output.\n\nThis is a style-owned rendering dimension layered on top of the\nexisting repeated-note state, not a new citation `Position`."
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Citation-specific option overrides merged over the style config."
+        },
+        "prefix": {
+          "description": "Prefix for the citation (use only when `wrap` doesn't suffice, e.g., \" (\" or \"[Ref \").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSortEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional citation sorting specification."
+        },
+        "subsequent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitationSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Configuration for subsequent citations.\nOverrides fields from the main citation spec when position is Subsequent.\nUseful for short-form citations in note-based styles or author-date styles\nthat show abbreviated citations after the first mention."
+        },
+        "suffix": {
+          "description": "Suffix for the citation (use only when `wrap` doesn't suffice).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "template": {
+          "description": "Default template when no localized override is selected.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "template-ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateReference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Reference to an embedded template preset or external template.\n\nIf both `template-ref` and `template` are present, `template` takes precedence."
+        },
+        "type-variants": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TemplateVariant"
+          },
+          "description": "Type-specific template overrides for citations. When present, replaces\nthe default citation template for references of the specified types.\nType-variant lookup happens after mode (integral/non-integral) resolution.\nIf both the main spec and the active mode sub-spec have a `type-variants`\nentry for the same type, the mode-specific one wins.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrap the entire citation in punctuation. Preferred over prefix/suffix."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "CitedStatus": {
+      "description": "Citation status filter.",
+      "oneOf": [
+        {
+          "const": "visible",
+          "description": "Match only references cited in the document.",
+          "type": "string"
+        },
+        {
+          "const": "any",
+          "description": "Match all references regardless of citation status.",
+          "type": "string"
+        }
+      ]
+    },
+    "CompoundNumericConfig": {
+      "description": "Configuration for compound numeric bibliography entries.\n\nGroups multiple references under a single citation number with sub-labels.\nUsed in chemistry journals (e.g., Angewandte Chemie).",
+      "properties": {
+        "collapse-subentries": {
+          "default": false,
+          "description": "Whether adjacent grouped sub-entries collapse in citations.\n\nWhen true, adjacent members from the same group may render as\n`1a,b` or `1a-c` instead of `1a,1b` or `1a,1b,1c`.",
+          "type": "boolean"
+        },
+        "sub-delimiter": {
+          "default": ", ",
+          "description": "Delimiter between sub-items (default: \", \").",
+          "type": "string"
+        },
+        "sub-label": {
+          "$ref": "#/$defs/SubLabelStyle",
+          "default": "alphabetic",
+          "description": "Sub-label style: alphabetic (a, b, c) or numeric (1, 2, 3)."
+        },
+        "sub-label-suffix": {
+          "default": ")",
+          "description": "Suffix after sub-label (e.g., \")\" → \"a)\", \".\" → \"a.\").",
+          "type": "string"
+        },
+        "subentry": {
+          "default": true,
+          "description": "Whether grouped item citations render sub-entry labels (`1a`, `1b`).\n\nWhen false, grouped item citations render the whole-group number (`1`).",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "Config": {
+      "description": "Top-level style configuration.",
+      "properties": {
+        "contributors": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Contributor formatting defaults. Accepts a preset name (e.g., \"apa\")\nor explicit configuration."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "dates": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Date formatting defaults. Accepts a preset name (e.g., \"long\")\nor explicit configuration."
+        },
+        "integral-name-memory": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameMemoryConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Integral citation name-memory behavior."
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hyperlink configuration."
+        },
+        "locale-override": {
+          "description": "Style-level locale override ID loaded from `locales/overrides/<id>.*`.\n\nThis patches the locale selected by `StyleInfo.default_locale` without\nduplicating the full base locale. Runtime loading is limited to the\nstyle-global config; nested citation or bibliography configs are ignored.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "localize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Localize"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Localization settings."
+        },
+        "locators": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocatorConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Locator rendering configuration. Accepts a preset name (e.g., \"note\")\nor explicit configuration."
+        },
+        "multilingual": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultilingualConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Multilingual rendering defaults. Accepts a preset name (e.g., `\"apa\"`, `\"chicago\"`)\nor an explicit configuration block."
+        },
+        "notes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NoteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Document-level note marker placement and punctuation movement rules."
+        },
+        "org-abbreviation-memory": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OrgAbbreviationMemoryConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Organizational name abbreviation expansion policy."
+        },
+        "page-range-format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PageRangeFormat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Page range formatting (expanded, minimal, chicago)."
+        },
+        "processing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Processing"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Processing mode (author-date, numeric, etc.)."
+        },
+        "punctuation-in-quote": {
+          "description": "Whether to place periods/commas inside quotation marks.\ntrue = American style (\"text.\"), false = British style (\"text\".)\nDefaults to false; en-US locale typically sets this to true.",
+          "type": "boolean"
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from terms, labels, and abbreviated dates.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "substitute": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubstituteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Substitution rules for missing data."
+        },
+        "titles": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitlesConfigEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Title formatting defaults. Accepts a preset name (e.g., \"apa\")\nor explicit configuration."
+        },
+        "volume-pages-delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Delimiter between volume/issue and pages for serial sources.\nProcessor adds trailing space when rendering.\nExamples: Comma (APA \", \"), Colon (Chicago \": \")."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ContributorConfig": {
+      "description": "Contributor formatting configuration.",
+      "properties": {
+        "and": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AndOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Conjunction between last two contributors."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "delimiter": {
+          "description": "The delimiter between contributors. Defaults to `\", \"` if not specified.\n`None` means \"not configured at this level\" and will not override an inherited value.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "delimiter-precedes-et-al": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPrecedesLast"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "When to include delimiter before \"et al.\"."
+        },
+        "delimiter-precedes-last": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPrecedesLast"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "When to include delimiter before the last contributor."
+        },
+        "demote-non-dropping-particle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DemoteNonDroppingParticle"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Handling of non-dropping particles (e.g., \"van\" in \"van Gogh\")."
+        },
+        "display-as-sort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DisplayAsSort"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "When to display a contributor's name in sort order."
+        },
+        "initialize-with": {
+          "description": "String to append after initialized given names (e.g., \". \" for \"J. Smith\").\nIf None, full given names are used (e.g., \"John Smith\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "initialize-with-hyphen": {
+          "description": "Whether to include a hyphen when initializing names (e.g., \"J.-P. Sartre\").",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How to render given names. See `NameForm` for variants.\nPer-scope overrides (per-mode, per-position) are expressed by setting\nthis field in the appropriate scope's contributor config block."
+        },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleOptionsEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "When and how to display contributor roles. Accepts a preset name\n(e.g., \"short-suffix\") or explicit configuration."
+        },
+        "shorten": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShortenListOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Shorten the list of contributors (et al. handling)."
+        },
+        "sort-separator": {
+          "description": "Delimiter between family and given name when inverted (e.g., `\", \"` → \"Smith, John\").\nDefaults to `\", \"` in the engine when not specified.\n`None` means \"not configured at this level\" and will not override an inherited value.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "ContributorConfigEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ContributorPreset",
+          "description": "A named preset (e.g., \"apa\", \"chicago\", \"vancouver\", \"springer\")."
+        },
+        {
+          "$ref": "#/$defs/ContributorConfig",
+          "description": "Explicit contributor configuration."
+        }
+      ],
+      "description": "Contributor config: either a preset name or explicit configuration.\n\nAllows styles to write `contributors: apa` as shorthand, or provide\nfull explicit configuration with field-level overrides."
+    },
+    "ContributorForm": {
+      "description": "How to render contributor names.",
+      "enum": [
+        "long",
+        "short",
+        "family-only",
+        "verb",
+        "verb-short"
+      ],
+      "type": "string"
+    },
+    "ContributorPreset": {
+      "description": "Contributor formatting presets.\n\nEach preset encodes the contributor formatting conventions for a major citation\nstyle or style family. Use doc comments to describe the visual behavior so\nstyle authors can choose the right preset without knowing style guide names.",
+      "oneOf": [
+        {
+          "const": "apa",
+          "description": "First author family-first, \"&\" symbol, et al. after 20 authors,\ninitials with period-space, comma before \"&\".\nExample: \"Smith, J. D., & Jones, M. K.\"",
+          "type": "string"
+        },
+        {
+          "const": "chicago",
+          "description": "First author family-first, \"and\" text, contextual serial comma,\nfull given names (no initials).\nExample: \"Smith, John D., and Mary K. Jones\"",
+          "type": "string"
+        },
+        {
+          "const": "vancouver",
+          "description": "All authors family-first, no conjunction, compact initials (no\nperiod/space), et al. after 6 of 7+.\nExample: \"Smith JD, Jones MK, Brown AB\"",
+          "type": "string"
+        },
+        {
+          "const": "ieee",
+          "description": "Given-first format, \"and\" text, initials with period-space,\ncomma before \"and\".\nExample: \"J. D. Smith, M. K. Jones, and A. B. Brown\"",
+          "type": "string"
+        },
+        {
+          "const": "harvard",
+          "description": "All authors family-first, \"and\" text, compact initials (period,\nno space), comma before \"and\".\nExample: \"Smith, J.D., Jones, M.K., and Brown, A.B.\"",
+          "type": "string"
+        },
+        {
+          "const": "springer",
+          "description": "All authors family-first, no conjunction, compact initials (no\nperiod/space), space sort-separator, et al. after 3 of 5+.\nExample: \"Smith JD, Jones MK, Brown AB\"",
+          "type": "string"
+        },
+        {
+          "const": "numeric-compact",
+          "description": "Numeric compact author list for journal-heavy corpora:\nall family-first, no conjunction, sort-only particle demotion,\nspace sort-separator, et al. after 6 of 7+.",
+          "type": "string"
+        },
+        {
+          "const": "numeric-medium",
+          "description": "Numeric medium author list variant:\nsame as `numeric-compact`, but et al. after 3 of 4+.",
+          "type": "string"
+        },
+        {
+          "const": "numeric-tight",
+          "description": "Numeric tight: all family-first, no initials, et al. after 3 of 7+.\nTighter than `numeric-compact` (use-first: 3 vs 6).\nExample: \"Smith J, Jones M, Brown A, et al.\"",
+          "type": "string"
+        },
+        {
+          "const": "numeric-large",
+          "description": "Numeric large: all family-first, no initials, et al. after 10 of 11+.\nFor biomedical journals that show nearly all authors.\nExample: \"Smith J, Jones M, Brown A, [10 authors], et al.\"",
+          "type": "string"
+        },
+        {
+          "const": "numeric-all-authors",
+          "description": "Numeric all-authors: all family-first, no conjunction, compact initials,\nno list shortening, particle demotion disabled.\nExample: \"Smith JD, Jones MK, Brown AB\"",
+          "type": "string"
+        },
+        {
+          "const": "numeric-given-dot",
+          "description": "Numeric given-first with period-only initials (no space), no conjunction,\nand comma delimiters.\nExample: \"J.D. Smith, M.K. Jones, A.B. Brown\"",
+          "type": "string"
+        },
+        {
+          "const": "annual-reviews",
+          "description": "Annual Reviews style: all family-first, no initials, et al. after 5 of 7+,\nparticle demotion never. Distinguishable by \"never\" demote policy.\nExample: \"van der Berg J, Smith M, Jones A, Brown B, White C, et al.\"",
+          "type": "string"
+        },
+        {
+          "const": "math-phys",
+          "description": "Math/physics author-date: all family-first, period initial (no trailing\nspace), comma sort-separator, no conjunction. Used across Springer\nmath/physics and related author-date journals.\nExample: \"Smith, J., Jones, M., Brown, A.\"",
+          "type": "string"
+        },
+        {
+          "const": "soc-sci-first",
+          "description": "Social science first-author inversion: first author family-first,\nremaining authors given-first, period-space initials, comma\nsort-separator, no conjunction. Common in sociology and civil engineering.\nExample: \"Smith, J. D., M. K. Jones, A. B. Brown\"",
+          "type": "string"
+        },
+        {
+          "const": "physics-numeric",
+          "description": "Physics numeric given-first: no author inversion, period-space initial,\nno conjunction, sort-only particle demotion. Used by numeric physics\njournals like APS.\nExample: \"J. Smith, M. Jones, A. Brown\"",
+          "type": "string"
+        }
+      ]
+    },
+    "ContributorRole": {
+      "description": "Contributor roles.",
+      "oneOf": [
+        {
+          "enum": [
+            "author",
+            "chair",
+            "editor",
+            "translator",
+            "director",
+            "publisher",
+            "recipient",
+            "interviewer",
+            "interviewee",
+            "guest",
+            "inventor",
+            "counsel",
+            "composer",
+            "collection-editor",
+            "container-author",
+            "editorial-director",
+            "textual-editor",
+            "illustrator",
+            "original-author",
+            "reviewed-author"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "DateConfig": {
+      "description": "Date formatting configuration.",
+      "properties": {
+        "approximation-marker": {
+          "description": "Marker for approximate dates (e.g., \"ca. \" or \"~\"). None suppresses display.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "era-labels": {
+          "$ref": "#/$defs/EraLabels",
+          "default": "default",
+          "description": "Era label profile controlling which era suffixes are shown."
+        },
+        "month": {
+          "$ref": "#/$defs/MonthFormat"
+        },
+        "negative-unspecified-years": {
+          "$ref": "#/$defs/NegativeUnspecifiedYears",
+          "default": "range",
+          "description": "How negative EDTF years with unspecified digits are rendered."
+        },
+        "open-range-marker": {
+          "description": "Marker for open-ended ranges (e.g., \"–present\"). None uses locale default.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "range-delimiter": {
+          "default": "–",
+          "description": "Delimiter for date ranges (default: en-dash \"–\").",
+          "type": "string"
+        },
+        "show-seconds": {
+          "default": false,
+          "description": "Whether to include seconds in time display (default: false).",
+          "type": "boolean"
+        },
+        "show-timezone": {
+          "default": false,
+          "description": "Whether to include timezone in time display (default: false).",
+          "type": "boolean"
+        },
+        "time-format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TimeFormat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Time display format. None suppresses time rendering."
+        },
+        "uncertainty-marker": {
+          "description": "Marker for uncertain dates (e.g., \"?\" or \"uncertain\"). None suppresses display.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "month"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "DateConfigEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DatePreset",
+          "description": "A named preset (e.g., \"long\", \"short\", \"numeric\", \"iso\")."
+        },
+        {
+          "$ref": "#/$defs/DateConfig",
+          "description": "Explicit date configuration."
+        }
+      ],
+      "description": "Date config: either a preset name or explicit configuration.\n\nAllows styles to write `dates: long` as shorthand, or provide\nfull explicit configuration with field-level overrides."
+    },
+    "DateForm": {
+      "description": "Date rendering forms.",
+      "oneOf": [
+        {
+          "enum": [
+            "year",
+            "year-month",
+            "full",
+            "month-day",
+            "year-month-day",
+            "day-month-abbr-year"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "month-abbr-day-year",
+          "description": "Abbreviated month + day + year in US order: \"Jan 15, 2024\".",
+          "type": "string"
+        }
+      ]
+    },
+    "DatePosition": {
+      "description": "Placement of issued dates inside bibliography entries.",
+      "oneOf": [
+        {
+          "const": "after-author",
+          "description": "Immediately after the contributor component.",
+          "type": "string"
+        },
+        {
+          "const": "after-title",
+          "description": "Immediately after the title component.",
+          "type": "string"
+        },
+        {
+          "const": "terminal",
+          "description": "At the end of the entry.",
+          "type": "string"
+        }
+      ]
+    },
+    "DatePreset": {
+      "description": "Date formatting presets.\n\nEach preset defines how dates are displayed in citations and bibliographies,\nincluding month format, EDTF uncertainty/approximation markers, and range\ndelimiters.",
+      "oneOf": [
+        {
+          "const": "long",
+          "description": "Long month names, EDTF markers, en-dash ranges.\nExample: \"January 15, 2024\", \"ca. 2024\", \"2024?\"",
+          "type": "string"
+        },
+        {
+          "const": "short",
+          "description": "Short month names, EDTF markers, en-dash ranges.\nExample: \"Jan 15, 2024\"",
+          "type": "string"
+        },
+        {
+          "const": "numeric",
+          "description": "Numeric months, EDTF markers, en-dash ranges.\nExample: \"1/15/2024\"",
+          "type": "string"
+        },
+        {
+          "const": "iso",
+          "description": "ISO 8601 numeric format, no EDTF markers.\nExample: \"2024-01-15\"",
+          "type": "string"
+        }
+      ]
+    },
+    "DateVariable": {
+      "description": "Date variables.",
+      "enum": [
+        "issued",
+        "accessed",
+        "original-published",
+        "submitted",
+        "event-date"
+      ],
+      "type": "string"
+    },
+    "DelimiterPrecedesLast": {
+      "description": "When to use delimiter before last contributor.",
+      "enum": [
+        "after-inverted-name",
+        "always",
+        "never",
+        "contextual"
+      ],
+      "type": "string"
+    },
+    "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
+      "type": "string"
+    },
+    "DemoteNonDroppingParticle": {
+      "description": "Options for demoting non-dropping particles.",
+      "enum": [
+        "never",
+        "sort-only",
+        "display-and-sort"
+      ],
+      "type": "string"
+    },
+    "Disambiguation": {
+      "description": "Disambiguation settings.\n\nControls how ambiguous citations are disambiguated in the output.",
+      "properties": {
+        "add-givenname": {
+          "default": false,
+          "description": "Whether to add given names to disambiguate similarly-named authors.",
+          "type": "boolean"
+        },
+        "givenname-rule": {
+          "$ref": "#/$defs/GivennameRule",
+          "default": "by-cite",
+          "description": "Which author positions receive given-name expansion."
+        },
+        "names": {
+          "description": "Whether to attempt disambiguation by expanding author names.",
+          "type": "boolean"
+        },
+        "year-suffix": {
+          "description": "Whether to append year suffixes (a, b, c, ...) for multiple works from the same author-year.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "names",
+        "year-suffix"
+      ],
+      "type": "object"
+    },
+    "DisambiguationScope": {
+      "description": "Scope for disambiguation (e.g., year suffix assignment).",
+      "oneOf": [
+        {
+          "const": "globally",
+          "description": "Disambiguate across all items in the bibliography.",
+          "type": "string"
+        },
+        {
+          "const": "locally",
+          "description": "Disambiguate only within the current group.",
+          "type": "string"
+        }
+      ]
+    },
+    "DisplayAsSort": {
+      "description": "When to display names in sort order (family-first).",
+      "enum": [
+        "all",
+        "first",
+        "none"
+      ],
+      "type": "string"
+    },
+    "EraLabels": {
+      "description": "Era label profile for date rendering.",
+      "oneOf": [
+        {
+          "const": "default",
+          "description": "Preserve current behavior: negative years use locale `before-era`, positive years unlabeled.",
+          "type": "string"
+        },
+        {
+          "const": "bc-ad",
+          "description": "Negative years use locale `bc`, positive years use locale `ad`.",
+          "type": "string"
+        },
+        {
+          "const": "bce-ce",
+          "description": "Negative years use locale `bce`, positive years use locale `ce`.",
+          "type": "string"
+        }
+      ]
+    },
+    "FieldMatcher": {
+      "anyOf": [
+        {
+          "description": "Match exact field value.",
+          "type": "string"
+        },
+        {
+          "description": "Match any of multiple values.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "Field value matcher."
+    },
+    "GeneralTerm": {
+      "description": "A list of general terms for citation formatting.\n\nThese are the standard terms that appear in bibliographies and citations,\nincluding prepositions (in, at, from, by), punctuation terms (and, et al),\ndate-related terms (accessed, no-date, circa), locator terms (page, chapter, volume),\nand special phrases (ibid, forthcoming, available-at).",
+      "oneOf": [
+        {
+          "const": "in",
+          "description": "The preposition \"in\" (e.g., \"in Smith, 2020\").",
+          "type": "string"
+        },
+        {
+          "const": "accessed",
+          "description": "The term used for access dates (e.g., \"accessed May 1\").",
+          "type": "string"
+        },
+        {
+          "const": "retrieved",
+          "description": "The term used for retrieval statements (e.g., \"retrieved from URL\").",
+          "type": "string"
+        },
+        {
+          "const": "at",
+          "description": "The preposition \"at\" (e.g., \"at the conference\").",
+          "type": "string"
+        },
+        {
+          "const": "from",
+          "description": "The preposition \"from\" (e.g., \"from the publisher\").",
+          "type": "string"
+        },
+        {
+          "const": "of",
+          "description": "The preposition \"of\" (e.g., \"special issue of\").",
+          "type": "string"
+        },
+        {
+          "const": "to",
+          "description": "The preposition \"to\" (e.g., \"from x to y\").",
+          "type": "string"
+        },
+        {
+          "const": "by",
+          "description": "The preposition \"by\" (e.g., \"by John Smith\").",
+          "type": "string"
+        },
+        {
+          "const": "no-date",
+          "description": "The term used when no date is available (e.g., \"n.d.\").",
+          "type": "string"
+        },
+        {
+          "const": "anonymous",
+          "description": "The term used for anonymous authorship (e.g., \"anonymous\").",
+          "type": "string"
+        },
+        {
+          "const": "circa",
+          "description": "The term used for approximate dates (e.g., \"circa\").",
+          "type": "string"
+        },
+        {
+          "const": "available-at",
+          "description": "The phrase used for availability statements (e.g., \"available at URL\").",
+          "type": "string"
+        },
+        {
+          "const": "ibid",
+          "description": "The term used for immediately repeated citations (e.g., \"ibid.\").",
+          "type": "string"
+        },
+        {
+          "const": "and",
+          "description": "The conjunction \"and\" (e.g., \"Smith and Jones\").",
+          "type": "string"
+        },
+        {
+          "const": "et-al",
+          "description": "The abbreviation for omitted additional names (e.g., \"et al.\").",
+          "type": "string"
+        },
+        {
+          "const": "and-others",
+          "description": "The phrase \"and others\" (generic use).",
+          "type": "string"
+        },
+        {
+          "const": "forthcoming",
+          "description": "The term used for forthcoming works (e.g., \"forthcoming\").",
+          "type": "string"
+        },
+        {
+          "const": "online",
+          "description": "The term used for online resources (e.g., \"online\").",
+          "type": "string"
+        },
+        {
+          "const": "here",
+          "description": "The adverb \"here\".",
+          "type": "string"
+        },
+        {
+          "const": "deposited",
+          "description": "The term used for deposited materials.",
+          "type": "string"
+        },
+        {
+          "const": "review-of",
+          "description": "The phrase used to introduce reviewed works (e.g., \"review of\").",
+          "type": "string"
+        },
+        {
+          "const": "original-work-published",
+          "description": "The phrase used for original publication references (e.g., \"originally published\").",
+          "type": "string"
+        },
+        {
+          "const": "patent",
+          "description": "The term used for patents (e.g., \"patent\").",
+          "type": "string"
+        },
+        {
+          "const": "volume",
+          "description": "The general term for volume locators (e.g., \"volume\", \"vol.\").",
+          "type": "string"
+        },
+        {
+          "const": "issue",
+          "description": "The general term for issue locators (e.g., \"issue\", \"no.\").",
+          "type": "string"
+        },
+        {
+          "const": "page",
+          "description": "The general term for page locators (e.g., \"page\", \"p.\", \"pp.\").",
+          "type": "string"
+        },
+        {
+          "const": "chapter",
+          "description": "The general term for chapter locators (e.g., \"chapter\", \"ch.\").",
+          "type": "string"
+        },
+        {
+          "const": "edition",
+          "description": "The general term for editions (e.g., \"edition\", \"ed.\").",
+          "type": "string"
+        },
+        {
+          "const": "section",
+          "description": "The general term for section locators (e.g., \"section\", \"§\").",
+          "type": "string"
+        },
+        {
+          "const": "personal-communication",
+          "description": "The label for personal communications (e.g., \"personal communication\").",
+          "type": "string"
+        }
+      ]
+    },
+    "GivennameRule": {
+      "description": "Controls which author positions receive given-name expansion during disambiguation.\n\nMaps to CSL's `givenname-disambiguation-rule` attribute on `<citation>`.\nThe engine collapses these to two scopes: `PrimaryName` and\n`PrimaryNameWithInitials` expand only the first (primary) author; all other\nvalues expand all positions. Initials vs full form is always driven by the\ncontributor config's `initialize-with` / `name-form` settings.",
+      "oneOf": [
+        {
+          "const": "by-cite",
+          "description": "Disambiguate per-cite with a minimal subset of names (CSL 1.0.1 default).\nEngine behaviour: expand all positions (per-cite minimal-subset deferred).",
+          "type": "string"
+        },
+        {
+          "const": "all-names",
+          "description": "Expand given names for all name positions.",
+          "type": "string"
+        },
+        {
+          "const": "all-names-with-initials",
+          "description": "Expand given names (initials form) for all name positions.",
+          "type": "string"
+        },
+        {
+          "const": "primary-name",
+          "description": "Expand given name of the first (primary) author only.",
+          "type": "string"
+        },
+        {
+          "const": "primary-name-with-initials",
+          "description": "Expand given name (initials form) of the first (primary) author only.",
+          "type": "string"
+        }
+      ]
+    },
+    "GrammaticalGender": {
+      "description": "Grammatical gender used for locale agreement and term selection.",
+      "oneOf": [
+        {
+          "const": "masculine",
+          "description": "Masculine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "feminine",
+          "description": "Feminine grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "neuter",
+          "description": "Neuter grammatical gender.",
+          "type": "string"
+        },
+        {
+          "const": "common",
+          "description": "Common or shared grammatical gender.",
+          "type": "string"
+        }
+      ]
+    },
+    "Group": {
+      "description": "Grouping configuration for bibliography.\n\nSpecifies how bibliography entries should be grouped in the output.",
+      "properties": {
+        "template": {
+          "description": "Sort keys used to define group boundaries (e.g., [Author, Year]).",
+          "items": {
+            "$ref": "#/$defs/SortKey"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "GroupHeading": {
+      "anyOf": [
+        {
+          "description": "Fixed literal heading text.",
+          "properties": {
+            "literal": {
+              "description": "Literal heading value.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale general term key resolved at render time.",
+          "properties": {
+            "form": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TermForm"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional term form (defaults to long)."
+            },
+            "term": {
+              "$ref": "#/$defs/GeneralTerm",
+              "description": "Locale general term key."
+            }
+          },
+          "required": [
+            "term"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Locale-indexed heading map.",
+          "properties": {
+            "localized": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Map keyed by BCP 47 locale identifiers or language tags.",
+              "type": "object"
+            }
+          },
+          "required": [
+            "localized"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Localizable heading source for bibliography groups."
+    },
+    "GroupSelector": {
+      "description": "Selector predicate for matching references to groups.\n\nAll specified conditions must match (AND logic).\nUse the `not` field for negation-based fallback groups.",
+      "properties": {
+        "cited": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CitedStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Match references by citation status."
+        },
+        "field": {
+          "additionalProperties": {
+            "$ref": "#/$defs/FieldMatcher"
+          },
+          "description": "Match references by field values (e.g., language, keywords).",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "not": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GroupSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Negation for fallback groups.\nMatches references that do NOT match the nested selector."
+        },
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Match references by type."
+        }
+      },
+      "type": "object"
+    },
+    "GroupSort": {
+      "description": "Per-group sorting specification.\n\nSorting follows a template of sort keys, applied in order.\nThe first key is the primary sort, second is the tiebreaker, etc.",
+      "properties": {
+        "template": {
+          "description": "Ordered list of sort keys to apply.",
+          "items": {
+            "$ref": "#/$defs/GroupSortKey"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "GroupSortEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SortPreset",
+          "description": "A named sort preset (e.g., \"author-date-title\")."
+        },
+        {
+          "$ref": "#/$defs/GroupSort",
+          "description": "Explicit sort configuration."
+        }
+      ],
+      "description": "Citation sort configuration: either a preset name or explicit configuration."
+    },
+    "GroupSortKey": {
+      "description": "A single sort key in a group sorting template.",
+      "properties": {
+        "ascending": {
+          "default": true,
+          "description": "Sort order direction.",
+          "type": "boolean"
+        },
+        "key": {
+          "$ref": "#/$defs/SortKey2",
+          "description": "The field or variable to sort by."
+        },
+        "order": {
+          "description": "For type-based ordering: explicit type sequence.\n\nExample: `[\"legal-case\", \"statute\", \"treaty\"]` for Bluebook hierarchy.\nItems appear in this order regardless of alphabetical content.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "sort-order": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameSortOrder"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "For name-based sorting: culturally appropriate name order.\n\nExample: `given-family` for Vietnamese, `family-given` for Western."
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "IntegralNameContexts": {
+      "description": "Which document contexts participate in integral citation name memory.",
+      "oneOf": [
+        {
+          "const": "body-only",
+          "description": "Only body-text integral citations participate.",
+          "type": "string"
+        },
+        {
+          "const": "body-and-notes",
+          "description": "Body text and note citations both participate.",
+          "type": "string"
+        }
+      ]
+    },
+    "IntegralNameMemoryConfig": {
+      "description": "Integral citation name-memory policy.\n\nThe presence of this block enables full-then-short name memory for narrative\n(integral) citations. Absence disables it — there is no on/off field.",
+      "properties": {
+        "contexts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameContexts"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Which document contexts participate in name-memory tracking."
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameScope"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Where the first-mention memory resets."
+        },
+        "subsequent-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubsequentNameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The contributor form to use after the first mention in scope."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "IntegralNameScope": {
+      "description": "The scope where integral citation name-memory resets.",
+      "oneOf": [
+        {
+          "const": "document",
+          "description": "Keep one name-memory scope for the whole document.",
+          "type": "string"
+        },
+        {
+          "const": "chapter",
+          "description": "Reset name memory at chapter boundaries.",
+          "type": "string"
+        },
+        {
+          "const": "section",
+          "description": "Reset name memory at section boundaries.",
+          "type": "string"
+        }
+      ]
+    },
+    "LabelConfig": {
+      "description": "Configuration for label citation mode.",
+      "properties": {
+        "et-al-marker": {
+          "description": "Suffix appended when truncated. Alpha/Ams default: \"+\", Din default: \"\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "et-al-min": {
+          "description": "Max authors before truncation. Alpha/Ams default: 4, Din default: 3.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "et-al-names": {
+          "description": "Names shown when truncated (et-al). Alpha default: 3, Ams default: 4.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "multi-author-chars": {
+          "description": "Chars per author family name when 2+ authors. Preset default: 1.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "preset": {
+          "$ref": "#/$defs/LabelPreset",
+          "default": "alpha",
+          "description": "Preset that determines default parameters."
+        },
+        "single-author-chars": {
+          "description": "Chars taken from single author's family name. Preset default: 3 (Alpha/Ams), 4 (Din).",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "year-digits": {
+          "description": "Year digits: 2 or 4. Preset default: 2.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "LabelForm": {
+      "description": "Label rendering forms.",
+      "enum": [
+        "long",
+        "short",
+        "symbol"
+      ],
+      "type": "string"
+    },
+    "LabelForm2": {
+      "description": "How a locator label is displayed.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No label, bare value: \"33\"",
+          "type": "string"
+        },
+        {
+          "const": "short",
+          "description": "Short form: \"p. 33\"",
+          "type": "string"
+        },
+        {
+          "const": "long",
+          "description": "Long form: \"page 33\"",
+          "type": "string"
+        },
+        {
+          "const": "symbol",
+          "description": "Symbol form if available in locale",
+          "type": "string"
+        }
+      ]
+    },
+    "LabelPlacement": {
+      "description": "Label placement relative to contributor names.",
+      "enum": [
+        "prefix",
+        "suffix"
+      ],
+      "type": "string"
+    },
+    "LabelPreset": {
+      "description": "Label style preset conventions.",
+      "oneOf": [
+        {
+          "const": "alpha",
+          "description": "biblatex alphabetic / BibTeX alpha.bst: up to 4 authors, \"+\" marker, 2-digit year.",
+          "type": "string"
+        },
+        {
+          "const": "din",
+          "description": "DIN 1505-2: up to 3 authors, no et-al marker, 2-digit year.",
+          "type": "string"
+        },
+        {
+          "const": "ams",
+          "description": "American Mathematical Society: same label-generation algorithm as Alpha.",
+          "type": "string"
+        }
+      ]
+    },
+    "LabelRepeat": {
+      "description": "Whether labels appear on every segment, only the first, or none.",
+      "oneOf": [
+        {
+          "const": "all",
+          "description": "Label on every segment",
+          "type": "string"
+        },
+        {
+          "const": "first",
+          "description": "Label only on the first segment",
+          "type": "string"
+        },
+        {
+          "const": "none",
+          "description": "No labels",
+          "type": "string"
+        }
+      ]
+    },
+    "LabelWrap": {
+      "description": "Wrapper punctuation supported by citation and bibliography label options.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No outer punctuation.",
+          "type": "string"
+        },
+        {
+          "const": "parentheses",
+          "description": "Parentheses.",
+          "type": "string"
+        },
+        {
+          "const": "brackets",
+          "description": "Brackets.",
+          "type": "string"
+        },
+        {
+          "const": "superscript",
+          "description": "Superscript-style numeric labels.",
+          "type": "string"
+        }
+      ]
+    },
+    "LinkAnchor": {
+      "description": "Link anchor options.",
+      "oneOf": [
+        {
+          "const": "title",
+          "description": "Link the title component.",
+          "type": "string"
+        },
+        {
+          "const": "url",
+          "description": "Link the URL component itself.",
+          "type": "string"
+        },
+        {
+          "const": "doi",
+          "description": "Link the DOI component itself.",
+          "type": "string"
+        },
+        {
+          "const": "component",
+          "description": "Link the specific component this config is attached to.",
+          "type": "string"
+        },
+        {
+          "const": "entry",
+          "description": "Link the entire bibliography entry.",
+          "type": "string"
+        }
+      ]
+    },
+    "LinkTarget": {
+      "description": "Link target options.",
+      "enum": [
+        "url",
+        "doi",
+        "url-or-doi",
+        "pubmed",
+        "pmcid"
+      ],
+      "type": "string"
+    },
+    "LinksConfig": {
+      "description": "Structured link options.",
+      "properties": {
+        "anchor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinkAnchor"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "What text should be hyperlinked (title, url, etc.)."
+        },
+        "doi": {
+          "description": "Link value to the item's DOI.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "target": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinkTarget"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The target for the link (url, doi, etc.)."
+        },
+        "url": {
+          "description": "Link value to the item's URL.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "Localize": {
+      "description": "Localization scope settings.",
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/Scope"
+        }
+      },
+      "required": [
+        "scope"
+      ],
+      "type": "object"
+    },
+    "LocalizedTemplateSpec": {
+      "description": "Locale-scoped template override with optional fallback behavior.",
+      "properties": {
+        "default": {
+          "description": "Whether this override is the fallback when no locale matches.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "locale": {
+          "description": "Language tags that should select this template override.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "template": {
+          "description": "Template used when this localized override is selected.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "LocatorConfig": {
+      "description": "Top-level locator rendering configuration.",
+      "properties": {
+        "default-label-form": {
+          "$ref": "#/$defs/LabelForm2",
+          "default": "short",
+          "description": "Default label form for all locator kinds (default: Short)."
+        },
+        "fallback-delimiter": {
+          "default": ", ",
+          "description": "Fallback delimiter for unmatched compound locators (default: \", \").",
+          "type": "string"
+        },
+        "kinds": {
+          "additionalProperties": {
+            "$ref": "#/$defs/LocatorKindConfig"
+          },
+          "default": {},
+          "description": "Per-kind configuration overrides.",
+          "type": "object"
+        },
+        "patterns": {
+          "default": [],
+          "description": "Patterns for compound locators and type-specific rendering.",
+          "items": {
+            "$ref": "#/$defs/LocatorPattern"
+          },
+          "type": "array"
+        },
+        "range-format": {
+          "$ref": "#/$defs/PageRangeFormat",
+          "default": "expanded",
+          "description": "Range format for all locator kinds (default: Expanded)."
+        },
+        "strip-label-periods": {
+          "description": "Strip trailing periods from labels globally (e.g., \"p.\" → \"p\").",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "LocatorConfigEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LocatorPreset",
+          "description": "A preset name."
+        },
+        {
+          "$ref": "#/$defs/LocatorConfig",
+          "description": "Explicit configuration."
+        }
+      ],
+      "description": "Preset-or-explicit entry — same pattern as DateConfigEntry."
+    },
+    "LocatorKindConfig": {
+      "description": "Per-locator-kind configuration overrides.",
+      "properties": {
+        "label-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LabelForm2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the default label form for this locator kind."
+        },
+        "range-format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PageRangeFormat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the global range format for this locator kind."
+        },
+        "strip-label-periods": {
+          "description": "Strip trailing periods from labels (e.g., \"p.\" → \"p\").",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "LocatorPattern": {
+      "description": "A pattern matching a specific combination of LocatorType values.\n\nPatterns are tested in declaration order; first match wins.",
+      "properties": {
+        "delimiter": {
+          "default": ", ",
+          "description": "Delimiter between segments (default: \", \").",
+          "type": "string"
+        },
+        "kinds": {
+          "description": "The set of LocatorType values this pattern matches (order-insensitive).",
+          "items": {
+            "$ref": "#/$defs/LocatorType"
+          },
+          "type": "array"
+        },
+        "label-repeat": {
+          "$ref": "#/$defs/LabelRepeat",
+          "default": "all",
+          "description": "Whether labels appear on every segment, only the first, or none."
+        },
+        "order": {
+          "description": "Rendering order of segments when pattern matches.",
+          "items": {
+            "$ref": "#/$defs/LocatorType"
+          },
+          "type": "array"
+        },
+        "type-class": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeClass"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional gate on reference type class."
+        }
+      },
+      "required": [
+        "kinds",
+        "order"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "LocatorPreset": {
+      "description": "Named presets for common locator configurations.",
+      "oneOf": [
+        {
+          "const": "note",
+          "description": "Note style: bare page numbers, short labels for other kinds.",
+          "type": "string"
+        },
+        {
+          "const": "author-date",
+          "description": "Author-date / numbered: short labels for all kinds.",
+          "type": "string"
+        }
+      ]
+    },
+    "LocatorType": {
+      "description": "Known locator label keyword or custom kebab-case identifier.",
+      "type": "string"
+    },
+    "MonthFormat": {
+      "description": "Month display format.",
+      "enum": [
+        "long",
+        "short",
+        "numeric"
+      ],
+      "type": "string"
+    },
+    "MultilingualConfig": {
+      "description": "Multilingual rendering options.",
+      "properties": {
+        "name-mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultilingualMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Preferred rendering mode for names."
+        },
+        "preferred-script": {
+          "description": "Preferred script for transliterations (e.g., \"Latn\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preferred-transliteration": {
+          "description": "Ordered priority list of BCP 47 transliteration tags (e.g. `[\"ja-Latn-hepburn\", \"ja-Latn\"]`).\nTakes precedence over `preferred_script` when resolving transliterations.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "scripts": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ScriptConfig"
+          },
+          "description": "Script-specific behavior configuration.",
+          "type": "object"
+        },
+        "title-mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultilingualMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Preferred rendering mode for titles."
+        }
+      },
+      "type": "object"
+    },
+    "MultilingualConfigEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/MultilingualPreset",
+          "description": "A named preset (e.g., `\"apa\"`, `\"chicago\"`, `\"mla\"`, `\"ieee\"`)."
+        },
+        {
+          "$ref": "#/$defs/MultilingualConfig",
+          "description": "An explicit multilingual configuration block."
+        }
+      ],
+      "description": "Entry for `options.multilingual`: either a preset name or an explicit config block.\n\nStyle YAML can use a short preset name:\n```yaml\noptions:\n  multilingual: chicago\n```\nor a full explicit block:\n```yaml\noptions:\n  multilingual:\n    title-mode: combined\n    name-mode: transliterated\n    preferred-script: Latn\n```"
+    },
+    "MultilingualMode": {
+      "description": "Rendering modes for multilingual content.",
+      "oneOf": [
+        {
+          "const": "primary",
+          "description": "Use original script.",
+          "type": "string"
+        },
+        {
+          "const": "transliterated",
+          "description": "Use transliteration.",
+          "type": "string"
+        },
+        {
+          "const": "translated",
+          "description": "Use translation matching style locale.",
+          "type": "string"
+        },
+        {
+          "const": "combined",
+          "description": "Combine transliteration and translation: `romanized [translated]`.\nEquivalent to `Pattern([transliterated, {translated, brackets}])`.",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Ordered sequence of views joined by spaces.\n\nUse this when a style requires more than two views — e.g. Chicago's\n`romanized original [translated]` or MLA's `original [translated]`.\nEach segment specifies a view and an optional bracket wrap.\nSegments whose resolved text is empty or identical to the previous\nsegment are silently skipped (dedup).\n\nYAML form:\n```yaml\ntitle-mode:\n  pattern:\n    - view: transliterated\n    - view: original\n    - view: translated\n      wrap: brackets\n```",
+          "properties": {
+            "pattern": {
+              "items": {
+                "$ref": "#/$defs/MultilingualSegment"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "pattern"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "MultilingualPreset": {
+      "description": "Multilingual rendering policy presets.\n\nEach preset encodes the romanization and translation conventions for a major\ncitation style or style family when rendering references in an English-language\ncontext.  Style YAML authors can write a bare preset name:\n\n```yaml\noptions:\n  multilingual: chicago\n```\n\nand Citum resolves it to the full [`MultilingualConfig`] at load time.",
+      "oneOf": [
+        {
+          "const": "apa",
+          "description": "APA / Harvard / Vancouver / AMA / NLM / CSE family.\n\nTitles: `romanized [translated]`.  Names: romanized.\nMatches APA 7th-edition policy: no original CJK in bibliography;\ntranslation required in brackets.",
+          "type": "string"
+        },
+        {
+          "const": "mla",
+          "description": "MLA 9th-edition policy.\n\nTitles: `original [translated]`.  Names: romanized.\nOriginal CJK title shown first; translation in brackets.",
+          "type": "string"
+        },
+        {
+          "const": "chicago",
+          "description": "Chicago (Notes-Bibliography 18th / Author-Date 18th).\n\nTitles: `romanized original [translated]`.  Names: romanized.\nRomanized form is primary; original CJK follows as a supplement;\nEnglish translation in brackets for general audiences.",
+          "type": "string"
+        },
+        {
+          "const": "ieee",
+          "description": "IEEE policy.\n\nTitles: romanized only.  Names: romanized.\nNo original CJK or translation required by the IEEE style guide.",
+          "type": "string"
+        }
+      ]
+    },
+    "MultilingualSegment": {
+      "description": "A single view segment in a `MultilingualMode::Pattern`.",
+      "properties": {
+        "view": {
+          "$ref": "#/$defs/MultilingualView",
+          "description": "Which textual view to render for this segment."
+        },
+        "wrap": {
+          "$ref": "#/$defs/SegmentWrap",
+          "description": "Optional wrapping applied around the resolved text."
+        }
+      },
+      "required": [
+        "view"
+      ],
+      "type": "object"
+    },
+    "MultilingualView": {
+      "description": "Which textual representation of a multilingual field to use in a pattern segment.",
+      "oneOf": [
+        {
+          "const": "original",
+          "description": "The original text as stored in the data.",
+          "type": "string"
+        },
+        {
+          "const": "transliterated",
+          "description": "The transliterated (romanized) form.",
+          "type": "string"
+        },
+        {
+          "const": "translated",
+          "description": "The translation matching the style locale.",
+          "type": "string"
+        }
+      ]
+    },
+    "NameForm": {
+      "description": "How to render the given-name component of a contributor name.\n\nControls whether full given names, family name only, or initialized\ngiven names are rendered. Used to express first/subsequent mention\ndifferences (Chicago) and integral/non-integral differences.\n\nInitialization formatting details (`initialize_with`, `initialize_with_hyphen`)\nare separate fields and only take effect when `NameForm::Initials` is active.",
+      "oneOf": [
+        {
+          "const": "full",
+          "description": "Render full given names: \"John D. Smith\".",
+          "type": "string"
+        },
+        {
+          "const": "family-only",
+          "description": "Render family name only, suppressing given names: \"Smith\".\nUsed for subsequent mentions in Chicago/Turabian note styles.",
+          "type": "string"
+        },
+        {
+          "const": "initials",
+          "description": "Render initialized given names using `initialize_with` separator.\nIf `initialize_with` is None, defaults to \". \" (e.g., \"J. Smith\").\nEmpty string gives compact initials: \"JD Smith\".",
+          "type": "string"
+        }
+      ]
+    },
+    "NameOrder": {
+      "description": "Name display order.",
+      "oneOf": [
+        {
+          "const": "given-first",
+          "description": "Display as \"Given Family\" (e.g., \"John Smith\").",
+          "type": "string"
+        },
+        {
+          "const": "family-first",
+          "description": "Display as \"Family, Given\" (e.g., \"Smith, John\").",
+          "type": "string"
+        },
+        {
+          "const": "family-first-only",
+          "description": "First contributor inverted (\"Family, Given\"); subsequent contributors given-first.",
+          "type": "string"
+        }
+      ]
+    },
+    "NameSortOrder": {
+      "description": "Name sorting order for culturally appropriate collation.",
+      "oneOf": [
+        {
+          "const": "family-given",
+          "description": "Family name first (Western convention).\nExample: \"Smith, John\" → \"S\" sorts before \"T\"",
+          "type": "string"
+        },
+        {
+          "const": "given-family",
+          "description": "Given name first (Vietnamese convention).\nExample: \"Nguyễn Văn A\" → \"Nguyễn\" sorts before \"Trần\"",
+          "type": "string"
+        }
+      ]
+    },
+    "NegativeUnspecifiedYears": {
+      "description": "Rendering policy for negative EDTF years with unspecified digits.",
+      "oneOf": [
+        {
+          "const": "range",
+          "description": "Render as explicit historical ranges (e.g., `-009u` → `100–91 BC`).",
+          "type": "string"
+        },
+        {
+          "const": "fuzzy",
+          "description": "Reserved for future prose-oriented output; falls back to `range` if selected.",
+          "type": "string"
+        }
+      ]
+    },
+    "NoteConfig": {
+      "description": "Document-level note marker placement rules.",
+      "properties": {
+        "number": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NoteNumberPlacement"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Desired location of the note marker relative to closing quotation marks."
+        },
+        "order": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NoteMarkerOrder"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Whether the note marker appears before or after the closest movable\npunctuation mark."
+        },
+        "punctuation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NoteQuotePlacement"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Desired location of movable punctuation relative to closing quotation\nmarks when note markers are introduced."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "NoteMarkerOrder": {
+      "description": "Controls whether a note marker appears before or after adjacent movable punctuation.",
+      "oneOf": [
+        {
+          "const": "before",
+          "description": "Place the note marker before the closest movable punctuation mark.",
+          "type": "string"
+        },
+        {
+          "const": "after",
+          "description": "Place the note marker after the closest movable punctuation mark.",
+          "type": "string"
+        }
+      ]
+    },
+    "NoteNumberPlacement": {
+      "description": "Controls where a footnote number marker is placed relative to closing quotation marks.",
+      "oneOf": [
+        {
+          "const": "inside",
+          "description": "Place the note marker inside the closing quotation mark.",
+          "type": "string"
+        },
+        {
+          "const": "outside",
+          "description": "Place the note marker outside the closing quotation mark.",
+          "type": "string"
+        },
+        {
+          "const": "same",
+          "description": "Place the note marker on the same side as the movable punctuation when\nonly one side has punctuation; otherwise default to outside.",
+          "type": "string"
+        }
+      ]
+    },
+    "NoteQuotePlacement": {
+      "description": "Controls where movable punctuation is placed relative to closing quotation marks.",
+      "oneOf": [
+        {
+          "const": "inside",
+          "description": "Keep movable punctuation inside the closing quotation mark.",
+          "type": "string"
+        },
+        {
+          "const": "outside",
+          "description": "Keep movable punctuation outside the closing quotation mark.",
+          "type": "string"
+        },
+        {
+          "const": "adaptive",
+          "description": "Follow org-cite-style adaptive behavior: punctuation stays inside when\nit is already flush with the closing quote, otherwise it is placed\noutside.",
+          "type": "string"
+        }
+      ]
+    },
+    "NoteStartTextCase": {
+      "description": "Text-case transform applied when a citation renders at note start.",
+      "oneOf": [
+        {
+          "const": "capitalize-first",
+          "description": "Uppercase the first character of the rendered citation.",
+          "type": "string"
+        },
+        {
+          "const": "lowercase",
+          "description": "Lowercase the rendered citation text.",
+          "type": "string"
+        }
+      ]
+    },
+    "NumberForm": {
+      "description": "Number rendering forms.",
+      "enum": [
+        "numeric",
+        "ordinal",
+        "roman"
+      ],
+      "type": "string"
+    },
+    "NumberVariable": {
+      "description": "Known number variable keyword or custom kebab-case identifier.",
+      "type": "string"
+    },
+    "OrgAbbreviationMemoryConfig": {
+      "description": "Organizational name abbreviation expansion policy.\n\nThe presence of this block enables first-mention expansion of org names —\n\"World Health Organization (WHO)\" on first mention, \"WHO\" thereafter.\nAbsence disables org abbreviation entirely.",
+      "properties": {
+        "contexts": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameContexts"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Which document contexts participate in org-abbreviation tracking."
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IntegralNameScope"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Where the first-mention memory resets."
+        },
+        "short-name-display": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShortNameDisplay"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How to display an organizational short name on the first integral mention."
+        }
+      },
+      "type": "object"
+    },
+    "PageRangeFormat": {
+      "description": "Page range formatting options.",
+      "oneOf": [
+        {
+          "const": "expanded",
+          "description": "Full expansion: 321-328 → 321–328",
+          "type": "string"
+        },
+        {
+          "const": "minimal",
+          "description": "Minimal digits: 321-328 → 321–8",
+          "type": "string"
+        },
+        {
+          "const": "minimal-two",
+          "description": "Minimal two digits: 321-328 → 321–28",
+          "type": "string"
+        },
+        {
+          "const": "chicago",
+          "description": "Chicago Manual of Style 15th ed rules",
+          "type": "string"
+        },
+        {
+          "const": "chicago16",
+          "description": "Chicago Manual of Style 16th/17th ed rules",
+          "type": "string"
+        }
+      ]
+    },
+    "Processing": {
+      "description": "Processing mode for citation/bibliography generation.\n\nDetermines how citations and bibliographies are sorted, grouped, and disambiguated.\nCan be specified as a simple string or with complex configuration maps:\n- A string: `\"author-date\"`, `\"numeric\"`, `\"note\"`, or `\"label\"`\n- A label config map: `{ label: { preset: din } }`\n- A custom config map: `{ sort: ..., group: ..., disambiguate: ... }`",
+      "oneOf": [
+        {
+          "const": "author-date",
+          "description": "Author-date styles (e.g., APA, Chicago).\nDefault bibliography ordering: author, year, title.",
+          "type": "string"
+        },
+        {
+          "const": "numeric",
+          "description": "Numeric styles (e.g., IEEE, Nature).\nDo not imply a bibliography sort; citations are numbered in order of appearance.",
+          "type": "string"
+        },
+        {
+          "const": "note",
+          "description": "Note styles (e.g., Chicago Notes-Bibliography).\nWith a bibliography default to author, title, year ordering.",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Label styles (e.g., Alpha, DIN 1505-2).\nDefault bibliography ordering: author, year, title.",
+          "properties": {
+            "label": {
+              "$ref": "#/$defs/LabelConfig"
+            }
+          },
+          "required": [
+            "label"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Fully custom processing behavior.\nExplicit `sort` configuration remains authoritative.",
+          "properties": {
+            "custom": {
+              "$ref": "#/$defs/ProcessingCustom"
+            }
+          },
+          "required": [
+            "custom"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ProcessingCustom": {
+      "description": "Custom processing configuration.\n\nAllows explicit specification of sorting, grouping, and disambiguation rules\nwithout relying on preset defaults.",
+      "properties": {
+        "disambiguate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Disambiguation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Disambiguation settings (optional)."
+        },
+        "group": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Group"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Bibliography grouping configuration (optional)."
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SortEntry"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Bibliography sorting configuration (optional)."
+        }
+      },
+      "type": "object"
+    },
+    "RepeatedAuthorRendering": {
+      "description": "Repeated-author rendering policies for bibliographies.",
+      "oneOf": [
+        {
+          "const": "full",
+          "description": "Always render full contributor names.",
+          "type": "string"
+        },
+        {
+          "const": "dash",
+          "description": "Replace repeated authors with an em dash.",
+          "type": "string"
+        },
+        {
+          "const": "dash-with-space",
+          "description": "Replace repeated authors with an em dash followed by a space.",
+          "type": "string"
+        }
+      ]
+    },
+    "RoleLabel": {
+      "description": "Configuration for role labels (e.g., \"eds.\", \"trans.\").",
+      "properties": {
+        "form": {
+          "$ref": "#/$defs/RoleLabelForm",
+          "default": "short",
+          "description": "Term form: short (\"eds.\") or long (\"editors\")."
+        },
+        "placement": {
+          "$ref": "#/$defs/LabelPlacement",
+          "default": "suffix",
+          "description": "Where to place the label relative to names."
+        },
+        "term": {
+          "description": "Locale term key for the role (e.g., \"editor\", \"translator\").",
+          "type": "string"
+        }
+      },
+      "required": [
+        "term"
+      ],
+      "type": "object"
+    },
+    "RoleLabelForm": {
+      "description": "Term form for role labels.",
+      "enum": [
+        "short",
+        "long"
+      ],
+      "type": "string"
+    },
+    "RoleLabelPreset": {
+      "description": "Named role-label presets for secondary contributor rendering.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "Suppress the configured role label.",
+          "type": "string"
+        },
+        {
+          "const": "verb-prefix",
+          "description": "Render the localized verb label before the names.",
+          "type": "string"
+        },
+        {
+          "const": "verb-short-prefix",
+          "description": "Render the localized short verb label before the names.",
+          "type": "string"
+        },
+        {
+          "const": "short-suffix",
+          "description": "Render the localized short label after the names.",
+          "type": "string"
+        },
+        {
+          "const": "long-suffix",
+          "description": "Render the localized long label after the names.",
+          "type": "string"
+        }
+      ]
+    },
+    "RoleOptions": {
+      "description": "Role display options.",
+      "properties": {
+        "form": {
+          "description": "Global role label form.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "omit": {
+          "description": "Contributor roles for which to omit the role description.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "prefix": {
+          "description": "Global prefix for role labels.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabelPreset"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Global role-label preset applied before legacy compatibility."
+        },
+        "roles": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RoleRendering"
+          },
+          "description": "Formatting for specific roles.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Global suffix for role labels.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "RoleOptionsEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RoleLabelPreset",
+          "description": "A named preset (e.g., \"short-suffix\", \"long-suffix\")."
+        },
+        {
+          "$ref": "#/$defs/RoleOptions",
+          "description": "Explicit role options."
+        }
+      ],
+      "description": "Role options: either a preset name or explicit configuration.\n\nAllows styles to write `role: short-suffix` as shorthand, or provide\nfull explicit configuration with field-level overrides."
+    },
+    "RoleRendering": {
+      "description": "Rendering options for contributor roles.",
+      "properties": {
+        "emph": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "name-order": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameOrder"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabelPreset"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per-role label preset override."
+        },
+        "small-caps": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "SchemaVersion": {
+      "description": "A schema version (major.minor).",
+      "type": "string"
+    },
+    "Scope": {
+      "description": "Localization scope.",
+      "enum": [
+        "global",
+        "per-item"
+      ],
+      "type": "string"
+    },
+    "ScriptConfig": {
+      "description": "Configuration for specific scripts.",
+      "properties": {
+        "delimiter": {
+          "description": "Custom delimiter between name parts for this script.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sort-separator": {
+          "description": "Custom delimiter between family and given name when this script is inverted.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "use-native-ordering": {
+          "default": false,
+          "description": "Whether to use native ordering for this script (e.g., FamilyGiven for CJK).",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "SegmentWrap": {
+      "description": "Bracket wrapping applied to a pattern segment.",
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "No wrapping.",
+          "type": "string"
+        },
+        {
+          "const": "brackets",
+          "description": "Wrap in square brackets: `[text]`.",
+          "type": "string"
+        },
+        {
+          "const": "parentheses",
+          "description": "Wrap in parentheses: `(text)`.",
+          "type": "string"
+        }
+      ]
+    },
+    "ShortNameDisplay": {
+      "description": "How to display a contributor's short name on the first integral mention.",
+      "oneOf": [
+        {
+          "const": "full-then-parenthetical",
+          "description": "\"Full Name (Short)\" on first mention (default). For narrative/integral context.",
+          "type": "string"
+        },
+        {
+          "const": "full-then-bracketed",
+          "description": "`\"Full Name [Short]\"` on first mention. For parenthetical context (already inside parens).",
+          "type": "string"
+        },
+        {
+          "const": "short-then-parenthetical",
+          "description": "\"Short (Full Name)\" on first mention.",
+          "type": "string"
+        },
+        {
+          "const": "short-then-bracketed",
+          "description": "\"Short [Full Name]\" on first mention.",
+          "type": "string"
+        }
+      ]
+    },
+    "ShortenListOptions": {
+      "description": "Et al. / list shortening options.",
+      "properties": {
+        "and-others": {
+          "$ref": "#/$defs/AndOtherOptions",
+          "default": "et-al",
+          "description": "How to render \"and others\"."
+        },
+        "delimiter-precedes-last": {
+          "$ref": "#/$defs/DelimiterPrecedesLast",
+          "default": "contextual",
+          "description": "When to use delimiter before last name."
+        },
+        "min": {
+          "description": "Minimum number of names to trigger shortening.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "subsequent-min": {
+          "description": "Minimum number of names to trigger shortening on subsequent cites.\nDefaults to `min` if not set.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "subsequent-use-first": {
+          "description": "Number of names to show when shortened on subsequent cites.\nDefaults to `use_first` if not set.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "use-first": {
+          "description": "Number of names to show when shortened.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "use-last": {
+          "description": "Number of names to show after the ellipsis (et-al-use-last).",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "min",
+        "use-first"
+      ],
+      "type": "object"
+    },
+    "SimpleVariable": {
+      "description": "Simple string variables.\n\nUse `variable:` for string passthrough fields, even when the field name is\nalso present in [`NumberVariable`]. For example, `variable: volume` keeps the\nsource value as plain text, while `number: volume` opts into numeric\nformatting behavior.",
+      "enum": [
+        "doi",
+        "isbn",
+        "issn",
+        "url",
+        "pmid",
+        "pmcid",
+        "abstract",
+        "note",
+        "annote",
+        "keyword",
+        "genre",
+        "medium",
+        "source",
+        "status",
+        "archive",
+        "archive-location",
+        "archive-name",
+        "archive-place",
+        "archive-collection",
+        "archive-collection-id",
+        "archive-series",
+        "archive-box",
+        "archive-folder",
+        "archive-item",
+        "archive-url",
+        "eprint-id",
+        "eprint-server",
+        "eprint-class",
+        "publisher",
+        "publisher-place",
+        "original-publisher",
+        "original-publisher-place",
+        "event-place",
+        "dimensions",
+        "scale",
+        "version",
+        "locator",
+        "container-title-short",
+        "authority",
+        "code",
+        "reporter",
+        "page",
+        "section",
+        "volume",
+        "number",
+        "docket-number",
+        "patent-number",
+        "standard-number",
+        "report-number",
+        "ads-bibcode"
+      ],
+      "type": "string"
+    },
+    "Sort": {
+      "description": "Sorting configuration.\n\nSpecifies how bibliography entries are ordered.",
+      "properties": {
+        "render-substitutions": {
+          "default": false,
+          "description": "Whether to apply the same name substitutions during sorting as during rendering.",
+          "type": "boolean"
+        },
+        "shorten-names": {
+          "default": false,
+          "description": "Whether to shorten name lists for sorting the same as for display.",
+          "type": "boolean"
+        },
+        "template": {
+          "description": "Sort keys in order of application.",
+          "items": {
+            "$ref": "#/$defs/SortSpec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object"
+    },
+    "SortEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SortPreset",
+          "description": "A named sort preset (e.g., `author-date-title`, `author-title-date`)."
+        },
+        {
+          "$ref": "#/$defs/Sort",
+          "description": "Explicit sort configuration with custom keys and order."
+        }
+      ],
+      "description": "Sort configuration: either a preset name or explicit configuration.\n\nCan be a preset name like `author-date-title` or a full `Sort` struct with explicit settings."
+    },
+    "SortKey": {
+      "description": "Available sort keys.\n\nSpecifies what field to sort bibliography entries by.",
+      "oneOf": [
+        {
+          "const": "author",
+          "description": "Sort by the work's author(s).",
+          "type": "string"
+        },
+        {
+          "const": "year",
+          "description": "Sort by publication year.",
+          "type": "string"
+        },
+        {
+          "const": "title",
+          "description": "Sort by the work's title.",
+          "type": "string"
+        },
+        {
+          "const": "citation-number",
+          "description": "Sort by citation order (typically used for numeric styles).",
+          "type": "string"
+        }
+      ]
+    },
+    "SortKey2": {
+      "description": "Sort key selector.",
+      "oneOf": [
+        {
+          "const": "type",
+          "description": "Sort by reference type.",
+          "type": "string"
+        },
+        {
+          "const": "author",
+          "description": "Sort by author/contributor.",
+          "type": "string"
+        },
+        {
+          "const": "title",
+          "description": "Sort by title.",
+          "type": "string"
+        },
+        {
+          "const": "issued",
+          "description": "Sort by issued date.",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Sort by custom field.",
+          "properties": {
+            "field": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "field"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SortPreset": {
+      "description": "Sort order presets for bibliography entries.\n\nEach preset encodes the sort key sequence for a citation style family.\nUse for the `bibliography.sort` field to avoid repeating boilerplate key lists.",
+      "oneOf": [
+        {
+          "const": "author-date-title",
+          "description": "Author → year → title. Standard for author-date styles (APA, Chicago, Harvard).",
+          "type": "string"
+        },
+        {
+          "const": "author-title-date",
+          "description": "Author → title → year. Used in some footnote and note styles.",
+          "type": "string"
+        },
+        {
+          "const": "citation-number",
+          "description": "Citation number only. Used in numeric styles (Vancouver, IEEE).",
+          "type": "string"
+        }
+      ]
+    },
+    "SortSpec": {
+      "description": "A single sort specification.\n\nDefines one sort dimension with its key and direction.",
+      "properties": {
+        "ascending": {
+          "default": true,
+          "description": "Whether to sort in ascending order (default: true).",
+          "type": "boolean"
+        },
+        "key": {
+          "$ref": "#/$defs/SortKey",
+          "description": "The field to sort by."
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "type": "object"
+    },
+    "StyleBase": {
+      "description": "A named, compiled-in style base that serves as an inheritance root.\n\nA style file declares `extends: <key>` to inherit a complete base style.\nAny top-level fields in the file (`options`, `citation`, `bibliography`,\netc.) are merged over the base, with local fields taking\nultimate precedence.",
+      "oneOf": [
+        {
+          "const": "elsevier-harvard-core",
+          "description": "Hidden Elsevier Harvard family root.",
+          "type": "string"
+        },
+        {
+          "const": "elsevier-with-titles-core",
+          "description": "Hidden Elsevier with-titles family root.",
+          "type": "string"
+        },
+        {
+          "const": "elsevier-vancouver-core",
+          "description": "Hidden Elsevier Vancouver family root.",
+          "type": "string"
+        },
+        {
+          "const": "springer-basic-author-date-core",
+          "description": "Hidden Springer Basic author-date root.",
+          "type": "string"
+        },
+        {
+          "const": "springer-basic-brackets-core",
+          "description": "Hidden Springer Basic brackets root.",
+          "type": "string"
+        },
+        {
+          "const": "springer-vancouver-brackets-core",
+          "description": "Hidden Springer Vancouver root.",
+          "type": "string"
+        },
+        {
+          "const": "taylor-and-francis-chicago-author-date-core",
+          "description": "Hidden Taylor & Francis Chicago root.",
+          "type": "string"
+        },
+        {
+          "const": "taylor-and-francis-council-of-science-editors-author-date-core",
+          "description": "Hidden Taylor & Francis CSE root.",
+          "type": "string"
+        },
+        {
+          "const": "taylor-and-francis-national-library-of-medicine-core",
+          "description": "Hidden Taylor & Francis NLM root.",
+          "type": "string"
+        },
+        {
+          "const": "chicago-shortened-notes-bibliography-core",
+          "description": "Hidden Chicago shortened-notes root.",
+          "type": "string"
+        },
+        {
+          "const": "chicago-notes-18th",
+          "description": "Chicago Manual of Style 18th edition — notes without bibliography.",
+          "type": "string"
+        },
+        {
+          "const": "chicago-author-date-18th",
+          "description": "Chicago Manual of Style 18th edition — author-date system.",
+          "type": "string"
+        },
+        {
+          "const": "chicago-shortened-notes-bibliography",
+          "description": "Chicago Manual of Style (shortened notes and bibliography).",
+          "type": "string"
+        },
+        {
+          "const": "apa-7th",
+          "description": "APA 7th edition — author-date system.",
+          "type": "string"
+        },
+        {
+          "const": "elsevier-harvard",
+          "description": "Elsevier Harvard (author-date).",
+          "type": "string"
+        },
+        {
+          "const": "elsevier-with-titles",
+          "description": "Elsevier with Titles (numeric).",
+          "type": "string"
+        },
+        {
+          "const": "elsevier-vancouver",
+          "description": "Elsevier Vancouver (numeric).",
+          "type": "string"
+        },
+        {
+          "const": "springer-basic-author-date",
+          "description": "Springer Basic (author-date).",
+          "type": "string"
+        },
+        {
+          "const": "springer-vancouver-brackets",
+          "description": "Springer Vancouver Brackets (numeric).",
+          "type": "string"
+        },
+        {
+          "const": "springer-basic-brackets",
+          "description": "Springer Basic Brackets (numeric).",
+          "type": "string"
+        },
+        {
+          "const": "american-medical-association",
+          "description": "American Medical Association 11th edition (numeric).",
+          "type": "string"
+        },
+        {
+          "const": "ieee",
+          "description": "Institute of Electrical and Electronics Engineers (numeric).",
+          "type": "string"
+        },
+        {
+          "const": "taylor-and-francis-chicago-author-date",
+          "description": "Taylor & Francis Chicago author-date.",
+          "type": "string"
+        },
+        {
+          "const": "taylor-and-francis-council-of-science-editors-author-date",
+          "description": "Taylor & Francis Council of Science Editors author-date.",
+          "type": "string"
+        },
+        {
+          "const": "taylor-and-francis-national-library-of-medicine",
+          "description": "Taylor & Francis National Library of Medicine.",
+          "type": "string"
+        },
+        {
+          "const": "modern-language-association",
+          "description": "Modern Language Association 9th edition (author-page).",
+          "type": "string"
+        }
+      ]
+    },
+    "StyleInfo": {
+      "description": "Style metadata.",
+      "properties": {
+        "citum-version": {
+          "description": "Minimum Citum engine version required to load and render this style.\n\nAccepts a [`semver::VersionReq`]-compatible string (e.g. `\">=0.38.0\"`,\n`\"^0.40\"`). When the running engine does not satisfy the requirement,\nthe resolver returns\n[`ResolutionError::VersionMismatch`]\ninstead of attempting to deserialize fields the engine may not\nunderstand. Omit for styles that use only stable, long-lived features.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "default-locale": {
+          "description": "Default locale for the style (e.g., \"en-US\", \"de-DE\").\nUsed for locale-aware term resolution.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "Short summary of the style's intended use or provenance.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "edition": {
+          "description": "Edition or version qualifier used alongside `short_name` to\ndisambiguate multiple editions of the same style family\n(e.g. `\"7th\"`, `\"18th edition\"`). Omit when only one edition exists.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fields": {
+          "description": "Discipline classifications for this style.",
+          "items": {
+            "$ref": "#/$defs/CitationField"
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "Stable identifier for the style, usually a URI or slug.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "short-name": {
+          "description": "Concise display name for the style family, used by UIs to label\nsearch results and match banners (e.g. `\"APA\"`, `\"Chicago Notes\"`,\n`\"MLA\"`). Omit for journal-specific styles whose full title is their\nidentity. Combine with `edition` to produce labels like `\"APA 7th\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StyleSource"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Provenance: set when this style was adapted from a CSL 1.0 source."
+        },
+        "title": {
+          "description": "Human-readable title of the style.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "StyleLink": {
+      "description": "A hyperlink associated with a style (documentation, self-link, etc.).",
+      "properties": {
+        "href": {
+          "description": "Link target for related style metadata.",
+          "type": "string"
+        },
+        "rel": {
+          "description": "Relationship type for the link, such as `self` or `documentation`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "href"
+      ],
+      "type": "object"
+    },
+    "StylePerson": {
+      "description": "A person credit (author or contributor) for a style.",
+      "properties": {
+        "email": {
+          "description": "Contact email for the credited person.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Display name for the credited person.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uri": {
+          "description": "URI identifying the credited person.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "StyleReference": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StyleBase",
+          "description": "A named builtin style base."
+        },
+        {
+          "description": "A URI reference to a remote or local style.\n\nSupported schemes: `file://`, `https://`, `git+https://`, `cid:`.",
+          "type": "string"
+        }
+      ],
+      "description": "A reference to a base style, which can be either a named builtin base,\na URI (e.g., `file://...`, `@hub/...`, `https://...`, `git+https://...`),\nor a content-addressed identifier (`cid:bafkrei...`)."
+    },
+    "StyleSource": {
+      "description": "Provenance block for styles adapted from a CSL 1.0 source.",
+      "properties": {
+        "adapted-by": {
+          "description": "Who performed the adaptation (e.g., \"citum-migrate\" or a person's name).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "csl-id": {
+          "description": "The original CSL style ID (URI).",
+          "type": "string"
+        },
+        "license": {
+          "description": "License URI (e.g., CC BY-SA).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "description": "Links from the original CSL style (documentation, self, etc.).",
+          "items": {
+            "$ref": "#/$defs/StyleLink"
+          },
+          "type": "array"
+        },
+        "original-authors": {
+          "description": "Original CSL style authors.",
+          "items": {
+            "$ref": "#/$defs/StylePerson"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "csl-id"
+      ],
+      "type": "object"
+    },
+    "SubLabelStyle": {
+      "description": "Sub-label style for compound numeric bibliography entries.",
+      "oneOf": [
+        {
+          "const": "alphabetic",
+          "description": "Alphabetic sub-labels: a, b, c, ...",
+          "type": "string"
+        },
+        {
+          "const": "numeric",
+          "description": "Numeric sub-labels: 1, 2, 3, ...",
+          "type": "string"
+        }
+      ]
+    },
+    "SubsequentAuthorSubstituteRule": {
+      "description": "Rules for subsequent author substitution.",
+      "oneOf": [
+        {
+          "const": "complete-all",
+          "description": "Substitute only if ALL authors match.",
+          "type": "string"
+        },
+        {
+          "const": "complete-each",
+          "description": "Substitute each matching name individually.",
+          "type": "string"
+        },
+        {
+          "const": "partial-each",
+          "description": "Substitute each matching name until the first mismatch.",
+          "type": "string"
+        },
+        {
+          "const": "partial-first",
+          "description": "Substitute only the first name if it matches.",
+          "type": "string"
+        }
+      ]
+    },
+    "SubsequentNameForm": {
+      "description": "The contributor form used after the first integral mention in scope.\n\n`Short` preserves non-dropping particles (\"van Beethoven\"); `FamilyOnly`\nstrips them (\"Beethoven\"). MLA-style narrative memory uses `Short`.",
+      "oneOf": [
+        {
+          "const": "short",
+          "description": "Use the short contributor form for subsequent mentions.",
+          "type": "string"
+        },
+        {
+          "const": "family-only",
+          "description": "Use family name only (without non-dropping particles) for subsequent mentions.",
+          "type": "string"
+        }
+      ]
+    },
+    "Substitute": {
+      "description": "Explicit substitution configuration.",
+      "properties": {
+        "contributor-role-form": {
+          "description": "Form to use for contributor roles when substituting.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "overrides": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/$defs/SubstituteKey"
+            },
+            "type": "array"
+          },
+          "description": "Type-specific substitution overrides.",
+          "type": "object"
+        },
+        "role-substitute": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "Per-role fallback chains for non-author contributor substitution.\n\nKeys and fallback entries normalize to canonical kebab-case role names.\nBuilt-in template roles use locale-aware labels automatically. Custom\nrole names still participate in fallback and suppression even when they\ndo not have a dedicated template enum variant.",
+          "type": "object"
+        },
+        "template": {
+          "default": [],
+          "description": "Ordered list of fields to try as substitutes.",
+          "items": {
+            "$ref": "#/$defs/SubstituteKey"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "SubstituteConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SubstitutePreset",
+          "description": "A named preset (e.g., \"standard\", \"editor-first\", \"title-first\")."
+        },
+        {
+          "$ref": "#/$defs/Substitute",
+          "description": "Explicit substitution configuration."
+        }
+      ],
+      "description": "Substitution rules for missing author data."
+    },
+    "SubstituteKey": {
+      "description": "Fields that can be used as author substitutes.",
+      "enum": [
+        "editor",
+        "title",
+        "translator"
+      ],
+      "type": "string"
+    },
+    "SubstitutePreset": {
+      "description": "Substitute presets for author substitution fallback logic.\n\nThese presets define the order in which fields are tried when the primary\nauthor is missing. Most styles follow the standard order, but some have\nvariations.",
+      "oneOf": [
+        {
+          "const": "standard",
+          "description": "Standard substitution order: Editor → Title → Translator.\nUsed by most citation styles (APA, Chicago, etc.).",
+          "type": "string"
+        },
+        {
+          "const": "editor-first",
+          "description": "Editor-first: Editor → Translator → Title.\nPrioritizes contributors over title.",
+          "type": "string"
+        },
+        {
+          "const": "title-first",
+          "description": "Title-first: Title → Editor → Translator.\nUsed when anonymous works should show title prominently.",
+          "type": "string"
+        },
+        {
+          "const": "editor-short",
+          "description": "Editor only with short role labels.",
+          "type": "string"
+        },
+        {
+          "const": "editor-long",
+          "description": "Editor only with long role labels.",
+          "type": "string"
+        },
+        {
+          "const": "editor-translator-short",
+          "description": "Editor then translator with short role labels.",
+          "type": "string"
+        },
+        {
+          "const": "editor-translator-long",
+          "description": "Editor then translator with long role labels.",
+          "type": "string"
+        },
+        {
+          "const": "editor-title-short",
+          "description": "Editor then title with short role labels.",
+          "type": "string"
+        },
+        {
+          "const": "editor-title-long",
+          "description": "Editor then title with long role labels.",
+          "type": "string"
+        },
+        {
+          "const": "editor-translator-title-short",
+          "description": "Editor then translator then title with short role labels.",
+          "type": "string"
+        },
+        {
+          "const": "editor-translator-title-long",
+          "description": "Editor then translator then title with long role labels.",
+          "type": "string"
+        }
+      ]
+    },
+    "TemplateAddOperation": {
+      "additionalProperties": false,
+      "description": "Addition operation that inserts a component before or after an anchor.",
+      "properties": {
+        "after": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateComponentSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Anchor selector after which the component should be inserted."
+        },
+        "before": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateComponentSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Anchor selector before which the component should be inserted."
+        },
+        "component": {
+          "$ref": "#/$defs/TemplateComponent",
+          "description": "Component to insert."
+        }
+      },
+      "required": [
+        "component"
+      ],
+      "type": "object"
+    },
+    "TemplateComponent": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TemplateContributor"
+        },
+        {
+          "$ref": "#/$defs/TemplateDate"
+        },
+        {
+          "$ref": "#/$defs/TemplateTitle"
+        },
+        {
+          "$ref": "#/$defs/TemplateNumber"
+        },
+        {
+          "$ref": "#/$defs/TemplateVariable"
+        },
+        {
+          "$ref": "#/$defs/TemplateGroup"
+        },
+        {
+          "$ref": "#/$defs/TemplateTerm"
+        }
+      ],
+      "description": "A template component - the building blocks of citation/bibliography templates.\n\nEach variant handles a specific data type with appropriate formatting options."
+    },
+    "TemplateComponentSelector": {
+      "additionalProperties": true,
+      "description": "Partial component selector used to locate anchors in a template.",
+      "type": "object"
+    },
+    "TemplateContributor": {
+      "additionalProperties": false,
+      "description": "A contributor component for rendering names.",
+      "properties": {
+        "and": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AndOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the conjunction between the last two names.\nUse `none` for bibliography when citation uses `text` or `symbol`."
+        },
+        "contributor": {
+          "$ref": "#/$defs/ContributorRole",
+          "description": "Which contributor role to render (author, editor, etc.)."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "delimiter": {
+          "description": "Custom delimiter between names (overrides global setting).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "$ref": "#/$defs/ContributorForm",
+          "description": "How to display the contributor (long names, short, with label, etc.)."
+        },
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit grammatical gender override for role-label agreement."
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional role label configuration (e.g., \"eds.\" for editors)."
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "name-order": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameOrder"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the global name order for this specific component.\nUse to show editors as \"Given Family\" even when global setting is \"Family, Given\"."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "shorten": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ShortenListOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Shorten the list of names (et al. configuration)."
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "sort-separator": {
+          "description": "Delimiter between family and given name when inverted (overrides global setting).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "contributor",
+        "form"
+      ],
+      "type": "object"
+    },
+    "TemplateDate": {
+      "additionalProperties": false,
+      "description": "A date component for rendering dates.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "date": {
+          "$ref": "#/$defs/DateVariable"
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fallback": {
+          "description": "Fallback components if the primary date is missing.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "form": {
+          "$ref": "#/$defs/DateForm"
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "date",
+        "form"
+      ],
+      "type": "object"
+    },
+    "TemplateGroup": {
+      "additionalProperties": false,
+      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "group": {
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": "array"
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "group"
+      ],
+      "type": "object"
+    },
+    "TemplateModifyOperation": {
+      "additionalProperties": false,
+      "description": "Rendering-only modification for the component matched by `match`.",
+      "properties": {
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LabelForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the localized number label form when modifying number components."
+        },
+        "match": {
+          "$ref": "#/$defs/TemplateComponentSelector",
+          "description": "Selector identifying exactly one component to modify."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "match"
+      ],
+      "type": "object"
+    },
+    "TemplateNumber": {
+      "additionalProperties": false,
+      "description": "A number component (volume, issue, pages, etc.).",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NumberForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit grammatical gender override for number/ordinal agreement."
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LabelForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "number": {
+          "$ref": "#/$defs/NumberVariable"
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "show-with-locator": {
+          "description": "When `true`, show this pages component even when a locator is present in a note-style citation.\nBy default, pages are suppressed in note-style citations when a locator is present.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "number"
+      ],
+      "type": "object"
+    },
+    "TemplatePreset": {
+      "description": "Available embedded template presets.\n\nThese reference battle-tested templates for common citation styles.\nSee `citum_schema::embedded` for the actual template implementations.",
+      "oneOf": [
+        {
+          "const": "apa",
+          "description": "APA 7th edition (author-date)",
+          "type": "string"
+        },
+        {
+          "const": "chicago-author-date",
+          "description": "Chicago Manual of Style (author-date)",
+          "type": "string"
+        },
+        {
+          "const": "vancouver",
+          "description": "Vancouver (numeric)",
+          "type": "string"
+        },
+        {
+          "const": "ieee",
+          "description": "IEEE (numeric)",
+          "type": "string"
+        },
+        {
+          "const": "harvard",
+          "description": "Harvard/Elsevier (author-date)",
+          "type": "string"
+        },
+        {
+          "const": "numeric-citation",
+          "description": "Numeric citation number only (citation-focused preset)",
+          "type": "string"
+        }
+      ]
+    },
+    "TemplateReference": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TemplatePreset",
+          "description": "A named builtin template preset."
+        },
+        {
+          "description": "A URI reference to a remote or local template.",
+          "type": "string"
+        }
+      ],
+      "description": "A reference to a template, which can be either a named builtin preset\nor a URI (e.g., `file://...`, `@hub/...`, `https://...`)."
+    },
+    "TemplateRemoveOperation": {
+      "additionalProperties": false,
+      "description": "Removal operation for the component matched by `match`.",
+      "properties": {
+        "match": {
+          "$ref": "#/$defs/TemplateComponentSelector",
+          "description": "Selector identifying exactly one component to remove."
+        }
+      },
+      "required": [
+        "match"
+      ],
+      "type": "object"
+    },
+    "TemplateTerm": {
+      "additionalProperties": false,
+      "description": "A term component for rendering locale-specific text.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TermForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Form: long (default), short, or symbol."
+        },
+        "gender": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrammaticalGender"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Explicit grammatical gender override for term selection."
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "term": {
+          "$ref": "#/$defs/GeneralTerm",
+          "description": "Which term to render."
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "term"
+      ],
+      "type": "object"
+    },
+    "TemplateTitle": {
+      "additionalProperties": false,
+      "description": "A title component.",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "disambiguate-only": {
+          "description": "When true, suppress this title component unless the reference needs\ndisambiguation (i.e. multiple works by the same author appear in the\ndocument). Used by author-class styles (e.g. MLA) where the title\nappears in citations only to resolve same-author ambiguity.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "title": {
+          "$ref": "#/$defs/TitleType"
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "type": "object"
+    },
+    "TemplateVariable": {
+      "additionalProperties": false,
+      "description": "A simple variable component (DOI, ISBN, URL, etc.).",
+      "properties": {
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "links": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinksConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Structured link options (DOI, URL)."
+        },
+        "name-form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override name form (e.g., initials, full, family-only)."
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to the rendered value."
+        },
+        "variable": {
+          "$ref": "#/$defs/SimpleVariable"
+        },
+        "vertical-align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical alignment to apply to rendered output."
+        },
+        "wrap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap)."
+        }
+      },
+      "required": [
+        "variable"
+      ],
+      "type": "object"
+    },
+    "TemplateVariant": {
+      "anyOf": [
+        {
+          "description": "Complete replacement template used by Template V1/V2 styles.",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          },
+          "type": "array"
+        },
+        {
+          "$ref": "#/$defs/TemplateVariantDiff",
+          "description": "Structural diff applied to a parent template during style resolution."
+        }
+      ],
+      "description": "Type-specific template override, either as a complete legacy template or a V3 diff."
+    },
+    "TemplateVariantDiff": {
+      "additionalProperties": false,
+      "description": "Structural diff that derives a type-specific template from a parent template.",
+      "properties": {
+        "add": {
+          "description": "Component additions applied in authored order.",
+          "items": {
+            "$ref": "#/$defs/TemplateAddOperation"
+          },
+          "type": "array"
+        },
+        "extends": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeSelector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional parent type variant selector within the same section."
+        },
+        "modify": {
+          "description": "Rendering-only modifications applied in authored order.",
+          "items": {
+            "$ref": "#/$defs/TemplateModifyOperation"
+          },
+          "type": "array"
+        },
+        "remove": {
+          "description": "Component removals applied in authored order.",
+          "items": {
+            "$ref": "#/$defs/TemplateRemoveOperation"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "TermForm": {
+      "description": "Form for term lookup.\n\nSpecifies which form variant of a term should be used in citation output.",
+      "oneOf": [
+        {
+          "const": "long",
+          "description": "Long form of a term (e.g., \"page\" vs \"p.\").",
+          "type": "string"
+        },
+        {
+          "const": "short",
+          "description": "Short form of a term (e.g., \"p.\" vs \"page\").",
+          "type": "string"
+        },
+        {
+          "const": "verb",
+          "description": "Verb form of a term (e.g., \"edited by\").",
+          "type": "string"
+        },
+        {
+          "const": "verb-short",
+          "description": "Short verb form of a term (e.g., \"ed.\" vs \"edited by\").",
+          "type": "string"
+        },
+        {
+          "const": "symbol",
+          "description": "Symbol form of a term (e.g., \"§\" for section).",
+          "type": "string"
+        }
+      ]
+    },
+    "TextCase": {
+      "description": "Text-case transform applied to title-like fields.\n\nStyles select which transform applies to which field category.\nThe engine provides the generic primitives; styles own the selection.",
+      "oneOf": [
+        {
+          "const": "title",
+          "description": "English headline-style title case (capitalize principal words).",
+          "type": "string"
+        },
+        {
+          "const": "sentence",
+          "description": "Generic sentence case (capitalize first word only).",
+          "type": "string"
+        },
+        {
+          "const": "sentence-apa",
+          "description": "APA-style sentence case: capitalize first word of main title\nand first word after each subtitle boundary.",
+          "type": "string"
+        },
+        {
+          "const": "sentence-nlm",
+          "description": "NLM-style sentence case: capitalize first word of main title only;\nsubtitles preserve only explicit/protected capitals.",
+          "type": "string"
+        },
+        {
+          "const": "capitalize-first",
+          "description": "Capitalize the first letter of the value.",
+          "type": "string"
+        },
+        {
+          "const": "lowercase",
+          "description": "Transform the entire value to lowercase.",
+          "type": "string"
+        },
+        {
+          "const": "uppercase",
+          "description": "Transform the entire value to uppercase.",
+          "type": "string"
+        },
+        {
+          "const": "as-is",
+          "description": "No transformation; render the value exactly as stored.",
+          "type": "string"
+        }
+      ]
+    },
+    "TimeFormat": {
+      "description": "Time display format.",
+      "oneOf": [
+        {
+          "const": "hour12",
+          "description": "12-hour clock with AM/PM (e.g., \"11:30 PM\")",
+          "type": "string"
+        },
+        {
+          "const": "hour24",
+          "description": "24-hour clock (e.g., \"23:30\")",
+          "type": "string"
+        }
+      ]
+    },
+    "TitleForm": {
+      "description": "Title rendering forms.",
+      "enum": [
+        "short",
+        "long"
+      ],
+      "type": "string"
+    },
+    "TitlePreset": {
+      "description": "Title formatting presets.\n\nEach preset defines how different types of titles (articles, books, journals)\nare formatted. Presets typically differ in whether titles are quoted, italicized,\nor plain.",
+      "oneOf": [
+        {
+          "const": "apa",
+          "description": "APA style: article titles plain, book/journal titles italic.\nExample: Article title. *Book Title*. *Journal Title*.",
+          "type": "string"
+        },
+        {
+          "const": "chicago",
+          "description": "Chicago style: article titles quoted, book/journal titles italic.\nExample: \"Article Title.\" *Book Title*. *Journal Title*.",
+          "type": "string"
+        },
+        {
+          "const": "ieee",
+          "description": "IEEE style: article titles quoted, book/journal titles italic.\nExample: \"Article title,\" *Book Title*. *Journal Title*.",
+          "type": "string"
+        },
+        {
+          "const": "humanities",
+          "description": "Humanities style: monographs, periodicals, and serials all italic,\narticles plain. Common in geography, history, and social sciences.\nExample: Article title. *Book Title*. *Journal Title*. *Series Title*.",
+          "type": "string"
+        },
+        {
+          "const": "journal-emphasis",
+          "description": "Journal-focused emphasis: periodicals and serials italic,\nmonographs plain.",
+          "type": "string"
+        },
+        {
+          "const": "scientific",
+          "description": "Scientific/Vancouver style: all titles plain (no formatting).\nExample: Article title. Book title. Journal title.",
+          "type": "string"
+        }
+      ]
+    },
+    "TitleRendering": {
+      "description": "Rendering options for titles.",
+      "properties": {
+        "emph": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "locale-overrides": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TitleRendering"
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "prefix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "quote": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "suffix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "text-case": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Text-case transform to apply to this title category."
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "TitleTerminator": {
+      "description": "Terminator punctuation for bibliography titles.",
+      "oneOf": [
+        {
+          "const": "period",
+          "description": "Period.",
+          "type": "string"
+        },
+        {
+          "const": "comma",
+          "description": "Comma.",
+          "type": "string"
+        },
+        {
+          "const": "none",
+          "description": "No terminator.",
+          "type": "string"
+        }
+      ]
+    },
+    "TitleType": {
+      "description": "Types of titles.",
+      "oneOf": [
+        {
+          "const": "primary",
+          "description": "The primary title of the cited work.",
+          "type": "string"
+        },
+        {
+          "const": "parent-monograph",
+          "description": "Title of a book/monograph containing the cited work.",
+          "type": "string"
+        },
+        {
+          "const": "parent-serial",
+          "description": "Title of a periodical/serial containing the cited work.",
+          "type": "string"
+        }
+      ]
+    },
+    "TitlesConfig": {
+      "description": "Title formatting configuration by title type.",
+      "properties": {
+        "component": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleRendering"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Formatting for component titles (articles, chapters)."
+        },
+        "container-monograph": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleRendering"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Formatting for monograph containers (book containing chapters)."
+        },
+        "custom": {
+          "additionalProperties": true,
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "default": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleRendering"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Default formatting for all titles."
+        },
+        "monograph": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleRendering"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Formatting for monograph titles (books)."
+        },
+        "periodical": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleRendering"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Formatting for periodical titles (journals, magazines)."
+        },
+        "serial": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TitleRendering"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Formatting for serial titles (series)."
+        },
+        "type-mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Mapping of reference types to title categories.\nCategory keys: monograph, periodical, component.\nExample: { \"thesis\": \"monograph\", \"article-journal\": \"periodical\" }",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "TitlesConfigEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TitlePreset",
+          "description": "A named preset (e.g., \"apa\", \"chicago\", \"humanities\", \"scientific\")."
+        },
+        {
+          "$ref": "#/$defs/TitlesConfig",
+          "description": "Explicit title configuration."
+        }
+      ],
+      "description": "Title config: either a preset name or explicit configuration.\n\nAllows styles to write `titles: apa` as shorthand, or provide\nfull explicit configuration with field-level overrides."
+    },
+    "TypeClass": {
+      "description": "A coarse reference genre used as an optional gate on locator patterns.",
+      "oneOf": [
+        {
+          "const": "legal",
+          "description": "Legal citations (e.g., \"legal-case\", \"statute\")",
+          "type": "string"
+        },
+        {
+          "const": "classical",
+          "description": "Classical works with traditional numbering",
+          "type": "string"
+        },
+        {
+          "const": "standard",
+          "description": "Standard reference types",
+          "type": "string"
+        }
+      ]
+    },
+    "TypeSelector": {
+      "description": "Selector for reference types in overrides.\nCan be a single type string or a list of types.",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "Single": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Single"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "Multiple": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "Multiple"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "VerticalAlign": {
+      "description": "Vertical text alignment relative to the baseline.",
+      "oneOf": [
+        {
+          "const": "baseline",
+          "description": "Render at the baseline (default).",
+          "type": "string"
+        },
+        {
+          "const": "superscript",
+          "description": "Render as superscript.",
+          "type": "string"
+        },
+        {
+          "const": "subscript",
+          "description": "Render as subscript.",
+          "type": "string"
+        }
+      ]
+    },
+    "WrapConfig": {
+      "description": "Wrapping punctuation and optional inner affixes applied around a rendered value.\n\nCombines the wrap punctuation with optional text that appears inside the wrap\n(between the wrap character and the rendered content).",
+      "properties": {
+        "inner-prefix": {
+          "description": "Text inserted after the opening wrap character but before the content.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inner-suffix": {
+          "description": "Text inserted after the content but before the closing wrap character.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "punctuation": {
+          "$ref": "#/$defs/WrapPunctuation",
+          "description": "The wrapping punctuation style."
+        }
+      },
+      "required": [
+        "punctuation"
+      ],
+      "type": "object"
+    },
+    "WrapPunctuation": {
+      "description": "Punctuation to wrap a component in.",
+      "enum": [
+        "parentheses",
+        "brackets",
+        "quotes"
+      ],
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The new Citum Style model.\n\nThis is the target schema for Citum, featuring declarative options\nand simple template components instead of procedural conditionals.",
+  "properties": {
+    "bibliography": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BibliographySpec"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Bibliography specification."
+    },
+    "citation": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CitationSpec"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Citation specification."
+    },
+    "custom": {
+      "additionalProperties": true,
+      "description": "Custom user-defined fields for extensions.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "extends": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StyleReference"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Extends a base style, with optional local overrides.\n\nWhen present, the base [`StyleReference`](style_base::StyleReference) is resolved and the local\noverrides are merged before any further processing. Explicit `options`,\n`citation`, and `bibliography` keys at the same document level take\nprecedence over the resolved base."
+    },
+    "extends-pin": {
+      "description": "Optional content-addressed integrity pin for the parent style referenced\nby [`extends`](Self::extends).\n\nWhen present, the resolver verifies that the SHA-256 of the fetched\nparent matches this CIDv1 string before merging. Mismatches abort\nresolution with [`ResolutionError::IntegrityFailure`]. Absent means\n\"no integrity check\" — appropriate for `file://` parents under user\ncontrol or trusted local registries.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "info": {
+      "$ref": "#/$defs/StyleInfo",
+      "default": {},
+      "description": "Style metadata."
+    },
+    "options": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Config"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Global style options."
+    },
+    "templates": {
+      "additionalProperties": {
+        "items": {
+          "$ref": "#/$defs/TemplateComponent"
+        },
+        "type": "array"
+      },
+      "description": "Named reusable templates.",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "version": {
+      "$ref": "#/$defs/SchemaVersion",
+      "default": "0.59.0",
+      "description": "Style schema version."
+    }
+  },
+  "title": "Style",
+  "type": "object",
+  "unevaluatedProperties": false
+}

--- a/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
@@ -20,6 +20,7 @@ info:
   short-name: "AMA"
   edition: "11th edition"
 options:
+  multilingual: romanized-translated
   locators:
     strip-label-periods: true
   substitute: editor-short

--- a/crates/citum-schema-style/embedded/styles/apa-7th.yaml
+++ b/crates/citum-schema-style/embedded/styles/apa-7th.yaml
@@ -62,10 +62,7 @@ options:
       emph: true
     serial:
       text-case: as-is
-  multilingual:
-    title-mode: combined
-    name-mode: transliterated
-    preferred-script: Latn
+  multilingual: romanized-translated
   page-range-format: expanded
   punctuation-in-quote: true
 citation:

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -31,6 +31,7 @@ info:
   short-name: "Chicago Author-Date"
   edition: "18th edition"
 options:
+  multilingual: romanized-translated
   locators: note
   processing:
     disambiguate:

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
@@ -33,6 +33,7 @@ info:
   short-name: "Chicago Notes"
   edition: "18th edition"
 options:
+  multilingual: romanized-translated
   processing: note
   substitute: editor-translator-short
   contributors:

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -33,6 +33,7 @@ info:
   edition: "18th edition"
   default-locale: en-US
 options:
+  multilingual: romanized-translated
   locale-override: en-US-chicago
   processing: note
   contributors:

--- a/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
@@ -18,6 +18,7 @@ info:
       rel: documentation
   short-name: "Elsevier Harvard"
 options:
+  multilingual: romanized-translated
   processing:
     sort:
       template:

--- a/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
@@ -16,6 +16,7 @@ info:
       rel: documentation
   short-name: "Vancouver"
 options:
+  multilingual: romanized-translated
   substitute:
     contributor-role-form: long
     template:

--- a/crates/citum-schema-style/embedded/styles/elsevier-with-titles-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-with-titles-core.yaml
@@ -17,6 +17,7 @@ info:
     - href: http://www.elsevier.com/journals/journal-of-hazardous-materials/0304-3894/guide-for-authors#68001
       rel: documentation
 options:
+  multilingual: romanized-translated
   substitute:
     contributor-role-form: short
     template:

--- a/crates/citum-schema-style/embedded/styles/ieee.yaml
+++ b/crates/citum-schema-style/embedded/styles/ieee.yaml
@@ -17,6 +17,7 @@ info:
       rel: documentation
   short-name: "IEEE"
 options:
+  multilingual: romanized-only
   substitute: editor-translator-short
   processing: numeric
   contributors:

--- a/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
@@ -19,6 +19,7 @@ info:
     - href: http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf
       rel: documentation
 options:
+  multilingual: romanized-translated
   processing:
     sort:
       template:

--- a/crates/citum-schema-style/embedded/styles/springer-basic-brackets-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-brackets-core.yaml
@@ -21,6 +21,7 @@ info:
     - href: http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf
       rel: documentation
 options:
+  multilingual: romanized-translated
   substitute:
     template:
     - editor

--- a/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets-core.yaml
@@ -19,6 +19,7 @@ info:
     - href: https://dam.springernature.com/file/1iVex7Gr46Q8xLzdF9RNhT/*/Key+Style+Points_Dec_24.pdf?authcred=Q29weVVSTDpDMHB5X1VSTA==
       rel: documentation
 options:
+  multilingual: romanized-translated
   substitute: standard
   processing: numeric
   contributors:

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
@@ -6,6 +6,7 @@ info:
 
 extends: chicago-author-date-18th
 options:
+  multilingual: romanized-translated
   page-range-format: expanded
   contributors:
     role:

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
@@ -17,6 +17,7 @@ info:
     - href: http://www.tandf.co.uk/journals/authors/style/reference/tf_CSE.pdf
       rel: documentation
 options:
+  multilingual: romanized-translated
   processing:
     sort:
       template:

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-national-library-of-medicine-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-national-library-of-medicine-core.yaml
@@ -17,6 +17,7 @@ info:
     - href: https://files.taylorandfrancis.com/tf_NLM.pdf
       rel: documentation
 options:
+  multilingual: romanized-translated
   substitute: editor-long
   processing: numeric
   contributors: numeric-medium

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -16,6 +16,7 @@ pub mod processing;
 pub mod scoped;
 pub mod substitute;
 
+pub use crate::presets::{MultilingualConfigEntry, MultilingualPreset};
 pub use bibliography::{
     ArticleJournalBibliographyConfig, ArticleJournalNoPageFallback, BibliographyConfig,
     BibliographyPartitionHeading, BibliographyPartitionKind, BibliographyPartitionMode,
@@ -37,7 +38,10 @@ pub use locators::{
     LabelForm, LabelRepeat, LocatorConfig, LocatorConfigEntry, LocatorKindConfig, LocatorPattern,
     LocatorPreset, TypeClass,
 };
-pub use multilingual::{MultilingualConfig, MultilingualMode, ScriptConfig};
+pub use multilingual::{
+    MultilingualConfig, MultilingualMode, MultilingualSegment, MultilingualView, ScriptConfig,
+    SegmentWrap,
+};
 pub use processing::{
     CitationSortPolicy, Disambiguation, GivennameRule, Group, LabelConfig, LabelParams,
     LabelPreset, Processing, ProcessingCustom, Sort, SortEntry, SortKey, SortSpec,
@@ -75,8 +79,14 @@ pub struct Config {
     /// Localization settings.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub localize: Option<Localize>,
-    /// Multilingual rendering defaults.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Multilingual rendering defaults. Accepts a preset name (e.g., `"romanized-translated"`,
+    /// `"romanized-only"`) or an explicit configuration block.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_multilingual_config",
+        default
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<MultilingualConfigEntry>"))]
     pub multilingual: Option<MultilingualConfig>,
     /// Contributor formatting defaults. Accepts a preset name (e.g., "apa")
     /// or explicit configuration.
@@ -171,8 +181,14 @@ pub struct CitationOptions {
     /// Localization settings.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub localize: Option<Localize>,
-    /// Multilingual rendering defaults.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Multilingual rendering defaults. Accepts a preset name (e.g., `"romanized-translated"`,
+    /// `"romanized-only"`) or an explicit configuration block.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_multilingual_config",
+        default
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<MultilingualConfigEntry>"))]
     pub multilingual: Option<MultilingualConfig>,
     /// Contributor formatting defaults.
     #[serde(
@@ -265,8 +281,14 @@ pub struct BibliographyOptions {
     /// Localization settings.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub localize: Option<Localize>,
-    /// Multilingual rendering defaults.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Multilingual rendering defaults. Accepts a preset name (e.g., `"romanized-translated"`,
+    /// `"romanized-only"`) or an explicit configuration block.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_multilingual_config",
+        default
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<MultilingualConfigEntry>"))]
     pub multilingual: Option<MultilingualConfig>,
     /// Contributor formatting defaults.
     #[serde(
@@ -794,6 +816,17 @@ where
     Ok(value.map(|entry| entry.resolve()))
 }
 
+/// Deserialize multilingual config from either a preset name or an explicit block.
+fn deserialize_multilingual_config<'de, D>(
+    deserializer: D,
+) -> Result<Option<MultilingualConfig>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<crate::presets::MultilingualConfigEntry> = Option::deserialize(deserializer)?;
+    Ok(value.map(|entry| entry.resolve()))
+}
+
 impl<'de> Deserialize<'de> for Config {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -810,7 +843,11 @@ impl<'de> Deserialize<'de> for Config {
             locale_override: Option<String>,
             #[serde(skip_serializing_if = "Option::is_none")]
             localize: Option<Localize>,
-            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde(
+                skip_serializing_if = "Option::is_none",
+                deserialize_with = "deserialize_multilingual_config",
+                default
+            )]
             multilingual: Option<MultilingualConfig>,
             #[serde(
                 skip_serializing_if = "Option::is_none",
@@ -1231,5 +1268,70 @@ locale-override: en-US-chicago
         let cfg: NoteConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(cfg.unknown_fields.contains_key("future-key"));
         assert_eq!(cfg.punctuation, Some(NoteQuotePlacement::Inside));
+    }
+
+    #[test]
+    fn test_multilingual_preset_romanized_translated_parses_and_resolves() {
+        // `romanized-translated` resolves to Combined title mode (romanized [translated])
+        let yaml = r#"multilingual: romanized-translated"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let ml = config.multilingual.unwrap();
+        assert_eq!(ml.title_mode, Some(MultilingualMode::Combined));
+        assert_eq!(ml.name_mode, Some(MultilingualMode::Transliterated));
+        assert_eq!(ml.preferred_script.as_deref(), Some("Latn"));
+    }
+
+    #[test]
+    fn test_multilingual_preset_romanized_only_parses_and_resolves() {
+        // `romanized-only` resolves to Transliterated title mode (no translation)
+        let yaml = r#"multilingual: romanized-only"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let ml = config.multilingual.unwrap();
+        assert_eq!(ml.title_mode, Some(MultilingualMode::Transliterated));
+        assert_eq!(ml.name_mode, Some(MultilingualMode::Transliterated));
+        assert_eq!(ml.preferred_script.as_deref(), Some("Latn"));
+    }
+
+    #[test]
+    fn test_multilingual_explicit_block_transliterated_roundtrips() {
+        // Verify a Transliterated explicit block survives YAML serialize→deserialize.
+        let yaml = r#"
+multilingual:
+  title-mode: transliterated
+  preferred-script: Latn
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let ml = config.multilingual.clone().unwrap();
+        assert_eq!(ml.title_mode, Some(MultilingualMode::Transliterated));
+        assert_eq!(ml.preferred_script.as_deref(), Some("Latn"));
+
+        let yaml2 = serde_yaml::to_string(&config).unwrap();
+        let config2: Config = serde_yaml::from_str(&yaml2).unwrap();
+        assert_eq!(config2.multilingual, config.multilingual);
+    }
+
+    #[test]
+    fn test_multilingual_pattern_block_roundtrips() {
+        // Exercises the externally-tagged `{pattern: [...]}` YAML path — the case that
+        // breaks under serde_yaml's untagged+enum limitation without the custom Deserialize.
+        let yaml = r#"
+multilingual:
+  title-mode:
+    pattern:
+      - view: original
+      - view: translated
+        wrap: brackets
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let ml = config.multilingual.clone().unwrap();
+        assert!(
+            matches!(ml.title_mode, Some(MultilingualMode::Pattern(_))),
+            "expected Pattern mode, got {:?}",
+            ml.title_mode
+        );
+
+        let yaml2 = serde_yaml::to_string(&config).unwrap();
+        let config2: Config = serde_yaml::from_str(&yaml2).unwrap();
+        assert_eq!(config2.multilingual, config.multilingual);
     }
 }

--- a/crates/citum-schema-style/src/options/multilingual.rs
+++ b/crates/citum-schema-style/src/options/multilingual.rs
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use std::collections::HashMap;
 
 /// Multilingual rendering options.
@@ -32,7 +32,7 @@ pub struct MultilingualConfig {
 }
 
 /// Rendering modes for multilingual content.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum MultilingualMode {
@@ -42,9 +42,82 @@ pub enum MultilingualMode {
     Transliterated,
     /// Use translation matching style locale.
     Translated,
-    /// Combine multiple views (e.g., "transliterated \[translated\]").
-    /// For now, this is a placeholder for more complex formatting strings.
+    /// Combine transliteration and translation: `romanized [translated]`.
+    /// Equivalent to `Pattern([transliterated, {translated, brackets}])`.
     Combined,
+    /// Ordered sequence of views joined by spaces.
+    ///
+    /// Use this when a style requires more than two views — e.g. Chicago's
+    /// `romanized original [translated]` or MLA's `original [translated]`.
+    /// Each segment specifies a view and an optional bracket wrap.
+    /// Segments whose resolved text is empty or identical to the previous
+    /// segment are silently skipped (dedup).
+    ///
+    /// YAML form:
+    /// ```yaml
+    /// title-mode:
+    ///   pattern:
+    ///     - view: transliterated
+    ///     - view: original
+    ///     - view: translated
+    ///       wrap: brackets
+    /// ```
+    Pattern(Vec<MultilingualSegment>),
+}
+
+/// A single view segment in a `MultilingualMode::Pattern`.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct MultilingualSegment {
+    /// Which textual view to render for this segment.
+    pub view: MultilingualView,
+    /// Optional wrapping applied around the resolved text.
+    #[serde(default, skip_serializing_if = "SegmentWrap::is_none")]
+    pub wrap: SegmentWrap,
+}
+
+/// Which textual representation of a multilingual field to use in a pattern segment.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum MultilingualView {
+    /// The original text as stored in the data.
+    Original,
+    /// The transliterated (romanized) form.
+    Transliterated,
+    /// The translation matching the style locale.
+    Translated,
+}
+
+/// Bracket wrapping applied to a pattern segment.
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum SegmentWrap {
+    /// No wrapping.
+    #[default]
+    None,
+    /// Wrap in square brackets: `[text]`.
+    Brackets,
+    /// Wrap in parentheses: `(text)`.
+    Parentheses,
+}
+
+impl SegmentWrap {
+    /// Returns `true` when the variant is `None` (used for skip-serializing).
+    pub fn is_none(&self) -> bool {
+        matches!(self, SegmentWrap::None)
+    }
+
+    /// Apply the wrap to a string slice, returning the wrapped form.
+    pub fn apply(&self, text: &str) -> String {
+        match self {
+            SegmentWrap::None => text.to_string(),
+            SegmentWrap::Brackets => format!("[{text}]"),
+            SegmentWrap::Parentheses => format!("({text})"),
+        }
+    }
 }
 
 /// Configuration for specific scripts.
@@ -61,4 +134,92 @@ pub struct ScriptConfig {
     /// Custom delimiter between family and given name when this script is inverted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort_separator: Option<String>,
+}
+
+/// Custom deserializer for [`MultilingualMode`].
+///
+/// Unit variants are accepted as plain strings (`"primary"`, `"transliterated"`, etc.).
+/// The `Pattern` variant is accepted as a single-key map `{pattern: [...]}`.
+///
+/// A hand-written `deserialize_any` visitor is used instead of serde's derived
+/// `deserialize_enum` because `serde_yaml` cannot pass enum-variant input through
+/// an outer `#[serde(untagged)]` wrapper — the standard derive would fail with
+/// *"untagged and internally tagged enums do not support enum input"* when a
+/// serialized `Pattern` value is round-tripped through [`crate::presets::MultilingualConfigEntry`].
+impl<'de> de::Deserialize<'de> for MultilingualMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ModeVisitor;
+
+        impl<'de> de::Visitor<'de> for ModeVisitor {
+            type Value = MultilingualMode;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(
+                    f,
+                    "a multilingual mode string (\"primary\", \"transliterated\", \
+                     \"translated\", \"combined\") or a pattern object {{pattern: [...]}}"
+                )
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "primary" => Ok(MultilingualMode::Primary),
+                    "transliterated" => Ok(MultilingualMode::Transliterated),
+                    "translated" => Ok(MultilingualMode::Translated),
+                    "combined" => Ok(MultilingualMode::Combined),
+                    _ => Err(E::unknown_variant(
+                        v,
+                        &[
+                            "primary",
+                            "transliterated",
+                            "translated",
+                            "combined",
+                            "pattern",
+                        ],
+                    )),
+                }
+            }
+
+            fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let key: String = map
+                    .next_key()?
+                    .ok_or_else(|| de::Error::custom("expected \"pattern\" key, got empty map"))?;
+                if key != "pattern" {
+                    return Err(de::Error::unknown_field(&key, &["pattern"]));
+                }
+                let segments: Vec<MultilingualSegment> = map.next_value()?;
+                if map.next_key::<String>()?.is_some() {
+                    return Err(de::Error::custom("unexpected extra key in pattern object"));
+                }
+                Ok(MultilingualMode::Pattern(segments))
+            }
+
+            /// serde_yaml serialises `{pattern: [...]}` as an externally-tagged enum
+            /// (not a plain map), so we also need to handle enum access.
+            fn visit_enum<A: de::EnumAccess<'de>>(self, data: A) -> Result<Self::Value, A::Error> {
+                use de::VariantAccess as _;
+                let (variant, access): (String, _) = data.variant()?;
+                if variant == "pattern" {
+                    let segments: Vec<MultilingualSegment> = access.newtype_variant()?;
+                    Ok(MultilingualMode::Pattern(segments))
+                } else {
+                    Err(de::Error::unknown_variant(
+                        &variant,
+                        &[
+                            "primary",
+                            "transliterated",
+                            "translated",
+                            "combined",
+                            "pattern",
+                        ],
+                    ))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(ModeVisitor)
+    }
 }

--- a/crates/citum-schema-style/src/presets.rs
+++ b/crates/citum-schema-style/src/presets.rs
@@ -28,6 +28,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! 3. Skip presets entirely and specify everything explicitly
 
 use crate::grouping::{GroupSort, GroupSortKey, SortKey as GroupSortKey_};
+use crate::options::multilingual::{MultilingualConfig, MultilingualMode};
 use crate::options::{
     AndOptions, ContributorConfig, DateConfig, DelimiterPrecedesLast, DemoteNonDroppingParticle,
     DisplayAsSort, MonthFormat, NameForm, ShortenListOptions, Sort, SortKey, SortSpec, Substitute,
@@ -760,6 +761,149 @@ impl SubstitutePreset {
                 unknown_fields: std::collections::BTreeMap::new(),
             },
         }
+    }
+}
+
+/// Multilingual rendering policy presets.
+///
+/// Each preset encodes the romanization and translation conventions for a major
+/// citation style or style family when rendering references in an English-language
+/// context.  Style YAML authors can write a bare preset name:
+///
+/// ```yaml
+/// options:
+///   multilingual: romanized-translated
+/// ```
+///
+/// and Citum resolves it to the full [`MultilingualConfig`] at load time.
+///
+/// Preset names describe the **rendering behavior**, not a specific style family.
+/// For CJK-inclusive 3-way views (e.g. `romanized original [translated]`) use an
+/// explicit `pattern:` block instead — that display is something these styles
+/// *allow*, not something they mandate by default.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum MultilingualPreset {
+    /// Romanize titles and append an English translation in brackets.
+    ///
+    /// Title pattern: `romanized [translated]` (= `Combined` mode).
+    /// Names: romanized.  Script: `Latn`.
+    ///
+    /// Appropriate for APA, Chicago, MLA, Harvard, Vancouver, AMA, NLM, CSE,
+    /// and most other English-language styles.  All of these styles require
+    /// romanized names and romanized titles; translation is recommended or
+    /// required for non-English titles; original-script display is a house
+    /// option that styles *allow* but do not mandate.
+    RomanizedTranslated,
+    /// Romanize titles and names only — no translation appended.
+    ///
+    /// Title pattern: romanized form only (= `Transliterated` mode).
+    /// Names: romanized.  Script: `Latn`.
+    ///
+    /// Appropriate for IEEE and numeric styles where the translation bracket
+    /// is typically omitted.
+    RomanizedOnly,
+}
+
+impl MultilingualPreset {
+    /// Resolve this preset into a concrete [`MultilingualConfig`].
+    pub fn config(self) -> MultilingualConfig {
+        match self {
+            MultilingualPreset::RomanizedTranslated => MultilingualConfig {
+                title_mode: Some(MultilingualMode::Combined),
+                name_mode: Some(MultilingualMode::Transliterated),
+                preferred_script: Some("Latn".to_string()),
+                ..Default::default()
+            },
+            MultilingualPreset::RomanizedOnly => MultilingualConfig {
+                title_mode: Some(MultilingualMode::Transliterated),
+                name_mode: Some(MultilingualMode::Transliterated),
+                preferred_script: Some("Latn".to_string()),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+/// Entry for `options.multilingual`: either a preset name or an explicit config block.
+///
+/// Style YAML can use a short preset name:
+/// ```yaml
+/// options:
+///   multilingual: romanized-translated
+/// ```
+/// or a full explicit block:
+/// ```yaml
+/// options:
+///   multilingual:
+///     title-mode: combined
+///     name-mode: transliterated
+///     preferred-script: Latn
+/// ```
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum MultilingualConfigEntry {
+    /// A named preset (`"romanized-translated"` or `"romanized-only"`).
+    Preset(MultilingualPreset),
+    /// An explicit multilingual configuration block.
+    Explicit(Box<MultilingualConfig>),
+}
+
+impl MultilingualConfigEntry {
+    /// Resolve this entry into a concrete [`MultilingualConfig`].
+    pub fn resolve(self) -> MultilingualConfig {
+        match self {
+            MultilingualConfigEntry::Preset(p) => p.config(),
+            MultilingualConfigEntry::Explicit(c) => *c,
+        }
+    }
+}
+
+/// Custom deserializer for [`MultilingualConfigEntry`].
+///
+/// Accepts either a bare preset name (`"romanized-translated"`, `"romanized-only"`) or a full
+/// `MultilingualConfig` map block. A hand-written visitor is used instead of
+/// `#[serde(untagged)]` because the untagged mechanism wraps inner
+/// deserializers in a content-based buffer that converts externally-tagged
+/// YAML maps (like `{pattern: [...]}`) into serde enum inputs — and those
+/// inputs cannot be re-dispatched through `deserialize_any`, causing a
+/// *"untagged and internally tagged enums do not support enum input"* error
+/// on serialization roundtrips.
+impl<'de> serde::Deserialize<'de> for MultilingualConfigEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct EntryVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for EntryVisitor {
+            type Value = MultilingualConfigEntry;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "a multilingual preset name or an explicit config block")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                let preset =
+                    MultilingualPreset::deserialize(serde::de::value::StrDeserializer::new(v))?;
+                Ok(MultilingualConfigEntry::Preset(preset))
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let config = MultilingualConfig::deserialize(
+                    serde::de::value::MapAccessDeserializer::new(map),
+                )?;
+                Ok(MultilingualConfigEntry::Explicit(Box::new(config)))
+            }
+        }
+
+        deserializer.deserialize_any(EntryVisitor)
     }
 }
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -2338,10 +2338,10 @@
           ]
         },
         "multilingual": {
-          "description": "Multilingual rendering defaults.",
+          "description": "Multilingual rendering defaults. Accepts a preset name (e.g., `\"romanized-translated\"`,\n`\"romanized-only\"`) or an explicit configuration block.",
           "anyOf": [
             {
-              "$ref": "#/$defs/MultilingualConfig"
+              "$ref": "#/$defs/MultilingualConfigEntry"
             },
             {
               "type": "null"
@@ -2973,6 +2973,34 @@
         "per-item"
       ]
     },
+    "MultilingualConfigEntry": {
+      "description": "Entry for `options.multilingual`: either a preset name or an explicit config block.\n\nStyle YAML can use a short preset name:\n```yaml\noptions:\n  multilingual: romanized-translated\n```\nor a full explicit block:\n```yaml\noptions:\n  multilingual:\n    title-mode: combined\n    name-mode: transliterated\n    preferred-script: Latn\n```",
+      "anyOf": [
+        {
+          "description": "A named preset (`\"romanized-translated\"` or `\"romanized-only\"`).",
+          "$ref": "#/$defs/MultilingualPreset"
+        },
+        {
+          "description": "An explicit multilingual configuration block.",
+          "$ref": "#/$defs/MultilingualConfig"
+        }
+      ]
+    },
+    "MultilingualPreset": {
+      "description": "Multilingual rendering policy presets.\n\nEach preset encodes the romanization and translation conventions for a major\ncitation style or style family when rendering references in an English-language\ncontext.  Style YAML authors can write a bare preset name:\n\n```yaml\noptions:\n  multilingual: romanized-translated\n```\n\nand Citum resolves it to the full [`MultilingualConfig`] at load time.\n\nPreset names describe the **rendering behavior**, not a specific style family.\nFor CJK-inclusive 3-way views (e.g. `romanized original [translated]`) use an\nexplicit `pattern:` block instead — that display is something these styles\n*allow*, not something they mandate by default.",
+      "oneOf": [
+        {
+          "description": "Romanize titles and append an English translation in brackets.\n\nTitle pattern: `romanized [translated]` (= `Combined` mode).\nNames: romanized.  Script: `Latn`.\n\nAppropriate for APA, Chicago, MLA, Harvard, Vancouver, AMA, NLM, CSE,\nand most other English-language styles.  All of these styles require\nromanized names and romanized titles; translation is recommended or\nrequired for non-English titles; original-script display is a house\noption that styles *allow* but do not mandate.",
+          "type": "string",
+          "const": "romanized-translated"
+        },
+        {
+          "description": "Romanize titles and names only — no translation appended.\n\nTitle pattern: romanized form only (= `Transliterated` mode).\nNames: romanized.  Script: `Latn`.\n\nAppropriate for IEEE and numeric styles where the translation bracket\nis typically omitted.",
+          "type": "string",
+          "const": "romanized-only"
+        }
+      ]
+    },
     "MultilingualConfig": {
       "description": "Multilingual rendering options.",
       "type": "object",
@@ -3044,9 +3072,82 @@
           "const": "translated"
         },
         {
-          "description": "Combine multiple views (e.g., \"transliterated \\[translated\\]\").\nFor now, this is a placeholder for more complex formatting strings.",
+          "description": "Combine transliteration and translation: `romanized [translated]`.\nEquivalent to `Pattern([transliterated, {translated, brackets}])`.",
           "type": "string",
           "const": "combined"
+        },
+        {
+          "description": "Ordered sequence of views joined by spaces.\n\nUse this when a style requires more than two views — e.g. Chicago's\n`romanized original [translated]` or MLA's `original [translated]`.\nEach segment specifies a view and an optional bracket wrap.\nSegments whose resolved text is empty or identical to the previous\nsegment are silently skipped (dedup).\n\nYAML form:\n```yaml\ntitle-mode:\n  pattern:\n    - view: transliterated\n    - view: original\n    - view: translated\n      wrap: brackets\n```",
+          "type": "object",
+          "properties": {
+            "pattern": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/MultilingualSegment"
+              }
+            }
+          },
+          "required": [
+            "pattern"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "MultilingualSegment": {
+      "description": "A single view segment in a `MultilingualMode::Pattern`.",
+      "type": "object",
+      "properties": {
+        "view": {
+          "description": "Which textual view to render for this segment.",
+          "$ref": "#/$defs/MultilingualView"
+        },
+        "wrap": {
+          "description": "Optional wrapping applied around the resolved text.",
+          "$ref": "#/$defs/SegmentWrap"
+        }
+      },
+      "required": [
+        "view"
+      ]
+    },
+    "MultilingualView": {
+      "description": "Which textual representation of a multilingual field to use in a pattern segment.",
+      "oneOf": [
+        {
+          "description": "The original text as stored in the data.",
+          "type": "string",
+          "const": "original"
+        },
+        {
+          "description": "The transliterated (romanized) form.",
+          "type": "string",
+          "const": "transliterated"
+        },
+        {
+          "description": "The translation matching the style locale.",
+          "type": "string",
+          "const": "translated"
+        }
+      ]
+    },
+    "SegmentWrap": {
+      "description": "Bracket wrapping applied to a pattern segment.",
+      "oneOf": [
+        {
+          "description": "No wrapping.",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Wrap in square brackets: `[text]`.",
+          "type": "string",
+          "const": "brackets"
+        },
+        {
+          "description": "Wrap in parentheses: `(text)`.",
+          "type": "string",
+          "const": "parentheses"
         }
       ]
     },
@@ -4575,10 +4676,10 @@
           ]
         },
         "multilingual": {
-          "description": "Multilingual rendering defaults.",
+          "description": "Multilingual rendering defaults. Accepts a preset name (e.g., `\"romanized-translated\"`,\n`\"romanized-only\"`) or an explicit configuration block.",
           "anyOf": [
             {
-              "$ref": "#/$defs/MultilingualConfig"
+              "$ref": "#/$defs/MultilingualConfigEntry"
             },
             {
               "type": "null"
@@ -5417,10 +5518,10 @@
           ]
         },
         "multilingual": {
-          "description": "Multilingual rendering defaults.",
+          "description": "Multilingual rendering defaults. Accepts a preset name (e.g., `\"romanized-translated\"`,\n`\"romanized-only\"`) or an explicit configuration block.",
           "anyOf": [
             {
-              "$ref": "#/$defs/MultilingualConfig"
+              "$ref": "#/$defs/MultilingualConfigEntry"
             },
             {
               "type": "null"

--- a/docs/specs/MULTILINGUAL.md
+++ b/docs/specs/MULTILINGUAL.md
@@ -165,19 +165,50 @@ Future: `preferred-transliteration` style option will allow explicit method sele
 
 ## 2. Style Configuration
 
-A new global configuration section `multilingual` will be added to the Citum style schema.
+The `multilingual` key under `options` controls romanization and translation policy for
+the style.  It accepts either a **preset name** or an **explicit configuration block**.
+
+### 2.1 Preset names
+
+Preset names describe the **rendering behavior**, not a specific style family.
+They are the preferred way to configure multilingual rendering in embedded styles.
+
+```yaml
+options:
+  multilingual: romanized-translated   # or: romanized-only
+```
+
+| Preset | Title rendering | Name rendering | Typical use |
+|---|---|---|---|
+| `romanized-translated` | `romanized [translated]` (= `combined`) | romanized | APA, Chicago, MLA, Harvard, Vancouver, AMA, NLM, CSE |
+| `romanized-only` | romanized only | romanized | IEEE and numeric styles |
+
+All major English-language styles *require* romanized names and titles and *recommend*
+a translation bracket for non-English titles.  Showing original-script text alongside
+romanization is something these styles *allow* as a house option, not something they
+mandate.  Use an explicit `pattern:` block (§2.3) to opt in to CJK-inclusive rendering.
+
+### 2.2 Explicit configuration
+
+For cases where no preset matches, a full block can be provided:
 
 ```yaml
 options:
   multilingual:
     # Preferred view for titles.
-    # The value is a mode key or a combined pattern such as "transliterated [translated]".
-    # See the style schema for the authoritative grammar.
-    title-mode: "transliterated [translated]"
+    # Simple modes: primary | transliterated | translated | combined
+    title-mode: combined          # combined = "romanized [translated]"
+
+    # For three-way views use the pattern form:
+    # title-mode:
+    #   pattern:
+    #     - view: transliterated
+    #     - view: original
+    #     - view: translated
+    #       wrap: brackets       # none | brackets | parentheses
 
     # Preferred view for names.
-    # See the style schema for the authoritative value set.
-    name-mode: "transliterated"
+    name-mode: transliterated
 
     # Preferred script for transliterations (e.g., "Latn", "Cyrl")
     preferred-script: "Latn"
@@ -188,6 +219,14 @@ options:
         use-native-ordering: true # FamilyGiven for CJK
         delimiter: ""            # No space between Family/Given
 ```
+
+### 2.3 Pattern mode
+
+`Pattern` is an ordered list of view segments joined by spaces.  It is used for styles
+like Chicago (`romanized original [translation]`) or MLA (`original [translation]`) that
+combine more than two views.  Segments whose resolved text is empty or identical to the
+previous segment are silently skipped (dedup), so missing transliterations do not produce
+duplicate text.
 
 ## 3. Processor Logic
 


### PR DESCRIPTION
## Summary

- Add two behavior-first multilingual presets (`romanized-translated`, `romanized-only`) so styles opt into the correct rendering policy with a single YAML key
- Add `MultilingualMode::Pattern` — an ordered segment list enabling explicit CJK-inclusive views (e.g. `romanized original [translation]`) as an opt-in, not a default
- Wire presets into all 14 embedded core styles; migrate `apa-7th.yaml` from an inline block to the preset form
- Custom `Deserialize` impls avoid a `serde_yaml` untagged+enum roundtrip failure when `Pattern` values are serialized and re-parsed

## Style matrix

| Preset | Titles | Names | Typical use |
|---|---|---|---|
| `romanized-translated` | `romanized [translated]` | romanized | APA, Chicago, MLA, Harvard, Vancouver, AMA, NLM, CSE |
| `romanized-only` | romanized only | romanized | IEEE and numeric styles |

3-way CJK display (original + romanized + [translation]) is something these styles *allow* but do not mandate — opt in via an explicit `pattern:` block.

## Test plan

- [ ] `cargo nextest run` — 1493/1493 passing
- [ ] `cargo doc --no-deps -p citum-schema-style` — no broken links (CI gate)
- [ ] Portfolio quality gate — 154 styles, fidelity=1.0, warnings=0
- [ ] 2 new schema unit tests (preset parse+resolve for both preset names)
- [ ] 1 real serialize→deserialize roundtrip test (motivated by the `serde_yaml` bug this PR fixes)
- [ ] 4 Pattern-mode engine unit tests (3-way Chicago, 2-way MLA, dedup, missing segment)
- [ ] 2 end-to-end rendering tests pinned to exact `assert_eq!` output

---

## Revision — review fixes

Changes made to address CI failure, Copilot inline comments, and editorial feedback:

**Preset naming redesign (editorial):** Replaced style-family preset names (`apa`/`mla`/`chicago`/`ieee`) with behavior-first names (`romanized-translated`/`romanized-only`). The old names mixed "which style" with "what the rendering does" and were misleading once `mla`/`chicago` resolved identically to `apa`. Behavior names are self-documenting and don't imply a style mandate where none exists. All 15 style YAMLs updated accordingly.

**CI fix — broken intra-doc link:** `multilingual.rs:148` referenced `` [`MultilingualConfigEntry`] `` which is out of scope; fully qualified to `` [`crate::presets::MultilingualConfigEntry`] ``.

**`assert_eq!` rewrites (Copilot):** Both end-to-end rendering helpers replaced multiple `contains()`/`!contains()` + `find()` position checks (disallowed by `CODING_STANDARDS.md`) with a single `assert_eq!` pinned to the captured actual output. The MLA assertion implicitly proves the romanized form is absent.

**Renamed helpers (Copilot):** `given_chicago_style_multilingual_preset_when_rendering_a_japanese_article_then_title_shows_three_way_form` → `chicago_pattern_renders_three_way_japanese_title`; `given_mla_style_multilingual_preset_when_rendering_a_japanese_article_then_title_shows_original_and_translation` → `mla_pattern_renders_original_and_translation_chinese_title`. Fixes the rustfmt line-break-before-`{` issue and the misleading "japanese" name on the Chinese-data MLA fixture.

**Roundtrip test (Copilot):** `test_multilingual_explicit_block_still_deserializes` had a comment claiming it "round-trips" but only deserialized. Replaced with `test_multilingual_explicit_block_deserializes_and_roundtrips` that does a full `serde_yaml::to_string` → `serde_yaml::from_str` cycle — directly testing the regression the custom `Deserialize` impls protect against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
