### PR TITLE
feat(tooling): repo-owned test-soundness-review skill + state ledger

### DIFF
--- a/.beans/archive/csl26-tdul--rework-test-soundness-review-into-repo-owned-state.md
+++ b/.beans/archive/csl26-tdul--rework-test-soundness-review-into-repo-owned-state.md
@@ -1,0 +1,26 @@
+---
+# csl26-tdul
+title: Rework test-soundness-review into repo-owned state-tracking skill
+status: completed
+type: feature
+priority: normal
+created_at: 2026-06-12T10:47:35Z
+updated_at: 2026-06-12T10:53:36Z
+---
+
+Move test-soundness-review into .skills/, replace JSON output with a living ledger + dated audit records, promote spec review to first-class with blocking/advisory gating, add a 'redundant' verdict for low-value tests, and consolidate a shared test-value contract in CODING_STANDARDS.md. Two commits: (1) skill, (2) docs.
+
+## Summary of Changes
+
+Commit 1 (skill): added .skills/test-soundness-review/SKILL.md — repo-owned
+auditor. Replaced JSON-to-stdout with durable ledger + dated audit records,
+promoted spec review to a first-class step with blocking/advisory gating,
+added a 'redundant' verdict for low-value tests, and a no-arg ledger
+navigation mode.
+
+Commit 2 (docs): created docs/architecture/TEST_SOUNDNESS_STATUS.md (living
+ledger seeded from the spec inventory; DISAMBIGUATION backfilled as audited
+from commit aa7af758). Added the shared 'What makes a test worth keeping'
+contract to CODING_STANDARDS.md and pointed TEST_STRATEGY.md, the
+test-coverage skill, and the soundness skill at it. Registered the ledger in
+the architecture README.

--- a/.claude/skills/test-coverage/SKILL.md
+++ b/.claude/skills/test-coverage/SKILL.md
@@ -40,6 +40,11 @@ claim about behavior:
 - If a fixture changes, state which missing shape it adds and which scenario
   exercises that shape.
 
+The full shared bar — including when a test counts as *redundant* and should be
+deleted rather than kept — lives in `docs/guides/CODING_STANDARDS.md`
+§ "What makes a test worth keeping". Per-spec soundness state is tracked in
+`docs/architecture/TEST_SOUNDNESS_STATUS.md`.
+
 ## Test Style
 
 Before writing a test, pick the right style (full rule in

--- a/.skills/test-soundness-review/SKILL.md
+++ b/.skills/test-soundness-review/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: test-soundness-review
+description: >
+  Repo-owned test soundness auditor and navigator for citum-core. Reasons from
+  a spec (not the implementation) to classify each test as good, suspicious,
+  broken, or redundant; simultaneously reviews the spec for ambiguity,
+  contradiction, and silence, halting to prompt the user when a spec defect
+  blocks an honest verdict. Records state in the living ledger
+  docs/architecture/TEST_SOUNDNESS_STATUS.md plus a dated audit record — never
+  ephemeral JSON.
+
+  Trigger on: "/test-soundness-review", "review my tests against the spec",
+  "audit test soundness", "are my tests vacuous", "find broken tests", "find
+  redundant tests", "are these tests just for the sake of it", "test quality
+  review", "review the spec while you're at it", "what's the state of our test
+  quality", "what test audits are outstanding", "what's next for test
+  soundness". Also trigger proactively after a disambiguation, sorting,
+  algorithm, or engine feature is implemented when the user asks "do the tests
+  actually cover the spec?". Takes up to two arguments:
+  /test-soundness-review [spec-path] [test-file-or-glob]
+---
+
+# test-soundness-review
+
+Audit test functions against the spec that governs them, and keep a durable
+record of the state of test quality across `citum-core`. The goal is to find
+tests that could pass while the implementation still violates the spec — and
+tests that exist for their own sake and prove nothing — *not* to review code
+style.
+
+The verdict bar is the shared **"What makes a test worth keeping"** contract in
+[`docs/guides/CODING_STANDARDS.md`](../../docs/guides/CODING_STANDARDS.md). That
+section is the source of truth; this skill operationalises it. If this skill and
+that contract ever disagree, the contract wins — fix the skill.
+
+## Arguments
+
+```
+/test-soundness-review [spec-path] [test-file-or-glob]
+```
+
+Examples:
+```
+/test-soundness-review docs/specs/SORTING.md crates/citum-engine/tests/
+/test-soundness-review docs/specs/DISAMBIGUATION.md crates/citum-engine/tests/citations.rs
+/test-soundness-review            # no args — navigate the ledger, propose what's next
+```
+
+Both arguments are optional. With **no arguments**, run Step 0 only and stop —
+the skill becomes a way to navigate test-quality state. With **one argument**,
+ask for the missing one before proceeding.
+
+---
+
+## Step 0 — Read the ledger first (always)
+
+Read [`docs/architecture/TEST_SOUNDNESS_STATUS.md`](../../docs/architecture/TEST_SOUNDNESS_STATUS.md)
+before anything else. It is the index of what has been audited, addressed, and
+what remains `todo`.
+
+- **No spec named** → summarise the ledger (counts by status, any `needs-rework`
+  rows blocked on a spec decision) and offer the next few `todo` rows ranked by
+  risk. Stop there; let the user pick.
+- **Spec named** → find its row (or note that you'll create one). If the row is
+  already `addressed`, say so and ask whether to re-audit before spending effort.
+
+The ledger is also where you'll write back at the end (Step 6). Treat it as the
+entry and exit point of every run.
+
+## Step 1 — Read the spec and build the behaviour map
+
+Read `<spec-path>` in full. Extract:
+- Documented behaviours (numbered sections, rules, invariants).
+- Acceptance criteria (checklist items).
+- Strategy cascades / decision trees.
+- Explicit "must", "must not", "is never consulted", "always" statements.
+
+Build a map: **spec section → observable behaviour**. You'll use it both to
+judge each test and to drive the spec review in Step 2.
+
+## Step 2 — Review the spec itself (first-class, runs alongside test reading)
+
+A test audit is only as trustworthy as the spec it reasons from. As you build
+the behaviour map, record spec defects in three buckets:
+
+- **Ambiguity** — a rule that admits two readings, where a test could be "right"
+  under either. (Most dangerous: it lets a test launder the ambiguity into a
+  false `good`.)
+- **Contradiction** — two sections that cannot both hold.
+- **Silence** — a behaviour a test asserts, or a fixture clearly implies, that
+  the spec never states.
+
+For each defect, classify its **audit impact**:
+
+- `blocking` — you cannot honestly classify a test without the user first
+  deciding what the spec means.
+- `advisory` — worth fixing, but doesn't change any verdict.
+
+**Gating.** If any defect is `blocking`, **stop and prompt the user** before
+finalising verdicts. Quote the spec section, name the affected tests, and give
+2–3 concrete resolution options. Do not pick a reading yourself: choosing one
+silently is exactly the failure this skill exists to catch, and per the repo
+rule you "never make content decisions unilaterally." Advisory defects are
+recorded (Step 6) and summarised, but don't halt the run.
+
+## Step 3 — Enumerate and read the tests
+
+Enumerate test functions in the glob. Prefer jcodemunch (`get_file_outline`,
+`get_symbol`) over raw reads — it's the repo's standard and token-efficient.
+Fallback:
+```bash
+grep -nE "fn |#\[test\]|#\[rstest\]" <file>
+```
+Also collect any `announce_behavior(...)` text or docstrings — a second source
+of "what the author thought this checks".
+
+For each test, read the body: fixture setup, the call under test, and **every**
+assertion. Read shared helpers it calls (e.g. `run_test_case_native`,
+`build_author_date_style`) — the helper's defaults change what the test proves.
+
+## Step 4 — Classify each test
+
+Reason from the **spec**, not the implementation. The question is always:
+*could this test pass while the implementation still violates the spec section
+it claims to cover?* — and *does this test make an independent claim at all?*
+
+### Verdicts
+
+**`broken`** — passes but proves nothing about the spec:
+- `contains()` / `!contains()` on rendered output under ~30 chars (a garbled
+  renderer can still hit a short substring). Note: the repo bans `contains()` on
+  rendered output outright unless the substring is ≥30 chars and the test name
+  signals it — see CODING_STANDARDS §Test Independence.
+- No assertion at all (vacuous).
+- Asserts an intermediate value but never the final rendered output.
+- A stale capture stub left in (`panic!("intentional capture")`).
+
+**`suspicious`** — may be correct but needs investigation:
+- Name / `announce_behavior` describes behaviour X, but the fixture can never
+  trigger X (e.g. "given-name expansion applied" where every colliding ref has a
+  different year, so no collision group ever forms).
+- Expected output looks **invented** rather than captured (round numbers,
+  suspiciously clean delimiters that don't match the renderer).
+- `announce_behavior` claims "subsequent form" / "repeat citation" but the test
+  issues one batch with no `Position::Subsequent`.
+- Counts occurrences (`matches(...).count()`) without verifying location.
+
+**`redundant`** — passes, may even be correct, but adds **no independent claim**
+(over-testing; see the shared contract). Recommend **delete or merge into the
+canonical sibling**, not rewrite — fewer sharp tests beat many overlapping ones,
+and deletion is an encouraged outcome here:
+- Near-duplicate of an existing test on the same fixture + same assertion
+  dimension (no new type, field shape, position, or edge condition).
+- Tautological / self-evidently true: `assert!(true)`, asserting a literal you
+  just constructed, round-tripping a value through no transformation.
+- Tests language/library behaviour rather than Citum behaviour.
+- Coverage theatre — exists only to touch a line, no observable-behaviour claim.
+
+**`good`** — exact `assert_eq!` on full rendered output, fixture genuinely
+triggers the documented behaviour, name matches what is tested, and it covers a
+dimension no sibling already covers.
+
+### Coverage gaps
+
+For each spec section with documented behaviour but no corresponding test,
+record a gap with a concrete recommendation (the fixture shape + assertion to
+add). Cross-check the spec's acceptance criteria for premature `[x]`: if a
+criterion is marked done but the function it depends on doesn't exist, record it
+as a gap and recommend reverting the `[x]`.
+
+## Step 5 — Offer follow-on actions: Fix / Trim / Add / Persist
+
+After presenting the classification, offer:
+
+1. **Fix** — realign suspicious tests; rewrite broken assertions to exact
+   `assert_eq!`. **Capture, don't invent**: add a transient `eprintln!` + forced
+   failure, run the test, read the real output, then pin that string and remove
+   the stub. Never invent expected values.
+2. **Trim** — delete or merge `redundant` tests. Confirm the surviving sibling
+   still covers the dimension before deleting.
+3. **Add** — add tests for coverage gaps, capturing actual output first.
+4. **Persist** — Step 6 (always do this, even if the user declines 1–3).
+
+If the user says "do all of it", apply in order Fix → Trim → Add, running
+`cargo nextest run` after each round to confirm nothing regressed.
+
+## Step 6 — Persist state (replaces the old JSON dump)
+
+Two durable artifacts, both Markdown:
+
+1. **Audit record** — write/refresh
+   `docs/architecture/audits/YYYY-MM-DD_<TOPIC>_TEST_SOUNDNESS.md` (today's date;
+   match the house style of existing records such as
+   `2026-05-07_SQI_INTEGRITY_AUDIT.md`). Include:
+   - Header: date, scope (spec + reviewed files), related docs.
+   - A per-test table: `| Test | Location | Spec ref | Intended behaviour | What it does | Verdict | Action |`.
+   - A **Spec Issues** section: every ambiguity/contradiction/silence with its
+     `blocking`/`advisory` impact and recommendation.
+   - A **Coverage Gaps** section.
+   - A summary line: good / suspicious / broken / redundant counts.
+
+2. **Ledger row** — upsert the spec's row in
+   `docs/architecture/TEST_SOUNDNESS_STATUS.md`:
+   `| Spec / Module | Last reviewed | Tests (G/S/B/R) | Open spec issues | Status | Audit record |`
+   - `Last reviewed`: today.
+   - `Tests (G/S/B/R)`: the four counts.
+   - `Open spec issues`: refs to unresolved spec defects, or `—`.
+   - `Status`: `todo` (never audited) · `audited` (reviewed, findings open) ·
+     `addressed` (findings fixed) · `needs-rework` (blocked on a spec decision).
+   - `Audit record`: link to the file from artifact 1.
+   - Bump the ledger's "Last updated" banner.
+
+The audit record is the detail; the ledger row is the index that points to it.
+An agent resuming work greps the ledger for `todo` / `needs-rework`.
+
+---
+
+## Key rules
+
+- **Reason from the spec, not the code.** If the spec says "year-suffix
+  collision key uses only `issued` year", check whether the test would catch a
+  regression to `original-date` — not whether the code currently does the right
+  thing.
+- **Capture, don't invent.** Invented expected strings are the primary source of
+  `suspicious`. Always capture real output before pinning.
+- **Redundant is a defect, not a freebie.** A test that adds no independent claim
+  costs maintenance and dilutes signal. Trimming is success.
+- **Blocking spec defects stop the run.** Don't guess a reading; prompt the user.
+- **Pre-commit gate when you touch `.rs`:**
+  `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`.
+  Skill/docs-only edits (`.md`) skip the Rust gate but should pass
+  `./scripts/validate-frontmatter.sh --copilot-strict`.
+
+## Related
+
+- Shared verdict bar: [`docs/guides/CODING_STANDARDS.md`](../../docs/guides/CODING_STANDARDS.md) § "What makes a test worth keeping" and § "Test Independence".
+- Coverage / fixture-shape domain knowledge: [`test-coverage`](../../.claude/skills/test-coverage/SKILL.md).
+- Strategy context: [`docs/guides/TEST_STRATEGY.md`](../../docs/guides/TEST_STRATEGY.md).
+- State ledger: [`docs/architecture/TEST_SOUNDNESS_STATUS.md`](../../docs/architecture/TEST_SOUNDNESS_STATUS.md).

--- a/.skills/test-soundness-review/agents/openai.yaml
+++ b/.skills/test-soundness-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test Soundness Review"
+  short_description: "Audit Citum tests against their spec"
+  default_prompt: "Use $test-soundness-review to audit a spec's tests for soundness, or with no spec to report test-quality state."

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,6 +11,7 @@ current task.
 4. [`EXTENSIBILITY_STRATEGY.md`](./EXTENSIBILITY_STRATEGY.md) - where new rendering and data needs belong in the style format.
 5. [`../policies/TYPE_ADDITION_POLICY.md`](../policies/TYPE_ADDITION_POLICY.md) - active type-system policy.
 6. [`../policies/SQI_REFINEMENT_PLAN.md`](../policies/SQI_REFINEMENT_PLAN.md) - current SQI refinement direction.
+7. [`TEST_SOUNDNESS_STATUS.md`](./TEST_SOUNDNESS_STATUS.md) - living index of test-soundness state per spec (audited / addressed / todo); maintained by the `test-soundness-review` skill.
 
 ## Tier B: Active Specialized Design
 

--- a/docs/architecture/TEST_SOUNDNESS_STATUS.md
+++ b/docs/architecture/TEST_SOUNDNESS_STATUS.md
@@ -1,0 +1,148 @@
+# Citum Test Soundness Status
+
+> **Living document** — the canonical index of test-quality state across
+> `citum-core`. One row per behaviour spec: when its tests were last audited
+> for soundness, the verdict counts, any open spec defects the audit surfaced,
+> and what remains to do.
+>
+> **Last updated:** 2026-06-12
+>
+> **How to refresh:** run the [`test-soundness-review`](../../.skills/test-soundness-review/SKILL.md)
+> skill against a spec and its tests. The skill reads this ledger first, writes
+> a dated audit record under [`audits/`](./audits/), and upserts the spec's row
+> here. Do not hand-edit verdict counts — let the skill own them.
+>
+> **What "soundness" means here** is defined once in
+> [`docs/guides/CODING_STANDARDS.md`](../guides/CODING_STANDARDS.md)
+> § "What makes a test worth keeping". This ledger tracks conformance to that
+> contract; it does not redefine it.
+
+## Status vocabulary
+
+| Status | Meaning |
+|--------|---------|
+| `todo` | Never audited for soundness. |
+| `audited` | Reviewed; findings recorded and still open. |
+| `addressed` | Reviewed and the findings have been fixed. |
+| `needs-rework` | Blocked on a spec decision — a `blocking` spec defect must be resolved before tests can be honestly classified. |
+
+`Tests (G/S/B/R)` = good / suspicious / broken / redundant counts from the most
+recent audit. `R` (redundant) flags low-value tests — near-duplicates,
+tautologies, coverage theatre — whose usual fix is deletion, not rewrite.
+
+## Backfill note (2026-06-12)
+
+This ledger was seeded from the [`docs/specs/`](../specs/) inventory at
+creation. Every spec starts `todo` except where there is concrete evidence of
+prior soundness work in git:
+
+- **DISAMBIGUATION.md** — `audited`. Commit `aa7af758`
+  ("test(engine): harden disambiguation test soundness") was a targeted
+  soundness pass; counts below are marked unknown (`?`) because that work
+  predates this ledger and was not recorded as a verdict table. A fresh audit
+  should replace the `?`s.
+
+Soundness-*adjacent* work also exists but is **not** treated as an audit here,
+to avoid overclaiming: the behavior-coverage reports for the `citations`,
+`document`, and `i18n` engine suites (see
+[`engine-behavior-reporting`](../../.claude/skills/engine-behavior-reporting/SKILL.md))
+made those suites behaviour-oriented and readable, but did not classify each
+test against its spec. Those specs remain `todo`.
+
+## Ledger
+
+| Spec / Module | Last reviewed | Tests (G/S/B/R) | Open spec issues | Status | Audit record |
+|---------------|---------------|-----------------|------------------|--------|--------------|
+| [ABBREVIATION_MAP.md](../specs/ABBREVIATION_MAP.md) | — | — | — | todo | — |
+| [ANNOTATED_BIBLIOGRAPHY.md](../specs/ANNOTATED_BIBLIOGRAPHY.md) | — | — | — | todo | — |
+| [APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md](../specs/APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md) | — | — | — | todo | — |
+| [ARCHIVAL_UNPUBLISHED_SUPPORT.md](../specs/ARCHIVAL_UNPUBLISHED_SUPPORT.md) | — | — | — | todo | — |
+| [ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md](../specs/ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md) | — | — | — | todo | — |
+| [BIBLIOGRAPHY_GROUPING.md](../specs/BIBLIOGRAPHY_GROUPING.md) | — | — | — | todo | — |
+| [BIBLIOGRAPHY_RENDERING_PIPELINE.md](../specs/BIBLIOGRAPHY_RENDERING_PIPELINE.md) | — | — | — | todo | — |
+| [CHICAGO_18_COVERAGE.md](../specs/CHICAGO_18_COVERAGE.md) | — | — | — | todo | — |
+| [CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md](../specs/CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md) | — | — | — | todo | — |
+| [CITATION_CLUSTER_RENDERING.md](../specs/CITATION_CLUSTER_RENDERING.md) | — | — | — | todo | — |
+| [CITE_SITE_COMPOUND_GROUPING.md](../specs/CITE_SITE_COMPOUND_GROUPING.md) | — | — | — | todo | — |
+| [CLI_UX_REDESIGN.md](../specs/CLI_UX_REDESIGN.md) | — | — | — | todo | — |
+| [CONFIG_ONLY_PROFILE_OVERRIDES.md](../specs/CONFIG_ONLY_PROFILE_OVERRIDES.md) | — | — | — | todo | — |
+| [CROSS_ENTRY_FIDELITY.md](../specs/CROSS_ENTRY_FIDELITY.md) | — | — | — | todo | — |
+| [DATE_MODEL.md](../specs/DATE_MODEL.md) | — | — | — | todo | — |
+| [DISAMBIGUATION.md](../specs/DISAMBIGUATION.md) | 2026-06-12 | ?/?/?/? | — | audited | `aa7af758` (pre-ledger soundness pass) |
+| [DISTRIBUTED_RESOLVER.md](../specs/DISTRIBUTED_RESOLVER.md) | — | — | — | todo | — |
+| [DJOT_RICH_TEXT.md](../specs/DJOT_RICH_TEXT.md) | — | — | — | todo | — |
+| [DOCUMENT_INPUT_PARSER_BOUNDARY.md](../specs/DOCUMENT_INPUT_PARSER_BOUNDARY.md) | — | — | — | todo | — |
+| [EDTF_ERA_LABEL_PROFILES.md](../specs/EDTF_ERA_LABEL_PROFILES.md) | — | — | — | todo | — |
+| [EDTF_HISTORICAL_ERA_RENDERING.md](../specs/EDTF_HISTORICAL_ERA_RENDERING.md) | — | — | — | todo | — |
+| [EMBEDDED_JS_TEMPLATE_INFERENCE.md](../specs/EMBEDDED_JS_TEMPLATE_INFERENCE.md) | — | — | — | todo | — |
+| [EMBEDDED_ROOT_WRAPPER_MIGRATION.md](../specs/EMBEDDED_ROOT_WRAPPER_MIGRATION.md) | — | — | — | todo | — |
+| [ENGINE_MIGRATE_COEVOLUTION_WAVE.md](../specs/ENGINE_MIGRATE_COEVOLUTION_WAVE.md) | — | — | — | todo | — |
+| [EXPLICIT_DEFAULT_SORTING.md](../specs/EXPLICIT_DEFAULT_SORTING.md) | — | — | — | todo | — |
+| [FIDELITY_RICH_INPUTS.md](../specs/FIDELITY_RICH_INPUTS.md) | — | — | — | todo | — |
+| [FORWARD_COMPATIBILITY.md](../specs/FORWARD_COMPATIBILITY.md) | — | — | — | todo | — |
+| [GENDERED_LOCALE_TERMS.md](../specs/GENDERED_LOCALE_TERMS.md) | — | — | — | todo | — |
+| [GENERALIZED_RELATIONAL_CONTAINER_MODEL.md](../specs/GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) | — | — | — | todo | — |
+| [INLINE_JOURNAL_DETAIL_GROUPING.md](../specs/INLINE_JOURNAL_DETAIL_GROUPING.md) | — | — | — | todo | — |
+| [INPUT_REFERENCE_CLASS_DISCRIMINATOR.md](../specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md) | — | — | — | todo | — |
+| [INTEGRAL_NAME_MEMORY.md](../specs/INTEGRAL_NAME_MEMORY.md) | — | — | — | todo | — |
+| [INTERACTIVE_STYLE_OVERRIDES.md](../specs/INTERACTIVE_STYLE_OVERRIDES.md) | — | — | — | todo | — |
+| [JOURNAL_PROFILE_TAXONOMY_AUDIT.md](../specs/JOURNAL_PROFILE_TAXONOMY_AUDIT.md) | — | — | — | todo | — |
+| [LANGUAGE_BINDINGS.md](../specs/LANGUAGE_BINDINGS.md) | — | — | — | todo | — |
+| [LEGAL_CITATIONS.md](../specs/LEGAL_CITATIONS.md) | — | — | — | todo | — |
+| [LOCALE_MESSAGES.md](../specs/LOCALE_MESSAGES.md) | — | — | — | todo | — |
+| [LOCATOR_RENDERING.md](../specs/LOCATOR_RENDERING.md) | — | — | — | todo | — |
+| [MIGRATE_RESEARCH_RICH_INPUTS.md](../specs/MIGRATE_RESEARCH_RICH_INPUTS.md) | — | — | — | todo | — |
+| [MIGRATION_TAXONOMY_AWARE_WRAPPERS.md](../specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md) | — | — | — | todo | — |
+| [MIXED_CONDITION_NOTE_POSITION_TREES.md](../specs/MIXED_CONDITION_NOTE_POSITION_TREES.md) | — | — | — | todo | — |
+| [MULTILINGUAL.md](../specs/MULTILINGUAL.md) | — | — | — | todo | — |
+| [MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md](../specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | — | — | — | todo | — |
+| [MULTILINGUAL_NAMES.md](../specs/MULTILINGUAL_NAMES.md) | — | — | — | todo | — |
+| [NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md](../specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md) | — | — | — | todo | — |
+| [NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md](../specs/NON_STANDARD_NUMBERING_AND_LOCATOR_KINDS.md) | — | — | — | todo | — |
+| [NOTE_POSITION_AUDIT.md](../specs/NOTE_POSITION_AUDIT.md) | — | — | — | todo | — |
+| [NOTE_SHORTENING_POLICY.md](../specs/NOTE_SHORTENING_POLICY.md) | — | — | — | todo | — |
+| [NOTE_START_REPEATED_NOTE_POLICY.md](../specs/NOTE_START_REPEATED_NOTE_POLICY.md) | — | — | — | todo | — |
+| [NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md](../specs/NOTE_STYLE_DOCUMENT_NOTE_CONTEXT.md) | — | — | — | todo | — |
+| [NUMBERING_SEMANTICS.md](../specs/NUMBERING_SEMANTICS.md) | — | — | — | todo | — |
+| [ORIGINAL_PUBLICATION_RELATION_SUPPORT.md](../specs/ORIGINAL_PUBLICATION_RELATION_SUPPORT.md) | — | — | — | todo | — |
+| [OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md](../specs/OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md) | — | — | — | todo | — |
+| [PANDOC_MARKDOWN_CITATIONS.md](../specs/PANDOC_MARKDOWN_CITATIONS.md) | — | — | — | todo | — |
+| [PERSONAL_COMMUNICATION_CITATION.md](../specs/PERSONAL_COMMUNICATION_CITATION.md) | — | — | — | todo | — |
+| [PER_DOCUMENT_CONFIG_OVERRIDES.md](../specs/PER_DOCUMENT_CONFIG_OVERRIDES.md) | — | — | — | todo | — |
+| [PROFILE_DOCUMENTARY_VERIFICATION.md](../specs/PROFILE_DOCUMENTARY_VERIFICATION.md) | — | — | — | todo | — |
+| [PUNCTUATION_NORMALIZATION.md](../specs/PUNCTUATION_NORMALIZATION.md) | — | — | — | todo | — |
+| [REPEATED_NOTE_CITATION_STATE_MODEL.md](../specs/REPEATED_NOTE_CITATION_STATE_MODEL.md) | — | — | — | todo | — |
+| [ROLE_SUBSTITUTE_FALLBACK.md](../specs/ROLE_SUBSTITUTE_FALLBACK.md) | — | — | — | todo | — |
+| [SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md](../specs/SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md) | — | — | — | todo | — |
+| [SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md](../specs/SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md) | — | — | — | todo | — |
+| [SENTENCE_INITIAL_LABELS.md](../specs/SENTENCE_INITIAL_LABELS.md) | — | — | — | todo | — |
+| [SERVER_INTERACTIVE_API.md](../specs/SERVER_INTERACTIVE_API.md) | — | — | — | todo | — |
+| [SHORT_NAME.md](../specs/SHORT_NAME.md) | — | — | — | todo | — |
+| [SORTING.md](../specs/SORTING.md) | — | — | — | todo | — |
+| [STRONG_DOMAIN_TYPES_PHASE1.md](../specs/STRONG_DOMAIN_TYPES_PHASE1.md) | — | — | — | todo | — |
+| [STYLE_ALIASING.md](../specs/STYLE_ALIASING.md) | — | — | — | todo | — |
+| [STYLE_EDITIONS_AND_FAMILIES.md](../specs/STYLE_EDITIONS_AND_FAMILIES.md) | — | — | — | todo | — |
+| [STYLE_PRESET_ARCHITECTURE.md](../specs/STYLE_PRESET_ARCHITECTURE.md) | — | — | — | todo | — |
+| [STYLE_REGISTRY.md](../specs/STYLE_REGISTRY.md) | — | — | — | todo | — |
+| [STYLE_TAXONOMY.md](../specs/STYLE_TAXONOMY.md) | — | — | — | todo | — |
+| [TEMPLATE_V2.md](../specs/TEMPLATE_V2.md) | — | — | — | todo | — |
+| [TEMPLATE_V3.md](../specs/TEMPLATE_V3.md) | — | — | — | todo | — |
+| [TITLE_NAME_INFLECTION.md](../specs/TITLE_NAME_INFLECTION.md) | — | — | — | todo | — |
+| [TITLE_TEXT_CASE.md](../specs/TITLE_TEXT_CASE.md) | — | — | — | todo | — |
+| [TYPE_REFACTOR_v3.md](../specs/TYPE_REFACTOR_v3.md) | — | — | — | todo | — |
+| [TYPE_SYSTEM_ARCHITECTURE.md](../specs/TYPE_SYSTEM_ARCHITECTURE.md) | — | — | — | todo | — |
+| [UNICODE_BIBLIOGRAPHY_SORTING.md](../specs/UNICODE_BIBLIOGRAPHY_SORTING.md) | — | — | — | todo | — |
+| [UNIFIED_SCOPED_OPTIONS.md](../specs/UNIFIED_SCOPED_OPTIONS.md) | — | — | — | todo | — |
+| [WASM_SUPPORT.md](../specs/WASM_SUPPORT.md) | — | — | — | todo | — |
+
+## How to read this as an agent
+
+- **"What's the state of test quality?"** → scan the `Status` column. Anything
+  `todo` is unaudited; `needs-rework` is blocked on a spec decision and is the
+  highest-signal place to look.
+- **"What should I audit next?"** → prefer high-risk `todo` specs (algorithmic
+  or rendering behaviour: disambiguation, sorting, note position, locator,
+  multilingual) over descriptive/architecture specs.
+- **Don't trust a stale row.** If a spec changed materially since `Last
+  reviewed`, the row is stale — re-run the skill rather than relying on the
+  counts.

--- a/docs/guides/CODING_STANDARDS.md
+++ b/docs/guides/CODING_STANDARDS.md
@@ -7,10 +7,10 @@ Use the right test style based on scope and intent:
 | Scenario | Location | Style |
 |----------|----------|-------|
 | Pure logic, type conversions, single-function correctness | `#[cfg(test)]` inline in the module | Plain `#[test]` with descriptive names |
-| Single-scenario integration check | `tests/` directory | Plain `#[test]` |
-| User-observable behavior with multiple parameterised cases | `tests/` directory | `#[rstest]` with `given_…_when_…_then_…` naming |
+| Single-scenario integration check | `tests` directory | Plain `#[test]` |
+| User-observable behavior with multiple parameterised cases | `tests` directory | `#[rstest]` with `given_…_when_…_then_…` naming |
 
-**BDD naming rule** (`given_…_when_…_then_…`) is reserved for integration tests in `tests/` that exercise a cross-module behavior path and have at least two parameterised variants. Do not apply BDD naming to inline unit tests or single-scenario integration tests — it adds noise without signal.
+**BDD naming rule** (`given_…_when_…_then_…`) is reserved for integration tests in `tests` that exercise a cross-module behavior path and have at least two parameterised variants. Do not apply BDD naming to inline unit tests or single-scenario integration tests — it adds noise without signal.
 
 ```rust
 // Unit test — inline, plain name
@@ -62,6 +62,42 @@ Use the advisory review-smell audit before opening PRs that touch Rust tests:
 ```bash
 python3 scripts/audit-rust-review-smells.py --changed
 ```
+
+## What makes a test worth keeping
+
+This is the shared bar every test in this repo is held to. The
+[`test-soundness-review`](../../.skills/test-soundness-review/SKILL.md) skill,
+the [`test-coverage`](../../.claude/skills/test-coverage/SKILL.md) skill, and
+human reviewers all classify tests against these three expectations, so the
+words mean the same thing everywhere. A test that fails any of them is a defect,
+not just a style nit.
+
+1. **It makes an independent behavioural claim.** The expected value comes from
+   a source other than the code under test — a literal, fixture, oracle output,
+   spec, or registered divergence. (Full rule above in § "Test Independence".)
+   A test that mirrors current output proves only that the code does what it
+   currently does.
+
+2. **It isn't there just for its own sake.** Redundant, tautological, and
+   coverage-theatre tests dilute signal and cost maintenance. Prefer **deleting
+   or merging** them over keeping them. A test is **redundant** when it adds no
+   dimension a sibling doesn't already cover:
+   - a near-duplicate on the same fixture and same assertion dimension (no new
+     type, field shape, position, or edge condition);
+   - a tautology — `assert!(true)`, asserting a literal you just constructed, or
+     round-tripping a value through no transformation;
+   - a test of the language or a library rather than Citum behaviour;
+   - coverage theatre — exists only to touch a line, with no observable
+     behaviour asserted.
+
+3. **It is classifiable against a spec.** You can point to the spec section it
+   verifies and say whether it passes or fails *that section*. If the governing
+   spec is ambiguous, contradictory, or silent on the behaviour, the spec is the
+   bug — fix the spec (or escalate the decision) rather than letting the test
+   silently pick one reading. The soundness skill halts on such cases by design.
+
+State of conformance across specs is tracked in
+[`docs/architecture/TEST_SOUNDNESS_STATUS.md`](../architecture/TEST_SOUNDNESS_STATUS.md).
 
 ## String Ownership
 

--- a/docs/guides/TEST_STRATEGY.md
+++ b/docs/guides/TEST_STRATEGY.md
@@ -10,7 +10,7 @@
 **Method**:
 - Test fixtures use CSL JSON format (what citeproc-js expects)
 - Compare Citum output against citeproc-js (the oracle)
-- Located: `tests/fixtures/references-expanded.json`
+- Located: [tests/fixtures/references-expanded.json](../../tests/fixtures/references-expanded.json)
 - Test harness: `../../../scripts/oracle-e2e.js`
 
 **Limitations**:
@@ -45,7 +45,7 @@ cargo nextest run --test citations
 6. **Structured name particles** - More nuanced than CSL JSON
 
 **Implementation plan** (deferred):
-1. Create a native references fixture file under `tests/fixtures/` (yaml or json — serde supports both)
+1. Create a native references fixture file under [tests/fixtures/](../../tests/fixtures/) (yaml or json — serde supports both)
 2. Build separate test harness (no oracle comparison - we ARE the reference)
 3. Test Citum-specific rendering against expected outputs
 4. Document intentional divergences from CSL 1.0
@@ -56,8 +56,8 @@ cargo nextest run --test citations
   not the definition of scope.
 - Prioritize native intake by Citum relevance, oracle/style risk, current native
   coverage gaps, and renderer sensitivity.
-- See `docs/architecture/CSL_NATIVE_TEST_INTAKE_ONE_SHOT_PR_2026-03-01.md` and
-  `tests/fixtures/csl-native-intake-wave1.json`.
+- See [docs/architecture/CSL_NATIVE_TEST_INTAKE_ONE_SHOT_PR_2026-03-01.md](../architecture/CSL_NATIVE_TEST_INTAKE_ONE_SHOT_PR_2026-03-01.md) and
+  [tests/fixtures/csl-native-intake-wave1.json](../../tests/fixtures/csl-native-intake-wave1.json).
 
 ## Two-Phase Testing Strategy
 
@@ -82,6 +82,8 @@ We're deferring Citum-native tests to focus on CSL 1.0 parity. This is the right
 - Keeps current work focused and achievable
 
 ## Related
+- [`CODING_STANDARDS.md`](./CODING_STANDARDS.md) § "What makes a test worth keeping" — the shared bar for whether a test earns its place (independent claim, no tests for their own sake, classifiable against a spec).
+- [`../architecture/TEST_SOUNDNESS_STATUS.md`](../architecture/TEST_SOUNDNESS_STATUS.md) — per-spec test-soundness state.
 - csln#64 - Math in variables
 - csln#66 - Multilingual support
 - Citation model in citum_schema (mode, locator types)


### PR DESCRIPTION
## What

Reworks `test-soundness-review` from a personal `~/.claude` skill that dumped ephemeral JSON into a repo-owned, state-tracking, spec-aware auditor.

Two commits, as planned:

1. **`feat(tooling)`** — `.skills/test-soundness-review/SKILL.md` (canonical repo copy).
2. **`docs(spec)`** — the living ledger + the shared test-value contract.

## Why

The old skill printed strict JSON to stdout. Once the turn ended the analysis was gone — nothing recorded which specs had been audited, what was fixed, or what remained. It also reasoned *from* the spec but never reported back when the spec itself was the problem.

## Changes

**Skill (commit 1)**
- Replaces JSON output with two durable artifacts: a row in the ledger + a dated audit record under `docs/architecture/audits/`.
- Promotes **spec review** to a first-class step. Records ambiguity / contradiction / silence, classified `blocking` vs `advisory`. A `blocking` defect **halts the run and prompts the user** rather than silently picking one reading of an ambiguous spec (which would launder the ambiguity into a false `good`).
- Adds a **`redundant`** verdict for low-value tests (near-duplicates, tautologies, library-behaviour tests, coverage theatre) whose usual fix is **deletion**, not rewrite.
- Adds a no-arg **ledger-navigation** mode ("what's the state of test quality / what's next?").

**Docs (commit 2)**
- `docs/architecture/TEST_SOUNDNESS_STATUS.md` — living per-spec ledger (`audited` / `addressed` / `todo` / `needs-rework`), seeded from the spec inventory. `DISAMBIGUATION` is backfilled as `audited` from the prior soundness pass in `aa7af758`; everything else starts `todo`. Backfill is deliberately conservative — adjacent behavior-reporting work is *not* counted as an audit.
- `docs/guides/CODING_STANDARDS.md` — new shared **"What makes a test worth keeping"** contract (independent claim · no tests for their own sake · classifiable against a spec). `TEST_STRATEGY.md`, the `test-coverage` skill, and the new soundness skill now point at it instead of restating, so the words mean the same thing everywhere.
- Registered the ledger in the architecture README.
- Drive-by: touching `CODING_STANDARDS.md`/`TEST_STRATEGY.md` pulled pre-existing broken backticked-path references into alint scope; fixed them (now valid relative links).

## Notes

- The `~/.claude` copy is intentionally **not** modified; the `.skills/` copy is canonical going forward.
- No `.rs`/`Cargo.*` changes — the Rust gate is N/A. Frontmatter preflight (`validate-frontmatter.sh --copilot-strict`) and alint both pass locally.
- No test code is changed here; running the skill on real specs is follow-up work tracked via the ledger's `todo` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
