### PR TITLE
feat(engine): per-document style overrides

### DIFF
--- a/.beans/archive/csl26-cq35--interactive-api-per-document-style-overrides.md
+++ b/.beans/archive/csl26-cq35--interactive-api-per-document-style-overrides.md
@@ -1,0 +1,35 @@
+---
+# csl26-cq35
+title: 'Interactive API: per-document style overrides'
+status: completed
+type: feature
+priority: normal
+created_at: 2026-06-04T14:21:32Z
+updated_at: 2026-06-04T18:23:49Z
+---
+
+The interactive server API (`format_document` + session `open_session`) accepts a `StyleInput` union (`id`/`uri`/`path`/`yaml`) but has no mechanism to merge a partial per-document override over a base style.
+
+Word-processor hosts (citum-office) need per-document overrides: e.g. APA base style but `author_connector: &` for one document only, without editing the shared style.
+
+## Scope
+
+- Add a per-document override input to `FormatDocumentRequest` and `open_session` (e.g. `style_overrides`: partial style YAML/JSON merged over the resolved base style).
+- Apply the merge after style resolution, before processing; scope to the request/session only.
+- Define which fields are overrideable (connectors, et-al thresholds, particle handling, etc.).
+- Tests: base style + override changes rendered output for that request only; base style untouched.
+
+## Origin
+
+Required by citum-office P2 "Document Overrides" dialog. Tracked gap in
+citum-office docs/specs/01-cdip-protocol.md § Known Engine Gaps.
+
+## Summary of Changes
+
+- Added `Style::apply_overlay` public method in `citum-schema-style` — thin wrapper over the existing `merge_style_overlay` (used by `extends` inheritance), making overlay merge available to surface crates.
+- Added `apply_style_overrides(style, overlay_src)` helper and `style_overrides: Option<String>` field to `FormatDocumentRequest` in `citum-engine`. The override is applied in `format_document_with_style` (the single choke point), covering all three entry points (`format_document`, `format_document_with_resolver`, `format_document_with_style`).
+- Wired `style_overrides` into `citum-server` `OpenSessionParams` and the `open_session` handler (pre-merge before `DocumentSession::new`). Also added to schema-mirror `FormatDocumentParams`.
+- `format_document` server path flows through automatically (deserializes `FormatDocumentRequest` directly).
+- Tests: 3 engine unit tests (`apply_style_overrides_merges_option_field`, `style_overrides_invalid_yaml_returns_parse_error`, `style_overrides_and_symbol_changes_rendered_output`), 1 session test (`session_style_override_produces_divergent_output`), 2 server RPC tests (`format_document_style_overrides_changes_and_connector`, `open_session_style_overrides_changes_and_connector`).
+- Spec at `docs/specs/INTERACTIVE_STYLE_OVERRIDES.md`.
+- Schemas regenerated.

--- a/.beans/csl26-cpb7--interactive-api-nocite-bibliography-only-entries.md
+++ b/.beans/csl26-cpb7--interactive-api-nocite-bibliography-only-entries.md
@@ -1,0 +1,25 @@
+---
+# csl26-cpb7
+title: 'Interactive API: nocite (bibliography-only entries)'
+status: todo
+type: feature
+priority: normal
+created_at: 2026-06-04T14:21:41Z
+updated_at: 2026-06-04T14:21:41Z
+---
+
+The interactive server API (`format_document` + session methods) has no `nocite` parameter. Hosts cannot include a reference in the bibliography without creating an in-text citation.
+
+Word-processor hosts (citum-office) need no-cite / bibliography-only entries: the user adds a work to the reference list (e.g. "further reading") without citing it in text. This is standard citeproc/Pandoc `nocite` behaviour.
+
+## Scope
+
+- Add an optional `nocite: [ref_id, ...]` field to `FormatDocumentRequest` and to the session API (e.g. a `set_nocite` method or a field on `put_references`).
+- Included refs appear in the bibliography output but produce no `formatted_citations` entry.
+- Interaction with bibliography sort/grouping: nocite entries sort alongside cited entries.
+- Tests: a ref present only in `nocite` appears in `bibliography.entries` but not in `formatted_citations`.
+
+## Origin
+
+Required by citum-office P2 no-cite UX. Tracked gap in
+citum-office docs/specs/01-cdip-protocol.md § Known Engine Gaps.

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -37,6 +37,16 @@ use super::{
 pub struct FormatDocumentRequest {
     /// The style to use (may be resolved locally or by an adapter).
     pub style: StyleInput,
+    /// Optional partial-style overlay (YAML or JSON) merged over the resolved base
+    /// style for this request only.
+    ///
+    /// Accepts any subset of the style YAML schema — e.g. just `options.contributors`
+    /// to change `and`/et-al behaviour, or a full citation spec. Uses the same
+    /// null-aware, typed-merge semantics as `extends` inheritance: supplied fields
+    /// win over base style fields; an explicit `~` (null) value clears an inherited
+    /// field. The base style is never mutated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style_overrides: Option<String>,
     /// Optional locale override as a BCP 47 language tag (e.g. `en-US`).
     /// When omitted or set to en-US the engine uses its built-in en-US locale;
     /// other locales emit a warning and fall back to en-US until adapter-side
@@ -106,6 +116,31 @@ impl From<ProcessorError> for FormatDocumentError {
     }
 }
 
+/// Parse a partial-style overlay (YAML or JSON) and merge it over `style` in place.
+///
+/// Called internally by `format_document_with_style`; also available to surface crates
+/// (e.g. `citum-server`) that pre-resolve the style before handing it to the processor.
+///
+/// Uses the same null-aware, typed-merge semantics as `extends` inheritance.
+/// Calls `apply_scoped_options` after the merge so that overlay fields that affect
+/// scoped options (label_wrap, date_position, repeated_author_rendering, etc.) take
+/// effect in the same way they do during normal style resolution.
+///
+/// # Errors
+///
+/// Returns `FormatDocumentError::StyleParse` if the overlay cannot be parsed.
+pub fn apply_style_overrides(
+    style: &mut Style,
+    overlay_src: &str,
+) -> Result<(), FormatDocumentError> {
+    let overlay = Style::from_yaml_bytes(overlay_src.as_bytes()).map_err(|e| {
+        FormatDocumentError::StyleParse(format!("Failed to parse style_overrides: {e}"))
+    })?;
+    style.apply_overlay(&overlay);
+    style.apply_scoped_options();
+    Ok(())
+}
+
 /// Format a complete document's citations and bibliography (convenience wrapper).
 ///
 /// This function resolves the style locally using `StyleInput::resolve_local`.
@@ -169,6 +204,12 @@ pub fn format_document_with_style(
     request: FormatDocumentRequest,
 ) -> Result<FormatDocumentResult, FormatDocumentError> {
     let mut warnings = Vec::new();
+
+    // Apply per-request style overrides (merge over the resolved base style).
+    let mut style = style;
+    if let Some(src) = &request.style_overrides {
+        apply_style_overrides(&mut style, src)?;
+    }
 
     // Locale: the engine has no resolver chain for non-en-US locales.
     // Adapters with a citum_store dep can pre-resolve and call
@@ -570,6 +611,7 @@ mod tests {
         TemplateComponent, TemplateContributor, TemplateDate, TemplateDateVariable,
         WrapPunctuation,
     };
+    use citum_schema::options::{AndOptions, ContributorConfig};
     use citum_schema::reference::{EdtfString, InputReference, Monograph, MonographType, Title};
     use citum_schema::{CitationSpec, StyleInfo};
 
@@ -627,6 +669,7 @@ mod tests {
         let refs = make_test_bibliography();
         let request = FormatDocumentRequest {
             style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
             locale: None,
             output_format: OutputFormatKind::Plain,
             refs,
@@ -666,6 +709,7 @@ mod tests {
 
         let request = FormatDocumentRequest {
             style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
             locale: None,
             output_format: OutputFormatKind::Plain,
             refs,
@@ -716,6 +760,7 @@ mod tests {
 
         let request = FormatDocumentRequest {
             style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
             locale: None,
             output_format: OutputFormatKind::Plain,
             refs: RefsInput::Json(serde_json::to_value(refs).unwrap()),
@@ -771,6 +816,7 @@ mod tests {
 
         let request = FormatDocumentRequest {
             style: StyleInput::Yaml(yaml_style),
+            style_overrides: None,
             locale: None,
             output_format: OutputFormatKind::Plain,
             refs: RefsInput::Json(serde_json::to_value(refs).unwrap()),
@@ -789,6 +835,7 @@ mod tests {
     fn format_document_uri_input_unresolved() {
         let request = FormatDocumentRequest {
             style: StyleInput::Uri("https://example.com/style.yaml".to_string()),
+            style_overrides: None,
             locale: None,
             output_format: OutputFormatKind::Plain,
             refs: RefsInput::Json(serde_json::Value::Object(Default::default())),
@@ -853,6 +900,7 @@ mod tests {
 
         let request = FormatDocumentRequest {
             style: StyleInput::Id("any-id".to_string()),
+            style_overrides: None,
             locale: None,
             output_format: OutputFormatKind::Plain,
             refs,
@@ -874,6 +922,189 @@ mod tests {
         assert!(
             !res.formatted_citations[0].text.is_empty(),
             "formatted citation text should not be empty"
+        );
+    }
+
+    /// Build an author-date style whose citation template renders contributor short form.
+    fn make_two_author_style() -> Style {
+        Style {
+            info: StyleInfo {
+                title: Some("Override Test Style".to_string()),
+                id: Some("override-test".into()),
+                ..Default::default()
+            },
+            options: Some(Config {
+                processing: Some(Processing::AuthorDate),
+                // Explicitly set `and: text` so the override to `symbol` is observable
+                // in rendered output without relying on any default connector.
+                contributors: Some(ContributorConfig {
+                    and: Some(AndOptions::Text),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            citation: Some(CitationSpec {
+                template: Some(vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author,
+                        form: ContributorForm::Short,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: TemplateDateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some(", ".to_string()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]),
+                wrap: Some(WrapPunctuation::Parentheses.into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// Build a refs input with a two-author book so the "and" connector is exercised.
+    ///
+    /// Uses inline YAML (the reliably tested deserialization path) rather than
+    /// round-tripping through `serde_json::to_value` which may not preserve the
+    /// contributor tagged-enum layout the engine expects.
+    fn make_two_author_refs() -> RefsInput {
+        RefsInput::Yaml(
+            r#"duo2024:
+  class: monograph
+  id: duo2024
+  type: book
+  title: Duo Work
+  issued: "2024"
+  author:
+    - family: Smith
+      given: Alice
+    - family: Jones
+      given: Bob
+"#
+            .to_string(),
+        )
+    }
+
+    /// Helper: produce a single-item citation occurrence for a given ref id.
+    fn cite(ref_id: &str) -> CitationOccurrence {
+        CitationOccurrence {
+            id: "c1".to_string(),
+            items: vec![CitationOccurrenceItem {
+                id: ref_id.to_string(),
+                locator: None,
+                prefix: None,
+                suffix: None,
+                integral_name_state: None,
+                org_abbreviation_state: None,
+            }],
+            mode: None,
+            note_number: None,
+            suppress_author: None,
+            grouped: None,
+            prefix: None,
+            suffix: None,
+            sentence_start: None,
+        }
+    }
+
+    #[test]
+    fn style_overrides_and_symbol_changes_rendered_output() {
+        let base_style = make_two_author_style();
+        let refs = make_two_author_refs();
+
+        // given: base style produces a citation containing "and"
+        let request_base = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs: refs.clone(),
+            citations: vec![cite("duo2024")],
+            document_options: None,
+        };
+        let result_base = format_document_with_style(base_style.clone(), request_base).unwrap();
+        let text_base = &result_base.formatted_citations[0].text;
+        assert!(
+            text_base.contains("and"),
+            "base style should use text 'and' connector, got: {text_base:?}"
+        );
+
+        // when: style_overrides switches connector to symbol "&"
+        let request_override = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: Some("options:\n  contributors:\n    and: symbol\n".to_string()),
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![cite("duo2024")],
+            document_options: None,
+        };
+        let result_override =
+            format_document_with_style(base_style.clone(), request_override).unwrap();
+        let text_override = &result_override.formatted_citations[0].text;
+        assert!(
+            text_override.contains('&'),
+            "overridden style should use '&' connector, got: {text_override:?}"
+        );
+
+        // then: base style struct is untouched — still has Text, not Symbol
+        let base_and = base_style
+            .options
+            .as_ref()
+            .and_then(|o| o.contributors.as_ref())
+            .and_then(|c| c.and.as_ref());
+        assert!(
+            matches!(base_and, Some(&AndOptions::Text)),
+            "base style must not be mutated; expected And::Text, got: {base_and:?}"
+        );
+    }
+
+    #[test]
+    fn style_overrides_invalid_yaml_returns_parse_error() {
+        let style = make_test_style();
+        let refs = make_test_bibliography();
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: Some("{ unclosed yaml: [".to_string()),
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![],
+            document_options: None,
+        };
+
+        match format_document_with_style(style, request) {
+            Err(FormatDocumentError::StyleParse(msg)) => {
+                assert!(
+                    msg.contains("style_overrides"),
+                    "error message should mention style_overrides, got: {msg}"
+                );
+            }
+            other => panic!("expected StyleParse error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_style_overrides_merges_option_field() {
+        let mut style = make_test_style();
+        apply_style_overrides(&mut style, "options:\n  contributors:\n    and: symbol\n")
+            .expect("apply_style_overrides should succeed");
+
+        let and_option = style
+            .options
+            .as_ref()
+            .and_then(|o| o.contributors.as_ref())
+            .and_then(|c| c.and.as_ref());
+        assert!(
+            matches!(and_option, Some(&AndOptions::Symbol)),
+            "expected And::Symbol after override, got: {and_option:?}"
         );
     }
 }

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -17,9 +17,9 @@ mod style_input;
 mod types;
 
 pub use document::{
-    FormatDocumentError, FormatDocumentRequest, FormatDocumentResult, format_document,
-    format_document_with_resolver, format_document_with_style, unknown_enum_warnings,
-    unknown_reference_class_warnings,
+    FormatDocumentError, FormatDocumentRequest, FormatDocumentResult, apply_style_overrides,
+    format_document, format_document_with_resolver, format_document_with_style,
+    unknown_enum_warnings, unknown_reference_class_warnings,
 };
 pub use forward_compat::{UnknownFieldPath, collect_unknown_field_paths};
 pub use refs_input::RefsInput;

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -834,4 +834,89 @@ mod tests {
         assert_eq!(session.version(), before_version);
         assert_eq!(session.get_citations().len(), before_citations.len());
     }
+
+    /// Two sessions opened from the same base style but with different overrides
+    /// must produce divergent output for the same two-author citation.
+    #[test]
+    fn session_style_override_produces_divergent_output() {
+        use crate::api::apply_style_overrides;
+        use citum_schema::options::{AndOptions, ContributorConfig};
+
+        // base style with explicit `and: text`
+        let mut base_style = style();
+        assert!(
+            base_style.options.is_some(),
+            "style() must return options: Some(...) for this test's contributor setup to take effect"
+        );
+        if let Some(opts) = base_style.options.as_mut() {
+            opts.contributors = Some(ContributorConfig {
+                and: Some(AndOptions::Text),
+                ..Default::default()
+            });
+        }
+
+        // two-author reference via inline YAML
+        let two_author_refs = RefsInput::Yaml(
+            r#"duo2024:
+  class: monograph
+  id: duo2024
+  type: book
+  title: Duo Work
+  issued: "2024"
+  author:
+    - family: Smith
+      given: Alice
+    - family: Jones
+      given: Bob
+"#
+            .to_string(),
+        );
+
+        // session 1: no override — uses "and" text
+        let mut session_base = DocumentSession::new(
+            base_style.clone(),
+            StyleInput::Yaml(String::new()),
+            None,
+            OutputFormatKind::Plain,
+            None,
+        );
+        session_base.put_references(two_author_refs.clone());
+        let result_base = session_base
+            .insert_citations_batch(vec![citation("c1", "duo2024")])
+            .expect("base session should render");
+        let text_base = result_base.affected_citations[0].text.clone();
+
+        // session 2: override switches to "&" symbol
+        let mut style_overridden = base_style.clone();
+        apply_style_overrides(
+            &mut style_overridden,
+            "options:\n  contributors:\n    and: symbol\n",
+        )
+        .expect("override should parse");
+        let mut session_override = DocumentSession::new(
+            style_overridden,
+            StyleInput::Yaml(String::new()),
+            None,
+            OutputFormatKind::Plain,
+            None,
+        );
+        session_override.put_references(two_author_refs);
+        let result_override = session_override
+            .insert_citations_batch(vec![citation("c1", "duo2024")])
+            .expect("override session should render");
+        let text_override = result_override.affected_citations[0].text.clone();
+
+        assert!(
+            text_base.contains("and"),
+            "base session should use text 'and', got: {text_base:?}"
+        );
+        assert!(
+            text_override.contains('&'),
+            "override session should use '&', got: {text_override:?}"
+        );
+        assert_ne!(
+            text_base, text_override,
+            "sessions with different overrides should produce different output"
+        );
+    }
 }

--- a/crates/citum-engine/src/api/style_input.rs
+++ b/crates/citum-engine/src/api/style_input.rs
@@ -107,7 +107,7 @@ info:
         let result = input.resolve_local();
         match result {
             Err(crate::api::FormatDocumentError::UnresolvedInput(msg)) => {
-                assert!(msg.contains("apa-7th"));
+                assert!(msg.contains("Style ID 'apa-7th' requires resolver chain"));
             }
             _ => panic!("Expected UnresolvedInput error"),
         }
@@ -148,7 +148,7 @@ info:
         let result = input.resolve_local();
         match result {
             Err(crate::api::FormatDocumentError::StylePath(msg)) => {
-                assert!(msg.contains("Failed to read"));
+                assert!(msg.contains("Failed to read style from '/nonexistent/path/style.yaml'"));
             }
             _ => panic!("Expected StylePath error"),
         }
@@ -160,7 +160,7 @@ info:
         let result = input.resolve_local();
         match result {
             Err(crate::api::FormatDocumentError::StyleParse(msg)) => {
-                assert!(msg.contains("Failed to parse"));
+                assert!(msg.contains("Failed to parse inline YAML style:"));
             }
             _ => panic!("Expected StyleParse error"),
         }

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -114,8 +114,8 @@ pub use api::{
     DocumentOptions, DocumentSession, DocumentSessionError, EntryMetadata, FormatDocumentError,
     FormatDocumentRequest, FormatDocumentResult, FormattedBibliography, FormattedCitation,
     OpenSessionResult, OutputFormatKind, PreviewCitationResult, RefsInput, SessionMutationResult,
-    StyleInput, Warning, WarningLevel, format_document, format_document_with_resolver,
-    format_document_with_style,
+    StyleInput, Warning, WarningLevel, apply_style_overrides, format_document,
+    format_document_with_resolver, format_document_with_style,
 };
 pub use citum_schema::options::{Config, Processing};
 pub use citum_schema::reference::{

--- a/crates/citum-schema-style/src/style/model.rs
+++ b/crates/citum-schema-style/src/style/model.rs
@@ -115,6 +115,19 @@ impl Style {
         crate::options::scoped::apply_scoped_style_options(self);
     }
 
+    /// Merge a partial overlay style over this style in place; overlay fields win.
+    ///
+    /// Overlay merging is typed and matches `extends` inheritance for the fields it supports:
+    /// - `info`, `templates`, `options`, and `custom` are merged (overlay wins for `Some` fields / keys).
+    /// - `citation` / `bibliography` are deep-merged; explicit YAML `~` can clear inherited fields when
+    ///   `overlay.raw_yaml` is populated (e.g. via `Style::from_yaml_bytes`).
+    ///
+    /// The caller is responsible for calling [`apply_scoped_options`](Self::apply_scoped_options)
+    /// afterwards if scoped-option side-effects (label-wrap, date-position, etc.) are needed.
+    pub fn apply_overlay(&mut self, overlay: &Style) {
+        super::overlay::merge_style_overlay(self, overlay);
+    }
+
     /// Parse a Citum style from YAML bytes, preserving raw YAML for
     /// null-aware overlay merging during preset resolution.
     ///

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -48,7 +48,7 @@ use citum_engine::{
 #[cfg(feature = "session")]
 use citum_engine::{
     CitationInsertPosition, CitationOccurrence, CitationOccurrenceItem, DocumentSession,
-    OpenSessionResult, OutputFormatKind, RefsInput,
+    OpenSessionResult, OutputFormatKind, RefsInput, apply_style_overrides,
 };
 use citum_schema::Style;
 use serde::{Deserialize, Serialize};
@@ -153,6 +153,10 @@ pub struct ValidateStyleParams {
 pub struct FormatDocumentParams {
     /// Style identifier, path, URI, or inline YAML.
     pub style: StyleInput,
+    /// Optional partial-style overlay (YAML or JSON) merged over the resolved base
+    /// style for this request only. Uses the same null-aware, typed-merge semantics
+    /// as `extends` inheritance. The base style is never mutated.
+    pub style_overrides: Option<String>,
     /// Optional BCP 47 locale override.
     pub locale: Option<String>,
     /// Output format (plain, html, djot, latex, typst). Defaults to plain.
@@ -176,6 +180,10 @@ pub struct FormatDocumentParams {
 pub struct OpenSessionParams {
     /// Style identifier, path, URI, or inline YAML.
     pub style: StyleInput,
+    /// Optional partial-style overlay (YAML or JSON) merged over the resolved base
+    /// style for this session. Uses the same null-aware, typed-merge semantics as
+    /// `extends` inheritance. The base style is never mutated.
+    pub style_overrides: Option<String>,
     /// Optional BCP 47 locale override.
     pub locale: Option<String>,
     /// Output format (plain, html, djot, latex, typst). Defaults to plain.
@@ -416,7 +424,11 @@ impl RpcDispatcher {
     fn open_session(&mut self, params: &Value, id: Value) -> Result<Value, ServerError> {
         let params: OpenSessionParams = serde_json::from_value(params.clone())
             .map_err(|e| ServerError::CitationError(format!("Invalid request JSON: {e}")))?;
-        let style = resolve_style_input(&params.style)?;
+        let mut style = resolve_style_input(&params.style)?;
+        if let Some(src) = &params.style_overrides {
+            apply_style_overrides(&mut style, src)
+                .map_err(|e| ServerError::StyleValidation(e.to_string()))?;
+        }
         let session = DocumentSession::new(
             style,
             params.style,

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -536,8 +536,7 @@ fn invalid_output_format_returns_error() {
     );
     let err = dispatch(req).expect_err("invalid output format should error");
     assert_eq!(err.0, Some(json!(12)));
-    assert!(err.1.contains("unsupported output format"));
-    assert!(err.1.contains("pdf"));
+    assert!(err.1.contains("unsupported output format: pdf"));
 }
 
 #[test]
@@ -561,5 +560,114 @@ fn render_bibliography_typst_returns_labeled_markup() {
     assert_eq!(
         content,
         "Hawking, S. (1988). #emph[A Brief History of Time] <ref-ITEM-2>"
+    );
+}
+
+/// Two-author bibliography for testing the `and` connector override.
+fn duo_refs() -> serde_json::Value {
+    json!({
+        "DUO-1": {
+            "id": "DUO-1",
+            "class": "monograph",
+            "type": "book",
+            "title": "Collaborative Work",
+            "author": [
+                {"family": "Smith", "given": "Alice"},
+                {"family": "Jones", "given": "Bob"}
+            ],
+            "issued": "2024"
+        }
+    })
+}
+
+// --- style_overrides ---
+
+#[test]
+fn format_document_style_overrides_changes_and_connector() {
+    // APA uses `&` by default; override to `text` should produce "and".
+    let req_base = make_request(
+        60,
+        "format_document",
+        json!({
+            "style": {"kind": "path", "value": apa_style_path()},
+            "refs": duo_refs(),
+            "citations": [{"id": "cite-1", "items": [{"id": "DUO-1"}]}]
+        }),
+    );
+    let result_base = dispatch(req_base).expect("base format_document should succeed");
+    let text_base = result_base["result"]["formatted_citations"][0]["text"]
+        .as_str()
+        .expect("citation text should be a string");
+    assert!(
+        text_base.contains('&'),
+        "APA base style should use '&' connector, got: {text_base:?}"
+    );
+
+    // With style_overrides switching to text "and"
+    let req_override = make_request(
+        61,
+        "format_document",
+        json!({
+            "style": {"kind": "path", "value": apa_style_path()},
+            "style_overrides": "options:\n  contributors:\n    and: text\n",
+            "refs": duo_refs(),
+            "citations": [{"id": "cite-1", "items": [{"id": "DUO-1"}]}]
+        }),
+    );
+    let result_override = dispatch(req_override).expect("override format_document should succeed");
+    let text_override = result_override["result"]["formatted_citations"][0]["text"]
+        .as_str()
+        .expect("citation text should be a string");
+    assert!(
+        !text_override.contains('&'),
+        "overridden style should not use '&' connector, got: {text_override:?}"
+    );
+    assert_ne!(
+        text_base, text_override,
+        "overridden and base outputs should differ"
+    );
+}
+
+#[test]
+fn open_session_style_overrides_changes_and_connector() {
+    let mut dispatcher = RpcDispatcher::new_stdio();
+
+    // Session opened with `and: text` override
+    dispatcher
+        .dispatch(make_request(
+            62,
+            "open_session",
+            json!({
+                "style": {"kind": "path", "value": apa_style_path()},
+                "style_overrides": "options:\n  contributors:\n    and: text\n"
+            }),
+        ))
+        .expect("open_session with style_overrides should succeed");
+
+    dispatcher
+        .dispatch(make_request(
+            63,
+            "put_references",
+            json!({"session_id": "default", "refs": duo_refs()}),
+        ))
+        .expect("put_references should succeed");
+
+    let inserted = dispatcher
+        .dispatch(make_request(
+            64,
+            "insert_citation",
+            json!({
+                "session_id": "default",
+                "citation": {"id": "cite-1", "items": [{"id": "DUO-1"}]}
+            }),
+        ))
+        .expect("insert_citation should succeed");
+
+    let text = inserted["result"]["affected_citations"][0]["text"]
+        .as_str()
+        .expect("citation text should be a string");
+    assert!(
+        !text.contains('&'),
+        "session with and:text override should not use '&', got: {text:?}"
     );
 }

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2847,6 +2847,13 @@
         "description": "Style identifier, path, URI, or inline YAML.",
         "$ref": "#/$defs/StyleInput"
       },
+      "style_overrides": {
+        "description": "Optional partial-style overlay (YAML or JSON) merged over the resolved base\nstyle for this request only. Uses the same null-aware, typed-merge semantics\nas `extends` inheritance. The base style is never mutated.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "locale": {
         "description": "Optional BCP 47 locale override.",
         "type": [

--- a/docs/specs/INTERACTIVE_STYLE_OVERRIDES.md
+++ b/docs/specs/INTERACTIVE_STYLE_OVERRIDES.md
@@ -1,0 +1,73 @@
+# Interactive API: Per-Document Style Overrides
+
+Status: Active
+
+Bean: csl26-cq35
+
+## Overview
+
+The `format_document` and `open_session` APIs accept an optional `style_overrides`
+field containing a partial style (YAML or JSON string). The overlay is merged over
+the resolved base style before processing, scoped to that request or session only.
+The base style is never mutated.
+
+## Motivation
+
+Word-processor hosts (e.g. citum-office) maintain a single shared style per
+project (e.g. APA 7th) but must honour per-document preferences — a different
+contributor connector (`&` instead of "and"), tighter et-al thresholds, alternate
+particle handling — without editing or duplicating the shared style.
+
+## Field
+
+```json
+{
+  "style": { "kind": "id", "value": "apa" },
+  "style_overrides": "options:\n  contributors:\n    and: symbol\n",
+  "refs": …,
+  "citations": …
+}
+```
+
+`style_overrides` accepts any subset of the Citum style YAML schema. JSON is also
+accepted (YAML is a JSON superset). Only the keys present in the overlay are
+applied; absent keys leave the base style unchanged.
+
+## Merge semantics
+
+The overlay is applied using the same null-aware, typed-merge logic as `extends`
+inheritance (`Style::apply_overlay` → `merge_style_overlay`):
+
+- **Options**: granular field-by-field merge via `Config::merge`. Supplying
+  `options.contributors.and: symbol` changes only that one sub-key; all other
+  contributor settings are inherited from the base style.
+- **Citation / bibliography specs**: deep-merged via typed `merge_citation_spec` /
+  `merge_bibliography_spec`.
+- **Templates**: per-key map merge (overlay key wins).
+- **Null clears**: an explicit YAML `~` (null) value for an `Option` field clears
+  the inherited value.
+
+## Scope
+
+- `format_document`: overlay applies to that single request.
+- `open_session`: overlay is baked into the session style at construction; all
+  subsequent mutations within the session use the overridden style.
+
+## Overrideable fields
+
+Any field in the style YAML schema is overrideable, including but not limited to:
+
+- `options.contributors` — `and`, `et-al-min`, `et-al-use-first`, `name-form`,
+  `demote-non-dropping-particle`, `display-as-sort`, …
+- `options.dates` — date format presets/config
+- `options.locators` — locator label config
+- `options.titles` — title case/rendering config
+- `options.processing` — processing mode (author-date, numeric, …)
+- `options.localize` — scope
+- `citation.*` — citation template, wrap, collapse, sort
+- `bibliography.*` — bibliography template, sort, partition
+
+## Out of scope (future)
+
+- Per-citation overrides (item-level).
+- Locale term overrides (tracked separately; see locale gap).


### PR DESCRIPTION
## Summary

- Add `style_overrides: Option<String>` to `FormatDocumentRequest` and `open_session` params so word-processor hosts (citum-office) can apply per-document overrides (e.g. APA base + `and: &` for one document) without editing the shared style.
- Implementation reuses `merge_style_overlay` / `Config::merge` from the existing `extends` inheritance path — no new merge logic. `Style::apply_overlay` (new public method on `citum-schema-style`) exposes it for surface-crate use.
- Engine choke point is `format_document_with_style`; `open_session` pre-merges before `DocumentSession::new`. `format_document` server path flows through `FormatDocumentRequest` deserialization automatically.

## Test plan

- [x] `cargo nextest run -E 'test(style_overrides) | test(session_style_override) | test(open_session_style) | test(format_document_style_overrides)'` — 6 new tests all pass
- [x] `cargo nextest run` — 1515/1515 pass
- [x] Pre-push gate: fmt + clippy + nextest all green
- [x] Schema regenerated (`docs/schemas/server.json` updated)
- [x] Spec added at `docs/specs/INTERACTIVE_STYLE_OVERRIDES.md`

Bean: csl26-cq35
