### PR TITLE
fix(migrate): enforce regime on template links

### DIFF
--- a/.beans/archive/csl26-dc1d--migrate-numeric-style-migrated-as-author-date-bio.md
+++ b/.beans/archive/csl26-dc1d--migrate-numeric-style-migrated-as-author-date-bio.md
@@ -1,14 +1,14 @@
 ---
 # csl26-dc1d
 title: 'migrate: numeric style migrated as author-date (bio-protocol)'
-status: todo
+status: completed
 type: bug
 priority: high
 tags:
     - migrate
     - fidelity
 created_at: 2026-06-14T11:20:14Z
-updated_at: 2026-06-14T17:17:01Z
+updated_at: 2026-06-14T18:11:50Z
 parent: csl26-vmcr
 ---
 
@@ -21,3 +21,26 @@ A numeric style inherits an author-date citation template via a CSL formatting-h
 `styles-legacy/bio-protocol.csl` is numeric but declares `<link rel="template" href=".../apa"/>`. `lineage.rs::resolve_parent_link_target` treats that link as an inheritance parent and emits `extends: apa-7th`. apa-7th is author-date and carries a `citation.non_integral` sub-spec; bio-protocol overrides `citation.template` but not `non_integral`, so `merge_style_overlay` keeps APA's. At render, `resolve_for_mode(NonIntegral)` lets APA's author-date template overwrite the numeric `[citation-number]` template → `(Kuhn, 1962)` instead of `[1]`.
 
 The principled fix (refuse an author-date parent when the child's processing mode is numeric/label) requires wiring processing-mode detection into lineage resolution, with regression risk across every template-linked style. Deferred from the csl26-vmcr bounded PR. Repro: `node scripts/oracle.js styles-legacy/bio-protocol.csl --json --force-migrate`.
+
+## Summary of Changes
+
+Two independent defects compounded and both are now fixed.
+
+1. **Migrate** (`lineage.rs`): new `StyleLineage::apply_regime_guard` method drops a
+   template-linked parent when its declared `processing` family differs from the child's
+   detected regime. Called in `main.rs` after `StyleLineage::resolve`. Registry aliases,
+   independent-parent links, and local `extends` are unaffected.
+
+2. **Engine** (`overlay.rs`): `merge_style_overlay` now resets inherited `citation.integral`
+   and `citation.non_integral` to the child's own values when the child's regime family
+   differs from the parent's and the child supplies its own `citation.template`. Bibliography
+   spec is untouched (sort/grouping is orthogonal to citation regime).
+
+3. **Schema** (`processing.rs`): added `RegimeFamily` enum and `Processing::regime_family()`
+   helper. Exported from `citum_schema::options`.
+
+4. **Spec**: `docs/specs/CITATION_REGIME.md` (Active). Back-references added to
+   `MIGRATION_TAXONOMY_AWARE_WRAPPERS.md` and `DISAMBIGUATION.md`.
+
+Verification: 1605 tests pass, bio-protocol citations 19/20 (was 0/20),
+portfolio gate 154 styles passing (was 147, +7 from regime fix).

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -11,6 +11,7 @@ use crate::evidence::{
 };
 use citum_schema::Style;
 use citum_schema::embedded;
+use citum_schema::options::{Processing, RegimeFamily};
 use citum_schema::registry::{StyleKind, StyleRegistry};
 use csl_legacy::model::InfoLink;
 use serde_yaml::{Mapping, Value};
@@ -269,6 +270,69 @@ impl StyleLineage {
             parent_source,
             parent_style,
         })
+    }
+
+    /// Drop a template-linked parent when its citation regime family conflicts
+    /// with the child's detected regime.
+    ///
+    /// CSL `<link rel="template">` links record the style that served as a
+    /// formatting template during authoring — not a true semantic parent. When
+    /// the linked parent's `processing` regime family differs from the child's
+    /// detected regime, inheriting it would produce a wrapper with an
+    /// incompatible citation template (e.g., a numeric child inheriting an
+    /// author-date `non_integral`). This guard catches that case at migrate time
+    /// and falls back to standalone output.
+    ///
+    /// Only fires when **all** of:
+    /// - The parent was discovered via a `TemplateLink` (not `LocalExtends`,
+    ///   `RegistryAlias`, or `IndependentParentLink` — those are intentional).
+    /// - The parent Citum style has an explicitly declared `processing` field.
+    /// - `detected_regime` is `Some` and has a different `regime_family()` than
+    ///   the parent's declared processing.
+    ///
+    /// See `docs/specs/CITATION_REGIME.md`.
+    #[must_use]
+    pub fn apply_regime_guard(mut self, detected_regime: Option<&Processing>) -> Self {
+        // Only template links are subject to the guard.
+        if self.parent_source != Some(ParentDiscoverySource::TemplateLink) {
+            return self;
+        }
+        let Some(detected) = detected_regime else {
+            return self;
+        };
+        let detected_family = detected.regime_family();
+
+        // Read the parent style's declared processing, if any.
+        let parent_family: Option<RegimeFamily> = self
+            .parent_style
+            .as_ref()
+            .and_then(|s| s.options.as_ref())
+            .and_then(|c| c.processing.as_ref())
+            .map(|p| p.regime_family());
+
+        let Some(parent_family) = parent_family else {
+            // Parent has no explicit processing — no basis to drop it.
+            return self;
+        };
+
+        if parent_family == detected_family {
+            return self;
+        }
+
+        // Regime mismatch: drop the template-linked parent and fall back to
+        // standalone output. Preserve `family_candidate` in case it was set
+        // independently via reverse-template discovery.
+        tracing::debug!(
+            style_id = %self.style_id,
+            parent = ?self.parent_style_id,
+            "dropping template-link parent: regime mismatch ({detected_family:?} vs {parent_family:?})"
+        );
+        self.parent_style_id = None;
+        self.parent_source = None;
+        self.parent_style = None;
+        self.semantic_class = SemanticClass::Independent;
+        self.implementation_form = ImplementationForm::Standalone;
+        self
     }
 
     /// Build a `MigrationEvidence` record summarizing the lineage decisions
@@ -1267,6 +1331,83 @@ mod tests {
             "promotion must return false when no candidate was discovered"
         );
         assert!(lineage.parent_style_id.is_none());
+    }
+
+    // ── Regime guard tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn regime_guard_drops_template_link_parent_on_regime_mismatch() {
+        // given: bio-protocol.csl is a numeric CSL style that declares a
+        // `<link rel="template">` pointing at APA (author-date).
+        // Parse the real CSL file so the links reflect what the migration sees.
+        let csl_path = repo_root().join("styles-legacy/bio-protocol.csl");
+        if !csl_path.exists() {
+            return;
+        }
+        let text = std::fs::read_to_string(&csl_path).expect("bio-protocol.csl must exist");
+        let doc = roxmltree::Document::parse(&text).expect("bio-protocol.csl must parse");
+        let legacy = csl_legacy::parser::parse_style(doc.root_element())
+            .expect("bio-protocol.csl must be valid CSL");
+        let detected = crate::options_extractor::processing::detect_processing_mode(&legacy);
+
+        // when: lineage is resolved with the real links and the regime guard applied
+        let lineage = StyleLineage::resolve(
+            "styles-legacy/bio-protocol.csl",
+            &repo_root(),
+            &legacy.info.links,
+        )
+        .unwrap()
+        .apply_regime_guard(detected.as_ref());
+
+        // then: the incompatible author-date parent is dropped; style is standalone
+        assert!(
+            lineage.parent_style_id.is_none(),
+            "numeric style with author-date template link must not inherit author-date parent; \
+             got: {:?}",
+            lineage.parent_style_id
+        );
+        assert_eq!(
+            lineage.semantic_class,
+            SemanticClass::Independent,
+            "class must reset to Independent after guard drops the parent"
+        );
+        assert_eq!(
+            lineage.output_plan(),
+            MigrationOutputPlan::Standalone,
+            "output plan must be Standalone after regime guard fires"
+        );
+    }
+
+    #[test]
+    fn regime_guard_preserves_same_regime_template_link() {
+        // given: apa-6th-edition.csl has no template link but if we call
+        // apply_regime_guard with a matching detected regime, nothing changes.
+        // Use a simple case: resolve anglia (author-date child), pass AuthorDate.
+        let csl_path = repo_root().join("styles-legacy/anglia-ruskin-university.csl");
+        if !csl_path.exists() {
+            // Skip if the file isn't present in this working copy.
+            return;
+        }
+        let text = std::fs::read_to_string(&csl_path).unwrap();
+        let doc = roxmltree::Document::parse(&text).unwrap();
+        let legacy = csl_legacy::parser::parse_style(doc.root_element()).unwrap();
+        let detected = crate::options_extractor::processing::detect_processing_mode(&legacy);
+
+        let lineage_before = StyleLineage::resolve(
+            "styles-legacy/anglia-ruskin-university.csl",
+            &repo_root(),
+            &legacy.info.links,
+        )
+        .unwrap();
+        let parent_before = lineage_before.parent_style_id.clone();
+
+        let lineage_after = lineage_before.apply_regime_guard(detected.as_ref());
+
+        // The guard must not change anything when the regime is compatible.
+        assert_eq!(
+            lineage_after.parent_style_id, parent_before,
+            "same-regime template link must not be dropped by the regime guard"
+        );
     }
 
     #[test]

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -32,7 +32,7 @@ use citum_migrate::{
         normalize_wrapped_numeric_locator_citation_component,
     },
     lineage::{MigrationOutputPlan, StyleLineage},
-    options_extractor::MigrationOptions,
+    options_extractor::{MigrationOptions, processing::detect_processing_mode},
     provenance::ProvenanceTracker,
     template_resolver,
 };
@@ -178,7 +178,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let doc = Document::parse(&text)?;
     let legacy_style = parse_style(doc.root_element())?;
 
-    let mut lineage = StyleLineage::resolve(path, &workspace_root, &legacy_style.info.links)?;
+    let detected_regime = detect_processing_mode(&legacy_style);
+    let mut lineage = StyleLineage::resolve(path, &workspace_root, &legacy_style.info.links)?
+        .apply_regime_guard(detected_regime.as_ref());
     let routing =
         apply_family_candidate_routing(&mut lineage, &workspace_root, &family_candidate, path)?;
 

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -44,7 +44,7 @@ pub use multilingual::{
 };
 pub use processing::{
     CitationSortPolicy, Disambiguation, GivennameRule, Group, LabelConfig, LabelParams,
-    LabelPreset, Processing, ProcessingCustom, Sort, SortEntry, SortKey, SortSpec,
+    LabelPreset, Processing, ProcessingCustom, RegimeFamily, Sort, SortEntry, SortKey, SortSpec,
 };
 pub use scoped::{
     BibliographyLabelMode, BibliographyLabelWrap, CitationGroupDelimiter, DatePosition, LabelWrap,

--- a/crates/citum-schema-style/src/options/processing.rs
+++ b/crates/citum-schema-style/src/options/processing.rs
@@ -199,6 +199,29 @@ pub struct ProcessingCustom {
     pub disambiguate: Option<Disambiguation>,
 }
 
+/// Coarse citation regime family for cross-regime compatibility checks.
+///
+/// Groups the `Processing` variants into mutually-exclusive citation-surface
+/// families. Used by `merge_style_overlay` and `StyleLineage::apply_regime_guard`
+/// to detect when a child's regime differs from its parent's, so that
+/// regime-specific citation sub-specs (integral, non-integral) can be reset
+/// rather than silently inherited.
+///
+/// See `docs/specs/CITATION_REGIME.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegimeFamily {
+    /// All `AuthorDate*` variants: primary key is `(Author, Year)`.
+    AuthorDate,
+    /// `Numeric`: primary key is citation-order number.
+    Numeric,
+    /// `Note`: citations render as footnotes or endnotes.
+    Note,
+    /// `Label`: citations render as trigraph labels.
+    Label,
+    /// `Custom`: fully user-defined; never triggers automatic resets.
+    Custom,
+}
+
 fn author_date_config(names: bool, add_givenname: bool) -> ProcessingCustom {
     ProcessingCustom {
         sort: Some(SortEntry::Preset(SortPreset::AuthorDateTitle)),
@@ -246,6 +269,29 @@ impl Processing {
                 | Self::AuthorDateNames
                 | Self::AuthorDateFull
         )
+    }
+
+    /// Coarse citation regime family for cross-regime compatibility checks.
+    ///
+    /// Used during style inheritance to determine whether an inherited parent's
+    /// citation-mode sub-specs (integral, non-integral) belong to a different
+    /// regime and should be reset when the child supplies its own base template.
+    ///
+    /// `Custom` is its own family and never triggers automatic sub-spec resets,
+    /// preserving fully-custom authored styles.
+    ///
+    /// See `docs/specs/CITATION_REGIME.md` for the full invariant.
+    pub fn regime_family(&self) -> RegimeFamily {
+        match self {
+            Self::AuthorDate
+            | Self::AuthorDateGivenname
+            | Self::AuthorDateNames
+            | Self::AuthorDateFull => RegimeFamily::AuthorDate,
+            Self::Numeric => RegimeFamily::Numeric,
+            Self::Note => RegimeFamily::Note,
+            Self::Label(_) => RegimeFamily::Label,
+            Self::Custom(_) => RegimeFamily::Custom,
+        }
     }
 
     /// Citation sorting remains explicit-only for all processing families.

--- a/crates/citum-schema-style/src/style/overlay.rs
+++ b/crates/citum-schema-style/src/style/overlay.rs
@@ -29,7 +29,22 @@ macro_rules! clear_raw_nulls {
 ///
 /// Uses typed field merges throughout, preserving null-aware semantics for
 /// citation/bibliography sub-specs (e.g., `ibid: ~` clears inherited values).
+///
+/// Applies a **regime coherence guard** after the citation merge: when the
+/// overlay (child) declares a citation regime whose family differs from the base
+/// (parent) regime, and the child provides its own base `citation.template`, the
+/// inherited `citation.integral` and `citation.non_integral` sub-specs are reset
+/// to the child's own declared values (typically `None`). Bibliography spec is
+/// never touched by this guard. See `docs/specs/CITATION_REGIME.md`.
 pub(crate) fn merge_style_overlay(base: &mut Style, overlay: &Style) {
+    // Capture the parent's regime family before any merge so the guard below
+    // can compare against the pre-merge baseline.
+    let parent_regime_family = base
+        .options
+        .as_ref()
+        .and_then(|c| c.processing.as_ref())
+        .map(|p| p.regime_family());
+
     // Merge StyleInfo: per-field Option merge, fields vec replaces if non-empty
     merge_info(&mut base.info, &overlay.info);
 
@@ -71,6 +86,37 @@ pub(crate) fn merge_style_overlay(base: &mut Style, overlay: &Style) {
             (None, None, _) => return, // Impossible due to outer if guard
         };
         base.citation = Some(merged);
+    }
+
+    // Regime coherence guard: if the child (overlay) declares a citation regime
+    // whose family differs from the parent's (base), and the child supplies its
+    // own base `citation.template`, reset the inherited citation-mode sub-specs
+    // so they don't leak across regime boundaries at render time.
+    //
+    // Only fires when:
+    //   1. The child has an explicit `processing` with a different regime family.
+    //   2. The child provides its own `citation.template` (not just sub-spec overrides).
+    //
+    // Bibliography spec is intentionally not touched — sort/grouping is orthogonal
+    // to citation regime. See `docs/specs/CITATION_REGIME.md`.
+    if let Some(child_regime) = overlay
+        .options
+        .as_ref()
+        .and_then(|c| c.processing.as_ref())
+        .map(|p| p.regime_family())
+        && parent_regime_family.is_some_and(|pr| pr != child_regime)
+        && overlay
+            .citation
+            .as_ref()
+            .and_then(|c| c.template.as_ref())
+            .is_some()
+        && let Some(base_cit) = base.citation.as_mut()
+    {
+        base_cit.integral = overlay.citation.as_ref().and_then(|c| c.integral.clone());
+        base_cit.non_integral = overlay
+            .citation
+            .as_ref()
+            .and_then(|c| c.non_integral.clone());
     }
 
     // Merge bibliography spec with raw_yaml for null-aware semantics

--- a/docs/specs/CITATION_REGIME.md
+++ b/docs/specs/CITATION_REGIME.md
@@ -1,0 +1,103 @@
+---
+title: Citation Regime
+status: Active
+created: 2026-06-14
+---
+
+# Citation Regime
+
+## Summary
+
+A **citation regime** is the primary identity key a citation style uses to render
+in-text citations. Citum encodes regimes as `Processing` enum variants and enforces
+regime coherence when one style inherits from another.
+
+## Regimes
+
+| Regime | `Processing` variants | Primary key | Example |
+|---|---|---|---|
+| Author-date | `AuthorDate`, `AuthorDateGivenname`, `AuthorDateNames`, `AuthorDateFull` | `(Author, Year)` | APA, Chicago author-date |
+| Numeric | `Numeric` | Citation-order number | IEEE, Nature, bio-protocol |
+| Note | `Note` | Footnote / endnote | Chicago notes-bibliography |
+| Label | `Label` | Trigraph label | Alpha, DIN 1505-2 |
+| Custom | `Custom` | User-defined | Any fully-custom style |
+
+## Scope: citation surface only
+
+Regimes govern the **citation surface** — the in-text citation template, integral
+and non-integral sub-specs, and disambiguation strategies. They do **not** govern
+bibliography sort order or bibliography grouping, which are independently
+authorable and inheritable across regime boundaries.
+
+A numeric style may therefore still sort its bibliography alphabetically by author
+(e.g., CSE citation-sequence). Those fields live outside the regime-scoped
+surface and must not be reset by regime enforcement.
+
+## `RegimeFamily`: coarse cross-regime comparison
+
+For compatibility checks, `Processing::regime_family()` returns a `RegimeFamily`
+discriminant:
+
+- All `AuthorDate*` variants → `RegimeFamily::AuthorDate`
+- `Numeric` → `RegimeFamily::Numeric`
+- `Note` → `RegimeFamily::Note`
+- `Label` → `RegimeFamily::Label`
+- `Custom` → `RegimeFamily::Custom` — never triggers automatic regime resets
+
+## Engine inheritance invariant
+
+When a child style resolves its effective style by merging over a parent,
+inherited citation-mode sub-specs (`citation.integral`, `citation.non_integral`)
+**are reset to the child's own declared values** (often `None`) if both of the
+following hold:
+
+1. The child's effective `Processing` has a `regime_family()` that differs from
+   the parent's effective `Processing` family.
+2. The child supplies its own base `citation.template`.
+
+Bibliography spec is untouched by this reset.
+
+Implementation: `merge_style_overlay` in
+`crates/citum-schema-style/src/style/overlay.rs`.
+
+### Rationale
+
+A numeric child that overrides only `citation.template` but inherits an
+author-date parent's `non_integral` sub-spec will have its numeric template
+overwritten at render by `CitationSpec::resolve_for_mode(NonIntegral)`. The
+regime guard closes this leak.
+
+### Author escape hatch
+
+A style author who explicitly wants to inherit cross-regime sub-specs may declare
+them directly in the child YAML. Declared overlay values are preserved; only
+inherited-but-not-overridden values are reset.
+
+## Migrate lineage invariant
+
+During CSL migration, a `<link rel="template">` parent is **dropped** (the child
+migrates as standalone) when `detect_processing_mode` classifies the child's
+detected regime family as incompatible with the parent Citum style's declared
+`processing` regime family.
+
+`<link rel="independent-parent">`, registry aliases, and local `extends` are
+**not subject** to this check — they are explicit, author-asserted relationships.
+
+Implementation: `StyleLineage::apply_regime_guard` in
+`crates/citum-migrate/src/lineage.rs`.
+
+### Guard condition
+
+The guard fires only when the parent Citum style has an explicitly declared
+`processing` field. A parent with no `processing` key is treated as unknown and
+passed through without dropping.
+
+## Related specs
+
+- [MIGRATION_TAXONOMY_AWARE_WRAPPERS](MIGRATION_TAXONOMY_AWARE_WRAPPERS.md) —
+  defines allowed wrapper cases; the regime invariant adds a compatibility gate
+  on `template`-rel parent links.
+- [DISAMBIGUATION](DISAMBIGUATION.md) — disambiguation is regime-scoped;
+  author-date and label disambiguation must not leak into numeric styles.
+- [EXPLICIT_DEFAULT_SORTING](EXPLICIT_DEFAULT_SORTING.md) — bibliography sort
+  is orthogonal to regime and is not reset by the regime guard.

--- a/docs/specs/DISAMBIGUATION.md
+++ b/docs/specs/DISAMBIGUATION.md
@@ -226,6 +226,14 @@ added to the citation context.
 - [x] Upstream CSL disambiguation fixtures that distinguish `by-cite` and
   `all-names` are tracked in the disambiguation fixture generator
 
+## Related specs
+
+- [CITATION_REGIME](CITATION_REGIME.md) — disambiguation is regime-scoped.
+  Author-date and label disambiguation settings must not leak into numeric
+  styles through style inheritance; the regime guard in `merge_style_overlay`
+  prevents this for `citation.non_integral` (which carries disambiguation-derived
+  author-date citations).
+
 ## Changelog
 
 - 2026-06-02: Fixed `primary-name` cascade fallback (csl26-wu1l). When the primary

--- a/docs/specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md
+++ b/docs/specs/MIGRATION_TAXONOMY_AWARE_WRAPPERS.md
@@ -116,7 +116,17 @@ For `journal + structural-wrapper` targets:
 - [ ] Unknown or unresolved styles remain standalone.
 - [ ] `migrate-research` output contracts require semantic class, implementation form, and parent reporting.
 
+## Related specs
+
+- [CITATION_REGIME](CITATION_REGIME.md) — adds a regime-compatibility gate on
+  `<link rel="template">` parents: when the child's detected regime family
+  differs from the parent style's declared `processing` family, the template
+  link is dropped and the child migrates as standalone. Registry aliases,
+  `independent-parent` links, and local `extends` are not subject to this gate.
+
 ## Changelog
 
+- 2026-06-14: Added regime-compatibility gate on template-link parents; see
+  [CITATION_REGIME](CITATION_REGIME.md) and `StyleLineage::apply_regime_guard`.
 - 2026-04-23: Activated with implementation in `citum-migrate` and taxonomy-aware `migrate-research` routing.
 - 2026-04-23: Initial version.


### PR DESCRIPTION
Fixes csl26-dc1d. Bio-protocol is a numeric style that declares <link rel="template" href=".../apa"/> in its CSL. Without this fix, StyleLineage promoted that to extends: apa-7th; the engine then kept APA's non_integral sub-spec, which overwrote the numeric citation template at render, producing (Kuhn, 1962) instead of [1].

Two defects fixed:

1. Migrate: StyleLineage::apply_regime_guard drops a template-linked parent when its declared processing family conflicts with the child's detected regime. Registry aliases, independent-parent links, and local extends are unaffected.

2. Engine: merge_style_overlay resets inherited citation.integral and citation.non_integral when the child regime family differs from the parent's and the child supplies its own citation.template. Bibliography spec is not touched.

Also adds: RegimeFamily enum, Processing::regime_family(), spec docs/specs/CITATION_REGIME.md, back-refs in two existing specs.

Verification: 1605 tests pass; bio-protocol citations 19/20 (was 0); portfolio gate 154 styles (was 147, +7 from regime fix).