### PR TITLE
refactor(engine): clarify delimiter-join loops in render

### DIFF
--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -208,6 +208,12 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
     entry_output
 }
 
+/// Append a rendered component to `entry_output`, inserting spacing or the
+/// `default_separator` according to bibliography house-style punctuation rules.
+///
+/// The separator logic inspects the boundary between the accumulated output
+/// and the incoming `rendered` string; `punctuation_in_quote` controls whether
+/// a period should be pulled inside a preceding closing quotation mark.
 pub(crate) fn append_rendered_component(
     entry_output: &mut String,
     rendered: &str,
@@ -220,13 +226,17 @@ pub(crate) fn append_rendered_component(
         let sep_first_char = default_separator.chars().next().unwrap_or('.');
         let trimmed_last = last_visible_non_space_char(entry_output).unwrap_or(' ');
         let ends_with_punctuation = is_final_punctuation(trimmed_last);
+        // The incoming component already carries its own leading separator (e.g. ", " or "; ").
         let starts_with_separator = matches!(first_char, ',' | ';' | ':' | ' ' | '.' | '(');
 
         if starts_with_separator {
+            // The rendered component is self-delimiting — don't add a separator.
+            // Exception: an opening parenthesis needs a leading space unless already spaced.
             if first_char == '(' && !last_char.is_whitespace() && last_char != '[' {
                 entry_output.push(' ');
             }
         } else if ends_with_punctuation {
+            // Output already ends in terminal punctuation — just ensure a separating space.
             if !last_char.is_whitespace() {
                 entry_output.push(' ');
             }
@@ -234,6 +244,7 @@ pub(crate) fn append_rendered_component(
             && (last_char == '"' || last_char == '\u{201D}')
             && sep_first_char == '.'
         {
+            // Punctuation-in-quote: pull the period inside the closing quotation mark.
             entry_output.pop();
             let quote_str = if last_char == '\u{201D}' {
                 ".\u{201D} "
@@ -242,12 +253,15 @@ pub(crate) fn append_rendered_component(
             };
             entry_output.push_str(quote_str);
         } else if !last_char.is_whitespace() && !first_char.is_whitespace() {
+            // Both sides are non-space — insert the configured separator between them.
             entry_output.push_str(default_separator);
         } else if !last_char.is_whitespace()
             && first_char.is_whitespace()
             && default_separator.starts_with('.')
             && !ends_with_punctuation
         {
+            // The next component leads with whitespace and the separator is period-prefixed:
+            // supply the missing period so the gap doesn't swallow the sentence boundary.
             entry_output.push('.');
         }
     }

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -54,6 +54,49 @@ fn resolve_punctuation_collision(first: char, second: char) -> String {
     }
 }
 
+/// Append `delim` to `content`, applying house-style punctuation rules at the join point.
+///
+/// Three cases are handled in priority order:
+/// 1. **Punctuation-in-quote** – when `punctuation_in_quote` is set and `delim` starts with
+///    a comma, the comma is pulled *inside* a preceding closing quotation mark (`"` or `\u{201D}`)
+///    before appending the rest of the delimiter.
+/// 2. **Punctuation collision** – when the last char of `content` and the first char of `delim`
+///    are both terminal punctuation, the pair is resolved via [`resolve_punctuation_collision`]
+///    (e.g. `".` + `". "` → `". "` rather than `".. "`).
+/// 3. **Default** – append `delim` verbatim.
+#[inline]
+#[allow(
+    clippy::string_slice,
+    reason = "UTF-8 safe slicing based on char boundary checks"
+)]
+fn push_delimiter(content: &mut String, delim: &str, punctuation_in_quote: bool) {
+    let delim_first = delim.chars().next();
+    let content_last = content.chars().last();
+
+    if punctuation_in_quote
+        && delim_first == Some(',')
+        && (content.ends_with('"') || content.ends_with('\u{201D}'))
+    {
+        // Case 1: pull the leading comma inside the closing quotation mark.
+        let is_curly = content.ends_with('\u{201D}');
+        content.pop();
+        content.push(',');
+        content.push(if is_curly { '\u{201D}' } else { '"' });
+        content.push_str(&delim[1..]);
+    } else if let (Some(last), Some(first)) = (content_last, delim_first)
+        && is_terminal_punctuation(last)
+        && is_terminal_punctuation(first)
+    {
+        // Case 2: two adjacent terminal punctuation marks — merge them and skip the duplicate.
+        content.pop();
+        content.push_str(&resolve_punctuation_collision(last, first));
+        content.push_str(&delim[first.len_utf8()..]);
+    } else {
+        // Case 3: no special rule — append the delimiter verbatim.
+        content.push_str(delim);
+    }
+}
+
 /// Render a processed template into a final citation string using `PlainText` format.
 #[must_use]
 pub fn citation_to_string(
@@ -91,34 +134,9 @@ pub fn citation_to_string_with_format<F: OutputFormat<Output = String>>(
         .is_some_and(|cfg| cfg.punctuation_in_quote);
 
     let mut content = String::new();
-    #[allow(
-        clippy::string_slice,
-        reason = "UTF-8 safe slicing based on char boundary checks"
-    )]
     for (i, part) in parts.iter().enumerate() {
         if i > 0 {
-            let delim_first = delim.chars().next();
-            let content_last = content.chars().last();
-
-            if punctuation_in_quote
-                && delim_first == Some(',')
-                && (content.ends_with('"') || content.ends_with('\u{201D}'))
-            {
-                let is_curly = content.ends_with('\u{201D}');
-                content.pop();
-                content.push(',');
-                content.push(if is_curly { '\u{201D}' } else { '"' });
-                content.push_str(&delim[1..]);
-            } else if let (Some(last), Some(first)) = (content_last, delim_first)
-                && is_terminal_punctuation(last)
-                && is_terminal_punctuation(first)
-            {
-                content.pop();
-                content.push_str(&resolve_punctuation_collision(last, first));
-                content.push_str(&delim[first.len_utf8()..]);
-            } else {
-                content.push_str(delim);
-            }
+            push_delimiter(&mut content, delim, punctuation_in_quote);
         }
         content.push_str(part);
     }


### PR DESCRIPTION
## Summary

- Extract the three-branch delimiter-join logic in `citation_to_string_with_format` into a small `#[inline] push_delimiter` helper, with each typographic rule named in a comment (punctuation-in-quote, punctuation collision, verbatim)
- Simplify the loop body to the readable intent: "for each part after the first, push the delimiter, then push the part"
- Add explanatory `//` comments to every arm of the `append_rendered_component` spacing chain in `bibliography.rs`, labeling what each branch encodes

## Zero-cost guarantees

- `push_delimiter` is `#[inline]` and takes `&mut String` / `&str` — no extra allocations or passes
- `clippy::string_slice` allow-attr moved from the loop site to the helper where it is actually used
- Existing `resolve_punctuation_collision` lookup table and `is_terminal_punctuation` predicate untouched

## Test plan

- [x] 758 engine tests pass (`cargo nextest run -p citum-engine`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] APA workflow test (`./scripts/workflow-test.sh styles-legacy/apa.csl`) identical output
