### PR TITLE
feat(schema): citation sentence_start signal

### DIFF
--- a/.beans/archive/csl26-ynra--integral-citation-clusters-terminology-spec-senten.md
+++ b/.beans/archive/csl26-ynra--integral-citation-clusters-terminology-spec-senten.md
@@ -1,0 +1,19 @@
+---
+# csl26-ynra
+title: 'Integral citation clusters: terminology spec + sentence-start signal'
+status: completed
+type: feature
+priority: normal
+created_at: 2026-06-03T21:08:46Z
+updated_at: 2026-06-03T21:55:51Z
+---
+
+Document the citation/CitationItem/CitationMode terminology; add sentence_start bool to Citation for sentence-initial capitalization; wire the CapitalizeFirst transform in the engine; write INTEGRAL_CITATION_CLUSTERS.md spec. Affix-placement configurability is deferred as a future enhancement. Djot auto-detection of sentence position is a separate follow-up.
+
+## Summary of Changes
+
+- Added `sentence_start: bool` to `Citation` (citum-schema-data) and `sentence_start: Option<bool>` to `CitationOccurrence` (api/types.rs) so server/document callers can pass the signal through
+- Engine applies locale-aware `CapitalizeFirst` via `resolve_text_case` + `apply_text_case_markup_aware` when `sentence_start` is set
+- Wrote `docs/specs/INTEGRAL_CITATION_CLUSTERS.md` (Active) — terminology glossary, list-like integral default, affix placement contract, sentence_start design with natbib/biblatex prior art
+- 4 new tests (3 engine BDD + 1 schema round-trip), 1498/1498 passing
+- PR #874 merged with Copilot review integrated; CI green

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -42,6 +42,7 @@ fn main() {
         suffix: None,
         note_number: None,
         grouped: false,
+        sentence_start: false,
         items: vec![CitationItem {
             id: "weinberg1971".to_string(),
             locator: None,

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -661,6 +661,7 @@ mod tests {
             grouped: None,
             prefix: None,
             suffix: None,
+            sentence_start: None,
         };
 
         let request = FormatDocumentRequest {
@@ -710,6 +711,7 @@ mod tests {
             grouped: None,
             prefix: None,
             suffix: None,
+            sentence_start: None,
         };
 
         let request = FormatDocumentRequest {
@@ -764,6 +766,7 @@ mod tests {
             grouped: None,
             prefix: None,
             suffix: None,
+            sentence_start: None,
         };
 
         let request = FormatDocumentRequest {
@@ -845,6 +848,7 @@ mod tests {
             grouped: None,
             prefix: None,
             suffix: None,
+            sentence_start: None,
         };
 
         let request = FormatDocumentRequest {

--- a/crates/citum-engine/src/api/types.rs
+++ b/crates/citum-engine/src/api/types.rs
@@ -151,6 +151,9 @@ pub struct CitationOccurrence {
     /// Optional suffix text after all formatted items.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suffix: Option<String>,
+    /// Signal that this cluster opens a sentence; host supplies this explicitly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sentence_start: Option<bool>,
 }
 
 impl From<CitationOccurrence> for citum_schema::data::citation::Citation {
@@ -162,6 +165,7 @@ impl From<CitationOccurrence> for citum_schema::data::citation::Citation {
             note_number: occ.note_number,
             suppress_author: occ.suppress_author.unwrap_or(false),
             grouped: occ.grouped.unwrap_or(false),
+            sentence_start: occ.sentence_start.unwrap_or(false),
             prefix: occ.prefix,
             suffix: occ.suffix,
             position: None, // Assigned by processor

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -605,7 +605,21 @@ impl Processor {
         let output = self.apply_citation_input_affixes(citation, content, &fmt);
         let wrapped = self.apply_spec_wrap_and_affixes(citation, &effective_spec, output, &fmt);
 
-        Ok(fmt.finish(wrapped))
+        // If the host signals that this cluster opens a sentence, capitalize
+        // the leading character of the composed output.  The markup-aware
+        // variant skips leading punctuation (e.g. an opening parenthesis) so
+        // only the first alphabetic character is affected.
+        let finalized = if citation.sentence_start {
+            let case = crate::values::text_case::resolve_text_case(
+                citum_schema::options::titles::TextCase::CapitalizeFirst,
+                Some(self.locale.locale.as_str()),
+            );
+            crate::values::text_case::apply_text_case_markup_aware(&wrapped, case)
+        } else {
+            wrapped
+        };
+
+        Ok(fmt.finish(finalized))
     }
 
     /// Render multiple citations in document order.

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -2460,3 +2460,103 @@ citation:
         ]
     );
 }
+
+// --- sentence_start capitalization ---
+
+#[test]
+fn test_sentence_start_capitalizes_lowercase_prefix() {
+    // Given: an integral citation with a lowercase prefix and sentence_start true
+    let style = build_author_date_style(false, false, false, None, None);
+    let bib = citum_schema::bib_map![
+        "smith2020" => make_book("smith2020", "Smith", "John", 2020, "A Book"),
+    ];
+    let processor = Processor::new(style, bib);
+
+    let citation = Citation {
+        mode: CitationMode::Integral,
+        prefix: Some("see also".to_string()),
+        sentence_start: true,
+        items: vec![CitationItem {
+            id: "smith2020".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // When: rendered
+    let result = processor.process_citation(&citation).expect("render");
+
+    // Then: leading "s" of "see also" is capitalized
+    assert!(
+        result.starts_with("See also"),
+        "expected 'See also …' but got: {result}"
+    );
+}
+
+#[test]
+fn test_sentence_start_noop_on_capitalized_author() {
+    // Given: an integral citation with no prefix (author leads) and sentence_start true
+    let style = build_author_date_style(false, false, false, None, None);
+    let bib = citum_schema::bib_map![
+        "smith2020" => make_book("smith2020", "Smith", "John", 2020, "A Book"),
+    ];
+    let processor = Processor::new(style, bib);
+
+    let citation = Citation {
+        mode: CitationMode::Integral,
+        sentence_start: true,
+        items: vec![CitationItem {
+            id: "smith2020".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let without_flag = Citation {
+        sentence_start: false,
+        ..citation.clone()
+    };
+
+    // When: rendered with and without the flag
+    let with_result = processor
+        .process_citation(&citation)
+        .expect("render with flag");
+    let without_result = processor
+        .process_citation(&without_flag)
+        .expect("render without flag");
+
+    // Then: output is identical (author "Smith" already starts with a capital)
+    assert_eq!(
+        with_result, without_result,
+        "sentence_start should be a no-op when the cluster already starts with a capital"
+    );
+}
+
+#[test]
+fn test_sentence_start_false_leaves_output_unchanged() {
+    // Given: a citation with a lowercase prefix and sentence_start false (default)
+    let style = build_author_date_style(false, false, false, None, None);
+    let bib = citum_schema::bib_map![
+        "smith2020" => make_book("smith2020", "Smith", "John", 2020, "A Book"),
+    ];
+    let processor = Processor::new(style, bib);
+
+    let citation = Citation {
+        mode: CitationMode::Integral,
+        prefix: Some("see also".to_string()),
+        sentence_start: false,
+        items: vec![CitationItem {
+            id: "smith2020".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // When: rendered
+    let result = processor.process_citation(&citation).expect("render");
+
+    // Then: "see also" remains lowercase
+    assert!(
+        result.starts_with("see also"),
+        "expected 'see also …' (lowercase) but got: {result}"
+    );
+}

--- a/crates/citum-schema-data/src/citation.rs
+++ b/crates/citum-schema-data/src/citation.rs
@@ -112,6 +112,16 @@ pub struct Citation {
     /// Item order is preserved and sorting is suppressed when this flag is set.
     #[serde(default, skip_serializing_if = "is_false")]
     pub grouped: bool,
+    /// Signal that this citation cluster opens a sentence, so its leading
+    /// character should be capitalized (e.g. "see also …" → "See also …").
+    ///
+    /// The processor cannot infer sentence context from rendered text; the host
+    /// (document pipeline, WASM bridge, or editor) supplies this flag
+    /// explicitly — mirroring LaTeX's capitalized cite commands (`\Citet`,
+    /// `\Parencite`, `\Textcite`). When `false` (the default), no
+    /// capitalization transform is applied.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub sentence_start: bool,
 }
 
 impl Citation {

--- a/crates/citum-schema/tests/json_deserialization.rs
+++ b/crates/citum-schema/tests/json_deserialization.rs
@@ -16,7 +16,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
     reason = "Panicking is acceptable and often desired in test, benchmark, and example code."
 )]
 
-use citum_schema::citation::{CitationItem, IntegralNameState};
+use citum_schema::citation::{Citation, CitationItem, IntegralNameState};
 use citum_schema::options::{IntegralNameContexts, IntegralNameScope};
 use citum_schema::reference::{ClassExtension, InputReference, Monograph, NumberingType};
 use citum_schema::{InputBibliography, Style};
@@ -204,6 +204,39 @@ fn test_citation_item_integral_name_state_round_trip() {
     assert_eq!(
         reparsed.integral_name_state,
         Some(IntegralNameState::Subsequent)
+    );
+}
+
+#[test]
+fn test_citation_sentence_start_round_trip() {
+    // Given: a citation JSON with sentence-start set
+    let json = r#"{
+        "items": [{"id": "smith2020"}],
+        "sentence-start": true
+    }"#;
+
+    // When: deserialized
+    let citation: Citation = serde_json::from_str(json).expect("citation should parse");
+
+    // Then: sentence_start is true
+    assert!(citation.sentence_start);
+
+    // And: round-trips cleanly
+    let serialized = serde_json::to_string(&citation).expect("citation should serialize");
+    let reparsed: Citation = serde_json::from_str(&serialized).expect("citation should round-trip");
+    assert!(reparsed.sentence_start);
+
+    // Given: sentence-start omitted (default false)
+    let json_default = r#"{"items": [{"id": "smith2020"}]}"#;
+    let default_citation: Citation =
+        serde_json::from_str(json_default).expect("default citation should parse");
+    // Then: sentence_start is false and field is absent from serialization
+    assert!(!default_citation.sentence_start);
+    let serialized_default =
+        serde_json::to_string(&default_citation).expect("default citation should serialize");
+    assert!(
+        !serialized_default.contains("sentence-start"),
+        "sentence-start should be omitted when false"
     );
 }
 

--- a/docs/schemas/citation.json
+++ b/docs/schemas/citation.json
@@ -69,6 +69,10 @@
         "grouped": {
           "description": "If true, the entire citation is a single dynamic compound set.\n\nThe first item acts as the head and subsequent items are merged as tails\nin the bibliography. Ignored for non-numeric (compound-numeric) styles.\nItem order is preserved and sorting is suppressed when this flag is set.",
           "type": "boolean"
+        },
+        "sentence-start": {
+          "description": "Signal that this citation cluster opens a sentence, so its leading\ncharacter should be capitalized (e.g. \"see also …\" → \"See also …\").\n\nThe processor cannot infer sentence context from rendered text; the host\n(document pipeline, WASM bridge, or editor) supplies this flag\nexplicitly — mirroring LaTeX's capitalized cite commands (`\\Citet`,\n`\\Parencite`, `\\Textcite`). When `false` (the default), no\ncapitalization transform is applied.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/docs/specs/INTEGRAL_CITATION_CLUSTERS.md
+++ b/docs/specs/INTEGRAL_CITATION_CLUSTERS.md
@@ -1,0 +1,163 @@
+# Integral Citation Clusters Specification
+
+**Status:** Active
+**Version:** 1.0
+**Date:** 2026-06-03
+**Related:** `crates/citum-schema-data/src/citation.rs`,
+`crates/citum-engine/src/processor/citation.rs`,
+`docs/specs/INTEGRAL_NAME_MEMORY.md`,
+`docs/specs/REPEATED_NOTE_CITATION_STATE_MODEL.md`
+
+---
+
+## Purpose
+
+Define the authoritative vocabulary for the in-text citation model, document
+the default rendering behavior for multi-work narrative citations, specify the
+`sentence_start` signal for sentence-initial capitalization, and record future
+extension points.
+
+---
+
+## Terminology and Glossary
+
+| Concept | Citum name | Serialized form | Notes |
+|---|---|---|---|
+| One in-text citation event | **citation cluster** | `Citation` (struct) | A single call-out in the text; may cite one or more works |
+| One reference within a cluster | **cite** / **citation item** | `CitationItem` (struct) | Carries the citekey, locator, item-level prefix/suffix |
+| Narrative / in-text form | **integral** | `"mode": "integral"` | Author rendered inline; e.g. "Smith (2020) argues…" |
+| Parenthetical form | **non-integral** | `"mode": "non-integral"` (default) | Author inside parens; e.g. "(Smith, 2020)" |
+
+### Key invariant: mode is cluster-scoped
+
+`CitationMode` (`Integral` / `NonIntegral`) is a property of the **cluster**,
+not of individual citation items. A mixed-mode cluster — some items narrative,
+others parenthetical — is typographically incoherent and is not supported.
+`Citation.mode` applies uniformly to all items in `Citation.items`. The same
+invariant applies to `suppress_author`: per-item suppression is not supported.
+
+---
+
+## Multi-Work Narrative Clusters (default behavior)
+
+When a cluster cites multiple works in integral/narrative mode, the default
+rendering is **list-like prose**:
+
+> Smith (2020) and Jones (2021) both argue…
+
+> Smith (2020), Jones (2021), and Brown (2022) all contend…
+
+The join is locale-aware (conjunction term, optional serial comma) and is
+handled by `join_integral_groups` in
+`crates/citum-engine/src/processor/citation.rs`.
+
+### Non-goal: cluster-like (semicolon) narrative form
+
+A style might conceptually want to preserve semicolons in a narrative cluster:
+
+> Smith (2020); Jones (2021) both argue…
+
+This form is **not currently supported** and is not on the roadmap. If a
+concrete style requirement arises, it can be implemented as an opt-in under
+`citation.integral.multi-cite-form: cluster` (list-like remains the default)
+using the existing `multi-cite-delimiter` override as an internal escape hatch.
+Until a real request exists, that escape hatch is intentionally undocumented.
+
+---
+
+## Cluster-Level Affixes ("see also", prefixes)
+
+Cluster-level affixes are placed by **conventional position relative to the
+citation wrap**:
+
+| Mode | Affix placement | Example |
+|---|---|---|
+| Non-integral (parenthetical) | **Inside** the parentheses | `(see also Smith 2020)` |
+| Integral (narrative) | **Outside** / part of prose | `see also Smith (2020)` |
+
+This is the current implemented behavior (`apply_citation_input_affixes` +
+`apply_spec_wrap_and_affixes` in `citation.rs`) and is the documented contract.
+
+### Future enhancement: configurable affix placement
+
+Some styles may want to override the convention (e.g. keep affixes inside
+parentheses even for narrative clusters). This can be added as
+`citation.affix-placement: inside | outside` (defaulting to the conventional
+behavior) if users request it. This is **not currently implemented**.
+
+---
+
+## Sentence-Initial Capitalization (`sentence_start`)
+
+### The problem
+
+When an integral cluster begins a sentence and the cluster starts with a
+lowercase affix, the leading character must be capitalized:
+
+```
+# With prefix "see also" (lowercase)
+    integral, mid-sentence:    see also Smith (2020) argues …
+    integral, sentence-start:  See also Smith (2020) argues …
+```
+
+The standalone processor cannot detect sentence position from rendered text. An
+author-led cluster (e.g. "Smith (2020)") is already capitalized by virtue of
+the author's name, so this only matters when a lowercase element leads.
+
+### Prior art: natbib / biblatex capitalized commands
+
+LaTeX resolves the same ambiguity by requiring the author to choose a command
+variant at the call site:
+
+| System | Lowercase | Capitalized |
+|---|---|---|
+| natbib | `\citet{key}` | `\Citet{key}` |
+| biblatex | `\parencite{key}` | `\Parencite{key}` |
+| biblatex | `\textcite{key}` | `\Textcite{key}` |
+| biblatex | `\citeauthor{key}` | `\Citeauthor{key}` |
+
+The capital variant signals to the formatter that the citation opens a sentence
+and any lowercase prefix (or name particle such as "von" / "van der") should be
+capitalized. Citum adopts the same explicit-signal model: the *host* supplies
+the flag; the *processor* applies the transform.
+
+### `Citation.sentence_start`
+
+```rust
+pub sentence_start: bool,  // default false
+```
+
+When `true`, the engine applies `CapitalizeFirst` to the **first alphabetic
+character** of the fully-composed cluster output (after affixes and wrap).
+The markup-aware variant is used, so leading punctuation (e.g. an opening
+parenthesis), HTML tags, and LaTeX/Typst command prefixes are skipped rather
+than corrupted:
+
+```
+"(see also Smith 2020)"   →  "(See also Smith 2020)"
+"see also Smith (2020)"   →  "See also Smith (2020)"
+"Smith (2020)"            →  "Smith (2020)"   (no-op: already capital)
+```
+
+The transform is applied regardless of citation mode and is a no-op when the
+composed output already starts with a capital letter.
+
+### Who sets the flag?
+
+The flag is **caller-supplied**, not auto-detected:
+
+- **Document pipeline / `format_document`**: the Djot/Markdown document
+  processor can inspect surrounding text to auto-populate the flag. This is a
+  **deferred follow-up** (see below).
+- **WASM bridge / hub editor**: the editor knows cursor position and can set
+  `sentence_start` when inserting a citation after a sentence boundary.
+- **FFI callers**: pass `sentence_start: true` when the citation is known to
+  begin a sentence.
+- **Standalone `process_citation` API**: default `false`; callers that know
+  the context set it explicitly.
+
+### Deferred: auto-detection in the document pipeline
+
+Automatic detection of sentence boundaries in `format_document` (Djot/Markdown)
+is a follow-up task. Until implemented, the flag must be set explicitly by the
+host. This matches natbib/biblatex behavior: the author chooses the form.


### PR DESCRIPTION
## Summary

- Adds `sentence_start: bool` to `Citation` (default `false`, wire-stable — existing documents unchanged)
- When `true`, applies `CapitalizeFirst` to the composed cluster output after affixes and wrap; markup-aware variant skips leading punctuation like `(` so it is not corrupted
- Mirrors LaTeX natbib/biblatex capitalized cite commands (`\Citet`, `\Parencite`, `\Textcite`): the host knows sentence context; the processor cannot infer it from rendered text
- Adds `docs/specs/INTEGRAL_CITATION_CLUSTERS.md`: authoritative terminology glossary (Citation cluster / CitationItem / CitationMode), list-like integral multi-cite default, affix placement contract (future enhancement note), and `sentence_start` design rationale with natbib/biblatex prior art
- Regenerates `docs/schemas/citation.json`

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues
- [x] `cargo nextest run` — 1498/1498 passed (4 new tests: 3 engine BDD + 1 schema round-trip)
- [x] Schema regenerated and staged
- [x] CI green
- [x] Copilot review integrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
