### PR TITLE
chore(beans): clarify migration fidelity backlog

### DIFF
--- a/.beans/csl26-21ep--migrate-compact-physics-form-title-suppression.md
+++ b/.beans/csl26-21ep--migrate-compact-physics-form-title-suppression.md
@@ -4,9 +4,17 @@ title: 'migrate: compact physics form title suppression'
 status: todo
 type: bug
 priority: low
+tags:
+    - migrate
+    - fidelity
+    - style-family
 created_at: 2026-06-10T16:56:45Z
-updated_at: 2026-06-10T16:56:45Z
+updated_at: 2026-06-12T17:25:53Z
 parent: csl26-vmcr
 ---
 
-Cluster C5 (small band, physics family) from docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md. Compact physics styles should suppress article titles and render page-only locators ('T. S. Kuhn, Philosophy of Science 37, 1 (1970)'); migrated output includes the title and drops the page. Evidence: springer-physics-author-date (11/38). One bounded migrate-research pass.
+Cluster C5 (small band, physics family) from docs/architecture/audits/2026-06-10_MIGRATE_RANDOM_SAMPLE_BASELINE.md. This is a proven random-sample migration fidelity defect, but not yet proven to be converter-only, engine-side, or schema-driven.
+
+Compact physics styles should suppress article titles and render page-only locators (`T. S. Kuhn, Philosophy of Science 37, 1 (1970)`). Migrated output includes the title and drops the page. Evidence: `springer-physics-author-date` (11/38).
+
+Next step: one bounded migrate-research pass that classifies the root cause before implementation.

--- a/.beans/csl26-aynr--migrate-output-driven-template-synthesis.md
+++ b/.beans/csl26-aynr--migrate-output-driven-template-synthesis.md
@@ -1,15 +1,21 @@
 ---
 # csl26-aynr
 title: 'migrate: output-driven template synthesis'
-status: draft
+status: todo
 type: feature
 priority: normal
+tags:
+    - migrate
+    - fidelity
+    - architecture
 created_at: 2026-06-11T16:06:50Z
-updated_at: 2026-06-11T16:10:38Z
+updated_at: 2026-06-12T17:25:53Z
 ---
 
-Direction surfaced while closing the csl26-vmcr wave (pointer in docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md). Motivation: every fragile bug that wave fixed (C3 order scrambling, conditional leakage, suppressed-variable poison, wrapper variants) lived in the structural XML layout compiler -- compiling a procedural CSL layout tree into declarative templates is a semantic mismatch patched bug by bug. XML attribute/options extraction was never the problem.
+Direction surfaced while closing the csl26-vmcr wave (pointer in docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md) and was reinforced by PR #910's measured-candidate selection work. Motivation: every fragile bug that wave fixed or exposed (C3 order scrambling, conditional leakage, suppressed-variable poison, wrapper variants) lived in the structural XML layout compiler -- compiling a procedural CSL layout tree into declarative templates is a semantic mismatch patched bug by bug. XML attribute/options extraction was never the problem.
 
 Replace XML layout compilation entirely: synthesize Citum templates by searching the candidate space against citeproc-js reference output. All machinery exists in-process after the csl26-vmcr wave: EmbeddedTemplateRuntime (deno_core) renders the citeproc reference; citum-engine renders candidates; token_jaccard in crates/citum-migrate/src/measured_citation.rs is the oracle-mirroring fitness function. Generalize measured selection from arbitrating 2 candidates to a propose/render/score/mutate loop (mutations: component order, affixes, labels, group boundaries; seeds: inferrer output). XML read only for declarative attributes (et-al, initialize-with, sort) -- the layout tree is never compiled. Deterministic, no LLM in the loop.
 
-Prerequisites: held-out fixture items, positional scenario coverage (first/subsequent/ibid/locator), bounded mutation space. Acceptance test: the seeded random-100 scorecard (seed 20260610). Needs a spec in docs/specs/ before implementation.
+Status: promoted to `todo` because this is the sustainable long-term migration strategy, but implementation remains blocked on design. Needs a spec in docs/specs/ before code.
+
+Prerequisites: held-out fixture items, positional scenario coverage (first/subsequent/ibid/locator), bounded mutation space, and an explicit candidate-family budget so scoring cannot become unbounded. Acceptance test: the seeded random-100 scorecard (seed 20260610).

--- a/.beans/csl26-h7xz--document-template-inferrer-in-rendering-workflowmd.md
+++ b/.beans/csl26-h7xz--document-template-inferrer-in-rendering-workflowmd.md
@@ -6,8 +6,11 @@ type: task
 priority: low
 tags:
     - dx
+    - migrate
+    - docs
+    - template-inferrer
 created_at: 2026-02-08T06:29:15Z
-updated_at: 2026-04-25T20:20:08Z
+updated_at: 2026-06-12T17:25:53Z
 ---
 
 Add usage docs for scripts/infer-template.js and scripts/lib/template-inferrer.js to docs/guides/RENDERING_WORKFLOW.md. Cover CLI flags (--section, --json, --verbose), example commands, and how it fits into the hybrid migration strategy.

--- a/.beans/csl26-rksq--public-migrate-page-scorecard-page-weekly-ci-regen.md
+++ b/.beans/csl26-rksq--public-migrate-page-scorecard-page-weekly-ci-regen.md
@@ -4,8 +4,12 @@ title: Public Migrate page, scorecard page, weekly CI regeneration
 status: todo
 type: task
 priority: deferred
+tags:
+    - migrate
+    - docs
+    - scorecard
 created_at: 2026-06-10T16:28:16Z
-updated_at: 2026-06-11T15:57:01Z
+updated_at: 2026-06-12T17:25:53Z
 parent: csl26-vmcr
 blocked_by:
     - csl26-rj4c

--- a/.beans/csl26-vmcr--promote-citum-migrate-with-random-sample-fidelity.md
+++ b/.beans/csl26-vmcr--promote-citum-migrate-with-random-sample-fidelity.md
@@ -1,11 +1,15 @@
 ---
 # csl26-vmcr
 title: Promote citum-migrate with random-sample fidelity metrics
-status: in-progress
+status: todo
 type: epic
 priority: deferred
+tags:
+    - fidelity
+    - scorecard
+    - migrate
 created_at: 2026-06-10T16:27:51Z
-updated_at: 2026-06-11T15:57:01Z
+updated_at: 2026-06-12T17:25:53Z
 ---
 
 Public docs site (docs.citum.org) never mentions citum-migrate. Goal: measure converter quality on a seeded, stratified random sample of ~100 independent parent CSL styles using existing fidelity+SQI tooling, record a baseline audit, then publish a Migrate page with truthful metrics and a weekly CI-regenerated scorecard. Quality bar: >=80% of sampled styles at >=90% combined strict citation+bibliography fidelity, no style class below 60%; below the bar, run a migrate-research improvement wave first. Plan: ~/.claude/plans/i-have-a-task-federated-gosling.md
@@ -14,4 +18,16 @@ Public docs site (docs.citum.org) never mentions citum-migrate. Goal: measure co
 
 Improvement wave concluded; publication deferred. The 80/100 quality bar was not met and is no longer a near-term target: baseline 43/100 at >=90% combined strict fidelity, 53/100 after the wave (note-class repeat forms, suppressed-variable poison, wrapper full variants, measured citation selection PR #907), plus the C3 order/leakage fix (PR #908, merged) expected to add several more points. Reaching 80 requires flipping the entire 80-90% close-miss band AND most of the 70-80% band AND note-class recovery -- multiple waves with rising cost per point, with remaining gaps increasingly engine-level rather than converter-level.
 
-Decision: stop LLM-driven improvement waves; no Migrate page or weekly scorecard until the number is earned by ordinary engineering. Remaining levers stay in backlog as normal bugs: csl26-y4o7 (engine once-only consumption semantics), csl26-21ep (C5 physics compact form, low). The public-page task csl26-rksq is deferred indefinitely. Full record: docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md.
+Decision: stop LLM-driven improvement waves; no Migrate page or weekly scorecard until the number is earned by ordinary engineering. Full record: docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md.
+
+## Active migration backlog
+
+- csl26-y4o7: engine/migrate once-only variable consumption semantics. This is the clearest current engine-side migration fidelity blocker: migrated YAML can be structurally reasonable but still lose bibliography fields because suppressed groups consume variables inconsistently.
+- csl26-21ep: compact physics style-family migration defect. This is a proven fidelity gap for the random-sample physics cluster, but it still needs diagnosis before classifying as converter-only, engine-side, or schema-driven.
+- csl26-aynr: output-driven template synthesis. This is the long-term sustainable migration architecture after the measured-candidate PRs; it needs a spec before implementation.
+- csl26-h7xz: document the template inferrer in the rendering workflow.
+- csl26-rksq: public Migrate page, scorecard page, and weekly regeneration. Deferred until fidelity metrics justify publication.
+
+## Not direct migration blockers
+
+The following open draft/schema beans are broader multilingual or data-model backlog, not direct blockers for the current CSL random-sample migration fidelity work: csl26-6rjq, csl26-xz2t, csl26-1b4e, csl26-dno4, csl26-ldgf, csl26-9oee. Triage them in a separate multilingual/schema bean-hygiene pass if they need promotion, scrapping, or decomposition.

--- a/.beans/csl26-y4o7--engine-once-only-variable-consumption-semantics-au.md
+++ b/.beans/csl26-y4o7--engine-once-only-variable-consumption-semantics-au.md
@@ -1,11 +1,22 @@
 ---
 # csl26-y4o7
-title: 'engine: once-only variable consumption semantics audit'
+title: 'engine/migrate: once-only variable consumption semantics audit'
 status: todo
 type: task
+priority: normal
+tags:
+    - engine
+    - migrate
+    - fidelity
 created_at: 2026-06-10T17:28:39Z
-updated_at: 2026-06-10T17:28:39Z
+updated_at: 2026-06-12T17:25:53Z
 parent: csl26-vmcr
 ---
 
-Follow-up from C2 (bean csl26-sfir). The engine renders each reference variable at most once per bibliography entry (first occurrence wins), but consumption semantics are inconsistent: a suppressed top-level leaf component does NOT consume its variable, while members of suppressed groups DO consume (and depth-1 vs depth-2 members behaved differently in zfa probes). Decide and document the intended semantics: should suppress: true components ever claim a variable? Candidates: crates/citum-engine/src/processor/rendering/grouped/. An engine-side fix would also repair existing checked-in YAML, not just fresh migrations. Evidence repro: /tmp/dup-min.yaml pattern in C2 pass notes (suppressed group [parent-serial,date] before live group [parent-serial,volume] starves the live group).
+Random-sample migration blocker surfaced by C2 (bean csl26-sfir). Migrated bibliography templates can contain a suppressed fallback group before the live group that should render the same variable later. The engine's once-only variable consumption then decides whether the migrated style loses fields such as volume/page data, so this is tagged as both `engine` and `migrate`.
+
+The engine renders each reference variable at most once per bibliography entry (first occurrence wins), but consumption semantics are inconsistent: a suppressed top-level leaf component does NOT consume its variable, while members of suppressed groups DO consume it. Depth-1 vs depth-2 members also behaved differently in zfa probes.
+
+Decide and document the intended semantics: should `suppress: true` components ever claim a variable? Candidate code area: `crates/citum-engine/src/processor/rendering/grouped/`. An engine-side fix would repair existing checked-in YAML, not just fresh migrations.
+
+Evidence repro: `/tmp/dup-min.yaml` pattern in C2 pass notes, where suppressed group `[parent-serial,date]` before live group `[parent-serial,volume]` starves the live group.

--- a/.beans/csl26-y4o7--engine-once-only-variable-consumption-semantics-au.md
+++ b/.beans/csl26-y4o7--engine-once-only-variable-consumption-semantics-au.md
@@ -19,4 +19,4 @@ The engine renders each reference variable at most once per bibliography entry (
 
 Decide and document the intended semantics: should `suppress: true` components ever claim a variable? Candidate code area: `crates/citum-engine/src/processor/rendering/grouped/`. An engine-side fix would repair existing checked-in YAML, not just fresh migrations.
 
-Evidence repro: `/tmp/dup-min.yaml` pattern in C2 pass notes, where suppressed group `[parent-serial,date]` before live group `[parent-serial,volume]` starves the live group.
+Evidence trail: archived bean csl26-sfir records the C2 fix and routes the residual engine consumption-semantics question here. Reconstruct a checked-in regression fixture from the failing pattern before implementation: a suppressed group containing `parent-serial`/date before a live group containing `parent-serial`/volume can starve the live group.


### PR DESCRIPTION
## Summary
- promote and tag the active migration-fidelity bean set
- clarify `csl26-y4o7` as an engine-origin migration blocker
- separate direct CSL migration blockers from adjacent multilingual/schema drafts

## Test Plan
- `beans check`
- `beans list --tag migrate`
- `beans list --tag fidelity`
- `beans show csl26-vmcr`
- `beans show csl26-y4o7`

Rust gate skipped by pre-push hook because only `.beans/*.md` changed.
