### PR TITLE
fix(engine): warn on unknown reference fields

### DIFF
--- a/.beans/archive/csl26-q1nc--warn-on-unknown-fields-in-bibliography-input.md
+++ b/.beans/archive/csl26-q1nc--warn-on-unknown-fields-in-bibliography-input.md
@@ -1,0 +1,22 @@
+---
+# csl26-q1nc
+title: warn on unknown fields in bibliography input
+status: completed
+type: bug
+priority: high
+created_at: 2026-06-09T20:27:36Z
+updated_at: 2026-06-09T20:36:15Z
+---
+
+References with misspelled fields (e.g. lang: instead of language:, parent: instead of container:) are silently swallowed by the #[serde(flatten)] unknown_fields catch-alls on reference Deser structs. No warning anywhere — caused silent data loss in PR #895 CNE fixtures.
+
+Fix: add unknown_reference_field_warnings(&Bibliography) -> Vec<Warning> in citum-engine/src/api/document.rs alongside unknown_reference_class_warnings; wire into session.rs + format_document central aggregation; CLI check (with --strict escalation) and render refs present it.
+
+- [x] engine fn + export
+- [x] central aggregation (session.rs, document.rs)
+- [x] CLI check.rs + render refs presentation
+- [x] tests in crates/citum-engine/tests/forward_compatibility.rs
+
+## Summary of Changes
+
+Added InputReference::unknown_fields() accessor (class_dispatch over all 18 typed classes; None for unknown-class). New engine API unknown_reference_field_warnings(&Bibliography) in api/document.rs, exported from api/mod.rs and wired into both central warning aggregation points (api/session.rs open-session path and format_document), so WASM/FFI/document adapters surface it too. CLI: citum check reports the warnings (hard error under --strict); citum render refs prints them to stderr. Two tests in crates/citum-engine/tests/forward_compatibility.rs (positive + clean negative). Verified against the broken PR #895 CNE fixture: all three lang/parent typos are now reported.

--- a/crates/citum-cli/src/commands/check.rs
+++ b/crates/citum-cli/src/commands/check.rs
@@ -30,22 +30,43 @@ pub(super) fn run_check(args: CheckArgs) -> CliResult {
                 let class_warnings = citum_engine::api::unknown_reference_class_warnings(&bib);
                 warnings.extend(class_warnings.into_iter().map(|w| w.message));
 
+                // Forward-compat: fields captured by the `unknown_fields`
+                // catch-all. Hard errors in strict mode, warnings otherwise.
+                let field_messages: Vec<String> =
+                    citum_engine::api::unknown_reference_field_warnings(&bib)
+                        .into_iter()
+                        .map(|w| w.message)
+                        .collect();
+
                 // For enums, we need a processor context
                 let processor = citum_engine::Processor::new(citum_schema::Style::default(), bib);
                 let enum_warnings = citum_engine::api::unknown_enum_warnings(&processor);
                 warnings.extend(enum_warnings.into_iter().map(|w| w.message));
 
+                let mut ok = true;
+                let mut error = None;
+                if !field_messages.is_empty() {
+                    if args.strict {
+                        ok = false;
+                        // Each message is a complete sentence; join with a
+                        // space rather than "; " to avoid ".;" punctuation.
+                        error = Some(format!("strict: {}", field_messages.join(" ")));
+                    } else {
+                        warnings.extend(field_messages);
+                    }
+                }
+
                 CheckItem {
                     kind: "bibliography",
                     path: display,
-                    ok: true,
+                    ok,
                     schema_version: None,
                     warnings: if warnings.is_empty() {
                         None
                     } else {
                         Some(warnings)
                     },
-                    error: None,
+                    error,
                 }
             }
             Err(e) => CheckItem {

--- a/crates/citum-cli/src/commands/render/mod.rs
+++ b/crates/citum-cli/src/commands/render/mod.rs
@@ -142,6 +142,12 @@ pub(super) fn run_render_refs(args: RenderRefsArgs) -> CliResult {
     let style_obj = load_any_style(&args.style, args.no_semantics)?;
     let bibliography = load_merged_bibliography(&args.bibliography)?;
 
+    // Forward-compat: surface fields the engine silently captured (and will
+    // ignore) so data typos are visible at authoring time.
+    for warning in citum_engine::api::unknown_reference_field_warnings(&bibliography.references) {
+        eprintln!("Warning: {}", warning.message);
+    }
+
     let item_ids = if let Some(k) = args.keys.clone() {
         k
     } else {

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -8,7 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use crate::api::AnnotationStyle;
 use crate::error::ProcessorError;
 use crate::processor::Processor;
-use crate::reference::{Bibliography, Citation};
+use crate::reference::Citation;
 use crate::render::djot::Djot;
 use crate::render::format::OutputFormat;
 use crate::render::html::Html;
@@ -17,16 +17,13 @@ use crate::render::markdown::Markdown;
 use crate::render::plain::PlainText;
 use crate::render::typst::Typst;
 use citum_schema::Style;
-use citum_schema::locale::{GeneralTerm, TermForm};
-use citum_schema::reference::{
-    ClassExtension, CollectionType, ContributorRole as ReferenceRole, MonographComponentType,
-    MonographType, ReferenceClass, SerialComponentType,
-};
-use citum_schema::template::ContributorRole as TemplateRole;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use super::warnings::{
+    unknown_enum_warnings, unknown_reference_class_warnings, unknown_reference_field_warnings,
+};
 use super::{
     BibliographyEntry, CitationOccurrence, DocumentOptions, EntryMetadata, FormattedBibliography,
     FormattedBibliographyBlock, FormattedCitation, OutputFormatKind, RefsInput, StyleInput,
@@ -248,6 +245,7 @@ pub fn format_document_with_style(
     let bibliography = request.refs.resolve_local()?;
     let mut processor = Processor::new(style, bibliography);
     warnings.extend(unknown_reference_class_warnings(&processor.bibliography));
+    warnings.extend(unknown_reference_field_warnings(&processor.bibliography));
     warnings.extend(unknown_enum_warnings(&processor));
 
     if let Some(opts) = &request.document_options {
@@ -405,175 +403,6 @@ pub fn format_document_with_style(
         bibliography_blocks,
         warnings,
     })
-}
-
-/// Scan the bibliography for unknown reference classes and return compatibility warnings.
-pub fn unknown_reference_class_warnings(bibliography: &Bibliography) -> Vec<Warning> {
-    bibliography
-        .iter()
-        .filter_map(|(ref_id, reference)| {
-            let ReferenceClass::Unknown(class) = reference.class() else {
-                return None;
-            };
-            Some(Warning {
-                level: WarningLevel::Warning,
-                code: "unknown_reference_class".to_string(),
-                citation_id: None,
-                ref_id: Some(ref_id.clone()),
-                message: format!(
-                    "Reference '{ref_id}' uses unknown class '{class}'; rendering will use only fields this engine understands."
-                ),
-            })
-        })
-        .collect()
-}
-
-/// Scan the style and bibliography for unknown enum variants and term keys.
-///
-/// Returns a list of structured compatibility warnings for encounter of
-/// unknown variants that were captured via the tolerant-enum mechanism.
-pub fn unknown_enum_warnings(processor: &Processor) -> Vec<Warning> {
-    let mut warnings = Vec::new();
-
-    // 1. Scan bibliography
-    for (ref_id, reference) in &processor.bibliography {
-        match reference.extension() {
-            ClassExtension::Monograph(r) => {
-                if let MonographType::Unknown(s) = &r.r#type {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: Some(ref_id.clone()),
-                        message: format!("Reference '{ref_id}' uses unknown monograph type '{s}'; rendering will use default monograph formatting."),
-                    });
-                }
-            }
-            ClassExtension::Collection(r) => {
-                if let CollectionType::Unknown(s) = &r.r#type {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: Some(ref_id.clone()),
-                        message: format!("Reference '{ref_id}' uses unknown collection type '{s}'; rendering will use default collection formatting."),
-                    });
-                }
-            }
-            ClassExtension::CollectionComponent(r) => {
-                if let MonographComponentType::Unknown(s) = &r.r#type {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: Some(ref_id.clone()),
-                        message: format!("Reference '{ref_id}' uses unknown monograph component type '{s}'; rendering will use default chapter formatting."),
-                    });
-                }
-            }
-            ClassExtension::SerialComponent(r) => {
-                if let SerialComponentType::Unknown(s) = &r.r#type {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: Some(ref_id.clone()),
-                        message: format!("Reference '{ref_id}' uses unknown serial component type '{s}'; rendering will use default article formatting."),
-                    });
-                }
-            }
-            _ => {}
-        }
-
-        for contributor in reference.all_contributor_entries() {
-            if let ReferenceRole::Unknown(s) = &contributor.role {
-                warnings.push(Warning {
-                    level: WarningLevel::Warning,
-                    code: "unknown_enum_variant".to_string(),
-                    citation_id: None,
-                    ref_id: Some(ref_id.clone()),
-                    message: format!("Reference '{ref_id}' uses unknown contributor role '{s}'; this role may be ignored during rendering."),
-                });
-            }
-        }
-    }
-
-    // 2. Scan Style
-    if let Some(templates) = &processor.style.templates {
-        for (name, template) in templates {
-            scan_template_for_unknowns(template, &format!("template '{name}'"), &mut warnings);
-        }
-    }
-    if let Some(citation) = &processor.style.citation
-        && let Some(template) = &citation.template
-    {
-        scan_template_for_unknowns(template, "citation layout", &mut warnings);
-    }
-    if let Some(bib) = &processor.style.bibliography
-        && let Some(template) = &bib.template
-    {
-        scan_template_for_unknowns(template, "bibliography layout", &mut warnings);
-    }
-
-    warnings
-}
-
-fn scan_template_for_unknowns(
-    components: &[citum_schema::template::TemplateComponent],
-    location: &str,
-    warnings: &mut Vec<Warning>,
-) {
-    use citum_schema::template::TemplateComponent;
-    for component in components {
-        match component {
-            TemplateComponent::Term(t) => {
-                if let GeneralTerm::Unknown(s) = &t.term {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: None,
-                        message: format!("Style {location} uses unknown locale term key '{s}'; this term may render as empty."),
-                    });
-                }
-                if let Some(TermForm::Unknown(s)) = &t.form {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: None,
-                        message: format!("Style {location} uses unknown term form '{s}'; falling back to long form."),
-                    });
-                }
-            }
-            TemplateComponent::Contributor(c) => {
-                if let TemplateRole::Unknown(s) = &c.contributor {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: None,
-                        message: format!("Style {location} uses unknown contributor role '{s}'; this role may be ignored."),
-                    });
-                }
-            }
-            TemplateComponent::Date(d) => {
-                if let citum_schema::template::DateForm::Unknown(s) = &d.form {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: None,
-                        message: format!("Style {location} uses unknown date form '{s}'; falling back to year only."),
-                    });
-                }
-            }
-            TemplateComponent::Group(g) => {
-                scan_template_for_unknowns(&g.group, location, warnings);
-            }
-            _ => {}
-        }
-    }
 }
 
 /// Process citations and return formatted text.
@@ -755,6 +584,7 @@ where
 mod tests {
     use super::*;
     use crate::api::CitationOccurrenceItem;
+    use crate::reference::Bibliography;
     use crate::{
         Config, ContributorForm, ContributorRole, DateForm, Processing, Rendering,
         TemplateComponent, TemplateContributor, TemplateDate, TemplateDateVariable,

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -15,11 +15,11 @@ mod refs_input;
 mod session;
 mod style_input;
 mod types;
+mod warnings;
 
 pub use document::{
     FormatDocumentError, FormatDocumentRequest, FormatDocumentResult, apply_style_overrides,
     format_document, format_document_with_resolver, format_document_with_style,
-    unknown_enum_warnings, unknown_reference_class_warnings,
 };
 pub use forward_compat::{UnknownFieldPath, collect_unknown_field_paths};
 pub use refs_input::RefsInput;
@@ -33,4 +33,7 @@ pub use types::{
     BibliographyEntry, CitationOccurrence, CitationOccurrenceItem, DocumentOptions, EntryMetadata,
     FormattedBibliography, FormattedBibliographyBlock, FormattedCitation, OutputFormatKind,
     Warning, WarningLevel,
+};
+pub use warnings::{
+    unknown_enum_warnings, unknown_reference_class_warnings, unknown_reference_field_warnings,
 };

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -21,6 +21,7 @@ use super::{
     CitationOccurrence, CitationOccurrenceItem, DocumentOptions, FormatDocumentError,
     FormattedBibliography, FormattedCitation, OutputFormatKind, RefsInput, StyleInput, Warning,
     WarningLevel, unknown_enum_warnings, unknown_reference_class_warnings,
+    unknown_reference_field_warnings,
 };
 use crate::processor::Processor;
 use crate::reference::Citation;
@@ -359,6 +360,7 @@ impl DocumentSession {
             .resolve_local()?;
         let mut processor = Processor::new(self.style.clone(), bibliography);
         warnings.extend(unknown_reference_class_warnings(&processor.bibliography));
+        warnings.extend(unknown_reference_field_warnings(&processor.bibliography));
         warnings.extend(unknown_enum_warnings(&processor));
 
         if let Some(opts) = &self.document_options {

--- a/crates/citum-engine/src/api/warnings.rs
+++ b/crates/citum-engine/src/api/warnings.rs
@@ -1,0 +1,221 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Input-compatibility warning scanners.
+//!
+//! Each function inspects already-loaded inputs (style, bibliography) for
+//! constructs the engine tolerated but cannot act on — unknown reference
+//! classes, fields captured by the forward-compat `unknown_fields`
+//! catch-all, and unknown enum variants — and reports them as structured
+//! [`Warning`]s. Adapters (CLI, WASM, FFI) present these; they must never
+//! re-derive their own checks.
+
+use crate::processor::Processor;
+use crate::reference::Bibliography;
+use citum_schema::locale::{GeneralTerm, TermForm};
+use citum_schema::reference::{
+    ClassExtension, CollectionType, ContributorRole as ReferenceRole, MonographComponentType,
+    MonographType, ReferenceClass, SerialComponentType,
+};
+use citum_schema::template::ContributorRole as TemplateRole;
+
+use super::{Warning, WarningLevel};
+
+/// Scan the bibliography for unknown reference classes and return compatibility warnings.
+pub fn unknown_reference_class_warnings(bibliography: &Bibliography) -> Vec<Warning> {
+    bibliography
+        .iter()
+        .filter_map(|(ref_id, reference)| {
+            let ReferenceClass::Unknown(class) = reference.class() else {
+                return None;
+            };
+            Some(Warning {
+                level: WarningLevel::Warning,
+                code: "unknown_reference_class".to_string(),
+                citation_id: None,
+                ref_id: Some(ref_id.clone()),
+                message: format!(
+                    "Reference '{ref_id}' uses unknown class '{class}'; rendering will use only fields this engine understands."
+                ),
+            })
+        })
+        .collect()
+}
+
+/// Scan the bibliography for fields captured by the forward-compat
+/// `unknown_fields` catch-all and return per-reference warnings.
+///
+/// Unknown-class references are skipped here; they are already reported by
+/// [`unknown_reference_class_warnings`].
+pub fn unknown_reference_field_warnings(bibliography: &Bibliography) -> Vec<Warning> {
+    bibliography
+        .iter()
+        .filter_map(|(ref_id, reference)| {
+            let unknown = reference.unknown_fields()?;
+            if unknown.is_empty() {
+                return None;
+            }
+            let keys: Vec<&str> = unknown.keys().map(String::as_str).collect();
+            Some(Warning {
+                level: WarningLevel::Warning,
+                code: "unknown_reference_field".to_string(),
+                citation_id: None,
+                ref_id: Some(ref_id.clone()),
+                message: format!(
+                    "Reference '{ref_id}' has unknown field(s): {}; these fields are ignored during rendering.",
+                    keys.join(", ")
+                ),
+            })
+        })
+        .collect()
+}
+
+/// Scan the style and bibliography for unknown enum variants and term keys.
+///
+/// Returns a list of structured compatibility warnings for encounter of
+/// unknown variants that were captured via the tolerant-enum mechanism.
+pub fn unknown_enum_warnings(processor: &Processor) -> Vec<Warning> {
+    let mut warnings = Vec::new();
+
+    // 1. Scan bibliography
+    for (ref_id, reference) in &processor.bibliography {
+        match reference.extension() {
+            ClassExtension::Monograph(r) => {
+                if let MonographType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown monograph type '{s}'; rendering will use default monograph formatting."),
+                    });
+                }
+            }
+            ClassExtension::Collection(r) => {
+                if let CollectionType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown collection type '{s}'; rendering will use default collection formatting."),
+                    });
+                }
+            }
+            ClassExtension::CollectionComponent(r) => {
+                if let MonographComponentType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown monograph component type '{s}'; rendering will use default chapter formatting."),
+                    });
+                }
+            }
+            ClassExtension::SerialComponent(r) => {
+                if let SerialComponentType::Unknown(s) = &r.r#type {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown serial component type '{s}'; rendering will use default article formatting."),
+                    });
+                }
+            }
+            _ => {}
+        }
+
+        for contributor in reference.all_contributor_entries() {
+            if let ReferenceRole::Unknown(s) = &contributor.role {
+                warnings.push(Warning {
+                    level: WarningLevel::Warning,
+                    code: "unknown_enum_variant".to_string(),
+                    citation_id: None,
+                    ref_id: Some(ref_id.clone()),
+                    message: format!("Reference '{ref_id}' uses unknown contributor role '{s}'; this role may be ignored during rendering."),
+                });
+            }
+        }
+    }
+
+    // 2. Scan Style
+    if let Some(templates) = &processor.style.templates {
+        for (name, template) in templates {
+            scan_template_for_unknowns(template, &format!("template '{name}'"), &mut warnings);
+        }
+    }
+    if let Some(citation) = &processor.style.citation
+        && let Some(template) = &citation.template
+    {
+        scan_template_for_unknowns(template, "citation layout", &mut warnings);
+    }
+    if let Some(bib) = &processor.style.bibliography
+        && let Some(template) = &bib.template
+    {
+        scan_template_for_unknowns(template, "bibliography layout", &mut warnings);
+    }
+
+    warnings
+}
+
+fn scan_template_for_unknowns(
+    components: &[citum_schema::template::TemplateComponent],
+    location: &str,
+    warnings: &mut Vec<Warning>,
+) {
+    use citum_schema::template::TemplateComponent;
+    for component in components {
+        match component {
+            TemplateComponent::Term(t) => {
+                if let GeneralTerm::Unknown(s) = &t.term {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown locale term key '{s}'; this term may render as empty."),
+                    });
+                }
+                if let Some(TermForm::Unknown(s)) = &t.form {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown term form '{s}'; falling back to long form."),
+                    });
+                }
+            }
+            TemplateComponent::Contributor(c) => {
+                if let TemplateRole::Unknown(s) = &c.contributor {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown contributor role '{s}'; this role may be ignored."),
+                    });
+                }
+            }
+            TemplateComponent::Date(d) => {
+                if let citum_schema::template::DateForm::Unknown(s) = &d.form {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: None,
+                        message: format!("Style {location} uses unknown date form '{s}'; falling back to year only."),
+                    });
+                }
+            }
+            TemplateComponent::Group(g) => {
+                scan_template_for_unknowns(&g.group, location, warnings);
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/citum-engine/tests/forward_compatibility.rs
+++ b/crates/citum-engine/tests/forward_compatibility.rs
@@ -489,3 +489,67 @@ fn forward_compat_snapshot_matches() {
         );
     }
 }
+
+/// Build an engine [`citum_engine::Bibliography`] from an `InputBibliography`
+/// YAML literal, keyed by the given reference IDs in order.
+fn bibliography_from_yaml(yaml: &str, ids: &[&str]) -> citum_engine::Bibliography {
+    let parsed: InputBibliography = serde_yaml::from_str(yaml).expect("fixture parses");
+    assert_eq!(
+        ids.len(),
+        parsed.references.len(),
+        "fixture reference count must match the expected IDs"
+    );
+    ids.iter()
+        .map(|id| (*id).to_string())
+        .zip(parsed.references)
+        .collect()
+}
+
+#[test]
+fn unknown_reference_field_warnings_reports_captured_keys() {
+    let yaml = r#"
+references:
+  - id: future-ref
+    class: serial-component
+    type: article
+    lang: zh
+    title: A future-shaped article
+    parent:
+      type: academic-journal
+      title: A future-shaped journal
+"#;
+    let bibliography = bibliography_from_yaml(yaml, &["future-ref"]);
+
+    let warnings = citum_engine::api::unknown_reference_field_warnings(&bibliography);
+
+    assert_eq!(warnings.len(), 1);
+    let warning = &warnings[0];
+    assert_eq!(warning.code, "unknown_reference_field");
+    assert_eq!(warning.ref_id.as_deref(), Some("future-ref"));
+    assert_eq!(
+        warning.message,
+        "Reference 'future-ref' has unknown field(s): lang, parent; \
+         these fields are ignored during rendering."
+    );
+}
+
+#[test]
+fn unknown_reference_field_warnings_is_silent_for_clean_references() {
+    let yaml = r#"
+references:
+  - id: clean-ref
+    class: serial-component
+    type: article
+    language: en
+    title: A well-formed article
+    container:
+      class: serial
+      type: academic-journal
+      title: A well-formed journal
+"#;
+    let bibliography = bibliography_from_yaml(yaml, &["clean-ref"]);
+
+    let warnings = citum_engine::api::unknown_reference_field_warnings(&bibliography);
+
+    assert!(warnings.is_empty(), "clean reference must not warn");
+}

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -1254,6 +1254,15 @@ impl InputReference {
         class_dispatch!(&self.extension, |r| r.accessed.clone(), unknown(_) => None)
     }
 
+    /// Return the forward-compat `unknown_fields` captured for this reference.
+    ///
+    /// Returns `None` for unknown-class references: their fields are kept
+    /// wholesale in [`UnknownClassData::fields`] and reported separately via
+    /// the unknown-class warning.
+    pub fn unknown_fields(&self) -> Option<&std::collections::BTreeMap<String, JsonValue>> {
+        class_dispatch!(&self.extension, |r| Some(&r.unknown_fields), unknown(_) => None)
+    }
+
     /// Return the embedded inline reference behind `original` if any.
     ///
     /// All 16 reference classes that carry an `original` relation expose it via


### PR DESCRIPTION
## Problem

Misspelled reference fields (`lang:` instead of `language:`, `parent:` instead of `container:`) are silently swallowed by the forward-compat `unknown_fields` catch-all on every class payload — no warning anywhere. This caused undetected data loss in the CNE Chicago fixtures of #895: the language and journal-container data simply vanished from rendering.

The forward-compat spec intends graceful degradation *with* application-layer warnings; the warning half existed for styles (`collect_unknown_field_paths`) but was never implemented for references.

## Changes

- **`citum-schema-data`**: `InputReference::unknown_fields()` accessor via the existing `class_dispatch!` macro (all 18 typed classes; `None` for unknown-class payloads, which are already covered by the unknown-class warning).
- **`citum-engine`**: new `unknown_reference_field_warnings(&Bibliography) -> Vec<Warning>` in `api/document.rs`, alongside its siblings `unknown_reference_class_warnings` / `unknown_enum_warnings`, and wired into both central warning aggregation points (`api/session.rs` open-session path and `format_document`). All adapters — CLI, WASM/hub, FFI/labs — get the warning for free.
- **`citum-cli`**:
  - `citum check` lists the warnings per bibliography; under `--strict` they become hard errors.
  - `citum render refs` prints them to stderr (non-fatal) so data typos are visible at authoring time.

## Verification

Against the broken #895 fixture:

```
OK   bibliography multilingual-cne-chicago.yaml
  ! Reference 'cne-hua-linfu-article' has unknown field(s): lang, parent; these fields are ignored during rendering.
  ! Reference 'cne-kang-ubang-book' has unknown field(s): lang; these fields are ignored during rendering.
  ! Reference 'cne-abe-yoshio-book' has unknown field(s): lang; these fields are ignored during rendering.
```

`--strict` exits non-zero on the same input. Two new tests in `crates/citum-engine/tests/forward_compatibility.rs`. Full gate green: fmt, clippy `-D warnings`, 1538 tests passing.

Bean: csl26-q1nc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
