### PR TITLE
chore(tooling): add justfile for task running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This overrides any global "prefer Bash" or "use Explore" rule. Choose by intent,
 
 **NEVER use the `Explore` subagent for code in this repo** — jcodemunch replaces it. Explore is allowed only for non-code docs sweeps.
 
-jcodemunch is indexed as `local/citum-core` (~184 files, 2308 symbols). See `crates/README.md` for the crate map.
+jcodemunch is indexed as `local/citum-core` (~184 files, 2308 symbols). See [crates/README.md](crates/README.md) for the crate map.
 
 **Stale index → refresh, do not bail.** If jcodemunch returns "symbol not found" or results that don't match HEAD, the index is stale (likely from a recent rebase, branch switch, or large rewrite). Re-index before falling back to Read/Grep — re-indexing costs less than a fresh codebase scan:
 
@@ -32,7 +32,7 @@ Falling back to Read/Grep on a stale index is the failure mode that has historic
 
 Transition citation management from CSL 1.0 (procedural XML) to Citum (declarative, type-safe Rust/YAML). Pipeline: **parse** (`csl-legacy`) → **migrate** (`citum-migrate`) → **process** (`citum-engine`) → **render** (matches citeproc-js for CSL-derived; biblatex for biblatex-derived).
 
-See `crates/README.md` for crate layout and `docs/architecture/DESIGN_PRINCIPLES.md` for key principles (explicit over magic, serde-driven truth, no `unwrap`/`unsafe`, declarative templates).
+See [crates/README.md](crates/README.md) for crate layout and [DESIGN_PRINCIPLES.md](docs/architecture/DESIGN_PRINCIPLES.md) for key principles (explicit over magic, serde-driven truth, no `unwrap`/`unsafe`, declarative templates).
 
 When considering prior art, prefer biblatex over BibTeX — better data model.
 
@@ -40,15 +40,15 @@ When considering prior art, prefer biblatex over BibTeX — better data model.
 
 Before committing `.rs`, `Cargo.toml`, or `Cargo.lock`:
 ```bash
-cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run
+just pre-commit    # Or: cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run
 ```
 Run `cargo fmt` first if needed, then re-check. **Do not commit if any check fails.** Docs (`.md`) and styles (`.yaml`) skip checks.
 
-This command is the authoritative gate for this repo. Do **not** substitute a generic wrapper that weakens it by skipping `cargo fmt --check`, swallowing clippy warnings, or replacing `cargo nextest run` with a weaker test command. Run the gate above verbatim.
+This command is the authoritative gate for this repo. Do **not** substitute a generic wrapper that weakens it by skipping `cargo fmt --check`, swallowing clippy warnings, or replacing `cargo nextest run` with a weaker test command. Run the gate above verbatim or via `just pre-commit`.
 
-If `crates/citum-cli/` or `crates/citum-schema*/` changed, regenerate schemas in the same commit:
+If the `citum-cli` or `citum-schema*` crates changed, regenerate schemas in the same commit:
 ```bash
-cargo run --bin citum --features schema -- schema --out-dir docs/schemas && git add docs/schemas/
+just schema-gen    # Or: cargo run --bin citum --features schema -- schema --out-dir docs/schemas && git add docs/schemas/
 ```
 
 **Do not** bump `STYLE_SCHEMA_VERSION` or `[workspace.package].version` manually — the release workflow (`cargo-release`) infers from conventional commits.
@@ -57,7 +57,7 @@ cargo run --bin citum --features schema -- schema --out-dir docs/schemas && git 
 
 Conventional Commits: `type(scope): subject`, lowercase, **50/72 rule**, no `Co-Authored-By`.
 
-`main` is branch-protected and merges via **rebase-merge** → linear history. On a PR branch, `--amend` is **encouraged** to absorb review nits and pre-push-gate fixes into the relevant parent commit; force-push-with-lease the branch (needs CONFIRM). "Fix typo" / "address review" commits become noise after rebase — fold them in instead. Never `--amend` a commit on `main`. Prefer **`jj`** for local change-stack management (see `docs/guides/JJ_AI_CHANGE_STACK.md`); Git remains the public surface.
+`main` is branch-protected and merges via **rebase-merge** → linear history. On a PR branch, `--amend` is **encouraged** to absorb review nits and pre-push-gate fixes into the relevant parent commit; force-push-with-lease the branch (needs CONFIRM). "Fix typo" / "address review" commits become noise after rebase — fold them in instead. Never `--amend` a commit on `main`. Prefer **`jj`** for local change-stack management (see [JJ_AI_CHANGE_STACK.md](docs/guides/JJ_AI_CHANGE_STACK.md)); Git remains the public surface.
 
 **Versioning signals:**
 
@@ -78,14 +78,14 @@ All new or modified **public Rust items** need `///` doc comments (one clear sen
 
 | Kind | Directory |
 |---|---|
-| Feature / design specs | `docs/specs/` (use template) |
-| Operational audit records | `docs/architecture/audits/` (date-stamped) |
-| Architectural decisions | `docs/architecture/` |
-| Active behavioral rules | `docs/policies/` |
-| Operational how-tos | `docs/guides/` |
-| Reference lookups | `docs/reference/` |
+| Feature / design specs | [docs/specs/](docs/specs/) (use template) |
+| Operational audit records | [docs/architecture/audits/](docs/architecture/audits/) (date-stamped) |
+| Architectural decisions | [docs/architecture/](docs/architecture/) |
+| Active behavioral rules | [docs/policies/](docs/policies/) |
+| Operational how-tos | [docs/guides/](docs/guides/) |
+| Reference lookups | [docs/reference/](docs/reference/) |
 
-Non-trivial features: spec in `docs/specs/` first (status `Draft` → `Active` in the implementation commit). Reference the spec path in the bean.
+Non-trivial features: spec in [docs/specs/](docs/specs/) first (status `Draft` → `Active` in the implementation commit). Reference the spec path in the bean.
 
 ## Workflow Entry Points
 
@@ -122,7 +122,7 @@ Style tasks: `/style-evolve` (`upgrade`, `migrate`, `create`). Rust quality:
 
 Branch protection on `main` — all changes via PR. Branch **before** committing when a PR is planned. Pre-commit gate above is required for Rust.
 
-**First action in any fresh clone:** run `scripts/install-hooks.sh` (sets `core.hooksPath .githooks`). The tracked hooks enforce the commit-msg 50/72 + conventional format, bean hygiene, and the pre-push Rust gate *locally* — without them, those checks fail only in CI.
+**First action in any fresh clone:** run [scripts/install-hooks.sh](scripts/install-hooks.sh) (sets `core.hooksPath .githooks`). The tracked hooks enforce the commit-msg 50/72 + conventional format, bean hygiene, and the pre-push Rust gate *locally* — without them, those checks fail only in CI.
 
 **After every push on a PR branch:** `gh pr checks <PR> --watch`. If failing, `gh run view <run-id> --log-failed`. Task is not done until CI passes.
 
@@ -134,30 +134,28 @@ Branch protection on `main` — all changes via PR. Branch **before** committing
 
 ## Test Commands
 
+Use `just` recipes or raw commands:
 ```bash
-cargo nextest run                                          # all tests
-./scripts/workflow-test.sh styles-legacy/apa.csl           # oracle + batch impact
-node scripts/oracle.js styles-legacy/apa.csl               # component-level diff
-node scripts/report-core.js > /tmp/r.json && \
-  node scripts/check-core-quality.js \
-    --report /tmp/r.json \
-    --baseline scripts/report-data/core-quality-baseline.json
+just test                                                  # or cargo nextest run (all tests)
+just workflow-test styles-legacy/apa.csl                   # or ./scripts/workflow-test.sh styles-legacy/apa.csl
+just oracle styles-legacy/apa.csl                          # or node scripts/oracle.js styles-legacy/apa.csl
+just check-core-quality                                    # or node scripts/report-core.js > /tmp/r.json && ...
 ```
 
-Full catalogue and the **test-assertion rule** (no `contains()` with substrings <30 chars): `docs/guides/CODING_STANDARDS.md`. Test style (BDD `given/when/then`, `rstest` for parameterised): same doc.
+Full catalogue and the **test-assertion rule** (no `contains()` with substrings <30 chars): [CODING_STANDARDS.md](docs/guides/CODING_STANDARDS.md). Test style (BDD `given/when/then`, `rstest` for parameterised): same doc.
 
 ## Optional: jj Change Stack
 
-If `.jj` is present, see `docs/guides/JJ_AI_CHANGE_STACK.md`. Git remains the public surface. **jj skips all git hooks** — run commit-msg / pre-commit / pre-push manually before `jj git push`.
+If `.jj` is present, see [JJ_AI_CHANGE_STACK.md](docs/guides/JJ_AI_CHANGE_STACK.md). Git remains the public surface. **jj skips all git hooks** — run commit-msg / pre-commit / pre-push manually before `jj git push`.
 
 ## Pointers
 
-- Crate map: `crates/README.md`
-- Design principles: `docs/architecture/DESIGN_PRINCIPLES.md`
-- Architecture index: `docs/architecture/README.md`
-- Live fidelity: `docs/TIER_STATUS.md`
-- Coding standards: `docs/guides/CODING_STANDARDS.md`
-- Locale authoring: `docs/guides/AUTHORING_LOCALES.md`
-- Domain Expert workflow: `docs/guides/DOMAIN_EXPERT.md`
-- Repo-local harness spec: `docs/specs/REPO_LOCAL_HARNESS.md`
+- Crate map: [crates/README.md](crates/README.md)
+- Design principles: [docs/architecture/DESIGN_PRINCIPLES.md](docs/architecture/DESIGN_PRINCIPLES.md)
+- Architecture index: [docs/architecture/README.md](docs/architecture/README.md)
+- Live fidelity: [docs/TIER_STATUS.md](docs/TIER_STATUS.md)
+- Coding standards: [docs/guides/CODING_STANDARDS.md](docs/guides/CODING_STANDARDS.md)
+- Locale authoring: [docs/guides/AUTHORING_LOCALES.md](docs/guides/AUTHORING_LOCALES.md)
+- Domain Expert workflow: [docs/guides/DOMAIN_EXPERT.md](docs/guides/DOMAIN_EXPERT.md)
+- Repo-local harness spec: [docs/specs/REPO_LOCAL_HARNESS.md](docs/specs/REPO_LOCAL_HARNESS.md)
 - Frontmatter preflight: `./scripts/validate-frontmatter.sh --copilot-strict`

--- a/README.md
+++ b/README.md
@@ -62,13 +62,21 @@ cd citum-core
 ./scripts/dev-env.sh cargo test --workspace
 ```
 
-`./scripts/bootstrap.sh full` fetches the `styles-legacy/` and `tests/csl-test-suite/` submodules needed for migration and oracle workflows.
+For orchestrating common developer tasks (testing, quality gates, schema generation, etc.), this repository supports [just](https://github.com/casey/just). Run `just` at the root to see available recipes.
+
+`./scripts/bootstrap.sh full` fetches the `styles-legacy/` and tests/csl-test-suite submodules needed for migration and oracle workflows.
 
 `./scripts/dev-env.sh <cmd>` keeps `CARGO_TARGET_DIR` outside the repo at `${XDG_CACHE_HOME:-$HOME/.cache}/citum-core/target`.
 
 ### Key Commands
 
 Render references:
+
+```bash
+just render-refs styles/apa-7th.yaml tests/fixtures/references-expanded.json
+```
+
+Alternatively, run the raw command:
 
 ```bash
 cargo run --bin citum -- render refs \
@@ -79,6 +87,12 @@ cargo run --bin citum -- render refs \
 Validate a style and references:
 
 ```bash
+just check-style styles/apa-7th.yaml tests/fixtures/references-expanded.json
+```
+
+Alternatively, run the raw command:
+
+```bash
 cargo run --bin citum -- check \
   -s styles/apa-7th.yaml \
   -b tests/fixtures/references-expanded.json
@@ -87,10 +101,22 @@ cargo run --bin citum -- check \
 Validate all production styles:
 
 ```bash
+just validate-production-styles
+```
+
+Alternatively, run the script directly:
+
+```bash
 ./scripts/validate-production-styles.sh
 ```
 
 Convert reference formats:
+
+```bash
+just convert-refs tests/fixtures/references-expanded.json /tmp/refs.ris
+```
+
+Alternatively, run the raw command:
 
 ```bash
 cargo run --bin citum -- convert refs tests/fixtures/references-expanded.json \
@@ -102,11 +128,17 @@ Run `citum --help` for the full command surface.
 
 ### Crate Map
 
-See [`crates/README.md`](./crates/README.md) for the workspace layout and where work usually happens.
+See [crates/README.md](./crates/README.md) for the workspace layout and where work usually happens.
 
 ### Pre-Commit Gate
 
-Before committing `.rs`, `Cargo.toml`, or `Cargo.lock`:
+Before committing `.rs`, `Cargo.toml`, or `Cargo.lock`, run:
+
+```bash
+just pre-commit
+```
+
+Alternatively, run the raw commands:
 
 ```bash
 ./scripts/dev-env.sh cargo fmt --check
@@ -125,11 +157,11 @@ Conventional Commits (`type(scope): subject`, lowercase, 50/72 rule). See [`CONT
 | Resource | Location |
 |---|---|
 | Full user docs | [docs.citum.org](https://docs.citum.org) |
-| Specifications | [`docs/specs/`](./docs/specs/) |
-| Rendering workflow | [`docs/guides/RENDERING_WORKFLOW.md`](./docs/guides/RENDERING_WORKFLOW.md) |
-| Style authoring guide | [`docs/guides/style-author-guide.md`](./docs/guides/style-author-guide.md) |
-| Migration docs | [`crates/citum-migrate/README.md`](./crates/citum-migrate/README.md) |
-| Contributing | [`CONTRIBUTING.md`](./CONTRIBUTING.md) |
+| Specifications | [docs/specs/](./docs/specs/) |
+| Rendering workflow | [docs/guides/RENDERING_WORKFLOW.md](./docs/guides/RENDERING_WORKFLOW.md) |
+| Style authoring guide | [docs/guides/style-author-guide.md](./docs/guides/style-author-guide.md) |
+| Migration docs | [crates/citum-migrate/README.md](./crates/citum-migrate/README.md) |
+| Contributing | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 
 ## License
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,61 @@
+# Citum Project justfile
+# See https://github.com/casey/just for documentation
+
+# Default recipe: run the pre-commit gate
+default: pre-commit
+
+# Run the pre-commit gate (formatting check, clippy warnings as errors, and tests)
+pre-commit:
+    ./scripts/dev-env.sh cargo fmt --check
+    ./scripts/dev-env.sh cargo clippy --all-targets --all-features -- -D warnings
+    ./scripts/dev-env.sh cargo nextest run
+
+# Run all tests via nextest
+test:
+    ./scripts/dev-env.sh cargo nextest run
+
+# Regenerate schemas when crates/citum-cli or schema crates change
+schema-gen:
+    ./scripts/dev-env.sh cargo run --bin citum --features schema -- schema --out-dir docs/schemas
+    git add docs/schemas/
+
+# Bootstrap the development environment (setup can be 'minimal' or 'full')
+bootstrap setup="minimal":
+    ./scripts/bootstrap.sh {{setup}}
+
+# Render bibliography references using a style
+render-refs style="styles/embedded/apa-7th.yaml" refs="tests/fixtures/references-expanded.json":
+    ./scripts/dev-env.sh cargo run --bin citum -- render refs -s {{style}} -b {{refs}}
+
+# Validate a style YAML and reference library file
+check-style style="styles/embedded/apa-7th.yaml" refs="tests/fixtures/references-expanded.json":
+    ./scripts/dev-env.sh cargo run --bin citum -- check -s {{style}} -b {{refs}}
+
+# Validate all production styles in the repository
+validate-production-styles:
+    ./scripts/validate-production-styles.sh
+
+# Convert a bibliography reference library to another format (e.g. ris, csl-json)
+convert-refs input output:
+    ./scripts/dev-env.sh cargo run --bin citum -- convert refs {{input}} --output {{output}}
+
+# Run the local oracle comparison for a specific style (e.g. styles-legacy/apa.csl)
+oracle style:
+    node scripts/oracle.js {{style}}
+
+# Run the oracle + batch-impact workflow test on a legacy CSL file (e.g. styles-legacy/apa.csl)
+workflow-test csl:
+    ./scripts/workflow-test.sh {{csl}}
+
+# Generate a core rendering fidelity report and validate it against baseline quality gates (fails if any style's fidelity drops below 1.0)
+check-core-quality:
+    node scripts/report-core.js > /tmp/r.json
+    node scripts/check-core-quality.js --report /tmp/r.json --baseline scripts/report-data/core-quality-baseline.json
+
+# Refresh Top-10 oracle aggregate baselines
+oracle-refresh:
+    node scripts/oracle-batch-aggregate.js styles-legacy/ --top 10
+
+# Validate YAML frontmatter for local contributor AI skills and commands
+validate-frontmatter flags='--copilot-strict':
+    ./scripts/validate-frontmatter.sh {{flags}}


### PR DESCRIPTION
This PR introduces a root `justfile` to organize and document common developer workflows and command shortcuts, aligning with our Rust-centric developer environment.

### Changes
- **Root `justfile`**: Consolidates common commands (pre-commit checks, schema generation, nextest runs, oracle tests, and quality reporting).
- **`CLAUDE.md`**: Updated to document the new `just` shortcuts alongside the original raw commands.

### Benefits
- Centralizes scattered polyglot (Node, Python, Bash) script invocations.
- Makes tasks self-documenting (via `just --list`).
- Provides a standard, single-source-of-truth entry point for AI agents to run formatting, clippy, and test gates reliably.
