### PR TITLE
feat(migrate): random-corpus fidelity scorecard and baseline

### DIFF
--- a/.beans/csl26-21ep--migrate-compact-physics-form-title-suppression.md
+++ b/.beans/csl26-21ep--migrate-compact-physics-form-title-suppression.md
@@ -1,0 +1,12 @@
+---
+# csl26-21ep
+title: 'migrate: compact physics form title suppression'
+status: todo
+type: bug
+priority: low
+created_at: 2026-06-10T16:56:45Z
+updated_at: 2026-06-10T16:56:45Z
+parent: csl26-vmcr
+---
+
+Cluster C5 (small band, physics family) from docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md. Compact physics styles should suppress article titles and render page-only locators ('T. S. Kuhn, Philosophy of Science 37, 1 (1970)'); migrated output includes the title and drops the page. Evidence: springer-physics-author-date (11/38). One bounded migrate-research pass.

--- a/.beans/csl26-3fw0--migrate-note-class-full-note-template-run-on.md
+++ b/.beans/csl26-3fw0--migrate-note-class-full-note-template-run-on.md
@@ -1,0 +1,12 @@
+---
+# csl26-3fw0
+title: 'migrate: note-class full-note template run-on'
+status: todo
+type: bug
+priority: high
+created_at: 2026-06-10T16:56:45Z
+updated_at: 2026-06-10T16:56:45Z
+parent: csl26-vmcr
+---
+
+Cluster C4 (worst class: note 16/19 below bar, share at threshold 15.8%) from docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md. Note-class full-note citation templates lose delimiters/affixes wholesale producing run-on output ('"Title"PublisherPlace'), and use wrong name form (full instead of initials). Evidence: early-medieval-europe (citations 9/20), zeitschrift-fur-medienwissenschaft (7/20). One bounded migrate-research pass.

--- a/.beans/csl26-afwy--migrate-validate-type-variants-ops-at-emit-time.md
+++ b/.beans/csl26-afwy--migrate-validate-type-variants-ops-at-emit-time.md
@@ -1,0 +1,12 @@
+---
+# csl26-afwy
+title: 'migrate: validate type-variants ops at emit time'
+status: todo
+type: bug
+priority: high
+created_at: 2026-06-10T16:56:45Z
+updated_at: 2026-06-10T16:56:45Z
+parent: csl26-vmcr
+---
+
+Cluster C1 from docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md. citum-migrate emits bibliography.type-variants operations that reference components absent from the base template; the processor hard-fails the entire style at render (template variant operation matched no component). Evidence: zeitschrift-fur-fantastikforschung (interview), american-mathematical-society-label (patent). Fix in crates/citum-migrate: validate variant ops against the emitted base template; drop or repair invalid ops and record the decision in the evidence sidecar. Add regression tests. Converter must never emit YAML the processor rejects.

--- a/.beans/csl26-cxi9--migrate-bib-component-order-and-label-leakage.md
+++ b/.beans/csl26-cxi9--migrate-bib-component-order-and-label-leakage.md
@@ -1,0 +1,11 @@
+---
+# csl26-cxi9
+title: 'migrate: bib component order and label leakage'
+status: todo
+type: bug
+created_at: 2026-06-10T16:56:45Z
+updated_at: 2026-06-10T16:56:45Z
+parent: csl26-vmcr
+---
+
+Cluster C3 (~8 deep-failure numeric styles) from docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md. Migrated bibliography entries render components in scrambled order with label/affix leakage, e.g. brazilian-journal-of-psychiatry: citum '2017: 7: Vaswani A...: vol. 30: pp. 5998-6008: available at' vs oracle '7Vaswani A... 2017;30:599'. Also proceedings-of-the-estonian-academy-of-sciences-numeric (17/53). One bounded migrate-research pass.

--- a/.beans/csl26-rj4c--random-corpus-mode-baseline-run-for-migrate-sqi-sc.md
+++ b/.beans/csl26-rj4c--random-corpus-mode-baseline-run-for-migrate-sqi-sc.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: normal
 created_at: 2026-06-10T16:28:02Z
-updated_at: 2026-06-10T16:37:47Z
+updated_at: 2026-06-10T16:57:27Z
 parent: csl26-vmcr
 ---
 
@@ -14,6 +14,6 @@ Extend scripts/report-migrate-sqi.js with --corpus random --sample N --seed S: e
 - [x] sampler + classification + failure taxonomy in report-migrate-sqi.js
 - [x] tests in report-migrate-sqi.test.js (+ scripts/lib/corpus-sample.test.js)
 - [x] pilot run (sample 10) — wiring validated; allocator floor-scaling fix
-- [ ] full run (sample 100, fixed seed)
-- [ ] baseline audit doc + JSON snapshot committed
-- [ ] evaluate against quality bar, report to user
+- [x] full run (sample 100, seed 20260610)
+- [x] baseline audit doc + JSON snapshot committed (docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md)
+- [x] evaluate against quality bar, report to user — BELOW BAR: 43/100 at >=90%; improvement wave activated (clusters C1-C5)

--- a/.beans/csl26-rj4c--random-corpus-mode-baseline-run-for-migrate-sqi-sc.md
+++ b/.beans/csl26-rj4c--random-corpus-mode-baseline-run-for-migrate-sqi-sc.md
@@ -1,0 +1,19 @@
+---
+# csl26-rj4c
+title: Random-corpus mode + baseline run for migrate SQI scorecard
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-06-10T16:28:02Z
+updated_at: 2026-06-10T16:37:47Z
+parent: csl26-vmcr
+---
+
+Extend scripts/report-migrate-sqi.js with --corpus random --sample N --seed S: enumerate styles-legacy/*.csl independents, classify by citation-format attr, stratified seeded sampling (mulberry32), graceful failure taxonomy (migrate_failed/oracle_failed), headline aggregates (% styles >=90% strict fidelity, per-class breakdown). Extend report-migrate-sqi.test.js. Run pilot then full 100-style baseline; commit date-stamped audit in docs/architecture/audits/ + JSON snapshot in scripts/report-data/.
+
+- [x] sampler + classification + failure taxonomy in report-migrate-sqi.js
+- [x] tests in report-migrate-sqi.test.js (+ scripts/lib/corpus-sample.test.js)
+- [x] pilot run (sample 10) — wiring validated; allocator floor-scaling fix
+- [ ] full run (sample 100, fixed seed)
+- [ ] baseline audit doc + JSON snapshot committed
+- [ ] evaluate against quality bar, report to user

--- a/.beans/csl26-rksq--public-migrate-page-scorecard-page-weekly-ci-regen.md
+++ b/.beans/csl26-rksq--public-migrate-page-scorecard-page-weekly-ci-regen.md
@@ -1,0 +1,19 @@
+---
+# csl26-rksq
+title: Public Migrate page, scorecard page, weekly CI regeneration
+status: todo
+type: task
+created_at: 2026-06-10T16:28:16Z
+updated_at: 2026-06-10T16:28:16Z
+parent: csl26-vmcr
+blocked_by:
+    - csl26-rj4c
+---
+
+Publish citum-migrate on docs.citum.org once baseline numbers are in: docs/guides/MIGRATING_FROM_CSL.md rendered to docs/migrate.html via build-doc-pages.js; nav link in build-layout.js; Coming-from-CSL section on index.html; converter-fidelity card on reports.html; committed docs/reports/MIGRATE_SCORECARD.md rendered to migrate-scorecard.html; weekly .github/workflows/migrate-scorecard.yml regenerating the snapshot via automated PR. All claims sourced from the measured baseline; copy confirmed with user before commit.
+
+- [ ] MIGRATING_FROM_CSL.md guide + build-doc-pages entry
+- [ ] nav + index + reports tie-ins
+- [ ] scorecard markdown snapshot + page
+- [ ] weekly workflow
+- [ ] user confirms copy

--- a/.beans/csl26-sfir--migrate-bibliography-container-groups-dropped.md
+++ b/.beans/csl26-sfir--migrate-bibliography-container-groups-dropped.md
@@ -1,0 +1,12 @@
+---
+# csl26-sfir
+title: 'migrate: bibliography container groups dropped'
+status: todo
+type: bug
+priority: high
+created_at: 2026-06-10T16:56:45Z
+updated_at: 2026-06-10T16:56:45Z
+parent: csl26-vmcr
+---
+
+Cluster C2 (largest reach, ~24 close-miss styles in the 82-90% band) from docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md. Migrated bibliographies drop container/periodical groups: journal name, year, volume vanish from rendered entries, and citation-number prefixes are lost. Evidence: zeitschrift-fur-allgemeinmedizin renders 'Rodriguez M. Major Breakthrough...' where citeproc-js renders '16.Rodriguez M. Major Breakthrough... The New York Times. 2024'. One bounded migrate-research pass; measure with node scripts/report-migrate-sqi.js --corpus random --seed 20260610.

--- a/.beans/csl26-vmcr--promote-citum-migrate-with-random-sample-fidelity.md
+++ b/.beans/csl26-vmcr--promote-citum-migrate-with-random-sample-fidelity.md
@@ -1,0 +1,10 @@
+---
+# csl26-vmcr
+title: Promote citum-migrate with random-sample fidelity metrics
+status: in-progress
+type: epic
+created_at: 2026-06-10T16:27:51Z
+updated_at: 2026-06-10T16:27:51Z
+---
+
+Public docs site (docs.citum.org) never mentions citum-migrate. Goal: measure converter quality on a seeded, stratified random sample of ~100 independent parent CSL styles using existing fidelity+SQI tooling, record a baseline audit, then publish a Migrate page with truthful metrics and a weekly CI-regenerated scorecard. Quality bar: >=80% of sampled styles at >=90% combined strict citation+bibliography fidelity, no style class below 60%; below the bar, run a migrate-research improvement wave first. Plan: ~/.claude/plans/i-have-a-task-federated-gosling.md

--- a/.skills/migrate-research/SKILL.md
+++ b/.skills/migrate-research/SKILL.md
@@ -50,3 +50,16 @@ doesn't fit the four classifications, a stop condition missing from the guides, 
 migration artifact the evidence ladder doesn't anticipate — record the insight as a
 concrete bullet here and include the file update in the same commit or PR. Future
 research passes start with a richer surface.
+
+- (2026-06-10) Corpus-level cluster selection: before opening a pass, run
+  `node scripts/report-migrate-sqi.js --corpus random --seed 20260610` and pick
+  the cluster by reach from its fidelity headline + failure taxonomy, not from
+  the curated lab corpus alone. The random baseline and current cluster table
+  live in `docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md`.
+- (2026-06-10) A processor hard-fail on migrated output (e.g. a `type-variants`
+  op matching no component) is always `migration-artifact` with an emit-time
+  validation fix in `citum-migrate` plus a regression test — the converter must
+  never emit YAML the processor rejects. No evidence ladder needed.
+- (2026-06-10) Note-class run-on output (delimiters/affixes lost wholesale in
+  full-note citation templates) is one systemic cluster, not per-style defects;
+  do not open per-style passes for it.

--- a/docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md
+++ b/docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md
@@ -1,0 +1,252 @@
+# citum-migrate random-sample fidelity baseline
+
+> Audit record for bean `csl26-rj4c` (epic `csl26-vmcr`). First converter
+> measurement over a **random** corpus rather than the curated sentinel/lab
+> set. Companion JSON snapshot:
+> `scripts/report-data/migrate-random-baseline-2026-06-10.json`.
+
+## Methodology
+
+- Corpus: 100 of 2,844 independent parent styles in `styles-legacy/`,
+  drawn by `report-migrate-sqi.js --corpus random --seed 20260610` —
+  seeded, stratified by CSL `citation-format` class, fully reproducible.
+- Fidelity: strict citeproc-js oracle comparison through
+  `oracle.js --force-migrate` (checked-in `styles/*.yaml` cannot inflate
+  results; every style renders from fresh `citum-migrate` output).
+- Failures count against the headline: a style that cannot convert or
+  render is in the denominator.
+- Quality bar (decided 2026-06-10): publish-confident when ≥80% of sampled
+  styles reach ≥90% combined strict citation+bibliography fidelity and no
+  class falls below 60%.
+
+## Verdict: below the bar
+
+**43/100 styles at ≥90% combined strict fidelity** (bar: 80). Mean 83.2%,
+median 89.7%. Per class share at threshold: author-date 57.5%, numeric
+48.5%, author 20%, note 15.8%, label 0%. Both bar conditions fail; the
+improvement wave (Phase 3 of the epic) activates before any public claims.
+
+Two readings that shape the improvement plan:
+
+1. **Citations are largely solved; bibliographies are the gap.** A majority
+   of below-bar styles pass citations 20/20 while leaking 4–10 bibliography
+   entries. The distribution is heavily banded at 82–90%: 24 styles are
+   close misses. Converter fixes to a handful of shared bibliography
+   patterns plausibly move the headline by tens of points.
+2. **Structural quality is not the problem.** Migrated YAML SQI mean is
+   94.9 — on par with the curated corpus (96.3 on 2026-05-20). The
+   converter writes clean YAML that renders the wrong text.
+
+## Failure clusters (initial classification)
+
+Evidence: oracle entry diffs on representative styles per band, plus the
+two hard failures. Classification follows the migrate-research taxonomy.
+
+| # | Cluster | Evidence styles | Class mix | Classification | Est. reach |
+|---|---|---|---|---|---|
+| C1 | Emitted `type-variants` op references a component absent from the base template → processor hard-fails the whole style | zeitschrift-fur-fantastikforschung (`interview`), american-mathematical-society-label (`patent`) | any | migration-artifact (emit-time validation gap) | 2/100 direct, unknown corpus-wide |
+| C2 | Bibliography drops container/periodical groups (journal name, year, volume vanish from rendered entries; citation-number prefix lost) | zeitschrift-fur-allgemeinmedizin (32/38), large 82–90% numeric/author-date band | numeric, author-date | migration-artifact | ~24 close-miss styles |
+| C3 | Bibliography component order scrambled + label/affix leakage (`2017: 7: …: vol. 30: pp. …: available at`) | brazilian-journal-of-psychiatry (12/38), proceedings-of-the-estonian-academy-of-sciences-numeric (17/53) | numeric | migration-artifact | ~8 deep-failure styles |
+| C4 | Note-class full-note citation templates lose delimiters/affixes wholesale (`"Title"PublisherPlace` run-on), wrong name form (full vs initials) | early-medieval-europe (cit 9/20), zeitschrift-fur-medienwissenschaft (7/20), note band | note, author | migration-artifact | note class: 16/19 below bar |
+| C5 | Compact physics/abbreviated forms: article title should be suppressed, page-only locators (`37, 1 (1970)`) | springer-physics-author-date (11/38) | author-date | migration-artifact | small band, shared by physics family |
+
+Cluster C1 is also a converter-correctness bug independent of fidelity:
+`citum-migrate` must never emit YAML the processor rejects (validate
+variant ops at emit time; drop or repair the op and record it in
+evidence).
+
+Secondary observation (not fidelity): 24 sampled styles had discovered
+candidate parents but only 2 minimization attempts ran (both rejected).
+The family-candidate path under-fires on the random corpus; worth a
+separate look during the wave.
+
+## Improvement plan
+
+Tracked as child beans of epic `csl26-vmcr`; one bounded migrate-research
+pass per cluster, re-measured with the same seed after each landing.
+Priority order: C2 (largest reach) → C4 (worst class) → C1 (hard
+failures, small fix) → C3 → C5. The wave target is the published bar:
+80/100 at ≥90%, no class below 60%.
+
+## Measured report (generated 2026-06-10)
+
+
+- Generated: 2026-06-10T16:52:41.318Z
+- Commit: 4016d7cf
+- Corpus: random (100 of 2844 independent parents, seed 20260610)
+- Strata (sampled/population): author 5/10, author-date 40/1335, label 3/3, note 19/542, numeric 33/954
+
+## Fidelity headline
+
+- Styles at ≥90% combined strict fidelity: 43/100 (43%) — non-ok: oracle_failed 2
+- Combined strict fidelity (converted styles): mean 83.2%, p10 55.2%, median 89.7%, p90 100%
+
+### Per class
+
+| Class | Measured | ≥90% | Share | Mean | Median |
+|---|---:|---:|---:|---:|---:|
+| author | 5 | 1 | 20% | 86.9% | 87.7% |
+| author-date | 40 | 23 | 57.5% | 87.8% | 94.8% |
+| label | 3 | 0 | 0% | 46.6% | 74.1% |
+| note | 19 | 3 | 15.8% | 70.6% | 75.9% |
+| numeric | 33 | 16 | 48.5% | 86.4% | 89.8% |
+
+### Failure taxonomy
+
+| Style | Class | Status | Detail |
+|---|---|---|---|
+| zeitschrift-fur-fantastikforschung | author | oracle_failed | Processor failed: Error: template variant operation in `bibliography.type-variants[interview]` matched no component  |
+| american-mathematical-society-label | label | oracle_failed | Processor failed: Error: template variant operation in `bibliography.type-variants[patent]` matched no component  |
+
+## Aggregate
+
+| Subject | n | mean | p10 | p50 | p90 |
+|---|---:|---:|---:|---:|---:|
+| Migrated YAML SQI | 98 | 94.9 | 86.03 | 97.5 | 99.27 |
+| Public YAML SQI | 5 | 95.93 | 93.33 | 96.67 | 99.17 |
+| Migrated − Public | 4 | -0.42 | -3.07 | -0.44 | 2.76 |
+
+## Per-style
+
+| Style | Fidelity | Migrated SQI | Public SQI | Δ | LOC | Migrated dup/near/rep | Public dup/near/rep |
+|---|---:|---:|---:|---:|---:|---|---|
+| chicago-in-text-shortened-author | 16/20 • 34/37 | 95.03 | err | - | 665 | 0/0/85 | - |
+| chicago-in-text-shortened-author-no-url | 16/20 • 33/37 | 96.77 | err | - | 552 | 0/0/59 | - |
+| chicago-in-text-shortened-author-title-no-url | 20/20 • 32/37 | 96.7 | err | - | 543 | 0/0/59 | - |
+| modern-language-association-annotated-bibliography | 14/20 • 34/38 | 90.67 | err | - | 771 | 0/1/108 | - |
+| zeitschrift-fur-fantastikforschung | -/- • -/- | err | err | - | - | - | - |
+| antarctic-science | 19/20 • 38/38 | 92.77 | err | - | 224 | 0/0/3 | - |
+| anthropologie-et-societes | 20/20 • 37/38 | 96.03 | err | - | 236 | 0/0/4 | - |
+| australian-road-research-board | 18/20 • 38/38 | 85.57 | err | - | 213 | 0/0/15 | - |
+| berlin-school-of-economics-and-law-international-marketing-management | 20/20 • 36/38 | 85.73 | err | - | 143 | 0/0/6 | - |
+| bio-protocol | 6/20 • 31/38 | 76.27 | err | - | 1526 | 0/0/193 | - |
+| canadian-biosystems-engineering | 20/20 • 32/38 | 92.87 | err | - | 510 | 0/0/103 | - |
+| carolinea | 20/20 • 38/38 | 98.9 | err | - | 293 | 0/0/11 | - |
+| civitas-revista-de-ciencias-sociais | 19/20 • 26/38 | 99.4 | err | - | 327 | 0/0/3 | - |
+| evolution-letters | 20/20 • 37/38 | 99.37 | err | - | 209 | 0/0/2 | - |
+| freshwater-crayfish | 20/20 • 38/38 | 98.63 | err | - | 344 | 0/0/15 | - |
+| harvard-coventry-university | 19/20 • 33/38 | 84.03 | err | - | 1338 | 0/0/90 | - |
+| harvard-durham-university-business-school | 19/20 • 36/38 | 97.77 | err | - | 449 | 0/0/44 | - |
+| history-of-the-human-sciences | 20/20 • 38/38 | 86.03 | err | - | 177 | 0/0/3 | - |
+| institut-national-de-sante-publique-du-quebec-napp | 20/20 • 32/38 | 99 | err | - | 214 | 0/0/10 | - |
+| instituto-de-pesquisas-energeticas-e-nucleares | 7/20 • 28/38 | 99.13 | err | - | 225 | 0/0/7 | - |
+| interkulturelle-germanistik-gottingen | 17/20 • 36/38 | 97.8 | err | - | 408 | 0/0/19 | - |
+| jcom-journal-of-science-communication | 14/20 • 25/38 | 91 | err | - | 1271 | 0/1/147 | - |
+| journal-of-advertising-research | 18/20 • 14/46 | 98.07 | err | - | 382 | 0/0/11 | - |
+| journal-of-applied-entomology | 20/20 • 37/38 | 99.3 | err | - | 181 | 0/0/4 | - |
+| journal-of-contemporary-water-research-and-education | 19/20 • 35/38 | 85.8 | err | - | 1173 | 0/0/208 | - |
+| lien-social-et-politiques | 20/20 • 37/38 | 96.03 | err | - | 260 | 0/0/3 | - |
+| mammalia | 20/20 • 24/39 | 98.03 | err | - | 354 | 0/0/24 | - |
+| media-culture-and-society | 20/20 • 38/38 | 92.17 | err | - | 236 | 0/0/14 | - |
+| molecular-psychiatry | 20/20 • 33/38 | 98.37 | err | - | 323 | 0/0/18 | - |
+| ocean-and-coastal-research | 20/20 • 37/38 | 91.83 | err | - | 769 | 0/0/107 | - |
+| oecologia-australis | 19/20 • 36/38 | 93.27 | err | - | 771 | 0/0/102 | - |
+| pacific-science | 20/20 • 28/38 | 93.2 | err | - | 575 | 0/0/101 | - |
+| pakistan-journal-of-agricultural-sciences | 20/20 • 30/38 | 98 | err | - | 324 | 0/0/16 | - |
+| preslia | 19/20 • 36/38 | 85.8 | err | - | 188 | 0/0/5 | - |
+| raptor-journal | 20/20 • 31/38 | 98.3 | err | - | 310 | 0/0/9 | - |
+| reproduction | 17/20 • 38/38 | 96 | err | - | 221 | 0/0/3 | - |
+| social-cognitive-and-affective-neuroscience | 19/20 • 38/38 | 92.53 | err | - | 235 | 0/0/5 | - |
+| soil-science-and-plant-nutrition | 20/20 • 32/38 | 98.07 | err | - | 362 | 0/0/34 | - |
+| springer-physics-author-date | 20/20 • 11/38 | 96.1 | 99.17 | -3.07 | 166 | 0/0/1 | 0/0/6 |
+| the-holocene | 20/20 • 36/38 | 98.47 | err | - | 267 | 0/0/17 | - |
+| the-international-spectator | 8/20 • 31/38 | 97.23 | err | - | 375 | 0/0/53 | - |
+| the-open-university-harvard | 20/20 • 31/42 | 94.5 | err | - | 492 | 0/0/66 | - |
+| universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica | 20/20 • 37/38 | 92.63 | err | - | 207 | 0/0/3 | - |
+| universidade-estadual-paulista-campus-de-dracena-abnt | 9/20 • 34/38 | 95.13 | err | - | 320 | 0/0/23 | - |
+| zeitschrift-fur-religionswissenschaft-author-date | 20/20 • 37/38 | 95.3 | err | - | 246 | 0/0/17 | - |
+| american-mathematical-society-label | -/- • -/- | err | 93.8 | - | - | - | 0/2/27 |
+| bibtex | 8/20 • 3/38 | 84.73 | err | - | 245 | 0/0/19 | - |
+| din-1505-2-alphanumeric | 7/20 • 36/38 | 92.4 | 93.33 | -0.93 | 296 | 0/0/11 | 0/0/0 |
+| anabases | 15/20 • 29/38 | 97.9 | err | - | 265 | 0/0/33 | - |
+| bulletin-de-correspondance-hellenique | 15/20 • 31/38 | 98.43 | err | - | 187 | 0/0/15 | - |
+| chicago-notes-bibliography-access-dates | 20/20 • 33/37 | 95.1 | err | - | 669 | 0/0/92 | - |
+| chicago-shortened-notes-bibliography-classic-archive-place-first-no-url | 20/20 • 33/37 | 97.5 | err | - | 534 | 0/0/58 | - |
+| china-information | 11/20 • 8/41 | 93.87 | err | - | 856 | 0/0/85 | - |
+| donau-universitat-krems-department-fur-e-governance-in-wirthschaft-und-verwaltung | 17/20 • 35/38 | 96.03 | err | - | 518 | 0/0/72 | - |
+| early-medieval-europe | 9/20 • 0/0 | 56.67 | err | - | 71 | 0/0/0 | - |
+| histoire-at-politique | 18/20 • 34/38 | 94.37 | err | - | 263 | 0/1/36 | - |
+| iso690-full-note-es | 5/20 • 34/38 | 99.2 | err | - | 309 | 0/0/9 | - |
+| law-technology-and-humans | 18/20 • 35/38 | 95.9 | err | - | 612 | 0/0/83 | - |
+| mohr-siebeck-recht | 12/20 • 23/38 | 89.33 | err | - | 120 | 0/0/3 | - |
+| new-harts-rules-notes-initials-bracket-role-page-range-no-url | 18/20 • 30/37 | 99.1 | err | - | 242 | 0/0/9 | - |
+| pravny-obzor | 9/20 • 33/38 | 98.83 | err | - | 240 | 0/0/10 | - |
+| seminaire-saint-sulpice-ecole-theologie | 16/20 • 15/38 | 98.7 | err | - | 300 | 0/0/21 | - |
+| stuttgart-media-university | 14/20 • 21/38 | 97.5 | err | - | 317 | 0/0/40 | - |
+| the-journal-of-transport-history | 16/20 • 32/38 | 98.1 | err | - | 284 | 0/1/22 | - |
+| universite-de-sherbrooke-histoire | 16/20 • 34/38 | 98.43 | err | - | 309 | 0/0/26 | - |
+| vienna-legal | 14/20 • 16/38 | 97.4 | err | - | 486 | 0/0/49 | - |
+| zeitschrift-fur-medienwissenschaft | 7/20 • 0/0 | 56.67 | err | - | 48 | 0/0/0 | - |
+| advanced-science | 20/20 • 22/38 | 89.47 | err | - | 101 | 0/0/3 | - |
+| animal-migration | 20/20 • 17/38 | 98.4 | err | - | 270 | 0/0/6 | - |
+| brazilian-journal-of-psychiatry | 20/20 • 12/38 | 98.33 | err | - | 317 | 0/0/19 | - |
+| cellular-and-molecular-bioengineering | 20/20 • 37/38 | 97.5 | err | - | 379 | 0/0/58 | - |
+| clinical-journal-of-sport-medicine | 20/20 • 36/38 | 99.33 | err | - | 195 | 0/0/5 | - |
+| din-1505-2-numeric | 20/20 • 35/38 | 99.27 | err | - | 315 | 0/0/5 | - |
+| endoscopia | 20/20 • 38/38 | 97.47 | err | - | 384 | 0/0/43 | - |
+| european-journal-of-emergency-medicine | 20/20 • 38/38 | 99.37 | err | - | 245 | 0/0/0 | - |
+| frontiers-medical-journals | 20/20 • 38/38 | 96.23 | 96.67 | -0.44 | 197 | 0/0/0 | 0/0/0 |
+| heart-rhythm | 20/20 • 38/38 | 96.53 | err | - | 379 | 0/0/54 | - |
+| journal-of-cardiothoracic-and-vascular-anesthesia | 20/20 • 28/38 | 97.63 | err | - | 310 | 0/0/38 | - |
+| journal-of-industrial-and-engineering-chemistry | 20/20 • 30/38 | 98.07 | err | - | 345 | 0/0/8 | - |
+| journal-of-magnetic-resonance-imaging | 20/20 • 33/38 | 99 | err | - | 348 | 0/0/4 | - |
+| journal-of-nanoscience-and-nanotechnology | 20/20 • 23/38 | 89.17 | err | - | 114 | 0/0/6 | - |
+| journal-of-pediatric-gastroenterology-and-nutrition | 15/20 • 37/38 | 98.77 | err | - | 319 | 0/0/8 | - |
+| journal-of-the-american-animal-hospital-association | 20/20 • 15/38 | 98.77 | err | - | 314 | 0/0/6 | - |
+| journal-of-the-american-ceramic-society | 20/20 • 33/38 | 98.27 | err | - | 306 | 0/0/5 | - |
+| malaysian-orthopaedic-journal | 20/20 • 37/38 | 97.7 | err | - | 435 | 0/0/38 | - |
+| mycobiology | 20/20 • 37/38 | 99.5 | err | - | 177 | 0/0/2 | - |
+| ophthalmic-genetics | 20/20 • 37/38 | 98.2 | err | - | 448 | 0/0/22 | - |
+| opto-electronic-advances | 20/20 • 38/38 | 99.37 | err | - | 141 | 0/0/3 | - |
+| pest-management-science | 20/20 • 33/38 | 99.5 | err | - | 241 | 0/0/3 | - |
+| proceedings-of-the-estonian-academy-of-sciences-numeric | 20/20 • 17/53 | 97.13 | err | - | 486 | 0/0/38 | - |
+| proceedings-of-the-royal-society-b | 20/20 • 37/38 | 99.43 | 96.67 | 2.76 | 150 | 0/0/3 | 0/0/0 |
+| radiation-protection-dosimetry | 15/20 • 36/38 | 99 | err | - | 340 | 0/0/11 | - |
+| sanamed | 20/20 • 38/38 | 98.47 | err | - | 397 | 0/0/10 | - |
+| scientia-iranica | 20/20 • 33/39 | 98 | err | - | 319 | 0/0/20 | - |
+| the-journal-of-adhesive-dentistry | 10/20 • 36/38 | 98.2 | err | - | 231 | 0/1/10 | - |
+| the-journal-of-pure-and-applied-chemistry-research | 20/20 • 19/38 | 96.9 | err | - | 407 | 0/0/44 | - |
+| veterinary-record | 20/20 • 28/38 | 92.83 | err | - | 204 | 0/0/1 | - |
+| westfalische-wilhelms-universitat-munster-medizinische-fakultat | 20/20 • 25/38 | 97.8 | err | - | 360 | 0/0/39 | - |
+| world-applied-sciences-journal | 20/20 • 30/38 | 98.63 | err | - | 268 | 0/0/4 | - |
+| zeitschrift-fur-allgemeinmedizin | 20/20 • 32/38 | 98.43 | err | - | 289 | 0/0/5 | - |
+
+Columns: Migrated/Public SQI is a simple mean of `concision`, `fallbackRobustness`, and `presetUsage` (0–100). LOC is migrated YAML output lines. dup/near/rep counts come from `qualityBreakdown.subscores.concision` diagnostics in `report-core.js`.
+
+## Compression candidates
+
+Styles where the migrator discovered a candidate parent via the registry, a source CSL link, or a reverse `<info><link rel="template">` in an embedded canonical style. The scorecard tries the minimized wrapper form (`--family-candidate auto --minimize-wrapper`) for each candidate and accepts it only when oracle citation pass ≥ standalone, bibliography pass ≥ standalone, LOC decreases, and every minimized citation/bibliography entry is strictly equivalent after normalization.
+
+| Style | Candidate parent | Discovery source | Standalone LOC → Minimized LOC | Standalone fidelity → Minimized fidelity | Accepted |
+|---|---|---|---:|---|:---:|
+| modern-language-association-annotated-bibliography | modern-language-association | template-link | 789 → - | - → - | – |
+| zeitschrift-fur-fantastikforschung | modern-language-association | template-link | 292 → - | - → - | – |
+| bio-protocol | apa-7th | template-link | 1536 → - | - → - | – |
+| journal-of-contemporary-water-research-and-education | chicago-author-date-18th | template-link | 1188 → - | - → - | – |
+| mammalia | cse-name-year | template-link | 358 → - | - → - | – |
+| oecologia-australis | apa-7th | template-link | 781 → - | - → - | – |
+| pacific-science | apa-7th | template-link | 576 → - | - → - | – |
+| springer-physics-author-date | american-physics-society | template-link | 166 → 166 | 1/1 • 11/38 → 1/1 • 11/38 | ✗ |
+| the-holocene | sage-harvard | template-link | 286 → - | - → - | – |
+| zeitschrift-fur-religionswissenschaft-author-date | american-sociological-association | template-link | 264 → - | - → - | – |
+| american-mathematical-society-label | elsevier-with-titles | local-extends | 103 → - | - → - | – |
+| new-harts-rules-notes-initials-bracket-role-page-range-no-url | new-harts-rules-notes | template-link | 260 → - | - → - | – |
+| cellular-and-molecular-bioengineering | nlm-citation-sequence-superscript | template-link | 381 → - | - → - | – |
+| endoscopia | elsevier-vancouver | template-link | 387 → - | - → - | – |
+| european-journal-of-emergency-medicine | bmj | template-link | 258 → - | - → - | – |
+| frontiers-medical-journals | frontiers | template-link | 197 → 197 | 1/1 • 38/38 → 1/1 • 38/38 | ✗ |
+| journal-of-cardiothoracic-and-vascular-anesthesia | nlm-citation-sequence | template-link | 322 → - | - → - | – |
+| journal-of-industrial-and-engineering-chemistry | elsevier-vancouver | template-link | 351 → - | - → - | – |
+| journal-of-magnetic-resonance-imaging | biomed-central | template-link | 352 → - | - → - | – |
+| journal-of-the-american-ceramic-society | american-medical-association | template-link | 318 → - | - → - | – |
+| mycobiology | elsevier-vancouver | template-link | 183 → - | - → - | – |
+| opto-electronic-advances | nature | template-link | 154 → - | - → - | – |
+| scientia-iranica | the-optical-society | template-link | 339 → - | - → - | – |
+| the-journal-of-pure-and-applied-chemistry-research | american-chemical-society | template-link | 421 → - | - → - | – |
+| world-applied-sciences-journal | elsevier-with-titles | template-link | 287 → - | - → - | – |
+
+## Output Diagnostics
+
+| Style | LOC | Template components | Bibliography template | Bibliography variants | Pathological |
+|---|---:|---:|---:|---:|---|
+| apa-6th-edition | 994 | 189 | 30 | 35 | no |

--- a/scripts/lib/corpus-sample.js
+++ b/scripts/lib/corpus-sample.js
@@ -1,0 +1,149 @@
+/*
+ * Seeded, stratified sampling over the legacy CSL corpus.
+ *
+ * Used by report-migrate-sqi.js to build a reproducible "random" measurement
+ * corpus: independent parent styles are classified by their CSL
+ * `citation-format` category, then sampled per-stratum with a deterministic
+ * PRNG so a given seed always yields the same corpus.
+ */
+
+'use strict';
+
+const KNOWN_CLASSES = ['author-date', 'numeric', 'note', 'label', 'author'];
+
+/** Deterministic 32-bit PRNG (mulberry32). Returns floats in [0, 1). */
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Classify a CSL style by its `citation-format` category attribute.
+ * Returns one of KNOWN_CLASSES or 'unknown'.
+ */
+function classifyCitationFormat(cslText) {
+  if (typeof cslText !== 'string') return 'unknown';
+  const match = /citation-format="([^"]+)"/.exec(cslText);
+  if (!match) return 'unknown';
+  const value = match[1].trim();
+  return KNOWN_CLASSES.includes(value) ? value : 'unknown';
+}
+
+/** In-place Fisher–Yates shuffle driven by the supplied PRNG. */
+function shuffle(items, rand) {
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
+  return items;
+}
+
+/**
+ * Allocate `sampleSize` slots across strata proportionally to stratum size,
+ * holding a floor of `minPerStratum` (capped at stratum size) for every
+ * non-empty stratum. Deterministic: ties resolve by stratum name.
+ *
+ * @param {Map<string, number>} stratumSizes class -> population count
+ * @returns {Map<string, number>} class -> allocated count
+ */
+function allocateStrata(stratumSizes, sampleSize, minPerStratum) {
+  const names = [...stratumSizes.keys()].sort();
+  const population = names.reduce((sum, name) => sum + stratumSizes.get(name), 0);
+  const allocation = new Map();
+  if (population <= sampleSize) {
+    for (const name of names) allocation.set(name, stratumSizes.get(name));
+    return allocation;
+  }
+
+  // Scale the floor down when stratum floors alone would exceed the sample
+  // size (e.g. a pilot draw of 10 across 5 strata), so the requested size
+  // is always honored.
+  const effectiveMin = Math.min(
+    minPerStratum,
+    Math.max(1, Math.floor(sampleSize / names.length))
+  );
+  for (const name of names) {
+    const size = stratumSizes.get(name);
+    const proportional = Math.floor((size / population) * sampleSize);
+    allocation.set(name, Math.min(size, Math.max(proportional, effectiveMin)));
+  }
+
+  let total = [...allocation.values()].reduce((sum, n) => sum + n, 0);
+  // Grow toward the target from the largest strata (most remaining capacity),
+  // shrink from the largest allocations that are still above their floor.
+  while (total < sampleSize) {
+    const candidates = names
+      .filter((name) => allocation.get(name) < stratumSizes.get(name))
+      .sort((a, b) => stratumSizes.get(b) - stratumSizes.get(a) || a.localeCompare(b));
+    if (candidates.length === 0) break;
+    allocation.set(candidates[0], allocation.get(candidates[0]) + 1);
+    total += 1;
+  }
+  while (total > sampleSize) {
+    const floor = (name) => Math.min(stratumSizes.get(name), effectiveMin);
+    const candidates = names
+      .filter((name) => allocation.get(name) > floor(name))
+      .sort((a, b) => allocation.get(b) - allocation.get(a) || a.localeCompare(b));
+    if (candidates.length === 0) break;
+    allocation.set(candidates[0], allocation.get(candidates[0]) - 1);
+    total -= 1;
+  }
+  return allocation;
+}
+
+/**
+ * Draw a seeded, stratified sample from a classified corpus.
+ *
+ * @param {Array<{style: string, styleClass: string}>} classified
+ * @param {{sampleSize: number, seed: number, minPerStratum?: number}} options
+ * @returns {{sample: Array<{style: string, styleClass: string}>,
+ *            allocation: Object<string, number>,
+ *            population: number,
+ *            strata: Object<string, number>}}
+ */
+function stratifiedSample(classified, { sampleSize, seed, minPerStratum = 5 }) {
+  const byClass = new Map();
+  for (const entry of classified) {
+    if (!byClass.has(entry.styleClass)) byClass.set(entry.styleClass, []);
+    byClass.get(entry.styleClass).push(entry.style);
+  }
+  const stratumSizes = new Map();
+  for (const [name, styles] of byClass) {
+    styles.sort();
+    stratumSizes.set(name, styles.length);
+  }
+
+  const allocation = allocateStrata(stratumSizes, sampleSize, minPerStratum);
+  const rand = mulberry32(seed);
+  const sample = [];
+  // Consume the PRNG stream in sorted-stratum order so the draw is fully
+  // determined by (seed, corpus contents), not map insertion order.
+  for (const name of [...byClass.keys()].sort()) {
+    const pool = shuffle([...byClass.get(name)], rand);
+    for (const style of pool.slice(0, allocation.get(name) ?? 0)) {
+      sample.push({ style, styleClass: name });
+    }
+  }
+  sample.sort((a, b) => a.styleClass.localeCompare(b.styleClass) || a.style.localeCompare(b.style));
+
+  return {
+    sample,
+    allocation: Object.fromEntries([...allocation.entries()].sort()),
+    population: classified.length,
+    strata: Object.fromEntries([...stratumSizes.entries()].sort()),
+  };
+}
+
+module.exports = {
+  KNOWN_CLASSES,
+  mulberry32,
+  classifyCitationFormat,
+  allocateStrata,
+  stratifiedSample,
+};

--- a/scripts/lib/corpus-sample.test.js
+++ b/scripts/lib/corpus-sample.test.js
@@ -1,0 +1,118 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  mulberry32,
+  classifyCitationFormat,
+  allocateStrata,
+  stratifiedSample,
+} = require('./corpus-sample');
+
+test('classifyCitationFormat reads the citation-format category attribute', () => {
+  const csl = '<style class="in-text"><info><category citation-format="author-date"/></info></style>';
+  assert.equal(classifyCitationFormat(csl), 'author-date');
+  assert.equal(classifyCitationFormat('<style class="note"><info><category citation-format="note"/></info></style>'), 'note');
+  assert.equal(classifyCitationFormat('<style><info/></style>'), 'unknown');
+  assert.equal(classifyCitationFormat('<category citation-format="bogus-value"/>'), 'unknown');
+  assert.equal(classifyCitationFormat(null), 'unknown');
+});
+
+test('mulberry32 is deterministic per seed and differs across seeds', () => {
+  const first = mulberry32(42);
+  const second = mulberry32(42);
+  const sequenceA = [first(), first(), first()];
+  const sequenceB = [second(), second(), second()];
+  assert.deepEqual(sequenceA, sequenceB);
+  const other = mulberry32(43);
+  assert.notDeepEqual(sequenceA, [other(), other(), other()]);
+  for (const value of sequenceA) {
+    assert.ok(value >= 0 && value < 1);
+  }
+});
+
+test('allocateStrata holds per-stratum floors and hits the sample size', () => {
+  const sizes = new Map([
+    ['author-date', 1000],
+    ['numeric', 1500],
+    ['note', 300],
+    ['label', 8],
+  ]);
+  const allocation = allocateStrata(sizes, 100, 5);
+  const total = [...allocation.values()].reduce((sum, n) => sum + n, 0);
+  assert.equal(total, 100);
+  assert.ok(allocation.get('label') >= 5);
+  assert.ok(allocation.get('note') >= 5);
+  assert.ok(allocation.get('numeric') > allocation.get('author-date'));
+});
+
+test('allocateStrata honors small sample sizes by scaling the floor', () => {
+  const sizes = new Map([
+    ['author', 10],
+    ['author-date', 1335],
+    ['label', 3],
+    ['note', 542],
+    ['numeric', 954],
+  ]);
+  const allocation = allocateStrata(sizes, 10, 5);
+  const total = [...allocation.values()].reduce((sum, n) => sum + n, 0);
+  assert.equal(total, 10);
+  for (const count of allocation.values()) {
+    assert.ok(count >= 1);
+  }
+});
+
+test('allocateStrata takes everything when population fits the sample', () => {
+  const sizes = new Map([['author-date', 3], ['note', 2]]);
+  const allocation = allocateStrata(sizes, 100, 5);
+  assert.deepEqual([...allocation.entries()].sort(), [
+    ['author-date', 3],
+    ['note', 2],
+  ]);
+});
+
+function syntheticCorpus() {
+  const classified = [];
+  const push = (styleClass, count) => {
+    for (let i = 0; i < count; i++) {
+      classified.push({ style: `${styleClass}-style-${String(i).padStart(3, '0')}`, styleClass });
+    }
+  };
+  push('author-date', 120);
+  push('numeric', 180);
+  push('note', 40);
+  push('label', 6);
+  return classified;
+}
+
+test('stratifiedSample is reproducible for a given seed', () => {
+  const corpus = syntheticCorpus();
+  const first = stratifiedSample(corpus, { sampleSize: 50, seed: 20260610 });
+  const second = stratifiedSample(corpus, { sampleSize: 50, seed: 20260610 });
+  assert.deepEqual(first.sample, second.sample);
+  assert.equal(first.sample.length, 50);
+  const different = stratifiedSample(corpus, { sampleSize: 50, seed: 7 });
+  assert.notDeepEqual(
+    first.sample.map((entry) => entry.style),
+    different.sample.map((entry) => entry.style)
+  );
+});
+
+test('stratifiedSample covers every non-empty stratum and reports metadata', () => {
+  const corpus = syntheticCorpus();
+  const drawn = stratifiedSample(corpus, { sampleSize: 50, seed: 1 });
+  const sampledClasses = new Set(drawn.sample.map((entry) => entry.styleClass));
+  assert.deepEqual([...sampledClasses].sort(), ['author-date', 'label', 'note', 'numeric']);
+  assert.equal(drawn.population, corpus.length);
+  assert.equal(drawn.strata.numeric, 180);
+  const allocated = Object.values(drawn.allocation).reduce((sum, n) => sum + n, 0);
+  assert.equal(allocated, 50);
+  // label stratum (6 styles) is below the floor of 5 only if smaller than it;
+  // here it must contribute at least min(5, 6) = 5 styles.
+  assert.ok(drawn.allocation.label >= 5);
+});
+
+test('stratifiedSample draws without duplicates', () => {
+  const drawn = stratifiedSample(syntheticCorpus(), { sampleSize: 100, seed: 99 });
+  const names = drawn.sample.map((entry) => entry.style);
+  assert.equal(new Set(names).size, names.length);
+});

--- a/scripts/oracle-migrate-batch.js
+++ b/scripts/oracle-migrate-batch.js
@@ -140,6 +140,20 @@ function runOracleMigrateOnly(styleName, args) {
   });
 
   if (proc.status !== 0 && proc.status !== 1) {
+    // oracle.js exits >1 on hard failures but still writes a structured
+    // JSON error to stdout; prefer that reason over bare stderr/exit code.
+    try {
+      const parsed = JSON.parse(proc.stdout || '');
+      if (parsed.error) {
+        return {
+          style: styleName,
+          error: parsed.error,
+          details: parsed.reason || null,
+        };
+      }
+    } catch {
+      // fall through to the generic exec failure below
+    }
     return {
       style: styleName,
       error: 'oracle_exec_failed',

--- a/scripts/report-data/migrate-random-baseline-2026-06-10.json
+++ b/scripts/report-data/migrate-random-baseline-2026-06-10.json
@@ -1,0 +1,2031 @@
+{
+  "generated": "2026-06-10T16:52:41.318Z",
+  "commit": "4016d7cf",
+  "corpus": "random",
+  "sample": {
+    "seed": 20260610,
+    "requested": 100,
+    "population": 2844,
+    "strata": {
+      "author": 10,
+      "author-date": 1335,
+      "label": 3,
+      "note": 542,
+      "numeric": 954
+    },
+    "allocation": {
+      "author": 5,
+      "author-date": 40,
+      "label": 3,
+      "note": 19,
+      "numeric": 33
+    }
+  },
+  "aggregate": {
+    "migrated": {
+      "n": 98,
+      "mean": 94.9,
+      "p10": 86.03,
+      "p50": 97.5,
+      "p90": 99.27
+    },
+    "public": {
+      "n": 5,
+      "mean": 95.93,
+      "p10": 93.33,
+      "p50": 96.67,
+      "p90": 99.17
+    },
+    "delta": {
+      "n": 4,
+      "mean": -0.42,
+      "p10": -3.07,
+      "p50": -0.44,
+      "p90": 2.76
+    },
+    "fidelityHeadline": {
+      "threshold": 90,
+      "overall": {
+        "measured": 100,
+        "statuses": {
+          "ok": 98,
+          "oracle_failed": 2
+        },
+        "atThreshold": 43,
+        "shareAtThreshold": 43,
+        "combined": {
+          "n": 98,
+          "mean": 83.2,
+          "p10": 55.2,
+          "p50": 89.7,
+          "p90": 100
+        }
+      },
+      "perClass": {
+        "author": {
+          "measured": 5,
+          "statuses": {
+            "ok": 4,
+            "oracle_failed": 1
+          },
+          "atThreshold": 1,
+          "shareAtThreshold": 20,
+          "combined": {
+            "n": 4,
+            "mean": 86.9,
+            "p10": 82.8,
+            "p50": 87.7,
+            "p90": 91.2
+          }
+        },
+        "author-date": {
+          "measured": 40,
+          "statuses": {
+            "ok": 40
+          },
+          "atThreshold": 23,
+          "shareAtThreshold": 57.5,
+          "combined": {
+            "n": 40,
+            "mean": 87.8,
+            "p10": 67.2,
+            "p50": 94.8,
+            "p90": 100
+          }
+        },
+        "label": {
+          "measured": 3,
+          "statuses": {
+            "oracle_failed": 1,
+            "ok": 2
+          },
+          "atThreshold": 0,
+          "shareAtThreshold": 0,
+          "combined": {
+            "n": 2,
+            "mean": 46.6,
+            "p10": 19,
+            "p50": 74.1,
+            "p90": 74.1
+          }
+        },
+        "note": {
+          "measured": 19,
+          "statuses": {
+            "ok": 19
+          },
+          "atThreshold": 3,
+          "shareAtThreshold": 15.8,
+          "combined": {
+            "n": 19,
+            "mean": 70.6,
+            "p10": 35,
+            "p50": 75.9,
+            "p90": 93
+          }
+        },
+        "numeric": {
+          "measured": 33,
+          "statuses": {
+            "ok": 33
+          },
+          "atThreshold": 16,
+          "shareAtThreshold": 48.5,
+          "combined": {
+            "n": 33,
+            "mean": 86.4,
+            "p10": 63.8,
+            "p50": 89.8,
+            "p90": 100
+          }
+        }
+      }
+    }
+  },
+  "results": [
+    {
+      "style": "chicago-in-text-shortened-author",
+      "styleClass": "author",
+      "fidelity": {
+        "citations": {
+          "passed": 16,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 34,
+          "total": 37
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 95.03,
+      "publicSqi": null,
+      "outputLines": 665
+    },
+    {
+      "style": "chicago-in-text-shortened-author-no-url",
+      "styleClass": "author",
+      "fidelity": {
+        "citations": {
+          "passed": 16,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 37
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.77,
+      "publicSqi": null,
+      "outputLines": 552
+    },
+    {
+      "style": "chicago-in-text-shortened-author-title-no-url",
+      "styleClass": "author",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 32,
+          "total": 37
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.7,
+      "publicSqi": null,
+      "outputLines": 543
+    },
+    {
+      "style": "modern-language-association-annotated-bibliography",
+      "styleClass": "author",
+      "fidelity": {
+        "citations": {
+          "passed": 14,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 34,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 90.67,
+      "publicSqi": null,
+      "outputLines": 771
+    },
+    {
+      "style": "zeitschrift-fur-fantastikforschung",
+      "styleClass": "author",
+      "fidelity": {
+        "error": "Citum rendering failed",
+        "details": "Processor failed: \nError: template variant operation in `bibliography.type-variants[interview]` matched no component\n"
+      },
+      "migratedSqi": null,
+      "publicSqi": null,
+      "outputLines": null
+    },
+    {
+      "style": "antarctic-science",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 92.77,
+      "publicSqi": null,
+      "outputLines": 224
+    },
+    {
+      "style": "anthropologie-et-societes",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.03,
+      "publicSqi": null,
+      "outputLines": 236
+    },
+    {
+      "style": "australian-road-research-board",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 18,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 85.57,
+      "publicSqi": null,
+      "outputLines": 213
+    },
+    {
+      "style": "berlin-school-of-economics-and-law-international-marketing-management",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 85.73,
+      "publicSqi": null,
+      "outputLines": 143
+    },
+    {
+      "style": "bio-protocol",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 6,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 31,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 76.27,
+      "publicSqi": null,
+      "outputLines": 1526
+    },
+    {
+      "style": "canadian-biosystems-engineering",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 32,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 92.87,
+      "publicSqi": null,
+      "outputLines": 510
+    },
+    {
+      "style": "carolinea",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.9,
+      "publicSqi": null,
+      "outputLines": 293
+    },
+    {
+      "style": "civitas-revista-de-ciencias-sociais",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 26,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.4,
+      "publicSqi": null,
+      "outputLines": 327
+    },
+    {
+      "style": "evolution-letters",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.37,
+      "publicSqi": null,
+      "outputLines": 209
+    },
+    {
+      "style": "freshwater-crayfish",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.63,
+      "publicSqi": null,
+      "outputLines": 344
+    },
+    {
+      "style": "harvard-coventry-university",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 84.03,
+      "publicSqi": null,
+      "outputLines": 1338
+    },
+    {
+      "style": "harvard-durham-university-business-school",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.77,
+      "publicSqi": null,
+      "outputLines": 449
+    },
+    {
+      "style": "history-of-the-human-sciences",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 86.03,
+      "publicSqi": null,
+      "outputLines": 177
+    },
+    {
+      "style": "institut-national-de-sante-publique-du-quebec-napp",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 32,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99,
+      "publicSqi": null,
+      "outputLines": 214
+    },
+    {
+      "style": "instituto-de-pesquisas-energeticas-e-nucleares",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 7,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 28,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.13,
+      "publicSqi": null,
+      "outputLines": 225
+    },
+    {
+      "style": "interkulturelle-germanistik-gottingen",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 17,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.8,
+      "publicSqi": null,
+      "outputLines": 408
+    },
+    {
+      "style": "jcom-journal-of-science-communication",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 14,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 25,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 91,
+      "publicSqi": null,
+      "outputLines": 1271
+    },
+    {
+      "style": "journal-of-advertising-research",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 18,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 14,
+          "total": 46
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.07,
+      "publicSqi": null,
+      "outputLines": 382
+    },
+    {
+      "style": "journal-of-applied-entomology",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.3,
+      "publicSqi": null,
+      "outputLines": 181
+    },
+    {
+      "style": "journal-of-contemporary-water-research-and-education",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 35,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 85.8,
+      "publicSqi": null,
+      "outputLines": 1173
+    },
+    {
+      "style": "lien-social-et-politiques",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.03,
+      "publicSqi": null,
+      "outputLines": 260
+    },
+    {
+      "style": "mammalia",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 24,
+          "total": 39
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.03,
+      "publicSqi": null,
+      "outputLines": 354
+    },
+    {
+      "style": "media-culture-and-society",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 92.17,
+      "publicSqi": null,
+      "outputLines": 236
+    },
+    {
+      "style": "molecular-psychiatry",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.37,
+      "publicSqi": null,
+      "outputLines": 323
+    },
+    {
+      "style": "ocean-and-coastal-research",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 91.83,
+      "publicSqi": null,
+      "outputLines": 769
+    },
+    {
+      "style": "oecologia-australis",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 93.27,
+      "publicSqi": null,
+      "outputLines": 771
+    },
+    {
+      "style": "pacific-science",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 28,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 93.2,
+      "publicSqi": null,
+      "outputLines": 575
+    },
+    {
+      "style": "pakistan-journal-of-agricultural-sciences",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 30,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98,
+      "publicSqi": null,
+      "outputLines": 324
+    },
+    {
+      "style": "preslia",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 85.8,
+      "publicSqi": null,
+      "outputLines": 188
+    },
+    {
+      "style": "raptor-journal",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 31,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.3,
+      "publicSqi": null,
+      "outputLines": 310
+    },
+    {
+      "style": "reproduction",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 17,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96,
+      "publicSqi": null,
+      "outputLines": 221
+    },
+    {
+      "style": "social-cognitive-and-affective-neuroscience",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 19,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 92.53,
+      "publicSqi": null,
+      "outputLines": 235
+    },
+    {
+      "style": "soil-science-and-plant-nutrition",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 32,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.07,
+      "publicSqi": null,
+      "outputLines": 362
+    },
+    {
+      "style": "springer-physics-author-date",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 11,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.1,
+      "publicSqi": 99.17,
+      "outputLines": 166
+    },
+    {
+      "style": "the-holocene",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.47,
+      "publicSqi": null,
+      "outputLines": 267
+    },
+    {
+      "style": "the-international-spectator",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 8,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 31,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.23,
+      "publicSqi": null,
+      "outputLines": 375
+    },
+    {
+      "style": "the-open-university-harvard",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 31,
+          "total": 42
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 94.5,
+      "publicSqi": null,
+      "outputLines": 492
+    },
+    {
+      "style": "universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 92.63,
+      "publicSqi": null,
+      "outputLines": 207
+    },
+    {
+      "style": "universidade-estadual-paulista-campus-de-dracena-abnt",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 9,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 34,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 95.13,
+      "publicSqi": null,
+      "outputLines": 320
+    },
+    {
+      "style": "zeitschrift-fur-religionswissenschaft-author-date",
+      "styleClass": "author-date",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 95.3,
+      "publicSqi": null,
+      "outputLines": 246
+    },
+    {
+      "style": "american-mathematical-society-label",
+      "styleClass": "label",
+      "fidelity": {
+        "error": "Citum rendering failed",
+        "details": "Processor failed: \nError: template variant operation in `bibliography.type-variants[patent]` matched no component\n"
+      },
+      "migratedSqi": null,
+      "publicSqi": 93.8,
+      "outputLines": null
+    },
+    {
+      "style": "bibtex",
+      "styleClass": "label",
+      "fidelity": {
+        "citations": {
+          "passed": 8,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 3,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 84.73,
+      "publicSqi": null,
+      "outputLines": 245
+    },
+    {
+      "style": "din-1505-2-alphanumeric",
+      "styleClass": "label",
+      "fidelity": {
+        "citations": {
+          "passed": 7,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 92.4,
+      "publicSqi": 93.33,
+      "outputLines": 296
+    },
+    {
+      "style": "anabases",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 15,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 29,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.9,
+      "publicSqi": null,
+      "outputLines": 265
+    },
+    {
+      "style": "bulletin-de-correspondance-hellenique",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 15,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 31,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.43,
+      "publicSqi": null,
+      "outputLines": 187
+    },
+    {
+      "style": "chicago-notes-bibliography-access-dates",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 37
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 95.1,
+      "publicSqi": null,
+      "outputLines": 669
+    },
+    {
+      "style": "chicago-shortened-notes-bibliography-classic-archive-place-first-no-url",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 37
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.5,
+      "publicSqi": null,
+      "outputLines": 534
+    },
+    {
+      "style": "china-information",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 11,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 8,
+          "total": 41
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 93.87,
+      "publicSqi": null,
+      "outputLines": 856
+    },
+    {
+      "style": "donau-universitat-krems-department-fur-e-governance-in-wirthschaft-und-verwaltung",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 17,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 35,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.03,
+      "publicSqi": null,
+      "outputLines": 518
+    },
+    {
+      "style": "early-medieval-europe",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 9,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 0,
+          "total": 0
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 56.67,
+      "publicSqi": null,
+      "outputLines": 71
+    },
+    {
+      "style": "histoire-at-politique",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 18,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 34,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 94.37,
+      "publicSqi": null,
+      "outputLines": 263
+    },
+    {
+      "style": "iso690-full-note-es",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 5,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 34,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.2,
+      "publicSqi": null,
+      "outputLines": 309
+    },
+    {
+      "style": "law-technology-and-humans",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 18,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 35,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 95.9,
+      "publicSqi": null,
+      "outputLines": 612
+    },
+    {
+      "style": "mohr-siebeck-recht",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 12,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 23,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 89.33,
+      "publicSqi": null,
+      "outputLines": 120
+    },
+    {
+      "style": "new-harts-rules-notes-initials-bracket-role-page-range-no-url",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 18,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 30,
+          "total": 37
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.1,
+      "publicSqi": null,
+      "outputLines": 242
+    },
+    {
+      "style": "pravny-obzor",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 9,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.83,
+      "publicSqi": null,
+      "outputLines": 240
+    },
+    {
+      "style": "seminaire-saint-sulpice-ecole-theologie",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 16,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 15,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.7,
+      "publicSqi": null,
+      "outputLines": 300
+    },
+    {
+      "style": "stuttgart-media-university",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 14,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 21,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.5,
+      "publicSqi": null,
+      "outputLines": 317
+    },
+    {
+      "style": "the-journal-of-transport-history",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 16,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 32,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.1,
+      "publicSqi": null,
+      "outputLines": 284
+    },
+    {
+      "style": "universite-de-sherbrooke-histoire",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 16,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 34,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.43,
+      "publicSqi": null,
+      "outputLines": 309
+    },
+    {
+      "style": "vienna-legal",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 14,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 16,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.4,
+      "publicSqi": null,
+      "outputLines": 486
+    },
+    {
+      "style": "zeitschrift-fur-medienwissenschaft",
+      "styleClass": "note",
+      "fidelity": {
+        "citations": {
+          "passed": 7,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 0,
+          "total": 0
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 56.67,
+      "publicSqi": null,
+      "outputLines": 48
+    },
+    {
+      "style": "advanced-science",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 22,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 89.47,
+      "publicSqi": null,
+      "outputLines": 101
+    },
+    {
+      "style": "animal-migration",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 17,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.4,
+      "publicSqi": null,
+      "outputLines": 270
+    },
+    {
+      "style": "brazilian-journal-of-psychiatry",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 12,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.33,
+      "publicSqi": null,
+      "outputLines": 317
+    },
+    {
+      "style": "cellular-and-molecular-bioengineering",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.5,
+      "publicSqi": null,
+      "outputLines": 379
+    },
+    {
+      "style": "clinical-journal-of-sport-medicine",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.33,
+      "publicSqi": null,
+      "outputLines": 195
+    },
+    {
+      "style": "din-1505-2-numeric",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 35,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.27,
+      "publicSqi": null,
+      "outputLines": 315
+    },
+    {
+      "style": "endoscopia",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.47,
+      "publicSqi": null,
+      "outputLines": 384
+    },
+    {
+      "style": "european-journal-of-emergency-medicine",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.37,
+      "publicSqi": null,
+      "outputLines": 245
+    },
+    {
+      "style": "frontiers-medical-journals",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.23,
+      "publicSqi": 96.67,
+      "outputLines": 197
+    },
+    {
+      "style": "heart-rhythm",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.53,
+      "publicSqi": null,
+      "outputLines": 379
+    },
+    {
+      "style": "journal-of-cardiothoracic-and-vascular-anesthesia",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 28,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.63,
+      "publicSqi": null,
+      "outputLines": 310
+    },
+    {
+      "style": "journal-of-industrial-and-engineering-chemistry",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 30,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.07,
+      "publicSqi": null,
+      "outputLines": 345
+    },
+    {
+      "style": "journal-of-magnetic-resonance-imaging",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99,
+      "publicSqi": null,
+      "outputLines": 348
+    },
+    {
+      "style": "journal-of-nanoscience-and-nanotechnology",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 23,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 89.17,
+      "publicSqi": null,
+      "outputLines": 114
+    },
+    {
+      "style": "journal-of-pediatric-gastroenterology-and-nutrition",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 15,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.77,
+      "publicSqi": null,
+      "outputLines": 319
+    },
+    {
+      "style": "journal-of-the-american-animal-hospital-association",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 15,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.77,
+      "publicSqi": null,
+      "outputLines": 314
+    },
+    {
+      "style": "journal-of-the-american-ceramic-society",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.27,
+      "publicSqi": null,
+      "outputLines": 306
+    },
+    {
+      "style": "malaysian-orthopaedic-journal",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.7,
+      "publicSqi": null,
+      "outputLines": 435
+    },
+    {
+      "style": "mycobiology",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.5,
+      "publicSqi": null,
+      "outputLines": 177
+    },
+    {
+      "style": "ophthalmic-genetics",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.2,
+      "publicSqi": null,
+      "outputLines": 448
+    },
+    {
+      "style": "opto-electronic-advances",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.37,
+      "publicSqi": null,
+      "outputLines": 141
+    },
+    {
+      "style": "pest-management-science",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.5,
+      "publicSqi": null,
+      "outputLines": 241
+    },
+    {
+      "style": "proceedings-of-the-estonian-academy-of-sciences-numeric",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 17,
+          "total": 53
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.13,
+      "publicSqi": null,
+      "outputLines": 486
+    },
+    {
+      "style": "proceedings-of-the-royal-society-b",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 37,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99.43,
+      "publicSqi": 96.67,
+      "outputLines": 150
+    },
+    {
+      "style": "radiation-protection-dosimetry",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 15,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 99,
+      "publicSqi": null,
+      "outputLines": 340
+    },
+    {
+      "style": "sanamed",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 38,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.47,
+      "publicSqi": null,
+      "outputLines": 397
+    },
+    {
+      "style": "scientia-iranica",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 33,
+          "total": 39
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98,
+      "publicSqi": null,
+      "outputLines": 319
+    },
+    {
+      "style": "the-journal-of-adhesive-dentistry",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 10,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 36,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.2,
+      "publicSqi": null,
+      "outputLines": 231
+    },
+    {
+      "style": "the-journal-of-pure-and-applied-chemistry-research",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 19,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 96.9,
+      "publicSqi": null,
+      "outputLines": 407
+    },
+    {
+      "style": "veterinary-record",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 28,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 92.83,
+      "publicSqi": null,
+      "outputLines": 204
+    },
+    {
+      "style": "westfalische-wilhelms-universitat-munster-medizinische-fakultat",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 25,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 97.8,
+      "publicSqi": null,
+      "outputLines": 360
+    },
+    {
+      "style": "world-applied-sciences-journal",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 30,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.63,
+      "publicSqi": null,
+      "outputLines": 268
+    },
+    {
+      "style": "zeitschrift-fur-allgemeinmedizin",
+      "styleClass": "numeric",
+      "fidelity": {
+        "citations": {
+          "passed": 20,
+          "total": 20
+        },
+        "bibliography": {
+          "passed": 32,
+          "total": 38
+        },
+        "error": null,
+        "details": null
+      },
+      "migratedSqi": 98.43,
+      "publicSqi": null,
+      "outputLines": 289
+    }
+  ]
+}

--- a/scripts/report-migrate-sqi.js
+++ b/scripts/report-migrate-sqi.js
@@ -20,6 +20,8 @@
  *   node scripts/report-migrate-sqi.js                       # default corpus (sentinels + lab)
  *   node scripts/report-migrate-sqi.js --corpus sentinels    # top-10 sentinels only
  *   node scripts/report-migrate-sqi.js --corpus lab          # migrate-research lab corpus only
+ *   node scripts/report-migrate-sqi.js --corpus random --sample 100 --seed 20260610
+ *                                                            # seeded stratified random independents
  *   node scripts/report-migrate-sqi.js --styles apa,ieee     # explicit set
  *   node scripts/report-migrate-sqi.js --out /tmp/sqi.json   # write JSON to file
  *   node scripts/report-migrate-sqi.js --markdown docs/architecture/...md
@@ -35,6 +37,7 @@ const { spawnSync } = require('child_process');
 const reportCore = require('./report-core.js');
 const { resolveAuthoredStylePath } = require('./oracle.js');
 const { normalizeText } = require('./oracle-utils.js');
+const { classifyCitationFormat, stratifiedSample } = require('./lib/corpus-sample.js');
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '..');
 const LEGACY_DIR = path.join(WORKSPACE_ROOT, 'styles-legacy');
@@ -78,6 +81,15 @@ const DIAGNOSTIC_STYLES = [
 
 const PATHOLOGICAL_OUTPUT_LINES = 1500;
 
+// Headline quality bar: share of measured styles whose combined strict
+// citation+bibliography pass rate reaches this fraction.
+const FIDELITY_HEADLINE_THRESHOLD = 0.9;
+
+// Default seed for `--corpus random`. Fixed so scheduled re-runs measure the
+// same corpus and stay trend-comparable; pass `--seed` to draw a fresh one.
+const DEFAULT_RANDOM_SEED = 20260610;
+const DEFAULT_RANDOM_SAMPLE = 100;
+
 function parseArgs(argv) {
   const args = {
     corpus: 'both',
@@ -86,6 +98,8 @@ function parseArgs(argv) {
     markdown: null,
     json: false,
     skipFidelity: false,
+    sample: DEFAULT_RANDOM_SAMPLE,
+    seed: DEFAULT_RANDOM_SEED,
   };
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
@@ -93,6 +107,16 @@ function parseArgs(argv) {
       args.corpus = argv[++i];
     } else if (arg === '--styles' && argv[i + 1]) {
       args.styles = argv[++i];
+    } else if (arg === '--sample' && argv[i + 1]) {
+      args.sample = Number(argv[++i]);
+      if (!Number.isInteger(args.sample) || args.sample <= 0) {
+        throw new Error('--sample must be a positive integer');
+      }
+    } else if (arg === '--seed' && argv[i + 1]) {
+      args.seed = Number(argv[++i]);
+      if (!Number.isInteger(args.seed)) {
+        throw new Error('--seed must be an integer');
+      }
     } else if (arg === '--out' && argv[i + 1]) {
       args.out = argv[++i];
     } else if (arg === '--markdown' && argv[i + 1]) {
@@ -116,19 +140,60 @@ function printHelp() {
   console.log('');
   console.log('Usage:');
   console.log('  node scripts/report-migrate-sqi.js');
-  console.log('  node scripts/report-migrate-sqi.js --corpus sentinels|lab|both');
+  console.log('  node scripts/report-migrate-sqi.js --corpus sentinels|lab|both|random');
+  console.log('  node scripts/report-migrate-sqi.js --corpus random --sample 100 --seed 20260610');
   console.log('  node scripts/report-migrate-sqi.js --styles apa,ieee');
   console.log('  node scripts/report-migrate-sqi.js --out /tmp/sqi.json --markdown docs/...md');
   console.log('  node scripts/report-migrate-sqi.js --skip-fidelity   # YAML scoring only, no oracle');
 }
 
+/** Top-level styles-legacy/*.csl names; dependents live under dependent/. */
+function enumerateIndependentStyles() {
+  return fs
+    .readdirSync(LEGACY_DIR)
+    .filter((name) => name.endsWith('.csl'))
+    .map((name) => path.basename(name, '.csl'))
+    .sort();
+}
+
+function classifyLegacyStyle(styleName) {
+  try {
+    const cslText = fs.readFileSync(path.join(LEGACY_DIR, `${styleName}.csl`), 'utf8');
+    return classifyCitationFormat(cslText);
+  } catch {
+    return 'unknown';
+  }
+}
+
+function resolveRandomCorpus(args) {
+  const classified = enumerateIndependentStyles().map((style) => ({
+    style,
+    styleClass: classifyLegacyStyle(style),
+  }));
+  const drawn = stratifiedSample(classified, {
+    sampleSize: args.sample,
+    seed: args.seed,
+  });
+  return {
+    styles: drawn.sample.map((entry) => entry.style),
+    sampleMeta: {
+      seed: args.seed,
+      requested: args.sample,
+      population: drawn.population,
+      strata: drawn.strata,
+      allocation: drawn.allocation,
+    },
+  };
+}
+
 function resolveCorpus(args) {
   if (args.styles) {
-    return args.styles.split(',').map((s) => s.trim()).filter(Boolean);
+    return { styles: args.styles.split(',').map((s) => s.trim()).filter(Boolean) };
   }
-  if (args.corpus === 'sentinels') return [...SENTINELS];
-  if (args.corpus === 'lab') return [...LAB_CORPUS];
-  if (args.corpus === 'both') return [...SENTINELS, ...LAB_CORPUS];
+  if (args.corpus === 'sentinels') return { styles: [...SENTINELS] };
+  if (args.corpus === 'lab') return { styles: [...LAB_CORPUS] };
+  if (args.corpus === 'both') return { styles: [...SENTINELS, ...LAB_CORPUS] };
+  if (args.corpus === 'random') return resolveRandomCorpus(args);
   throw new Error(`Unknown corpus: ${args.corpus}`);
 }
 
@@ -160,7 +225,7 @@ function migrateStyleToYaml(styleName) {
         '--emit-evidence', evidenceTmp,
         cslPath,
       ],
-      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 64 * 1024 * 1024 }
     );
     if (proc.status !== 0) {
       return {
@@ -206,7 +271,7 @@ function attemptMinimization(styleName) {
         '--emit-evidence', evidenceTmp,
         cslPath,
       ],
-      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 64 * 1024 * 1024 }
     );
     if (proc.status !== 0) return null;
     let evidence = null;
@@ -243,7 +308,7 @@ function oracleForYaml(styleName, yamlText, options = {}) {
     const proc = spawnSync(
       'node',
       oracleArgs,
-      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 64 * 1024 * 1024 }
     );
     // oracle.js exits with status 1 whenever fidelity is below 100%, even
     // when stdout contains a well-formed JSON report. Treat the run as
@@ -414,25 +479,38 @@ function countComponent(component) {
 }
 
 function runOracle(styles) {
-  const oracleArgs = [
-    path.join(WORKSPACE_ROOT, 'scripts', 'oracle-migrate-batch.js'),
-    '--styles', styles.join(','),
-    '--json',
-  ];
-  const proc = spawnSync('node', oracleArgs, {
-    cwd: WORKSPACE_ROOT,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (proc.status !== 0) {
-    throw new Error(`oracle-migrate-batch failed: ${proc.stderr || `exit=${proc.status}`}`);
+  // Read results via --out instead of stdout: a large corpus (100+ styles)
+  // overflows spawnSync's default 1 MB maxBuffer and kills the child with
+  // a null exit status.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'citum-oracle-batch-'));
+  const outPath = path.join(tmpDir, 'oracle-batch.json');
+  try {
+    const oracleArgs = [
+      path.join(WORKSPACE_ROOT, 'scripts', 'oracle-migrate-batch.js'),
+      '--styles', styles.join(','),
+      '--out', outPath,
+    ];
+    const proc = spawnSync('node', oracleArgs, {
+      cwd: WORKSPACE_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (proc.status !== 0 || !fs.existsSync(outPath)) {
+      const detail = (proc.stderr || '').trim()
+        || (proc.error ? proc.error.message : '')
+        || `exit=${proc.status} signal=${proc.signal}`;
+      throw new Error(`oracle-migrate-batch failed: ${detail}`);
+    }
+    const summary = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    const fidelity = new Map();
+    for (const row of summary.styles || []) {
+      fidelity.set(row.style, row);
+    }
+    return fidelity;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
-  const summary = JSON.parse(proc.stdout);
-  const fidelity = new Map();
-  for (const row of summary.styles || []) {
-    fidelity.set(row.style, row);
-  }
-  return fidelity;
 }
 
 function percentile(sorted, p) {
@@ -473,13 +551,155 @@ function aggregateDelta(rows) {
   };
 }
 
+/**
+ * Per-style measurement status for the fidelity headline. Conversion or
+ * oracle failures are data, not script errors: they count against the
+ * headline rather than aborting the run.
+ */
+function rowFidelityStatus(row) {
+  if (row.error) return 'migrate_failed';
+  if (row.fidelity?.error) return 'oracle_failed';
+  if (!row.fidelity) return 'fidelity_skipped';
+  const total = (row.fidelity.citations?.total || 0) + (row.fidelity.bibliography?.total || 0);
+  if (total === 0) return 'oracle_empty';
+  return 'ok';
+}
+
+/** Combined strict pass rate across citations + bibliography, or null. */
+function combinedFidelity(row) {
+  if (rowFidelityStatus(row) !== 'ok') return null;
+  const passed = (row.fidelity.citations?.passed || 0) + (row.fidelity.bibliography?.passed || 0);
+  const total = (row.fidelity.citations?.total || 0) + (row.fidelity.bibliography?.total || 0);
+  return passed / total;
+}
+
+function summarizeFidelity(rows, threshold) {
+  const statuses = {};
+  const values = [];
+  let atThreshold = 0;
+  for (const row of rows) {
+    const status = rowFidelityStatus(row);
+    statuses[status] = (statuses[status] || 0) + 1;
+    const fidelity = combinedFidelity(row);
+    if (fidelity != null) {
+      values.push(fidelity);
+      if (fidelity >= threshold) atThreshold += 1;
+    }
+  }
+  // Failures stay in the denominator: a style that cannot convert does not
+  // meet the bar, and hiding it would inflate the published number.
+  const measured = rows.length - (statuses.fidelity_skipped || 0);
+  values.sort((a, b) => a - b);
+  const pct = (value) => Number((value * 100).toFixed(1));
+  const mean = values.length
+    ? values.reduce((sum, value) => sum + value, 0) / values.length
+    : null;
+  return {
+    measured,
+    statuses,
+    atThreshold,
+    shareAtThreshold: measured ? pct(atThreshold / measured) : null,
+    combined: values.length
+      ? {
+          n: values.length,
+          mean: pct(mean),
+          p10: pct(values[Math.min(values.length - 1, Math.floor(values.length * 0.1))]),
+          p50: pct(values[Math.min(values.length - 1, Math.floor(values.length * 0.5))]),
+          p90: pct(values[Math.min(values.length - 1, Math.floor(values.length * 0.9))]),
+        }
+      : null,
+  };
+}
+
+/**
+ * Headline fidelity aggregates over scorecard rows: overall and per
+ * style-class summaries against FIDELITY_HEADLINE_THRESHOLD.
+ */
+function aggregateFidelityHeadline(rows, threshold = FIDELITY_HEADLINE_THRESHOLD) {
+  const measurable = rows.filter((row) => rowFidelityStatus(row) !== 'fidelity_skipped');
+  if (measurable.length === 0) return null;
+  const byClass = new Map();
+  for (const row of rows) {
+    const styleClass = row.styleClass || 'unknown';
+    if (!byClass.has(styleClass)) byClass.set(styleClass, []);
+    byClass.get(styleClass).push(row);
+  }
+  const perClass = {};
+  for (const [styleClass, classRows] of [...byClass.entries()].sort()) {
+    perClass[styleClass] = summarizeFidelity(classRows, threshold);
+  }
+  return {
+    threshold: Number((threshold * 100).toFixed(1)),
+    overall: summarizeFidelity(rows, threshold),
+    perClass,
+  };
+}
+
 function buildMarkdown(report) {
   const lines = [];
   lines.push(`# citum-migrate SQI baseline`);
   lines.push('');
   lines.push(`- Generated: ${report.generated}`);
   lines.push(`- Commit: ${report.commit}`);
-  lines.push(`- Corpus: ${report.corpus} (${report.results.length} styles)`);
+  if (report.sample) {
+    lines.push(
+      `- Corpus: random (${report.results.length} of ${report.sample.population} independent parents, seed ${report.sample.seed})`
+    );
+    const strata = Object.entries(report.sample.allocation)
+      .map(([name, count]) => `${name} ${count}/${report.sample.strata[name]}`)
+      .join(', ');
+    lines.push(`- Strata (sampled/population): ${strata}`);
+  } else {
+    lines.push(`- Corpus: ${report.corpus} (${report.results.length} styles)`);
+  }
+  const headline = report.aggregate.fidelityHeadline;
+  if (headline) {
+    lines.push('');
+    lines.push('## Fidelity headline');
+    lines.push('');
+    const overall = headline.overall;
+    const statuses = Object.entries(overall.statuses)
+      .filter(([status]) => status !== 'ok')
+      .map(([status, count]) => `${status} ${count}`)
+      .join(', ');
+    lines.push(
+      `- Styles at ≥${headline.threshold}% combined strict fidelity: ${overall.atThreshold}/${overall.measured} (${overall.shareAtThreshold}%)${statuses ? ` — non-ok: ${statuses}` : ''}`
+    );
+    if (overall.combined) {
+      lines.push(
+        `- Combined strict fidelity (converted styles): mean ${overall.combined.mean}%, p10 ${overall.combined.p10}%, median ${overall.combined.p50}%, p90 ${overall.combined.p90}%`
+      );
+    }
+    lines.push('');
+    lines.push('### Per class');
+    lines.push('');
+    lines.push(`| Class | Measured | ≥${headline.threshold}% | Share | Mean | Median |`);
+    lines.push('|---|---:|---:|---:|---:|---:|');
+    for (const [styleClass, summary] of Object.entries(headline.perClass)) {
+      lines.push(
+        `| ${styleClass} | ${summary.measured} | ${summary.atThreshold} | ${summary.shareAtThreshold ?? '-'}% | ${summary.combined?.mean ?? '-'}% | ${summary.combined?.p50 ?? '-'}% |`
+      );
+    }
+    const failures = report.results.filter((row) =>
+      ['migrate_failed', 'oracle_failed', 'oracle_empty'].includes(rowFidelityStatus(row))
+    );
+    if (failures.length > 0) {
+      lines.push('');
+      lines.push('### Failure taxonomy');
+      lines.push('');
+      lines.push('| Style | Class | Status | Detail |');
+      lines.push('|---|---|---|---|');
+      for (const row of failures) {
+        const status = rowFidelityStatus(row);
+        const detail = String(
+          row.error?.details || row.fidelity?.details || row.fidelity?.error || ''
+        )
+          .replace(/\s+/g, ' ')
+          .slice(0, 140);
+        lines.push(`| ${row.style} | ${row.styleClass ?? '-'} | ${status} | ${detail} |`);
+      }
+    }
+  }
   lines.push('');
   lines.push('## Aggregate');
   lines.push('');
@@ -568,12 +788,12 @@ function gitCommit() {
 
 function main() {
   const args = parseArgs(process.argv);
-  const styles = resolveCorpus(args);
+  const { styles, sampleMeta } = resolveCorpus(args);
   const fidelity = args.skipFidelity ? new Map() : runOracle(styles);
 
   const results = [];
   for (const style of styles) {
-    const row = { style };
+    const row = { style, styleClass: classifyLegacyStyle(style) };
     const migrated = migrateStyleToYaml(style);
     if (migrated.error) {
       row.error = migrated;
@@ -596,6 +816,7 @@ function main() {
         citations: fidelityRow.citations,
         bibliography: fidelityRow.bibliography,
         error: fidelityRow.error || null,
+        details: fidelityRow.details || null,
       };
     }
     // Attempt evidence-driven wrapper minimization only for styles the
@@ -675,10 +896,12 @@ function main() {
     generated: new Date().toISOString(),
     commit: gitCommit(),
     corpus: args.styles ? 'explicit' : args.corpus,
+    ...(sampleMeta ? { sample: sampleMeta } : {}),
     aggregate: {
       migrated: aggregateComposite(results, 'migrated'),
       public: aggregateComposite(results, 'public'),
       delta: aggregateDelta(results),
+      fidelityHeadline: args.skipFidelity ? null : aggregateFidelityHeadline(results),
     },
     results,
     diagnostics: {
@@ -725,4 +948,8 @@ module.exports = {
   evaluateMinimizationAcceptance,
   normalizedEqual,
   strictSectionEquivalent,
+  rowFidelityStatus,
+  combinedFidelity,
+  aggregateFidelityHeadline,
+  FIDELITY_HEADLINE_THRESHOLD,
 };

--- a/scripts/report-migrate-sqi.test.js
+++ b/scripts/report-migrate-sqi.test.js
@@ -5,7 +5,73 @@ const {
   evaluateMinimizationAcceptance,
   normalizedEqual,
   strictSectionEquivalent,
+  rowFidelityStatus,
+  combinedFidelity,
+  aggregateFidelityHeadline,
 } = require('./report-migrate-sqi');
+
+function okRow(styleClass, passed, total) {
+  return {
+    style: `${styleClass}-style-${passed}`,
+    styleClass,
+    fidelity: {
+      citations: { passed, total },
+      bibliography: { passed, total },
+      error: null,
+    },
+  };
+}
+
+test('rowFidelityStatus classifies failures as data, not crashes', () => {
+  assert.equal(rowFidelityStatus(okRow('numeric', 18, 18)), 'ok');
+  assert.equal(rowFidelityStatus({ style: 'x', error: { error: 'migrate_failed' } }), 'migrate_failed');
+  assert.equal(
+    rowFidelityStatus({ style: 'x', fidelity: { error: 'oracle_exec_failed' } }),
+    'oracle_failed'
+  );
+  assert.equal(rowFidelityStatus({ style: 'x' }), 'fidelity_skipped');
+  assert.equal(
+    rowFidelityStatus({
+      style: 'x',
+      fidelity: { citations: { passed: 0, total: 0 }, bibliography: { passed: 0, total: 0 } },
+    }),
+    'oracle_empty'
+  );
+});
+
+test('combinedFidelity merges citation and bibliography pass rates', () => {
+  const row = {
+    style: 'x',
+    fidelity: {
+      citations: { passed: 18, total: 18 },
+      bibliography: { passed: 16, total: 32 },
+    },
+  };
+  assert.equal(combinedFidelity(row), 34 / 50);
+  assert.equal(combinedFidelity({ style: 'x', error: { error: 'migrate_failed' } }), null);
+});
+
+test('aggregateFidelityHeadline keeps failures in the denominator', () => {
+  const rows = [
+    okRow('author-date', 18, 18),
+    okRow('author-date', 17, 18),
+    okRow('numeric', 9, 18),
+    { style: 'broken', styleClass: 'note', error: { error: 'migrate_failed', details: 'boom' } },
+  ];
+  const headline = aggregateFidelityHeadline(rows, 0.9);
+  assert.equal(headline.threshold, 90);
+  assert.equal(headline.overall.measured, 4);
+  assert.equal(headline.overall.atThreshold, 2);
+  assert.equal(headline.overall.shareAtThreshold, 50);
+  assert.equal(headline.overall.statuses.migrate_failed, 1);
+  assert.deepEqual(Object.keys(headline.perClass).sort(), ['author-date', 'note', 'numeric']);
+  assert.equal(headline.perClass['author-date'].shareAtThreshold, 100);
+  assert.equal(headline.perClass.note.combined, null);
+});
+
+test('aggregateFidelityHeadline returns null when fidelity was skipped', () => {
+  assert.equal(aggregateFidelityHeadline([{ style: 'a' }, { style: 'b' }], 0.9), null);
+});
 
 test('normalizedEqual ignores markup but preserves semantic text differences', () => {
   assert.equal(normalizedEqual('<i>Title</i>.', 'Title'), true);


### PR DESCRIPTION
## What

First objective measurement of `citum-migrate` conversion quality over a **random** corpus, plus the tooling to repeat it.

- `report-migrate-sqi.js` gains `--corpus random --sample N --seed S`: seeded, stratified sampling (new `scripts/lib/corpus-sample.js`) over the 2,844 independent parents in `styles-legacy/`, classified by CSL `citation-format`.
- Conversion/oracle failures are recorded per style as data (`migrate_failed` / `oracle_failed` / `oracle_empty`) and stay in the headline denominator.
- New fidelity-headline aggregates: share of styles at ≥90% combined strict citation+bibliography fidelity, overall and per class, plus a failure-taxonomy table.
- `oracle-migrate-batch.js` now surfaces the structured oracle error reason instead of bare `exit=2`; batch results flow through `--out` (the 100-style JSON overflowed `spawnSync`'s 1 MB stdout buffer).
- Baseline audit: `docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md` + slimmed JSON snapshot in `scripts/report-data/`.

## Measured result (seed 20260610, n=100)

**43/100 styles at ≥90% combined strict fidelity** — below the 80/100 publish bar. Mean 83.2%, median 89.7%. Per class: author-date 57.5%, numeric 48.5%, author 20%, note 15.8%, label 0%. Citations are largely solved; bibliographies carry the gap. Migrated YAML SQI stays high (mean 94.9).

Five failure clusters (C1–C5) are classified in the audit; one bug bean per cluster opened under epic `csl26-vmcr`. The public docs-site work (bean `csl26-rksq`) stays blocked until the wave clears the bar.

## Note for review

This PR also appends three dated insight bullets to `.skills/migrate-research/SKILL.md` under its self-improvement contract (corpus-level cluster selection, emit-time validation rule, note-class systemic cluster). Flagging explicitly since `.skills/**` is a harness control surface.

## Verification

- `node --test scripts/lib/corpus-sample.test.js scripts/report-migrate-sqi.test.js` — 16/16 pass (sampler determinism, stratification floors, classification, headline aggregation incl. failures-in-denominator).
- Pilot (`--sample 10`) and full (`--sample 100`) runs completed end-to-end; overlapping curated styles consistent with the 2026-05-20 baseline.
- No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
