### PR TITLE
fix(migrate): preserve CSL citation labels

### DIFF
--- a/.beans/archive/csl26-tzer--enginemigrate-citation-label-double-bracket-trigra.md
+++ b/.beans/archive/csl26-tzer--enginemigrate-citation-label-double-bracket-trigra.md
@@ -1,7 +1,7 @@
 ---
 # csl26-tzer
 title: 'engine/migrate: citation-label double-bracket + trigraph length'
-status: todo
+status: completed
 type: bug
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - migrate
     - engine
 created_at: 2026-06-14T11:19:46Z
-updated_at: 2026-06-14T11:49:29Z
+updated_at: 2026-06-17T00:52:22Z
 parent: csl26-vmcr
 blocked_by:
     - csl26-cvlm

--- a/crates/citum-engine/src/processor/labels.rs
+++ b/crates/citum-engine/src/processor/labels.rs
@@ -315,8 +315,8 @@ mod tests {
 
     #[test]
     fn test_ams_et_al_uses_4_initials() {
-        // AMS should use 4 initials in et-al case, not 3
-        // Vaswani, Shazeer, Parmar, Uszkoreit, ... 2017 → "VSPU+17" (4 chars)
+        // AMS/CSL should use 4 initials in et-al case with no marker.
+        // Vaswani, Shazeer, Parmar, Uszkoreit, ... 2017 → "VSPU17" (4 chars)
         let r = make_ref(
             vec![
                 Name::new("Vaswani", "Ashish"),
@@ -327,7 +327,7 @@ mod tests {
             ],
             2017,
         );
-        assert_eq!(generate_base_label(&r, &ams_params()), "VSPU+17");
+        assert_eq!(generate_base_label(&r, &ams_params()), "VSPU17");
     }
 
     #[test]

--- a/crates/citum-migrate/src/options_extractor/processing.rs
+++ b/crates/citum-migrate/src/options_extractor/processing.rs
@@ -4,8 +4,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{
-    GivennameRule, Group, LabelConfig, Processing, ProcessingCustom, Sort, SortEntry, SortKey,
-    SortSpec,
+    GivennameRule, Group, LabelConfig, LabelPreset, Processing, ProcessingCustom, Sort, SortEntry,
+    SortKey, SortSpec,
 };
 use citum_schema::presets::SortPreset;
 use csl_legacy::model::{CslNode, Style};
@@ -16,12 +16,7 @@ use std::collections::HashSet;
 /// Analyzes style attributes and layout patterns to determine if the style
 /// uses author-date, numeric, note-based, or label-based citation processing.
 pub fn detect_processing_mode(style: &Style) -> Option<Processing> {
-    // 0. Note styles are explicit in CSL and should map directly.
-    if style.class == "note" {
-        return Some(Processing::Note);
-    }
-
-    // 0b. Label (trigraph) styles render the generated `citation-label`
+    // 0. Label (trigraph) styles render the generated `citation-label`
     // variable (e.g. `[Kuhn62]`). The engine only emits citation labels under
     // `Processing::Label`, so the mode must be detected here or the label
     // renders empty.
@@ -35,7 +30,16 @@ pub fn detect_processing_mode(style: &Style) -> Option<Processing> {
     }
 
     if has_citation_label(&style.citation.layout.children) {
-        return Some(Processing::Label(LabelConfig::default()));
+        return Some(Processing::Label(LabelConfig {
+            preset: LabelPreset::Ams,
+            ..Default::default()
+        }));
+    }
+
+    // 0b. Note styles are explicit in CSL and should map directly when they
+    // do not render generated citation labels.
+    if style.class == "note" {
+        return Some(Processing::Note);
     }
 
     // 1. Explicitly numeric style
@@ -329,7 +333,27 @@ mod tests {
         // when the processing mode is detected
         let mode = detect_processing_mode(&style);
 
-        // then it is Label, so the engine will emit trigraph labels
+        // then it is Label with CSL-compatible label parameters
+        assert!(
+            matches!(mode, Some(Processing::Label(_))),
+            "expected Processing::Label, got: {mode:?}"
+        );
+        if let Some(Processing::Label(config)) = mode {
+            let params = config.effective_params();
+            assert_eq!(params.single_author_chars, 4);
+            assert_eq!(params.et_al_min, 5);
+            assert_eq!(params.et_al_marker, "");
+            assert_eq!(params.et_al_names, 4);
+        }
+    }
+
+    #[test]
+    fn detects_label_mode_before_note_mode() {
+        // given a note style whose citation renders the generated label
+        let style = style_with_citation_layout("note", r#"<text variable="citation-label"/>"#);
+
+        // then label processing wins because note processing cannot emit citation-label
+        let mode = detect_processing_mode(&style);
         assert!(
             matches!(mode, Some(Processing::Label(_))),
             "expected Processing::Label, got: {mode:?}"

--- a/crates/citum-schema-style/src/options/processing.rs
+++ b/crates/citum-schema-style/src/options/processing.rs
@@ -41,7 +41,7 @@ pub enum LabelPreset {
     Alpha,
     /// DIN 1505-2: up to 3 authors, no et-al marker, 2-digit year.
     Din,
-    /// American Mathematical Society: same label-generation algorithm as Alpha.
+    /// CSL/citeproc alphabetic labels used by American Mathematical Society styles.
     Ams,
 }
 
@@ -73,16 +73,16 @@ pub struct LabelConfig {
     /// Preset that determines default parameters.
     #[serde(default)]
     pub preset: LabelPreset,
-    /// Chars taken from single author's family name. Preset default: 3 (Alpha/Ams), 4 (Din).
+    /// Chars taken from single author's family name. Preset default: 3 (Alpha), 4 (Ams/Din).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub single_author_chars: Option<u8>,
     /// Chars per author family name when 2+ authors. Preset default: 1.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_author_chars: Option<u8>,
-    /// Max authors before truncation. Alpha/Ams default: 4, Din default: 3.
+    /// Max authors before truncation. Alpha default: 4, Ams default: 5, Din default: 3.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub et_al_min: Option<u8>,
-    /// Suffix appended when truncated. Alpha/Ams default: "+", Din default: "".
+    /// Suffix appended when truncated. Alpha default: "+", Ams/Din default: "".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub et_al_marker: Option<String>,
     /// Names shown when truncated (et-al). Alpha default: 3, Ams default: 4.
@@ -112,7 +112,7 @@ impl LabelConfig {
             default_et_al_names,
         ) = match self.preset {
             LabelPreset::Alpha => (3u8, 1u8, 4u8, "+".to_string(), 3u8),
-            LabelPreset::Ams => (3u8, 1u8, 4u8, "+".to_string(), 4u8),
+            LabelPreset::Ams => (4u8, 1u8, 5u8, String::new(), 4u8),
             LabelPreset::Din => (4u8, 1u8, 3u8, String::new(), 3u8),
         };
         LabelParams {
@@ -699,6 +699,28 @@ mod tests {
         assert_eq!(params.et_al_min, 3);
         assert_eq!(params.et_al_marker, "");
         assert_eq!(params.et_al_names, 3);
+        assert_eq!(params.year_digits, 2);
+    }
+
+    /// Test that LabelConfig::effective_params() applies AMS/CSL label defaults.
+    #[test]
+    fn test_label_config_ams_preset_defaults() {
+        let config = LabelConfig {
+            preset: LabelPreset::Ams,
+            single_author_chars: None,
+            multi_author_chars: None,
+            et_al_min: None,
+            et_al_marker: None,
+            et_al_names: None,
+            year_digits: None,
+        };
+
+        let params = config.effective_params();
+        assert_eq!(params.single_author_chars, 4);
+        assert_eq!(params.multi_author_chars, 1);
+        assert_eq!(params.et_al_min, 5);
+        assert_eq!(params.et_al_marker, "");
+        assert_eq!(params.et_al_names, 4);
         assert_eq!(params.year_digits, 2);
     }
 

--- a/crates/citum-schema-style/src/options/scoped.rs
+++ b/crates/citum-schema-style/src/options/scoped.rs
@@ -395,13 +395,6 @@ fn apply_citation_wrap_recursive(citation: &mut CitationSpec, wrap: LabelWrap) {
                 apply_citation_superscript(variant.as_template_mut());
             }
         }
-    } else {
-        update_label_wrap(citation.template.as_mut(), wrap);
-        if let Some(variants) = citation.type_variants.as_mut() {
-            for variant in variants.values_mut() {
-                update_label_wrap(variant.as_template_mut(), wrap);
-            }
-        }
     }
 
     for child in [

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -1322,6 +1322,88 @@ citation:
 }
 
 #[test]
+fn citation_bracket_label_wrap_keeps_label_component_bare() {
+    let resolved = Style::from_yaml_str(
+        r#"
+citation:
+  options:
+    label-wrap: brackets
+  template:
+    - number: citation-label
+"#,
+    )
+    .unwrap()
+    .try_into_resolved()
+    .expect("bracket citation label wrap should resolve");
+
+    let citation = resolved
+        .citation
+        .as_ref()
+        .expect("resolved style should include citation");
+    assert_eq!(
+        citation.wrap,
+        Some(template::WrapConfig::from(
+            template::WrapPunctuation::Brackets
+        ))
+    );
+
+    let citation_label_rendering = citation
+        .resolve_template()
+        .and_then(|template| {
+            template.iter().find_map(|component| match component {
+                template::TemplateComponent::Number(number)
+                    if matches!(number.number, template::NumberVariable::CitationLabel) =>
+                {
+                    Some(number.rendering.clone())
+                }
+                _ => None,
+            })
+        })
+        .expect("citation template should include citation-label");
+
+    assert_eq!(citation_label_rendering.wrap, None);
+}
+
+#[test]
+fn bibliography_bracket_label_wrap_still_wraps_label_component() {
+    let resolved = Style::from_yaml_str(
+        r#"
+bibliography:
+  options:
+    label-wrap: brackets
+  template:
+    - number: citation-label
+"#,
+    )
+    .unwrap()
+    .try_into_resolved()
+    .expect("bracket bibliography label wrap should resolve");
+
+    let bibliography_label_rendering = resolved
+        .bibliography
+        .as_ref()
+        .and_then(|bibliography| bibliography.resolve_template())
+        .and_then(|template| {
+            template.iter().find_map(|component| match component {
+                template::TemplateComponent::Number(number)
+                    if matches!(number.number, template::NumberVariable::CitationLabel) =>
+                {
+                    Some(number.rendering.clone())
+                }
+                _ => None,
+            })
+        })
+        .expect("bibliography template should include citation-label");
+
+    assert_eq!(
+        bibliography_label_rendering.wrap,
+        Some(template::WrapConfig::from(
+            template::WrapPunctuation::Brackets
+        ))
+    );
+}
+
+#[test]
 fn bibliography_rejects_superscript_label_wrap_at_parse_time() {
     let yaml = r#"
 bibliography:

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -2685,7 +2685,7 @@
           "default": "alpha"
         },
         "single-author-chars": {
-          "description": "Chars taken from single author's family name. Preset default: 3 (Alpha/Ams), 4 (Din).",
+          "description": "Chars taken from single author's family name. Preset default: 3 (Alpha), 4 (Ams/Din).",
           "type": [
             "integer",
             "null"
@@ -2705,7 +2705,7 @@
           "maximum": 255
         },
         "et-al-min": {
-          "description": "Max authors before truncation. Alpha/Ams default: 4, Din default: 3.",
+          "description": "Max authors before truncation. Alpha default: 4, Ams default: 5, Din default: 3.",
           "type": [
             "integer",
             "null"
@@ -2715,7 +2715,7 @@
           "maximum": 255
         },
         "et-al-marker": {
-          "description": "Suffix appended when truncated. Alpha/Ams default: \"+\", Din default: \"\".",
+          "description": "Suffix appended when truncated. Alpha default: \"+\", Ams/Din default: \"\".",
           "type": [
             "string",
             "null"
@@ -2757,7 +2757,7 @@
           "const": "din"
         },
         {
-          "description": "American Mathematical Society: same label-generation algorithm as Alpha.",
+          "description": "CSL/citeproc alphabetic labels used by American Mathematical Society styles.",
           "type": "string",
           "const": "ams"
         }


### PR DESCRIPTION
## Summary
- Use CSL-compatible AMS label defaults for migrated citation-label styles.
- Keep bracket label-wrap on citation clusters instead of wrapping each citation-label component.
- Archive completed bean csl26-tzer with the fix.

## Verification
- cargo test -p citum-schema-style label
- cargo test -p citum-migrate citation_label
- cargo test -p citum-engine test_ams_et_al_uses_4_initials
- node scripts/oracle.js styles-legacy/american-mathematical-society-label.csl --json --force-migrate
- just schema-gen
- just pre-commit
- pre-push hook: cargo fmt --check, cargo clippy --all-targets --all-features, cargo nextest run

## Notes
The AMS oracle now matches the target examples such as [Kuhn62] and VSPU17. The full oracle still reports unrelated bibliography and remaining citation-tail differences outside csl26-tzer.
