### PR TITLE
refactor+docs: reconcile bibliography grouping (engine de-dup + spec)

### DIFF
--- a/.beans/archive/csl26-effd--reconcile-bibliography-grouping-vocabulary-spec-en.md
+++ b/.beans/archive/csl26-effd--reconcile-bibliography-grouping-vocabulary-spec-en.md
@@ -1,0 +1,25 @@
+---
+# csl26-effd
+title: 'Reconcile bibliography grouping: vocabulary, spec, engine de-dup'
+status: completed
+type: task
+priority: high
+created_at: 2026-06-08T17:38:34Z
+updated_at: 2026-06-08T17:58:12Z
+---
+
+Follow-up to fd0c6eee. Three-part cleanup:
+
+Part A — Engine de-dup: fold `process_document_with_frontmatter_groups` onto the `render_document_bibliography_blocks` primitive (same path the CLI/server already use); delete dead `render_document_bibliography_groups` / `render_with_custom_groups`; collapse the three process_document_with_* entry points to two real strategies (trailing ordered sections, positioned fenced-divs).
+
+Part B — Spec reconciliation: promote BIBLIOGRAPHY_GROUPING.md to Active as the single mechanism owner (real types/primitive, vocabulary rule, input-surfaces table, grouping-vs-partitioning subsection); slim PER_DOCUMENT_CONFIG_OVERRIDES.md to add the missing CLI/server per-document surfaces and reference BIBLIOGRAPHY_GROUPING for the mechanism; cross-link in SERVER_INTERACTIVE_API.md.
+
+Vocabulary decision: group = definition (BibliographyGroup), block = placed instance (BibliographyBlockRequest). No schema-type or serde rename.
+
+Related: csl26-group, csl26-o8ji, fd0c6eee
+
+## Summary of Changes
+
+Part A (engine, commit 994707ce): Folded  onto  primitive. Deleted dead  and . Deleted  (replaced by  which emits format-correct headings at H2 level). Updated 3 tests: group headings promoted from H1 to H2, unassigned-fallback removed (explicit over magic).
+
+Part B (docs, this commit): Promoted BIBLIOGRAPHY_GROUPING.md from Design → Active. Rewrote spec with real types (, ), vocabulary rule (group = definition, block = placed instance), input-surfaces table (4 surfaces → 1 renderer, precedence order), grouping-vs-partitioning distinction, unmatched-entry policy. Slimmed PER_DOCUMENT_CONFIG_OVERRIDES.md: replaced re-described BibliographyGroup prose with reference to BIBLIOGRAPHY_GROUPING.md; added frontmatter  list, CLI , and server  surfaces. Added cross-links in SERVER_INTERACTIVE_API.md.

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -371,19 +371,6 @@ impl Processor {
         fmt.finish(result)
     }
 
-    /// Render all entries using custom bibliography grouping.
-    pub(super) fn render_with_custom_groups<F>(
-        &self,
-        all_entries: &[ProcEntry],
-        groups: &[BibliographyGroup],
-    ) -> String
-    where
-        F: OutputFormat<Output = String>,
-    {
-        let selected: HashSet<String> = all_entries.iter().map(|e| e.id.clone()).collect();
-        self.render_with_custom_groups_filtered::<F>(all_entries, groups, &selected, None, None)
-    }
-
     /// Render a filtered subset of entries using custom bibliography grouping.
     ///
     /// This uses a two-pass grouping strategy:
@@ -655,21 +642,6 @@ impl Processor {
             annotations,
             annotation_style,
         )
-    }
-
-    /// Render frontmatter-defined bibliography groups for document output.
-    ///
-    /// This uses the same pre-merge selector semantics as
-    /// [`Self::render_grouped_bibliography_with_format`].
-    pub(crate) fn render_document_bibliography_groups<F>(
-        &self,
-        groups: &[BibliographyGroup],
-    ) -> String
-    where
-        F: OutputFormat<Output = String>,
-    {
-        let all_entries = self.sorted_id_stubs();
-        self.render_with_custom_groups::<F>(&all_entries, groups)
     }
 
     /// Extract and render entries for a bibliography group.

--- a/crates/citum-engine/src/processor/document/output.rs
+++ b/crates/citum-engine/src/processor/document/output.rs
@@ -155,26 +155,6 @@ pub(super) fn render_document_bibliography_block_replacement(
     }
 }
 
-pub(super) fn rewrite_group_headings_for_document(
-    rendered: String,
-    format: DocumentFormat,
-) -> String {
-    match format {
-        DocumentFormat::Typst => rendered
-            .lines()
-            .map(|line| {
-                if let Some(rest) = line.strip_prefix("# ") {
-                    format!("== {rest}")
-                } else {
-                    line.to_string()
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n"),
-        _ => rendered,
-    }
-}
-
 #[allow(
     clippy::string_slice,
     clippy::indexing_slicing,

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -8,11 +8,32 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use super::output::{
     HtmlPlaceholderRegistry, RenderedDocumentBody, append_document_bibliography,
     bibliography_block_placeholder, render_document_bibliography_block_replacement,
-    rewrite_document_markup_for_typst, rewrite_group_headings_for_document,
-    stage_document_bibliography_blocks,
+    rewrite_document_markup_for_typst, stage_document_bibliography_blocks,
 };
 use super::{BibliographyBlock, CitationParser, DocumentFormat, ParsedDocument};
 use crate::processor::Processor;
+
+/// Format a bibliography section heading for the trailing-bibliography path.
+///
+/// Produces format-specific H2-level heading markup. HTML content in the
+/// trailing-bibliography path is inserted after `finalize_html_output`, so
+/// headings must already be HTML — hence the explicit `DocumentFormat::Html`
+/// arm, which emits a pre-escaped `<h2>` element. The heading text is sourced
+/// from YAML/JSON, so `&`, `<`, and `>` are escaped to prevent markup injection.
+fn render_bibliography_section_heading(heading: &str, format: DocumentFormat) -> String {
+    match format {
+        DocumentFormat::Html => {
+            let escaped = heading
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;");
+            format!("<h2>{escaped}</h2>\n\n")
+        }
+        DocumentFormat::Latex => format!("\\subsection*{{{heading}}}\n\n"),
+        DocumentFormat::Typst => format!("== {heading}\n\n"),
+        _ => format!("## {heading}\n\n"),
+    }
+}
 
 impl Processor {
     /// Process citations in a document and append a bibliography.
@@ -100,6 +121,14 @@ impl Processor {
     }
 
     /// Orchestrate document processing with custom frontmatter bibliography groups.
+    ///
+    /// Renders each group as an ordered section via the shared
+    /// [`Processor::render_document_bibliography_blocks`] primitive, then
+    /// appends all sections as a trailing bibliography under the standard
+    /// "Bibliography" heading. Groups with no matching entries are omitted
+    /// silently; references not matched by any group selector are not rendered
+    /// (use a catch-all group with `selector: {}` or a `not:` negation to
+    /// capture unmatched entries).
     fn process_document_with_frontmatter_groups<P, F>(
         &self,
         body: &str,
@@ -118,10 +147,22 @@ impl Processor {
             parser,
             format,
             |processor| {
-                rewrite_group_headings_for_document(
-                    processor.render_document_bibliography_groups::<F>(&groups),
-                    format,
-                )
+                let rendered_blocks =
+                    processor.render_document_bibliography_blocks::<F>(&groups, None, None);
+                let mut output = String::new();
+                for block in rendered_blocks {
+                    if block.entries.is_empty() {
+                        continue;
+                    }
+                    if !output.is_empty() {
+                        output.push_str("\n\n");
+                    }
+                    if let Some(heading) = block.heading {
+                        output.push_str(&render_bibliography_section_heading(&heading, format));
+                    }
+                    output.push_str(&block.body);
+                }
+                output
             },
         )
     }

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -590,9 +590,10 @@ Some text [@item1]."#;
         processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
 
     // Should have the frontmatter heading and bibliography groups rendered
+    // Groups are rendered as H2 sub-headings under the H1 Bibliography heading.
     assert_eq!(
         result,
-        "Some text (Doe, 2020).\n\n# Bibliography\n\n# Primary Sources\n\nJohn Doe (2020)\n\n# Secondary Sources\n\nJane Smith (2010)"
+        "Some text (Doe, 2020).\n\n# Bibliography\n\n## Primary Sources\n\nJohn Doe (2020)\n\n## Secondary Sources\n\nJane Smith (2010)"
     );
 }
 
@@ -673,6 +674,87 @@ Some text [@item1]."#;
     assert_eq!(
         result,
         "Some text (#link(<ref-item1>)[Doe, 2020]).\n\n= Bibliography\n\n== Primary Sources\n\nJohn Doe (2020) <ref-item1>\n\n== Secondary Sources\n\nJane Smith (2010) <ref-item2>"
+    );
+}
+
+#[test]
+// Given: a document with frontmatter bibliography groups processed as HTML
+// When: process_document is called with the Html output format
+// Then: group headings render as <h2> elements, not literal Markdown ## markers
+fn test_document_frontmatter_groups_html_h2_heading() {
+    let bib = make_test_bib();
+    let processor = Processor::new(make_author_date_style(), bib);
+    let parser = DjotParser;
+
+    let content = r#"---
+bibliography:
+  - id: primary
+    heading:
+      literal: "Primary Sources"
+    selector:
+      cited: visible
+  - id: rest
+    heading:
+      literal: "All Sources"
+    selector: {}
+---
+
+Some text [@item1]."#;
+
+    let result = processor.process_document::<_, crate::render::html::Html>(
+        content,
+        &parser,
+        DocumentFormat::Html,
+    );
+
+    // Group heading must be a pre-rendered HTML <h2>, not a Markdown ## that leaked through.
+    assert!(
+        result.contains("<h2>Primary Sources</h2>\n\n<div class"),
+        "expected HTML <h2> group heading in trailing bibliography, got: {result}"
+    );
+    assert!(
+        !result.contains("## Primary Sources"),
+        "Markdown heading must not appear in HTML output: {result}"
+    );
+}
+
+#[test]
+// Given: a document with a frontmatter group whose selector matches no entries
+// When: process_document is called
+// Then: the empty group emits no heading and no body in the output
+fn test_document_frontmatter_empty_group_omitted() {
+    let bib = make_test_bib();
+    let processor = Processor::new(make_author_date_style(), bib);
+    let parser = DjotParser;
+
+    let content = r#"---
+bibliography:
+  - id: cases
+    heading:
+      literal: "Cases"
+    selector:
+      type: legal-case
+  - id: books
+    heading:
+      literal: "Books"
+    selector:
+      type: book
+---
+
+Some text [@item1]."#;
+
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    // Empty "Cases" group must produce no heading or body.
+    assert!(
+        !result.contains("Cases"),
+        "empty group heading must not appear in output: {result}"
+    );
+    // Non-empty "Books" group must appear with its heading and both entries.
+    assert!(
+        result.contains("## Books\n\nJohn Doe (2020)\n\nJane Smith"),
+        "non-empty group must appear with heading and entries: {result}"
     );
 }
 
@@ -919,9 +1001,11 @@ First [+@item1]. Later [+@item1]."#;
     let result =
         processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
 
+    // Groups are H2 sub-headings. Unmatched refs (Jane Smith, not cited) are not
+    // rendered — use an explicit catch-all group with `selector: {}` to capture them.
     assert_eq!(
         result,
-        "First John Doe. Later Doe.\n\n# Bibliography\n\n# Cited Works\n\nJohn Doe (2020)\n\nJane Smith (2010)"
+        "First John Doe. Later Doe.\n\n# Bibliography\n\n## Cited Works\n\nJohn Doe (2020)"
     );
 }
 

--- a/docs/specs/BIBLIOGRAPHY_GROUPING.md
+++ b/docs/specs/BIBLIOGRAPHY_GROUPING.md
@@ -1,290 +1,163 @@
 # Bibliography Grouping Architecture
 
-**Status:** Design
+**Status:** Active
 **Created:** 2026-02-15
-**Related Issues:** csl26-group
+**Related:** bean `csl26-effd`, `csl26-o8ji`, `csl26-group`;
+`docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md`,
+`docs/specs/SERVER_INTERACTIVE_API.md`
 
 ## Overview
 
-This document defines the architecture for configurable bibliography grouping in Citum. The design enables styles to divide bibliographies into labeled sections with distinct sorting rules, addressing use cases from legal citations (type-based hierarchies) and multilingual bibliographies to primary/secondary source divisions in historical scholarship.
+This document defines the architecture for configurable bibliography grouping
+in Citum. The design enables styles and documents to divide a bibliography
+into labelled sections, each with its own selector, sort order, heading, and
+optional template override. Use cases include legal citations (type-based
+hierarchies), multilingual bibliographies, and primary/secondary source
+divisions in historical scholarship.
 
-## Problem Statement
+## Vocabulary
 
-Current implementation provides only basic hardcoded support for separating visible vs silent (nocite) citations under an "Additional Reading" heading. Real-world use cases require:
+| Term | Meaning |
+|---|---|
+| **group** | A declarative definition: what belongs in a section, how it is headed, sorted, and rendered (`BibliographyGroup`). |
+| **block** | A group placed in document order: the group definition plus a caller-supplied stable identifier (`BibliographyBlockRequest`). |
 
-1. **Legal Hierarchy (The Bluebook):** Type-based grouping with rigid ordering (Constitutions → Statutes → Cases) that ignores alphabetical content
-2. **Multilingual Grouping (Juris-M):** Language-based grouping with distinct sorting logic per group (Vietnamese by given-name, English by family-name)
-3. **Primary/Secondary Source Divisions:** Common in historical and humanities scholarship, where primary documents must be listed separately from secondary literature.
-4. **Topical Groupings:** Custom field-based grouping (keywords, reference types, custom metadata)
-
-The critical requirement is **per-group sorting** - a simple "group then sort" approach fails when different groups require different collation rules.
+The same `BibliographyGroup` type is used in the style schema, in document
+frontmatter, and (wrapped in a `BibliographyBlockRequest`) in the CLI and
+server API. A reader should see "group" where the focus is the definition
+and "block" where the focus is placement in a rendered document.
 
 ## Design Principles
 
-### Three Orthogonal Concerns
+1. **First-match semantics** — a reference appears in the first group whose
+   selector matches it and in no subsequent group. This prevents duplication
+   and is essential for legal citation hierarchies.
+2. **Explicit over magic** — all grouping is declared in YAML or JSON; no
+   hardcoded hierarchies.
+3. **Graceful degradation** — omitting groups produces a flat bibliography.
+4. **Per-group sorting** — each group may override the global sort with its
+   own sort spec, enabling culturally appropriate collation within sections.
 
-1. **Selection** - Which items belong to which group (predicate logic)
-2. **Ordering** - How groups appear relative to each other (sequence)
-3. **Presentation** - Per-group sorting, headings, styling
+## Core Type: `BibliographyGroup`
 
-### Key Constraints
-
-- **First-match semantics:** Items appear in first matching group only (prevents duplication)
-- **Explicit over magic:** All grouping declared in YAML, no hardcoded hierarchies
-- **Graceful degradation:** Omitting `groups` field produces flat bibliography (current behavior)
-- **Per-group sorting:** Groups override global sort when culturally appropriate
-
-## Schema Design
-
-### BibliographySpec Extension
+Canonical Rust definition: `citum_schema::grouping::BibliographyGroup`
+(`crates/citum-schema-style/src/grouping.rs`).
 
 ```yaml
-bibliography:
-  # Global defaults
-  options: ...
-  template: ...
+# Minimal
+- id: cases
+  selector:
+    type: legal-case
 
-  # Optional grouping (omit for flat bibliography)
-  groups:
-    - id: primary-legal
-      heading: "Primary Sources"
-      selector:
-        type: [legal-case, statute, treaty]
-      sort:
-        template:
-          - key: type
-            order: [legal-case, statute, treaty]  # Explicit sequence
-          - key: issued
-
-    - id: vietnamese
-      heading: "Tài liệu tiếng Việt"
-      selector:
-        field:
-          language: vi
-      sort:
-        template:
-          - key: author
-            sort-order: given-family  # Vietnamese convention
-          - key: year
-
-    - id: other
-      heading: "Other Sources"
-      selector:
-        not:
-          type: [legal-case, statute, treaty]
-          field:
-            language: vi
-      sort:
-        template:
-          - key: author
-            sort-order: family-given
+# Full
+- id: vietnamese
+  heading:
+    literal: "Tài liệu tiếng Việt"
+  selector:
+    field:
+      language: vi
+  sort:
+    template:
+      - key: author
+        sort-order: given-family
+  template: ...         # optional entry-template override
+  disambiguate: locally # or globally (default)
 ```
 
-### Rust Types
+### `GroupSelector`
 
-```rust
-pub struct BibliographySpec {
-    pub options: Option<Config>,
-    pub template: Option<Template>,
+| Field | Description |
+|---|---|
+| `type` | Match by reference type (single string or list). |
+| `cited` | `visible` (cited in document) or `any` (all references). To select only uncited references, use `not: { cited: visible }`. |
+| `field` | Match by arbitrary field value (e.g. `language: vi`). |
+| `not` | Negate a nested selector — use for catch-all groups. |
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub groups: Option<Vec<BibliographyGroup>>,
-}
+An empty selector (`selector: {}`) matches every reference not yet assigned
+to a prior group, making it a natural catch-all.
 
-pub struct BibliographyGroup {
-    /// Unique identifier for this group
-    pub id: String,
+### `GroupHeading`
 
-    /// Optional heading (omit for no heading)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub heading: Option<String>,
+One of:
+- `literal: "Cases"` — verbatim text.
+- `term: bibliography` (with optional sibling `form: long`) — locale-resolved term.
+- `localized: { zh: "中文文献", en-US: "Chinese-script sources" }` — per-locale map.
 
-    /// Selector predicate
-    pub selector: GroupSelector,
+Omit `heading:` entirely to render the group's entries with no section heading.
 
-    /// Optional per-group sorting (falls back to global sort if omitted)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort: Option<GroupSort>,
+## Rendering Primitive
 
-    /// Optional per-group template override
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub template: Option<Template>,
+**`Processor::render_document_bibliography_blocks`**
+(`crates/citum-engine/src/processor/bibliography/grouping.rs`)
 
-    /// Optional disambiguation scope
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub disambiguate: Option<DisambiguationScope>,
-}
+All document-level sectional bibliography rendering flows through this one
+function. It accepts an ordered `&[BibliographyGroup]` and a shared
+`assigned: HashSet<String>` dedup set, and returns a
+`Vec<RenderedBibliographyGroup>` — **one element per input group** (including
+empty ones). Each element carries a resolved `heading: Option<String>`, a
+formatted `body: String`, and an `entries` vec. Callers are responsible for
+filtering: the document pipeline skips groups where `entries.is_empty()`; the
+server API echoes every requested block by `id` regardless of emptiness.
 
-pub enum DisambiguationScope {
-    Globally,  // Default: cross-group suffixes
-    Locally,   // Reset suffixes within this group
-}
+The dedup set ensures first-match semantics across the full ordered sequence
+regardless of which input surface supplied the groups.
 
-pub struct GroupSelector {
-    /// Type-based filtering
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub r#type: Option<TypeSelector>,
+## Input Surfaces
 
-    /// Citation status filtering
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cited: Option<CitedStatus>,
+All four surfaces resolve to `&[BibliographyGroup]` before reaching the
+rendering primitive. Precedence when surfaces conflict is listed highest first.
 
-    /// Field-based filtering (language, keywords, etc.)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub field: Option<HashMap<String, FieldMatcher>>,
+| Surface | How to use | Wrapper type |
+|---|---|---|
+| **Caller / CLI / server** | `--bibliography-blocks <json>` on `citum render doc`; `bibliography_blocks` in `FormatDocumentRequest` | `BibliographyBlockRequest { id, group }` array |
+| **Fenced-div** | `:::bibliography{#id}` markers embedded in the document body | Parsed by the Djot/Markdown adapter |
+| **Frontmatter `bibliography:`** | Top-level YAML list of `BibliographyGroup` objects in document frontmatter | Bare `BibliographyGroup` array |
+| **Style `bibliography.groups`** | `groups:` list in the style's `bibliography:` section | Bare `BibliographyGroup` array |
 
-    /// Negation for fallback groups
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub not: Option<Box<GroupSelector>>,
-}
+When the frontmatter `bibliography:` list is present, the style-level
+`bibliography.groups` is ignored for that document. Caller/CLI/server blocks
+and fenced-div blocks are document-level mechanisms that also take precedence
+over style-level groups.
 
-pub enum TypeSelector {
-    Single(String),
-    Multiple(Vec<String>),
-}
+### Trailing vs. Positioned rendering
 
-pub enum CitedStatus {
-    Visible,  // Cited in document
-    Silent,   // Nocite only
-    Any,
-}
+- **Trailing** (frontmatter list and caller/CLI/server blocks): groups are
+  rendered as an ordered sequence appended after the document body, under an
+  automatic "Bibliography" H1 heading added by the engine. Group headings are
+  H2 sub-headings (`## heading` / `\subsection*` / `== heading` / `<h2>`).
+- **Positioned** (fenced-div blocks): each `:::bibliography{#id}` marker in
+  the body is replaced in-place by its rendered group. No automatic "Bibliography"
+  heading is added; authors control placement and headings in the document.
+- **API / server** (caller-supplied blocks): sections are appended as trailing
+  H2-level sections, with no automatic "Bibliography" wrapper heading. The
+  consuming application (e.g. a word processor) controls the top-level heading.
 
-pub enum FieldMatcher {
-    Exact(String),
-    Multiple(Vec<String>),
-    Pattern(FieldPattern),
-}
+## Grouping vs. Sort-Partitioning
 
-pub struct GroupSort {
-    pub template: Vec<GroupSortSpec>,
-}
+These are two distinct mechanisms and must not be confused.
 
-pub struct GroupSortSpec {
-    pub key: SortKey,
+| Feature | Purpose | Configured via |
+|---|---|---|
+| **Bibliography groups** | Divide a bibliography into explicitly declared sections by type, language, cited status, or custom field | `bibliography.groups` (style) or `bibliography:` (frontmatter/CLI/server) |
+| **Sort-partitioning** | Reorder and visually separate a multilingual bibliography by Unicode script (`script`) or item language (`language`) | `bibliography.options.sort-partitioning` (style) or `options.bibliography.sort-partitioning` (frontmatter) |
 
-    #[serde(default = "default_true")]
-    pub ascending: bool,
+Sort-partitioning is automatic and data-driven (the engine derives partition
+keys from reference metadata). Groups are explicit (the author or style designer
+declares each section). A bibliography can use both: groups divide by type,
+and sort-partitioning further reorders within a group by script.
 
-    /// For type-based ordering (e.g., [legal-case, statute, treaty])
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<Vec<String>>,
+When `label-mode: numeric` is active alongside partitioning, numeric labels
+run continuously across all partitions; restarting per partition would make
+cross-references ambiguous.
 
-    /// For name sorting (family-given vs given-family)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_order: Option<NameSortOrder>,
-}
-
-pub enum NameSortOrder {
-    FamilyGiven,  // Western convention
-    GivenFamily,  // Vietnamese convention
-}
-```
-
-## Processor Logic
-
-### High-Level Flow
-
-```rust
-pub fn render_grouped_bibliography(
-    &self,
-    refs: &[Reference],
-    style: &BibliographySpec,
-) -> Result<Vec<GroupedSection>, ProcessorError> {
-    let groups = style.groups.as_ref().ok_or_else(|| flat_bibliography)?;
-
-    let mut sections = Vec::new();
-    let mut assigned = HashSet::new();
-
-    for group in groups {
-        // Filter items matching this group's selector
-        let items: Vec<&Reference> = refs
-            .iter()
-            .filter(|r| !assigned.contains(&r.id))
-            .filter(|r| self.matches_selector(r, &group.selector))
-            .collect();
-
-        // Mark as assigned (first-match semantics)
-        for item in &items {
-            assigned.insert(&item.id);
-        }
-
-        // Sort using per-group or global sort
-        let sorted = self.sort_items(items, group.sort.as_ref().unwrap_or(&style.global_sort));
-
-        sections.push(GroupedSection {
-            heading: group.heading.clone(),
-            items: self.render_items(sorted, &group.template.unwrap_or(&style.template)),
-        });
-    }
-
-    // Fallback for ungrouped items
-    let unassigned: Vec<&Reference> = refs
-        .iter()
-        .filter(|r| !assigned.contains(&r.id))
-        .collect();
-
-    if !unassigned.is_empty() {
-        let sorted = self.sort_items(unassigned, &style.global_sort);
-        sections.push(GroupedSection {
-            heading: None,
-            items: self.render_items(sorted, &style.template),
-        });
-    }
-
-    Ok(sections)
-}
-
-fn matches_selector(&self, reference: &Reference, selector: &GroupSelector) -> bool {
-    let mut matches = true;
-
-    // Type filtering
-    if let Some(type_sel) = &selector.r#type {
-        matches &= match type_sel {
-            TypeSelector::Single(t) => reference.ref_type == *t,
-            TypeSelector::Multiple(types) => types.contains(&reference.ref_type),
-        };
-    }
-
-    // Citation status filtering
-    if let Some(cited) = &selector.cited {
-        matches &= match cited {
-            CitedStatus::Visible => self.cited_ids.contains(&reference.id),
-            CitedStatus::Silent => !self.cited_ids.contains(&reference.id),
-            CitedStatus::Any => true,
-        };
-    }
-
-    // Field filtering
-    if let Some(fields) = &selector.field {
-        for (field_name, matcher) in fields {
-            matches &= self.matches_field(reference, field_name, matcher);
-        }
-    }
-
-    // Negation
-    if let Some(not_sel) = &selector.not {
-        matches &= !self.matches_selector(reference, not_sel);
-    }
-
-    matches
-}
-```
-
-### Performance Considerations
-
-- **Complexity:** O(n × groups) for selector evaluation
-- **Optimization:** Pre-index by type/field for O(1) lookup if needed
-- **Typical case:** 3-5 groups, <1000 items per bibliography = negligible overhead
-
-## Use Case Examples
-
-### Legal Hierarchy (Bluebook)
+## Style-Level Groups
 
 ```yaml
 bibliography:
   groups:
     - id: cases
-      heading: "Cases"
+      heading:
+        literal: "Cases"
       selector:
         type: legal-case
       sort:
@@ -296,34 +169,61 @@ bibliography:
             ascending: false
 
     - id: statutes
-      heading: "Statutes"
+      heading:
+        literal: "Statutes"
       selector:
         type: statute
       sort:
         template:
           - key: title
+
+    - id: other
+      heading:
+        literal: "Secondary Sources"
+      selector:
+        not:
+          type: [legal-case, statute]
 ```
 
-**Input:** Brown (1954, supreme), District case (2020, trial), Roe (1973, supreme)
+Style-level groups apply to every document rendered with that style unless
+the document provides its own frontmatter `bibliography:` list or caller blocks.
 
-**Output:**
+## Per-Document Frontmatter Groups
+
+```yaml
+---
+bibliography:
+  - id: primary
+    heading:
+      literal: "Primary Sources"
+    selector:
+      type: [manuscript, interview, archival-document]
+
+  - id: secondary
+    heading:
+      literal: "Secondary Sources"
+    selector:
+      not:
+        type: [manuscript, interview, archival-document]
+---
 ```
-Cases
-Roe v. Wade, 410 U.S. 113 (1973).
-Brown v. Board of Education, 347 U.S. 483 (1954).
-District case (2020).
 
-Statutes
-[...]
-```
+**Unmatched entries are omitted.** The `not:` catch-all pattern above ensures
+all references appear. Without it, references not matching any group selector
+are silently skipped. This is intentional and consistent with how caller-supplied
+blocks work — use an explicit catch-all group to surface unmatched references.
 
-### Multilingual Sorting (Juris-M)
+See `docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md` for the full set of per-document
+override surfaces, including CLI flags and the server API.
+
+## Multilingual Sorting Example (Juris-M)
 
 ```yaml
 bibliography:
   groups:
     - id: vietnamese
-      heading: "Tài liệu tiếng Việt"
+      heading:
+        literal: "Tài liệu tiếng Việt"
       selector:
         field:
           language: vi
@@ -343,108 +243,42 @@ bibliography:
             sort-order: family-given
 ```
 
-**Input:** Nguyễn Văn A (vi), Trần Thị B (vi), Smith John (en)
+## Open Questions
 
-**Output:**
-```
-Tài liệu tiếng Việt
-Nguyễn Văn A. (2019).
-Trần Thị B. (2020).
+**Q: Should items appear in multiple groups?**
+**A:** No. First-match semantics prevent duplication. This is critical for
+legal citations where the same item must not appear in both "Cases" and
+"Secondary Sources."
 
-Smith, J. (2018).
-```
+**Q: Should nested groups be supported?**
+**A:** No. Flat groups with selectors are sufficient for all known use cases.
+Nesting adds complexity without clear benefit.
 
-### Topical Grouping
-
-```yaml
-bibliography:
-  groups:
-    - id: primary-sources
-      heading: "Primary Sources"
-      selector:
-        type: [manuscript, interview, archival-document]
-
-    - id: datasets
-      heading: "Datasets"
-      selector:
-        type: dataset
-
-    - id: secondary
-      heading: "Secondary Sources"
-      selector:
-        not:
-          type: [manuscript, interview, archival-document, dataset]
-```
-
-## User-Defined Grouping
-
-Users can override style-defined grouping by providing a custom `groups` field:
-
-```yaml
-# User's bibliography.yaml
-groups:
-  - id: must-read
-    heading: "Essential Reading"
-    selector:
-      field:
-        keywords: essential
-
-  - id: other
-    selector:
-      not:
-        field:
-          keywords: essential
-```
-
-**Processor precedence:** User-defined groups > Style-defined groups > Flat bibliography
+**Q: What about items that match no group?**
+**A:** They are omitted. Use an explicit catch-all group with `selector: {}`
+or a `not:` negation to capture remaining entries.
 
 ## Prior Art
 
-### biblatex
-
-Uses predicate-based filtering with explicit section commands:
-
-```latex
-\printbibliography[type=article,title=Articles]
-\printbibliography[nottype=article,title=Other Sources]
-```
-
-**Key insight:** Flat, declarative syntax with negation for fallback groups.
-
-### CSL 1.0
-
-No bibliography grouping constructs. All grouping is hardcoded in processors.
-
-**Citum opportunity:** First-class grouping support in style schema.
-
-### CSL-M
-
-Locale-specific `<layout>` elements for presentation, but no grouping.
-
-**Citum improvement:** Unified grouping + sorting + presentation model.
-
-## Open Questions
-
-**Q: Should we support nested groups?**
-**A:** No. Flat groups with selectors are sufficient for all known use cases. Nesting adds complexity without clear benefits.
-
-**Q: Should items appear in multiple groups?**
-**A:** No. First-match semantics prevent duplication, which is critical for legal citations.
-
-**Q: Performance with 10,000+ items?**
-**A:** Pre-index by type/field if benchmarks show O(n × groups) is problematic. Defer optimization until measured.
+- **biblatex** `\printbibliography[type=article,title=Articles]` — flat,
+  declarative, negation for catch-all. The Citum group selector generalises
+  this to multi-field predicates.
+- **CSL 1.0** — no grouping constructs; all grouping is hardcoded in processors.
+- **Juris-M / CSL-M** — locale-specific layout elements, but no general grouping.
 
 ## Compliance with Citum Principles
 
-- **Explicit Over Magic:** All grouping declared in YAML
-- **Declarative Templates:** Flat selector syntax, no procedural conditionals
-- **Code-as-Schema:** Rust structs drive JSON schema validation
-- **Graceful Degradation:** Omitting `groups` uses flat bibliography
-- **Multilingual Support:** Per-group sorting enables culturally appropriate collation
+- **Explicit Over Magic:** all grouping declared in YAML or JSON.
+- **Declarative Templates:** flat selector syntax, no procedural conditionals.
+- **Code-as-Schema:** `BibliographyGroup` Rust struct drives JSON Schema.
+- **Graceful Degradation:** omitting `groups` produces a flat bibliography.
+- **Multilingual Support:** per-group sorting enables culturally appropriate collation.
 
-## References
+## Changelog
 
-- The Bluebook: A Uniform System of Citation, 21st Edition
-- biblatex Manual, Section 3.6.5 (Bibliography Filters)
-- Juris-M Documentation (Multilingual Sorting)
-- CSL-M Specification (Legal Citations)
+- 2026-06-08: Status Design → Active. Rewrite to reflect implemented code:
+  canonical type, `render_document_bibliography_blocks` primitive, vocabulary
+  rule (group vs block), input-surfaces table, grouping-vs-partitioning
+  distinction, unmatched-entry policy. Remove speculative Rust/processor
+  sections. (csl26-effd, csl26-o8ji, fd0c6eee)
+- 2026-02-15: Initial draft.

--- a/docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
+++ b/docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md
@@ -2,7 +2,8 @@
 
 **Status:** Active
 **Date:** 2026-05-26
-**Related:** bean `csl26-tap8`, `docs/specs/INTEGRAL_NAME_MEMORY.md`, `docs/specs/UNIFIED_SCOPED_OPTIONS.md`
+**Related:** bean `csl26-tap8`, `docs/specs/INTEGRAL_NAME_MEMORY.md`,
+`docs/specs/UNIFIED_SCOPED_OPTIONS.md`, `docs/specs/BIBLIOGRAPHY_GROUPING.md`
 
 ## Purpose
 
@@ -26,7 +27,8 @@ consumers such as word-processor plugins.
 - CLI surface (`citum render doc` flags)
 - GUI consumer contract (same serde-derived Rust type; YAML/JSON/CBOR share one schema)
 - Implementation pattern (sparse-overlay model)
-- Relationship between per-document `sort-partitioning` and existing bibliography groups
+- Relationship between per-document `sort-partitioning` and bibliography groups
+- Per-document bibliography grouping surfaces (frontmatter list, CLI flag, server field)
 
 **Out of scope:**
 
@@ -116,20 +118,14 @@ Valid `by` values are `script` and `language`. The heading shape follows
 
 General-purpose bibliography divisions — primary vs. secondary sources, legal
 materials by category (cases / legislation / commentary), print vs. online —
-are **not** sort-partitioning. They are handled by the existing
-`DocumentFrontmatter.bibliography` field, which accepts a list of
-`BibliographyGroup` entries. Each group uses a `GroupSelector` (by type,
-cited status, or field value), an optional heading, an optional per-group
-sort, and an optional per-group template.
-
-OSCOLA's requirement for separate sections for cases, legislation, and
-secondary sources is expressed as bibliography groups with type selectors, not
-as sort-partitioning. Chicago divided bibliographies for large theses are
-likewise bibliography groups. Sort-partitioning is specifically the mechanism
+are **not** sort-partitioning. Sort-partitioning is specifically the mechanism
 for script/language-based multilingual reordering.
 
-This distinction resolves the naming confusion between the two features: they
-have different shapes, different selectors, and different purposes.
+General-purpose sectional bibliographies are handled by bibliography *groups*,
+a separate mechanism with its own type, selectors, and rendering primitive.
+See `docs/specs/BIBLIOGRAPHY_GROUPING.md` for the full type documentation,
+input surfaces, and examples. This spec covers only the per-document *access
+surfaces* for that mechanism (frontmatter list, CLI flag, server field).
 
 #### Interaction with numeric `label-mode`
 
@@ -284,6 +280,55 @@ bibliography:
 ---
 ```
 
+### Sectional bibliography grouping (per-document surfaces)
+
+Per-document sectional bibliographies are configured via three surfaces; all
+resolve to the same `BibliographyGroup` type before reaching the engine's
+shared rendering primitive. See `docs/specs/BIBLIOGRAPHY_GROUPING.md` for the
+full type definition, selector syntax, and precedence rules.
+
+**Frontmatter `bibliography:` list** — a top-level list of `BibliographyGroup`
+objects in document frontmatter. When present, it supersedes the style's own
+`bibliography.groups` list for that document:
+
+```yaml
+---
+bibliography:
+  - id: primary
+    heading:
+      literal: "Primary Sources"
+    selector:
+      type: [manuscript, interview, archival-document]
+
+  - id: secondary
+    heading:
+      literal: "Secondary Sources"
+    selector:
+      not:
+        type: [manuscript, interview, archival-document]
+---
+```
+
+Groups are rendered as ordered trailing sections (H2 under an automatic
+"Bibliography" H1), one per non-empty group. Entries matching no group are
+silently omitted — use an explicit catch-all `selector: {}` to surface them.
+
+**CLI `--bibliography-blocks <json>`** on `citum render doc` — an ordered JSON
+array of `BibliographyBlockRequest { id, group }` objects passed as a CLI flag.
+Takes precedence over frontmatter `bibliography:` and style-level groups:
+
+```
+citum render doc manuscript.djot -s oscola -b refs.json \
+  --bibliography-blocks '[{"id":"cases","group":{"selector":{"type":"legal-case"},"heading":{"literal":"Cases"}}},{"id":"other","group":{"selector":{},"heading":{"literal":"Other Sources"}}}]'
+```
+
+**Server `FormatDocumentRequest.bibliography_blocks`** — an ordered array of
+`BibliographyBlockRequest` items in the `format_document` RPC request. Intended
+for word-processor plugins and other GUI consumers. The consuming application
+controls the top-level "Bibliography" heading; the engine renders only the
+group sections. See `docs/specs/SERVER_INTERACTIVE_API.md` for the full field
+reference.
+
 ### CLI (`citum render doc`)
 
 `citum render doc` reads frontmatter `options:` automatically. No extra flags
@@ -367,6 +412,11 @@ when both are set.
 
 ## Changelog
 
+- 2026-06-08: Add sectional bibliography grouping to scope and Access Surfaces.
+  Replace re-described BibliographyGroup/GroupSelector prose with reference to
+  BIBLIOGRAPHY_GROUPING.md. Add three per-document group surfaces: frontmatter
+  `bibliography:` list, CLI `--bibliography-blocks`, server `bibliography_blocks`.
+  Cross-link SERVER_INTERACTIVE_API.md. (csl26-effd)
 - 2026-06-03: Status Draft → Active. Add worked example for
   `bibliography.repeated-author-rendering`; clarify default Chicago behaviour
   re CSL 18th-edition and CMOS §14.67.

--- a/docs/specs/SERVER_INTERACTIVE_API.md
+++ b/docs/specs/SERVER_INTERACTIVE_API.md
@@ -242,6 +242,13 @@ These types capture the rendered output along with metadata provided by the engi
 
 These types support sectional (split) bibliographies in `format_document`. Supply an ordered array of `BibliographyBlockRequest` in the request; get back a matching array of `FormattedBibliographyBlock` in the result. The engine threads a single dedup set across blocks so each reference appears in at most one block.
 
+`BibliographyBlockRequest` is the server surface for the bibliography grouping
+mechanism shared with frontmatter `bibliography:` lists and the CLI
+`--bibliography-blocks` flag. For the full `BibliographyGroup` type definition,
+`GroupSelector` syntax, precedence rules, and examples, see
+`docs/specs/BIBLIOGRAPHY_GROUPING.md`. For the per-document surfaces overview
+(frontmatter, CLI, server), see `docs/specs/PER_DOCUMENT_CONFIG_OVERRIDES.md`.
+
 **`BibliographyBlockRequest` fields:**
 
 | Field | Type | Required | Description |
@@ -297,7 +304,7 @@ Modelled on Pandoc citeproc: one call, all inputs, all outputs. Works in stdio, 
 | `output_format` | string | no | One of `plain` (default), `html`, `djot`, `latex`, `typst` |
 | `refs` | `RefsInput` | yes | Bibliography input: tagged path, YAML, JSON, or legacy bare JSON map |
 | `citations` | array | yes | Ordered `CitationOccurrence` items (document order) |
-| `bibliography_blocks` | array | no | Ordered `BibliographyBlockRequest` items for sectional bibliographies (see below) |
+| `bibliography_blocks` | array | no | Ordered `BibliographyBlockRequest` items for sectional bibliographies (see `BibliographyBlockRequest` above and `docs/specs/BIBLIOGRAPHY_GROUPING.md`) |
 | `document_options` | `DocumentOptions` | no | Document-level rendering config (see above) |
 
 **Example request:**


### PR DESCRIPTION
## Summary

Follow-up to fd0c6eee ("consolidate bib block rendering"). Two-part
cleanup that closes the vocabulary drift and spec inconsistency between
the bibliography grouping mechanism and its per-document access surfaces.

**Part A — Engine de-dup (994707ce)**
- Folded `process_document_with_frontmatter_groups` onto the
  `render_document_bibliography_blocks` primitive (already used by the
  CLI/server path); deleted dead `render_document_bibliography_groups`,
  `render_with_custom_groups`, and `rewrite_group_headings_for_document`
- Group headings are now rendered at H2 level (correct under the H1
  "Bibliography" wrapper); old path incorrectly emitted H1 headings
- Unassigned-entry fallback removed (explicit over magic: use a
  catch-all `selector: {}` group instead)
- 3 tests updated to match the corrected output

**Part B — Spec reconciliation (837beb44)**
- `BIBLIOGRAPHY_GROUPING.md` promoted Design -> Active; rewritten with
  real types, vocabulary rule (group = definition, block = placed
  instance), input-surfaces table (4 sources -> 1 renderer, precedence),
  grouping-vs-partitioning distinction, unmatched-entry policy
- `PER_DOCUMENT_CONFIG_OVERRIDES.md`: replaced re-described
  BibliographyGroup prose with reference to BIBLIOGRAPHY_GROUPING;
  added three per-document group surfaces (frontmatter `bibliography:`
  list, CLI `--bibliography-blocks`, server `bibliography_blocks`)
- `SERVER_INTERACTIVE_API.md`: cross-links added at `BibliographyBlockRequest`
  section and `bibliography_blocks` field

## Test plan

- [x] `cargo nextest run` — 1526 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [x] Review spec prose for accuracy (no code correctness risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
