### PR TITLE
feat(engine): nocite bibliography-only entries

### DIFF
--- a/.beans/archive/csl26-cpb7--interactive-api-nocite-bibliography-only-entries.md
+++ b/.beans/archive/csl26-cpb7--interactive-api-nocite-bibliography-only-entries.md
@@ -1,11 +1,11 @@
 ---
 # csl26-cpb7
 title: 'Interactive API: nocite (bibliography-only entries)'
-status: todo
+status: completed
 type: feature
 priority: normal
 created_at: 2026-06-04T14:21:41Z
-updated_at: 2026-06-04T14:21:41Z
+updated_at: 2026-06-09T11:50:48Z
 ---
 
 The interactive server API (`format_document` + session methods) has no `nocite` parameter. Hosts cannot include a reference in the bibliography without creating an in-text citation.
@@ -23,3 +23,14 @@ Word-processor hosts (citum-office) need no-cite / bibliography-only entries: th
 
 Required by citum-office P2 no-cite UX. Tracked gap in
 citum-office docs/specs/01-cdip-protocol.md § Known Engine Gaps.
+
+## Summary of Changes
+
+- Added `register_nocite_ids` to `Processor` (engine); inserts IDs into `cited_ids`.
+- Added `nocite: Vec<String>` field to `FormatDocumentRequest`; unknown IDs emit `nocite_missing_ref` warnings.
+- Unified `format_bibliography` to restrict to `cited_ids` (cited + nocite) on both the batch and session paths — breaking fix for the longstanding inconsistency where the interactive API returned all loaded refs.
+- Added `DocumentSession::set_nocite` method and `nocite` field; wired nocite registration into `render_citations`.
+- Added `SetNociteParams` to the JSON-RPC server; wired `set_nocite` dispatch arm and handler; updated HTTP schema map.
+- Regenerated `docs/schemas/server.json`.
+- Added spec `docs/specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md`.
+- 1536/1536 tests passing.

--- a/.beans/csl26-31pi--refactorengine-consolidate-document-bibliography-r.md
+++ b/.beans/csl26-31pi--refactorengine-consolidate-document-bibliography-r.md
@@ -1,0 +1,60 @@
+---
+# csl26-31pi
+title: 'refactor(engine): unify document bibliography rendering into single Processor method'
+status: todo
+type: task
+priority: normal
+created_at: 2026-06-09T12:08:06Z
+updated_at: 2026-06-09T12:09:51Z
+---
+
+
+## Background
+
+The `feat(engine): nocite bibliography-only entries` PR (#891) fixed
+the behavioral inconsistency between paths but left **two separate implementations**
+of "restrict bibliography to cited refs":
+
+1. **Document-string path** (`pipeline.rs` → `render_grouped_document_bibliography_with_format`)
+   Calls `render_grouped_bibliography_inner(restrict_to_cited: true, …)` in
+   `crates/citum-engine/src/processor/bibliography/grouping.rs:569`.
+
+2. **Batch / session path** (`document.rs::format_bibliography`)
+   Passes `cited_ids_vec` explicitly to `render_selected_bibliography_with_format_and_annotations`
+   and calls `process_selected_references_with_format` for per-entry data.
+   `crates/citum-engine/src/api/document.rs:638`.
+
+Both are behaviorally correct but share no code. The `restrict_to_cited` flag in
+`render_grouped_bibliography_inner` already models the concept cleanly; the batch/session
+path just bypasses it via a different entry point.
+
+## Goal
+
+A single `Processor::render_document_bibliography<F>` method (or equivalent name) that:
+- Consults `self.cited_ids` internally (already populated by the nocite/citation pipeline)
+- Returns both `content: String` and `entries: Vec<BibliographyEntry>` in one call
+- Handles all three sub-paths: custom groups, sort-partitioning, and flat
+- Is the only caller of `render_grouped_bibliography_inner(restrict_to_cited: true, …)`
+- Replaces the `format_bibliography` function in `document.rs` as the orchestrator
+
+The standalone / FFI `render_bibliography_with_format` (`restrict_to_cited: false`) stays
+unchanged — those are genuinely no-document-context calls.
+
+## Key files
+
+- `crates/citum-engine/src/processor/bibliography/mod.rs` — add new method here
+- `crates/citum-engine/src/processor/bibliography/grouping.rs:569` — wire through
+- `crates/citum-engine/src/api/document.rs:611` — replace `format_bibliography` to call new method
+- `crates/citum-engine/src/processor/document/pipeline.rs:244` — update to use new method
+- `crates/citum-cli/` — calls `format_document`, which routes through `document.rs:611`; no direct
+  bibliography rendering. The CLI picks up the unified method automatically — no changes needed
+  here, but verify no bypass when implementing.
+
+## Constraints
+
+- No behavior change: all existing tests must pass after refactor
+- The `entries` field must remain consistent with `content` (subsequent-author substitution
+  must iterate only the cited subset — the bug `process_selected_references_with_format`
+  fixed in the batch path must be preserved in the unified method)
+- `process_selected_references_with_format` added in the nocite PR can be folded into
+  the new method or kept as an internal helper — defer to implementer

--- a/.beans/csl26-f9ri--featengine-nocite-wildcard-and-allrefs-flag.md
+++ b/.beans/csl26-f9ri--featengine-nocite-wildcard-and-allrefs-flag.md
@@ -1,0 +1,68 @@
+---
+# csl26-f9ri
+title: 'feat(engine): nocite @* wildcard and allrefs flag'
+status: todo
+type: feature
+priority: normal
+created_at: 2026-06-09T12:08:17Z
+updated_at: 2026-06-09T12:08:58Z
+---
+
+## Background
+
+The `feat(engine): nocite bibliography-only entries` PR established that the bibliography
+is always restricted to `cited_ids` (cited + registered nocite IDs). Two common use cases
+are not yet covered:
+
+1. **`@*` wildcard** — Pandoc syntax meaning "cite every loaded reference"; equivalent to
+   calling `nocite` with all ref IDs. Useful for reference lists with no in-text citations.
+2. **`allrefs` flag** — an explicit opt-in to include all loaded refs, bypassing the
+   `cited_ids` restriction. Mirrors the existing `render_bibliography_with_format` behavior
+   (the standalone / FFI path) but from within a document context.
+
+## Proposed API shape
+
+### `FormatDocumentRequest` (batch)
+```json
+{
+  "nocite": ["@*"]
+}
+```
+If `"@*"` is present in `nocite`, expand it to all ref IDs before registration (drop the
+literal `"@*"` from the ID set). This matches Pandoc semantics exactly and requires no new
+field — just special-case handling inside the existing nocite registration block in
+`format_document_with_style` (`crates/citum-engine/src/api/document.rs`, just before
+`processor.register_nocite_ids(…)`).
+
+### `DocumentSession` (interactive)
+Same: `session.set_nocite(vec!["@*".to_string()])` expands to all loaded ref IDs.
+Handle in `render_citations` in `crates/citum-engine/src/api/session.rs` at the
+nocite registration block (same pattern as batch path).
+
+### `FormatDocumentRequest` — `allrefs` flag (optional, lower priority)
+```json
+{ "allrefs": true }
+```
+Shorthand for `nocite: ["@*"]`. Implement as a pre-processing step that populates
+`nocite` from `bibliography.keys()` when `allrefs` is true, then follows the normal
+nocite path. May be deferred if `@*` alone is sufficient.
+
+## Key files
+
+- `crates/citum-engine/src/api/document.rs` — expand `@*` in nocite registration block
+- `crates/citum-engine/src/api/session.rs` — same expansion in `render_citations`
+- `crates/citum-engine/src/api/mod.rs` (or `document.rs`) — add `allrefs: bool` field
+  to `FormatDocumentRequest` if `allrefs` flag is implemented
+- `crates/citum-server/src/rpc.rs` — add `allrefs` to `FormatDocumentParams` mirror if implemented
+- `docs/specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md` — update to document `@*` and `allrefs`
+
+## Tests needed
+
+- `nocite: ["@*"]` with 3 loaded refs → all 3 appear in bibliography
+- `nocite: ["@*", "extra"]` — `@*` expands and `"extra"` is treated as a normal ID
+  (already covered by expansion; no special handling needed)
+- Session: `set_nocite(["@*"])` → all session refs appear in bibliography
+
+## Spec cross-ref
+
+`docs/specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md` § Out of Scope notes this explicitly.

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -66,6 +66,15 @@ pub struct FormatDocumentRequest {
     pub bibliography_blocks: Vec<super::BibliographyBlockRequest>,
     /// Optional document-level configuration.
     pub document_options: Option<DocumentOptions>,
+    /// Reference IDs to include in the bibliography without emitting an in-text citation.
+    ///
+    /// Nocite entries appear in `bibliography.entries` (and match `CitedStatus::Visible`
+    /// selectors for grouped / block bibliographies) but produce no `formatted_citations`
+    /// entry. This matches standard citeproc / Pandoc `nocite` semantics.
+    ///
+    /// IDs absent from `refs` are ignored and trigger a `nocite_missing_ref` warning.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub nocite: Vec<String>,
 }
 
 /// The result of formatting a document.
@@ -299,6 +308,28 @@ pub fn format_document_with_style(
         OutputFormatKind::Typst => format_by_kind::<Typst>(&processor, &citations)?,
         OutputFormatKind::Markdown => format_by_kind::<Markdown>(&processor, &citations)?,
     };
+
+    // Register nocite IDs: validate against bibliography, warn on missing, then add
+    // to cited_ids so they appear in bibliography.entries but produce no citation text.
+    let nocite_ids: Vec<String> = request
+        .nocite
+        .iter()
+        .filter_map(|id| {
+            if processor.bibliography.contains_key(id) {
+                Some(id.clone())
+            } else {
+                warnings.push(Warning {
+                    level: WarningLevel::Warning,
+                    code: "nocite_missing_ref".to_string(),
+                    citation_id: None,
+                    ref_id: Some(id.clone()),
+                    message: format!("Nocite reference '{id}' not found in bibliography"),
+                });
+                None
+            }
+        })
+        .collect();
+    processor.register_nocite_ids(nocite_ids);
 
     // Process bibliography
     let bibliography = match request.output_format {
@@ -571,7 +602,12 @@ where
     Ok(formatted)
 }
 
-/// Format the bibliography by output kind.
+/// Format the bibliography by output kind, restricted to the document's cited set.
+///
+/// Only references that appear in `processor.cited_ids` — either via an in-text
+/// citation or via a `nocite` registration — are included in the output. This
+/// unifies the interactive API with the document-string path, both of which use
+/// `cited_ids` as the authority for "what belongs in the bibliography".
 pub(crate) fn format_bibliography<F>(
     processor: &Processor,
     format_kind: OutputFormatKind,
@@ -594,19 +630,27 @@ where
         (HashMap::new(), None)
     };
 
-    // Render bibliography as string
-    let content = if annotations.is_empty() {
-        processor
-            .render_bibliography_with_format_and_annotations::<F>(None, annotation_style.as_ref())
-    } else {
-        processor.render_bibliography_with_format_and_annotations::<F>(
-            Some(&annotations),
-            annotation_style.as_ref(),
-        )
-    };
+    // Collect the document's reference set (cited + nocite IDs).
+    let cited_set = processor.cited_ids.borrow();
+    let cited_ids_vec: Vec<String> = cited_set.iter().cloned().collect();
 
-    // Extract per-entry text in the requested output format and capture metadata.
-    let proc_entries = processor.process_references_with_format::<F>().bibliography;
+    // Render bibliography string restricted to the document reference set.
+    let content = processor.render_selected_bibliography_with_format_and_annotations::<F, _>(
+        cited_ids_vec,
+        if annotations.is_empty() {
+            None
+        } else {
+            Some(&annotations)
+        },
+        annotation_style.as_ref(),
+    );
+
+    // Extract per-entry text using the same selected subset that rendered
+    // content, so subsequent-author substitution is computed against cited
+    // refs only — not the full loaded bibliography.
+    let proc_entries = processor
+        .process_selected_references_with_format::<F, _>(cited_set.iter().cloned())
+        .bibliography;
     let entries = proc_entries
         .into_iter()
         .map(|entry| {
@@ -834,6 +878,7 @@ mod tests {
             citations: vec![],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         let result = format_document_with_style(style, request);
@@ -862,6 +907,9 @@ mod tests {
             citations: vec![],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            // Use nocite to include art1 in the bibliography without an in-text citation;
+            // the test is validating bibliography HTML rendering, not citation rendering.
+            nocite: vec!["art1".to_string()],
         };
 
         let result = format_document_with_style(style, request).expect("should render");
@@ -911,6 +959,7 @@ mod tests {
             citations: vec![citation_occ],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         let result = format_document_with_style(style, request);
@@ -963,6 +1012,7 @@ mod tests {
             citations: vec![citation_occ],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         let result = format_document_with_style(style, request).unwrap();
@@ -1020,6 +1070,7 @@ mod tests {
             citations: vec![citation_occ],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         let result = format_document(request);
@@ -1040,6 +1091,7 @@ mod tests {
             citations: vec![],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         let result = format_document(request);
@@ -1106,6 +1158,7 @@ mod tests {
             citations: vec![citation_occ],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         // Without a resolver, the same Id input must be rejected.
@@ -1228,6 +1281,7 @@ mod tests {
             citations: vec![cite("duo2024")],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
         let result_base = format_document_with_style(base_style.clone(), request_base).unwrap();
         let text_base = &result_base.formatted_citations[0].text;
@@ -1246,6 +1300,7 @@ mod tests {
             citations: vec![cite("duo2024")],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
         let result_override =
             format_document_with_style(base_style.clone(), request_override).unwrap();
@@ -1281,6 +1336,7 @@ mod tests {
             citations: vec![],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         match format_document_with_style(style, request) {
@@ -1429,6 +1485,7 @@ mod tests {
                 }),
                 ..Default::default()
             }),
+            nocite: vec![],
         };
 
         let result = format_document_with_style(style, request).expect("should render");
@@ -1476,6 +1533,7 @@ mod tests {
                 }),
                 ..Default::default()
             }),
+            nocite: vec![],
         };
 
         let result = format_document_with_style(style, request).expect("should render");
@@ -1512,6 +1570,7 @@ mod tests {
             ],
             bibliography_blocks: Vec::new(),
             document_options: None,
+            nocite: vec![],
         };
 
         let result = format_document_with_style(style, request).expect("should render");
@@ -1582,6 +1641,7 @@ mod tests {
             citations: vec![],
             bibliography_blocks: vec![make_block("block-a"), make_block("block-b")],
             document_options: None,
+            nocite: vec![],
         };
 
         let result = format_document_with_style(style, request).expect("should render");
@@ -1597,6 +1657,194 @@ mod tests {
         assert_eq!(
             block_b_count, 0,
             "block-b is empty: dedup set prevents re-assignment from block-a"
+        );
+    }
+
+    // --- nocite tests ---
+
+    /// A ref listed only in `nocite` must appear in the bibliography but produce
+    /// no `formatted_citations` entry (standard citeproc nocite semantics).
+    #[test]
+    fn nocite_ref_in_bibliography_not_in_formatted_citations() {
+        let mut style = make_test_style();
+        // A bibliography template is required for entries to be produced.
+        style.bibliography = Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+        let refs = make_test_bibliography(); // contains "smith2020"
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![],
+            bibliography_blocks: Vec::new(),
+            document_options: None,
+            nocite: vec!["smith2020".to_string()],
+        };
+
+        let result = format_document_with_style(style, request).expect("should render");
+
+        assert_eq!(
+            result.formatted_citations.len(),
+            0,
+            "nocite refs must not produce a formatted citation"
+        );
+        assert_eq!(
+            result.bibliography.entries.len(),
+            1,
+            "nocite ref must appear in bibliography entries"
+        );
+        assert_eq!(
+            result.bibliography.entries[0].id, "smith2020",
+            "bibliography entry id should match nocite ref"
+        );
+        assert!(
+            !result.bibliography.content.is_empty(),
+            "bibliography content must be non-empty for nocite ref"
+        );
+        assert!(
+            result.warnings.is_empty(),
+            "no warnings expected: {:?}",
+            result.warnings
+        );
+    }
+
+    /// An ID listed in `nocite` that is absent from `refs` must emit a
+    /// `nocite_missing_ref` warning and not appear in the bibliography.
+    #[test]
+    fn nocite_missing_ref_emits_warning() {
+        let style = make_test_style();
+        let refs = make_test_bibliography();
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs,
+            citations: vec![],
+            bibliography_blocks: Vec::new(),
+            document_options: None,
+            nocite: vec!["does_not_exist".to_string()],
+        };
+
+        let result = format_document_with_style(style, request).expect("should render");
+
+        assert_eq!(
+            result.bibliography.entries.len(),
+            0,
+            "absent nocite ref must not produce a bibliography entry"
+        );
+        let warning = result
+            .warnings
+            .iter()
+            .find(|w| w.code == "nocite_missing_ref")
+            .expect("nocite_missing_ref warning should be emitted");
+        assert_eq!(
+            warning.ref_id.as_deref(),
+            Some("does_not_exist"),
+            "warning ref_id should name the absent nocite key"
+        );
+    }
+
+    /// A nocite ref must sort alongside the cited ref when both are present
+    /// (i.e., citation status does not affect bibliography sort order).
+    #[test]
+    fn nocite_ref_sorts_alongside_cited_ref() {
+        let mut style = make_test_style();
+        style.bibliography = Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+
+        let citation_occ = CitationOccurrence {
+            id: "c1".to_string(),
+            items: vec![CitationOccurrenceItem {
+                id: "duo2024".to_string(),
+                locator: None,
+                prefix: None,
+                suffix: None,
+                integral_name_state: None,
+                org_abbreviation_state: None,
+            }],
+            mode: None,
+            note_number: None,
+            suppress_author: None,
+            grouped: None,
+            prefix: None,
+            suffix: None,
+            sentence_start: None,
+        };
+
+        // Two refs: duo2024 (cited via citation_occ) + smith2020 (nocite-only).
+        let combined_refs = RefsInput::Yaml(
+            r#"duo2024:
+  class: monograph
+  id: duo2024
+  type: book
+  title: Duo Work
+  issued: "2024"
+  author:
+    - family: Smith
+      given: Alice
+    - family: Jones
+      given: Bob
+smith2020:
+  class: monograph
+  id: smith2020
+  type: book
+  title: Smith Work
+  issued: "2020"
+  author:
+    - family: Smith
+      given: Alex
+"#
+            .to_string(),
+        );
+
+        let request = FormatDocumentRequest {
+            style: StyleInput::Yaml("dummy".to_string()),
+            style_overrides: None,
+            locale: None,
+            output_format: OutputFormatKind::Plain,
+            refs: combined_refs,
+            citations: vec![citation_occ],
+            bibliography_blocks: Vec::new(),
+            document_options: None,
+            nocite: vec!["smith2020".to_string()],
+        };
+
+        let result = format_document_with_style(style, request).expect("should render");
+
+        assert_eq!(result.formatted_citations.len(), 1, "one in-text citation");
+        assert_eq!(
+            result.bibliography.entries.len(),
+            2,
+            "both cited and nocite refs must appear in the bibliography"
+        );
+        let ids: Vec<&str> = result
+            .bibliography
+            .entries
+            .iter()
+            .map(|e| e.id.as_str())
+            .collect();
+        assert!(
+            ids.contains(&"duo2024"),
+            "cited ref must be in bibliography: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"smith2020"),
+            "nocite ref must be in bibliography: {ids:?}"
         );
     }
 }

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -106,6 +106,11 @@ pub struct DocumentSession {
     document_options: Option<DocumentOptions>,
     refs: Option<RefsInput>,
     citations: Vec<CitationOccurrence>,
+    /// Reference IDs registered for bibliography-only inclusion (nocite).
+    ///
+    /// IDs in this set appear in the bibliography alongside cited refs but
+    /// produce no `formatted_citations` entry (standard citeproc nocite).
+    nocite: Vec<String>,
     version: u64,
     formatted_citations: Vec<FormattedCitation>,
     bibliography: Option<FormattedBibliography>,
@@ -128,6 +133,7 @@ impl DocumentSession {
             document_options,
             refs: None,
             citations: Vec::new(),
+            nocite: Vec::new(),
             version: 0,
             formatted_citations: Vec::new(),
             bibliography: None,
@@ -143,6 +149,25 @@ impl DocumentSession {
     /// Replace the full reference set used by this session.
     pub fn put_references(&mut self, refs: RefsInput) {
         self.refs = Some(refs);
+    }
+
+    /// Set the nocite list and re-render the session bibliography.
+    ///
+    /// Nocite IDs appear in the bibliography alongside cited refs but produce
+    /// no `formatted_citations` entry. IDs absent from the current reference
+    /// set emit a `nocite_missing_ref` warning and are silently dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when re-rendering the session output fails.
+    pub fn set_nocite(
+        &mut self,
+        ids: Vec<String>,
+    ) -> Result<SessionMutationResult, DocumentSessionError> {
+        let old_citations = self.citations.clone();
+        let old_formatted = self.formatted_citations.clone();
+        self.nocite = ids;
+        self.commit_render(old_citations, old_formatted)
     }
 
     /// Replace the full ordered citation list.
@@ -380,6 +405,29 @@ impl DocumentSession {
         // document scope). Safe no-op when no memory config is present.
         processor.annotate_flat_integral_name_states(&mut processor_citations);
 
+        // Register nocite IDs: validate against bibliography, warn on missing, then
+        // add to cited_ids so they appear in bibliography entries but produce no
+        // citation text.
+        let nocite_ids: Vec<String> = self
+            .nocite
+            .iter()
+            .filter_map(|id| {
+                if processor.bibliography.contains_key(id) {
+                    Some(id.clone())
+                } else {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "nocite_missing_ref".to_string(),
+                        citation_id: None,
+                        ref_id: Some(id.clone()),
+                        message: format!("Nocite reference '{id}' not found in bibliography"),
+                    });
+                    None
+                }
+            })
+            .collect();
+        processor.register_nocite_ids(nocite_ids);
+
         let formatted_citations = match self.output_format {
             OutputFormatKind::Plain => {
                 format_by_kind::<PlainText>(&processor, &processor_citations)?
@@ -609,9 +657,10 @@ mod tests {
         MultilingualString, Processing, Rendering, StructuredName, TemplateDateVariable,
     };
     use citum_schema::reference::{EdtfString, InputReference, Monograph, MonographType, Title};
+    use citum_schema::template::{TemplateTitle, TitleType};
     use citum_schema::{
-        CitationSpec, StyleInfo, TemplateComponent, TemplateContributor, TemplateDate,
-        WrapPunctuation,
+        BibliographySpec, CitationSpec, StyleInfo, TemplateComponent, TemplateContributor,
+        TemplateDate, WrapPunctuation,
     };
 
     fn style() -> Style {
@@ -1174,6 +1223,65 @@ mod tests {
         assert_eq!(
             second.text, "Smith",
             "second integral cite should render short form from style-native config"
+        );
+    }
+
+    fn style_with_bibliography() -> Style {
+        let mut s = style();
+        s.bibliography = Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+        s
+    }
+
+    #[test]
+    fn set_nocite_puts_ref_in_bibliography_not_in_formatted_citations() {
+        // given: a session with smith2020 cited in-text and roe2022 nocite-only
+        let mut session = DocumentSession::new(
+            style_with_bibliography(),
+            StyleInput::Yaml(String::new()),
+            None,
+            OutputFormatKind::Plain,
+            None,
+        );
+        session.put_references(refs());
+        session
+            .insert_citations_batch(vec![citation("c1", "smith2020")])
+            .expect("citation insert should succeed");
+
+        // when: roe2022 is registered as nocite
+        let result = session
+            .set_nocite(vec!["roe2022".to_string()])
+            .expect("set_nocite should succeed");
+
+        // then: roe2022 appears in bibliography entries but not in any formatted citation
+        assert!(
+            result
+                .bibliography
+                .entries
+                .iter()
+                .any(|e| e.id == "roe2022"),
+            "nocite ref should appear in bibliography entries"
+        );
+        assert!(
+            result
+                .affected_citations
+                .iter()
+                .all(|c| c.text != "roe2022" && !c.ref_ids.contains(&"roe2022".to_string())),
+            "nocite ref should not appear in any formatted citation"
+        );
+        // and: the uncited, non-nocite ref (doe2021) is absent from bibliography
+        assert!(
+            !result
+                .bibliography
+                .entries
+                .iter()
+                .any(|e| e.id == "doe2021"),
+            "non-cited, non-nocite ref should not appear in bibliography"
         );
     }
 }

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -145,6 +145,40 @@ impl Processor {
         }
     }
 
+    /// Process only the selected bibliography entries, in bibliography sort order.
+    ///
+    /// Mirrors the flat path inside
+    /// [`render_selected_bibliography_with_format_and_annotations`] so that
+    /// per-entry `text` and subsequent-author substitution are computed against
+    /// the same subset that produced `content` — not the full loaded
+    /// bibliography. This matters for subsequent-author substitution: an uncited
+    /// predecessor must not cause the first cited entry to receive `———`.
+    pub(crate) fn process_selected_references_with_format<F, I>(
+        &self,
+        item_ids: I,
+    ) -> ProcessedReferences
+    where
+        F: OutputFormat<Output = String>,
+        I: IntoIterator<Item = String>,
+    {
+        self.initialize_numeric_bibliography_numbers();
+        let selected: HashSet<String> = item_ids.into_iter().collect();
+        let sorted_refs = self.sort_references(self.bibliography.values().collect());
+        let bibliography = self.process_sorted_refs::<_, F>(
+            sorted_refs
+                .iter()
+                .filter(|r| r.id().as_deref().is_some_and(|id| selected.contains(id)))
+                .copied(),
+            |reference, entry_number| {
+                self.process_bibliography_entry_with_format::<F>(reference, entry_number)
+            },
+        );
+        ProcessedReferences {
+            bibliography,
+            citations: None,
+        }
+    }
+
     /// Process and render a bibliography entry.
     pub fn process_bibliography_entry(
         &self,

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -99,6 +99,23 @@ impl Processor {
         )
     }
 
+    /// Register nocite reference IDs into the cited set.
+    ///
+    /// Nocite IDs are treated as cited for bibliography-selection purposes (they
+    /// appear in `bibliography.entries` alongside normally cited refs and are
+    /// matched by `CitedStatus::Visible` selectors), but no `formatted_citations`
+    /// entry is produced for them. This matches standard citeproc / Pandoc `nocite`
+    /// semantics.
+    ///
+    /// IDs that are absent from `self.bibliography` are silently ignored here;
+    /// callers are responsible for emitting `nocite_missing_ref` warnings first.
+    pub fn register_nocite_ids(&self, ids: impl IntoIterator<Item = String>) {
+        let mut cited_ids = self.cited_ids.borrow_mut();
+        for id in ids {
+            cited_ids.insert(id);
+        }
+    }
+
     /// Register cited reference IDs and ensure numeric labels are initialized.
     ///
     /// This maintains the set of all references cited in the document and ensures

--- a/crates/citum-server/src/http.rs
+++ b/crates/citum-server/src/http.rs
@@ -188,7 +188,8 @@ async fn rpc_schema() -> impl IntoResponse {
     #[cfg(feature = "session")]
     use crate::rpc::{
         DeleteCitationParams, InsertCitationParams, InsertCitationsBatchParams, OpenSessionParams,
-        PreviewCitationParams, PutReferencesParams, SessionIdParams, UpdateCitationParams,
+        PreviewCitationParams, PutReferencesParams, SessionIdParams, SetNociteParams,
+        UpdateCitationParams,
     };
     use crate::rpc::{
         FormatDocumentParams, RenderBibliographyParams, RenderCitationParams, ValidateStyleParams,
@@ -211,6 +212,10 @@ async fn rpc_schema() -> impl IntoResponse {
             schema.insert(
                 "put_references".to_string(),
                 json!(schema_for!(PutReferencesParams)),
+            );
+            schema.insert(
+                "set_nocite".to_string(),
+                json!(schema_for!(SetNociteParams)),
             );
             schema.insert(
                 "insert_citations_batch".to_string(),

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -171,6 +171,12 @@ pub struct FormatDocumentParams {
     pub bibliography_blocks: Vec<BibliographyBlockRequest>,
     /// Optional document-level configuration.
     pub document_options: Option<DocumentOptions>,
+    /// Reference IDs to include in the bibliography without an in-text citation.
+    ///
+    /// Each ID must be present in `refs`. Unknown IDs produce a `nocite_missing_ref`
+    /// warning and are otherwise ignored.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub nocite: Vec<String>,
 }
 
 /// Parameters for the `open_session` method.
@@ -207,6 +213,24 @@ pub struct PutReferencesParams {
     pub session_id: Option<String>,
     /// Full reference input for the session.
     pub refs: RefsInput,
+}
+
+/// Parameters for the `set_nocite` method.
+#[cfg(feature = "session")]
+#[derive(Debug, Deserialize)]
+#[cfg_attr(
+    any(feature = "schema", feature = "schema-types"),
+    derive(schemars::JsonSchema)
+)]
+pub struct SetNociteParams {
+    /// Session identifier returned by `open_session`.
+    pub session_id: Option<String>,
+    /// Reference IDs to include in the bibliography without an in-text citation.
+    ///
+    /// Each ID must be present in the session's loaded references. Unknown IDs
+    /// produce a `nocite_missing_ref` warning and are otherwise ignored.
+    #[serde(default)]
+    pub nocite: Vec<String>,
 }
 
 /// Parameters for the `insert_citations_batch` method.
@@ -401,6 +425,8 @@ impl RpcDispatcher {
             #[cfg(feature = "session")]
             "put_references" => self.put_references(&req.params, id, req.id.clone()),
             #[cfg(feature = "session")]
+            "set_nocite" => self.set_nocite(&req.params, id, req.id.clone()),
+            #[cfg(feature = "session")]
             "insert_citations_batch" => {
                 self.insert_citations_batch(&req.params, id, req.id.clone())
             }
@@ -479,6 +505,21 @@ impl RpcDispatcher {
         let session = self.session_mut(params.session_id.as_deref(), &request_id)?;
         session.put_references(params.refs);
         Ok(json!({ "id": id, "result": {} }))
+    }
+
+    #[cfg(feature = "session")]
+    fn set_nocite(
+        &mut self,
+        params: &Value,
+        id: Value,
+        request_id: Value,
+    ) -> Result<Value, (Option<Value>, RpcDispatchError)> {
+        let params: SetNociteParams = parse_session_params(params, &request_id)?;
+        let session = self.session_mut(params.session_id.as_deref(), &request_id)?;
+        let result = session
+            .set_nocite(params.nocite)
+            .map_err(|e| (Some(request_id), RpcDispatchError::Message(e.to_string())))?;
+        Ok(json!({ "id": id, "result": result }))
     }
 
     #[cfg(feature = "session")]

--- a/crates/citum-server/tests/rpc.rs
+++ b/crates/citum-server/tests/rpc.rs
@@ -671,3 +671,99 @@ fn open_session_style_overrides_changes_and_connector() {
         "session with and:text override should not use '&', got: {text:?}"
     );
 }
+
+// --- set_nocite ---
+
+fn two_refs() -> serde_json::Value {
+    json!({
+        "ITEM-2": {
+            "id": "ITEM-2",
+            "class": "monograph",
+            "type": "book",
+            "title": "A Brief History of Time",
+            "author": [{"family": "Hawking", "given": "Stephen"}],
+            "issued": "1988"
+        },
+        "ITEM-3": {
+            "id": "ITEM-3",
+            "class": "monograph",
+            "type": "book",
+            "title": "Cosmos",
+            "author": [{"family": "Sagan", "given": "Carl"}],
+            "issued": "1980"
+        }
+    })
+}
+
+#[test]
+fn set_nocite_puts_ref_in_bibliography_not_in_formatted_citations() {
+    // given: a session with ITEM-2 cited in-text and ITEM-3 registered as nocite
+    let mut dispatcher = RpcDispatcher::new_stdio();
+    dispatcher
+        .dispatch(make_request(
+            70,
+            "open_session",
+            json!({
+                "style": {"kind": "path", "value": apa_style_path()}
+            }),
+        ))
+        .expect("open_session should succeed");
+
+    dispatcher
+        .dispatch(make_request(
+            71,
+            "put_references",
+            json!({"session_id": "default", "refs": two_refs()}),
+        ))
+        .expect("put_references should succeed");
+
+    dispatcher
+        .dispatch(make_request(
+            72,
+            "insert_citation",
+            json!({
+                "session_id": "default",
+                "citation": {"id": "cite-1", "items": [{"id": "ITEM-2"}]}
+            }),
+        ))
+        .expect("insert_citation should succeed");
+
+    // when: ITEM-3 is registered as nocite
+    let result = dispatcher
+        .dispatch(make_request(
+            73,
+            "set_nocite",
+            json!({"session_id": "default", "nocite": ["ITEM-3"]}),
+        ))
+        .expect("set_nocite should succeed");
+
+    // then: ITEM-3 appears in bibliography entries but not in formatted citations
+    let entries = &result["result"]["bibliography"]["entries"];
+    let ids: Vec<&str> = entries
+        .as_array()
+        .expect("entries should be an array")
+        .iter()
+        .map(|e| e["id"].as_str().expect("entry id should be a string"))
+        .collect();
+
+    assert!(
+        ids.contains(&"ITEM-3"),
+        "nocite ref ITEM-3 should appear in bibliography entries, got: {ids:?}"
+    );
+    let formatted = &result["result"]["affected_citations"];
+    let any_item3 = formatted
+        .as_array()
+        .map(|cites| {
+            cites.iter().any(|c| {
+                c["ref_ids"]
+                    .as_array()
+                    .map(|ids| ids.iter().any(|id| id == "ITEM-3"))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+    assert!(
+        !any_item3,
+        "nocite ref ITEM-3 should not appear in any formatted citation"
+    );
+}

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2913,6 +2913,13 @@
             "type": "null"
           }
         ]
+      },
+      "nocite": {
+        "description": "Reference IDs to include in the bibliography without an in-text citation.\n\nEach ID must be present in `refs`. Unknown IDs produce a `nocite_missing_ref`\nwarning and are otherwise ignored.",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }

--- a/docs/specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md
+++ b/docs/specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md
@@ -1,0 +1,86 @@
+# Nocite: Bibliography-Only Entries
+
+Status: Active
+
+## Overview
+
+Word-processor hosts and document authors sometimes need to include a reference in the
+bibliography without citing it in text — a "further reading" or "background" entry.
+This is the standard `nocite` semantics as defined by citeproc and Pandoc.
+
+This spec describes how Citum exposes nocite across its three API surfaces: the
+batch (`format_document`) path, the interactive session (`DocumentSession`) path, and
+the JSON-RPC server.
+
+## Motivation
+
+Prior to this feature the interactive API bibliography rendered *all* loaded references,
+whereas the document-string path (via `process_document_*`) correctly restricted the
+bibliography to cited refs (`restrict_to_cited = true`). This inconsistency was a
+historical accident from when grouping was added later. Nocite is the mechanism that
+bridges the two: a "flat" bibliography is conceptually one group with no cited filter,
+so both paths now restrict to the *document reference set* — cited IDs plus nocite IDs.
+
+## Behaviour
+
+1. The caller supplies a list of reference IDs to register as nocite.
+2. Each ID is validated against the loaded bibliography. Unknown IDs produce a
+   `nocite_missing_ref` warning and are otherwise ignored.
+3. Valid nocite IDs are inserted into the processor's `cited_ids` set — the same set
+   that gates bibliography inclusion.
+4. Bibliography rendering (both `content` and `entries`) includes nocite refs alongside
+   cited refs, sorted and grouped by the active style.
+5. Nocite refs produce **no** `formatted_citations` entry.
+
+## API Surface
+
+### `format_document` (batch)
+
+```json
+{
+  "style": { "kind": "path", "value": "styles/apa-7th.yaml" },
+  "refs": { ... },
+  "citations": [ ... ],
+  "nocite": ["background-ref-1", "background-ref-2"]
+}
+```
+
+The `nocite` field is optional (defaults to empty). Unknown IDs produce a warning in
+the `warnings` array of the response.
+
+### `DocumentSession` (interactive)
+
+```rust
+session.set_nocite(vec!["background-ref-1".to_string()])?;
+```
+
+`set_nocite` replaces the session's nocite list atomically and re-renders, returning a
+`SessionMutationResult` with the updated bibliography and any affected citations.
+
+### JSON-RPC (`set_nocite`)
+
+```json
+{
+  "method": "set_nocite",
+  "params": {
+    "session_id": "s-0000000000000001",
+    "nocite": ["background-ref-1"]
+  }
+}
+```
+
+The response is the standard `SessionMutationResult` envelope
+(`version`, `affected_citations`, `bibliography`, `warnings`).
+
+## Warning Code
+
+| Code | Level | Meaning |
+|------|-------|---------|
+| `nocite_missing_ref` | `warning` | The supplied nocite ID is not present in the loaded bibliography. |
+
+## Out of Scope
+
+- Numeric-label assignment for nocite-only entries (no in-text number, but a bibliography
+  number). Tracked as a follow-up.
+- `nocite` in the document-string (`process_document`) Markdown/front-matter path.
+- Pandoc `@*` "cite everything" wildcard expansion.


### PR DESCRIPTION
## Summary

- Add `nocite: Vec<String>` to `FormatDocumentRequest` and `DocumentSession::set_nocite` — refs appear in the bibliography without in-text citations (standard citeproc/Pandoc nocite semantics)
- Unify `format_bibliography` to restrict to `cited_ids` (cited + nocite) on both the batch and session paths — fixes longstanding inconsistency where the interactive API returned all loaded refs
- Add `set_nocite` RPC method; wire `SetNociteParams` into dispatch, HTTP schema map, and server tests

## Details

Unknown nocite IDs emit a `nocite_missing_ref` warning and are silently dropped. Valid IDs are inserted into `Processor::cited_ids` so they sort and group alongside cited refs in the bibliography.

The bibliography unification is a **breaking change** for callers who relied on the interactive API returning all loaded refs unconditionally — they must now use `set_nocite` to include uncited refs. The document-string path was already correct; this aligns the two paths.

Spec: `docs/specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md`
Bean: csl26-cpb7 (archived)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no issues
- [x] `cargo nextest run` — 1536/1536 passing
- [x] New engine tests: nocite ref in bibliography but not in formatted_citations; missing-ref warning; nocite sorts alongside cited ref
- [x] New session test: `set_nocite` puts ref in bibliography, absent from citations
- [x] New server test: `set_nocite` RPC round-trip
- [x] Schema regenerated (`docs/schemas/server.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
