### PR TITLE
fix(engine): pass citation mode through preview_citation

### DIFF
--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -404,7 +404,7 @@ impl WasmDocumentSession {
         let position = parse_optional_json(position_json, "position")?;
         let result = self
             .inner
-            .preview_citation(items, position)
+            .preview_citation(items, None, position)
             .map_err(|e| e.to_string())?;
         serde_json::to_string(&result).map_err(|e| format!("Result serialization failed: {e}"))
     }

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -232,6 +232,7 @@ impl DocumentSession {
     pub fn preview_citation(
         &self,
         items: Vec<CitationOccurrenceItem>,
+        mode: Option<citum_schema::data::citation::CitationMode>,
         position: Option<CitationInsertPosition>,
     ) -> Result<PreviewCitationResult, DocumentSessionError> {
         let mut citations = self.citations.clone();
@@ -242,7 +243,7 @@ impl DocumentSession {
             CitationOccurrence {
                 id: preview_id.clone(),
                 items,
-                mode: None,
+                mode,
                 note_number: None,
                 suppress_author: None,
                 grouped: None,
@@ -822,18 +823,33 @@ mod tests {
 
     #[test]
     fn preview_does_not_mutate_session() {
-        let mut session = session();
+        use citum_schema::data::citation::CitationMode;
+
+        let mut session = DocumentSession::new(
+            integral_name_style(),
+            StyleInput::Yaml(String::new()),
+            None,
+            OutputFormatKind::Plain,
+            None,
+        );
+        session.put_references(smith_refs());
         session
             .insert_citations_batch(vec![citation("c1", "smith2020")])
             .expect("batch insert should render");
         let before_version = session.version();
         let before_citations = session.get_citations();
+        let preview_items = citation("preview", "smith2020").items;
 
-        let preview = session
-            .preview_citation(citation("preview", "doe2021").items, None)
+        let default_preview = session
+            .preview_citation(preview_items.clone(), None, None)
             .expect("preview should render");
+        let integral_preview = session
+            .preview_citation(preview_items, Some(CitationMode::Integral), None)
+            .expect("integral preview should render");
 
-        assert!(!preview.preview.is_empty());
+        assert!(!default_preview.preview.is_empty());
+        assert!(!integral_preview.preview.is_empty());
+        assert_ne!(default_preview.preview, integral_preview.preview);
         assert_eq!(session.version(), before_version);
         assert_eq!(session.get_citations().len(), before_citations.len());
     }

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -280,6 +280,8 @@ pub struct PreviewCitationParams {
     pub session_id: Option<String>,
     /// Citation items to preview.
     pub items: Vec<CitationOccurrenceItem>,
+    /// Citation mode for the preview (integral / non-integral).
+    pub mode: Option<citum_schema::data::citation::CitationMode>,
     /// Optional neighbour-ID position context.
     pub position: Option<CitationInsertPosition>,
 }
@@ -546,7 +548,7 @@ impl RpcDispatcher {
         let params: PreviewCitationParams = parse_session_params(params, &request_id)?;
         let session = self.session_mut(params.session_id.as_deref(), &request_id)?;
         let result = session
-            .preview_citation(params.items, params.position)
+            .preview_citation(params.items, params.mode, params.position)
             .map_err(session_method_error(&request_id))?;
         Ok(json!({ "id": id, "result": result }))
     }


### PR DESCRIPTION
## Summary

- Adds `mode` field to `PreviewCitationParams` in `citum-server`
- Passes mode through to `session.preview_citation` so integral/non-integral is reflected in the preview render
- Updates `citum-bindings` and the internal test call (both pass `None`, preserving existing behaviour)

## Test plan

- [ ] Rebuild Tauri app; open command palette, add a ref, toggle In text / As citation — preview updates correctly