### PR TITLE
docs: record migrate improvement wave outcome

### DIFF
--- a/.beans/archive/csl26-rj4c--random-corpus-mode-baseline-run-for-migrate-sqi-sc.md
+++ b/.beans/archive/csl26-rj4c--random-corpus-mode-baseline-run-for-migrate-sqi-sc.md
@@ -1,11 +1,11 @@
 ---
 # csl26-rj4c
 title: Random-corpus mode + baseline run for migrate SQI scorecard
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-06-10T16:28:02Z
-updated_at: 2026-06-10T16:57:27Z
+updated_at: 2026-06-11T15:57:01Z
 parent: csl26-vmcr
 ---
 
@@ -17,3 +17,9 @@ Extend scripts/report-migrate-sqi.js with --corpus random --sample N --seed S: e
 - [x] full run (sample 100, seed 20260610)
 - [x] baseline audit doc + JSON snapshot committed (docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md)
 - [x] evaluate against quality bar, report to user — BELOW BAR: 43/100 at >=90%; improvement wave activated (clusters C1-C5)
+
+## Summary of Changes
+
+Shipped the random-corpus scorecard mode (--corpus random --sample N --seed S in scripts/report-migrate-sqi.js with stratified mulberry32 sampling, citation-format classification, and failure taxonomy), tests, and the full 100-style baseline run (seed 20260610). Baseline recorded in docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md with JSON snapshot in scripts/report-data/migrate-random-baseline-2026-06-10.json.
+
+Verdict: 43/100 styles at >=90% combined strict fidelity, below the 80/100 bar. The follow-up improvement wave (clusters C1-C5, beans under csl26-vmcr) lifted the measured headline to 53/100 before PR #908; outcome and the decision to stop further waves are recorded in docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md.

--- a/.beans/csl26-aynr--migrate-output-driven-template-synthesis.md
+++ b/.beans/csl26-aynr--migrate-output-driven-template-synthesis.md
@@ -1,0 +1,15 @@
+---
+# csl26-aynr
+title: 'migrate: output-driven template synthesis'
+status: draft
+type: feature
+priority: normal
+created_at: 2026-06-11T16:06:50Z
+updated_at: 2026-06-11T16:10:38Z
+---
+
+Direction surfaced while closing the csl26-vmcr wave (pointer in docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md). Motivation: every fragile bug that wave fixed (C3 order scrambling, conditional leakage, suppressed-variable poison, wrapper variants) lived in the structural XML layout compiler -- compiling a procedural CSL layout tree into declarative templates is a semantic mismatch patched bug by bug. XML attribute/options extraction was never the problem.
+
+Replace XML layout compilation entirely: synthesize Citum templates by searching the candidate space against citeproc-js reference output. All machinery exists in-process after the csl26-vmcr wave: EmbeddedTemplateRuntime (deno_core) renders the citeproc reference; citum-engine renders candidates; token_jaccard in crates/citum-migrate/src/measured_citation.rs is the oracle-mirroring fitness function. Generalize measured selection from arbitrating 2 candidates to a propose/render/score/mutate loop (mutations: component order, affixes, labels, group boundaries; seeds: inferrer output). XML read only for declarative attributes (et-al, initialize-with, sort) -- the layout tree is never compiled. Deterministic, no LLM in the loop.
+
+Prerequisites: held-out fixture items, positional scenario coverage (first/subsequent/ibid/locator), bounded mutation space. Acceptance test: the seeded random-100 scorecard (seed 20260610). Needs a spec in docs/specs/ before implementation.

--- a/.beans/csl26-rksq--public-migrate-page-scorecard-page-weekly-ci-regen.md
+++ b/.beans/csl26-rksq--public-migrate-page-scorecard-page-weekly-ci-regen.md
@@ -3,8 +3,9 @@
 title: Public Migrate page, scorecard page, weekly CI regeneration
 status: todo
 type: task
+priority: deferred
 created_at: 2026-06-10T16:28:16Z
-updated_at: 2026-06-10T16:28:16Z
+updated_at: 2026-06-11T15:57:01Z
 parent: csl26-vmcr
 blocked_by:
     - csl26-rj4c

--- a/.beans/csl26-vmcr--promote-citum-migrate-with-random-sample-fidelity.md
+++ b/.beans/csl26-vmcr--promote-citum-migrate-with-random-sample-fidelity.md
@@ -3,8 +3,15 @@
 title: Promote citum-migrate with random-sample fidelity metrics
 status: in-progress
 type: epic
+priority: deferred
 created_at: 2026-06-10T16:27:51Z
-updated_at: 2026-06-10T16:27:51Z
+updated_at: 2026-06-11T15:57:01Z
 ---
 
 Public docs site (docs.citum.org) never mentions citum-migrate. Goal: measure converter quality on a seeded, stratified random sample of ~100 independent parent CSL styles using existing fidelity+SQI tooling, record a baseline audit, then publish a Migrate page with truthful metrics and a weekly CI-regenerated scorecard. Quality bar: >=80% of sampled styles at >=90% combined strict citation+bibliography fidelity, no style class below 60%; below the bar, run a migrate-research improvement wave first. Plan: ~/.claude/plans/i-have-a-task-federated-gosling.md
+
+## Outcome (2026-06-11)
+
+Improvement wave concluded; publication deferred. The 80/100 quality bar was not met and is no longer a near-term target: baseline 43/100 at >=90% combined strict fidelity, 53/100 after the wave (note-class repeat forms, suppressed-variable poison, wrapper full variants, measured citation selection PR #907), plus the C3 order/leakage fix (PR #908, merged) expected to add several more points. Reaching 80 requires flipping the entire 80-90% close-miss band AND most of the 70-80% band AND note-class recovery -- multiple waves with rising cost per point, with remaining gaps increasingly engine-level rather than converter-level.
+
+Decision: stop LLM-driven improvement waves; no Migrate page or weekly scorecard until the number is earned by ordinary engineering. Remaining levers stay in backlog as normal bugs: csl26-y4o7 (engine once-only consumption semantics), csl26-21ep (C5 physics compact form, low). The public-page task csl26-rksq is deferred indefinitely. Full record: docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md.

--- a/docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md
+++ b/docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md
@@ -1,0 +1,58 @@
+# Migrate Random-Sample Improvement Wave — Outcome
+
+- **Date:** 2026-06-11
+- **Epic:** `csl26-vmcr` (promote citum-migrate with random-sample fidelity metrics)
+- **Baseline:** [2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md](2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md) — 43/100 styles at ≥90% combined strict fidelity (seed 20260610, strict `--force-migrate` oracle)
+- **Quality bar:** 80/100 at ≥90%, no style class below 60% — **not met; publication deferred**
+
+## What the wave shipped
+
+| Change | PR | Effect |
+|---|---|---|
+| note-class citation repeat forms | merged pre-wave-end | part of 43 → 52 |
+| strip suppressed variable poison | merged pre-wave-end | part of 43 → 52 |
+| full variants in wrapper emission | merged pre-wave-end | part of 43 → 52 |
+| measured inferred-vs-XML citation selection (`csl26-jav1`) | #907 | 52 → 53; note-class at-threshold 15.8% → 21.1%; removes the wrong-template failure mode permanently |
+| C3: default-branch bibliography order + conditional leakage (`csl26-cxi9`) | #908 | probe styles flipped to ≥90% (`zeitschrift-fur-allgemeinmedizin` 52/58 → 58/58, `brazilian-journal-of-psychiatry` 47/58 → 53/58, estonian proceedings → 56/58, `scientia-iranica` → 54/58); sentinels hold |
+
+The last measured full-corpus headline (before #908) was **53/100**. No full re-measure
+was run after #908; based on the 24-style close-miss band composition, the
+post-#908 headline is estimated near 60/100. Anyone needing the exact figure can run:
+
+```bash
+node scripts/report-migrate-sqi.js --corpus random --sample 100 --seed 20260610
+```
+
+## Why the wave stopped
+
+1. **Arithmetic.** Flipping the *entire* 80–90% close-miss band (24 styles) only
+   reaches 77/100. The bar additionally requires recovery from the 70–80% band
+   and note-class lifting from ~21% to 60%+ at-threshold — multiple further waves.
+2. **Economics.** Cost per point rose sharply across the wave: the early
+   deterministic fixes delivered 43 → 52 cheaply; `csl26-jav1` (the most
+   expensive item) delivered +1 overall. C3 was cheap *because* it was a single
+   root-cause bug; the remaining clusters are not.
+3. **Locus of the gaps.** The remaining failure clusters are increasingly
+   engine-level (e.g. once-only variable consumption semantics, `csl26-y4o7`),
+   not converter-level — consistent with the converter-plateau note in
+   `crates/citum-migrate/CLAUDE.md`.
+
+## Decision
+
+- Stop LLM-driven improvement waves on the migrate fidelity number.
+- Defer the public Migrate page and weekly scorecard (`csl26-rksq`,
+  priority `deferred`) until the number is earned by ordinary engineering.
+- Remaining levers stay in the backlog as normal bugs: `csl26-y4o7`
+  (engine consumption semantics; fixing it also repairs checked-in styles),
+  `csl26-21ep` (C5 physics compact form, low priority).
+- The random-corpus scorecard mode and the seeded baseline remain the
+  measurement instrument of record for any future attempt.
+
+## Recorded idea: output-driven template synthesis
+
+Surfaced while closing this wave: retire XML layout compilation entirely and
+synthesize Citum templates by searching candidates against citeproc-js
+reference output, using the in-process machinery this wave built (deno_core
+reference rendering, citum-engine candidate rendering, oracle-mirroring
+similarity scoring). Full write-up, prerequisites, and acceptance criteria:
+standalone draft bean `csl26-aynr`.


### PR DESCRIPTION
## What

Session wrap-up for the `csl26-vmcr` migrate improvement wave: records the outcome and closes the books, no code changes.

- New audit `docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md`: wave results (43/100 baseline → 53/100 measured after #907, estimated ~60 after #908), why the 80/100 bar is out of near-term reach, and the decision to stop LLM-driven waves and defer the public Migrate page.
- Bean `csl26-rj4c` (random-corpus scorecard tooling + baseline) completed with summary — all todos shipped.
- Epic `csl26-vmcr` and page task `csl26-rksq` set to priority `deferred` with the outcome recorded in the epic body.
- Remaining levers stay in backlog as normal bugs: `csl26-y4o7` (engine consumption semantics), `csl26-21ep` (C5, low).

## Verification

Docs/beans only — no build-affecting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
