### PR TITLE
fix(migrate): gate url/accessed to web types

### DIFF
--- a/.beans/csl26-e94m--migrate-spurious-urlaccessed-on-non-web-types-spli.md
+++ b/.beans/csl26-e94m--migrate-spurious-urlaccessed-on-non-web-types-spli.md
@@ -1,11 +1,11 @@
 ---
 # csl26-e94m
 title: 'migrate: spurious url/accessed on non-web types (split from ivjp)'
-status: todo
+status: in-progress
 type: bug
 priority: normal
 created_at: 2026-06-15T00:09:28Z
-updated_at: 2026-06-15T00:09:38Z
+updated_at: 2026-06-15T16:16:11Z
 parent: csl26-vmcr
 ---
 
@@ -24,8 +24,36 @@ Source gate (jar.csl:153-158): url/accessed live under `<if type="webpage"><if v
 
 The leak's primary site is the **base** template (the interview entry renders via base, not a type-variant). Any base-template content change — wrapping the bare `accessed` term, or suppressing url/accessed — propagates through `extends` to type-variants that inherit the base (e.g. jar `legal_case`), and that triggers a **latent diff-resolver mismatch**: migrate's round-trip validator (`crates/citum-migrate/src/template_diff.rs::apply_template_variant_diff`) accepts a diff, but the engine's resolver (`crates/citum-schema-style/src/template/resolution.rs::resolve_template_variant`) resolves it differently, corrupting the variant's rendering (jar "Brown v. Board of Education" flips pass→fail). Verified 2026-06-14: `in`-only leaves the base untouched and Brown passes; gating base `accessed` corrupts Brown while fixing the interview.
 
-## Plan
+## Diagnosis (2026-06-15)
 
-- [ ] Reproduce and fix the migrate-vs-engine diff-application mismatch so a base/parent change cannot corrupt `extends`-based type-variants. Likely: align `apply_template_variant_diff` with `resolve_template_variant`, or harden migrate's round-trip check to validate via the engine resolver so only engine-safe diffs are emitted.
-- [ ] With the diff resolver hardened, gate url + the `accessed` term/date on web types only (`webpage`, `post`, `post-weblog`), per the source `type=` conditional. The `crates/citum-migrate/src/fixups/gating.rs` infrastructure (companion run + group wrapping) and `fixups/template.rs` webpage special-casing are the starting points.
-- [ ] Verify the two repros above no longer show spurious url/accessed, and the full migrate batch (`oracle-migrate-batch.js`) shows no regression (especially jar `legal_case`).
+The url/accessed gate cannot be safely applied within the current `build_final_style` architecture.
+The root cause is that diff encoding (`build_type_variants`) is computed in the same pass as fixup
+application. Any fixup that touches the base template changes the diff weights for type-variant
+encoding. Specifically:
+
+- Gating url/accessed on the base template shifts the base→`legal_case` diff weight, causing
+  `bill` to win as a parent variant instead of the base (jar Brown v. Board regression).
+- Moving the gate AFTER `build_type_variants` makes it inconsistent with the base stored in
+  `Diff.extends` references.
+- `engine_validate_variants` (round-trip safety net) validates structural correctness of the diff
+  but cannot fix the wrong template content selected via a corrupted diff weight.
+
+This is a systemic problem, not a one-off. Any future fixup that touches the base template will
+face the same ordering trap.
+
+## Pivot: spec-first (2026-06-15)
+
+Instead of patching the ordering in-place, this PR delivers a spec documenting the required
+refactor: `docs/specs/MIGRATE_FULL_FIRST_ARCHITECTURE.md`.
+
+The spec defines the **Full-first, normalize-later** design:
+1. Phase 1 — apply all semantic fixups to Full (standalone) type templates.
+2. Phase 2 — run `build_type_variants` once, after all fixups, as a pure compression pass.
+
+## Remaining work (implementation)
+
+- [ ] Restructure `build_final_style` so `build_type_variants` is called only after all fixups.
+- [ ] Apply `postprocess_inferred_bibliography` on both inferred and XML-seed-winner paths.
+- [ ] Restore `engine_validate_variants` as the Phase 2 round-trip safety net.
+- [ ] Implement `gate_web_only_url_accessed` as a Phase 1 fixup per the spec.
+- [ ] Verify Brown passes and url/accessed leak is fixed; full batch shows no regression.

--- a/crates/citum-migrate/src/fixups/gating.rs
+++ b/crates/citum-migrate/src/fixups/gating.rs
@@ -18,7 +18,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use citum_schema::{
     locale::GeneralTerm,
     template::{
-        ContributorRole, DelimiterPunctuation, TemplateComponent, TemplateGroup, TitleType,
+        ContributorRole, DateVariable, DelimiterPunctuation, SimpleVariable, TemplateComponent,
+        TemplateGroup, TitleType, TypeSelector,
     },
 };
 
@@ -79,6 +80,100 @@ fn is_live_in_term(component: &TemplateComponent) -> bool {
         component,
         TemplateComponent::Term(term)
             if term.term == GeneralTerm::In && component.rendering().suppress != Some(true)
+    )
+}
+
+/// Reference types that citeproc-js gates url/accessed on.
+///
+/// Matches the `type="webpage post post-weblog"` conditional in CSL source.
+const WEB_TYPES: &[&str] = &["webpage", "post", "post-weblog"];
+
+/// Gate url and accessed components to web-only type templates.
+///
+/// citeproc-js renders url and the `accessed` term/date only when
+/// `type="webpage post post-weblog"`. The converter flattens the wrapping
+/// `<if type="webpage">` gate into the base template, so url and accessed
+/// leak into every entry type. This fixup restores the gate:
+///
+/// - **Base and non-web type-templates** (`webpage`, `post`, `post-weblog`
+///   absent from the selector): url variable, accessed date, and bare
+///   `accessed` label terms are removed. An orphan `accessed` term with no
+///   accompanying accessed date is purely spurious and is dropped.
+/// - **Web type-templates** (selector matches a web type): left untouched so
+///   the engine keeps its url/accessed rendering.
+///
+/// Must be called **before** `build_type_variants` so that the cleaned base
+/// and type-template components are captured in diffs consistently.
+pub fn gate_web_only_url_accessed(
+    base_template: &mut Vec<TemplateComponent>,
+    type_templates: &mut indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>,
+) {
+    strip_url_accessed(base_template);
+    for (selector, template) in type_templates.iter_mut() {
+        if !super::selector_matches_any(selector, WEB_TYPES) {
+            strip_url_accessed(template);
+        }
+    }
+}
+
+/// Removes url variable, accessed date, and bare accessed label terms from a template.
+///
+/// An `accessed` term immediately followed by an accessed date is a label/date
+/// pair introduced by the CSL webpage block; both are dropped. An orphan
+/// `accessed` term with no accompanying accessed date is also dropped.
+fn strip_url_accessed(template: &mut Vec<TemplateComponent>) {
+    let original = std::mem::take(template);
+    let mut out: Vec<TemplateComponent> = Vec::with_capacity(original.len());
+    let mut iter = original.into_iter().peekable();
+
+    while let Some(component) = iter.next() {
+        if is_url_variable(&component) || is_accessed_date(&component) {
+            // Drop url and standalone accessed-date components unconditionally.
+            continue;
+        }
+        if is_accessed_term(&component) {
+            // Consume the accessed term and any immediately following accessed
+            // date (the pair introduced by the CSL webpage accessed block).
+            // Neither renders correctly on non-web types; both are dropped.
+            if iter.peek().is_some_and(is_accessed_date) {
+                iter.next(); // drop the accompanying date too
+            }
+            continue;
+        }
+        // Recurse into groups so nested url/accessed are also cleaned.
+        let mut component = component;
+        if let TemplateComponent::Group(ref mut group) = component {
+            strip_url_accessed(&mut group.group);
+            // If the group is now empty after stripping, omit it entirely.
+            if group.group.is_empty() {
+                continue;
+            }
+        }
+        out.push(component);
+    }
+
+    *template = out;
+}
+
+fn is_url_variable(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Variable(v) if v.variable == SimpleVariable::Url
+    )
+}
+
+fn is_accessed_date(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Date(d) if d.date == DateVariable::Accessed
+    )
+}
+
+fn is_accessed_term(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Term(t)
+            if t.term == GeneralTerm::Accessed && component.rendering().suppress != Some(true)
     )
 }
 
@@ -203,5 +298,114 @@ mod tests {
             &template[0],
             TemplateComponent::Term(term) if term.term == GeneralTerm::In
         ));
+    }
+
+    // ── gate_web_only_url_accessed tests ────────────────────────────────────
+
+    fn url_variable() -> TemplateComponent {
+        use citum_schema::template::{SimpleVariable, TemplateVariable};
+        TemplateComponent::Variable(TemplateVariable {
+            variable: SimpleVariable::Url,
+            ..Default::default()
+        })
+    }
+
+    fn accessed_date() -> TemplateComponent {
+        TemplateComponent::Date(TemplateDate {
+            date: DateVariable::Accessed,
+            ..Default::default()
+        })
+    }
+
+    fn accessed_term() -> TemplateComponent {
+        TemplateComponent::Term(TemplateTerm {
+            term: GeneralTerm::Accessed,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn given_base_template_with_url_and_accessed_when_gated_then_all_stripped() {
+        // jar-style base: issued_date, url_variable, accessed_term, accessed_date
+        // citeproc-js only emits these for webpage/post types; non-web base must
+        // not carry them.
+        let mut base = vec![
+            issued_date(),
+            url_variable(),
+            accessed_term(),
+            accessed_date(),
+        ];
+        let mut type_templates = indexmap::IndexMap::new();
+        gate_web_only_url_accessed(&mut base, &mut type_templates);
+        assert_eq!(base.len(), 1, "only issued_date should remain in the base");
+        assert!(
+            matches!(&base[0], TemplateComponent::Date(d) if d.date == DateVariable::Issued),
+            "remaining component should be the issued date"
+        );
+    }
+
+    #[test]
+    fn given_non_web_type_template_with_url_when_gated_then_url_removed() {
+        // An article-journal type-template must not carry url/accessed even if
+        // it was flattened from a source conditional.
+        let mut base = vec![issued_date()];
+        let mut type_templates = indexmap::IndexMap::new();
+        type_templates.insert(
+            TypeSelector::Single("article-journal".to_string()),
+            vec![issued_date(), url_variable()],
+        );
+        gate_web_only_url_accessed(&mut base, &mut type_templates);
+        let article = type_templates
+            .get(&TypeSelector::Single("article-journal".to_string()))
+            .expect("article-journal template should still exist");
+        assert_eq!(
+            article.len(),
+            1,
+            "url should be removed from article-journal template"
+        );
+        assert!(
+            matches!(&article[0], TemplateComponent::Date(d) if d.date == DateVariable::Issued),
+            "issued date should remain in article-journal template"
+        );
+    }
+
+    #[test]
+    fn given_webpage_type_template_with_url_when_gated_then_url_retained() {
+        // webpage entries should keep url/accessed intact — that is the correct
+        // citeproc-js behaviour for web sources.
+        let mut base = vec![issued_date()];
+        let mut type_templates = indexmap::IndexMap::new();
+        type_templates.insert(
+            TypeSelector::Single("webpage".to_string()),
+            vec![
+                issued_date(),
+                url_variable(),
+                accessed_term(),
+                accessed_date(),
+            ],
+        );
+        gate_web_only_url_accessed(&mut base, &mut type_templates);
+        let webpage = type_templates
+            .get(&TypeSelector::Single("webpage".to_string()))
+            .expect("webpage template should still exist");
+        assert_eq!(
+            webpage.len(),
+            4,
+            "url, accessed-term and accessed-date should be retained for webpage type"
+        );
+    }
+
+    #[test]
+    fn given_orphan_accessed_term_with_no_date_when_gated_then_term_dropped() {
+        // A bare accessed term with no following accessed date is purely
+        // spurious: there is no date to gate the label on, so drop it.
+        let mut base = vec![issued_date(), accessed_term()];
+        let mut type_templates = indexmap::IndexMap::new();
+        gate_web_only_url_accessed(&mut base, &mut type_templates);
+        assert_eq!(base.len(), 1, "orphan accessed term should be dropped");
+        assert!(
+            matches!(&base[0], TemplateComponent::Date(d) if d.date == DateVariable::Issued),
+            "only issued date should remain"
+        );
     }
 }

--- a/crates/citum-migrate/src/fixups/mod.rs
+++ b/crates/citum-migrate/src/fixups/mod.rs
@@ -19,6 +19,17 @@ pub fn gate_leaked_in_term(template: &mut Vec<TemplateComponent>) {
     gating::gate_leaked_in_term(template);
 }
 
+/// Gates url and accessed components to web-only type templates.
+///
+/// Must be called before `build_type_variants` so that the cleaned base and
+/// type-template components are reflected consistently in derived diffs.
+pub fn gate_web_only_url_accessed(
+    base_template: &mut Vec<TemplateComponent>,
+    type_templates: &mut indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>,
+) {
+    gating::gate_web_only_url_accessed(base_template, type_templates);
+}
+
 /// Returns whether a type selector matches any candidate type name.
 #[must_use]
 pub fn selector_matches_any(selector: &TypeSelector, candidates: &[&str]) -> bool {

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -28,7 +28,8 @@ use citum_migrate::{
     },
     fixups::{
         ensure_numeric_locator_citation_component, ensure_personal_communication_omitted,
-        move_group_wrap_to_citation_items, normalize_author_date_locator_citation_component,
+        gate_web_only_url_accessed, move_group_wrap_to_citation_items,
+        normalize_author_date_locator_citation_component, normalize_legal_case_type_template,
         normalize_wrapped_numeric_locator_citation_component,
     },
     lineage::{MigrationOutputPlan, StyleLineage},
@@ -96,6 +97,18 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
             .as_ref()
             .and_then(|bib| bib.sort.as_ref()),
     );
+
+    // Gate url and accessed to web-only types on the FINAL selected templates,
+    // matching citeproc-js `type="webpage post post-weblog"`. Must run here
+    // (after synthesis selects the winning base + type-templates) rather than
+    // in the XML seed, so synthesis scoring and the inferred webpage-merge are
+    // unaffected. Must also run before build_type_variants so the cleaned base
+    // and per-type components are captured in diffs consistently.
+    {
+        let mut empty = TypeTemplateMap::new();
+        let type_templates = c.type_templates.as_mut().unwrap_or(&mut empty);
+        gate_web_only_url_accessed(&mut c.new_bib, type_templates);
+    }
 
     // [PRUNING] Remove bibliography type-variants identical to the primary template.
     if let Some(type_templates) = c.type_templates.as_mut() {
@@ -869,6 +882,13 @@ fn select_and_process_bibliography_template(
 
     if inferred_bib_source {
         postprocess_inferred_bibliography(&mut new_bib, &mut type_templates, legacy_style);
+    } else {
+        // Path-independent semantic fixups must also run on the XML-seed path.
+        // normalize_legal_case_type_template corrects the XML compiler's
+        // legal_case shape (authority/editor/volume) to the base-shaped form;
+        // without it a gated base lets `bill` win as the `extends` parent and
+        // the wrong shape is emitted (jar "Brown v. Board of Education").
+        normalize_legal_case_type_template(legacy_style, &mut type_templates);
     }
 
     (new_bib, type_templates, inferred_bib_source)

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -5,10 +5,13 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Template variant diff computation for bibliography type-variant generation.
 
-use citum_schema::template::{
-    Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
-    TemplateModifyOperation, TemplateRemoveOperation, TemplateVariant, TemplateVariantDiff,
-    TypeSelector,
+use citum_schema::{
+    BibliographySpec, Style,
+    template::{
+        Rendering, TemplateAddOperation, TemplateComponent, TemplateComponentSelector,
+        TemplateModifyOperation, TemplateRemoveOperation, TemplateVariant, TemplateVariantDiff,
+        TypeSelector,
+    },
 };
 use std::collections::BTreeMap;
 
@@ -24,6 +27,7 @@ pub(crate) fn build_type_variants(
 ) -> TypeVariantMap {
     let mut variants = TypeVariantMap::new();
     let mut candidate_parents: Vec<(TypeSelector, Vec<TemplateComponent>)> = Vec::new();
+    let intended_templates = type_templates.clone();
 
     for (selector, template) in type_templates {
         let variant = template_variant_from_full_template(
@@ -34,6 +38,62 @@ pub(crate) fn build_type_variants(
         );
         variants.insert(selector.clone(), variant);
         candidate_parents.push((selector, template));
+    }
+
+    engine_validate_variants(default_template, variants, &intended_templates)
+}
+
+/// Validate all derived variants through the engine's authoritative resolver.
+///
+/// Constructs a throwaway [`Style`] that mirrors what the engine will load,
+/// resolves it with the same logic the engine uses at render time, and
+/// compares each engine-resolved template against the original intended target.
+/// Any variant whose engine-resolved form diverges from the intent is demoted
+/// to [`TemplateVariant::Full`] so the engine can use it without reconstruction.
+///
+/// This eliminates the latent migrate-vs-engine diff-resolver mismatch where
+/// migrate's private pairwise check accepted diffs that the engine's recursive
+/// `extends` resolution would apply differently (e.g. corrupting `legal_case`
+/// when the shared base template was modified by a fixup).
+pub(crate) fn engine_validate_variants(
+    default_template: &[TemplateComponent],
+    mut variants: TypeVariantMap,
+    intended_templates: &TypeTemplateMap,
+) -> TypeVariantMap {
+    // Build a minimal throwaway style that carries exactly the section template
+    // and the candidate variant map — no extends, no version, no citum-version
+    // constraint — so try_into_resolved() only runs resolve_style_template_variants.
+    let probe = Style {
+        bibliography: Some(BibliographySpec {
+            template: Some(default_template.to_vec()),
+            type_variants: Some(variants.clone()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let engine_resolved_variants = probe
+        .try_into_resolved()
+        .ok()
+        .and_then(|s| s.bibliography)
+        .and_then(|bib| bib.type_variants);
+
+    for (selector, variant) in &mut variants {
+        if !matches!(variant, TemplateVariant::Diff(_)) {
+            continue;
+        }
+        let Some(target) = intended_templates.get(selector) else {
+            continue;
+        };
+        let engine_template = engine_resolved_variants
+            .as_ref()
+            .and_then(|m| m.get(selector))
+            .and_then(TemplateVariant::as_template);
+        if engine_template != Some(target.as_slice()) {
+            // Engine resolves this diff to a different template than intended:
+            // demote to Full so the engine uses the correct template verbatim.
+            *variant = TemplateVariant::Full(target.clone());
+        }
     }
 
     variants
@@ -400,4 +460,118 @@ fn lcs_pairs(left: &[String], right: &[String]) -> Vec<(usize, usize)> {
         }
     }
     pairs
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod tests {
+    use super::*;
+    use citum_schema::template::{
+        SimpleVariable, TemplateComponent, TemplateTitle, TemplateVariable, TemplateVariant,
+        TemplateVariantDiff, TitleType, TypeSelector,
+    };
+
+    fn title_component() -> TemplateComponent {
+        TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            ..Default::default()
+        })
+    }
+
+    fn url_component() -> TemplateComponent {
+        use citum_schema::template::SimpleVariable;
+        TemplateComponent::Variable(TemplateVariable {
+            variable: SimpleVariable::Url,
+            ..Default::default()
+        })
+    }
+
+    fn url_selector() -> TemplateComponentSelector {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "variable".to_string(),
+            serde_json::to_value(SimpleVariable::Url).unwrap(),
+        );
+        TemplateComponentSelector { fields }
+    }
+
+    #[test]
+    fn given_diff_with_anchor_absent_from_base_when_engine_validated_then_demoted_to_full() {
+        // Regression guard for the migrate-vs-engine diff-resolver mismatch:
+        // a Diff whose remove operation targets an anchor not present in the
+        // default template must be caught by engine_validate_variants and
+        // demoted to Full so the engine can use the correct template verbatim.
+        //
+        // This mirrors what can happen when a base-fixup removes a component
+        // (e.g. url) after a Diff was derived against the old base — the stored
+        // Diff would reference the now-absent component, causing the engine to
+        // fail resolution and producing wrong output.
+        let default_template = vec![title_component()];
+
+        // "article" intended: [title_component] (url was never there after fixup)
+        // but a hand-crafted Diff still tries to remove url, which the engine
+        // cannot find in the section template.
+        let bad_diff = TemplateVariant::Diff(TemplateVariantDiff {
+            remove: vec![citum_schema::template::TemplateRemoveOperation {
+                match_selector: url_selector(),
+            }],
+            ..Default::default()
+        });
+
+        let mut variants = TypeVariantMap::new();
+        variants.insert(TypeSelector::Single("article".to_string()), bad_diff);
+
+        let mut intended = TypeTemplateMap::new();
+        intended.insert(
+            TypeSelector::Single("article".to_string()),
+            vec![title_component()],
+        );
+
+        let result = engine_validate_variants(&default_template, variants, &intended);
+        let article = result
+            .get(&TypeSelector::Single("article".to_string()))
+            .expect("article variant should be present");
+
+        assert!(
+            matches!(article, TemplateVariant::Full(_)),
+            "bad Diff with absent anchor should be demoted to Full by engine_validate_variants"
+        );
+        let TemplateVariant::Full(template) = article else {
+            panic!("variant should be Full after demotion");
+        };
+        assert_eq!(
+            template,
+            &vec![title_component()],
+            "demoted Full template should match the original intended template"
+        );
+    }
+
+    #[test]
+    fn given_correct_diff_when_engine_validated_then_diff_retained() {
+        // A Diff that the engine can round-trip correctly must not be demoted.
+        let default_template = vec![title_component(), url_component()];
+
+        // "article" drops url — a valid diff the engine can apply.
+        let mut type_templates = TypeTemplateMap::new();
+        type_templates.insert(
+            TypeSelector::Single("article".to_string()),
+            vec![title_component()],
+        );
+
+        let variants = build_type_variants(&default_template, type_templates);
+        let article = variants
+            .get(&TypeSelector::Single("article".to_string()))
+            .expect("article variant should be present");
+
+        assert!(
+            matches!(article, TemplateVariant::Diff(_)),
+            "a valid Diff should be kept as Diff — engine_validate_variants must not demote correct diffs"
+        );
+    }
 }

--- a/docs/specs/MIGRATE_FULL_FIRST_ARCHITECTURE.md
+++ b/docs/specs/MIGRATE_FULL_FIRST_ARCHITECTURE.md
@@ -1,0 +1,237 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+-->
+
+# citum-migrate: Full-First Type-Variant Architecture
+
+**Status:** Draft
+**Date:** 2026-06-15
+**Bean:** `csl26-e94m` (trigger), see also `csl26-fk0w` (co-evolution epic)
+**Related:**
+[`OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md`](OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md),
+[`docs/architecture/audits/2026-06-14_MIGRATE_FIDELITY_LOCUS_CLASSIFICATION.md`](../architecture/audits/2026-06-14_MIGRATE_FIDELITY_LOCUS_CLASSIFICATION.md)
+
+## Problem
+
+`citum-migrate` currently conflates two distinct concerns in `build_final_style`
+([`main.rs`](../../crates/citum-migrate/src/main.rs)):
+
+1. **Semantic fixups** — correcting synthesis output to match citeproc-js
+   behavior (e.g. gating `url`/`accessed` to web types, normalizing
+   `legal_case`, ensuring media type templates exist).
+2. **Diff encoding** — compressing the `TypeTemplateMap` of full per-type
+   templates into a `TypeVariantMap` whose entries may be `Diff` (extends a
+   parent) or `Full` (standalone), implemented in `build_type_variants`
+   ([`template_diff.rs`](../../crates/citum-migrate/src/template_diff.rs)).
+
+Because diff encoding is computed immediately after fixups run on the *same
+pass* over the assembled style, any fixup that touches the base template or a
+type template affects the diff weights computed against it. The ordering is
+load-bearing in a way that makes it impossible to add or move fixups without
+risking variant corruption.
+
+### Concrete failure: url/accessed gating (csl26-e94m)
+
+citeproc-js gates `url` and `accessed` at **render time** based on reference
+type (`type="webpage post post-weblog"`). The CSL XML compiler drops this
+`<if type="webpage">` gate when compiling the layout tree, so url/accessed leak
+into the base template for all types.
+
+The natural fix is a post-synthesis fixup that strips url/accessed from the
+base template and all non-web type templates. But doing this before
+`build_type_variants` changes which candidate parent wins for `legal_case` (the
+base→`legal_case` diff weight shifts, `bill` wins as parent instead of the
+base), corrupting the Brown v. Board of Education test case. Moving the fixup
+after `build_type_variants` makes it inconsistent with the base stored in
+`Diff.extends` references.
+
+This is not a fixable ordering problem within the current design. It is a
+symptom of conflating fixup application with diff encoding.
+
+### Root cause in general terms
+
+Diff encoding requires a stable, finalized base template. The current pipeline
+finalizes the base and encodes diffs in the same pass, so any late-arriving
+fixup that is correct at the semantic level is incorrect at the structural
+level (corrupts existing diffs) or cannot be applied at all.
+
+The same class of problem will recur for any fixup that:
+- Removes a component from the base that is referenced by existing diffs
+- Adds a component to the base that changes which variant is the cheapest diff
+- Reorders or wraps base components in ways that shift LCS alignment
+
+`gate_leaked_in_term` (`csl26-ivjp`) avoided this class because it only
+operates on **type-variant** templates after they are flattened from the base,
+never on the base itself. That exemption cannot be assumed for future fixups.
+
+## Proposed Design: Full-First, Normalize-Later
+
+Separate fixup application from diff encoding by ensuring `build_type_variants`
+is called only after all fixups have run, operating on finalized Full templates.
+
+### Two-phase assembly in `build_final_style`
+
+**Phase 1 — Full templates:** assemble the base template and a
+`TypeTemplateMap` where every entry is a complete, standalone
+`Vec<TemplateComponent>`. Apply all semantic fixups at this stage. No
+`Diff`/`extends` references exist yet; fixups see only concrete template
+components and can modify them freely.
+
+**Phase 2 — Compression:** pass the finalized base and `TypeTemplateMap` to
+`build_type_variants` (or a renamed successor). This function computes diffs
+purely as a serialization optimization. It emits `TemplateVariant::Diff` only
+when the diff round-trips correctly through `engine_validate_variants`; all
+others emit `TemplateVariant::Full`. The output is the `TypeVariantMap` stored
+in the style.
+
+```
+Synthesis
+  └─ select_and_process_bibliography_template
+       → (new_bib: Full, type_templates: TypeTemplateMap of Full)
+
+Phase 1 — Fixups (order-independent within this phase)
+  ├─ postprocess_inferred_bibliography        (scrubs artifacts, relaxes suppression)
+  ├─ normalize_legal_case_type_template       (semantic: legal-case formatting)
+  ├─ ensure_inferred_media_type_templates     (semantic: media type completeness)
+  ├─ ensure_inferred_patent_type_template     (semantic: patent template)
+  ├─ gate_web_only_url_accessed          ← NEW: strips url/accessed from non-web types
+  └─ [future fixups, freely ordered]
+
+Phase 2 — Compression (pure serialization pass)
+  └─ build_type_variants(finalized_base, finalized_type_templates)
+       → TypeVariantMap (Diff where safe, Full otherwise)
+```
+
+### What changes
+
+| Component | Current role | New role |
+|---|---|---|
+| `build_type_variants` | Called once in `build_final_style` immediately after fixups; result is the stored output | Called once at the END of `build_final_style`, after ALL fixups; semantics unchanged |
+| `postprocess_inferred_bibliography` | Only called on the inferred path | Called on all paths (inferred and XML-seed winner), since it encodes semantic knowledge, not inference artifacts |
+| `engine_validate_variants` | Disabled / commented out | Restored as the round-trip safety net for Phase 2. A `Diff` that fails engine round-trip is demoted to `Full`; this is the only correctness gate needed for compression. |
+| Fixups that touch base template | Ordering is load-bearing | Ordering within Phase 1 is free; only constraint is Phase 1 before Phase 2 |
+| `gate_web_only_url_accessed` | Could not be added without regression | Added in Phase 1; strips url/accessed from base and non-web type templates before compression |
+
+### What does NOT change
+
+- The synthesis loop (`src/synthesis/`), scoring, and candidate selection are
+  unchanged. This refactor is downstream of synthesis selection.
+- The XML seed candidate survives as Phase 1 input (as `OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md`
+  specifies, until it wins ≈0 selections).
+- `options_extractor/` (et-al thresholds, sort keys, etc.) is unaffected.
+- The `TemplateVariant::Diff` / `TemplateVariant::Full` schema is unchanged.
+- The style YAML serialization format is unchanged.
+
+## Refactor vs. Rewrite
+
+A full rewrite of `citum-migrate` around the Phase 2 synthesis loop would
+address the same class of problem but at far greater scope and risk. The
+diagnosis for the current tail fidelity is that failures are
+**converter-dominated** (wrong or missing template data from the synthesis
+candidates), not architecture-dominated. The Full-first ordering fix is
+targeted and verifiable: it unblocks a class of fixups (render-time gating)
+that are currently impossible to apply without regression.
+
+The synthesis loop itself is already the correct architecture per
+`OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md` Phase 2. The problem is in the assembly
+code that handles the synthesis loop's *output*, not the loop itself.
+
+A rewrite should be evaluated separately, after the fidelity locus
+classification matures and the XML seed wins ≈0 selections. At that point the
+XML compiler can be removed and the fixup layer audited for which functions
+compensate for XML-seed artifacts (can be deleted) vs. encode genuine semantic
+knowledge (must survive in any rewrite). See [Fixup Audit](#fixup-audit) below.
+
+## Fixup Audit
+
+Classifying the current fixup surface by purpose, to inform future rewrite
+scope:
+
+| Fixup | File | Class | Notes |
+|---|---|---|---|
+| `gate_leaked_in_term` | `fixups/gating.rs` | XML-seed artifact | `<if>` group flattening drops the enclosing group; type-variant specialization leaves a bare `in` term. Needed only because the XML compiler flattens conditionals. |
+| `scrub_inferred_literal_artifacts` | `fixups/template.rs` | Inference artifact | Removes literal strings injected by the inferrer that have no schema equivalent. |
+| `relax_inferred_bibliography_date_suppression` | `bib_postprocess.rs` | Inference artifact | Synthesis can over-suppress dates; this relaxes the suppression. |
+| `repair_inferred_bibliography_type_templates` | `bib_postprocess.rs` | Synthesis gap | Injects missing `primary-title` / `publisher` into type templates that should inherit them. Compensates for synthesis not yet reaching those components. |
+| `normalize_legal_case_type_template` | `fixups/media.rs` | Semantic knowledge | Legal-case formatting rules (no quotes, no parent-monograph, strip certain terms, etc.). Independent of XML compilation; survives any rewrite. |
+| `ensure_inferred_media_type_templates` | `fixups/media.rs` | Semantic knowledge | Creates audio-recording / video templates when the legacy CSL signals them. |
+| `ensure_inferred_patent_type_template` | `fixups/media.rs` | Semantic knowledge | Creates patent template when expected. |
+| `ensure_personal_communication_omitted` | `fixups/media.rs` | Semantic knowledge | Omits personal-comm types per legacy behavior. |
+| `should_merge_inferred_type_template` | `fixups/template.rs` | Synthesis integration | Decides which XML-compiled type templates survive into the inferred path. Becomes vestigial when the XML seed wins ≈0 selections. |
+| `gate_web_only_url_accessed` (proposed) | `fixups/gating.rs` | Semantic knowledge | Mirrors citeproc-js render-time type= gate; independent of XML compilation. |
+
+**Observation:** the fixup layer is roughly half XML-seed-artifact compensators
+(deletable when the XML seed is removed) and half genuine semantic knowledge
+(must survive). The semantic fixups are the stable surface to preserve in a
+future rewrite.
+
+## CLI Flag Consideration
+
+The normalization/compression pass (Phase 2) is a pure serialization
+optimization. It does not affect correctness — a style with all
+`TemplateVariant::Full` entries is semantically identical to one with Diff
+entries, just larger. This suggests an optional `--no-compress-variants` flag
+for debugging, where Phase 2 is skipped and all type-variant entries are emitted
+as `Full`. This is low-priority but useful for diagnosing diff-encoding bugs.
+
+Conversely, a `--compress-variants` flag applied to already-migrated styles
+(analogous to SQI) would allow retroactive compression of styles authored with
+explicit Full entries. This is a natural follow-on, not in scope for this
+refactor.
+
+## Acceptance Criteria
+
+- [ ] `build_type_variants` is called only once in `build_final_style`, after
+  all fixups have run.
+- [ ] `postprocess_inferred_bibliography` runs on both the inferred and
+  XML-seed-winner paths (currently inferred-only).
+- [ ] `engine_validate_variants` is restored and active (demotes unsafe Diffs
+  to Full).
+- [ ] `gate_web_only_url_accessed` is implemented as a Phase 1 fixup, gating
+  url/accessed on web types only.
+- [ ] Brown v. Board of Education (`legal_case` in jar) passes after the gate
+  is applied.
+- [ ] `url`/`accessed` no longer appear in non-web type renders (jar interview,
+  early-medieval-europe article-journal).
+- [ ] Full migrate batch (`oracle-migrate-batch.js`) shows no regression vs.
+  the pre-branch baseline.
+- [ ] `build_final_style` and its assembly helpers are extracted from
+  `main.rs` into a focused module, with the Phase 1 / Phase 2 boundary as a
+  function boundary; `main.rs` is back under the house size limit.
+- [ ] All tests pass (`just pre-commit`).
+
+## Implementation Notes
+
+The refactor is localized to `main.rs::build_final_style` and the call site for
+`build_type_variants`. The fixup functions themselves do not change; only their
+call order relative to `build_type_variants` changes.
+
+`postprocess_inferred_bibliography` currently holds some fixups that reference
+`inferred_bib_source` to decide whether to run. Extracting those into a
+separate function (or removing the guard) is the main structural change needed.
+
+`engine_validate_variants` was previously removed with a `// TEMP: skip`
+comment. Restoring it is independent of the ordering refactor and can be done
+in the same commit.
+
+### Decompose `main.rs`
+
+`crates/citum-migrate/src/main.rs` is ~1970 LOC — far over the 300-line house
+limit and the single reason the two-phase ordering is hard to see and hard to
+change safely. The refactor is the natural point to split it:
+
+- **`build_final_style`** and its assembly helpers (the Phase 1 / Phase 2 split)
+  belong in a dedicated `assembly.rs` (or `final_style/` module), so the
+  phase boundary is a module boundary, not a comment in a 2000-line file.
+- The CLI entry (`main`, arg parsing, I/O) stays in `main.rs`; everything that
+  manipulates templates moves out.
+- `select_and_process_bibliography_template` and the `inferred_bib_source`
+  plumbing move alongside `build_final_style` so the path-selection logic sits
+  next to the code that consumes it.
+
+This decomposition is a precondition, not a side effect: the current size is
+why a load-bearing ordering constraint could hide in `build_final_style`
+undetected. Splitting Phase 1 (fixups) and Phase 2 (compression) into separate
+functions in a focused module makes the "all fixups before any compression"
+invariant structurally enforceable rather than convention.


### PR DESCRIPTION
## Summary

- Gates migrated bibliography URL/accessed output to web-like types before pruning and type-variant compression.
- Keeps `legal_case` normalization on the XML-seed path.
- Restores pre-sfi3 type-variant derivation while retaining engine validation for bad diffs.

## Deferred

`csl26-sfi3` remains follow-up: grouping raw templates before wrapper/lineage resolution shadows parent-aware templates.

## Verification

- `cargo build -q --bin citum-migrate`
- `cargo test -q -p citum-migrate template_diff::tests`
- `cargo test -q -p citum-migrate gating::tests`
- `node scripts/oracle.js styles-legacy/journal-of-advertising-research.csl --json --force-migrate`
  - expected remaining mismatch: Mikolov paper-conference container gap; Bengio, State of JS, and Brown pass.
- `node scripts/oracle.js styles-legacy/china-information.csl --json --force-migrate`
  - grouping regression avoided; summary 19/20 citations, 33/38 bibliography.
- `node scripts/report-migrate-sqi.js --corpus random --sample 100 --seed 20260610 --json`
  - 0 fidelity regressions against `/tmp/sqi_fix.json`; migrated mean 90.78.
- `just pre-commit`
- manual `.githooks/pre-push` range check
