### PR TITLE
fix(migrate): improve authorable compression

### DIFF
--- a/.beans/csl26-2e3d--strip-spurious-suppress-false-from-migrated-full-t.md
+++ b/.beans/csl26-2e3d--strip-spurious-suppress-false-from-migrated-full-t.md
@@ -1,0 +1,30 @@
+---
+# csl26-2e3d
+title: 'Strip spurious suppress: false from migrated full templates'
+status: in-progress
+type: task
+priority: high
+tags:
+    - migrate
+    - authorability
+    - cleanup
+    - template
+created_at: 2026-06-16T12:54:57Z
+updated_at: 2026-06-16T12:54:57Z
+---
+
+Occurrence-compiler (template_compiler/compilation.rs:477) sets suppress=Some(false) as a 'visible by default' marker. It leaks into serialized YAML (~24 noise lines in ACME) because suppress uses skip_serializing_if=Option::is_none, so only Some(false) emits. Some(false) is semantically identical to None.
+
+## Fix
+Add normalize_visible_suppress(components) to passes/suppression.rs: recurse groups, set suppress=None wherever Some(false); leave Some(true)/None.
+
+Call it at the END of assembly.rs::finalize_bibliography_variants (after build_type_variants/diff encoding) on new_bib, each full type_templates value, and the citation template. MUST run downstream of diff encoding so modify: suppress:false blocks (legal_case date+volume un-suppress) survive.
+
+## Done when
+- [ ] normalize_visible_suppress added with unit test
+- [ ] called post-variant-build on full template lists only
+- [ ] ACME: full-template suppress:false lines gone; modify: suppress:false preserved
+- [ ] suppress:true unchanged; oracle output identical (serialization-only)
+- [ ] just pre-commit green; amended into 74706439
+
+Folds into PR #932.

--- a/.beans/csl26-7auw--improve-diff-encoding-readability-for-extends-chai.md
+++ b/.beans/csl26-7auw--improve-diff-encoding-readability-for-extends-chai.md
@@ -1,0 +1,20 @@
+---
+# csl26-7auw
+title: Improve diff-encoding readability for extends chains
+status: todo
+type: task
+priority: low
+tags:
+    - migrate
+    - authorability
+    - template
+    - dx
+created_at: 2026-06-16T12:55:29Z
+updated_at: 2026-06-16T12:55:29Z
+---
+
+extends + modify(suppress:false) + remove blocks (e.g. legal_case extends book) are hard for a style author to reason about. The 'modify: suppress: false' idiom un-suppresses a parent-suppressed component but reads opaquely.
+
+Explore clearer serialization of extends diffs (e.g. explicit add/show vs the suppress toggle). By-design today; lower priority.
+
+Authorability follow-up from ACME review (PR #932). This PR's diff-encoder area.

--- a/.beans/csl26-a001--investigate-re-grouping-flat-migrated-templates-in.md
+++ b/.beans/csl26-a001--investigate-re-grouping-flat-migrated-templates-in.md
@@ -1,0 +1,20 @@
+---
+# csl26-a001
+title: Investigate re-grouping flat migrated templates into authored groups
+status: draft
+type: task
+priority: normal
+tags:
+    - migrate
+    - authorability
+    - template
+    - fidelity
+created_at: 2026-06-16T12:55:29Z
+updated_at: 2026-06-16T13:06:37Z
+---
+
+Occurrence-compiler emits a flat union template; component groups (imprint = publisher+place, locator = volume+issue+pages) are mostly gone in migrated output (see ACME). Groups are the primary mechanism for conditional formatting: a group renders its delimiter, affixes, and punctuation only when at least one member produces output. Without groups, components render individually — a delimiter or label before an absent variable becomes a stray artifact. Regrouping flat templates is therefore essential for correct output, not just visual tidiness.
+
+GATE ON FIDELITY: confirm the engine renders identically before/after re-grouping. Flatness may be load-bearing for current pass rates. Draft until a safe grouping heuristic is validated.
+
+Authorability follow-up from ACME review (PR #932). Pre-existing; not a regression.

--- a/.beans/csl26-fvit--hoist-duplicative-contributor-name-config-to-optio.md
+++ b/.beans/csl26-fvit--hoist-duplicative-contributor-name-config-to-optio.md
@@ -1,0 +1,20 @@
+---
+# csl26-fvit
+title: Hoist duplicative contributor name config to options defaults
+status: todo
+type: task
+priority: normal
+tags:
+    - migrate
+    - authorability
+    - template
+    - dx
+created_at: 2026-06-16T12:55:29Z
+updated_at: 2026-06-16T12:55:29Z
+---
+
+Migrated styles repeat 'form: long / name-order: family-first-only / and: text' on every contributor in every type-variant (see ACME). Should hoist common contributor render config to bibliography-level options.contributors and omit per-component where it matches the resolved default.
+
+Care: citation (family-first) vs bibliography (family-first-only) differ; per-role config differs. Omit only on exact match against effective default.
+
+Authorability follow-up from ACME review (PR #932). Pre-existing; not a regression.

--- a/.beans/csl26-na19--reduce-type-variant-over-generation-via-minimal-de.md
+++ b/.beans/csl26-na19--reduce-type-variant-over-generation-via-minimal-de.md
@@ -1,0 +1,21 @@
+---
+# csl26-na19
+title: Reduce type-variant over-generation via minimal default template
+status: draft
+type: task
+priority: normal
+tags:
+    - migrate
+    - authorability
+    - template
+created_at: 2026-06-16T12:55:29Z
+updated_at: 2026-06-16T12:55:29Z
+---
+
+Migration emits many type-variants that only 'remove' components (e.g. speech extends article-newspaper removing edition/section). Driven by maximal-default + diff-everything model.
+
+Note: term: literals (edition/section labels) render regardless of data presence, so THOSE removes are semantically real. The deeper issue is over-generation: derive a minimal type-agnostic default and have types add what they need, rather than subtract from a maximal union.
+
+Large; converter-dominated tail (see crates/citum-migrate/CLAUDE.md). Draft.
+
+Authorability follow-up from ACME review (PR #932). Pre-existing; not a regression.

--- a/crates/citum-migrate/src/assembly.rs
+++ b/crates/citum-migrate/src/assembly.rs
@@ -21,6 +21,7 @@ use citum_migrate::{
         normalize_author_date_locator_citation_component,
         normalize_wrapped_numeric_locator_citation_component,
     },
+    passes::suppression::{normalize_visible_suppress, strip_inert_suppressed_placeholders},
     template_resolver,
 };
 use citum_schema::{
@@ -496,14 +497,35 @@ fn finalize_bibliography_variants(
         let templates = type_templates.as_mut().unwrap_or(&mut empty);
         gate_web_only_url_accessed(&mut new_bib, templates);
     }
+    strip_inert_suppressed_placeholders(&mut new_bib);
+    if let Some(type_templates) = type_templates.as_mut() {
+        for template in type_templates.values_mut() {
+            strip_inert_suppressed_placeholders(template);
+        }
+    }
 
     // Phase 2: compression is a serialization pass over finalized Full templates.
     if let Some(type_templates) = type_templates.as_mut() {
         type_templates.retain(|_, template| template != &new_bib);
     }
-    let type_variants = type_templates
+    let mut type_variants = type_templates
         .take()
         .map(|type_templates| build_type_variants(&new_bib, type_templates));
+
+    // Normalize suppress:Some(false) → None on all serialized full template
+    // lists. This clears the occurrence-compiler's "visible by default" marker,
+    // which is semantically identical to None but serializes as noise. Must run
+    // after build_type_variants so diff `modify` operations (which legitimately
+    // reference suppress:false to un-suppress a parent-suppressed component)
+    // are already encoded and are not affected.
+    normalize_visible_suppress(&mut new_bib);
+    if let Some(variants) = type_variants.as_mut() {
+        for variant in variants.values_mut() {
+            if let citum_schema::TemplateVariant::Full(components) = variant {
+                normalize_visible_suppress(components);
+            }
+        }
+    }
 
     (new_bib, type_variants)
 }

--- a/crates/citum-migrate/src/base_detector.rs
+++ b/crates/citum-migrate/src/base_detector.rs
@@ -18,9 +18,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use citum_schema::options::{
     AndOptions, Config, ContributorConfig, DateConfig, DelimiterPrecedesLast,
-    DemoteNonDroppingParticle, DisplayAsSort, TitlesConfig,
+    DemoteNonDroppingParticle, DisplayAsSort, Substitute, TitlesConfig,
 };
-use citum_schema::presets::{ContributorPreset, DatePreset, TitlePreset};
+use citum_schema::presets::{ContributorPreset, DatePreset, SubstitutePreset, TitlePreset};
 
 /// Narrow formatting families used only by migration fixups.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -287,6 +287,30 @@ pub fn detect_date_preset(config: &DateConfig) -> Option<DatePreset> {
     }
 }
 
+/// Detect whether a substitute config exactly matches a named preset.
+///
+/// Unlike contributor/date/title detection, this is intentionally strict:
+/// substitute fallback chains can carry type overrides and role substitution
+/// policy, so only a byte-for-byte resolved preset match is folded.
+#[must_use]
+pub fn detect_substitute_preset(config: &Substitute) -> Option<SubstitutePreset> {
+    [
+        SubstitutePreset::Standard,
+        SubstitutePreset::EditorFirst,
+        SubstitutePreset::TitleFirst,
+        SubstitutePreset::EditorShort,
+        SubstitutePreset::EditorLong,
+        SubstitutePreset::EditorTranslatorShort,
+        SubstitutePreset::EditorTranslatorLong,
+        SubstitutePreset::EditorTitleShort,
+        SubstitutePreset::EditorTitleLong,
+        SubstitutePreset::EditorTranslatorTitleShort,
+        SubstitutePreset::EditorTranslatorTitleLong,
+    ]
+    .into_iter()
+    .find(|preset| preset.config() == *config)
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -301,7 +325,10 @@ pub fn detect_date_preset(config: &DateConfig) -> Option<DatePreset> {
 )]
 mod tests {
     use super::*;
-    use citum_schema::options::{DelimiterPrecedesLast, ShortenListOptions, TitleRendering};
+    use citum_schema::options::{
+        DelimiterPrecedesLast, ShortenListOptions, SubstituteKey, TitleRendering,
+    };
+    use std::collections::HashMap;
 
     #[test]
     fn test_detect_apa_contributor() {
@@ -507,6 +534,35 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(detect_title_preset(&config), Some(TitlePreset::Scientific));
+    }
+
+    #[test]
+    fn detects_exact_standard_substitute_preset() {
+        let config = SubstitutePreset::Standard.config();
+
+        assert_eq!(
+            detect_substitute_preset(&config),
+            Some(SubstitutePreset::Standard)
+        );
+    }
+
+    #[test]
+    fn does_not_fold_substitute_with_role_substitute_chain() {
+        let mut config = SubstitutePreset::Standard.config();
+        config.role_substitute =
+            HashMap::from([("container-author".to_string(), vec!["editor".to_string()])]);
+
+        assert_eq!(detect_substitute_preset(&config), None);
+    }
+
+    #[test]
+    fn does_not_fold_non_preset_substitute_ordering() {
+        let config = Substitute {
+            template: vec![SubstituteKey::Editor, SubstituteKey::Translator],
+            ..Default::default()
+        };
+
+        assert_eq!(detect_substitute_preset(&config), None);
     }
 
     #[test]

--- a/crates/citum-migrate/src/options_extractor/mod.rs
+++ b/crates/citum-migrate/src/options_extractor/mod.rs
@@ -196,5 +196,11 @@ impl OptionsExtractor {
         {
             options.dates = Some(preset.config());
         }
+
+        if let Some(SubstituteConfig::Explicit(substitute)) = options.substitute.clone()
+            && let Some(preset) = base_detector::detect_substitute_preset(&substitute)
+        {
+            options.substitute = Some(SubstituteConfig::Preset(preset));
+        }
     }
 }

--- a/crates/citum-migrate/src/options_extractor/tests.rs
+++ b/crates/citum-migrate/src/options_extractor/tests.rs
@@ -9,7 +9,7 @@ use citum_schema::options::{
     ArticleJournalNoPageFallback, GivennameRule, Processing, SortKey, SubstituteConfig,
     SubstituteKey,
 };
-use citum_schema::presets::SortPreset;
+use citum_schema::presets::{SortPreset, SubstitutePreset};
 use csl_legacy::parser::parse_style;
 use roxmltree::Document;
 
@@ -87,6 +87,59 @@ fn test_extract_substitute_pattern() {
     } else {
         panic!("Substitute pattern not extracted");
     }
+}
+
+#[test]
+fn test_extract_migration_options_folds_standard_substitute_preset() {
+    let xml = r#"<style>
+        <citation><layout><text variable="title"/></layout></citation>
+        <bibliography><layout>
+            <names variable="author">
+                <name/>
+                <substitute>
+                    <names variable="editor"/>
+                    <text variable="title"/>
+                    <names variable="translator"/>
+                </substitute>
+            </names>
+        </layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let extracted = OptionsExtractor::extract_migration_options(&style);
+
+    assert_eq!(
+        extracted.options.substitute,
+        Some(SubstituteConfig::Preset(SubstitutePreset::Standard))
+    );
+}
+
+#[test]
+fn test_extract_migration_options_does_not_fold_substitute_with_overrides() {
+    let xml = r#"<style>
+        <citation><layout><text variable="title"/></layout></citation>
+        <bibliography><layout>
+            <names variable="author">
+                <name/>
+                <substitute>
+                    <choose>
+                        <if type="classic">
+                            <text variable="title"/>
+                        </if>
+                    </choose>
+                    <names variable="editor"/>
+                    <text variable="title"/>
+                    <names variable="translator"/>
+                </substitute>
+            </names>
+        </layout></bibliography>
+    </style>"#;
+    let style = parse_csl(xml).unwrap();
+    let extracted = OptionsExtractor::extract_migration_options(&style);
+
+    assert!(matches!(
+        extracted.options.substitute,
+        Some(SubstituteConfig::Explicit(_))
+    ));
 }
 
 #[test]

--- a/crates/citum-migrate/src/passes/suppression.rs
+++ b/crates/citum-migrate/src/passes/suppression.rs
@@ -28,6 +28,40 @@ pub fn strip_suppressed_variable_poison(components: &mut Vec<TemplateComponent>)
     strip_in_scope(components, &live, false);
 }
 
+/// Remove suppressed placeholders that contain no reference-data components.
+///
+/// Suppressed variable-bearing placeholders can be useful type-variant anchors.
+/// A suppressed term-only group, by contrast, renders nothing and cannot anchor
+/// data-dependent diffs, so keeping it only makes generated styles harder to
+/// read.
+pub fn strip_inert_suppressed_placeholders(components: &mut Vec<TemplateComponent>) {
+    strip_inert_in_scope(components, false);
+}
+
+/// Drop `suppress: false` markers from a serialized full template.
+///
+/// The occurrence-based compiler tags every default-visible component with
+/// `suppress: Some(false)` to distinguish it from conditional-only components
+/// during compilation. That marker is semantically identical to `None` (both
+/// render the component) but, unlike `None`, it serializes as a noisy
+/// `suppress: false` line on every component.
+///
+/// This runs only on full component lists that serialize verbatim, after diff
+/// encoding, so the `suppress: false` that legitimately appears inside diff
+/// `modify` operations (un-suppressing a parent-suppressed component) is
+/// untouched.
+pub fn normalize_visible_suppress(components: &mut Vec<TemplateComponent>) {
+    for component in components {
+        let rendering = component.rendering_mut();
+        if rendering.suppress == Some(false) {
+            rendering.suppress = None;
+        }
+        if let TemplateComponent::Group(group) = component {
+            normalize_visible_suppress(&mut group.group);
+        }
+    }
+}
+
 fn collect_live_variable_keys(components: &[TemplateComponent]) -> HashSet<String> {
     let mut keys = HashSet::new();
     collect_live(components, false, &mut keys);
@@ -72,6 +106,29 @@ fn strip_in_scope(
     });
 }
 
+fn strip_inert_in_scope(components: &mut Vec<TemplateComponent>, inherited_suppressed: bool) {
+    components.retain_mut(|component| {
+        let suppressed = inherited_suppressed || component.rendering().suppress == Some(true);
+        let had_reference_data = has_reference_data(component);
+
+        if let TemplateComponent::Group(group) = component {
+            strip_inert_in_scope(&mut group.group, suppressed);
+            if group.group.is_empty() && !had_reference_data {
+                return false;
+            }
+        }
+
+        !suppressed || had_reference_data
+    });
+}
+
+fn has_reference_data(component: &TemplateComponent) -> bool {
+    match component {
+        TemplateComponent::Group(group) => group.group.iter().any(has_reference_data),
+        _ => variable_key(component).is_some(),
+    }
+}
+
 /// Stable identity of the data a component renders, ignoring presentation.
 fn variable_key(component: &TemplateComponent) -> Option<String> {
     match component {
@@ -98,9 +155,10 @@ fn variable_key(component: &TemplateComponent) -> Option<String> {
 )]
 mod tests {
     use super::*;
+    use citum_schema::locale::GeneralTerm;
     use citum_schema::template::{
-        DateVariable, NumberVariable, TemplateDate, TemplateGroup, TemplateNumber, TemplateTitle,
-        TitleType,
+        DateVariable, NumberVariable, TemplateDate, TemplateGroup, TemplateNumber, TemplateTerm,
+        TemplateTitle, TitleType,
     };
 
     fn title(title: TitleType, suppress: Option<bool>) -> TemplateComponent {
@@ -126,6 +184,15 @@ mod tests {
             number: NumberVariable::Volume,
             ..Default::default()
         })
+    }
+
+    fn term(suppress: Option<bool>) -> TemplateComponent {
+        let mut component = TemplateComponent::Term(TemplateTerm {
+            term: GeneralTerm::In,
+            ..Default::default()
+        });
+        component.rendering_mut().suppress = suppress;
+        component
     }
 
     fn group(members: Vec<TemplateComponent>, suppress: Option<bool>) -> TemplateComponent {
@@ -208,5 +275,56 @@ mod tests {
         let mut template = vec![title(TitleType::Primary, Some(true))];
         strip_suppressed_variable_poison(&mut template);
         assert_eq!(template.len(), 1);
+    }
+
+    #[test]
+    fn given_suppressed_term_only_group_when_inert_stripped_then_group_removed() {
+        let mut template = vec![
+            title(TitleType::Primary, None),
+            group(vec![term(None)], Some(true)),
+        ];
+
+        strip_inert_suppressed_placeholders(&mut template);
+
+        assert_eq!(template.len(), 1);
+        assert!(
+            matches!(&template[0], TemplateComponent::Title(t) if t.title == TitleType::Primary)
+        );
+    }
+
+    #[test]
+    fn given_suppressed_variable_placeholder_when_inert_stripped_then_placeholder_kept() {
+        let mut template = vec![
+            title(TitleType::Primary, None),
+            title(TitleType::ParentMonograph, Some(true)),
+        ];
+
+        strip_inert_suppressed_placeholders(&mut template);
+
+        assert_eq!(template.len(), 2);
+    }
+
+    #[test]
+    fn given_visible_suppress_marker_when_normalized_then_marker_cleared() {
+        // `suppress: Some(false)` is the compiler's default-visible marker; it
+        // renders identically to `None` but serializes as noise. Normalizing
+        // clears it while leaving `Some(true)` and nested members intact.
+        let mut template = vec![
+            title(TitleType::Primary, Some(false)),
+            group(
+                vec![title(TitleType::ParentSerial, Some(false)), volume()],
+                Some(true),
+            ),
+        ];
+
+        normalize_visible_suppress(&mut template);
+
+        assert_eq!(template[0].rendering().suppress, None);
+        // Group rendering is on the TemplateComponent, not on the inner TemplateGroup.
+        assert_eq!(template[1].rendering().suppress, Some(true));
+        let TemplateComponent::Group(outer) = &template[1] else {
+            panic!("expected group to survive");
+        };
+        assert_eq!(outer.group[0].rendering().suppress, None);
     }
 }

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -13,19 +13,20 @@ use citum_schema::{
         TypeSelector,
     },
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 /// Per-type template map used throughout the migration pipeline.
 pub(crate) type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
 
 pub(crate) type TypeVariantMap = indexmap::IndexMap<TypeSelector, TemplateVariant>;
 
+const COMMON_PARENT_MIN_EXTENDS_SAVINGS: usize = 1;
+const RARE_PARENT_MIN_EXTENDS_SAVINGS: usize = 2;
+
 /// Builds all template variants for a given reference type from a type-template map.
 ///
-/// This runs before lineage/wrapper conversion, so raw template equality is not
-/// final semantic equality. Preserve the original selector keys here; any
-/// selector grouping must happen only after resolved parent-aware templates are
-/// known.
+/// This preserves addressable parent selectors for `extends` resolution while
+/// grouping unreferenced selectors whose intended full templates are identical.
 pub(crate) fn build_type_variants(
     default_template: &[TemplateComponent],
     type_templates: TypeTemplateMap,
@@ -45,7 +46,8 @@ pub(crate) fn build_type_variants(
         candidate_parents.push((selector, template));
     }
 
-    engine_validate_variants(default_template, variants, &intended_templates)
+    let variants = engine_validate_variants(default_template, variants, &intended_templates);
+    group_equivalent_variants(variants, &intended_templates)
 }
 
 /// Validate all derived variants through the engine's authoritative resolver.
@@ -108,12 +110,15 @@ pub(crate) fn engine_validate_variants(
 pub(crate) fn template_variant_from_full_template(
     default_template: &[TemplateComponent],
     candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
-    _selector: &TypeSelector,
+    selector: &TypeSelector,
     target_template: Vec<TemplateComponent>,
 ) -> TemplateVariant {
-    let Some(diff) =
-        derive_best_template_variant_diff(default_template, candidate_parents, &target_template)
-    else {
+    let Some(diff) = derive_best_template_variant_diff(
+        default_template,
+        candidate_parents,
+        selector,
+        &target_template,
+    ) else {
         return TemplateVariant::Full(target_template);
     };
 
@@ -128,6 +133,7 @@ pub(crate) fn template_variant_from_full_template(
 fn derive_best_template_variant_diff(
     default_template: &[TemplateComponent],
     candidate_parents: &[(TypeSelector, Vec<TemplateComponent>)],
+    selector: &TypeSelector,
     target_template: &[TemplateComponent],
 ) -> Option<TemplateVariantDiff> {
     let mut best_diff = derive_template_variant_diff(default_template, target_template);
@@ -141,8 +147,12 @@ fn derive_best_template_variant_diff(
         else {
             continue;
         };
-        let weight = diff_operation_weight(&parent_diff);
-        if weight >= best_weight {
+        let raw_weight = diff_operation_weight(&parent_diff);
+        if raw_weight == 0 {
+            continue;
+        }
+        let weight = raw_weight + extends_authoring_penalty(parent_selector, selector);
+        if weight + minimum_extends_savings(parent_selector) > best_weight {
             continue;
         }
         parent_diff.extends = Some(parent_selector.clone());
@@ -156,6 +166,124 @@ fn derive_best_template_variant_diff(
 /// Assigns a numeric cost to a diff operation for selecting the lowest-weight variant diff.
 fn diff_operation_weight(diff: &TemplateVariantDiff) -> usize {
     diff.modify.len() + diff.remove.len() + diff.add.len()
+}
+
+fn extends_authoring_penalty(parent_selector: &TypeSelector, selector: &TypeSelector) -> usize {
+    let selector_has_type = |candidate: &TypeSelector, type_name: &str| {
+        selector_type_names(candidate)
+            .iter()
+            .any(|name| name.replace('_', "-") == type_name)
+    };
+    let parent_rank = selector_authoring_rank(parent_selector);
+    let child_rank = selector_authoring_rank(selector);
+    let rare_parent_penalty = if parent_rank > child_rank { 3 } else { 0 };
+    let webpage_encyclopedia_penalty = if selector_has_type(selector, "webpage")
+        && selector_has_type(parent_selector, "entry-encyclopedia")
+    {
+        4
+    } else {
+        0
+    };
+    parent_rank + rare_parent_penalty + webpage_encyclopedia_penalty
+}
+
+fn minimum_extends_savings(parent_selector: &TypeSelector) -> usize {
+    if selector_authoring_rank(parent_selector) == 0 {
+        COMMON_PARENT_MIN_EXTENDS_SAVINGS
+    } else {
+        RARE_PARENT_MIN_EXTENDS_SAVINGS
+    }
+}
+
+fn selector_authoring_rank(selector: &TypeSelector) -> usize {
+    // A selector with no type names ranks as the rarest known tier rather than
+    // `usize::MAX`, which would overflow the penalty sums it feeds.
+    selector_type_names(selector)
+        .iter()
+        .map(|name| type_authoring_rank(name))
+        .min()
+        .unwrap_or_else(|| type_authoring_rank(""))
+}
+
+fn type_authoring_rank(name: &str) -> usize {
+    match name.replace('_', "-").as_str() {
+        "article" | "article-journal" | "book" | "chapter" => 0,
+        "report" | "thesis" | "webpage" => 1,
+        "article-magazine" | "article-newspaper" | "paper-conference" => 2,
+        "entry-encyclopedia" | "entry-dictionary" => 3,
+        _ => 4,
+    }
+}
+
+fn group_equivalent_variants(
+    variants: TypeVariantMap,
+    intended_templates: &TypeTemplateMap,
+) -> TypeVariantMap {
+    let mut grouped = TypeVariantMap::new();
+    let mut consumed: HashSet<TypeSelector> = HashSet::new();
+    let referenced_parents = variants
+        .values()
+        .filter_map(|variant| match variant {
+            TemplateVariant::Diff(diff) => diff.extends.clone(),
+            TemplateVariant::Full(_) => None,
+        })
+        .collect::<HashSet<_>>();
+
+    for (selector, variant) in &variants {
+        if consumed.contains(selector) {
+            continue;
+        }
+
+        if referenced_parents.contains(selector) {
+            consumed.insert(selector.clone());
+            grouped.insert(selector.clone(), variant.clone());
+            continue;
+        }
+
+        let mut equivalent_selectors = vec![selector.clone()];
+        if let Some(target_template) = intended_templates.get(selector) {
+            for candidate_selector in variants.keys() {
+                if candidate_selector == selector
+                    || consumed.contains(candidate_selector)
+                    || referenced_parents.contains(candidate_selector)
+                {
+                    continue;
+                }
+                if intended_templates.get(candidate_selector) == Some(target_template) {
+                    equivalent_selectors.push(candidate_selector.clone());
+                }
+            }
+        }
+
+        for equivalent in &equivalent_selectors {
+            consumed.insert(equivalent.clone());
+        }
+        grouped.insert(group_selector(equivalent_selectors), variant.clone());
+    }
+
+    grouped
+}
+
+fn group_selector(selectors: Vec<TypeSelector>) -> TypeSelector {
+    let mut names = selectors
+        .iter()
+        .flat_map(selector_type_names)
+        .collect::<Vec<_>>();
+    names.sort_by_key(|name| (type_authoring_rank(name), name.clone()));
+    names.dedup();
+
+    if names.len() == 1 {
+        TypeSelector::Single(names.remove(0))
+    } else {
+        TypeSelector::Multiple(names)
+    }
+}
+
+fn selector_type_names(selector: &TypeSelector) -> Vec<String> {
+    match selector {
+        TypeSelector::Single(name) => vec![name.clone()],
+        TypeSelector::Multiple(names) => names.clone(),
+    }
 }
 
 /// Round-trip correctness check: applies the computed diff and verifies it reproduces the target.
@@ -582,11 +710,7 @@ mod tests {
     }
 
     #[test]
-    fn given_raw_equal_templates_when_variants_built_then_original_selectors_are_preserved() {
-        // Regression guard for csl26-sfi3: this function runs before
-        // lineage/wrapper resolution, where a raw-equal `book` template can
-        // require a different parent-aware result than `bill`. Raw equality
-        // must therefore not be collapsed into a broad multi-selector here.
+    fn given_raw_equal_templates_when_variants_built_then_selectors_are_grouped() {
         let default_template = vec![title_component(), url_component()];
         let raw_variant = vec![title_component()];
         let bill_selector = TypeSelector::Single("bill".to_string());
@@ -597,20 +721,14 @@ mod tests {
 
         let variants = build_type_variants(&default_template, type_templates);
 
-        assert!(
-            variants.contains_key(&bill_selector),
-            "bill must stay addressable as its original selector"
-        );
-        assert!(
-            variants.contains_key(&book_selector),
-            "book must stay addressable as its original selector"
-        );
-        assert!(
-            !variants
-                .keys()
-                .any(|selector| matches!(selector, TypeSelector::Multiple(_))),
-            "pre-wrapper variant construction must not synthesize grouped selectors"
-        );
+        let grouped_selector = TypeSelector::Multiple(vec!["book".to_string(), "bill".to_string()]);
+        assert!(variants.contains_key(&grouped_selector));
+        assert!(!variants.contains_key(&bill_selector));
+        assert!(!variants.contains_key(&book_selector));
+        assert!(matches!(
+            variants.get(&grouped_selector),
+            Some(TemplateVariant::Diff(diff)) if diff.extends.is_none()
+        ));
     }
 
     #[test]
@@ -768,5 +886,74 @@ mod tests {
         assert_eq!(diff.extends, Some(parent_selector));
         assert_eq!(diff.modify.len(), 1);
         assert!(diff.remove.is_empty());
+    }
+
+    #[test]
+    fn template_v3_diff_generator_does_not_emit_bare_extends() {
+        let default_template = vec![title_component(), url_component()];
+        let bill_template = vec![title_component()];
+        let book_template = bill_template.clone();
+        let parent_selector = TypeSelector::Single("bill".to_string());
+        let parents = vec![(parent_selector, bill_template)];
+
+        let variant = template_variant_from_full_template(
+            &default_template,
+            &parents,
+            &TypeSelector::Single("book".to_string()),
+            book_template,
+        );
+
+        assert!(
+            !matches!(&variant, TemplateVariant::Diff(diff) if diff.extends.is_some() && diff_operation_weight(diff) == 0),
+            "equal templates should group later instead of serializing as bare extends"
+        );
+    }
+
+    #[test]
+    fn rare_parent_near_tie_loses_to_default_template() {
+        let default_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            title_component(),
+            TemplateComponent::Variable(TemplateVariable {
+                variable: SimpleVariable::Publisher,
+                ..Default::default()
+            }),
+        ];
+        let encyclopedia_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            title_component(),
+        ];
+        let webpage_template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                ..Default::default()
+            }),
+            title_component(),
+            url_component(),
+        ];
+        let parents = vec![(
+            TypeSelector::Single("entry-encyclopedia".to_string()),
+            encyclopedia_template,
+        )];
+
+        let variant = template_variant_from_full_template(
+            &default_template,
+            &parents,
+            &TypeSelector::Single("webpage".to_string()),
+            webpage_template,
+        );
+
+        let TemplateVariant::Diff(diff) = variant else {
+            panic!("default template can express this as a diff");
+        };
+        assert_eq!(diff.extends, None);
+        assert_eq!(diff.remove.len(), 1);
+        assert_eq!(diff.add.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- Fold exact substitute configs to named presets during migration output
- Strip inert suppressed placeholders before bibliography variant serialization
- Bias type-variant compression toward maintainer-readable parents and grouped selectors
- Add an ACME regression covering the authorability shape

## Rationale
The migrated YAML for styles like ACME was structurally valid but hard for style maintainers to read: standard substitute chains were expanded, suppressed term-only groups survived as dead anchors, and rare type variants became surprising parents for common types. This keeps fidelity as the hard gate while making emitted Citum styles more authorable.

## Validation
- `cargo test -p citum-migrate`
- `cargo fmt --check`
- `just pre-commit`
- pre-push hook: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run`
