### PR TITLE
fix(migrate): preserve pre-wrapper type variants

### DIFF
--- a/.beans/archive/csl26-sfi3--migrate-parent-aware-type-variant-grouping.md
+++ b/.beans/archive/csl26-sfi3--migrate-parent-aware-type-variant-grouping.md
@@ -1,0 +1,67 @@
+---
+# csl26-sfi3
+title: 'migrate: parent-aware type-variant grouping'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-06-15T22:21:14Z
+updated_at: 2026-06-15T22:30:00Z
+parent: csl26-vmcr
+---
+
+Follow-up split from csl26-e94m. The attempted normalization that grouped
+identical bibliography type-variant templates is not safe yet.
+
+## Diagnosis
+
+The regression is not that the engine cannot match `TypeSelector::Multiple`.
+The bibliography path does match multi-selectors.
+
+The actual bug is migration ordering. The experimental grouping pass grouped
+raw type templates before lineage/wrapper diffing and before wrapper semantics
+selected the final parent-aware template. In `china-information`, raw `book`
+equals `bill`, so grouping created a shared selector for `bill,book,...`. After
+wrapper resolution, however, `book` needs a larger parent-aware template. The
+early multi-selector shadows that resolved template and regresses output.
+
+`engine_validate_variants` is still useful as a structural safety net for bad
+diffs, but it cannot prove that early grouping selected the semantically right
+parent/template before wrapper resolution.
+
+## Scope
+
+- Do not reintroduce raw-template grouping in `template_diff.rs`.
+- Design a parent-aware grouping pass that runs only after final resolved
+  template and wrapper semantics are known.
+- Alternatively, disable grouping for wrapper output until a parent-aware pass
+  exists.
+- Preserve original sibling-mining behavior until grouping is made
+  parent-aware.
+- Keep temporary debug controls out of the production path; this should not
+  require `CITUM_DBG_*` or `CITUM_DISABLE_VARIANT_GROUPING` hooks.
+
+## Acceptance
+
+- `styles-legacy/china-information.csl` does not regress when grouping is
+  enabled.
+- Grouped selectors preserve distinct resolved output for `book` versus `bill`
+  when wrapper semantics require different templates.
+- Seeded random-100 SQI shows no fidelity regressions against the current
+  csl26-e94m baseline.
+- Full repo gate passes before shipping any implementation.
+
+## References
+
+- PR #929 RTM decision: ship csl26-e94m and defer csl26-sfi3.
+- Migration surface: `crates/citum-migrate/src/template_diff.rs`.
+- Engine resolver surface:
+  `crates/citum-schema-style/src/template/resolution.rs`.
+
+## Closure
+
+Completed by locking the migration-order invariant in `template_diff.rs`:
+pre-wrapper type-variant construction preserves original selector keys and does
+not synthesize `TypeSelector::Multiple` from raw-equal templates. Sibling diff
+mining remains allowed because it keeps selectors addressable. Parent-aware
+post-resolution grouping remains deferred until it can run after final
+child/parent wrapper templates are known.

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -21,6 +21,11 @@ pub(crate) type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateC
 pub(crate) type TypeVariantMap = indexmap::IndexMap<TypeSelector, TemplateVariant>;
 
 /// Builds all template variants for a given reference type from a type-template map.
+///
+/// This runs before lineage/wrapper conversion, so raw template equality is not
+/// final semantic equality. Preserve the original selector keys here; any
+/// selector grouping must happen only after resolved parent-aware templates are
+/// known.
 pub(crate) fn build_type_variants(
     default_template: &[TemplateComponent],
     type_templates: TypeTemplateMap,
@@ -572,6 +577,38 @@ mod tests {
         assert!(
             matches!(article, TemplateVariant::Diff(_)),
             "a valid Diff should be kept as Diff — engine_validate_variants must not demote correct diffs"
+        );
+    }
+
+    #[test]
+    fn given_raw_equal_templates_when_variants_built_then_original_selectors_are_preserved() {
+        // Regression guard for csl26-sfi3: this function runs before
+        // lineage/wrapper resolution, where a raw-equal `book` template can
+        // require a different parent-aware result than `bill`. Raw equality
+        // must therefore not be collapsed into a broad multi-selector here.
+        let default_template = vec![title_component(), url_component()];
+        let raw_variant = vec![title_component()];
+        let bill_selector = TypeSelector::Single("bill".to_string());
+        let book_selector = TypeSelector::Single("book".to_string());
+        let mut type_templates = TypeTemplateMap::new();
+        type_templates.insert(bill_selector.clone(), raw_variant.clone());
+        type_templates.insert(book_selector.clone(), raw_variant);
+
+        let variants = build_type_variants(&default_template, type_templates);
+
+        assert!(
+            variants.contains_key(&bill_selector),
+            "bill must stay addressable as its original selector"
+        );
+        assert!(
+            variants.contains_key(&book_selector),
+            "book must stay addressable as its original selector"
+        );
+        assert!(
+            !variants
+                .keys()
+                .any(|selector| matches!(selector, TypeSelector::Multiple(_))),
+            "pre-wrapper variant construction must not synthesize grouped selectors"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Preserve original bibliography type-variant selectors before lineage/wrapper resolution.
- Add a regression guard for the `china-information` raw-equal `bill`/`book` ordering failure shape.
- Archive completed bean `csl26-sfi3` in the same commit.

## Validation
- `cargo test -p citum-migrate template_diff -- --nocapture`
- `node scripts/report-migrate-sqi.js --styles china-information` (composite 89.83, citations 19/20, bibliography 33/38)
- `node scripts/report-migrate-sqi.js --corpus random --sample 100 --seed 20260610 --out /tmp/csl26-sfi3-random.json` (100 styles, migrated mean 90.78, 65 at threshold)
- `just pre-commit`
- push pre-push gate: fmt, clippy, nextest 1616/1616 passed
