### PR TITLE
feat(engine): wire name-memory through session API

### DIFF
--- a/.beans/archive/csl26-ktq6--wire-document-optionsintegral-name-memory-through.md
+++ b/.beans/archive/csl26-ktq6--wire-document-optionsintegral-name-memory-through.md
@@ -1,11 +1,11 @@
 ---
 # csl26-ktq6
 title: Wire document_options.integral_name_memory through the processor
-status: todo
+status: completed
 type: feature
 priority: normal
 created_at: 2026-06-04T13:59:01Z
-updated_at: 2026-06-04T13:59:01Z
+updated_at: 2026-06-04T20:22:54Z
 ---
 
 The session and Tier 1 `format_document` APIs accept `document_options.integral_name_memory` but do not apply it. The processor renders without document-level narrative (integral) name memory, so first-full-then-short behaviour across a document is not honoured.
@@ -22,3 +22,11 @@ Currently `citum-engine/src/api/session.rs` (and the Tier 1 path) emit an `integ
 ## Origin
 
 Split out from csl26-3yk1 (session API). The warning string in `session.rs` previously cited csl26-wq0y in error; wq0y is integration-test scope only.
+
+## Summary of Changes
+
+- Added  helper method () on  in . Derives  from citation order and  (for body/note placement), then delegates to the existing  path.
+- Changed  visibility from  to  so API modules can call it.
+- Wired both changes into the Tier 1  path () and the Tier 2  path (): builds override processor first, then annotates citations after the missing-ref retain loop.
+- Removed the  warning from both paths.
+- Added 4 new unit tests covering first-full/subsequent-short and the disabled override guard, in both API modules.

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -236,6 +236,14 @@ pub fn format_document_with_style(
     warnings.extend(unknown_enum_warnings(&processor));
 
     if let Some(opts) = &request.document_options {
+        // Rebuild the processor with the document-level integral-name override
+        // before applying scalar field mutations (show_semantics etc.) so that
+        // those mutations are not lost when the processor is reconstructed.
+        if let Some(new_proc) = processor
+            .processor_with_document_integral_name_override(opts.integral_name_memory.as_ref())
+        {
+            processor = new_proc;
+        }
         if let Some(show_semantics) = opts.show_semantics {
             processor.show_semantics = show_semantics;
         }
@@ -244,15 +252,6 @@ pub fn format_document_with_style(
         }
         if let Some(abbr_map) = opts.abbreviation_map.clone() {
             processor.abbreviation_map = Some(abbr_map);
-        }
-        if opts.integral_name_memory.is_some() {
-            warnings.push(Warning {
-                level: WarningLevel::Warning,
-                code: "integral_name_memory_not_applied".to_string(),
-                citation_id: None,
-                ref_id: None,
-                message: "document_options.integral_name_memory is accepted but not yet wired through the processor; tracked in csl26-ktq6.".to_string(),
-            });
         }
     }
 
@@ -279,6 +278,11 @@ pub fn format_document_with_style(
         });
         citations.push(citation);
     }
+
+    // Annotate integral-name First/Subsequent state from the processor's
+    // effective config (no document structure available; all citations share
+    // document scope). Safe no-op when no memory config is present.
+    processor.annotate_flat_integral_name_states(&mut citations);
 
     // Process citations
     let formatted_citations = match request.output_format {
@@ -1105,6 +1109,218 @@ mod tests {
         assert!(
             matches!(and_option, Some(&AndOptions::Symbol)),
             "expected And::Symbol after override, got: {and_option:?}"
+        );
+    }
+
+    // --- integral_name_memory wiring ---
+
+    /// Build a style that has integral-name memory configured with scope=Document,
+    /// contexts=BodyAndNotes, subsequent_form=Short, and an integral sub-template
+    /// that renders the author in Long (given + family) form.
+    fn make_integral_name_style() -> Style {
+        use citum_schema::options::{
+            IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, SubsequentNameForm,
+        };
+        Style {
+            info: StyleInfo {
+                title: Some("Integral Name Memory Test".to_string()),
+                id: Some("integral-name-memory-test".into()),
+                ..Default::default()
+            },
+            options: Some(Config {
+                processing: Some(Processing::AuthorDate),
+                integral_name_memory: Some(IntegralNameMemoryConfig {
+                    scope: Some(IntegralNameScope::Document),
+                    contexts: Some(IntegralNameContexts::BodyAndNotes),
+                    subsequent_form: Some(SubsequentNameForm::Short),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            citation: Some(CitationSpec {
+                integral: Some(Box::new(CitationSpec {
+                    template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author,
+                        form: ContributorForm::Long,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    })]),
+                    ..Default::default()
+                })),
+                template: Some(vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author,
+                        form: ContributorForm::Short,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: TemplateDateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                ]),
+                wrap: Some(WrapPunctuation::Parentheses.into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn make_smith_refs() -> RefsInput {
+        RefsInput::Yaml(
+            r#"smith2020:
+  class: monograph
+  id: smith2020
+  type: book
+  title: Smith Book
+  issued: "2020"
+  author:
+    - family: Smith
+      given: John
+"#
+            .to_string(),
+        )
+    }
+
+    fn make_integral_occ(id: &str, ref_id: &str) -> CitationOccurrence {
+        CitationOccurrence {
+            id: id.to_string(),
+            items: vec![CitationOccurrenceItem {
+                id: ref_id.to_string(),
+                locator: None,
+                prefix: None,
+                suffix: None,
+                integral_name_state: None,
+                org_abbreviation_state: None,
+            }],
+            mode: Some(citum_schema::data::citation::CitationMode::Integral),
+            note_number: None,
+            suppress_author: None,
+            grouped: None,
+            prefix: None,
+            suffix: None,
+            sentence_start: None,
+        }
+    }
+
+    #[test]
+    fn document_options_integral_name_memory_first_full_then_short() {
+        use crate::processor::document::DocumentIntegralNameOverride;
+
+        let style = make_integral_name_style();
+        let refs = make_smith_refs();
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![
+                make_integral_occ("c1", "smith2020"),
+                make_integral_occ("c2", "smith2020"),
+            ],
+            document_options: Some(DocumentOptions {
+                integral_name_memory: Some(DocumentIntegralNameOverride {
+                    enabled: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let result = format_document_with_style(style, request).expect("should render");
+
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.code == "integral_name_memory_not_applied"),
+            "stale warning must not appear: {:?}",
+            result.warnings
+        );
+        assert_eq!(
+            result.formatted_citations[0].text, "John Smith",
+            "first integral cite should render full name form"
+        );
+        assert_eq!(
+            result.formatted_citations[1].text, "Smith",
+            "second integral cite of same author should render short form"
+        );
+    }
+
+    #[test]
+    fn document_options_integral_name_memory_disabled_keeps_full_form() {
+        use crate::processor::document::DocumentIntegralNameOverride;
+
+        let style = make_integral_name_style();
+        let refs = make_smith_refs();
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![
+                make_integral_occ("c1", "smith2020"),
+                make_integral_occ("c2", "smith2020"),
+            ],
+            document_options: Some(DocumentOptions {
+                integral_name_memory: Some(DocumentIntegralNameOverride {
+                    enabled: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let result = format_document_with_style(style, request).expect("should render");
+
+        // With memory disabled both occurrences should render the natural integral
+        // template form (Long = "John Smith") without any subsequent rewrite.
+        assert_eq!(
+            result.formatted_citations[0].text, "John Smith",
+            "first integral cite: {}",
+            result.formatted_citations[0].text
+        );
+        assert_eq!(
+            result.formatted_citations[1].text, "John Smith",
+            "second integral cite should also be full when memory is disabled"
+        );
+    }
+
+    #[test]
+    fn style_native_integral_name_memory_applied_without_document_override() {
+        // Style has integral_name_memory in its own options; no document_options
+        // override is supplied. The flat API must still annotate First/Subsequent.
+        let style = make_integral_name_style();
+        let refs = make_smith_refs();
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![
+                make_integral_occ("c1", "smith2020"),
+                make_integral_occ("c2", "smith2020"),
+            ],
+            document_options: None,
+        };
+
+        let result = format_document_with_style(style, request).expect("should render");
+
+        assert_eq!(
+            result.formatted_citations[0].text, "John Smith",
+            "first integral cite should render full name form"
+        );
+        assert_eq!(
+            result.formatted_citations[1].text, "Smith",
+            "second integral cite should render short form from style-native config"
         );
     }
 }

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -336,6 +336,13 @@ impl DocumentSession {
         warnings.extend(unknown_enum_warnings(&processor));
 
         if let Some(opts) = &self.document_options {
+            // Rebuild the processor with the document-level integral-name override
+            // before applying scalar field mutations so those are not lost.
+            if let Some(new_proc) = processor
+                .processor_with_document_integral_name_override(opts.integral_name_memory.as_ref())
+            {
+                processor = new_proc;
+            }
             if let Some(show_semantics) = opts.show_semantics {
                 processor.show_semantics = show_semantics;
             }
@@ -344,15 +351,6 @@ impl DocumentSession {
             }
             if let Some(abbr_map) = opts.abbreviation_map.clone() {
                 processor.abbreviation_map = Some(abbr_map);
-            }
-            if opts.integral_name_memory.is_some() {
-                warnings.push(Warning {
-                    level: WarningLevel::Warning,
-                    code: "integral_name_memory_not_applied".to_string(),
-                    citation_id: None,
-                    ref_id: None,
-                    message: "document_options.integral_name_memory is accepted but not yet wired through the processor; tracked in csl26-ktq6.".to_string(),
-                });
             }
         }
 
@@ -375,6 +373,11 @@ impl DocumentSession {
             });
             processor_citations.push(citation);
         }
+
+        // Annotate integral-name First/Subsequent state from the processor's
+        // effective config (no document structure available; all citations share
+        // document scope). Safe no-op when no memory config is present.
+        processor.annotate_flat_integral_name_states(&mut processor_citations);
 
         let formatted_citations = match self.output_format {
             OutputFormatKind::Plain => {
@@ -917,6 +920,244 @@ mod tests {
         assert_ne!(
             text_base, text_override,
             "sessions with different overrides should produce different output"
+        );
+    }
+
+    // --- integral_name_memory wiring ---
+
+    /// Build a style with integral-name memory configured (scope=Document,
+    /// subsequent_form=Short) and an integral sub-template rendering Long names.
+    fn integral_name_style() -> Style {
+        use citum_schema::options::{
+            IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, SubsequentNameForm,
+        };
+        Style {
+            info: StyleInfo {
+                title: Some("Integral Name Memory Session Test".to_string()),
+                id: Some("integral-name-memory-session-test".into()),
+                ..Default::default()
+            },
+            options: Some(Config {
+                processing: Some(Processing::AuthorDate),
+                integral_name_memory: Some(IntegralNameMemoryConfig {
+                    scope: Some(IntegralNameScope::Document),
+                    contexts: Some(IntegralNameContexts::BodyAndNotes),
+                    subsequent_form: Some(SubsequentNameForm::Short),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            citation: Some(CitationSpec {
+                integral: Some(Box::new(CitationSpec {
+                    template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author,
+                        form: ContributorForm::Long,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    })]),
+                    ..Default::default()
+                })),
+                template: Some(vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author,
+                        form: ContributorForm::Short,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: TemplateDateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some(", ".to_string()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]),
+                wrap: Some(WrapPunctuation::Parentheses.into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn smith_refs() -> RefsInput {
+        RefsInput::Yaml(
+            r#"smith2020:
+  class: monograph
+  id: smith2020
+  type: book
+  title: Smith Book
+  issued: "2020"
+  author:
+    - family: Smith
+      given: John
+"#
+            .to_string(),
+        )
+    }
+
+    fn integral_citation(id: &str, ref_id: &str) -> CitationOccurrence {
+        CitationOccurrence {
+            id: id.to_string(),
+            items: vec![crate::api::CitationOccurrenceItem {
+                id: ref_id.to_string(),
+                locator: None,
+                prefix: None,
+                suffix: None,
+                integral_name_state: None,
+                org_abbreviation_state: None,
+            }],
+            mode: Some(citum_schema::data::citation::CitationMode::Integral),
+            note_number: None,
+            suppress_author: None,
+            grouped: None,
+            prefix: None,
+            suffix: None,
+            sentence_start: None,
+        }
+    }
+
+    #[test]
+    fn session_document_options_integral_name_memory_first_full_then_short() {
+        use crate::processor::document::DocumentIntegralNameOverride;
+
+        let mut session = DocumentSession::new(
+            integral_name_style(),
+            StyleInput::Yaml(String::new()),
+            None,
+            OutputFormatKind::Plain,
+            Some(DocumentOptions {
+                integral_name_memory: Some(DocumentIntegralNameOverride {
+                    enabled: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        );
+        session.put_references(smith_refs());
+        let result = session
+            .insert_citations_batch(vec![
+                integral_citation("c1", "smith2020"),
+                integral_citation("c2", "smith2020"),
+            ])
+            .expect("should render");
+
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.code == "integral_name_memory_not_applied"),
+            "stale warning must not appear: {:?}",
+            result.warnings
+        );
+
+        let first = result
+            .affected_citations
+            .iter()
+            .find(|c| c.id == "c1")
+            .expect("c1 should be in result");
+        let second = result
+            .affected_citations
+            .iter()
+            .find(|c| c.id == "c2")
+            .expect("c2 should be in result");
+
+        assert_eq!(
+            first.text, "John Smith",
+            "first integral cite should render full name form"
+        );
+        assert_eq!(
+            second.text, "Smith",
+            "second integral cite of same author should render short form"
+        );
+    }
+
+    #[test]
+    fn session_document_options_integral_name_memory_disabled_keeps_full_form() {
+        use crate::processor::document::DocumentIntegralNameOverride;
+
+        let mut session = DocumentSession::new(
+            integral_name_style(),
+            StyleInput::Yaml(String::new()),
+            None,
+            OutputFormatKind::Plain,
+            Some(DocumentOptions {
+                integral_name_memory: Some(DocumentIntegralNameOverride {
+                    enabled: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        );
+        session.put_references(smith_refs());
+        let result = session
+            .insert_citations_batch(vec![
+                integral_citation("c1", "smith2020"),
+                integral_citation("c2", "smith2020"),
+            ])
+            .expect("should render");
+
+        let first = result
+            .affected_citations
+            .iter()
+            .find(|c| c.id == "c1")
+            .expect("c1 should be in result");
+        let second = result
+            .affected_citations
+            .iter()
+            .find(|c| c.id == "c2")
+            .expect("c2 should be in result");
+
+        // Memory disabled — both occurrences render the natural Long form.
+        assert_eq!(
+            first.text, "John Smith",
+            "first integral cite with disabled memory: {}",
+            first.text
+        );
+        assert_eq!(
+            second.text, "John Smith",
+            "second integral cite should also be full when memory is disabled"
+        );
+    }
+
+    #[test]
+    fn session_style_native_integral_name_memory_applied_without_document_override() {
+        // Style has integral_name_memory in its own options; no document_options
+        // override is supplied. The flat session API must still annotate.
+        let mut session = DocumentSession::new(
+            integral_name_style(),
+            StyleInput::Yaml(String::new()),
+            None,
+            OutputFormatKind::Plain,
+            None,
+        );
+        session.put_references(smith_refs());
+        let result = session
+            .insert_citations_batch(vec![
+                integral_citation("c1", "smith2020"),
+                integral_citation("c2", "smith2020"),
+            ])
+            .expect("should render");
+
+        let first = result
+            .affected_citations
+            .iter()
+            .find(|c| c.id == "c1")
+            .expect("c1 should be in result");
+        let second = result
+            .affected_citations
+            .iter()
+            .find(|c| c.id == "c2")
+            .expect("c2 should be in result");
+
+        assert_eq!(
+            first.text, "John Smith",
+            "first integral cite should render full name form"
+        );
+        assert_eq!(
+            second.text, "Smith",
+            "second integral cite should render short form from style-native config"
         );
     }
 }

--- a/crates/citum-engine/src/processor/document/integral_names.rs
+++ b/crates/citum-engine/src/processor/document/integral_names.rs
@@ -80,7 +80,31 @@ impl Processor {
         self.normalize_note_context(&normalized)
     }
 
-    pub(super) fn processor_with_document_integral_name_override(
+    /// Annotate integral-name First/Subsequent state across a flat, ordered
+    /// citation list (API paths with no parsed document).
+    ///
+    /// Citations are processed in list order. A citation with a `note_number`
+    /// is treated as a note context; otherwise as body prose. There is no
+    /// chapter/section structure, so all citations share the document scope
+    /// regardless of the configured [`IntegralNameScope`].
+    pub(crate) fn annotate_flat_integral_name_states(&self, citations: &mut [Citation]) {
+        let contexts: Vec<IntegralNameContext> = citations
+            .iter()
+            .map(|citation| IntegralNameContext {
+                placement: if citation.note_number.is_some() {
+                    CitationPlacement::ManualFootnote {
+                        label: String::new(),
+                    }
+                } else {
+                    CitationPlacement::InlineProse
+                },
+                structure: CitationStructure::default(),
+            })
+            .collect();
+        self.annotate_integral_name_states(citations, &contexts);
+    }
+
+    pub(crate) fn processor_with_document_integral_name_override(
         &self,
         override_config: Option<&DocumentIntegralNameOverride>,
     ) -> Option<Self> {


### PR DESCRIPTION
## Summary

- Adds `annotate_flat_integral_name_states` (new `pub(crate)` method on `Processor`) that derives `IntegralNameContext` from citation order and `note_number`, then delegates to the existing `annotate_integral_name_states` path
- Widens `processor_with_document_integral_name_override` from `pub(super)` to `pub(crate)` for API access
- Wires both into the Tier 1 `format_document_with_style` and Tier 2 `DocumentSession::render_citations` paths: rebuild processor from the override first, then annotate citations after the missing-ref retain loop
- Removes the `integral_name_memory_not_applied` warning from both paths
- Adds 4 unit tests covering first-full/subsequent-short and the disabled-override guard in each API module

## Test plan

- [x] `cargo nextest run -p citum-engine -E 'test(integral_name)'` — 19 tests pass
- [x] `cargo nextest run` — 775/775 pass
- [x] `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
