### PR TITLE
feat(migrate): citum-analyze enhancements (README, --json fix, in-process batch, --coverage-gap)

### DIFF
--- a/.beans/archive/csl26-t56t--citum-analyze-readme-json-fixes-in-process-batch-t.md
+++ b/.beans/archive/csl26-t56t--citum-analyze-readme-json-fixes-in-process-batch-t.md
@@ -1,0 +1,23 @@
+---
+# csl26-t56t
+title: 'citum-analyze: README, JSON fixes, in-process batch test, coverage-gap mode'
+status: completed
+type: feature
+priority: normal
+created_at: 2026-06-16T14:14:54Z
+updated_at: 2026-06-16T14:45:15Z
+---
+
+Four-phase enhancement of crates/citum-analyze:
+1. Fix --json output routed via tracing::debug! (savings, profile_discovery, batch_test)
+2. In-process batch test (kill cargo-run-per-style spawning)
+3. README documenting both binaries and all modes
+4. New --coverage-gap mode: corpus-wide set-diff of legacy CSL features vs migrate compiled output → prioritized converter gaps + auto-discovered preset families
+
+
+## Summary of Changes
+
+- **Phase 1** (`savings.rs`, `profile_discovery.rs`): Fixed `--json` output routed through `tracing::debug!` (silent without `RUST_LOG=debug`) — now writes to stdout.
+- **Phase 2** (`batch_test.rs`, `Cargo.toml`): Replaced two `cargo run` spawns per style with in-process library calls (`csl_legacy` → `citum_migrate` → `citum_schema` → `citum_engine`). Full-corpus pass is now seconds, not hours.
+- **Phase 3** (`README.md`): New README documenting both binaries, all five modes with exact invocations, and pipeline integration.
+- **Phase 4** (`semantic.rs`, `coverage_gap.rs`, `main.rs`): Extracted `SemanticItem`/Jaccard helpers into `semantic.rs`. New `--coverage-gap` mode walks the full independent-style corpus in-process and emits two reports: prioritized converter gaps and preset-family clusters (Jaccard ≥ 0.65).

--- a/.beans/csl26-4wec--coverage-gap-normalize-varnum-for-number-variables.md
+++ b/.beans/csl26-4wec--coverage-gap-normalize-varnum-for-number-variables.md
@@ -1,0 +1,19 @@
+---
+# csl26-4wec
+title: 'coverage-gap: normalize var:/num: for number variables in legacy extractor'
+status: todo
+type: task
+priority: normal
+created_at: 2026-06-16T15:48:49Z
+updated_at: 2026-06-16T15:48:49Z
+---
+
+coverage_gap.rs::collect_legacy_features emits var:page, var:volume, var:issue, var:edition from CSL <text variable="X"/> nodes. But migrate likely converts these to NumberVariable (Number(NumberVariable::Volume)), producing num:volume in compiled output. This creates false-positive gaps for ~2782 (volume), ~2798 (page), ~1701 (issue), ~2422 (edition) styles.
+
+Investigate: check what compile_from_xml actually produces for <text variable="volume"/> — is it TemplateComponent::Number(NumberVariable::Volume) or TemplateComponent::Variable(SimpleVariable::Volume)?
+
+If NumberVariable: update collect_legacy_features to emit num:{citum_key} for the known num-normalized variables (page→pages, volume, issue, edition, number-of-pages, number-of-volumes, citation-number, collection-number, chapter-number, number). Also handle the CSL 'page' → Citum 'pages' rename.
+
+This is a follow-up to csl26-t56t (coverage-gap mode). Run --coverage-gap after the fix to verify these gaps collapse.
+
+Files: crates/citum-analyze/src/coverage_gap.rs (collect_legacy_features)

--- a/.beans/csl26-4wec--coverage-gap-normalize-varnum-for-number-variables.md
+++ b/.beans/csl26-4wec--coverage-gap-normalize-varnum-for-number-variables.md
@@ -4,8 +4,12 @@ title: 'coverage-gap: normalize var:/num: for number variables in legacy extract
 status: todo
 type: task
 priority: normal
+tags:
+    - citum-analyze
+    - coverage-gap
+    - migrate
 created_at: 2026-06-16T15:48:49Z
-updated_at: 2026-06-16T15:48:49Z
+updated_at: 2026-06-16T16:20:29Z
 ---
 
 coverage_gap.rs::collect_legacy_features emits var:page, var:volume, var:issue, var:edition from CSL <text variable="X"/> nodes. But migrate likely converts these to NumberVariable (Number(NumberVariable::Volume)), producing num:volume in compiled output. This creates false-positive gaps for ~2782 (volume), ~2798 (page), ~1701 (issue), ~2422 (edition) styles.

--- a/.beans/csl26-auh3--migrate-unhandled-csl-variables-event-collection-t.md
+++ b/.beans/csl26-auh3--migrate-unhandled-csl-variables-event-collection-t.md
@@ -4,8 +4,11 @@ title: 'migrate: unhandled CSL variables — event, collection-title, translator
 status: todo
 type: feature
 priority: normal
+tags:
+    - migrate
+    - coverage-gap
 created_at: 2026-06-16T15:49:01Z
-updated_at: 2026-06-16T15:49:01Z
+updated_at: 2026-06-16T16:20:29Z
 ---
 
 After coverage-gap key-mapping fixes (csl26-t56t), these variables remain as genuine converter gaps across the independent-style corpus:

--- a/.beans/csl26-auh3--migrate-unhandled-csl-variables-event-collection-t.md
+++ b/.beans/csl26-auh3--migrate-unhandled-csl-variables-event-collection-t.md
@@ -1,0 +1,23 @@
+---
+# csl26-auh3
+title: 'migrate: unhandled CSL variables — event, collection-title, translator, original-date'
+status: todo
+type: feature
+priority: normal
+created_at: 2026-06-16T15:49:01Z
+updated_at: 2026-06-16T15:49:01Z
+---
+
+After coverage-gap key-mapping fixes (csl26-t56t), these variables remain as genuine converter gaps across the independent-style corpus:
+
+Rank / Feature / Affected styles (approx):
+- var:event (1249): conference/event name. Not in SimpleVariable or TitleType. May need SimpleVariable::Event or a dedicated EventTitle component.
+- var:collection-title (1669): series title. Not a TitleType variant — no TitleType::Series. May need a new TitleType or a SimpleVariable passthrough.
+- names:translator (715): translator contributor role. Check if ContributorRole has a Translator variant; if not, add it and wire into the contributor compiler.
+- date:original-date (470): original publication date. Check if DateVariable has OriginalDate; if not, add it.
+- var:year-suffix (428): author-date disambiguation suffix. This is processor-generated, not a template variable — converter correctly omits it; document that it's handled by engine disambiguation, not by template.
+- var:section (753), var:authority (704): verify these are in SimpleVariable (Section and Authority exist) and trace why migrate drops them.
+
+Approach: for each item, trace the csl_legacy node compiler path (crates/citum-migrate/src/template_compiler/node_compiler.rs) to see whether the variable is handled, silently dropped, or needs a schema addition.
+
+Priority sequence: collection-title (1669) > translator (715) > event (1249) > original-date (470).

--- a/.beans/csl26-qqdt--style-registry-corpus-driven-preset-priority-from.md
+++ b/.beans/csl26-qqdt--style-registry-corpus-driven-preset-priority-from.md
@@ -1,33 +1,28 @@
 ---
 # csl26-qqdt
-title: 'style registry: corpus-driven preset priority from coverage-gap clusters'
+title: 'schema-style: corpus-driven preset discovery for config concerns'
 status: todo
 type: task
 priority: normal
+tags:
+    - registry
+    - presets
+    - citum-analyze
 created_at: 2026-06-16T15:49:15Z
-updated_at: 2026-06-16T15:49:15Z
+updated_at: 2026-06-16T16:20:53Z
 ---
 
-The --coverage-gap preset-family clusters (csl26-t56t) provide corpus-wide data on which Citum base styles cover the most independent styles at Jaccard ≥ 0.65. Use this as the priority order for the preset/alias registry.
+The `--config-presets` mode (csl26-t56t) discovers per-concern config
+shapes (contributors, dates, titles, locators) across the CSL corpus that do
+not match any existing named preset in citum-schema-style.
 
-Top clusters by independent-style count:
-1. elsevier-with-titles-core: 2698 styles
-2. taylor-and-francis-cse-author-date[-core]: 998 styles
-3. springer-basic-author-date[-core]: 969 styles
-4. taylor-and-francis-chicago-author-date[-core]: 979 styles
-5. apa-7th: 958 styles
-6. chicago-author-date-18th: 952 styles
-7. elsevier-with-titles: 790 styles
-8. springer-basic-brackets[-core]: 776 styles
-9. springer-vancouver-brackets: 774 styles
-10. taylor-and-francis-national-library-of-medicine[-core]: 179 styles
-11. ieee: 176 styles
-12. chicago-notes-18th: 74 styles
-13. modern-language-association: 67 styles
+Run the report and promote the highest-frequency unnamed shapes as new named
+presets in citum-schema-style/src/presets.rs (ContributorPreset, DatePreset,
+TitlePreset) or options/locators.rs (LocatorPreset).
 
-Observations:
-- The -core / non-core pairs (e.g. springer-basic-author-date vs springer-basic-author-date-core) match nearly identical style sets, suggesting they differ only in minor rendering; consider whether both need registry entries or one can alias the other.
-- elsevier-with-titles-core covers 2698 styles vs elsevier-with-titles's 790 — the core variant is the dominant one; document this.
-- chicago-notes-18th only matches 74 styles but covers the humanities/notes niche which is strategically important.
+Priority order: rank by corpus_count within each concern. Run:
 
-Action: use these counts to order the preset priority list in docs/specs/STYLE_TAXONOMY.md and/or the style registry spec. Re-run --coverage-gap after converter fixes to see counts shift upward (currently depressed because many styles show false-positive gaps from the key-mapping bugs).
+```bash
+cargo run --bin citum-analyze -- styles-legacy --config-presets --json \
+  | jq '.concerns[] | {concern, candidates: .candidates[:5]}'
+```

--- a/.beans/csl26-qqdt--style-registry-corpus-driven-preset-priority-from.md
+++ b/.beans/csl26-qqdt--style-registry-corpus-driven-preset-priority-from.md
@@ -1,0 +1,33 @@
+---
+# csl26-qqdt
+title: 'style registry: corpus-driven preset priority from coverage-gap clusters'
+status: todo
+type: task
+priority: normal
+created_at: 2026-06-16T15:49:15Z
+updated_at: 2026-06-16T15:49:15Z
+---
+
+The --coverage-gap preset-family clusters (csl26-t56t) provide corpus-wide data on which Citum base styles cover the most independent styles at Jaccard ≥ 0.65. Use this as the priority order for the preset/alias registry.
+
+Top clusters by independent-style count:
+1. elsevier-with-titles-core: 2698 styles
+2. taylor-and-francis-cse-author-date[-core]: 998 styles
+3. springer-basic-author-date[-core]: 969 styles
+4. taylor-and-francis-chicago-author-date[-core]: 979 styles
+5. apa-7th: 958 styles
+6. chicago-author-date-18th: 952 styles
+7. elsevier-with-titles: 790 styles
+8. springer-basic-brackets[-core]: 776 styles
+9. springer-vancouver-brackets: 774 styles
+10. taylor-and-francis-national-library-of-medicine[-core]: 179 styles
+11. ieee: 176 styles
+12. chicago-notes-18th: 74 styles
+13. modern-language-association: 67 styles
+
+Observations:
+- The -core / non-core pairs (e.g. springer-basic-author-date vs springer-basic-author-date-core) match nearly identical style sets, suggesting they differ only in minor rendering; consider whether both need registry entries or one can alias the other.
+- elsevier-with-titles-core covers 2698 styles vs elsevier-with-titles's 790 — the core variant is the dominant one; document this.
+- chicago-notes-18th only matches 74 styles but covers the humanities/notes niche which is strategically important.
+
+Action: use these counts to order the preset priority list in docs/specs/STYLE_TAXONOMY.md and/or the style registry spec. Re-run --coverage-gap after converter fixes to see counts shift upward (currently depressed because many styles show false-positive gaps from the key-mapping bugs).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,9 +643,11 @@ dependencies = [
 name = "citum-analyze"
 version = "0.68.0"
 dependencies = [
+ "citum-engine",
  "citum-migrate",
  "citum-schema",
  "csl-legacy",
+ "indexmap 2.14.0",
  "roxmltree 0.21.1",
  "serde",
  "serde_json",

--- a/crates/citum-analyze/Cargo.toml
+++ b/crates/citum-analyze/Cargo.toml
@@ -20,6 +20,8 @@ tracing.workspace = true
 csl_legacy = { package = "csl-legacy", path = "../csl-legacy" }
 citum_schema = { package = "citum-schema", path = "../citum-schema" }
 citum_migrate = { package = "citum-migrate", path = "../citum-migrate" }
+citum_engine = { package = "citum-engine", path = "../citum-engine" }
+indexmap = "2"
 roxmltree = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/citum-analyze/README.md
+++ b/crates/citum-analyze/README.md
@@ -1,0 +1,130 @@
+# citum-analyze
+
+Internal corpus-analysis tooling for the `styles-legacy/` CSL 1.0 collection.
+Provides static census and structural comparison modes that feed migrate
+converter work, style-preset discovery, and taxonomy authoring. Not published.
+
+## Binaries
+
+| Binary | Purpose |
+|---|---|
+| `citum-analyze` | Five corpus-census modes (see below) |
+| `citum-batch-test` | Per-style migrate + engine pass/fail across the full corpus |
+
+## citum-analyze modes
+
+All modes accept a path to the `styles-legacy/` directory as the first argument.
+Append `--json` to route structured output to stdout (parseable by `jq`).
+
+### Default — feature-frequency census
+
+```bash
+cargo run --bin citum-analyze -- styles-legacy/
+cargo run --bin citum-analyze -- styles-legacy/ --json | jq '.top_features[:10]'
+```
+
+Reports raw CSL attribute and element frequencies across all independent styles.
+Useful for a quick corpus overview.
+
+### `--rank-parents` — parent/dependent ranking
+
+```bash
+cargo run --bin citum-analyze -- styles-legacy/ --rank-parents --json
+cargo run --bin citum-analyze -- styles-legacy/ --rank-parents --format author-date --json
+```
+
+Ranks parent styles by how many dependent styles reference them. Feeds
+[`docs/reference/STYLE_PRIORITY.md`](../../docs/reference/STYLE_PRIORITY.md) and
+informs which independent styles to prioritize in the converter backlog.
+
+Filters: `--format author-date|numeric|note|label`.
+
+### `--quantify-savings` — preset / locale-override savings estimate
+
+```bash
+cargo run --bin citum-analyze -- styles-legacy/ --quantify-savings --json | jq '.summary'
+```
+
+Estimates how many CSL styles presets, aliases, and locale overrides can absorb.
+Feeds the preset-fidelity bean and [`docs/specs/STYLE_TAXONOMY.md`](../../docs/specs/STYLE_TAXONOMY.md).
+
+### `--identify-profiles` — journal-profile candidate audit
+
+```bash
+cargo run --bin citum-analyze -- styles-legacy/ --identify-profiles --json | jq '.summary'
+```
+
+Audits the hardcoded shortlist of journal-profile candidates (defined in
+`src/profile_discovery.rs`) against the live corpus. Each candidate is run
+through the migrate pipeline in-process and Jaccard-matched against
+[`StyleBase::all()`](../citum-schema/). Feeds
+[`docs/specs/STYLE_TAXONOMY.md`](../../docs/specs/STYLE_TAXONOMY.md) and
+architecture audit records.
+
+### `--coverage-gap` — corpus-wide converter-gap analysis
+
+```bash
+cargo run --bin citum-analyze -- styles-legacy/ --coverage-gap
+cargo run --bin citum-analyze -- styles-legacy/ --coverage-gap --json | jq '.prioritized_gaps[:10]'
+cargo run --bin citum-analyze -- styles-legacy/ --coverage-gap --json | jq '.preset_families[:5]'
+```
+
+Runs every independent style in `styles-legacy/` through the migrate XML
+compilation pipeline in-process, then computes two reports:
+
+**Prioritized converter gaps** — CSL features present in the legacy source that
+are absent from migrate's compiled output, ranked by how many independent styles
+are affected. This is the primary feed for `citum-migrate` converter work: "fix
+construct X to recover N styles."
+
+**Preset-family clusters** — independent styles whose compiled semantic set
+closely matches a Citum base style (Jaccard similarity ≥ 0.65), listed per base.
+Data-driven extension of `--identify-profiles` from a hardcoded shortlist to the
+full corpus.
+
+> **Note on false positives.** The gap list uses set difference as a *heuristic*
+> for "dropped by migrate." Some features are intentionally normalized away by
+> `fixups` (e.g. locator citation injection). The list is a triage aid, not a
+> ground-truth bug list. Walking all macros (not only reachable ones) may also
+> include a small number of dead-macro features.
+
+## citum-batch-test
+
+```bash
+cargo run --bin citum-batch-test -- styles-legacy/ --json | jq '{total,migration_success,migration_failed}'
+cargo run --bin citum-batch-test -- styles-legacy/ --sample 300 --verbose
+cargo run --bin citum-batch-test -- styles-legacy/ --json > /tmp/batch.json
+```
+
+Runs every `.csl` file through the full in-process pipeline:
+
+1. Parse legacy CSL XML (`csl_legacy::parser::parse_style`).
+2. Compile templates (`citum_migrate::compilation::compile_from_xml`).
+3. Assemble a minimal `citum_schema::Style` and validate it via `serde_yaml` roundtrip.
+4. Instantiate `citum_engine::Processor::new` to verify engine acceptance.
+
+Reports per-category counts and error-type breakdowns. All styles in the
+directory are tested (including `dependent/`); dependent styles are expected to
+fail at step 1 since they contain no layouts.
+
+Options:
+
+| Flag | Effect |
+|---|---|
+| `--verbose` | Print each style's result as it runs |
+| `--sample N` | Test a pseudo-random sample of N styles |
+| `--json` | Emit final `BatchResults` as JSON |
+
+## How this feeds the pipeline
+
+| Mode | Consumer |
+|---|---|
+| `--rank-parents` | `docs/reference/STYLE_PRIORITY.md` — which parents to support first |
+| `--quantify-savings` | Preset/alias taxonomy decisions |
+| `--identify-profiles` | `docs/specs/STYLE_TAXONOMY.md`, architecture audits |
+| `--coverage-gap` | `citum-migrate` converter backlog (gap list); preset registry seed (family clusters) |
+| `citum-batch-test` | Corpus regression check after converter changes |
+
+For iterative converter work (fixing a specific gap and re-testing), see the
+`/migrate-research` skill — that skill owns the fix-and-measure loop. The tools
+here are static census only.

--- a/crates/citum-analyze/src/batch_test.rs
+++ b/crates/citum-analyze/src/batch_test.rs
@@ -3,29 +3,35 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-#![allow(missing_docs, reason = "bin crate")]
-/*
-SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
-*/
+//! Batch Migration Tester — runs every CSL 1.0 style in a directory through
+//! the full migrate + engine pipeline in-process and reports pass/fail rates.
+//!
+//! Running in-process (no `cargo run` spawns) makes a full-corpus pass take
+//! seconds rather than hours.
+//!
+//! Usage: `citum-batch-test <styles_dir> [--verbose] [--sample N] [--json]`
 
-//! Batch Migration Tester
-//!
-//! Runs CSL 1.0 → Citum migration on all styles and reports success rates.
-//!
-//! Usage: `citum_batch_test` <`styles_dir`> [--verbose] [--sample N]
+#![allow(missing_docs, reason = "bin crate")]
 
 use std::collections::HashMap;
 use std::env;
-use std::fs;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+
 use walkdir::WalkDir;
 
+use citum_migrate::{OptionsExtractor, compilation, provenance::ProvenanceTracker};
+use citum_schema::{BibliographySpec, CitationSpec, Style};
+
+/// Parsed CLI arguments for `citum-batch-test`.
 struct CliArgs {
+    /// Path to the directory containing `.csl` files.
     styles_dir: String,
+    /// Print each style's result individually.
     verbose: bool,
+    /// Emit final results as JSON.
     json_output: bool,
+    /// Run on a pseudo-random sample of this size instead of the full corpus.
     sample_size: Option<usize>,
 }
 
@@ -66,13 +72,112 @@ fn collect_styles(styles_dir: &str, sample_size: Option<usize>) -> Vec<PathBuf> 
     styles
 }
 
+/// Aggregated results across all tested styles.
+#[derive(Default, serde::Serialize)]
+struct BatchResults {
+    total: usize,
+    migration_success: usize,
+    migration_failed: usize,
+    processor_failed: usize,
+    yaml_invalid: usize,
+    migration_errors: HashMap<String, usize>,
+    processor_errors: HashMap<String, usize>,
+    yaml_errors: HashMap<String, usize>,
+}
+
+/// Per-style test outcome.
+enum TestResult {
+    /// Migrate + schema roundtrip + engine instantiation all passed.
+    Success,
+    /// Legacy CSL parse or migrate compilation failed.
+    MigrationFailed(String),
+    /// Assembled `Style` could not be round-tripped through `serde_yaml`.
+    YamlInvalid(String),
+    /// Engine `Processor` could not be instantiated from the migrated style.
+    ProcessorFailed(String),
+}
+
+/// Test a single CSL style file in-process.
+///
+/// 1. Parses the legacy CSL XML with `csl_legacy::parser::parse_style`.
+/// 2. Runs the migrate XML compilation pipeline (`compile_from_xml`).
+/// 3. Assembles a minimal `citum_schema::Style` and round-trips it through `serde_yaml`.
+/// 4. Instantiates `citum_engine::Processor::new` to verify engine acceptance.
+fn test_style(path: &Path) -> TestResult {
+    // Step 1: parse legacy XML
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => return TestResult::MigrationFailed(format!("read: {e}")),
+    };
+    let doc = match roxmltree::Document::parse(&content) {
+        Ok(d) => d,
+        Err(e) => return TestResult::MigrationFailed(format!("xml parse: {e}")),
+    };
+    let legacy = match csl_legacy::parser::parse_style(doc.root_element()) {
+        Ok(s) => s,
+        Err(e) => return TestResult::MigrationFailed(format!("csl parse: {e}")),
+    };
+
+    // Step 2: migrate in-process
+    let opts = OptionsExtractor::extract_migration_options(&legacy);
+    let mut options = opts.options;
+    let tracker = ProvenanceTracker::new(false);
+    let output = compilation::compile_from_xml(&legacy, &mut options, false, &tracker);
+
+    // Step 3: assemble minimal Style and validate YAML roundtrip
+    let style = Style {
+        options: Some(options),
+        bibliography: Some(BibliographySpec {
+            template: if output.bibliography.is_empty() {
+                None
+            } else {
+                Some(output.bibliography)
+            },
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            template: if output.citation.is_empty() {
+                None
+            } else {
+                Some(output.citation)
+            },
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let yaml = match serde_yaml::to_string(&style) {
+        Ok(y) => y,
+        Err(e) => return TestResult::YamlInvalid(format!("serialize: {e}")),
+    };
+    if let Err(e) = serde_yaml::from_str::<Style>(&yaml) {
+        return TestResult::YamlInvalid(e.to_string());
+    }
+
+    // Step 4: engine instantiation check
+    let bib: citum_engine::Bibliography = indexmap::IndexMap::new();
+    let catch = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        citum_engine::Processor::new(style, bib)
+    }));
+    if let Err(e) = catch {
+        let msg = e
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| e.downcast_ref::<&str>().copied())
+            .unwrap_or("panic")
+            .to_string();
+        return TestResult::ProcessorFailed(msg);
+    }
+
+    TestResult::Success
+}
+
 #[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
 fn run_batch(cli: CliArgs) {
     let styles = collect_styles(&cli.styles_dir, cli.sample_size);
     let total = styles.len();
     let mut results = BatchResults::default();
 
-    tracing::debug!("Testing {total} styles...\n");
+    eprintln!("Testing {total} styles...");
 
     for (i, path) in styles.iter().enumerate() {
         let result = test_style(path);
@@ -85,7 +190,7 @@ fn run_batch(cli: CliArgs) {
             TestResult::Success => {
                 results.migration_success += 1;
                 if cli.verbose {
-                    tracing::debug!("[{}/{}] ✅ {}", i + 1, total, name);
+                    eprintln!("[{}/{}] ✅ {}", i + 1, total, name);
                 }
             }
             TestResult::MigrationFailed(err) => {
@@ -95,8 +200,8 @@ fn run_batch(cli: CliArgs) {
                     .entry(categorize_error(err))
                     .or_insert(0) += 1;
                 if cli.verbose {
-                    tracing::debug!(
-                        "[{}/{}] ❌ {} - Migration: {}",
+                    eprintln!(
+                        "[{}/{}] ❌ {} — Migration: {}",
                         i + 1,
                         total,
                         name,
@@ -111,8 +216,8 @@ fn run_batch(cli: CliArgs) {
                     .entry(categorize_error(err))
                     .or_insert(0) += 1;
                 if cli.verbose {
-                    tracing::debug!(
-                        "[{}/{}] ⚠️  {} - Processor: {}",
+                    eprintln!(
+                        "[{}/{}] ⚠️  {} — Processor: {}",
                         i + 1,
                         total,
                         name,
@@ -127,8 +232,8 @@ fn run_batch(cli: CliArgs) {
                     .entry(categorize_error(err))
                     .or_insert(0) += 1;
                 if cli.verbose {
-                    tracing::debug!(
-                        "[{}/{}] ❌ {} - Invalid YAML: {}",
+                    eprintln!(
+                        "[{}/{}] ❌ {} — Invalid YAML: {}",
                         i + 1,
                         total,
                         name,
@@ -139,7 +244,7 @@ fn run_batch(cli: CliArgs) {
         }
 
         if !cli.verbose && (i + 1) % 100 == 0 {
-            tracing::debug!("  Processed {}/{}", i + 1, total);
+            eprintln!("  Processed {}/{}", i + 1, total);
         }
     }
 
@@ -147,10 +252,8 @@ fn run_batch(cli: CliArgs) {
 
     if cli.json_output {
         match serde_json::to_string_pretty(&results) {
-            Ok(json) => tracing::debug!("{json}"),
-            Err(err) => {
-                tracing::debug!("Error: Failed to serialize batch test results to JSON: {err}");
-            }
+            Ok(json) => writeln!(std::io::stdout(), "{json}").unwrap_or(()),
+            Err(err) => eprintln!("Error: serializing batch results: {err}"),
         }
     } else {
         print_results(&results);
@@ -161,90 +264,18 @@ fn run_batch(cli: CliArgs) {
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        tracing::debug!("Usage: citum_batch_test <styles_dir> [--verbose] [--sample N]");
-        tracing::debug!("");
-        tracing::debug!("Options:");
-        tracing::debug!("  --verbose    Show individual style results");
-        tracing::debug!("  --sample N   Only test N random styles");
-        tracing::debug!("  --json       Output as JSON");
+        eprintln!("Usage: citum-batch-test <styles_dir> [--verbose] [--sample N] [--json]");
+        eprintln!();
+        eprintln!("Options:");
+        eprintln!("  --verbose    Show individual style results");
+        eprintln!("  --sample N   Only test N pseudo-random styles");
+        eprintln!("  --json       Output final results as JSON");
         std::process::exit(1);
     }
     run_batch(parse_cli(&args));
 }
 
-#[derive(Default, serde::Serialize)]
-struct BatchResults {
-    total: usize,
-    migration_success: usize,
-    migration_failed: usize,
-    processor_failed: usize,
-    yaml_invalid: usize,
-    migration_errors: HashMap<String, usize>,
-    processor_errors: HashMap<String, usize>,
-    yaml_errors: HashMap<String, usize>,
-}
-
-enum TestResult {
-    Success,
-    MigrationFailed(String),
-    ProcessorFailed(String),
-    YamlInvalid(String),
-}
-
-fn test_style(path: &Path) -> TestResult {
-    // Step 1: Run migration
-    let migrate_output = Command::new("cargo")
-        .args(["run", "-q", "--bin", "citum_migrate", "--"])
-        .arg(path)
-        .output();
-
-    let migrate_output = match migrate_output {
-        Ok(o) => o,
-        Err(e) => return TestResult::MigrationFailed(format!("spawn error: {e}")),
-    };
-
-    if !migrate_output.status.success() {
-        let stderr = String::from_utf8_lossy(&migrate_output.stderr);
-        return TestResult::MigrationFailed(stderr.to_string());
-    }
-
-    let yaml_content = String::from_utf8_lossy(&migrate_output.stdout);
-
-    // Step 2: Validate YAML parses as Style
-    let style_result: Result<citum_schema::Style, _> = serde_yaml::from_str(&yaml_content);
-    if let Err(e) = style_result {
-        return TestResult::YamlInvalid(e.to_string());
-    }
-
-    // Step 3: Write to temp file and run processor
-    let temp_path = std::env::temp_dir().join("citum_batch_test.yaml");
-    if let Err(e) = fs::write(&temp_path, yaml_content.as_bytes()) {
-        return TestResult::ProcessorFailed(format!("write error: {e}"));
-    }
-
-    let proc_output = Command::new("cargo")
-        .args(["run", "-q", "--bin", "citum_engine", "--"])
-        .arg(&temp_path)
-        .output();
-
-    let proc_output = match proc_output {
-        Ok(o) => o,
-        Err(e) => return TestResult::ProcessorFailed(format!("spawn error: {e}")),
-    };
-
-    if !proc_output.status.success() {
-        let stderr = String::from_utf8_lossy(&proc_output.stderr);
-        return TestResult::ProcessorFailed(stderr.to_string());
-    }
-
-    // Clean up
-    let _ = fs::remove_file(&temp_path);
-
-    TestResult::Success
-}
-
 fn categorize_error(err: &str) -> String {
-    // Extract meaningful error category from error message
     if err.contains("unknown attribute")
         && let Some(attr) = err.split("unknown attribute: ").nth(1)
     {
@@ -270,8 +301,6 @@ fn categorize_error(err: &str) -> String {
     if err.contains("Error parsing style") {
         return "parse error".to_string();
     }
-
-    // Truncate to first line
     err.lines()
         .next()
         .unwrap_or("unknown")
@@ -283,7 +312,7 @@ fn categorize_error(err: &str) -> String {
 fn truncate(s: &str, max: usize) -> String {
     let first_line = s.lines().next().unwrap_or(s);
     if first_line.chars().count() > max {
-        format!("{}...", first_line.chars().take(max).collect::<String>())
+        format!("{}…", first_line.chars().take(max).collect::<String>())
     } else {
         first_line.to_string()
     }
@@ -291,32 +320,32 @@ fn truncate(s: &str, max: usize) -> String {
 
 #[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
 fn print_results(results: &BatchResults) {
-    tracing::debug!("\n=== Batch Migration Test Results ===\n");
-    tracing::debug!("Total styles tested: {}", results.total);
-    tracing::debug!("");
-
-    let success_rate = (results.migration_success as f64 / results.total as f64) * 100.0;
-    tracing::debug!(
-        "Migration + Processor Success: {} ({:.1}%)",
-        results.migration_success,
-        success_rate
+    println!("\n=== Batch Migration Test Results ===\n");
+    println!("Total styles tested: {}", results.total);
+    println!();
+    let success_rate = if results.total > 0 {
+        (results.migration_success as f64 / results.total as f64) * 100.0
+    } else {
+        0.0
+    };
+    println!(
+        "Migration + Engine Success: {} ({:.1}%)",
+        results.migration_success, success_rate
     );
-    tracing::debug!("Migration Failed: {}", results.migration_failed);
-    tracing::debug!("YAML Invalid: {}", results.yaml_invalid);
-    tracing::debug!("Processor Failed: {}", results.processor_failed);
+    println!("Migration Failed:          {}", results.migration_failed);
+    println!("YAML Invalid:              {}", results.yaml_invalid);
+    println!("Processor Failed:          {}", results.processor_failed);
 
     if !results.migration_errors.is_empty() {
-        tracing::debug!("\n--- Migration Errors ---");
+        println!("\n--- Migration Errors ---");
         print_error_summary(&results.migration_errors);
     }
-
     if !results.yaml_errors.is_empty() {
-        tracing::debug!("\n--- YAML Validation Errors ---");
+        println!("\n--- YAML Validation Errors ---");
         print_error_summary(&results.yaml_errors);
     }
-
     if !results.processor_errors.is_empty() {
-        tracing::debug!("\n--- Processor Errors ---");
+        println!("\n--- Processor Errors ---");
         print_error_summary(&results.processor_errors);
     }
 }
@@ -324,11 +353,10 @@ fn print_results(results: &BatchResults) {
 fn print_error_summary(errors: &HashMap<String, usize>) {
     let mut items: Vec<_> = errors.iter().collect();
     items.sort_by(|a, b| b.1.cmp(a.1));
-
     for (error, count) in items.iter().take(10) {
-        tracing::debug!("  {count:5} - {error}");
+        println!("  {count:5} - {error}");
     }
     if items.len() > 10 {
-        tracing::debug!("  ... and {} more error types", items.len() - 10);
+        println!("  … and {} more error types", items.len() - 10);
     }
 }

--- a/crates/citum-analyze/src/config_presets.rs
+++ b/crates/citum-analyze/src/config_presets.rs
@@ -1,0 +1,355 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Corpus-wide config-preset discovery: which per-concern config shapes are unnamed?
+//!
+//! Walks all independent CSL styles, extracts the per-concern config blocks that
+//! migration populates (`contributors`, `dates`, `titles`, `locators`), and checks
+//! each observed shape against the named presets in `citum-schema-style`.
+//!
+//! Only **unnamed** shapes — recurring ≥ [`MIN_FREQUENCY`] times and matching no
+//! existing preset exactly — are emitted. These are candidates for new named presets
+//! in `citum-schema-style`. Matched shapes are tallied in the per-concern summary so
+//! coverage context is preserved even though individual matches are suppressed.
+//!
+//! Invoke via `citum-analyze <styles_dir> --config-presets [--json]`.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::io::Write as _;
+use std::path::Path;
+
+use walkdir::WalkDir;
+
+use citum_migrate::OptionsExtractor;
+use citum_schema::options::{
+    ContributorConfig, DateConfig, LocatorConfig, LocatorPreset, TitlesConfig,
+};
+use citum_schema::presets::{ContributorPreset, DatePreset, TitlePreset};
+use csl_legacy::parser::parse_style;
+
+/// Minimum number of distinct styles an unnamed config shape must appear in to be reported.
+const MIN_FREQUENCY: u32 = 3;
+
+/// Maximum example style slugs per candidate entry.
+const MAX_EXAMPLES: usize = 5;
+
+/// A recurring config shape that does not match any existing named preset.
+#[derive(Debug, serde::Serialize)]
+pub struct PresetCandidate {
+    /// Number of corpus styles sharing this exact config shape.
+    pub corpus_count: u32,
+    /// Up to [`MAX_EXAMPLES`] style slugs that use this config.
+    pub example_styles: Vec<String>,
+    /// Serialized config block: the literal shape a new preset would encode.
+    pub canonical_config: serde_json::Value,
+}
+
+/// Per-concern summary: preset coverage count and unnamed-candidate list.
+#[derive(Debug, serde::Serialize)]
+pub struct ConcernReport {
+    /// Concern name: `"contributors"`, `"dates"`, `"titles"`, or `"locators"`.
+    pub concern: String,
+    /// Styles whose non-default config for this concern matched a named preset exactly.
+    pub matched_style_count: u32,
+    /// Styles with a non-default config that did not match any preset.
+    pub unmatched_style_count: u32,
+    /// Unnamed shapes above [`MIN_FREQUENCY`], ranked by corpus count descending.
+    pub candidates: Vec<PresetCandidate>,
+}
+
+/// Full config-preset analysis report.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct ConfigPresetReport {
+    /// Total CSL styles analyzed.
+    pub total_analyzed: u32,
+    /// Styles that failed to parse or load options.
+    pub parse_errors: u32,
+    /// Per-concern results in order: contributors, dates, titles, locators.
+    pub concerns: Vec<ConcernReport>,
+}
+
+/// Run the config-preset analysis and emit the report to stdout or stderr.
+pub fn run_config_presets(styles_dir: &str, json_output: bool) {
+    let report = analyze_config_presets(Path::new(styles_dir));
+    if json_output {
+        match serde_json::to_string_pretty(&report) {
+            Ok(json) => writeln!(std::io::stdout(), "{json}").unwrap_or(()),
+            Err(err) => eprintln!("Error: serializing config-preset report: {err}"),
+        }
+    } else {
+        print_config_preset_report(&report);
+    }
+}
+
+fn analyze_config_presets(styles_dir: &Path) -> ConfigPresetReport {
+    let entries: Vec<_> = WalkDir::new(styles_dir)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "csl"))
+        .collect();
+    let corpus_size = entries.len();
+    eprintln!("Analyzing {corpus_size} styles for config-preset gaps...");
+
+    // concern name → (canonical_key → (count, examples, display value))
+    let mut concern_maps: [HashMap<String, (u32, Vec<String>, serde_json::Value)>; 4] =
+        Default::default();
+
+    let mut total_analyzed = 0u32;
+    let mut parse_errors = 0u32;
+
+    for (i, entry) in entries.iter().enumerate() {
+        let path = entry.path();
+        let slug = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        let Ok(content) = std::fs::read_to_string(path) else {
+            parse_errors += 1;
+            continue;
+        };
+        let Ok(doc) = roxmltree::Document::parse(&content) else {
+            parse_errors += 1;
+            continue;
+        };
+        let Ok(legacy) = parse_style(doc.root_element()) else {
+            parse_errors += 1;
+            continue;
+        };
+
+        // Options extraction: XML attribute parsing only — no compile or engine call.
+        let config = OptionsExtractor::extract_migration_options(&legacy).options;
+        total_analyzed += 1;
+
+        if let Some(v) = config.contributors
+            && v != ContributorConfig::default()
+        {
+            accumulate(&mut concern_maps[0], &slug, &v);
+        }
+        if let Some(v) = config.dates
+            && v != DateConfig::default()
+        {
+            accumulate(&mut concern_maps[1], &slug, &v);
+        }
+        if let Some(v) = config.titles
+            && v != TitlesConfig::default()
+        {
+            accumulate(&mut concern_maps[2], &slug, &v);
+        }
+        if let Some(v) = config.locators
+            && v != LocatorConfig::default()
+        {
+            accumulate(&mut concern_maps[3], &slug, &v);
+        }
+
+        if (i + 1) % 500 == 0 {
+            eprintln!("  {}/{corpus_size}", i + 1);
+        }
+    }
+    eprintln!("  done ({corpus_size} styles).");
+
+    let [contributor_map, date_map, title_map, locator_map] = concern_maps;
+
+    let concerns = vec![
+        build_concern("contributors", contributor_map, &contributor_named_keys()),
+        build_concern("dates", date_map, &date_named_keys()),
+        build_concern("titles", title_map, &title_named_keys()),
+        build_concern("locators", locator_map, &locator_named_keys()),
+    ];
+
+    ConfigPresetReport {
+        total_analyzed,
+        parse_errors,
+        concerns,
+    }
+}
+
+/// Accumulate a serializable config value into a frequency map.
+fn accumulate(
+    map: &mut HashMap<String, (u32, Vec<String>, serde_json::Value)>,
+    slug: &str,
+    value: &impl serde::Serialize,
+) {
+    let raw = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
+    let sorted = sort_json_keys(&raw);
+    let key = sorted.to_string();
+    let entry = map.entry(key).or_insert((0, Vec::new(), sorted));
+    entry.0 += 1;
+    if entry.1.len() < MAX_EXAMPLES {
+        entry.1.push(slug.to_string());
+    }
+}
+
+/// Build a [`ConcernReport`] by comparing accumulated keys against the named-preset set.
+fn build_concern(
+    name: &str,
+    counts: HashMap<String, (u32, Vec<String>, serde_json::Value)>,
+    named_keys: &HashSet<String>,
+) -> ConcernReport {
+    let mut matched = 0u32;
+    let mut unmatched = 0u32;
+    let mut candidates = Vec::new();
+
+    for (key, (count, examples, canonical_config)) in counts {
+        if named_keys.contains(&key) {
+            matched += count;
+        } else {
+            unmatched += count;
+            if count >= MIN_FREQUENCY {
+                candidates.push(PresetCandidate {
+                    corpus_count: count,
+                    example_styles: examples,
+                    canonical_config,
+                });
+            }
+        }
+    }
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.corpus_count));
+
+    ConcernReport {
+        concern: name.to_string(),
+        matched_style_count: matched,
+        unmatched_style_count: unmatched,
+        candidates,
+    }
+}
+
+/// Recursively sort JSON object keys for a stable canonical representation.
+fn sort_json_keys(v: &serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => {
+            let sorted: BTreeMap<_, _> = map.iter().collect();
+            let new_map: serde_json::Map<_, _> = sorted
+                .into_iter()
+                .map(|(k, v)| (k.clone(), sort_json_keys(v)))
+                .collect();
+            serde_json::Value::Object(new_map)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(sort_json_keys).collect())
+        }
+        other => other.clone(),
+    }
+}
+
+// ── Preset enumerators ──────────────────────────────────────────────────────
+//
+// These lists enumerate all current variants of each preset enum so the report
+// can reverse-match observed configs against them. Keep in sync with the enum
+// definitions in `citum-schema-style/src/presets.rs` and
+// `citum-schema-style/src/options/locators.rs`.
+
+fn preset_keys<P: serde::Serialize>(
+    presets: impl IntoIterator<Item = (P, impl serde::Serialize)>,
+) -> HashSet<String> {
+    presets
+        .into_iter()
+        .map(|(_, config)| {
+            let raw = serde_json::to_value(&config).unwrap_or(serde_json::Value::Null);
+            sort_json_keys(&raw).to_string()
+        })
+        .collect()
+}
+
+fn contributor_named_keys() -> HashSet<String> {
+    // keep in sync with ContributorPreset in presets.rs
+    let variants = [
+        ContributorPreset::Apa,
+        ContributorPreset::Chicago,
+        ContributorPreset::Vancouver,
+        ContributorPreset::Ieee,
+        ContributorPreset::Harvard,
+        ContributorPreset::Springer,
+        ContributorPreset::NumericCompact,
+        ContributorPreset::NumericMedium,
+        ContributorPreset::NumericTight,
+        ContributorPreset::NumericLarge,
+        ContributorPreset::NumericAllAuthors,
+        ContributorPreset::NumericGivenDot,
+        ContributorPreset::AnnualReviews,
+        ContributorPreset::MathPhys,
+        ContributorPreset::SocSciFirst,
+        ContributorPreset::PhysicsNumeric,
+    ];
+    preset_keys(variants.iter().map(|p| (p, p.config())))
+}
+
+fn date_named_keys() -> HashSet<String> {
+    // keep in sync with DatePreset in presets.rs
+    let variants = [
+        DatePreset::Long,
+        DatePreset::Short,
+        DatePreset::Numeric,
+        DatePreset::Iso,
+    ];
+    preset_keys(variants.iter().map(|p| (p, p.config())))
+}
+
+fn title_named_keys() -> HashSet<String> {
+    // keep in sync with TitlePreset in presets.rs
+    let variants = [
+        TitlePreset::Apa,
+        TitlePreset::Chicago,
+        TitlePreset::Ieee,
+        TitlePreset::Humanities,
+        TitlePreset::JournalEmphasis,
+        TitlePreset::Scientific,
+    ];
+    preset_keys(variants.iter().map(|p| (p, p.config())))
+}
+
+fn locator_named_keys() -> HashSet<String> {
+    // keep in sync with LocatorPreset in options/locators.rs
+    let variants = [LocatorPreset::Note, LocatorPreset::AuthorDate];
+    preset_keys(variants.into_iter().map(|p| (p, p.config())))
+}
+
+// ── Human-readable output ───────────────────────────────────────────────────
+
+#[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
+fn print_config_preset_report(report: &ConfigPresetReport) {
+    println!("=== Config-Preset Discovery Report ===\n");
+    println!("Styles analyzed: {}", report.total_analyzed);
+    println!("Parse errors:    {}", report.parse_errors);
+    println!();
+
+    for concern in &report.concerns {
+        println!("=== {} ===", concern.concern.to_ascii_uppercase());
+        println!(
+            "  {} styles matched existing presets, {} styles unmatched",
+            concern.matched_style_count, concern.unmatched_style_count
+        );
+        if concern.candidates.is_empty() {
+            println!("  (no unnamed shapes ≥ {MIN_FREQUENCY} styles above threshold)");
+        } else {
+            println!(
+                "  {} unnamed shapes (≥ {MIN_FREQUENCY} styles):\n",
+                concern.candidates.len()
+            );
+            println!("  {:>6}  Examples", "Styles");
+            println!("  {}", "-".repeat(60));
+            for (rank, c) in concern.candidates.iter().enumerate() {
+                let examples = c.example_styles.join(", ");
+                let examples_trunc = if examples.chars().count() > 44 {
+                    format!("{}…", examples.chars().take(43).collect::<String>())
+                } else {
+                    examples
+                };
+                println!("  {:>6}  {}", c.corpus_count, examples_trunc);
+                let config_str = serde_json::to_string(&c.canonical_config)
+                    .unwrap_or_else(|_| String::from("{?}"));
+                let config_trunc = if config_str.chars().count() > 100 {
+                    format!("{}…", config_str.chars().take(99).collect::<String>())
+                } else {
+                    config_str
+                };
+                println!("         Config[{}]: {config_trunc}", rank + 1);
+                println!();
+            }
+        }
+        println!();
+    }
+}

--- a/crates/citum-analyze/src/coverage_gap.rs
+++ b/crates/citum-analyze/src/coverage_gap.rs
@@ -1,0 +1,382 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Corpus-wide coverage-gap analysis: which CSL features does migrate drop?
+//!
+//! Walks all CSL files in a styles directory, runs each through the
+//! `citum-migrate` XML compilation pipeline in-process, and compares the raw
+//! CSL feature references in the legacy source against the compiled Citum
+//! template output. The difference is the **converter gap** — constructs
+//! present in the CSL source that do not appear in migrate's output.
+//!
+//! Produces two output reports:
+//! - **`prioritized_gaps`**: features ranked by how many styles are affected —
+//!   the actionable feed for `citum-migrate` converter work.
+//! - **`preset_families`**: independent styles whose compiled output closely
+//!   matches a Citum base style (Jaccard ≥ threshold) — data-driven discovery
+//!   of preset/alias candidates.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
+
+use walkdir::WalkDir;
+
+use crate::semantic::{
+    SemanticItem, collect_base_semantic_sets, jaccard_similarity, semantic_to_legacy_key,
+    template_to_set,
+};
+use citum_migrate::{OptionsExtractor, compilation, fixups, provenance::ProvenanceTracker};
+use citum_schema::StyleBase;
+use citum_schema::options::Processing;
+use csl_legacy::model::CslNode;
+use csl_legacy::parser::parse_style;
+
+/// Similarity threshold for including a style in a preset-family cluster.
+const PRESET_SIMILARITY_THRESHOLD: f32 = 0.65;
+
+/// Maximum example style slugs to include per gap entry.
+const MAX_EXAMPLES: usize = 5;
+
+/// An entry in the prioritized converter-gap list.
+#[derive(Debug, serde::Serialize)]
+pub struct ConverterGapEntry {
+    /// Feature key, e.g. `"var:author"`, `"num:volume"`, `"date:issued"`.
+    pub feature: String,
+    /// Independent styles where this feature is present in legacy but absent from compiled output.
+    pub corpus_count: u32,
+    /// Up to [`MAX_EXAMPLES`] style slugs exhibiting this gap.
+    pub example_styles: Vec<String>,
+}
+
+/// A single style within a preset-family cluster.
+#[derive(Debug, serde::Serialize)]
+pub struct MatchedStyle {
+    /// Style file slug, e.g. `"taylor-and-francis-chicago-author-date"`.
+    pub slug: String,
+    /// Average of `bibliography_similarity` and `citation_similarity`.
+    pub combined_similarity: f32,
+    /// Bibliography-only Jaccard similarity.
+    pub bibliography_similarity: f32,
+    /// Citation-only Jaccard similarity.
+    pub citation_similarity: f32,
+}
+
+/// A cluster of independent styles that closely match a Citum base.
+#[derive(Debug, serde::Serialize)]
+pub struct PresetFamilyEntry {
+    /// The Citum base style key, e.g. `"apa"`, `"chicago-author-date"`.
+    pub base: String,
+    /// Matched independent styles, sorted by similarity descending.
+    pub matched_styles: Vec<MatchedStyle>,
+}
+
+/// Full coverage-gap analysis output.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct CoverageGapReport {
+    /// Number of CSL styles analyzed.
+    pub total_analyzed: u32,
+    /// Number of styles that failed to parse or compile.
+    pub parse_errors: u32,
+    /// Converter gaps ranked by corpus weight (highest first).
+    pub prioritized_gaps: Vec<ConverterGapEntry>,
+    /// Preset-family clusters (combined similarity ≥ threshold).
+    pub preset_families: Vec<PresetFamilyEntry>,
+}
+
+/// Run the corpus-wide coverage-gap analysis and print or emit the report.
+pub fn run_coverage_gap(styles_dir: &str, json_output: bool) {
+    let report = analyze_coverage_gap(Path::new(styles_dir));
+    if json_output {
+        match serde_json::to_string_pretty(&report) {
+            Ok(json) => writeln!(std::io::stdout(), "{json}").unwrap_or(()),
+            Err(err) => eprintln!("Error: serializing coverage-gap report: {err}"),
+        }
+    } else {
+        print_coverage_gap_report(&report);
+    }
+}
+
+fn analyze_coverage_gap(styles_dir: &Path) -> CoverageGapReport {
+    let tracker = ProvenanceTracker::new(false);
+    let bases = collect_base_semantic_sets();
+
+    // Collect upfront so we can show progress against a known total.
+    let entries: Vec<_> = WalkDir::new(styles_dir)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "csl"))
+        .collect();
+    let corpus_size = entries.len();
+    eprintln!("Analyzing {corpus_size} styles...");
+
+    let mut gap_counts: HashMap<String, (u32, Vec<String>)> = HashMap::new();
+    let mut family_matches: HashMap<String, Vec<MatchedStyle>> = HashMap::new();
+    let mut total_analyzed = 0u32;
+    let mut parse_errors = 0u32;
+
+    for (i, entry) in entries.iter().enumerate() {
+        let path = entry.path();
+        let slug = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        match analyze_one_style(path, &tracker) {
+            Ok((legacy_features, compiled_features, bib_set, cit_set)) => {
+                total_analyzed += 1;
+                for gap_feature in legacy_features.difference(&compiled_features) {
+                    let (count, examples) = gap_counts
+                        .entry(gap_feature.clone())
+                        .or_insert_with(|| (0, Vec::new()));
+                    *count += 1;
+                    if examples.len() < MAX_EXAMPLES {
+                        examples.push(slug.clone());
+                    }
+                }
+                match_against_bases(&slug, &bib_set, &cit_set, &bases, &mut family_matches);
+            }
+            Err(_) => parse_errors += 1,
+        }
+
+        if (i + 1) % 500 == 0 {
+            eprintln!("  {}/{corpus_size}", i + 1);
+        }
+    }
+    eprintln!("  done ({corpus_size} styles).");
+
+    build_report(total_analyzed, parse_errors, gap_counts, family_matches)
+}
+
+fn match_against_bases(
+    slug: &str,
+    bib_set: &HashSet<SemanticItem>,
+    cit_set: &HashSet<SemanticItem>,
+    bases: &[(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)],
+    family_matches: &mut HashMap<String, Vec<MatchedStyle>>,
+) {
+    for (base, base_bib_set, base_cit_sets) in bases {
+        let bib_sim = jaccard_similarity(bib_set, base_bib_set);
+        let cit_sim = if base_cit_sets.is_empty() {
+            1.0
+        } else {
+            base_cit_sets
+                .iter()
+                .map(|s| jaccard_similarity(cit_set, s))
+                .fold(0.0_f32, f32::max)
+        };
+        let combined = f32::midpoint(bib_sim, cit_sim);
+        if combined >= PRESET_SIMILARITY_THRESHOLD {
+            family_matches
+                .entry(base.key().to_string())
+                .or_default()
+                .push(MatchedStyle {
+                    slug: slug.to_string(),
+                    combined_similarity: combined,
+                    bibliography_similarity: bib_sim,
+                    citation_similarity: cit_sim,
+                });
+        }
+    }
+}
+
+fn analyze_one_style(
+    path: &Path,
+    tracker: &ProvenanceTracker,
+) -> Result<
+    (
+        HashSet<String>,
+        HashSet<String>,
+        HashSet<SemanticItem>,
+        HashSet<SemanticItem>,
+    ),
+    String,
+> {
+    let content = fs::read_to_string(path).map_err(|e| format!("read: {e}"))?;
+    let doc = roxmltree::Document::parse(&content).map_err(|e| format!("xml: {e}"))?;
+    let legacy = parse_style(doc.root_element()).map_err(|e| format!("csl: {e}"))?;
+
+    let legacy_features = collect_legacy_features(&legacy);
+
+    let opts = OptionsExtractor::extract_migration_options(&legacy);
+    let mut options = opts.options;
+    let output = compilation::compile_from_xml(&legacy, &mut options, false, tracker);
+
+    let mut citation_template = output.citation.clone();
+    if matches!(options.processing, Some(Processing::Numeric)) {
+        fixups::ensure_numeric_locator_citation_component(
+            &legacy.citation.layout,
+            &mut citation_template,
+        );
+    } else if legacy.class == "in-text" {
+        fixups::normalize_author_date_locator_citation_component(
+            &legacy.citation.layout,
+            &legacy.macros,
+            &mut citation_template,
+        );
+    }
+
+    let bib_set = template_to_set(&output.bibliography);
+    let cit_set = template_to_set(&citation_template);
+    let compiled_features: HashSet<String> = bib_set
+        .iter()
+        .chain(cit_set.iter())
+        .map(semantic_to_legacy_key)
+        .collect();
+
+    Ok((legacy_features, compiled_features, bib_set, cit_set))
+}
+
+/// Collect all CSL feature keys referenced anywhere in a legacy style's macros and layouts.
+///
+/// Walking all macros rather than only reachable ones may include a small number of
+/// "dead macro" features; these show up as false positives in the gap list. Known-benign
+/// fixup normalizations (e.g. locator citation injection) are also visible here.
+pub fn collect_legacy_features(style: &csl_legacy::model::Style) -> HashSet<String> {
+    let mut features = HashSet::new();
+    collect_features_from_nodes(&style.citation.layout.children, &mut features);
+    if let Some(ref bib) = style.bibliography {
+        collect_features_from_nodes(&bib.layout.children, &mut features);
+    }
+    for macro_ in &style.macros {
+        collect_features_from_nodes(&macro_.children, &mut features);
+    }
+    features
+}
+
+fn collect_features_from_nodes(nodes: &[CslNode], features: &mut HashSet<String>) {
+    for node in nodes {
+        match node {
+            CslNode::Text(t) => {
+                if let Some(var) = &t.variable {
+                    features.insert(format!("var:{var}"));
+                }
+                if let Some(term) = &t.term {
+                    features.insert(format!("term:{term}"));
+                }
+            }
+            CslNode::Number(n) => {
+                features.insert(format!("num:{}", n.variable));
+            }
+            CslNode::Date(d) => {
+                features.insert(format!("date:{}", d.variable));
+            }
+            CslNode::Names(n) => {
+                for var in n.variable.split_whitespace() {
+                    features.insert(format!("names:{var}"));
+                }
+                collect_features_from_nodes(&n.children, features);
+            }
+            CslNode::Label(l) => {
+                if let Some(var) = &l.variable {
+                    features.insert(format!("term:{var}"));
+                }
+            }
+            CslNode::Group(g) => collect_features_from_nodes(&g.children, features),
+            CslNode::Choose(c) => {
+                collect_features_from_nodes(&c.if_branch.children, features);
+                for branch in &c.else_if_branches {
+                    collect_features_from_nodes(&branch.children, features);
+                }
+                if let Some(else_nodes) = &c.else_branch {
+                    collect_features_from_nodes(else_nodes, features);
+                }
+            }
+            CslNode::Name(_) | CslNode::EtAl(_) | CslNode::Substitute(_) => {}
+        }
+    }
+}
+
+fn build_report(
+    total_analyzed: u32,
+    parse_errors: u32,
+    gap_counts: HashMap<String, (u32, Vec<String>)>,
+    family_matches: HashMap<String, Vec<MatchedStyle>>,
+) -> CoverageGapReport {
+    let mut prioritized_gaps: Vec<ConverterGapEntry> = gap_counts
+        .into_iter()
+        .map(
+            |(feature, (corpus_count, example_styles))| ConverterGapEntry {
+                feature,
+                corpus_count,
+                example_styles,
+            },
+        )
+        .collect();
+    prioritized_gaps.sort_by_key(|e| std::cmp::Reverse(e.corpus_count));
+
+    let mut preset_families: Vec<PresetFamilyEntry> = family_matches
+        .into_iter()
+        .map(|(base, mut styles)| {
+            styles.sort_by(|a, b| {
+                b.combined_similarity
+                    .partial_cmp(&a.combined_similarity)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            PresetFamilyEntry {
+                base,
+                matched_styles: styles,
+            }
+        })
+        .collect();
+    preset_families.sort_by_key(|f| std::cmp::Reverse(f.matched_styles.len()));
+
+    CoverageGapReport {
+        total_analyzed,
+        parse_errors,
+        prioritized_gaps,
+        preset_families,
+    }
+}
+
+#[allow(clippy::cognitive_complexity, reason = "macro-heavy output code")]
+fn print_coverage_gap_report(report: &CoverageGapReport) {
+    println!("=== Coverage-Gap Report ===\n");
+    println!("Styles analyzed:  {}", report.total_analyzed);
+    println!("Parse errors:     {}", report.parse_errors);
+    println!();
+
+    println!("=== Prioritized Converter Gaps (top 40) ===\n");
+    println!("{:>4}  {:<44} {:>6}  Examples", "Rank", "Feature", "Styles");
+    println!("{}", "-".repeat(80));
+    for (i, entry) in report.prioritized_gaps.iter().take(40).enumerate() {
+        let examples = entry.example_styles.join(", ");
+        let examples_trunc = if examples.chars().count() > 40 {
+            format!("{}…", examples.chars().take(39).collect::<String>())
+        } else {
+            examples
+        };
+        println!(
+            "{:>4}  {:<44} {:>6}  {}",
+            i + 1,
+            entry.feature,
+            entry.corpus_count,
+            examples_trunc,
+        );
+    }
+
+    println!("\n=== Preset-Family Clusters (similarity ≥ {PRESET_SIMILARITY_THRESHOLD:.2}) ===\n");
+    for family in report.preset_families.iter().take(20) {
+        println!(
+            "  {} ({} styles):",
+            family.base,
+            family.matched_styles.len()
+        );
+        for style in family.matched_styles.iter().take(5) {
+            println!(
+                "    - {} (combined {:.2}, bib {:.2}, cit {:.2})",
+                style.slug,
+                style.combined_similarity,
+                style.bibliography_similarity,
+                style.citation_similarity
+            );
+        }
+        if family.matched_styles.len() > 5 {
+            println!("    … and {} more", family.matched_styles.len() - 5);
+        }
+    }
+}

--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -9,6 +9,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 #![allow(missing_docs, reason = "bin/main")]
 
 mod analyzer;
+mod config_presets;
 mod coverage_gap;
 mod profile_discovery;
 mod ranker;
@@ -35,6 +36,7 @@ fn main() {
     let quantify_savings = args.iter().any(|arg| arg == "--quantify-savings");
     let identify_profiles = args.iter().any(|arg| arg == "--identify-profiles");
     let coverage_gap = args.iter().any(|arg| arg == "--coverage-gap");
+    let config_presets = args.iter().any(|arg| arg == "--config-presets");
 
     // Check for format filter (--format author-date, --format numeric, etc.)
     let format_filter = args
@@ -43,7 +45,9 @@ fn main() {
         .and_then(|i| args.get(i + 1))
         .map(std::string::String::as_str);
 
-    if coverage_gap {
+    if config_presets {
+        config_presets::run_config_presets(styles_dir, json_output);
+    } else if coverage_gap {
         coverage_gap::run_coverage_gap(styles_dir, json_output);
     } else if identify_profiles {
         profile_discovery::run_profile_discovery(styles_dir, json_output);
@@ -86,6 +90,14 @@ fn print_usage() {
         "      and which independent styles match a Citum base style (preset-family clusters)."
     );
     eprintln!();
+    eprintln!("  citum_analyze <styles_dir> --config-presets [--json]");
+    eprintln!(
+        "      Discover recurring per-concern config shapes (contributors, dates, titles, locators)"
+    );
+    eprintln!(
+        "      that do not match any existing named preset — candidates for new presets in citum-schema-style."
+    );
+    eprintln!();
     eprintln!("Examples:");
     eprintln!("  citum_analyze styles-legacy/");
     eprintln!("  citum_analyze styles-legacy/ --rank-parents");
@@ -93,4 +105,7 @@ fn print_usage() {
     eprintln!("  citum_analyze styles-legacy/ --quantify-savings --json");
     eprintln!("  citum_analyze styles-legacy/ --identify-profiles --json");
     eprintln!("  citum_analyze styles-legacy/ --coverage-gap --json | jq '.prioritized_gaps[:10]'");
+    eprintln!(
+        "  citum_analyze styles-legacy/ --config-presets --json | jq '.concerns[].candidates[:3]'"
+    );
 }

--- a/crates/citum-analyze/src/main.rs
+++ b/crates/citum-analyze/src/main.rs
@@ -9,9 +9,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 #![allow(missing_docs, reason = "bin/main")]
 
 mod analyzer;
+mod coverage_gap;
 mod profile_discovery;
 mod ranker;
 mod savings;
+pub mod semantic;
 mod util;
 
 use std::env;
@@ -32,6 +34,7 @@ fn main() {
     let rank_parents = args.iter().any(|arg| arg == "--rank-parents");
     let quantify_savings = args.iter().any(|arg| arg == "--quantify-savings");
     let identify_profiles = args.iter().any(|arg| arg == "--identify-profiles");
+    let coverage_gap = args.iter().any(|arg| arg == "--coverage-gap");
 
     // Check for format filter (--format author-date, --format numeric, etc.)
     let format_filter = args
@@ -40,7 +43,9 @@ fn main() {
         .and_then(|i| args.get(i + 1))
         .map(std::string::String::as_str);
 
-    if identify_profiles {
+    if coverage_gap {
+        coverage_gap::run_coverage_gap(styles_dir, json_output);
+    } else if identify_profiles {
         profile_discovery::run_profile_discovery(styles_dir, json_output);
     } else if quantify_savings {
         savings::run_savings_report(styles_dir, json_output);
@@ -73,10 +78,19 @@ fn print_usage() {
         "      Audit the current journal-profile candidate shortlist with normalized IDs and repo evidence."
     );
     eprintln!();
+    eprintln!("  citum_analyze <styles_dir> --coverage-gap [--json]");
+    eprintln!(
+        "      Report which CSL features migrate drops across the corpus (prioritized converter gaps)"
+    );
+    eprintln!(
+        "      and which independent styles match a Citum base style (preset-family clusters)."
+    );
+    eprintln!();
     eprintln!("Examples:");
     eprintln!("  citum_analyze styles-legacy/");
     eprintln!("  citum_analyze styles-legacy/ --rank-parents");
     eprintln!("  citum_analyze styles-legacy/ --rank-parents --format author-date --json");
     eprintln!("  citum_analyze styles-legacy/ --quantify-savings --json");
     eprintln!("  citum_analyze styles-legacy/ --identify-profiles --json");
+    eprintln!("  citum_analyze styles-legacy/ --coverage-gap --json | jq '.prioritized_gaps[:10]'");
 }

--- a/crates/citum-analyze/src/profile_discovery.rs
+++ b/crates/citum-analyze/src/profile_discovery.rs
@@ -11,12 +11,11 @@ use std::path::{Path, PathBuf};
 
 use crate::util::short_name_from_identifier;
 
+use crate::semantic::{
+    SemanticItem, collect_base_semantic_sets, jaccard_similarity, template_to_set,
+};
 use citum_migrate::{OptionsExtractor, compilation, fixups, provenance::ProvenanceTracker};
 use citum_schema::StyleBase;
-use citum_schema::locale::GeneralTerm;
-use citum_schema::template::{
-    ContributorRole, DateVariable, NumberVariable, SimpleVariable, TemplateComponent, TitleType,
-};
 use csl_legacy::parser::parse_style;
 
 const AUDITED_CANDIDATES: &[AuditedCandidateSpec] = &[
@@ -121,11 +120,12 @@ pub fn run_profile_discovery(styles_dir: &str, json_output: bool) {
 
     if json_output {
         match serde_json::to_string_pretty(&report) {
-            Ok(json) => tracing::debug!("{json}"),
+            Ok(json) => {
+                use std::io::Write as _;
+                writeln!(std::io::stdout(), "{json}").unwrap_or(());
+            }
             Err(err) => {
-                tracing::debug!(
-                    "Error: Failed to serialize profile discovery report to JSON: {err}"
-                );
+                eprintln!("Error: serializing profile discovery report: {err}");
             }
         }
     } else {
@@ -262,52 +262,6 @@ struct LegacyStyleMetadata {
     title: String,
     citation_format: Option<String>,
     fields: Vec<String>,
-}
-
-/// A simplified semantic representation of a template component.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-enum SemanticItem {
-    Variable(SimpleVariable),
-    Number(NumberVariable),
-    Date(DateVariable),
-    Contributor(ContributorRole),
-    Title(TitleType),
-    Term(GeneralTerm),
-}
-
-fn collect_base_semantic_sets()
--> Vec<(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)> {
-    StyleBase::all()
-        .iter()
-        .map(|base| {
-            let style = base.base().into_resolved();
-            let bib_set = style
-                .bibliography
-                .as_ref()
-                .and_then(|b| b.template.as_ref())
-                .map(|t| template_to_set(t))
-                .unwrap_or_default();
-
-            let mut cit_sets = Vec::new();
-            if let Some(cit) = &style.citation {
-                if let Some(t) = &cit.template {
-                    cit_sets.push(template_to_set(t));
-                }
-                if let Some(i) = &cit.integral
-                    && let Some(t) = &i.template
-                {
-                    cit_sets.push(template_to_set(t));
-                }
-                if let Some(ni) = &cit.non_integral
-                    && let Some(t) = &ni.template
-                {
-                    cit_sets.push(template_to_set(t));
-                }
-            }
-
-            (base.clone(), bib_set, cit_sets)
-        })
-        .collect()
 }
 
 fn audit_candidate(
@@ -576,45 +530,6 @@ fn normalize_style_id(style_id: &str, renamed_styles: &HashMap<String, String>) 
         .get(&normalized)
         .cloned()
         .unwrap_or(normalized)
-}
-
-fn jaccard_similarity(left: &HashSet<SemanticItem>, right: &HashSet<SemanticItem>) -> f32 {
-    let intersection = left.intersection(right).count();
-    let union = left.union(right).count();
-
-    if union == 0 {
-        1.0
-    } else {
-        intersection as f32 / union as f32
-    }
-}
-
-/// Maps a template component to semantic items; structural wrappers (Conditional, Substitute, etc.) are intentionally skipped.
-fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem>) {
-    match component {
-        TemplateComponent::Variable(v) => items.push(SemanticItem::Variable(v.variable.clone())),
-        TemplateComponent::Number(n) => items.push(SemanticItem::Number(n.number.clone())),
-        TemplateComponent::Date(d) => items.push(SemanticItem::Date(d.date.clone())),
-        TemplateComponent::Contributor(c) => {
-            items.push(SemanticItem::Contributor(c.contributor.clone()));
-        }
-        TemplateComponent::Title(t) => items.push(SemanticItem::Title(t.title.clone())),
-        TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term.clone())),
-        TemplateComponent::Group(g) => {
-            for child in &g.group {
-                to_semantic_items(child, items);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn template_to_set(template: &[TemplateComponent]) -> HashSet<SemanticItem> {
-    let mut items = Vec::new();
-    for component in template {
-        to_semantic_items(component, &mut items);
-    }
-    items.into_iter().collect()
 }
 
 fn sanitize_url(url: &str) -> String {

--- a/crates/citum-analyze/src/savings.rs
+++ b/crates/citum-analyze/src/savings.rs
@@ -17,9 +17,12 @@ pub fn run_savings_report(styles_dir: &str, json_output: bool) {
         Ok(report) => {
             if json_output {
                 match serde_json::to_string_pretty(&report) {
-                    Ok(json) => tracing::debug!("{json}"),
+                    Ok(json) => {
+                        use std::io::Write as _;
+                        writeln!(std::io::stdout(), "{json}").unwrap_or(());
+                    }
                     Err(error) => {
-                        tracing::debug!("Failed to serialize report to JSON: {error}");
+                        eprintln!("Error: serializing savings report: {error}");
                         std::process::exit(1);
                     }
                 }
@@ -28,7 +31,7 @@ pub fn run_savings_report(styles_dir: &str, json_output: bool) {
             }
         }
         Err(error) => {
-            tracing::debug!("Failed to analyze corpus savings: {error}");
+            eprintln!("Error: analyzing corpus savings: {error}");
             std::process::exit(1);
         }
     }

--- a/crates/citum-analyze/src/semantic.rs
+++ b/crates/citum-analyze/src/semantic.rs
@@ -1,0 +1,168 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Shared semantic representation for CSL-to-Citum comparison.
+//!
+//! Used by [`crate::profile_discovery`] (auditing known candidates) and
+//! [`crate::coverage_gap`] (corpus-wide gap analysis). Both modules reduce
+//! compiled templates to sets of [`SemanticItem`]s and compare them via
+//! Jaccard similarity or feature-key set arithmetic.
+
+use std::collections::HashSet;
+
+use citum_schema::StyleBase;
+use citum_schema::locale::GeneralTerm;
+use citum_schema::template::{
+    ContributorRole, DateVariable, NumberVariable, SimpleVariable, TemplateComponent, TitleType,
+};
+
+/// A simplified semantic representation of a compiled template component.
+///
+/// Structural wrappers (Conditional, Substitute, Separator, Layout, etc.) are
+/// intentionally omitted; only content-bearing items are captured.
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum SemanticItem {
+    /// A text-variable reference (non-title, non-numeric).
+    Variable(SimpleVariable),
+    /// A numeric variable reference.
+    Number(NumberVariable),
+    /// A date variable reference.
+    Date(DateVariable),
+    /// A contributor-role reference (`<names>` element).
+    Contributor(ContributorRole),
+    /// A title reference (typed).
+    Title(TitleType),
+    /// A locale term reference.
+    Term(GeneralTerm),
+}
+
+/// Convert a `SemanticItem` to a CSL-compatible feature key.
+///
+/// The key format mirrors what [`crate::coverage_gap::collect_legacy_features`]
+/// produces from the raw CSL source:
+/// `"var:title"`, `"num:volume"`, `"date:issued"`, `"names:author"`, `"term:and"`.
+///
+/// Several Citum schema names diverge from their CSL 1.0 counterparts:
+/// - [`TitleType`] variants (`Primary`, `ParentMonograph`, …) are reverse-mapped to
+///   their CSL variable names (`title`, `container-title`).
+/// - [`SimpleVariable::Doi`] / [`SimpleVariable::Url`] use uppercase in CSL (`DOI`,
+///   `URL`) but lowercase serde names in Citum.
+/// - [`SimpleVariable::ArchiveLocation`] uses an underscore in CSL (`archive_location`)
+///   but a hyphen in Citum serde (`archive-location`).
+pub fn semantic_to_legacy_key(item: &SemanticItem) -> String {
+    fn serialize<T: serde::Serialize>(v: &T) -> String {
+        serde_json::to_string(v)
+            .unwrap_or_default()
+            .trim_matches('"')
+            .to_string()
+    }
+    match item {
+        SemanticItem::Variable(v) => {
+            let csl_name = match v {
+                SimpleVariable::Doi => "DOI",
+                SimpleVariable::Url => "URL",
+                SimpleVariable::ArchiveLocation => "archive_location",
+                _ => return format!("var:{}", serialize(v)),
+            };
+            format!("var:{csl_name}")
+        }
+        SemanticItem::Number(n) => format!("num:{}", serialize(n)),
+        SemanticItem::Date(d) => format!("date:{}", serialize(d)),
+        SemanticItem::Contributor(c) => format!("names:{}", serialize(c)),
+        SemanticItem::Title(t) => {
+            // TitleType uses Citum-internal names; reverse-map to CSL 1.0 variable names.
+            let csl_var = match t {
+                TitleType::Primary => "title",
+                TitleType::ParentMonograph | TitleType::ParentSerial => "container-title",
+                _ => return format!("var:{}", serialize(t)),
+            };
+            format!("var:{csl_var}")
+        }
+        SemanticItem::Term(t) => format!("term:{}", serialize(t)),
+    }
+}
+
+/// Recursively collect `SemanticItem`s from a single `TemplateComponent`.
+///
+/// Structural wrappers (Conditional, Substitute, Separator, Layout, etc.) are
+/// traversed but not emitted as items.
+pub fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<SemanticItem>) {
+    match component {
+        TemplateComponent::Variable(v) => items.push(SemanticItem::Variable(v.variable.clone())),
+        TemplateComponent::Number(n) => items.push(SemanticItem::Number(n.number.clone())),
+        TemplateComponent::Date(d) => items.push(SemanticItem::Date(d.date.clone())),
+        TemplateComponent::Contributor(c) => {
+            items.push(SemanticItem::Contributor(c.contributor.clone()));
+        }
+        TemplateComponent::Title(t) => items.push(SemanticItem::Title(t.title.clone())),
+        TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term.clone())),
+        TemplateComponent::Group(g) => {
+            for child in &g.group {
+                to_semantic_items(child, items);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Reduce a template slice to the set of distinct `SemanticItem`s it references.
+pub fn template_to_set(template: &[TemplateComponent]) -> HashSet<SemanticItem> {
+    let mut items = Vec::new();
+    for component in template {
+        to_semantic_items(component, &mut items);
+    }
+    items.into_iter().collect()
+}
+
+/// Jaccard similarity between two semantic sets: `|A ∩ B| / |A ∪ B|`.
+///
+/// Returns `1.0` when both sets are empty (two empty templates are considered identical).
+pub fn jaccard_similarity(left: &HashSet<SemanticItem>, right: &HashSet<SemanticItem>) -> f32 {
+    let intersection = left.intersection(right).count();
+    let union = left.union(right).count();
+    if union == 0 {
+        1.0
+    } else {
+        intersection as f32 / union as f32
+    }
+}
+
+/// Pre-compute bibliography and citation semantic sets for every `StyleBase`.
+///
+/// Returns `(base, bib_set, cit_sets)` where `cit_sets` may contain one or more
+/// sets from the base's citation template, integral, and non-integral sub-templates.
+pub fn collect_base_semantic_sets()
+-> Vec<(StyleBase, HashSet<SemanticItem>, Vec<HashSet<SemanticItem>>)> {
+    StyleBase::all()
+        .iter()
+        .map(|base| {
+            let style = base.base().into_resolved();
+            let bib_set = style
+                .bibliography
+                .as_ref()
+                .and_then(|b| b.template.as_ref())
+                .map(|t| template_to_set(t))
+                .unwrap_or_default();
+
+            let mut cit_sets = Vec::new();
+            if let Some(cit) = &style.citation {
+                if let Some(t) = &cit.template {
+                    cit_sets.push(template_to_set(t));
+                }
+                if let Some(i) = &cit.integral
+                    && let Some(t) = &i.template
+                {
+                    cit_sets.push(template_to_set(t));
+                }
+                if let Some(ni) = &cit.non_integral
+                    && let Some(t) = &ni.template
+                {
+                    cit_sets.push(template_to_set(t));
+                }
+            }
+            (base.clone(), bib_set, cit_sets)
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary

- **Fix `--json` output** (`savings.rs`, `profile_discovery.rs`): JSON was emitted via `tracing::debug!`, silenced unless `RUST_LOG=debug`. Now writes to stdout — `--json | jq` works without any env var.
- **In-process `citum-batch-test`** (`batch_test.rs`): Replaced two `cargo run` spawns per style with direct library calls through `csl_legacy` → `citum_migrate` → `citum_schema` → `citum_engine`. Full-corpus pass is now seconds instead of hours.
- **README** (`crates/citum-analyze/README.md`): Documents both binaries, all five modes with exact invocations and flags, and how each feeds the migrate/preset/taxonomy pipeline.
- **`--coverage-gap` mode** (`semantic.rs`, `coverage_gap.rs`, `main.rs`): New corpus-wide analysis. Extracts `SemanticItem`/Jaccard helpers into a shared `semantic.rs` (used by both `profile_discovery` and the new mode). `coverage_gap.rs` walks all independent styles in-process and emits two reports: prioritized converter gaps (CSL features present in legacy but absent from compiled output, ranked by style count) and preset-family clusters (styles whose compiled semantic set matches a `StyleBase` with Jaccard ≥ 0.65).

Closes bean `csl26-t56t`.

## Test plan

- [x] `cargo run --bin citum-analyze -- styles-legacy/ --quantify-savings --json | jq .` — produces JSON (was silent before)
- [x] `cargo run --bin citum-analyze -- styles-legacy/ --identify-profiles --json | jq '.summary'` — produces JSON
- [x] `cargo run --bin citum-batch-test -- styles-legacy/ --sample 300 --json | jq '{total,migration_success,migration_failed}'` — runs in seconds, not minutes
- [x] `cargo run --bin citum-analyze -- styles-legacy/ --coverage-gap | head -50` — prints gap table and family clusters
- [x] `cargo run --bin citum-analyze -- styles-legacy/ --coverage-gap --json | jq '.prioritized_gaps[:5]'` — structured output
