### PR TITLE
fix(engine): compose typst strong markup

### DIFF
--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -217,12 +217,13 @@ impl Processor {
 
         // Terminal formats (Typst, LaTeX) need the same placeholder flow so
         // the body markup can be converted to the target format after citations
-        // are replaced with NUL-token placeholders.
+        // are replaced with NUL-token placeholders. This is a converted-output
+        // path, not passthrough; passthrough is limited to Plain/Djot/Markdown.
         if matches!(format, DocumentFormat::Typst | DocumentFormat::Latex) {
             let mut placeholders = HtmlPlaceholderRegistry::default();
-            // Note styles emit raw footnote syntax that the body markup
-            // converter doesn't understand; fall back to the passthrough path
-            // and let the caller handle conversion separately if needed.
+            // Note styles still emit source footnote syntax that the terminal
+            // body renderer does not yet model, so keep that narrow legacy
+            // exception isolated from author-date terminal conversion.
             let content = if self.is_note_style() {
                 self.process_note_document::<F>(content, parsed)
             } else {
@@ -398,7 +399,8 @@ impl Processor {
             };
             placeholders.apply(converted)
         } else {
-            // Passthrough path (Plain, Djot, Markdown, note-style Typst/LaTeX).
+            // Passthrough path for Plain/Djot/Markdown, plus the isolated
+            // note-style Typst/LaTeX exception documented in render_document_body.
             // Keep the heading-rewrite for Typst in case headings came from
             // bibliography group labels rather than body markup.
             let content = rewrite_document_markup_for_typst(rendered.content, format);

--- a/crates/citum-engine/src/render/rich_text.rs
+++ b/crates/citum-engine/src/render/rich_text.rs
@@ -436,7 +436,7 @@ mod tests {
     fn test_djot_nested_formatting_preserves_typst_markup() {
         let fmt = Typst;
         let result = render_djot_inline("_emphasized *bold* text_", &fmt);
-        assert_eq!(result, "#emph[emphasized *bold* text]");
+        assert_eq!(result, "#emph[emphasized #strong[bold] text]");
     }
 
     #[test]

--- a/crates/citum-engine/src/render/test_formats.rs
+++ b/crates/citum-engine/src/render/test_formats.rs
@@ -190,6 +190,15 @@ mod tests {
     }
 
     #[test]
+    fn test_typst_strong_composes_when_nested() {
+        let fmt = Typst;
+        let inner = fmt.strong(fmt.text("Note"));
+        let outer = fmt.strong(inner);
+
+        assert_eq!(outer, "#strong[#strong[Note]]");
+    }
+
+    #[test]
     fn test_typst_contributor_small_caps() {
         let component = ProcTemplateComponent {
             template_component: tc_contributor!(Author, Long, small_caps = true),

--- a/crates/citum-engine/src/render/typst.rs
+++ b/crates/citum-engine/src/render/typst.rs
@@ -84,7 +84,7 @@ impl OutputFormat for Typst {
         if content.is_empty() {
             return content;
         }
-        format!("*{content}*")
+        format!("#strong[{content}]")
     }
 
     fn small_caps(&self, content: Self::Output) -> Self::Output {

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -1567,6 +1567,71 @@ fn given_djot_block_quote_when_rendered_as_typst_then_quote_block_is_emitted() {
     );
 }
 
+fn given_djot_notice_with_nested_strong_when_rendered_as_typst_then_strong_markup_is_composable() {
+    let processor = example_document_processor("styles/embedded/apa-7th.yaml");
+    let parser = DjotParser;
+    let document = concat!(
+        "{.citum-demo-notice}\n",
+        "**Note**: This notice is outside any footnote.\n\n",
+        "---\n\n",
+        "**Features illustrated**: source markup, thematic breaks, and citations.\n\n",
+        "A later citation still resolves [@kuhn1962].\n",
+    );
+
+    let output = processor.process_document::<_, citum_engine::render::typst::Typst>(
+        document,
+        &parser,
+        DocumentFormat::Typst,
+    );
+
+    assert!(
+        output.contains("#strong[#strong[Note]]"),
+        "Djot nested strong input **Note** should render as composable Typst strong markup, got: {output}"
+    );
+    assert!(
+        !output.contains("**Note**"),
+        "raw Djot strong delimiters should not leak into Typst output, got: {output}"
+    );
+    assert!(
+        !output.contains("{.citum-demo-notice}"),
+        "raw Djot paragraph attributes should not leak into Typst output, got: {output}"
+    );
+    assert!(
+        output.contains("#link(<ref-kuhn1962>)") && output.contains("Kuhn"),
+        "citation placeholder replacement should still produce Typst links, got: {output}"
+    );
+}
+
+fn given_djot_notice_with_nested_strong_when_rendered_as_djot_then_source_markup_passes_through() {
+    let processor = example_document_processor("styles/embedded/apa-7th.yaml");
+    let parser = DjotParser;
+    let document = concat!(
+        "{.citum-demo-notice}\n",
+        "**Note**: This notice is outside any footnote.\n\n",
+        "---\n\n",
+        "A later citation still resolves [@kuhn1962].\n",
+    );
+
+    let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
+        document,
+        &parser,
+        DocumentFormat::Djot,
+    );
+
+    assert!(
+        output.contains("**Note**"),
+        "Djot passthrough output should preserve source body markup, got: {output}"
+    );
+    assert!(
+        output.contains("{.citum-demo-notice}"),
+        "Djot passthrough output should preserve source attributes, got: {output}"
+    );
+    assert!(
+        output.contains("Kuhn") && !output.contains("[@kuhn1962]"),
+        "citation text should be rendered while body markup passes through, got: {output}"
+    );
+}
+
 fn given_markdown_block_quote_when_rendered_as_latex_then_quote_environment_is_emitted() {
     let processor = example_document_processor("styles/embedded/apa-7th.yaml");
     let parser = MarkdownParser;
@@ -1634,6 +1699,22 @@ mod body_markup_terminal_formats {
             "A Djot block quote rendered to Typst should produce #quote(block: true) with correctly mapped inline markup.",
         );
         super::given_djot_block_quote_when_rendered_as_typst_then_quote_block_is_emitted();
+    }
+
+    #[test]
+    fn djot_notice_nested_strong_renders_as_composable_typst() {
+        announce_behavior(
+            "A Djot notice paragraph using nested strong markup (`**...**`) outside footnotes should render as composable Typst strong markup while preserving citation placeholder replacement.",
+        );
+        super::given_djot_notice_with_nested_strong_when_rendered_as_typst_then_strong_markup_is_composable();
+    }
+
+    #[test]
+    fn djot_passthrough_preserves_notice_source_markup() {
+        announce_behavior(
+            "Djot passthrough output should preserve source body markup while still replacing citation markers.",
+        );
+        super::given_djot_notice_with_nested_strong_when_rendered_as_djot_then_source_markup_passes_through();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- render Typst strong text with #strong[...] instead of delimiter stars
- add Djot-to-Typst regression coverage for nested strong outside footnotes
- clarify the terminal-output pipeline comment around passthrough vs converted output

## Tests
- cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run
- citum render doc -s apa -b docs/demo-refs.yaml docs/demo.djot --format typst > /tmp/demo.typ
- typst compile /tmp/demo.typ /tmp/demo.pdf
