### PR TITLE
fix(engine): suppress genre that echoes item type

### DIFF
--- a/.beans/archive/csl26-ya9b--migrate-spurious-urlaccessed-leaked-termtype-text.md
+++ b/.beans/archive/csl26-ya9b--migrate-spurious-urlaccessed-leaked-termtype-text.md
@@ -1,15 +1,17 @@
 ---
 # csl26-ya9b
 title: 'migrate: spurious URL/accessed + leaked term/type text in bibliography'
-status: todo
+status: completed
 type: bug
 priority: normal
 tags:
     - fidelity
     - migrate
 created_at: 2026-06-14T11:21:02Z
-updated_at: 2026-06-14T17:16:46Z
+updated_at: 2026-06-14T22:25:33Z
 parent: csl26-vmcr
+blocking:
+    - csl26-ivjp
 ---
 
 Migrated bibliographies emit fields citeproc omits and leak literal term/type text. china-information: 'Renaissance Art and Culture. Entry encyclopedia. in. Encyclopedia of World History' (leaked 'Entry encyclopedia. in.'); trailing 'accessed' / 'https://...' on non-web types across journal-of-advertising-research, early-medieval-europe. Converter-level: type-template selection emits an entry-encyclopedia literal and unconditional url/accessed. Repro: node scripts/oracle.js styles-legacy/china-information.csl --json --force-migrate
@@ -23,3 +25,29 @@ Not a single converter locus — three distinct defects across two layers, each 
 3. **Spurious url/accessed** — template generation: url/accessed emitted on non-web types.
 
 Entries also show unrelated low-fidelity gaps (missing publisher, dropped volume/pages, patent date format) — compounding defects per the 2026-06-14 locus audit. Deferred from the csl26-vmcr bounded PR for the same reason as csl26-dc1d: cross-layer, multi-cause, not bounded. Repro: `node scripts/oracle.js styles-legacy/china-information.csl --json --force-migrate`.
+
+## Summary of Changes
+
+Scoped to defect #1 (the genre echo). Defects #2 (`in.`) and #3 (spurious
+url/accessed) are split to follow-up bean csl26-ivjp — both are cross-layer
+template-generation changes with a broad regression surface (the original
+deferral reason from csl26-vmcr).
+
+**Root-cause correction:** the bean blamed the data-layer genre injection
+(`scholarly.rs`), but that injection is *load-bearing* — `ref_type()` reads the
+injected genre back to report the entry sub-type for type-variant selection
+(e.g. APA's entry-encyclopedia variant). Removing it regressed APA variant
+routing. The real leak is the *engine rendering* a genre value that merely
+restates the reference's own type.
+
+**Fix (engine, bounded):** `resolve_variable_value` (`citum-engine/src/values/
+variable.rs`) now suppresses `SimpleVariable::Genre` when the normalized genre
+equals `reference.ref_type()`. Such a genre is the data model's internal
+type-carrier (round-tripped for variant selection), which citeproc never emits.
+Styles that render real genres (genre != type) are unaffected; APA variant
+routing is untouched.
+
+**Verification:** 1605 tests pass; china-information no longer leaks
+"Entry encyclopedia." (`Vasari, G. Renaissance Art and Culture. in.
+Encyclopedia of World History. 2022`); portfolio gate 154 styles, fidelity 1.0,
+0 warnings (no regression).

--- a/.beans/csl26-ivjp--migrate-leaked-in-spurious-urlaccessed-in-migrated.md
+++ b/.beans/csl26-ivjp--migrate-leaked-in-spurious-urlaccessed-in-migrated.md
@@ -1,0 +1,27 @@
+---
+# csl26-ivjp
+title: 'migrate: leaked in. + spurious url/accessed in migrated bibliographies'
+status: todo
+type: bug
+priority: normal
+created_at: 2026-06-14T22:25:17Z
+updated_at: 2026-06-14T22:25:17Z
+parent: csl26-vmcr
+---
+
+Split from csl26-ya9b after the bounded genre-echo fix (defect #1) landed. Two template-generation defects remain; both are cross-layer with a broad regression surface (preserving CSL type/host conditionals during template specialization), which is why csl26-ya9b deferred them from the csl26-vmcr bounded PR.
+
+## Remaining defects
+
+- [ ] **Leaked `in.`** — the migrated `article-newspaper` template emits an unconditional `term: in` that fires with no host container. Visible in china-information: `Vasari, G. Renaissance Art and Culture. in. Encyclopedia of World History. 2022` (citeproc omits the `in.`). Locus: `crates/citum-migrate/src/template_compiler/`, `passes/suppression.rs`. Gate the term on host/parent-title presence.
+- [ ] **Spurious url/accessed on non-web types** — url/accessed emitted on non-web types across journal-of-advertising-research, early-medieval-europe. Locus: `crates/citum-migrate/src/template_compiler/`, `fixups/template.rs` (already special-cases webpage/accessed). Gate on the type-conditional citeproc uses.
+
+## Repro
+
+```
+node scripts/oracle.js styles-legacy/china-information.csl --json --force-migrate
+node scripts/oracle.js styles-legacy/journal-of-advertising-research.csl --json --force-migrate
+node scripts/oracle.js styles-legacy/early-medieval-europe.csl --json --force-migrate
+```
+
+Note: these styles also carry unrelated low-fidelity gaps (missing publisher, dropped volume/pages, name form) per the 2026-06-14 locus audit — compounding defects under a binary threshold.

--- a/crates/citum-engine/src/values/variable.rs
+++ b/crates/citum-engine/src/values/variable.rs
@@ -142,7 +142,15 @@ fn resolve_variable_value(
         SimpleVariable::PublisherPlace => reference.publisher_place(),
         SimpleVariable::OriginalPublisher => reference.original_publisher_str(),
         SimpleVariable::OriginalPublisherPlace => reference.original_publisher_place(),
-        SimpleVariable::Genre => reference.genre().map(|k| options.locale.lookup_genre(&k)),
+        // A genre that merely restates the reference's own type (e.g. an
+        // entry-encyclopedia carrying genre "entry-encyclopedia") is the data
+        // model's internal type-carrier, round-tripped through `ref_type()` for
+        // variant selection. citeproc never emits it, so rendering it only leaks
+        // literal type text into migrated bibliographies.
+        SimpleVariable::Genre => reference
+            .genre()
+            .filter(|genre| *genre != reference.ref_type())
+            .map(|k| options.locale.lookup_genre(&k)),
         SimpleVariable::Medium => reference.medium().map(|k| options.locale.lookup_medium(&k)),
         SimpleVariable::Status => reference.status(),
         SimpleVariable::Abstract | SimpleVariable::Note => None,


### PR DESCRIPTION
## What

Stops migrated bibliographies from leaking literal type text such as
`Entry encyclopedia.` Fixes defect #1 of csl26-ya9b (china-information).

## Root cause

The bean blamed the data-layer genre injection in `scholarly.rs`, but that
injection is **load-bearing**: `ref_type()` reads the injected genre back to
report an entry's sub-type for type-variant selection (e.g. APA's
`entry-encyclopedia` variant). Removing it regressed APA variant routing.

The real defect is the **engine rendering** a genre that merely restates the
reference's own type — a value citeproc never emits.

## Fix

`resolve_variable_value` (`citum-engine/src/values/variable.rs`) now drops
`SimpleVariable::Genre` when the normalized genre equals `ref_type()`. Such a
genre is the data model's internal type-carrier. Styles rendering real genres
(`genre != type`) and type-variant routing are unaffected.

## Scope

Defects #2 (leaked `in.`) and #3 (spurious url/accessed) are split to follow-up
bean `csl26-ivjp` — cross-layer template-generation work with a broad
regression surface (the original deferral reason from csl26-vmcr).

## Verification

- `just pre-commit`: 1605 tests pass; fmt + clippy clean
- `cargo doc --no-deps`: clean
- Oracle: china-information no longer renders `Entry encyclopedia.`
  (`Vasari, G. Renaissance Art and Culture. in. Encyclopedia of World History. 2022`)
- Portfolio gate: 154 styles, fidelity 1.0, 0 warnings (no regression)
