### PR TITLE
fix(ci): scope release notes to previous tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,10 +402,13 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # Auto-generated release notes from PRs since last tag.
+          # Fetch all tags so we can find the previous one reliably.
+          git fetch --tags --quiet
+          PREV_TAG=$(git tag --sort=-version:refname -l 'v*' | grep -v "^${TAG}$" | head -1)
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \
+            --notes-start-tag "$PREV_TAG" \
             --verify-tag \
             release-artifacts/*.tar.gz \
             release-artifacts/SHA256SUMS \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,11 +404,16 @@ jobs:
           set -euo pipefail
           # Fetch all tags so we can find the previous one reliably.
           git fetch --tags --quiet
-          PREV_TAG=$(git tag --sort=-version:refname -l 'v*' | grep -v "^${TAG}$" | head -1)
+          PREV_TAG="$(git tag --sort=-version:refname -l 'v*' | grep -vxF "$TAG" | head -n 1 || true)"
+          NOTES_START_ARG=()
+          if [[ -n "$PREV_TAG" ]]; then
+            NOTES_START_ARG=(--notes-start-tag "$PREV_TAG")
+          fi
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \
-            --notes-start-tag "$PREV_TAG" \
+            "${NOTES_START_ARG[@]}" \
+            --verify-tag \
             --verify-tag \
             release-artifacts/*.tar.gz \
             release-artifacts/SHA256SUMS \


### PR DESCRIPTION
## Summary

- `--generate-notes` was comparing from `v0.61.1` for both the v0.63.0 and v0.64.0 releases, pulling in two prior releases worth of PRs.
- Root cause: without an explicit `--notes-start-tag`, GitHub falls back to whatever it considers the "last release" — which was stale in our case.
- Fix: fetch all tags in the release job and pass `--notes-start-tag "$PREV_TAG"` so the range is always `<prev>...<current>`.

The v0.64.0 release body has already been corrected directly via `gh release edit` (now compares `v0.63.0...v0.64.0`). Note that v0.63.0 has the same problem (`v0.61.1...v0.63.0` instead of `v0.62.0...v0.63.0`) — fix that separately if desired.

## Test plan

- [ ] Merge this PR, confirm the next release tag creates a release with the correct single-version range in its body.
