### PR TITLE
test(engine): harden disambiguation soundness

### DIFF
--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -22,6 +22,8 @@ These files are intentionally thin host wrappers:
 
 Runnable Codex fallback:
 - `./scripts/codex <role> <target...>`
+- Use `test-soundness-review` there for spec-driven test audits when a direct
+  skill invocation is unavailable.
 
 ## Files
 - `migration-researcher.md`

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -32,8 +32,9 @@ use citum_schema::{
     grouping::{GroupSort, GroupSortEntry, GroupSortKey, SortKey as GroupSortKeyType},
     options::{
         AndOptions, Config, ContributorConfig, DelimiterPrecedesLast, DisplayAsSort, GivennameRule,
-        IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, NameForm, Processing,
-        ProcessingCustom, ShortenListOptions, SubsequentNameForm,
+        IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, MultilingualConfig,
+        MultilingualMode, NameForm, Processing, ProcessingCustom, ShortenListOptions,
+        SubsequentNameForm,
     },
     reference::InputReference,
 };
@@ -1145,14 +1146,6 @@ fn explicit_citation_sort_by_author_reorders_cluster() {
 /// Verifies that `Contributor::Multilingual` entries participate in the
 /// collision-key path. Two refs share the same *original* family name and issued
 /// year → both receive a year suffix.
-///
-/// NOTE: The spec §4 specifies that when a style uses a non-`primary` display
-/// mode (transliteration, translation), the key should be built from the
-/// *displayed* name variant so transliteration-level collisions are caught.
-/// That path (`render_name_for_disambiguation`) is not yet implemented —
-/// `to_names_vec()` always reads `original`. A future test should add two refs
-/// whose originals differ but whose transliterations collide and assert they
-/// also receive year suffixes.
 fn disambiguation_multilingual_contributors_collide_on_original_family_name() {
     let a = common::make_multilingual_book(common::MultilingualBookParams {
         id: "ml-a",
@@ -1188,6 +1181,72 @@ fn disambiguation_multilingual_contributors_collide_on_original_family_name() {
         "김, (2020a); 김, (2020b)",
         "citation",
     );
+}
+
+/// DISAMBIGUATION.md §4: when the style renders transliterated names, the
+/// collision key is built from that displayed transliteration rather than from
+/// the distinct original-script names. With `add_givenname` enabled, the
+/// cascade resolves the transliterated-family collision by adding initials
+/// instead of falling through to year suffixes.
+fn disambiguation_multilingual_key_uses_transliterated_display_name() {
+    let input = vec![
+        common::make_multilingual_book(common::MultilingualBookParams {
+            id: "ml-tanaka-a",
+            original_family: "田中",
+            original_given: "太郎",
+            lang: "ja",
+            translit_script: "ja-Latn",
+            translit_family: "Tanaka",
+            translit_given: "Taro",
+            year: 2020,
+            title: "Book A",
+        }),
+        common::make_multilingual_book(common::MultilingualBookParams {
+            id: "ml-tanaka-b",
+            original_family: "谷中",
+            original_given: "次郎",
+            lang: "ja",
+            translit_script: "ja-Latn",
+            translit_family: "Tanaka",
+            translit_given: "Jiro",
+            year: 2020,
+            title: "Book B",
+        }),
+    ];
+
+    let mut style = common::build_author_date_style(true, false, true, None, None);
+    style.options = Some(Config {
+        multilingual: Some(MultilingualConfig {
+            name_mode: Some(MultilingualMode::Transliterated),
+            preferred_transliteration: Some(vec!["ja-Latn".to_string()]),
+            ..Default::default()
+        }),
+        ..style.options.take().unwrap_or_default()
+    });
+
+    let bibliography = input
+        .into_iter()
+        .filter_map(|item| item.id().map(|id| (id.to_string(), item)))
+        .collect();
+    let processor = Processor::new(style, bibliography);
+    let result = processor
+        .process_citation(&Citation {
+            items: vec![
+                CitationItem {
+                    id: "ml-tanaka-a".to_string(),
+                    ..Default::default()
+                },
+                CitationItem {
+                    id: "ml-tanaka-b".to_string(),
+                    ..Default::default()
+                },
+            ],
+            mode: CitationMode::NonIntegral,
+            ..Default::default()
+        })
+        .expect("citation should render");
+
+    assert_eq!(result, "T Tanaka, (2020); J Tanaka, (2020)");
 }
 
 // --- APA §8.15 Reprint Disambiguation ---
@@ -2025,14 +2084,6 @@ mod disambiguation {
     }
 
     #[test]
-    fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
-        announce_behavior(
-            "Subsequent-citation et al. thresholds should shorten a repeat citation more aggressively than the first cite.",
-        );
-        super::subsequent_et_al_thresholds_shorten_the_repeat_citation();
-    }
-
-    #[test]
     fn year_suffix_assigned_when_et_al_truncation_leaves_collision() {
         announce_behavior(
             "When et-al truncation collapses distinct author lists to the same prefix, the resulting collision group should still receive distinct year suffixes in title sort order.",
@@ -2065,6 +2116,14 @@ mod disambiguation {
     }
 
     #[test]
+    fn multilingual_key_uses_transliterated_display_name() {
+        announce_behavior(
+            "When the style renders transliterated names, distinct original-script names with the same transliteration must form a collision group.",
+        );
+        super::disambiguation_multilingual_key_uses_transliterated_display_name();
+    }
+
+    #[test]
     fn apa_reprint_year_suffix_attaches_to_issued_year_only() {
         announce_behavior(
             "APA §8.15 reprints with different original-dates should receive year-suffix on the \
@@ -2083,6 +2142,14 @@ mod contributor_scoping {
             "Citation-scoped contributor shortening should apply even when the template contributor has no explicit shorten block.",
         );
         super::citation_scoped_contributor_shorten_applies_without_component_override();
+    }
+
+    #[test]
+    fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
+        announce_behavior(
+            "Subsequent-citation et al. thresholds should shorten a repeat citation more aggressively than the first cite.",
+        );
+        super::subsequent_et_al_thresholds_shorten_the_repeat_citation();
     }
 }
 

--- a/docs/architecture/TEST_SOUNDNESS_STATUS.md
+++ b/docs/architecture/TEST_SOUNDNESS_STATUS.md
@@ -68,7 +68,7 @@ test against its spec. Those specs remain `todo`.
 | [CONFIG_ONLY_PROFILE_OVERRIDES.md](../specs/CONFIG_ONLY_PROFILE_OVERRIDES.md) | — | — | — | todo | — |
 | [CROSS_ENTRY_FIDELITY.md](../specs/CROSS_ENTRY_FIDELITY.md) | — | — | — | todo | — |
 | [DATE_MODEL.md](../specs/DATE_MODEL.md) | — | — | — | todo | — |
-| [DISAMBIGUATION.md](../specs/DISAMBIGUATION.md) | 2026-06-12 | ?/?/?/? | — | audited | `aa7af758` (pre-ledger soundness pass) |
+| [DISAMBIGUATION.md](../specs/DISAMBIGUATION.md) | 2026-06-12 | 24/0/0/0 | — | addressed | Added transliterated-name collision gap test; moved 1 out-of-scope wrapper out of the disambiguation behavior group. |
 | [DISTRIBUTED_RESOLVER.md](../specs/DISTRIBUTED_RESOLVER.md) | — | — | — | todo | — |
 | [DJOT_RICH_TEXT.md](../specs/DJOT_RICH_TEXT.md) | — | — | — | todo | — |
 | [DOCUMENT_INPUT_PARSER_BOUNDARY.md](../specs/DOCUMENT_INPUT_PARSER_BOUNDARY.md) | — | — | — | todo | — |

--- a/docs/guides/AGENT_SKILLS.md
+++ b/docs/guides/AGENT_SKILLS.md
@@ -15,6 +15,10 @@ This syncs the canonical `.skills/` tree into Codex's `$CODEX_HOME/skills`
 directory. Legacy `.codex/skills/` paths remain as compatibility shims for
 existing Codex installs.
 
+`./scripts/install-hooks.sh` also refreshes these symlinks, so the repo's
+standard first-clone setup keeps new repo skills visible to Codex without a
+separate manual sync step.
+
 ## Repo-Local Harness Boundary
 
 This repository owns its harness contract.
@@ -39,6 +43,7 @@ maintaining parallel copies.
 | `style-evolve` | Route style work: upgrade, migrate, or create a Citum style |
 | `migrate-research` | Autonomous research loop for citum_migrate fidelity gaps |
 | `rust-simplify` | One-file Rust quality pass using jcodemunch analysis |
+| `test-soundness-review` | Audit tests against the governing spec and update the soundness ledger |
 
 These skills are for citum-core contributors only. They require the repo to be present
 locally and reference internal docs by path.
@@ -78,6 +83,7 @@ Use them for lower-level role contracts, not as primary user-facing entrypoints.
 
 ## Mirror Rules
 
-- Keep workflow logic in `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` and
-  `docs/guides/STYLE_WORKFLOW_EXECUTION.md`.
+- Keep workflow logic in
+  [style workflow decision rules](../policies/STYLE_WORKFLOW_DECISION_RULES.md)
+  and [style workflow execution](STYLE_WORKFLOW_EXECUTION.md).
 - Keep skills thin and host-focused.

--- a/scripts/codex
+++ b/scripts/codex
@@ -9,6 +9,7 @@ Usage:
 Roles:
   style-evolve
   migration-researcher
+  test-soundness-review
   style-qa-reviewer
   rust-implementer
   spec-planner
@@ -47,6 +48,19 @@ Read:
 - $docs_guide
 
 Run one bounded migration cluster pass and report the classification.
+EOF
+      ;;
+    test-soundness-review)
+      cat <<EOF
+Use the test-soundness-review role for: $target
+
+Read:
+- $repo_root/.skills/test-soundness-review/SKILL.md
+- $repo_root/docs/guides/CODING_STANDARDS.md
+- $repo_root/docs/architecture/TEST_SOUNDNESS_STATUS.md
+
+Audit the named tests against the named spec, apply Fix → Trim → Add → Persist,
+and keep verdict counts in the ledger.
 EOF
       ;;
     style-qa-reviewer)
@@ -102,7 +116,7 @@ EOF
 
 model_for_role() {
   case "$1" in
-    rust-implementer|spec-planner)
+    rust-implementer|spec-planner|test-soundness-review)
       echo "gpt-5.4"
       ;;
     *)

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 git -C "$ROOT_DIR" config core.hooksPath .githooks
 echo "Git hooks configured: core.hooksPath = .githooks"
+"$ROOT_DIR/scripts/install-skills.sh"
+CODEX_SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
+echo "Repo skills refreshed in $CODEX_SKILLS_DIR"
 echo ""
 echo "Installed hooks:"
 echo "  pre-commit: Schema re-gen + bean hygiene"


### PR DESCRIPTION
## Summary
- Adds a DISAMBIGUATION §4 integration test for transliterated-name collision keys in `citations.rs`.
- Moves a subsequent et-al behavior wrapper out of the disambiguation behavior group.
- Updates the soundness ledger to `24/0/0/0` for DISAMBIGUATION and wires repo setup to refresh Codex skill symlinks.

## Validation
- `./scripts/validate-frontmatter.sh --copilot-strict`
- `python3 scripts/audit-rust-review-smells.py --changed`
- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`
- pre-push hook reran the full Rust gate: 1,567 tests passed
