### PR TITLE
Disambiguation migration presets

### DIFF
--- a/.beans/csl26-1861--migrate-fix-eager-disambiguation-defaults-bypassin.md
+++ b/.beans/csl26-1861--migrate-fix-eager-disambiguation-defaults-bypassin.md
@@ -1,14 +1,14 @@
 ---
 # csl26-1861
 title: 'migrate: fix eager disambiguation defaults bypassing Processing presets'
-status: todo
+status: in-progress
 type: task
 priority: normal
 tags:
     - migrate
     - fidelity
 created_at: 2026-06-13T11:55:30Z
-updated_at: 2026-06-13T11:55:30Z
+updated_at: 2026-06-13T14:20:00Z
 ---
 
 Deferred from the synthesis-loop PR (bean csl26-8txa). Surfaced while documenting
@@ -65,33 +65,42 @@ same delta philosophy `docs/specs/STYLE_PRESET_ARCHITECTURE.md` already uses for
 
 ## Open design questions (decide before implementing)
 
-1. **What should "author-date, unspecified" mean?** Owner leans **(b) opinionated Citum
-   default** (keep year-suffix on, on the theory that author-date styles want it) over
-   **(a) CSL-faithful** `{false,false,false}`. Whichever wins becomes the single canonical
-   default used by *both* the preset and extraction, so they agree and fold cleanly.
-2. **AuthorDate preset variants?** A single `AuthorDate` preset may be too coarse — consider
-   named variants (e.g. author-date with vs without year-suffix / given-name expansion) so
-   common real-world shapes each fold to a clean named value instead of `!custom`. Scope
-   this against the actual distribution of disambiguation configs in the corpus.
-3. **A `citum-migrate` flag for CSL-faithful vs Citum-opinionated extraction?** Possibly a
-   conversion flag toggling (a) vs (b) so strict-fidelity round-trips and opinionated
-   defaults are both reachable. Unsure it's worth the surface area — evaluate, don't assume.
+Resolved:
+
+1. **What should "author-date, unspecified" mean?** Use the opinionated Citum
+   B1 default: `year_suffix: true`, `names: false`, `add_givenname: false`.
+   This keeps same-author/same-year disambiguation active for author-date
+   styles while avoiding automatic name and given-name expansion.
+2. **AuthorDate preset variants?** Add named variants so common explicit CSL
+   disambiguation shapes fold to clean public values:
+   - `author-date`: B1, year suffix only.
+   - `author-date-givenname`: year suffix plus given-name expansion.
+   - `author-date-names`: year suffix plus name-list expansion.
+   - `author-date-full`: year suffix plus both name-list and given-name expansion.
+3. **A `citum-migrate` flag for CSL-faithful vs Citum-opinionated extraction?**
+   No. Migration uses Citum's class defaults and preserves explicit CSL
+   attributes as overrides; it does not add a second extraction mode.
 
 ## Scope / impact
 
 - Fidelity-affecting: changing the default changes every author-date style's rendered
   disambiguation, so this **moves the scorecard**. Required gates before accepting:
+  - `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings
+    && cargo nextest run`
   - `node scripts/report-migrate-sqi.js --corpus random --sample 100 --seed 20260610`
     (headline, no regression)
   - `node scripts/report-core.js > /tmp/r.json && node scripts/check-core-quality.js
     --report /tmp/r.json --baseline scripts/report-data/core-quality-baseline.json`
 - Update `test_extract_processing_disambiguation_defaults` and any author-date fixtures to
   the new expected folding.
+- Regenerate schemas because `Processing` gains public serialized variants.
 
 ## Documentation (do as part of this bean, describing the FIXED behavior)
 
-- New `docs/reference/` doc: the CSL→Citum `Processing` classification and its class-default
-  disambiguation/sort table; how migrate folds to named variants vs `!custom`.
-- One-line pointer from `docs/specs/OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md` (where it notes XML
-  is read "only for declarative attributes and options (… disambiguation …)"): disambiguation
-  is not synthesized; it is set by class-based `Processing` defaults during extraction.
+- [x] Add `docs/reference/PROCESSING_MIGRATION.md`: the CSL→Citum
+  `Processing` classification and its class-default disambiguation/sort table;
+  how migrate folds to named variants vs custom processing.
+- [x] Add one-line pointer from `docs/specs/OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md`
+  (where it notes XML is read "only for declarative attributes and options
+  (… disambiguation …)"): disambiguation is not synthesized; it is set by
+  class-based `Processing` defaults during extraction.

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -320,14 +320,7 @@ impl Processor {
 
     /// Return true when the active citation config requests CSL by-cite given-name expansion.
     fn uses_by_cite_givenname(config: &Config) -> bool {
-        let disambiguate = match config.processing.as_ref() {
-            Some(processing) => processing.config().disambiguate,
-            None => {
-                citum_schema::options::Processing::AuthorDate
-                    .config()
-                    .disambiguate
-            }
-        };
+        let disambiguate = config.effective_processing().config().disambiguate;
 
         disambiguate
             .as_ref()

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -1163,6 +1163,59 @@ mod tests {
     }
 
     #[test]
+    fn test_author_date_default_uses_year_suffix_without_name_expansion() {
+        use citum_schema::options::Processing;
+
+        let r1 = make_ref("r1", "Smith", "John", 2020);
+        let r2 = make_ref("r2", "Smith", "Alice", 2020);
+
+        let mut bib = Bibliography::new();
+        bib.insert("r1".to_string(), r1);
+        bib.insert("r2".to_string(), r2);
+
+        let config = Config {
+            processing: Some(Processing::AuthorDate),
+            ..Default::default()
+        };
+        let locale = Locale::en_us();
+
+        let disamb = Disambiguator::new(&bib, &config, &locale);
+        let hints = disamb.calculate_hints();
+        let r1_hints = hints.get("r1").unwrap();
+        let r2_hints = hints.get("r2").unwrap();
+
+        assert!(r1_hints.disamb_condition);
+        assert!(r2_hints.disamb_condition);
+        assert!(!r1_hints.expand_given_names);
+        assert!(!r2_hints.expand_given_names);
+        assert_eq!(r1_hints.min_names_to_show, None);
+        assert_eq!(r2_hints.min_names_to_show, None);
+
+        let style = make_author_date_style(config, None);
+        let processor = Processor::new(style, bib);
+
+        let rendered_r1 = processor.process_citation(&Citation::simple("r1")).unwrap();
+        let rendered_r2 = processor.process_citation(&Citation::simple("r2")).unwrap();
+
+        assert!(
+            rendered_r1.contains("2020a") || rendered_r1.contains("2020b"),
+            "expected r1 to receive a year suffix: {rendered_r1}"
+        );
+        assert!(
+            rendered_r2.contains("2020a") || rendered_r2.contains("2020b"),
+            "expected r2 to receive a year suffix: {rendered_r2}"
+        );
+        assert!(
+            !rendered_r1.contains("John") && !rendered_r1.contains("J."),
+            "expected r1 to avoid given-name expansion: {rendered_r1}"
+        );
+        assert!(
+            !rendered_r2.contains("Alice") && !rendered_r2.contains("A."),
+            "expected r2 to avoid given-name expansion: {rendered_r2}"
+        );
+    }
+
+    #[test]
     fn test_disambiguate_given_names() {
         use citum_schema::options::{Disambiguation, Processing, ProcessingCustom};
 

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -191,14 +191,7 @@ impl<'a> Disambiguator<'a> {
 
     /// Resolves disambiguation configuration from the processor config.
     fn disambiguation_flags(&self) -> DisambiguationFlags {
-        let disamb_config = match self.config.processing.as_ref() {
-            Some(processing) => processing.config().disambiguate,
-            None => {
-                citum_schema::options::Processing::AuthorDate
-                    .config()
-                    .disambiguate
-            }
-        };
+        let disamb_config = self.config.effective_processing().config().disambiguate;
 
         DisambiguationFlags {
             add_names: disamb_config.as_ref().is_some_and(|d| d.names),

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -473,14 +473,11 @@ fn compute_disamb_suffix<F: crate::render::format::OutputFormat<Output = String>
     fmt: &F,
 ) -> Option<String> {
     if hints.disamb_condition && date_form_displays_year(form) && !date.year().is_empty() {
-        // Check if year suffix is enabled. Fall back to AuthorDate default
-        // (year_suffix: true) when processing is not explicitly set, matching
-        // the behavior in disambiguation.rs which uses unwrap_or_default().
+        // Check if year suffix is enabled, resolving the processing default
+        // centrally so an unset `processing` matches the rest of the engine.
         let use_suffix = options
             .config
-            .processing
-            .as_ref()
-            .unwrap_or(&citum_schema::options::Processing::AuthorDate)
+            .effective_processing()
             .config()
             .disambiguate
             .as_ref()

--- a/crates/citum-migrate/src/citation_validate.rs
+++ b/crates/citum-migrate/src/citation_validate.rs
@@ -109,10 +109,10 @@ fn normalize_note_or_author_date_citation(
     style_name: &str,
 ) {
     let should_normalize = legacy_style.class == "note"
-        || matches!(
-            options.processing,
-            Some(citum_schema::options::Processing::AuthorDate)
-        );
+        || options
+            .processing
+            .as_ref()
+            .is_some_and(citum_schema::options::Processing::is_author_date_family);
     if !should_normalize {
         return;
     }

--- a/crates/citum-migrate/src/compilation.rs
+++ b/crates/citum-migrate/src/compilation.rs
@@ -142,10 +142,10 @@ pub fn compile_from_xml(
 
     // For author-date styles with in-text class, apply standard formatting.
     let is_in_text_class = legacy_style.class == "in-text";
-    let is_author_date_processing = matches!(
-        options.processing,
-        Some(citum_schema::options::Processing::AuthorDate)
-    );
+    let is_author_date_processing = options
+        .processing
+        .as_ref()
+        .is_some_and(citum_schema::options::Processing::is_author_date_family);
 
     // Apply to all in-text styles (both author-date and numeric)
     if is_in_text_class {

--- a/crates/citum-migrate/src/options_extractor/processing.rs
+++ b/crates/citum-migrate/src/options_extractor/processing.rs
@@ -4,8 +4,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{
-    Disambiguation, GivennameRule, Group, Processing, ProcessingCustom, Sort, SortEntry, SortKey,
-    SortSpec,
+    GivennameRule, Group, Processing, ProcessingCustom, Sort, SortEntry, SortKey, SortSpec,
 };
 use citum_schema::presets::SortPreset;
 use csl_legacy::model::{CslNode, Style};
@@ -52,38 +51,37 @@ pub fn detect_processing_mode(style: &Style) -> Option<Processing> {
         nodes_have_author_date_signal(&style.citation.layout.children, style, &mut visited_macros);
 
     if is_author_date {
-        // Extract disambiguation settings from citation-level attributes.
-        // Legacy CSL defaults are effectively "no extra names / no extra given
-        // names" unless explicitly requested. Defaulting to names=true here
-        // causes over-disambiguation and suppresses expected et-al behavior.
-        let givenname_rule = match style.citation.disambiguate_givenname_rule.as_deref() {
-            Some("primary-name") => GivennameRule::PrimaryName,
-            Some("primary-name-with-initials") => GivennameRule::PrimaryNameWithInitials,
-            Some("all-names-with-initials") => GivennameRule::AllNamesWithInitials,
-            Some("all-names") => GivennameRule::AllNames,
-            _ => GivennameRule::default(), // by-cite default
-        };
-
-        let disamb = Disambiguation {
-            names: style.citation.disambiguate_add_names.unwrap_or(false),
-            add_givenname: style.citation.disambiguate_add_givenname.unwrap_or(false),
-            givenname_rule,
-            // Author-date styles commonly rely on year suffixes; keep this true
-            // unless legacy style explicitly disables it.
-            year_suffix: style.citation.disambiguate_add_year_suffix.unwrap_or(true),
-        };
+        let mut custom = Processing::AuthorDate.config();
 
         let sort = style.citation.sort.as_ref().and_then(extract_sort);
-        let group = sort
-            .as_ref()
-            .map(SortEntry::resolve)
-            .and_then(|sort| extract_group_from_sort(&sort));
+        if let Some(sort) = sort {
+            // Preset sorts already carry their canonical group via the base
+            // config; only derive group from explicit (non-preset) sort keys.
+            if let SortEntry::Explicit(explicit_sort) = &sort {
+                custom.group = extract_group_from_sort(explicit_sort);
+            }
+            custom.sort = Some(sort);
+        }
 
-        let custom = ProcessingCustom {
-            sort,
-            group,
-            disambiguate: Some(disamb),
-        };
+        if let Some(disamb) = custom.disambiguate.as_mut() {
+            if let Some(names) = style.citation.disambiguate_add_names {
+                disamb.names = names;
+            }
+            if let Some(add_givenname) = style.citation.disambiguate_add_givenname {
+                disamb.add_givenname = add_givenname;
+            }
+            if let Some(year_suffix) = style.citation.disambiguate_add_year_suffix {
+                disamb.year_suffix = year_suffix;
+            }
+            disamb.givenname_rule = match style.citation.disambiguate_givenname_rule.as_deref() {
+                Some("primary-name") => GivennameRule::PrimaryName,
+                Some("primary-name-with-initials") => GivennameRule::PrimaryNameWithInitials,
+                Some("all-names-with-initials") => GivennameRule::AllNamesWithInitials,
+                Some("all-names") => GivennameRule::AllNames,
+                _ => GivennameRule::default(),
+            };
+        }
+
         return Some(fold_to_named_processing(custom));
     }
 
@@ -97,6 +95,9 @@ pub fn detect_processing_mode(style: &Style) -> Option<Processing> {
 fn fold_to_named_processing(custom: ProcessingCustom) -> Processing {
     for candidate in [
         Processing::AuthorDate,
+        Processing::AuthorDateGivenname,
+        Processing::AuthorDateNames,
+        Processing::AuthorDateFull,
         Processing::Numeric,
         Processing::Note,
     ] {

--- a/crates/citum-migrate/src/options_extractor/tests.rs
+++ b/crates/citum-migrate/src/options_extractor/tests.rs
@@ -24,7 +24,7 @@ fn test_extract_author_date_processing() {
     let style = parse_csl(xml).unwrap();
     let config = OptionsExtractor::extract(&style);
 
-    assert!(matches!(config.processing, Some(Processing::Custom(_))));
+    assert_eq!(config.processing, Some(Processing::AuthorDate));
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn test_extract_author_date_processing_from_nested_macro() {
     let style = parse_csl(xml).unwrap();
     let config = OptionsExtractor::extract(&style);
 
-    assert!(matches!(config.processing, Some(Processing::Custom(_))));
+    assert_eq!(config.processing, Some(Processing::AuthorDate));
 }
 
 #[test]
@@ -146,22 +146,16 @@ fn test_extract_processing_sort_uses_author_date_title_preset_for_duplicate_macr
     let style = parse_csl(xml).unwrap();
     let config = OptionsExtractor::extract(&style);
 
-    let Processing::Custom(custom) = config.processing.unwrap() else {
-        panic!("expected custom processing mode");
-    };
-
+    // Duplicate date macros deduplicate to [Author, Year], which maps to the
+    // AuthorDateTitle preset — so the style folds to the named variant, not Custom.
+    assert_eq!(config.processing, Some(Processing::AuthorDate));
+    let config_custom = config.processing.unwrap().config();
     assert!(matches!(
-        custom.sort,
+        config_custom.sort,
         Some(citum_schema::options::SortEntry::Preset(
             SortPreset::AuthorDateTitle
         ))
     ));
-
-    let group = custom.group.unwrap();
-    assert_eq!(
-        group.template,
-        vec![SortKey::Author, SortKey::Year, SortKey::Title]
-    );
 }
 
 #[test]
@@ -205,15 +199,74 @@ fn test_extract_processing_disambiguation_defaults() {
     let style = parse_csl(xml).unwrap();
     let config = OptionsExtractor::extract(&style);
 
-    let Processing::Custom(custom) = config.processing.unwrap() else {
-        panic!("expected custom processing mode");
-    };
-    let disamb = custom
-        .disambiguate
-        .expect("disambiguation should be present");
+    assert_eq!(config.processing, Some(Processing::AuthorDate));
+
+    let disamb = config.processing.unwrap().config().disambiguate.unwrap();
     assert!(!disamb.names);
     assert!(!disamb.add_givenname);
     assert!(disamb.year_suffix);
+}
+
+#[test]
+fn test_extract_processing_disambiguation_variant_givenname() {
+    let xml = r#"<style class="in-text">
+        <citation disambiguate-add-givenname="true">
+            <layout><text macro="year"/></layout>
+        </citation>
+        <bibliography><layout><text variable="title"/></layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let config = OptionsExtractor::extract(&style);
+
+    assert_eq!(config.processing, Some(Processing::AuthorDateGivenname));
+}
+
+#[test]
+fn test_extract_processing_disambiguation_variant_names() {
+    let xml = r#"<style class="in-text">
+        <citation disambiguate-add-names="true">
+            <layout><text macro="year"/></layout>
+        </citation>
+        <bibliography><layout><text variable="title"/></layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let config = OptionsExtractor::extract(&style);
+
+    assert_eq!(config.processing, Some(Processing::AuthorDateNames));
+}
+
+#[test]
+fn test_extract_processing_disambiguation_variant_full() {
+    let xml = r#"<style class="in-text">
+        <citation disambiguate-add-names="true" disambiguate-add-givenname="true">
+            <layout><text macro="year"/></layout>
+        </citation>
+        <bibliography><layout><text variable="title"/></layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let config = OptionsExtractor::extract(&style);
+
+    assert_eq!(config.processing, Some(Processing::AuthorDateFull));
+}
+
+#[test]
+fn test_extract_processing_disambiguation_year_suffix_false_stays_custom() {
+    let xml = r#"<style class="in-text">
+        <citation disambiguate-add-year-suffix="false">
+            <layout><text macro="year"/></layout>
+        </citation>
+        <bibliography><layout><text variable="title"/></layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let config = OptionsExtractor::extract(&style);
+
+    let Processing::Custom(custom) = config.processing.unwrap() else {
+        panic!("expected explicit year-suffix=false to stay custom");
+    };
+    let disamb = custom.disambiguate.unwrap();
+    assert!(!disamb.names);
+    assert!(!disamb.add_givenname);
+    assert!(!disamb.year_suffix);
 }
 
 #[test]
@@ -518,10 +571,10 @@ fn test_extract_givenname_rule_defaults_to_by_cite() {
     let style = parse_csl(xml).unwrap();
     let config = OptionsExtractor::extract(&style);
 
-    let Processing::Custom(custom) = config.processing.unwrap() else {
-        panic!("expected custom processing mode");
-    };
-    let disamb = custom.disambiguate.unwrap();
+    let processing = config.processing.unwrap();
+    assert_eq!(processing, Processing::AuthorDateGivenname);
+
+    let disamb = processing.config().disambiguate.unwrap();
     assert_eq!(
         disamb.givenname_rule,
         GivennameRule::ByCite,

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -526,6 +526,14 @@ pub enum LinkAnchor {
 }
 
 impl Config {
+    /// Effective processing mode, falling back to the default when unset.
+    ///
+    /// Centralizes the `processing: None` fallback so every consumer resolves
+    /// the same default (`Processing::default()`) instead of hardcoding it.
+    pub fn effective_processing(&self) -> Processing {
+        self.processing.clone().unwrap_or_default()
+    }
+
     /// Merge another config into this one, with `other` taking precedence.
     ///
     /// Used for combining global options with context-specific (citation/bibliography) options.
@@ -954,7 +962,10 @@ mod tests {
     fn test_author_date_processing() {
         let processing = Processing::AuthorDate;
         let config = processing.config();
-        assert!(config.disambiguate.unwrap().year_suffix);
+        let disambiguate = config.disambiguate.unwrap();
+        assert!(disambiguate.year_suffix);
+        assert!(!disambiguate.names);
+        assert!(!disambiguate.add_givenname);
         assert_eq!(
             processing.default_bibliography_sort(),
             Some(crate::presets::SortPreset::AuthorDateTitle)

--- a/crates/citum-schema-style/src/options/processing.rs
+++ b/crates/citum-schema-style/src/options/processing.rs
@@ -20,6 +20,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::presets::SortPreset;
 
+const PROCESSING_STRING_VARIANTS: &[&str] = &[
+    "author-date",
+    "author-date-givenname",
+    "author-date-names",
+    "author-date-full",
+    "numeric",
+    "note",
+    "label",
+];
+
 /// Label style preset conventions.
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -124,7 +134,7 @@ impl LabelConfig {
 ///
 /// Determines how citations and bibliographies are sorted, grouped, and disambiguated.
 /// Can be specified as a simple string or with complex configuration maps:
-/// - A string: `"author-date"`, `"numeric"`, `"note"`, or `"label"`
+/// - A string: `"author-date"`, `"author-date-full"`, `"numeric"`, `"note"`, or `"label"`
 /// - A label config map: `{ label: { preset: din } }`
 /// - A custom config map: `{ sort: ..., group: ..., disambiguate: ... }`
 // `rename_all` is retained for `JsonSchema` derive (custom `Serialize` /
@@ -135,9 +145,15 @@ impl LabelConfig {
 #[non_exhaustive]
 pub enum Processing {
     /// Author-date styles (e.g., APA, Chicago).
-    /// Default bibliography ordering: author, year, title.
+    /// Default bibliography ordering: author, year, title; disambiguates by year suffix.
     #[default]
     AuthorDate,
+    /// Author-date styles that also add given names during disambiguation.
+    AuthorDateGivenname,
+    /// Author-date styles that also expand name lists during disambiguation.
+    AuthorDateNames,
+    /// Author-date styles that expand name lists and add given names during disambiguation.
+    AuthorDateFull,
     /// Numeric styles (e.g., IEEE, Nature).
     /// Do not imply a bibliography sort; citations are numbered in order of appearance.
     Numeric,
@@ -183,6 +199,21 @@ pub struct ProcessingCustom {
     pub disambiguate: Option<Disambiguation>,
 }
 
+fn author_date_config(names: bool, add_givenname: bool) -> ProcessingCustom {
+    ProcessingCustom {
+        sort: Some(SortEntry::Preset(SortPreset::AuthorDateTitle)),
+        group: Some(Group {
+            template: vec![SortKey::Author, SortKey::Year],
+        }),
+        disambiguate: Some(Disambiguation {
+            names,
+            add_givenname,
+            givenname_rule: GivennameRule::default(),
+            year_suffix: true,
+        }),
+    }
+}
+
 impl Processing {
     /// Default bibliography sort for the processing family, if any.
     ///
@@ -192,12 +223,29 @@ impl Processing {
     /// - `Numeric` / `Custom`: None (no automatic sort)
     pub fn default_bibliography_sort(&self) -> Option<SortPreset> {
         match self {
-            Processing::AuthorDate => Some(SortPreset::AuthorDateTitle),
+            Processing::AuthorDate
+            | Processing::AuthorDateGivenname
+            | Processing::AuthorDateNames
+            | Processing::AuthorDateFull => Some(SortPreset::AuthorDateTitle),
             Processing::Numeric => None,
             Processing::Note => Some(SortPreset::AuthorTitleDate),
             Processing::Label(_) => Some(SortPreset::AuthorDateTitle),
             Processing::Custom(_) => None,
         }
+    }
+
+    /// Returns `true` for all author-date family variants.
+    ///
+    /// Centralizes the author-date family check so new variants don't require
+    /// updating scattered `matches!` blocks across the codebase.
+    pub fn is_author_date_family(&self) -> bool {
+        matches!(
+            self,
+            Self::AuthorDate
+                | Self::AuthorDateGivenname
+                | Self::AuthorDateNames
+                | Self::AuthorDateFull
+        )
     }
 
     /// Citation sorting remains explicit-only for all processing families.
@@ -214,18 +262,10 @@ impl Processing {
     /// preset defaults and user overrides. For `Custom` mode, returns the user-provided config as-is.
     pub fn config(&self) -> ProcessingCustom {
         match self {
-            Processing::AuthorDate => ProcessingCustom {
-                sort: Some(SortEntry::Preset(SortPreset::AuthorDateTitle)),
-                group: Some(Group {
-                    template: vec![SortKey::Author, SortKey::Year],
-                }),
-                disambiguate: Some(Disambiguation {
-                    names: true,
-                    add_givenname: true,
-                    givenname_rule: GivennameRule::default(),
-                    year_suffix: true,
-                }),
-            },
+            Processing::AuthorDate => author_date_config(false, false),
+            Processing::AuthorDateGivenname => author_date_config(false, true),
+            Processing::AuthorDateNames => author_date_config(true, false),
+            Processing::AuthorDateFull => author_date_config(true, true),
             Processing::Numeric => ProcessingCustom {
                 sort: None,
                 group: None,
@@ -263,6 +303,9 @@ impl Serialize for Processing {
     {
         match self {
             Processing::AuthorDate => serializer.serialize_str("author-date"),
+            Processing::AuthorDateGivenname => serializer.serialize_str("author-date-givenname"),
+            Processing::AuthorDateNames => serializer.serialize_str("author-date-names"),
+            Processing::AuthorDateFull => serializer.serialize_str("author-date-full"),
             Processing::Numeric => serializer.serialize_str("numeric"),
             Processing::Note => serializer.serialize_str("note"),
             Processing::Label(config) => {
@@ -298,13 +341,13 @@ impl<'de> Deserialize<'de> for Processing {
             fn visit_str<E: de::Error>(self, v: &str) -> Result<Processing, E> {
                 match v {
                     "author-date" => Ok(Processing::AuthorDate),
+                    "author-date-givenname" => Ok(Processing::AuthorDateGivenname),
+                    "author-date-names" => Ok(Processing::AuthorDateNames),
+                    "author-date-full" => Ok(Processing::AuthorDateFull),
                     "numeric" => Ok(Processing::Numeric),
                     "note" => Ok(Processing::Note),
                     "label" => Ok(Processing::Label(LabelConfig::default())),
-                    other => Err(E::unknown_variant(
-                        other,
-                        &["author-date", "numeric", "note", "label"],
-                    )),
+                    other => Err(E::unknown_variant(other, PROCESSING_STRING_VARIANTS)),
                 }
             }
 
@@ -316,10 +359,9 @@ impl<'de> Deserialize<'de> for Processing {
                         let custom: ProcessingCustom = access.newtype_variant()?;
                         Ok(Processing::Custom(custom))
                     }
-                    other => Err(de::Error::unknown_variant(
-                        other,
-                        &["author-date", "numeric", "note", "label", "custom"],
-                    )),
+                    // `custom` is the only externally-tagged variant; named
+                    // string forms are handled by `visit_str` above.
+                    other => Err(de::Error::unknown_variant(other, &["custom"])),
                 }
             }
 
@@ -643,6 +685,9 @@ mod tests {
     fn test_processing_citation_sort_policy() {
         let modes = vec![
             Processing::AuthorDate,
+            Processing::AuthorDateGivenname,
+            Processing::AuthorDateNames,
+            Processing::AuthorDateFull,
             Processing::Numeric,
             Processing::Note,
             Processing::Label(LabelConfig::default()),
@@ -657,20 +702,55 @@ mod tests {
         }
     }
 
-    /// Test that Processing::config() returns correct configuration for AuthorDate.
+    /// Test that Processing::config() returns correct configuration for author-date variants.
     #[test]
-    fn test_processing_author_date_config() {
-        let processing = Processing::AuthorDate;
-        let config = processing.config();
+    fn test_processing_author_date_variant_configs() {
+        let cases = [
+            (Processing::AuthorDate, false, false),
+            (Processing::AuthorDateGivenname, false, true),
+            (Processing::AuthorDateNames, true, false),
+            (Processing::AuthorDateFull, true, true),
+        ];
 
-        assert!(config.sort.is_some());
-        assert!(config.group.is_some());
-        assert!(config.disambiguate.is_some());
+        for (processing, names, add_givenname) in cases {
+            let config = processing.config();
 
-        let disambig = config.disambiguate.unwrap();
-        assert!(disambig.names);
-        assert!(disambig.add_givenname);
-        assert!(disambig.year_suffix);
+            assert_eq!(
+                config.sort,
+                Some(SortEntry::Preset(SortPreset::AuthorDateTitle))
+            );
+            assert_eq!(
+                config.group,
+                Some(Group {
+                    template: vec![SortKey::Author, SortKey::Year],
+                })
+            );
+
+            let disambig = config.disambiguate.unwrap();
+            assert_eq!(disambig.names, names);
+            assert_eq!(disambig.add_givenname, add_givenname);
+            assert_eq!(disambig.givenname_rule, GivennameRule::ByCite);
+            assert!(disambig.year_suffix);
+        }
+    }
+
+    /// Test that author-date processing variants round-trip through their public names.
+    #[test]
+    fn test_processing_author_date_variant_names() {
+        let cases = [
+            (Processing::AuthorDate, "author-date"),
+            (Processing::AuthorDateGivenname, "author-date-givenname"),
+            (Processing::AuthorDateNames, "author-date-names"),
+            (Processing::AuthorDateFull, "author-date-full"),
+        ];
+
+        for (processing, name) in cases {
+            let serialized = serde_yaml::to_string(&processing).unwrap();
+            assert_eq!(serialized.trim(), name);
+
+            let deserialized: Processing = serde_yaml::from_str(name).unwrap();
+            assert_eq!(deserialized, processing);
+        }
     }
 
     /// Test that Disambiguation defaults have correct values.

--- a/docs/reference/PROCESSING_MIGRATION.md
+++ b/docs/reference/PROCESSING_MIGRATION.md
@@ -1,0 +1,67 @@
+# CSL to Citum Processing Migration
+
+This reference records how `citum-migrate` classifies CSL styles into Citum
+`Processing` modes and how disambiguation defaults fold into named presets.
+
+## Classification
+
+Migration classifies processing from CSL structure before template synthesis:
+
+| CSL signal | Citum processing |
+| --- | --- |
+| `style class="note"` | `note` |
+| In-text citation layout renders `citation-number` | `numeric` |
+| In-text citation layout renders an author-date signal directly or through a macro | `author-date` or an author-date variant |
+| Label-style configuration | `label` |
+
+Template synthesis does not infer disambiguation. Migration reads CSL
+declarative attributes, applies the processing-class defaults below, and then
+folds the resulting configuration to the closest named preset.
+
+## Class Defaults
+
+| Processing | Sort | Group | Disambiguation |
+| --- | --- | --- | --- |
+| `author-date` | `author-date-title` | `author`, `year` | `year_suffix: true`, `names: false`, `add_givenname: false` |
+| `numeric` | none | none | none |
+| `note` | `author-title-date` | none | `year_suffix: false`, `names: true`, `add_givenname: false` |
+| `label` | `author-date-title` | none | `year_suffix: true`, `names: false`, `add_givenname: false` |
+
+The author-date default intentionally differs from CSL's raw omitted-attribute
+default. Citum treats same-author/same-year year suffixing as the useful
+author-date default, while name-list and given-name expansion remain explicit.
+
+## Author-Date Variants
+
+Author-date presets share the same sort and grouping defaults. They differ only
+in disambiguation strategy:
+
+| Preset | Year suffix | Name-list expansion | Given-name expansion |
+| --- | --- | --- | --- |
+| `author-date` | true | false | false |
+| `author-date-givenname` | true | false | true |
+| `author-date-names` | true | true | false |
+| `author-date-full` | true | true | true |
+
+`author-date-full` preserves the previous full-stack behavior under an explicit
+name. `author-date` now means year-suffix-only B1 behavior.
+
+## Folding Rules
+
+`citum-migrate` starts from the processing-class default, applies only explicit
+CSL disambiguation attributes, and compares the result with named presets:
+
+- A bare author-date CSL style folds to `processing: author-date`.
+- Explicit `disambiguate-add-givenname="true"` folds to
+  `processing: author-date-givenname`.
+- Explicit `disambiguate-add-names="true"` folds to
+  `processing: author-date-names`.
+- Explicit `disambiguate-add-names="true"` plus
+  `disambiguate-add-givenname="true"` folds to
+  `processing: author-date-full`.
+- Explicit `disambiguate-add-year-suffix="false"` remains custom because it
+  contradicts the author-date class default.
+
+`givenname-disambiguation-rule` defaults to `by-cite` when omitted. An explicit
+non-default rule is preserved in custom processing unless the full configuration
+still exactly matches a named preset.

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -2605,12 +2605,27 @@
       ]
     },
     "Processing": {
-      "description": "Processing mode for citation/bibliography generation.\n\nDetermines how citations and bibliographies are sorted, grouped, and disambiguated.\nCan be specified as a simple string or with complex configuration maps:\n- A string: `\"author-date\"`, `\"numeric\"`, `\"note\"`, or `\"label\"`\n- A label config map: `{ label: { preset: din } }`\n- A custom config map: `{ sort: ..., group: ..., disambiguate: ... }`",
+      "description": "Processing mode for citation/bibliography generation.\n\nDetermines how citations and bibliographies are sorted, grouped, and disambiguated.\nCan be specified as a simple string or with complex configuration maps:\n- A string: `\"author-date\"`, `\"author-date-full\"`, `\"numeric\"`, `\"note\"`, or `\"label\"`\n- A label config map: `{ label: { preset: din } }`\n- A custom config map: `{ sort: ..., group: ..., disambiguate: ... }`",
       "oneOf": [
         {
-          "description": "Author-date styles (e.g., APA, Chicago).\nDefault bibliography ordering: author, year, title.",
+          "description": "Author-date styles (e.g., APA, Chicago).\nDefault bibliography ordering: author, year, title; disambiguates by year suffix.",
           "type": "string",
           "const": "author-date"
+        },
+        {
+          "description": "Author-date styles that also add given names during disambiguation.",
+          "type": "string",
+          "const": "author-date-givenname"
+        },
+        {
+          "description": "Author-date styles that also expand name lists during disambiguation.",
+          "type": "string",
+          "const": "author-date-names"
+        },
+        {
+          "description": "Author-date styles that expand name lists and add given names during disambiguation.",
+          "type": "string",
+          "const": "author-date-full"
         },
         {
           "description": "Numeric styles (e.g., IEEE, Nature).\nDo not imply a bibliography sort; citations are numbered in order of appearance.",

--- a/docs/specs/OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md
+++ b/docs/specs/OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md
@@ -98,6 +98,9 @@ XML is read only for declarative attributes and options (et-al thresholds,
 `initialize-with`, sort keys, disambiguation and demotion options); the layout
 tree is never compiled as authority. During the transition the XML-compiled
 templates survive only as one seed candidate in the search space.
+Disambiguation is not synthesized from rendered output; it is extracted as
+class-based `Processing` configuration and folded to named presets as described
+in [`docs/reference/PROCESSING_MIGRATION.md`](../reference/PROCESSING_MIGRATION.md).
 
 ### How synthesis works, in plain terms
 


### PR DESCRIPTION
## Summary

- lock the csl26-1861 disambiguation migration decisions in the bean and reference docs
- add public author-date processing variants for B1/givenname/names/full disambiguation presets
- make bare `author-date` use the B1 default and fold exact explicit CSL shapes to named presets
- add an engine regression test for year-suffix-only author-date disambiguation

## Tests

- `cargo test -p citum-schema-style processing_author_date`
- `cargo test -p citum-migrate extract_author_date_processing`
- `cargo test -p citum-migrate processing_disambiguation`
- `cargo test -p citum-migrate extract_givenname_rule`
- `cargo test -p citum-engine test_author_date_default_uses_year_suffix_without_name_expansion`
- `cargo run --bin citum --features schema -- schema --out-dir docs/schemas`
- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run`
- `node scripts/report-migrate-sqi.js --corpus random --sample 100 --seed 20260610`
- `node scripts/report-core.js > /tmp/r.json && node scripts/check-core-quality.js --report /tmp/r.json --baseline scripts/report-data/core-quality-baseline.json`

Core quality passed with two existing reporter warnings recorded in `/tmp/r.json`.
