### PR TITLE
test(engine): harden multilingual test soundness

### DIFF
--- a/.beans/archive/csl26-l9lu--audit-multilingualmd-test-soundness.md
+++ b/.beans/archive/csl26-l9lu--audit-multilingualmd-test-soundness.md
@@ -1,0 +1,22 @@
+---
+# csl26-l9lu
+title: Audit MULTILINGUAL.md test soundness
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-12T14:11:15Z
+updated_at: 2026-06-12T15:42:33Z
+---
+
+Run /test-soundness-review against docs/specs/MULTILINGUAL.md and crates/citum-engine/tests/multilingual.rs. Classify tests (good/suspicious/broken/redundant), review spec for ambiguity/contradiction/silence, fix/trim/add per skill, persist ledger row, open PR.
+
+## Summary of Changes
+
+Audited docs/specs/MULTILINGUAL.md against crates/citum-engine/tests/multilingual.rs (verdicts 4 good / 0 suspicious / 3 broken / 1 redundant).
+
+- Fixed 3 broken short-contains tests with capture-and-pin exact assertions; the et-al test got a real kanji-author fixture (its old fixture had only Latin names).
+- Deleted 1 redundant Arabic test (output byte-identical to its sibling) and its unused fixture item.
+- Found the keyed-by-id JSON loader silently drops items that fail legacy CSL-JSON parsing — the fixture's three multilingual items were never loadable. Converted multilingual-cjk.json to native references format.
+- Added a gap test for the §2.1 romanized-translated preset end-to-end via apa-7th.
+- Filled the §3.1 Value Resolution placeholder; documented §3.4 locale-selected bibliography layouts (spec silences S1/S2).
+- Upserted the MULTILINGUAL.md ledger row (addressed).

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -62,11 +62,9 @@ fn test_cjk_name_rendering_asian_glyphs() {
         .process_citation(&single_item_citation("CSL-ASIAN-GLYPHS"))
         .expect("Asian glyphs citation should render");
 
-    // CSL test expects output to contain Japanese author name
-    assert!(
-        citation.contains("我妻"),
-        "Citation should contain Japanese author name"
-    );
+    // Plain CJK name with no parallel variants: the §1.3 fallback renders the
+    // original glyphs even under the APA romanized-translated preset.
+    assert_eq!(citation, "(我妻, 1960)");
 }
 
 #[test]
@@ -80,14 +78,12 @@ fn test_cjk_et_al_rendering() {
 
     let processor = Processor::new(style, bibliography);
     let citation = processor
-        .process_citation(&single_item_citation("CSL-ET-AL-KANJI"))
+        .process_citation(&single_item_citation("CJK-ET-AL-KANJI-AUTHORS"))
         .expect("et al. citation should render");
 
-    // Should render first author followed by et al.
-    assert!(
-        citation.contains("Zither") || citation.contains("et al"),
-        "Citation should contain author name or et al."
-    );
+    // Three kanji-named authors under APA shorten {min: 3, use-first: 1}:
+    // first author's family glyphs followed by the et-al term.
+    assert_eq!(citation, "(山田 et al., 2020)");
 }
 
 #[test]
@@ -104,31 +100,39 @@ fn test_arabic_short_forms_with_diacritics() {
         .process_citation(&single_item_citation("ARABIC-ASWANI-DIACRITICS"))
         .expect("Arabic citation with diacritics should render");
 
-    // Should render Arabic author name with proper diacritics
-    assert!(
-        citation.contains("al-Aswānī") || citation.contains("Alaa"),
-        "Citation should contain Arabic author name or transliteration"
-    );
+    // Romanized Arabic family name with macron and ʿayn must survive intact.
+    assert_eq!(citation, "(al-Aswānī, 2015)");
 }
 
 #[test]
-fn test_arabic_transliterated_forms() {
-    announce_behavior("Transliterated Arabic names are accepted and rendered correctly.");
+fn test_romanized_translated_preset_uses_parallel_metadata() {
+    announce_behavior(
+        "APA romanized-translated preset: names render romanized; titles render romanized [translated].",
+    );
     let root = project_root();
     let style = load_style(&root.join("styles/embedded/apa-7th.yaml"));
     let bibliography =
-        load_bibliography(&root.join("tests/fixtures/multilingual/multilingual-arabic.json"))
-            .expect("Arabic fixture should parse");
+        load_bibliography(&root.join("tests/fixtures/multilingual/multilingual-cjk.json"))
+            .expect("CJK fixture should parse");
 
     let processor = Processor::new(style, bibliography);
-    let citation = processor
-        .process_citation(&single_item_citation("ARABIC-ASWANI-TRANSLITERATED"))
-        .expect("Arabic citation with transliteration should render");
 
-    // Should render transliterated form
-    assert!(
-        citation.contains("al-Aswānī") || citation.contains("Alaa"),
-        "Citation should handle transliterated Arabic"
+    let citation = processor
+        .process_citation(&single_item_citation("CJK-JAPANESE-BOOK"))
+        .expect("Japanese book citation should render");
+    let entry = processor
+        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+            vec!["CJK-JAPANESE-BOOK".to_string()],
+        );
+
+    // §2.1 romanized-translated: the ja-Latn-hepburn name transliteration is
+    // preferred over the original kana in the citation.
+    assert_eq!(citation, "(Torusutoi, 1869)");
+    // §2.1 romanized-translated: the title renders as the ja-Latn-hepburn
+    // transliteration followed by the bracketed English translation.
+    assert_eq!(
+        entry,
+        "Torusutoi, L. (1869). _Sensō to Heiwa [War and Peace]_. Iwanami Shoten."
     );
 }
 
@@ -152,7 +156,7 @@ fn test_bibliography_locales_switch_full_entry_layouts() {
         );
     let default_entry = processor
         .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
-            vec!["CSL-ET-AL-KANJI".to_string()],
+            vec!["CSL-ET-AL-LATIN".to_string()],
         );
 
     assert!(

--- a/docs/architecture/TEST_SOUNDNESS_STATUS.md
+++ b/docs/architecture/TEST_SOUNDNESS_STATUS.md
@@ -94,7 +94,7 @@ test against its spec. Those specs remain `todo`.
 | [MIGRATE_RESEARCH_RICH_INPUTS.md](../specs/MIGRATE_RESEARCH_RICH_INPUTS.md) | — | — | — | todo | — |
 | [MIGRATION_TAXONOMY_AWARE_WRAPPERS.md](../specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md) | — | — | — | todo | — |
 | [MIXED_CONDITION_NOTE_POSITION_TREES.md](../specs/MIXED_CONDITION_NOTE_POSITION_TREES.md) | — | — | — | todo | — |
-| [MULTILINGUAL.md](../specs/MULTILINGUAL.md) | — | — | — | todo | — |
+| [MULTILINGUAL.md](../specs/MULTILINGUAL.md) | 2026-06-12 | 4/0/3/1 | — | addressed | Fixed 3 broken contains() tests (capture-and-pin); deleted 1 redundant Arabic twin; added §2.1 preset gap test after converting the CJK fixture to native format (its multilingual items were silently dropped by the legacy map loader); filled §3.1 placeholder; documented §3.4 locale layouts. Scope: multilingual.rs only — §1.3/§2.2/§2.3 resolution coverage lives in the unaudited i18n suite. |
 | [MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md](../specs/MULTILINGUAL_BIBLIOGRAPHY_PARTITIONING.md) | — | — | — | todo | — |
 | [MULTILINGUAL_NAMES.md](../specs/MULTILINGUAL_NAMES.md) | — | — | — | todo | — |
 | [NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md](../specs/NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md) | — | — | — | todo | — |

--- a/docs/specs/MULTILINGUAL.md
+++ b/docs/specs/MULTILINGUAL.md
@@ -235,7 +235,22 @@ duplicate text.
 
 ### 3.1 Value Resolution
 
-... [existing resolution logic] ...
+For each multilingual field, the requested view (from `title-mode` / `name-mode`
+or the preset) selects which variant renders:
+
+- `primary` — the `original` text, unchanged.
+- `transliterated` — the transliteration selected by the §1.3 matching strategy
+  (exact BCP 47 tag → script prefix via `preferred-script` → fallback to
+  `original`).
+- `translated` — the translation matching the style locale's base language;
+  falls back to `original` when no translation exists.
+- `combined` — the transliterated view followed by the translated view in
+  brackets (`romanized [translated]`); when no transliteration exists, the
+  original takes its place. The bracket segment is dropped when the translation
+  is missing or identical to the first segment.
+- `pattern` — the ordered segment list defined in §2.3.
+
+Simple (non-multilingual) values resolve to themselves under every mode.
 
 ### 3.2 Script-Aware Name Rendering
 
@@ -260,6 +275,19 @@ The processor must distinguish between:
 Labels ("Ed.", "vol.") will always use the **Style Locale**. Data fields will use the script determined by the **Data Language** and **Multilingual Mode**.
 
 When `field-languages` is present, the processor should prefer the field-scoped language over the entry-level language for that specific field. This is how Citum can format a chapter title as English while formatting the containing book title as German in the same entry.
+
+### 3.4 Locale-Selected Bibliography Layouts (experimental)
+
+`bibliography.locales[]` lets a style swap the *entire* entry template based on
+the reference's effective language. Each branch names the locales it serves
+(`locale: [ja, zh, ko]`) or is marked `default: true`; an entry whose
+entry-level `language` matches a branch renders with that branch's template,
+and all other entries use the default branch (or the top-level
+`bibliography.template` when no default branch exists).
+
+This is currently demonstrated by
+`styles/experimental/locale-specific-bibliography-layouts.yaml` and is not yet
+a committed part of the style schema contract.
 
 ## 4. Sorting & Transliteration
 

--- a/tests/fixtures/multilingual/multilingual-arabic.json
+++ b/tests/fixtures/multilingual/multilingual-arabic.json
@@ -13,19 +13,5 @@
     ],
     "issued": { "date-parts": [[2015]] },
     "publisher": "Cairo Publishers"
-  },
-  "ARABIC-ASWANI-TRANSLITERATED": {
-    "id": "ARABIC-ASWANI-TRANSLITERATED",
-    "class": "monograph",
-    "type": "book",
-    "title": "Arabic Work",
-    "author": [
-      {
-        "family": "al-Aswānī",
-        "given": "`Alā'"
-      }
-    ],
-    "issued": { "date-parts": [[2015]] },
-    "publisher": "Cairo Publishers"
   }
 }

--- a/tests/fixtures/multilingual/multilingual-cjk.json
+++ b/tests/fixtures/multilingual/multilingual-cjk.json
@@ -1,161 +1,185 @@
 {
   "comment": "CJK multilingual test data with original scripts and transliterations",
-  "CJK-JAPANESE-BOOK": {
-    "id": "CJK-JAPANESE-BOOK",
-    "class": "monograph",
-    "type": "book",
-    "title": {
-      "original": "戦争と平和",
-      "lang": "ja",
-      "transliterations": {
-        "ja-Latn-hepburn": "Sensō to Heiwa"
-      },
-      "translations": {
-        "en": "War and Peace"
-      }
-    },
-    "author": [
-      {
-        "original": {
-          "family": "トルストイ",
-          "given": "レオ"
-        },
+  "references": [
+    {
+      "id": "CJK-JAPANESE-BOOK",
+      "class": "monograph",
+      "type": "book",
+      "title": {
+        "original": "戦争と平和",
         "lang": "ja",
         "transliterations": {
-          "ja-Latn-hepburn": {
-            "family": "Torusutoi",
-            "given": "Leo"
-          }
+          "ja-Latn-hepburn": "Sensō to Heiwa"
         },
         "translations": {
-          "en": {
-            "family": "Tolstoy",
-            "given": "Leo"
+          "en": "War and Peace"
+        }
+      },
+      "author": [
+        {
+          "original": {
+            "family": "トルストイ",
+            "given": "レオ"
+          },
+          "lang": "ja",
+          "transliterations": {
+            "ja-Latn-hepburn": {
+              "family": "Torusutoi",
+              "given": "Leo"
+            }
+          },
+          "translations": {
+            "en": {
+              "family": "Tolstoy",
+              "given": "Leo"
+            }
           }
         }
-      }
-    ],
-    "issued": { "date-parts": [[1869]] },
-    "publisher": "Iwanami Shoten",
-    "publisher-place": "Tokyo"
-  },
-  "CJK-CHINESE-ARTICLE": {
-    "id": "CJK-CHINESE-ARTICLE",
-    "class": "serial-component",
-    "type": "article-journal",
-    "title": {
-      "original": "中国哲学的发展",
-      "lang": "zh",
-      "transliterations": {
-        "zh-Latn-pinyin": "Zhōngguó Zhéxué de Fāzhǎn"
-      },
-      "translations": {
-        "en": "Development of Chinese Philosophy"
-      }
+      ],
+      "issued": "1869",
+      "publisher": "Iwanami Shoten",
+      "publisher-place": "Tokyo"
     },
-    "author": [
-      {
-        "original": {
-          "family": "孔",
-          "given": "子"
-        },
+    {
+      "id": "CJK-CHINESE-ARTICLE",
+      "class": "serial-component",
+      "type": "article",
+      "title": {
+        "original": "中国哲学的发展",
         "lang": "zh",
         "transliterations": {
-          "zh-Latn-pinyin": {
-            "family": "Kǒng",
-            "given": "zǐ"
+          "zh-Latn-pinyin": "Zhōngguó Zhéxué de Fāzhǎn"
+        },
+        "translations": {
+          "en": "Development of Chinese Philosophy"
+        }
+      },
+      "author": [
+        {
+          "original": {
+            "family": "孔",
+            "given": "子"
+          },
+          "lang": "zh",
+          "transliterations": {
+            "zh-Latn-pinyin": {
+              "family": "Kǒng",
+              "given": "zǐ"
+            }
           }
         }
-      }
-    ],
-    "container-title": "中文学刊",
-    "issued": { "date-parts": [[2020]] },
-    "volume": "15",
-    "pages": "123-145"
-  },
-  "CJK-KOREAN-BOOK": {
-    "id": "CJK-KOREAN-BOOK",
-    "class": "monograph",
-    "type": "book",
-    "title": {
-      "original": "한국 문화의 이해",
-      "lang": "ko",
-      "transliterations": {
-        "ko-Latn-hangul": "Hanguk Munhwaui Ihaе"
-      },
-      "translations": {
-        "en": "Understanding Korean Culture"
-      }
+      ],
+      "container-title": "中文学刊",
+      "issued": "2020",
+      "volume": "15",
+      "pages": "123-145"
     },
-    "author": [
-      {
-        "original": {
-          "family": "김",
-          "given": "영희"
-        },
+    {
+      "id": "CJK-KOREAN-BOOK",
+      "class": "monograph",
+      "type": "book",
+      "title": {
+        "original": "한국 문화의 이해",
         "lang": "ko",
         "transliterations": {
-          "ko-Latn-hangul": {
-            "family": "Kim",
-            "given": "Young-hee"
+          "ko-Latn-hangul": "Hanguk Munhwaui Ihaе"
+        },
+        "translations": {
+          "en": "Understanding Korean Culture"
+        }
+      },
+      "author": [
+        {
+          "original": {
+            "family": "김",
+            "given": "영희"
+          },
+          "lang": "ko",
+          "transliterations": {
+            "ko-Latn-hangul": {
+              "family": "Kim",
+              "given": "Young-hee"
+            }
           }
         }
-      }
-    ],
-    "issued": { "date-parts": [[2021]] },
-    "publisher": "Seoul University Press",
-    "publisher-place": "Seoul"
-  },
-  "CSL-ASIAN-GLYPHS": {
-    "id": "CSL-ASIAN-GLYPHS",
-    "class": "monograph",
-    "type": "book",
-    "title": "民法",
-    "author": [
-      {
-        "family": "我妻",
-        "given": "栄"
-      }
-    ],
-    "issued": { "date-parts": [[1960]] },
-    "publisher": "有斐閣"
-  },
-  "CJK-JAPANESE-LANGUAGE-TAGGED": {
-    "id": "CJK-JAPANESE-LANGUAGE-TAGGED",
-    "class": "monograph",
-    "type": "book",
-    "title": "日本語の書誌",
-    "author": [
-      {
-        "family": "佐藤",
-        "given": "花子"
-      }
-    ],
-    "issued": { "date-parts": [[2018]] },
-    "publisher": "Tokyo Academic Press",
-    "publisher-place": "Tokyo",
-    "language": "ja"
-  },
-  "CSL-ET-AL-KANJI": {
-    "id": "CSL-ET-AL-KANJI",
-    "class": "monograph",
-    "type": "book",
-    "title": "Test Book",
-    "author": [
-      {
-        "family": "Zither",
-        "given": "Ziggy"
-      },
-      {
-        "family": "Yoda",
-        "given": "Yossarian"
-      },
-      {
-        "family": "Xylophone",
-        "given": "Xerxes"
-      }
-    ],
-    "issued": { "date-parts": [[2020]] },
-    "publisher": "Test Publisher"
-  }
+      ],
+      "issued": "2021",
+      "publisher": "Seoul University Press",
+      "publisher-place": "Seoul"
+    },
+    {
+      "id": "CSL-ASIAN-GLYPHS",
+      "class": "monograph",
+      "type": "book",
+      "title": "民法",
+      "author": [
+        {
+          "family": "我妻",
+          "given": "栄"
+        }
+      ],
+      "issued": "1960",
+      "publisher": "有斐閣"
+    },
+    {
+      "id": "CJK-JAPANESE-LANGUAGE-TAGGED",
+      "class": "monograph",
+      "type": "book",
+      "title": "日本語の書誌",
+      "author": [
+        {
+          "family": "佐藤",
+          "given": "花子"
+        }
+      ],
+      "issued": "2018",
+      "publisher": "Tokyo Academic Press",
+      "publisher-place": "Tokyo",
+      "language": "ja"
+    },
+    {
+      "id": "CJK-ET-AL-KANJI-AUTHORS",
+      "class": "monograph",
+      "type": "book",
+      "title": "日本語テスト",
+      "author": [
+        {
+          "family": "山田",
+          "given": "太郎"
+        },
+        {
+          "family": "田中",
+          "given": "次郎"
+        },
+        {
+          "family": "鈴木",
+          "given": "三郎"
+        }
+      ],
+      "issued": "2020",
+      "publisher": "テスト出版"
+    },
+    {
+      "id": "CSL-ET-AL-LATIN",
+      "class": "monograph",
+      "type": "book",
+      "title": "Test Book",
+      "author": [
+        {
+          "family": "Zither",
+          "given": "Ziggy"
+        },
+        {
+          "family": "Yoda",
+          "given": "Yossarian"
+        },
+        {
+          "family": "Xylophone",
+          "given": "Xerxes"
+        }
+      ],
+      "issued": "2020",
+      "publisher": "Test Publisher"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

`/test-soundness-review` run for `docs/specs/MULTILINGUAL.md` against `crates/citum-engine/tests/multilingual.rs`. Verdicts: **4 good / 0 suspicious / 3 broken / 1 redundant**.

### Test changes

- **Fixed 3 broken tests** that used short `contains()` on rendered output (banned by CODING_STANDARDS) — now pin captured exact output:
  - `test_cjk_name_rendering_asian_glyphs` → `(我妻, 1960)`
  - `test_arabic_short_forms_with_diacritics` → `(al-Aswānī, 2015)` (the old `|| contains("Alaa")` branch matched nothing in any fixture)
  - `test_cjk_et_al_rendering` → `(山田 et al., 2020)` — its old fixture item claimed "KANJI" but contained only Latin names (Zither/Yoda/Xylophone), so the claimed behavior could never trigger; it now uses a real three-kanji-author item (the Latin item survives as `CSL-ET-AL-LATIN` for the locale-layout test)
- **Deleted 1 redundant test** (`test_arabic_transliterated_forms`): differed from its sibling only in given-name apostrophes, which APA citations never render — byte-identical output, no independent claim
- **Added 1 gap test**: §2.1 `romanized-translated` preset end-to-end via embedded `apa-7th` — citation `(Torusutoi, 1869)`, entry `Torusutoi, L. (1869). _Sensō to Heiwa [War and Peace]_. Iwanami Shoten.`

### Loader finding (drives the fixture change)

The keyed-by-id JSON path in `citum-refs` parses each map value as **legacy CSL-JSON** and silently skips failures — so `multilingual-cjk.json`'s three multilingual items (object titles, parallel names) were **never loadable**; they were dead data no test could use. The fixture is converted to the native `{"references": [...]}` format (EDTF dates, native type names), which routes through `InputReference` and errors loudly instead of skipping.

### Spec changes (two advisory silences)

- §3.1 Value Resolution was a literal `... [existing resolution logic] ...` placeholder — now written from the implemented matching strategy and modes
- New §3.4 documents locale-selected bibliography layouts (experimental) — a test asserted this behavior but no spec stated it

### Ledger

`docs/architecture/TEST_SOUNDNESS_STATUS.md`: MULTILINGUAL.md row → `addressed` (4/0/3/1). Scope note: §1.3/§2.2/§2.3 resolution coverage lives in the unaudited i18n suite.

Gate: `cargo fmt --check` ✓ · clippy `-D warnings` ✓ · `cargo nextest run` 1567/1567 ✓ · frontmatter ✓
