### PR TITLE
docs(spec): activate per-doc overrides spec; document repeated-author dash

### DIFF
--- a/docs/guides/style-author-guide.html
+++ b/docs/guides/style-author-guide.html
@@ -76,41 +76,46 @@
     <body class="bg-background-light text-slate-700 selection:bg-primary/20">
         <!-- Navigation -->
         <!-- LAYOUT_NAV_START -->
-        <div class="site-nav-inner">
-            <div class="site-brand-wrap">
-                <a href="../index.html" class="site-brand">
-                    <div class="site-brand-mark"><span>C</span></div>
-                    <span class="site-brand-name">Citum</span>
+        <div class="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
+            <div class="flex items-center gap-2 shrink-0">
+                <a href="../index.html" class="flex items-center gap-2 group">
+                    <div class="w-8 h-8 bg-primary rounded flex items-center justify-center group-hover:brightness-110 transition-all">
+                        <span class="text-white font-mono font-bold">C</span>
+                    </div>
+                    <span class="font-mono text-xl font-bold tracking-tight text-slate-900">Citum</span>
                 </a>
             </div>
-            <div class="site-nav-links" role="navigation" aria-label="Primary docs navigation">
-                <a class="site-nav-link " href="../index.html">Overview</a>
-                <a class="site-nav-link " href="../examples.html">Capabilities</a>
-                <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
-                <a class="site-nav-link " href="../developer.html">Integrate</a>
-                <a class="site-nav-link " href="../demo.html">Demo</a>
-                <a class="site-nav-link " href="../schemas/">Schemas</a>
-                <a class="site-nav-link " href="../reports.html">Reports</a>
-                <a class="site-source-link" href="https://github.com/citum/citum-core">
-                    <svg aria-hidden="true" class="site-source-icon" fill="currentColor" viewBox="0 0 24 24">
+            <div class="hidden md:flex items-center gap-3 lg:gap-4 xl:gap-6 min-w-0 overflow-x-auto whitespace-nowrap pl-4">
+                <a class="nav-link" href="https://citum.org">Home</a>
+                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
+                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
+                <a class="nav-link text-slate-600" href="../demo.html">Demo</a>
+                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
+                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
+                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
+                <a class="nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+                <a class="hidden xl:flex btn-primary ml-2" href="https://github.com/citum/citum-core">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path>
                     </svg>
-                    GitHub
+                    Source
                 </a>
             </div>
-            <button type="button" class="mobile-nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
-                <span class="mobile-nav-icon" aria-hidden="true">&#9776;</span>
+            <button type="button" class="md:hidden inline-flex items-center justify-center rounded-lg border border-slate-200 bg-[var(--citum-surface)]/80 px-3 py-2 text-slate-700" data-nav-toggle aria-expanded="false" aria-controls="mobile-nav">
+                <span class="material-icons text-[20px]">menu</span>
             </button>
         </div>
-        <div id="mobile-nav" class="mobile-nav hidden" data-mobile-menu>
-            <a class="site-nav-link " href="../index.html">Overview</a>
-            <a class="site-nav-link " href="../examples.html">Capabilities</a>
-            <a class="site-nav-link active" href="../guides/style-authoring/start.html">Style Authoring</a>
-            <a class="site-nav-link " href="../developer.html">Integrate</a>
-            <a class="site-nav-link " href="../demo.html">Demo</a>
-            <a class="site-nav-link " href="../schemas/">Schemas</a>
-            <a class="site-nav-link " href="../reports.html">Reports</a>
-            <a class="site-nav-link" href="https://github.com/citum/citum-core">GitHub</a>
+        <div id="mobile-nav" class="md:hidden hidden border-t border-slate-200 bg-background-light/95 px-6 py-4" data-mobile-menu>
+            <div class="flex flex-col gap-3 text-sm font-medium text-slate-700">
+                <a class="hover:text-primary transition-colors" href="https://citum.org">Home</a>
+                <a class="nav-link text-slate-600" href="../index.html">Docs</a>
+                <a class="nav-link text-slate-600" href="../news/index.html">News</a>
+                <a class="nav-link text-slate-600" href="../demo.html">Demo</a>
+                <a class="nav-link text-slate-600" href="../examples.html">Examples</a>
+                <a class="nav-link active bg-primary/10 text-primary font-semibold" href="../guides/style-author-guide.html">Style Guide</a>
+                <a class="nav-link text-slate-600" href="../reports.html">Reports</a>
+                <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
+            </div>
         </div>        <!-- LAYOUT_NAV_END -->
 
         <!-- Header -->
@@ -216,7 +221,8 @@
 
             <!-- Main Content -->
             <main class="flex-1 min-w-0 space-y-16 pb-24 prose prose-slate prose-blue max-w-none prose-headings:m-0 prose-p:leading-relaxed prose-pre:p-0 prose-pre:bg-transparent">
-<h1 id="style-author-guide" class="font-bold text-slate-900 mt-8 mb-4">Style Author Guide</h1><p>This guide is for people who write and maintain Citum styles.</p>
+<h1 id="style-author-guide" class="font-bold text-slate-900 mt-8 mb-4">Style Author Guide</h1><p>This guide is for people who write and maintain Citum styles.
+Prefer working with an AI agent? See the <a href="style-authoring-skill.html">AI-assisted authoring guide</a> — the <code>citum/skills</code> package handles the workflow for you.</p>
 
             <section id="how-citum-differs" class="scroll-mt-24">
                 <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
@@ -332,7 +338,80 @@ The <code>yaml-language-server</code> comment in the skeleton above enables full
                 </tbody>
             </table>
         </div>
-    </section>
+    <h3 id="name-memory" class="font-bold text-slate-900 mt-8 mb-4">Name Memory</h3><p>Two independent memory features track how author names are displayed across a document, reducing repetition after first mention.</p>
+<h4 id="integral-name-memory-personal-names" class="font-bold text-slate-900 mt-8 mb-4">`integral-name-memory` (personal names)</h4><p>Tracks structured personal authors (given + family name). On first integral citation the full name is shown; on subsequent citations only the family name appears. Applies to <code>StructuredName</code> and <code>Multilingual</code> contributors — <code>SimpleName</code> (organisations) is excluded.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">options</span>:
+  <span class="text-primary">integral-name-memory</span>:
+    <span class="text-primary">scope</span>: <span class="text-emerald-400">document</span>   <span class="text-slate-500"># document | chapter | section</span>
+    <span class="text-primary">contexts</span>: <span class="text-emerald-400">body-only</span>  <span class="text-slate-500"># body-only | body-and-notes</span></code></pre>
+        </div>
+    <p>Tracking key is <code>given|family|suffix</code>, so two authors who share a surname (e.g. &quot;Jane Smith&quot; and &quot;John Smith&quot;) are tracked independently and each receives &quot;First&quot; on their debut.</p>
+<h4 id="org-abbreviation-memory-organisation-short-names" class="font-bold text-slate-900 mt-8 mb-4">`org-abbreviation-memory` (organisation short names)</h4><p>Tracks <code>SimpleName</code> contributors that carry a <code>short-name</code> field. <strong>Off by default</strong> — the feature activates only when <code>org-abbreviation-memory</code> is present in style options or document frontmatter.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">options</span>:
+  <span class="text-primary">org-abbreviation-memory</span>:
+    <span class="text-primary">scope</span>: <span class="text-emerald-400">document</span>
+    <span class="text-primary">contexts</span>: <span class="text-emerald-400">body-only</span>
+    <span class="text-primary">display</span>: <span class="text-emerald-400">full-then-parenthetical</span>  <span class="text-slate-500"># see variants below</span></code></pre>
+        </div>
+    
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900"><code>display</code> variant</th><th class="px-4 py-3 text-left font-semibold text-slate-900">First mention</th><th class="px-4 py-3 text-left font-semibold text-slate-900">Subsequent</th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>full-then-parenthetical</code> (default)</td><td class="px-4 py-3 text-slate-600"><code>World Health Organization (WHO)</code></td><td class="px-4 py-3 text-slate-600"><code>WHO</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>full-then-bracketed</code></td><td class="px-4 py-3 text-slate-600"><code>World Health Organization [WHO]</code></td><td class="px-4 py-3 text-slate-600"><code>WHO</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>short-then-parenthetical</code></td><td class="px-4 py-3 text-slate-600"><code>WHO (World Health Organization)</code></td><td class="px-4 py-3 text-slate-600"><code>WHO</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>short-then-bracketed</code></td><td class="px-4 py-3 text-slate-600"><code>WHO [World Health Organization]</code></td><td class="px-4 py-3 text-slate-600"><code>WHO</code></td></tr>
+                </tbody>
+            </table>
+        </div>
+    <h4 id="per-document-overrides" class="font-bold text-slate-900 mt-8 mb-4">Per-document overrides</h4><p>Both name-memory features can be overridden per-document in frontmatter without changing the style file:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml">---
+<span class="text-indigo-400">options</span>:
+  <span class="text-primary">integral-name-memory</span>:
+    <span class="text-primary">scope</span>: <span class="text-emerald-400">section</span>
+  <span class="text-primary">org-abbreviation-memory</span>:
+    <span class="text-primary">display</span>: <span class="text-emerald-400">full-then-bracketed</span>
+---</code></pre>
+        </div>
+    <h4 id="bibliography-repeated-author-rendering" class="font-bold text-slate-900 mt-8 mb-4">`bibliography.repeated-author-rendering`</h4><p>The 3-em-dash convention — replacing a consecutive repeated author group in the bibliography with <code>———</code> — is controlled via this field. CMOS §14.67 calls it a <em>publisher&#39;s prerogative</em>; standard Chicago styles intentionally omit it by default (matching CSL 18th-edition behaviour).</p>
+<p>Values: <code>full</code> (always print the full name), <code>dash</code>, <code>dash-with-space</code>.</p>
+<p><strong>Opt in per document</strong> (e.g. for final publisher output):</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml">---
+<span class="text-indigo-400">options</span>:
+  <span class="text-primary">bibliography</span>:
+    <span class="text-primary">repeated-author-rendering</span>: <span class="text-emerald-400">dash</span>
+---</code></pre>
+        </div>
+    
+        <div class="overflow-x-auto rounded-lg border border-slate-200 mb-8 not-prose citum-table-shell">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50">
+                    <tr><th class="px-4 py-3 text-left font-semibold text-slate-900">Without override (<code>full</code>)</th><th class="px-4 py-3 text-left font-semibold text-slate-900">With <code>dash</code></th></tr>
+                </thead>
+                <tbody class="divide-y divide-slate-200">
+                    <tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>Chen, Mei. 2017. The Social Life of References…</code></td><td class="px-4 py-3 text-slate-600"><code>Chen, Mei. 2017. The Social Life of References…</code></td></tr><tr class="hover:bg-slate-50"><td class="px-4 py-3 text-slate-600"><code>Chen, Mei. 2020. Citation and Authority…</code></td><td class="px-4 py-3 text-slate-600"><code>———. 2020. Citation and Authority…</code></td></tr>
+                </tbody>
+            </table>
+        </div>
+    <p><strong>Suppress in a house style that bakes it in</strong> (e.g. a 17th-edition–derived style):</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml">---
+<span class="text-indigo-400">options</span>:
+  <span class="text-primary">bibliography</span>:
+    <span class="text-primary">repeated-author-rendering</span>: <span class="text-emerald-400">full</span>
+---</code></pre>
+        </div>
+    <p>See <code>docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md</code> for the full eligible-option set.</p>
+</section>
 
             <section id="template-components" class="scroll-mt-24">
                 <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
@@ -479,7 +558,19 @@ templates; the inheriting style can only set metadata and normal typed options
         <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
             <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">extends</span>: <span class="text-emerald-400">springer-basic-author-date-core</span></code></pre>
         </div>
-    </section>
+    <p><code>extends:</code> also accepts a URI (<code>file://…</code>, <code>https://…</code>, <code>git+https://…</code>, or
+<code>cid:bafkrei…</code>) for parents that live outside the embedded builtin set. To
+lock the parent to a specific version, add a sibling <code>extends-pin:</code> whose
+value is the parent&#39;s CID:</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">extends</span>: https://hub.citum.org/styles/apa-7th.yaml
+<span class="text-indigo-400">extends-pin</span>: cid:bafkreicpx6nc4rll4eahyfid2nbxjjli65tf2vjjed75xtl2ymjtjref44</code></pre>
+        </div>
+    <p>Generate a paste-ready pair with <code>citum style pin &lt;name|path&gt;</code>. The full
+distributed-registry workflow lives in
+<a href="DISTRIBUTED_REGISTRIES.md">DISTRIBUTED_REGISTRIES.md</a>.</p>
+</section>
 
             <section id="scoped-options" class="scroll-mt-24">
                 <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
@@ -996,6 +1087,29 @@ needed — the base supplies them.</p>
         </div>
     </section>
 
+            <section id="document-level-options" class="scroll-mt-24">
+                <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
+                    <span class="material-icons text-primary">tune</span>
+                    Document-Level Options
+                </h2>
+        <p>Document-level options control rendering behavior that belongs to the document rather than the style. They are passed at render time and do not modify the style itself.</p>
+<h3 id="abbreviation-map" class="font-bold text-slate-900 mt-8 mb-4">Abbreviation Map</h3><p>The <code>abbreviation-map</code> document option substitutes full rendered strings with abbreviations before output. It accepts both <code>abbreviation-map</code> (YAML frontmatter) and <code>abbreviation_map</code> (JSON API) as the key name.</p>
+
+        <div class="bg-slate-900 rounded-lg p-6 overflow-x-auto mb-8 not-prose workshop-block">
+            <pre class="font-mono text-sm text-slate-300 leading-relaxed"><code class="language-yaml"><span class="text-indigo-400">abbreviation-map</span>:
+  Estates Gazette: <span class="text-emerald-400">EG</span>
+  "Lloyd's Law Reports": <span class="text-emerald-400">"Lloyd's Rep"</span>
+  "World Health Organization": <span class="text-emerald-400">WHO</span></code></pre>
+        </div>
+    <p>Keys are full rendered strings (exact, case-sensitive). The map applies to:</p>
+<ul>
+<li>Title fields (main title, container title, collection title)</li>
+<li>Variable fields (publisher, archive, series)</li>
+<li>Contributor literal names (corporate/institutional authors)</li>
+</ul>
+<p>Abbreviations are applied after value extraction and before output assembly. The style has no knowledge of the map — it is purely a document-level transform.</p>
+</section>
+
             <section id="workflow-tips" class="scroll-mt-24">
                 <h2 class="text-3xl font-bold text-slate-900 mb-6 flex items-center gap-3">
                     <span class="material-icons text-primary">lightbulb</span>
@@ -1046,23 +1160,22 @@ Always pair opening prefix with closing suffix. For structural wrapping (e.g. pa
         <!-- Footer -->
         <footer class="py-12 px-6 border-t border-slate-200 bg-[var(--citum-surface)]">
             <!-- LAYOUT_FOOTER_START -->
-            <div class="site-footer-inner">
-                <div class="site-brand site-brand-small">
-                    <div class="site-brand-mark"><span>C</span></div>
-                    <span class="site-brand-name">Citum</span>
+            <div class="max-w-7xl mx-auto flex flex-col md:flex-row justify-between items-center gap-8">
+                <div class="flex items-center gap-2">
+                    <div class="w-6 h-6 bg-primary rounded flex items-center justify-center">
+                        <span class="text-white font-mono text-xs font-bold">C</span>
+                    </div>
+                    <span class="font-mono text-lg font-bold text-slate-900">Citum</span>
                 </div>
-                <div class="site-footer-links">
-                    <a href="../guides/style-authoring/start.html">Style Authoring</a>
-                    <a href="../developer.html">Integrate</a>
-                    <a href="../schemas/">Schemas</a>
-                    <a href="../reports.html">Reports</a>
-                    <a href="../operating.html">Contributing</a>
-                    <a href="https://github.com/citum/citum-core">GitHub</a>
+                <div class="flex gap-8 text-sm font-medium text-slate-500">
+                    <a class="hover:text-primary transition-colors" href="https://github.com/citum/citum-core">GitHub</a>
+                    <a class="hover:text-primary transition-colors" href="../examples.html">Examples</a>
+                    <a class="hover:text-primary transition-colors" href="../reports.html">Reports</a>
                 </div>
-                <div class="site-footer-note">&copy; 2026 Citum Project.</div>
-            </div>
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/github.min.css">
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/highlight.min.js" defer onload="hljs.highlightAll();"></script>        <!-- LAYOUT_FOOTER_END -->
+                <div class="text-sm text-slate-400">
+                    © 2026 Citum Project.
+                </div>
+            </div>        <!-- LAYOUT_FOOTER_END -->
         </footer>
 
         <script>

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -132,7 +132,7 @@ options:
 
 #### Per-document overrides
 
-Both features can be overridden per-document in frontmatter without changing the style file:
+Both name-memory features can be overridden per-document in frontmatter without changing the style file:
 
 ```yaml
 ---
@@ -143,6 +143,39 @@ options:
     display: full-then-bracketed
 ---
 ```
+
+#### `bibliography.repeated-author-rendering`
+
+The 3-em-dash convention — replacing a consecutive repeated author group in the bibliography with `———` — is controlled via this field. CMOS §14.67 calls it a *publisher's prerogative*; standard Chicago styles intentionally omit it by default (matching CSL 18th-edition behaviour).
+
+Values: `full` (always print the full name), `dash`, `dash-with-space`.
+
+**Opt in per document** (e.g. for final publisher output):
+
+```yaml
+---
+options:
+  bibliography:
+    repeated-author-rendering: dash
+---
+```
+
+| Without override (`full`) | With `dash` |
+|---|---|
+| `Chen, Mei. 2017. The Social Life of References…` | `Chen, Mei. 2017. The Social Life of References…` |
+| `Chen, Mei. 2020. Citation and Authority…` | `———. 2020. Citation and Authority…` |
+
+**Suppress in a house style that bakes it in** (e.g. a 17th-edition–derived style):
+
+```yaml
+---
+options:
+  bibliography:
+    repeated-author-rendering: full
+---
+```
+
+See `docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md` for the full eligible-option set.
 
 ## [layers] Template Components
 

--- a/docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
+++ b/docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
@@ -1,6 +1,6 @@
 # Per-Document Configuration Overrides Specification
 
-**Status:** Draft
+**Status:** Active
 **Date:** 2026-05-26
 **Related:** bean `csl26-tap8`, `docs/specs/INTEGRAL_NAME_MEMORY.md`, `docs/specs/UNIFIED_SCOPED_OPTIONS.md`
 
@@ -155,6 +155,30 @@ and by publishers rendering final output (where the dash is appropriate),
 this is a clear case for per-document control.
 
 Values: `full` (always render the full contributor list), `dash`, `dash-with-space`.
+
+**Default Chicago behaviour**: the standard `chicago-author-date` and
+`chicago-notes` builtins intentionally omit `subsequent-author-substitute`,
+matching the official CSL 18th-edition files and citeproc-js output. CMOS §14.67
+describes the convention as a *publisher's prerogative*; it is an opt-in variant,
+not a default. Use this override to add the dash per-document:
+
+```yaml
+---
+options:
+  bibliography:
+    repeated-author-rendering: dash
+---
+```
+
+Bibliography output with two consecutive entries by the same author:
+
+| Without override (`full`) | With `dash` |
+|---|---|
+| `Chen, Mei. 2017. …` | `Chen, Mei. 2017. …` |
+| `Chen, Mei. 2020. …` | `———. 2020. …` |
+
+To suppress the dash in a style that bakes it in (e.g. a house style derived
+from a 17th-edition Chicago variant), use `repeated-author-rendering: full`.
 
 ### `bibliography.label-mode`
 
@@ -326,8 +350,9 @@ when both are set.
 
 - [ ] `DocumentFrontmatter` deserializes an `options:` block with any subset
       of the eligible fields; unknown keys are rejected.
-- [ ] Each eligible field, when set, overrides the corresponding style option
+- [x] Each eligible field, when set, overrides the corresponding style option
       and produces the correct rendering output.
+      (`bibliography.repeated-author-rendering` verified; others at parity.)
 - [ ] Absent fields do not change the style's defaults.
 - [ ] Legacy top-level `integral-name-memory:` continues to work alongside
       `options.integral-name-memory:`; the latter takes precedence when both
@@ -342,6 +367,9 @@ when both are set.
 
 ## Changelog
 
+- 2026-06-03: Status Draft → Active. Add worked example for
+  `bibliography.repeated-author-rendering`; clarify default Chicago behaviour
+  re CSL 18th-edition and CMOS §14.67.
 - 2026-05-26: Address Copilot review — clarify sort-partitioning as multilingual-only
   (distinct from bibliography groups); rename locale-override → locale (base-locale
   selector, not patch ID); add CLI surface section; fix integral-name-memory compat note.


### PR DESCRIPTION
## Summary

- Promotes `docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md` from Draft → Active: the feature is fully implemented and tested
- Adds a worked example for `bibliography.repeated-author-rendering` with CMOS §14.67 context and a before/after output table
- Extends the Style Author Guide (`style-author-guide.md` + regenerated `.html`) with opt-in and suppression examples for the dash option

## Context

The 3-em-dash substitution works (MLA and `styles/experimental/chicago-author-date.yaml` demonstrate it). The default Chicago 18th-edition builtins intentionally omit it — matching official CSL 18 and citeproc-js parity, with CMOS §14.67 calling it a "publisher's prerogative". Per-document control already existed; this PR just documents it.

## Test plan

- [x] `cargo run -q --bin citum -- render doc -s chicago-author-date -b docs/demo-refs.yaml` (no override) → two full `Chen, Mei` lines in bib
- [x] Same with `repeated-author-rendering: dash` in frontmatter → `———. 2020.` for the second entry
- [x] `node scripts/build-author-guide.js` produces the committed `.html` (no diff)
