### PR TITLE
Split SQI refinement from assembly

### DIFF
--- a/.beans/csl26-6bul--migrate-audit-fixture-coverage-for-measured-select.md
+++ b/.beans/csl26-6bul--migrate-audit-fixture-coverage-for-measured-select.md
@@ -1,0 +1,51 @@
+---
+# csl26-6bul
+title: 'migrate: audit fixture coverage for measured selection'
+status: todo
+type: task
+priority: high
+tags:
+    - migrate
+    - fixtures
+    - fidelity
+created_at: 2026-06-17T18:22:49Z
+updated_at: 2026-06-17T18:22:49Z
+---
+
+Output-driven template selection and synthesis are explicitly coverage-bound: the selector can only prefer measured evidence for behavior exercised by the selection fixtures, and the held-out gate only rejects regressions visible in held-out fixtures. This makes fixture sufficiency a first-class migration quality risk, not just a testing nicety.
+
+## Scope
+
+- Produce a fixture-coverage audit for `citum-migrate` measured citation/bibliography selection and synthesis.
+- Compare `tests/fixtures/references-expanded.json` and `tests/fixtures/references-heldout.json` against `tests/fixtures/coverage-manifest.json` and `scripts/report-data/fixture-sufficiency.yaml`.
+- Cross-check fixture coverage against CSL type-conditioned branches and seed-winner/debug evidence, especially cases where XML fallback or XML seed still wins in the random style scorecard.
+- Identify which gaps are selection-set gaps, held-out-set gaps, or latent XML-branch gaps that should remain XML-backed until exercised.
+- Add the highest-value fixture items or document a ranked deferred list when fixture construction needs domain input.
+- Keep selection and held-out examples disjoint so held-out validation remains a real over-fitting guard.
+
+## Initial risk targets
+
+- Rare or structurally distinctive item types: legal cases, legislation, patents, datasets, standards, encyclopedia/dictionary entries, newspaper/magazine articles, broadcasts, interviews, maps, theses, reports, and web pages.
+- Behavior families that often drive ugly or wrong migrated structure: URL/accessed gating, DOI suppression, contributor role fallback, editor/name-order handling, title casing, volume/pages delimiters, issued/accessed/date-parts, locale terms, and type-specific bibliography flattening.
+- Positional citation behavior for first, first-with-locator, subsequent, ibid, and ibid-with-locator scenarios when a style's branch behavior differs by position.
+
+## Acceptance Criteria
+
+- A generated or documented coverage report states which reference types and behavior families are covered by selection fixtures, held-out fixtures, both, or neither.
+- The report calls out any measured-selection wins that are weak because the fixture surface is too narrow, and any XML seed wins that likely reflect missing fixture evidence rather than true converter superiority.
+- High-value fixture additions land in `references-expanded` and/or `references-heldout`, or a ranked follow-up list explains why each item needs curator/domain input.
+- `scripts/check-testing-infra.js` and the existing fixture/frontmatter checks pass after fixture changes.
+- Targeted migration scorecard/oracle runs show no fidelity regression; improvements are accepted only when both selection and held-out evidence support them.
+- `docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md` or the output-driven synthesis spec links to the new coverage report once it exists.
+
+## References
+
+- `docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md`
+- `docs/specs/OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md`
+- `tests/fixtures/references-expanded.json`
+- `tests/fixtures/references-heldout.json`
+- `tests/fixtures/coverage-manifest.json`
+- `scripts/report-data/fixture-sufficiency.yaml`
+- `scripts/check-testing-infra.js`
+- `csl26-aynr` output-driven template synthesis
+- `csl26-hxhx` XML compiler removal blocker

--- a/crates/citum-migrate/src/assembly.rs
+++ b/crates/citum-migrate/src/assembly.rs
@@ -10,7 +10,6 @@ use crate::{
         is_inferred_bib_source, merge_inferred_type_templates, postprocess_bibliography_templates,
     },
     citation_validate,
-    template_diff::{TypeTemplateMap, TypeVariantMap, build_type_variants},
 };
 use citum_migrate::{
     analysis,
@@ -21,14 +20,17 @@ use citum_migrate::{
         normalize_author_date_locator_citation_component,
         normalize_wrapped_numeric_locator_citation_component,
     },
-    passes::suppression::{normalize_visible_suppress, strip_inert_suppressed_placeholders},
+    passes::suppression::strip_inert_suppressed_placeholders,
     template_resolver,
 };
 use citum_schema::{
     BibliographySpec, CitationCollapse, CitationSpec, Style, StyleInfo,
-    template::{TemplateComponent, WrapPunctuation},
+    template::{TemplateComponent, TemplateVariant, TypeSelector, WrapPunctuation},
 };
 use std::path::Path;
+
+type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
+type TypeVariantMap = indexmap::IndexMap<TypeSelector, TemplateVariant>;
 
 /// Borrowed pipeline state needed to assemble a standalone style variant.
 pub(crate) struct StandaloneAssembly<'a> {
@@ -504,28 +506,12 @@ fn finalize_bibliography_variants(
         }
     }
 
-    // Phase 2: compression is a serialization pass over finalized Full templates.
-    if let Some(type_templates) = type_templates.as_mut() {
-        type_templates.retain(|_, template| template != &new_bib);
-    }
-    let mut type_variants = type_templates
-        .take()
-        .map(|type_templates| build_type_variants(&new_bib, type_templates));
-
-    // Normalize suppress:Some(false) → None on all serialized full template
-    // lists. This clears the occurrence-compiler's "visible by default" marker,
-    // which is semantically identical to None but serializes as noise. Must run
-    // after build_type_variants so diff `modify` operations (which legitimately
-    // reference suppress:false to un-suppress a parent-suppressed component)
-    // are already encoded and are not affected.
-    normalize_visible_suppress(&mut new_bib);
-    if let Some(variants) = type_variants.as_mut() {
-        for variant in variants.values_mut() {
-            if let citum_schema::TemplateVariant::Full(components) = variant {
-                normalize_visible_suppress(components);
-            }
-        }
-    }
+    let type_variants = type_templates.map(|type_templates| {
+        type_templates
+            .into_iter()
+            .map(|(selector, template)| (selector, TemplateVariant::Full(template)))
+            .collect()
+    });
 
     (new_bib, type_variants)
 }
@@ -645,7 +631,14 @@ mod tests {
     use super::*;
     use citum_schema::{
         BibliographySpec, CitationSpec,
-        template::{SimpleVariable, TemplateVariable},
+        options::{
+            AndOptions, ContributorConfig, DisplayAsSort, NameForm, TextCase, TitleRendering,
+            TitlesConfig,
+        },
+        template::{
+            ContributorForm, ContributorRole, NameOrder, Rendering, SimpleVariable,
+            TemplateContributor, TemplateTitle, TemplateVariable, TitleType,
+        },
     };
     use csl_legacy::model::{
         Citation, Info, Layout, Sort as LegacySort, SortKey as LegacySortKey, Style as LegacyStyle,
@@ -772,6 +765,112 @@ mod tests {
                 .and_then(|citation| citation.collapse.clone()),
             Some(CitationCollapse::CitationNumber)
         );
+    }
+
+    #[test]
+    fn assembly_preserves_explicit_template_fields_for_sqi_refinement() {
+        let migrated = build_final_style(&minimal_legacy_style(), explicit_sqi_boundary_output());
+
+        let citation_template = migrated
+            .citation
+            .as_ref()
+            .and_then(|citation| citation.template.as_ref())
+            .expect("citation template should be present");
+        let TemplateComponent::Contributor(author) = citation_template
+            .first()
+            .expect("first citation component should be present")
+        else {
+            panic!("first citation component should remain a contributor");
+        };
+        assert_eq!(author.and, Some(AndOptions::Text));
+        assert_eq!(author.name_form, Some(NameForm::Initials));
+        assert_eq!(author.name_order, Some(NameOrder::FamilyFirstOnly));
+        let TemplateComponent::Title(title) = citation_template
+            .get(1)
+            .expect("second citation component should be present")
+        else {
+            panic!("second citation component should remain a title");
+        };
+        assert_eq!(title.rendering.text_case, Some(TextCase::SentenceApa));
+
+        let book_variant = migrated
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.type_variants.as_ref())
+            .and_then(|variants| variants.get(&TypeSelector::Single("book".to_string())))
+            .expect("book variant should be present");
+        let TemplateVariant::Full(book_template) = book_variant else {
+            panic!("assembly should emit full type variants before SQI refinement");
+        };
+        let TemplateComponent::Contributor(book_author) = book_template
+            .first()
+            .expect("book variant component should be present")
+        else {
+            panic!("book variant should remain a contributor template");
+        };
+        assert_eq!(book_author.and, Some(AndOptions::Text));
+        assert_eq!(book_author.name_form, Some(NameForm::Initials));
+        assert_eq!(book_author.name_order, Some(NameOrder::FamilyFirstOnly));
+    }
+
+    fn explicit_sqi_boundary_output() -> CompiledOutput {
+        let mut type_templates = TypeTemplateMap::new();
+        type_templates.insert(
+            TypeSelector::Single("book".to_string()),
+            vec![explicit_author_component()],
+        );
+
+        CompiledOutput {
+            options: citum_schema::options::Config {
+                contributors: Some(ContributorConfig {
+                    display_as_sort: Some(DisplayAsSort::First),
+                    and: Some(AndOptions::Text),
+                    name_form: Some(NameForm::Initials),
+                    ..ContributorConfig::default()
+                }),
+                titles: Some(TitlesConfig {
+                    default: Some(TitleRendering {
+                        text_case: Some(TextCase::SentenceApa),
+                        ..TitleRendering::default()
+                    }),
+                    ..TitlesConfig::default()
+                }),
+                ..citum_schema::options::Config::default()
+            },
+            bibliography_options: None,
+            citation_contributor_overrides: None,
+            bibliography_contributor_overrides: None,
+            new_cit: vec![
+                explicit_author_component(),
+                TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    rendering: Rendering {
+                        text_case: Some(TextCase::SentenceApa),
+                        ..Rendering::default()
+                    },
+                    ..TemplateTitle::default()
+                }),
+            ],
+            new_bib: vec![],
+            type_templates: Some(type_templates),
+            citation_wrap: None,
+            citation_prefix: None,
+            citation_suffix: None,
+            citation_delimiter: None,
+            citation_subsequent_override: None,
+            citation_ibid_override: None,
+        }
+    }
+
+    fn explicit_author_component() -> TemplateComponent {
+        TemplateComponent::Contributor(TemplateContributor {
+            contributor: ContributorRole::Author,
+            form: ContributorForm::Long,
+            name_order: Some(NameOrder::FamilyFirstOnly),
+            name_form: Some(NameForm::Initials),
+            and: Some(AndOptions::Text),
+            ..TemplateContributor::default()
+        })
     }
 
     fn legacy_sort(keys: &[&str]) -> LegacySort {

--- a/crates/citum-migrate/src/bib_postprocess.rs
+++ b/crates/citum-migrate/src/bib_postprocess.rs
@@ -20,7 +20,7 @@ use citum_schema::{
     },
 };
 
-use super::template_diff::TypeTemplateMap;
+type TypeTemplateMap = indexmap::IndexMap<TypeSelector, Vec<TemplateComponent>>;
 
 /// Extension trait to enumerate concrete type names from a `TypeSelector`.
 pub(crate) trait TypeSelectorNames {

--- a/crates/citum-migrate/src/lib.rs
+++ b/crates/citum-migrate/src/lib.rs
@@ -44,6 +44,7 @@ pub mod provenance;
 pub mod synthesis;
 /// CSL 1.0 to Citum template compilation.
 pub mod template_compiler;
+pub(crate) mod template_diff;
 /// Template resolution and preprocessing.
 pub mod template_resolver;
 /// Upsamples flattened legacy CSL 1.0 nodes into migration IR ([`ir::Node`])

--- a/crates/citum-migrate/src/main.rs
+++ b/crates/citum-migrate/src/main.rs
@@ -11,7 +11,6 @@ mod citation_validate;
 mod cli;
 mod output_plan;
 mod runtime;
-mod template_diff;
 
 use assembly::{
     StandaloneAssembly, TemplateSourceSelection, apply_measured_bibliography_selection,
@@ -33,6 +32,7 @@ use citum_migrate::{
     OptionsExtractor, compilation,
     lineage::StyleLineage,
     options_extractor::{MigrationOptions, processing::detect_processing_mode},
+    passes::sqi_refinement,
     provenance::ProvenanceTracker,
 };
 use csl_legacy::parser::parse_style;
@@ -138,6 +138,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &text,
         &workspace_root,
     );
+    let standalone_style = sqi_refinement::refine_style(standalone_style);
     // Measure the standalone form first so the evidence record can report
     // the compression delta without re-running the pipeline. Cheap: one YAML
     // serialization of an in-memory value.

--- a/crates/citum-migrate/src/passes/mod.rs
+++ b/crates/citum-migrate/src/passes/mod.rs
@@ -6,4 +6,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 pub mod deduplicate;
 pub mod grouping;
 pub mod reorder;
+/// Post-assembly SQI refinement passes.
+pub mod sqi_refinement;
 pub mod suppression;

--- a/crates/citum-migrate/src/passes/sqi_refinement.rs
+++ b/crates/citum-migrate/src/passes/sqi_refinement.rs
@@ -1,0 +1,970 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Post-assembly SQI refinement for migrated styles.
+
+use crate::{
+    passes::suppression::normalize_visible_suppress,
+    template_diff::{TypeTemplateMap, build_type_variants},
+};
+use citum_schema::{
+    BibliographySpec, CitationSpec, Style, TemplateVariant,
+    options::{AndOptions, ContributorConfig, DisplayAsSort},
+    template::{
+        NameOrder, Rendering, TemplateComponent, TemplateContributor, TemplateTitle, TitleType,
+        TypeSelector,
+    },
+};
+
+/// Refine a fully assembled style for compact, maintainable serialization.
+#[must_use]
+pub fn refine_style(mut style: Style) -> Style {
+    let candidates = HoistCandidates::from_style(&style);
+    encode_bibliography_type_variants(&mut style);
+    hoist_common_contributor_and(&mut style, candidates);
+    prune_style_against_options(&mut style);
+    normalize_serialized_suppress_markers(&mut style);
+    style
+}
+
+#[derive(Debug, Clone, Default)]
+struct HoistCandidates {
+    citation_and: CommonAnd,
+    bibliography_and: CommonAnd,
+}
+
+impl HoistCandidates {
+    fn from_style(style: &Style) -> Self {
+        let mut citation_templates = Vec::new();
+        collect_citation_templates(style.citation.as_ref(), &mut citation_templates);
+
+        let mut bibliography_templates = Vec::new();
+        collect_bibliography_templates(style.bibliography.as_ref(), &mut bibliography_templates);
+
+        Self {
+            citation_and: common_contributor_and_in_templates(citation_templates),
+            bibliography_and: common_contributor_and_in_templates(bibliography_templates),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+enum CommonAnd {
+    #[default]
+    NoContributors,
+    Value(AndOptions),
+    Ineligible,
+}
+
+impl CommonAnd {
+    fn value(&self) -> Option<&AndOptions> {
+        match self {
+            Self::Value(value) => Some(value),
+            Self::NoContributors | Self::Ineligible => None,
+        }
+    }
+}
+
+fn collect_citation_templates<'a>(
+    spec: Option<&'a CitationSpec>,
+    templates: &mut Vec<&'a [TemplateComponent]>,
+) {
+    let Some(spec) = spec else {
+        return;
+    };
+    if let Some(template) = spec.template.as_ref() {
+        templates.push(template);
+    }
+    if let Some(type_variants) = spec.type_variants.as_ref() {
+        collect_full_variant_templates(type_variants, templates);
+    }
+    collect_citation_templates(spec.integral.as_deref(), templates);
+    collect_citation_templates(spec.non_integral.as_deref(), templates);
+    collect_citation_templates(spec.subsequent.as_deref(), templates);
+    collect_citation_templates(spec.ibid.as_deref(), templates);
+}
+
+fn collect_bibliography_templates<'a>(
+    spec: Option<&'a BibliographySpec>,
+    templates: &mut Vec<&'a [TemplateComponent]>,
+) {
+    let Some(spec) = spec else {
+        return;
+    };
+    if let Some(template) = spec.template.as_ref() {
+        templates.push(template);
+    }
+    if let Some(type_variants) = spec.type_variants.as_ref() {
+        collect_full_variant_templates(type_variants, templates);
+    }
+}
+
+fn collect_full_variant_templates<'a>(
+    type_variants: &'a indexmap::IndexMap<TypeSelector, TemplateVariant>,
+    templates: &mut Vec<&'a [TemplateComponent]>,
+) {
+    for variant in type_variants.values() {
+        if let TemplateVariant::Full(template) = variant {
+            templates.push(template);
+        }
+    }
+}
+
+fn common_contributor_and_in_templates<'a>(
+    templates: impl IntoIterator<Item = &'a [TemplateComponent]>,
+) -> CommonAnd {
+    let mut common = None;
+    let mut saw_contributor = false;
+
+    for template in templates {
+        let mut contributors = Vec::new();
+        collect_contributors(template, &mut contributors);
+        for contributor in contributors {
+            saw_contributor = true;
+            let Some(and) = contributor.and.clone() else {
+                return CommonAnd::Ineligible;
+            };
+            match common {
+                None => common = Some(and),
+                Some(ref current) if current == &and => {}
+                Some(_) => return CommonAnd::Ineligible,
+            }
+        }
+    }
+
+    match (saw_contributor, common) {
+        (true, Some(and)) => CommonAnd::Value(and),
+        _ => CommonAnd::NoContributors,
+    }
+}
+
+fn collect_contributors<'a>(
+    template: &'a [TemplateComponent],
+    contributors: &mut Vec<&'a TemplateContributor>,
+) {
+    for component in template {
+        match component {
+            TemplateComponent::Contributor(contributor) => contributors.push(contributor),
+            TemplateComponent::Group(group) => collect_contributors(&group.group, contributors),
+            _ => {}
+        }
+    }
+}
+
+fn encode_bibliography_type_variants(style: &mut Style) {
+    let Some(bibliography) = style.bibliography.as_mut() else {
+        return;
+    };
+    let Some(base_template) = bibliography.template.as_ref() else {
+        return;
+    };
+    let Some(type_variants) = bibliography.type_variants.as_ref() else {
+        return;
+    };
+    if !type_variants
+        .values()
+        .all(|variant| matches!(variant, TemplateVariant::Full(_)))
+    {
+        return;
+    }
+
+    let Some(type_variants) = bibliography.type_variants.take() else {
+        return;
+    };
+    let mut type_templates = TypeTemplateMap::new();
+    for (selector, variant) in type_variants {
+        let TemplateVariant::Full(template) = variant else {
+            continue;
+        };
+        if template.as_slice() != base_template.as_slice() {
+            type_templates.insert(selector, template);
+        }
+    }
+
+    bibliography.type_variants =
+        (!type_templates.is_empty()).then(|| build_type_variants(base_template, type_templates));
+}
+
+fn hoist_common_contributor_and(style: &mut Style, candidates: HoistCandidates) {
+    let global_and = style
+        .options
+        .as_ref()
+        .and_then(|options| options.contributors.as_ref())
+        .and_then(|contributors| contributors.and.as_ref());
+
+    if global_and.is_none()
+        && let (Some(citation), Some(bibliography)) = (
+            candidates.citation_and.value(),
+            candidates.bibliography_and.value(),
+        )
+        && citation == bibliography
+    {
+        set_global_contributor_and(style, citation.clone());
+        return;
+    }
+
+    if let Some(and) = candidates.citation_and.value()
+        && Some(and) != global_and
+        && let Some(citation) = style.citation.as_mut()
+    {
+        set_citation_contributor_and(citation, and.clone());
+    }
+
+    if let Some(and) = candidates.bibliography_and.value()
+        && Some(and) != global_and
+        && let Some(bibliography) = style.bibliography.as_mut()
+    {
+        set_bibliography_contributor_and(bibliography, and.clone());
+    }
+}
+
+fn set_global_contributor_and(style: &mut Style, and: AndOptions) {
+    style
+        .options
+        .get_or_insert_with(Default::default)
+        .contributors
+        .get_or_insert_with(Default::default)
+        .and = Some(and);
+}
+
+fn set_citation_contributor_and(citation: &mut CitationSpec, and: AndOptions) {
+    citation
+        .options
+        .get_or_insert_with(Default::default)
+        .contributors
+        .get_or_insert_with(Default::default)
+        .and = Some(and);
+}
+
+fn set_bibliography_contributor_and(bibliography: &mut BibliographySpec, and: AndOptions) {
+    bibliography
+        .options
+        .get_or_insert_with(Default::default)
+        .contributors
+        .get_or_insert_with(Default::default)
+        .and = Some(and);
+}
+
+fn prune_style_against_options(style: &mut Style) {
+    let global_options = style.options.clone().unwrap_or_default();
+    if let Some(citation) = style.citation.as_mut() {
+        prune_citation_spec(citation, &global_options);
+    }
+    if let Some(bibliography) = style.bibliography.as_mut() {
+        let effective_options = bibliography.options.as_ref().map_or_else(
+            || global_options.clone(),
+            |options| options.merged_with(&global_options),
+        );
+        if let Some(template) = bibliography.template.as_mut() {
+            normalize_templates_against_options(
+                template,
+                TitleDefaultContext::Default,
+                &effective_options,
+            );
+        }
+        prune_type_variants(bibliography.type_variants.as_mut(), &effective_options);
+    }
+}
+
+fn prune_citation_spec(spec: &mut CitationSpec, inherited_options: &citum_schema::options::Config) {
+    let effective_options = spec.options.as_ref().map_or_else(
+        || inherited_options.clone(),
+        |options| options.merged_with(inherited_options),
+    );
+    if let Some(template) = spec.template.as_mut() {
+        normalize_templates_against_options(
+            template,
+            TitleDefaultContext::Default,
+            &effective_options,
+        );
+    }
+    prune_type_variants(spec.type_variants.as_mut(), &effective_options);
+    if let Some(integral) = spec.integral.as_mut() {
+        prune_citation_spec(integral, &effective_options);
+    }
+    if let Some(non_integral) = spec.non_integral.as_mut() {
+        prune_citation_spec(non_integral, &effective_options);
+    }
+    if let Some(subsequent) = spec.subsequent.as_mut() {
+        prune_citation_spec(subsequent, &effective_options);
+    }
+    if let Some(ibid) = spec.ibid.as_mut() {
+        prune_citation_spec(ibid, &effective_options);
+    }
+}
+
+fn prune_type_variants(
+    type_variants: Option<&mut indexmap::IndexMap<TypeSelector, TemplateVariant>>,
+    options: &citum_schema::options::Config,
+) {
+    let Some(type_variants) = type_variants else {
+        return;
+    };
+    for (selector, variant) in type_variants {
+        let title_context = selector_title_context(selector);
+        match variant {
+            TemplateVariant::Full(template) => {
+                normalize_templates_against_options(template, title_context, options);
+            }
+            TemplateVariant::Diff(diff) => {
+                for add in &mut diff.add {
+                    normalize_component_against_options(&mut add.component, title_context, options);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TitleDefaultContext<'a> {
+    Default,
+    RefType(&'a str),
+    Unknown,
+}
+
+fn selector_title_context(selector: &TypeSelector) -> TitleDefaultContext<'_> {
+    match selector {
+        TypeSelector::Single(ref_type) => TitleDefaultContext::RefType(ref_type),
+        TypeSelector::Multiple(_) => TitleDefaultContext::Unknown,
+    }
+}
+
+fn normalize_templates_against_options(
+    template: &mut [TemplateComponent],
+    title_context: TitleDefaultContext<'_>,
+    options: &citum_schema::options::Config,
+) {
+    for component in template {
+        normalize_component_against_options(component, title_context, options);
+    }
+}
+
+fn normalize_component_against_options(
+    component: &mut TemplateComponent,
+    title_context: TitleDefaultContext<'_>,
+    options: &citum_schema::options::Config,
+) {
+    match component {
+        TemplateComponent::Contributor(contributor) => {
+            if let Some(defaults) = options.contributors.as_ref() {
+                compact_inherited_contributor(contributor, defaults);
+            }
+        }
+        TemplateComponent::Title(title) => {
+            compact_inherited_title(title, title_context, options);
+        }
+        TemplateComponent::Group(group) => {
+            normalize_templates_against_options(&mut group.group, title_context, options);
+        }
+        _ => {}
+    }
+}
+
+fn compact_inherited_title(
+    title: &mut TemplateTitle,
+    title_context: TitleDefaultContext<'_>,
+    options: &citum_schema::options::Config,
+) {
+    let Some(defaults) = effective_title_rendering(&title.title, title_context, options) else {
+        return;
+    };
+
+    clear_rendering_field(&mut title.rendering.text_case, defaults.text_case);
+    clear_rendering_field(&mut title.rendering.emph, defaults.emph);
+    clear_rendering_field(&mut title.rendering.quote, defaults.quote);
+    clear_rendering_field(&mut title.rendering.strong, defaults.strong);
+    clear_rendering_field(&mut title.rendering.small_caps, defaults.small_caps);
+    clear_rendering_field(&mut title.rendering.prefix, defaults.prefix);
+    clear_rendering_field(&mut title.rendering.suffix, defaults.suffix);
+}
+
+fn clear_rendering_field<T: PartialEq>(field: &mut Option<T>, inherited: Option<T>) {
+    if field.as_ref() == inherited.as_ref() {
+        *field = None;
+    }
+}
+
+fn effective_title_rendering(
+    title_type: &TitleType,
+    title_context: TitleDefaultContext<'_>,
+    options: &citum_schema::options::Config,
+) -> Option<Rendering> {
+    let ref_type = match title_context {
+        TitleDefaultContext::Default => None,
+        TitleDefaultContext::RefType(ref_type) => Some(ref_type),
+        TitleDefaultContext::Unknown => return None,
+    };
+    let titles = options.titles.as_ref()?;
+    let mapped_category = ref_type.and_then(|rt| titles.type_mapping.get(rt));
+
+    let rendering = match title_type {
+        TitleType::ContainerTitle => {
+            if let Some(category) = mapped_category {
+                match category.as_str() {
+                    "periodical" => titles.periodical.as_ref(),
+                    "serial" => titles.serial.as_ref(),
+                    "monograph" | "collection" => titles
+                        .container_monograph
+                        .as_ref()
+                        .or(titles.monograph.as_ref()),
+                    _ => titles.default.as_ref(),
+                }
+            } else if let Some(ref_type) = ref_type {
+                if matches!(
+                    ref_type,
+                    "article-journal" | "article-magazine" | "article-newspaper" | "broadcast"
+                ) {
+                    titles.periodical.as_ref()
+                } else if matches!(ref_type, "chapter" | "paper-conference") {
+                    titles
+                        .container_monograph
+                        .as_ref()
+                        .or(titles.monograph.as_ref())
+                } else {
+                    titles.default.as_ref()
+                }
+            } else {
+                titles.default.as_ref()
+            }
+        }
+        TitleType::ParentSerial => {
+            if let Some(category) = mapped_category {
+                match category.as_str() {
+                    "periodical" => titles.periodical.as_ref(),
+                    "serial" => titles.serial.as_ref(),
+                    _ => titles.periodical.as_ref(),
+                }
+            } else if let Some(ref_type) = ref_type {
+                if matches!(
+                    ref_type,
+                    "article-journal" | "article-magazine" | "article-newspaper"
+                ) {
+                    titles.periodical.as_ref()
+                } else {
+                    titles.serial.as_ref()
+                }
+            } else {
+                titles.periodical.as_ref()
+            }
+        }
+        TitleType::ParentMonograph => titles
+            .container_monograph
+            .as_ref()
+            .or(titles.monograph.as_ref()),
+        TitleType::CollectionTitle => titles
+            .container_monograph
+            .as_ref()
+            .or(titles.monograph.as_ref())
+            .or(titles.default.as_ref()),
+        TitleType::Primary => {
+            if let Some(category) = mapped_category {
+                match category.as_str() {
+                    "component" => titles.component.as_ref(),
+                    "monograph" => titles.monograph.as_ref(),
+                    _ => titles.default.as_ref(),
+                }
+            } else if let Some(ref_type) = ref_type {
+                if matches!(
+                    ref_type,
+                    "article-journal"
+                        | "article-magazine"
+                        | "article-newspaper"
+                        | "chapter"
+                        | "entry"
+                        | "entry-dictionary"
+                        | "entry-encyclopedia"
+                        | "paper-conference"
+                        | "post"
+                        | "post-weblog"
+                ) {
+                    titles.component.as_ref()
+                } else if matches!(ref_type, "book" | "thesis" | "report") {
+                    titles.monograph.as_ref()
+                } else {
+                    titles.default.as_ref()
+                }
+            } else {
+                titles.default.as_ref()
+            }
+        }
+        _ => None,
+    };
+
+    Some(rendering.or(titles.default.as_ref())?.to_rendering())
+}
+
+fn compact_inherited_contributor(
+    contributor: &mut TemplateContributor,
+    defaults: &ContributorConfig,
+) {
+    if contributor.and.as_ref() == defaults.and.as_ref() {
+        contributor.and = None;
+    }
+    if contributor.shorten.as_ref() == defaults.shorten.as_ref() {
+        contributor.shorten = None;
+    }
+    if contributor.sort_separator.as_ref() == defaults.sort_separator.as_ref() {
+        contributor.sort_separator = None;
+    }
+    if contributor.name_form.as_ref() == defaults.name_form.as_ref() {
+        contributor.name_form = None;
+    }
+    if contributor
+        .name_order
+        .as_ref()
+        .is_some_and(|name_order| inherited_name_order_matches(contributor, defaults, name_order))
+    {
+        contributor.name_order = None;
+    }
+}
+
+fn inherited_name_order_matches(
+    contributor: &TemplateContributor,
+    defaults: &ContributorConfig,
+    name_order: &NameOrder,
+) -> bool {
+    if defaults
+        .effective_role_name_order(&contributor.contributor)
+        .is_some_and(|default| default == name_order)
+    {
+        return true;
+    }
+
+    matches!(
+        (defaults.display_as_sort.as_ref(), name_order),
+        (
+            Some(DisplayAsSort::All | DisplayAsSort::First),
+            NameOrder::FamilyFirst
+        ) | (Some(DisplayAsSort::First), NameOrder::FamilyFirstOnly)
+    )
+}
+
+fn normalize_serialized_suppress_markers(style: &mut Style) {
+    if let Some(citation) = style.citation.as_mut() {
+        normalize_citation_suppress(citation);
+    }
+    if let Some(bibliography) = style.bibliography.as_mut() {
+        if let Some(template) = bibliography.template.as_mut() {
+            normalize_visible_suppress(template);
+        }
+        normalize_variant_suppress(bibliography.type_variants.as_mut());
+    }
+}
+
+fn normalize_citation_suppress(spec: &mut CitationSpec) {
+    if let Some(template) = spec.template.as_mut() {
+        normalize_visible_suppress(template);
+    }
+    normalize_variant_suppress(spec.type_variants.as_mut());
+    if let Some(integral) = spec.integral.as_mut() {
+        normalize_citation_suppress(integral);
+    }
+    if let Some(non_integral) = spec.non_integral.as_mut() {
+        normalize_citation_suppress(non_integral);
+    }
+    if let Some(subsequent) = spec.subsequent.as_mut() {
+        normalize_citation_suppress(subsequent);
+    }
+    if let Some(ibid) = spec.ibid.as_mut() {
+        normalize_citation_suppress(ibid);
+    }
+}
+
+fn normalize_variant_suppress(
+    type_variants: Option<&mut indexmap::IndexMap<TypeSelector, TemplateVariant>>,
+) {
+    let Some(type_variants) = type_variants else {
+        return;
+    };
+    for variant in type_variants.values_mut() {
+        match variant {
+            TemplateVariant::Full(template) => normalize_visible_suppress(template),
+            TemplateVariant::Diff(diff) => {
+                for add in &mut diff.add {
+                    normalize_component_suppress(&mut add.component);
+                }
+            }
+        }
+    }
+}
+
+fn normalize_component_suppress(component: &mut TemplateComponent) {
+    let rendering = component.rendering_mut();
+    if rendering.suppress == Some(false) {
+        rendering.suppress = None;
+    }
+    if let TemplateComponent::Group(group) = component {
+        for child in &mut group.group {
+            normalize_component_suppress(child);
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod tests {
+    use super::*;
+    use citum_schema::{
+        options::{NameForm, TextCase, TitleRendering, TitlesConfig},
+        template::{
+            ContributorForm, ContributorRole, TemplateGroup, TemplateTitle, TemplateVariable,
+        },
+    };
+
+    fn author(and: Option<AndOptions>) -> TemplateComponent {
+        TemplateComponent::Contributor(TemplateContributor {
+            contributor: ContributorRole::Author,
+            form: ContributorForm::Long,
+            and,
+            ..TemplateContributor::default()
+        })
+    }
+
+    fn author_with_name_options() -> TemplateComponent {
+        TemplateComponent::Contributor(TemplateContributor {
+            contributor: ContributorRole::Author,
+            form: ContributorForm::Long,
+            name_order: Some(NameOrder::FamilyFirstOnly),
+            name_form: Some(NameForm::Initials),
+            and: Some(AndOptions::Text),
+            ..TemplateContributor::default()
+        })
+    }
+
+    fn primary_title(text_case: Option<TextCase>) -> TemplateComponent {
+        TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            rendering: Rendering {
+                text_case,
+                ..Rendering::default()
+            },
+            ..TemplateTitle::default()
+        })
+    }
+
+    fn url() -> TemplateComponent {
+        TemplateComponent::Variable(TemplateVariable {
+            variable: citum_schema::template::SimpleVariable::Url,
+            ..TemplateVariable::default()
+        })
+    }
+
+    fn style_options() -> citum_schema::options::Config {
+        citum_schema::options::Config {
+            contributors: Some(ContributorConfig {
+                display_as_sort: Some(DisplayAsSort::First),
+                and: Some(AndOptions::Text),
+                name_form: Some(NameForm::Initials),
+                ..ContributorConfig::default()
+            }),
+            titles: Some(TitlesConfig {
+                default: Some(TitleRendering {
+                    text_case: Some(TextCase::SentenceApa),
+                    ..TitleRendering::default()
+                }),
+                ..TitlesConfig::default()
+            }),
+            ..citum_schema::options::Config::default()
+        }
+    }
+
+    #[test]
+    fn common_contributor_and_is_hoisted_to_global_options() {
+        let style = Style {
+            citation: Some(CitationSpec {
+                template: Some(vec![author(Some(AndOptions::Text))]),
+                ..CitationSpec::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![author(Some(AndOptions::Text))]),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+
+        assert_eq!(
+            refined
+                .options
+                .as_ref()
+                .and_then(|options| options.contributors.as_ref())
+                .and_then(|contributors| contributors.and.as_ref()),
+            Some(&AndOptions::Text)
+        );
+        let citation_template = refined
+            .citation
+            .as_ref()
+            .and_then(|citation| citation.template.as_ref())
+            .expect("citation template should exist");
+        let TemplateComponent::Contributor(author) = &citation_template[0] else {
+            panic!("citation component should be author");
+        };
+        assert_eq!(author.and, None);
+    }
+
+    #[test]
+    fn scope_contributor_and_is_hoisted_without_global_match() {
+        let style = Style {
+            citation: Some(CitationSpec {
+                template: Some(vec![author(Some(AndOptions::Symbol))]),
+                ..CitationSpec::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![primary_title(None)]),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+
+        assert_eq!(
+            refined
+                .citation
+                .as_ref()
+                .and_then(|citation| citation.options.as_ref())
+                .and_then(|options| options.contributors.as_ref())
+                .and_then(|contributors| contributors.and.as_ref()),
+            Some(&AndOptions::Symbol)
+        );
+        assert!(
+            refined
+                .options
+                .as_ref()
+                .and_then(|options| options.contributors.as_ref())
+                .and_then(|contributors| contributors.and.as_ref())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn citation_base_subsequent_and_ibid_are_pruned_against_options() {
+        let style = Style {
+            options: Some(style_options()),
+            citation: Some(CitationSpec {
+                template: Some(vec![
+                    author_with_name_options(),
+                    primary_title(Some(TextCase::SentenceApa)),
+                ]),
+                subsequent: Some(Box::new(CitationSpec {
+                    template: Some(vec![author_with_name_options()]),
+                    ..CitationSpec::default()
+                })),
+                ibid: Some(Box::new(CitationSpec {
+                    template: Some(vec![author(Some(AndOptions::Text))]),
+                    ..CitationSpec::default()
+                })),
+                ..CitationSpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let citation = refined.citation.as_ref().expect("citation should exist");
+        let template = citation.template.as_ref().expect("template should exist");
+        let TemplateComponent::Contributor(author) = &template[0] else {
+            panic!("first component should be contributor");
+        };
+        assert_eq!(author.and, None);
+        assert_eq!(author.name_form, None);
+        assert_eq!(author.name_order, None);
+        let TemplateComponent::Title(title) = &template[1] else {
+            panic!("second component should be title");
+        };
+        assert_eq!(title.rendering.text_case, None);
+
+        let subsequent = citation
+            .subsequent
+            .as_ref()
+            .and_then(|spec| spec.template.as_ref())
+            .expect("subsequent template should exist");
+        let TemplateComponent::Contributor(subsequent_author) = &subsequent[0] else {
+            panic!("subsequent component should be contributor");
+        };
+        assert_eq!(subsequent_author.and, None);
+        assert_eq!(subsequent_author.name_form, None);
+
+        let ibid = citation
+            .ibid
+            .as_ref()
+            .and_then(|spec| spec.template.as_ref())
+            .expect("ibid template should exist");
+        let TemplateComponent::Contributor(ibid_author) = &ibid[0] else {
+            panic!("ibid component should be contributor");
+        };
+        assert_eq!(ibid_author.and, None);
+    }
+
+    #[test]
+    fn bibliography_full_variants_are_diffed_before_pruning() {
+        let mut type_variants = indexmap::IndexMap::new();
+        type_variants.insert(
+            TypeSelector::Single("book".to_string()),
+            TemplateVariant::Full(vec![TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author,
+                form: ContributorForm::Long,
+                and: None,
+                ..TemplateContributor::default()
+            })]),
+        );
+        let style = Style {
+            options: Some(citum_schema::options::Config {
+                contributors: Some(ContributorConfig {
+                    and: Some(AndOptions::Text),
+                    ..ContributorConfig::default()
+                }),
+                ..citum_schema::options::Config::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![author(Some(AndOptions::Text))]),
+                type_variants: Some(type_variants),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let variant = refined
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.type_variants.as_ref())
+            .and_then(|variants| variants.get(&TypeSelector::Single("book".to_string())))
+            .expect("book variant should exist");
+
+        let TemplateVariant::Full(template) = variant else {
+            panic!("non-rendering inherited-field difference should remain Full after diff phase");
+        };
+        let TemplateComponent::Contributor(author) = &template[0] else {
+            panic!("variant component should be contributor");
+        };
+        assert_eq!(author.and, None);
+    }
+
+    #[test]
+    fn diff_add_payloads_are_pruned_after_diff_generation() {
+        let mut type_variants = indexmap::IndexMap::new();
+        type_variants.insert(
+            TypeSelector::Single("webpage".to_string()),
+            TemplateVariant::Full(vec![primary_title(None), author(Some(AndOptions::Text))]),
+        );
+        let style = Style {
+            options: Some(citum_schema::options::Config {
+                contributors: Some(ContributorConfig {
+                    and: Some(AndOptions::Text),
+                    ..ContributorConfig::default()
+                }),
+                ..citum_schema::options::Config::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![primary_title(None)]),
+                type_variants: Some(type_variants),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let variant = refined
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.type_variants.as_ref())
+            .and_then(|variants| variants.get(&TypeSelector::Single("webpage".to_string())))
+            .expect("webpage variant should exist");
+
+        let TemplateVariant::Diff(diff) = variant else {
+            panic!("webpage variant should be encoded as a diff");
+        };
+        let TemplateComponent::Contributor(author) = &diff.add[0].component else {
+            panic!("added component should be contributor");
+        };
+        assert_eq!(author.and, None);
+    }
+
+    #[test]
+    fn suppress_false_is_normalized_on_full_templates_and_diff_adds() {
+        let mut visible_author = author(Some(AndOptions::Text));
+        visible_author.rendering_mut().suppress = Some(false);
+        let mut added_url = url();
+        added_url.rendering_mut().suppress = Some(false);
+        let mut type_variants = indexmap::IndexMap::new();
+        type_variants.insert(
+            TypeSelector::Single("webpage".to_string()),
+            TemplateVariant::Full(vec![visible_author.clone(), added_url]),
+        );
+        let style = Style {
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![visible_author]),
+                type_variants: Some(type_variants),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let bibliography = refined.bibliography.as_ref().expect("bibliography exists");
+        assert_eq!(
+            bibliography
+                .template
+                .as_ref()
+                .and_then(|template| template[0].rendering().suppress),
+            None
+        );
+
+        let variant = bibliography
+            .type_variants
+            .as_ref()
+            .and_then(|variants| variants.get(&TypeSelector::Single("webpage".to_string())))
+            .expect("webpage variant should exist");
+        let TemplateVariant::Diff(diff) = variant else {
+            panic!("webpage variant should be a diff");
+        };
+        assert_eq!(diff.add[0].component.rendering().suppress, None);
+    }
+
+    #[test]
+    fn contributor_without_explicit_and_blocks_hoist() {
+        let style = Style {
+            citation: Some(CitationSpec {
+                template: Some(vec![
+                    author(Some(AndOptions::Text)),
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![author(None)],
+                        ..TemplateGroup::default()
+                    }),
+                ]),
+                ..CitationSpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+
+        assert!(
+            refined
+                .citation
+                .as_ref()
+                .and_then(|citation| citation.options.as_ref())
+                .and_then(|options| options.contributors.as_ref())
+                .and_then(|contributors| contributors.and.as_ref())
+                .is_none()
+        );
+        let template = refined
+            .citation
+            .as_ref()
+            .and_then(|citation| citation.template.as_ref())
+            .expect("citation template exists");
+        let TemplateComponent::Contributor(author) = &template[0] else {
+            panic!("first component should be contributor");
+        };
+        assert_eq!(author.and, Some(AndOptions::Text));
+    }
+}

--- a/crates/citum-migrate/src/passes/sqi_refinement.rs
+++ b/crates/citum-migrate/src/passes/sqi_refinement.rs
@@ -163,10 +163,14 @@ fn encode_bibliography_type_variants(style: &mut Style) {
     let Some(type_variants) = bibliography.type_variants.as_ref() else {
         return;
     };
-    if !type_variants
+    let all_variants_full = type_variants
         .values()
-        .all(|variant| matches!(variant, TemplateVariant::Full(_)))
-    {
+        .all(|variant| matches!(variant, TemplateVariant::Full(_)));
+    if !all_variants_full {
+        debug_assert!(
+            all_variants_full,
+            "SQI refinement expects post-assembly bibliography variants to enter as Full templates"
+        );
         return;
     }
 
@@ -312,6 +316,10 @@ fn prune_type_variants(
                 for add in &mut diff.add {
                     normalize_component_against_options(&mut add.component, title_context, options);
                 }
+                // `modify.rendering` payloads are deliberately left explicit:
+                // a `suppress: false` modify can un-suppress a component that is
+                // suppressed in the base template, so pruning needs base-aware
+                // semantics rather than the component-local checks used here.
             }
         }
     }
@@ -585,6 +593,8 @@ fn normalize_variant_suppress(
                 for add in &mut diff.add {
                     normalize_component_suppress(&mut add.component);
                 }
+                // Do not normalize `modify.rendering.suppress`: `false` can be
+                // the meaningful diff that re-enables a base-suppressed anchor.
             }
         }
     }
@@ -612,6 +622,7 @@ fn normalize_component_suppress(component: &mut TemplateComponent) {
 )]
 mod tests {
     use super::*;
+    use citum_engine::{Processor, reference::Bibliography};
     use citum_schema::{
         options::{NameForm, TextCase, TitleRendering, TitlesConfig},
         template::{
@@ -642,6 +653,17 @@ mod tests {
     fn primary_title(text_case: Option<TextCase>) -> TemplateComponent {
         TemplateComponent::Title(TemplateTitle {
             title: TitleType::Primary,
+            rendering: Rendering {
+                text_case,
+                ..Rendering::default()
+            },
+            ..TemplateTitle::default()
+        })
+    }
+
+    fn container_title(text_case: Option<TextCase>) -> TemplateComponent {
+        TemplateComponent::Title(TemplateTitle {
+            title: TitleType::ContainerTitle,
             rendering: Rendering {
                 text_case,
                 ..Rendering::default()
@@ -744,6 +766,59 @@ mod tests {
                 .and_then(|contributors| contributors.and.as_ref())
                 .is_none()
         );
+    }
+
+    #[test]
+    fn preexisting_global_contributor_and_prunes_without_scope_hoist() {
+        let style = Style {
+            options: Some(citum_schema::options::Config {
+                contributors: Some(ContributorConfig {
+                    and: Some(AndOptions::Text),
+                    ..ContributorConfig::default()
+                }),
+                ..citum_schema::options::Config::default()
+            }),
+            citation: Some(CitationSpec {
+                template: Some(vec![author(Some(AndOptions::Text))]),
+                ..CitationSpec::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![author(Some(AndOptions::Text))]),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+
+        assert!(
+            refined
+                .citation
+                .as_ref()
+                .and_then(|citation| citation.options.as_ref())
+                .and_then(|options| options.contributors.as_ref())
+                .and_then(|contributors| contributors.and.as_ref())
+                .is_none()
+        );
+        assert!(
+            refined
+                .bibliography
+                .as_ref()
+                .and_then(|bibliography| bibliography.options.as_ref())
+                .and_then(|options| options.contributors.as_ref())
+                .and_then(|contributors| contributors.and.as_ref())
+                .is_none()
+        );
+        let citation_author = refined
+            .citation
+            .as_ref()
+            .and_then(|citation| citation.template.as_ref())
+            .and_then(|template| template.first())
+            .expect("citation author exists");
+        let TemplateComponent::Contributor(citation_author) = citation_author else {
+            panic!("citation component should be contributor");
+        };
+        assert_eq!(citation_author.and, None);
     }
 
     #[test]
@@ -850,6 +925,51 @@ mod tests {
     }
 
     #[test]
+    fn category_specific_type_mapping_title_defaults_are_compacted() {
+        let mut type_variants = indexmap::IndexMap::new();
+        type_variants.insert(
+            TypeSelector::Single("article-journal".to_string()),
+            TemplateVariant::Full(vec![container_title(Some(TextCase::SentenceApa))]),
+        );
+        let mut type_mapping = std::collections::HashMap::new();
+        type_mapping.insert("article-journal".to_string(), "periodical".to_string());
+        let style = Style {
+            options: Some(citum_schema::options::Config {
+                titles: Some(TitlesConfig {
+                    type_mapping,
+                    periodical: Some(TitleRendering {
+                        text_case: Some(TextCase::SentenceApa),
+                        ..TitleRendering::default()
+                    }),
+                    ..TitlesConfig::default()
+                }),
+                ..citum_schema::options::Config::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![primary_title(None)]),
+                type_variants: Some(type_variants),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let variant = refined
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.type_variants.as_ref())
+            .and_then(|variants| variants.get(&TypeSelector::Single("article-journal".to_string())))
+            .expect("article-journal variant should exist");
+        let TemplateVariant::Full(template) = variant else {
+            panic!("non-rendering title-kind difference should remain Full");
+        };
+        let TemplateComponent::Title(title) = &template[0] else {
+            panic!("variant component should be title");
+        };
+        assert_eq!(title.rendering.text_case, None);
+    }
+
+    #[test]
     fn diff_add_payloads_are_pruned_after_diff_generation() {
         let mut type_variants = indexmap::IndexMap::new();
         type_variants.insert(
@@ -928,6 +1048,116 @@ mod tests {
             panic!("webpage variant should be a diff");
         };
         assert_eq!(diff.add[0].component.rendering().suppress, None);
+    }
+
+    #[test]
+    fn diff_modify_suppress_false_remains_explicit() {
+        let mut base_title = primary_title(None);
+        base_title.rendering_mut().suppress = Some(true);
+        let mut unsuppressed_title = primary_title(None);
+        unsuppressed_title.rendering_mut().suppress = Some(false);
+        let mut type_variants = indexmap::IndexMap::new();
+        type_variants.insert(
+            TypeSelector::Single("book".to_string()),
+            TemplateVariant::Full(vec![unsuppressed_title]),
+        );
+        let style = Style {
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![base_title]),
+                type_variants: Some(type_variants),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let variant = refined
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.type_variants.as_ref())
+            .and_then(|variants| variants.get(&TypeSelector::Single("book".to_string())))
+            .expect("book variant should exist");
+        let TemplateVariant::Diff(diff) = variant else {
+            panic!("rendering-only suppress change should be a diff");
+        };
+        assert_eq!(diff.modify[0].rendering.suppress, Some(false));
+    }
+
+    #[test]
+    fn non_integral_suppress_false_is_normalized() {
+        let mut visible_author = author(Some(AndOptions::Text));
+        visible_author.rendering_mut().suppress = Some(false);
+        let style = Style {
+            citation: Some(CitationSpec {
+                non_integral: Some(Box::new(CitationSpec {
+                    template: Some(vec![visible_author]),
+                    ..CitationSpec::default()
+                })),
+                ..CitationSpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let non_integral = refined
+            .citation
+            .as_ref()
+            .and_then(|citation| citation.non_integral.as_ref())
+            .and_then(|spec| spec.template.as_ref())
+            .expect("non-integral template exists");
+        assert_eq!(non_integral[0].rendering().suppress, None);
+    }
+
+    #[test]
+    fn refinement_preserves_engine_rendering() {
+        let style = Style {
+            options: Some(citum_schema::options::Config {
+                contributors: Some(ContributorConfig {
+                    and: Some(AndOptions::Text),
+                    name_form: Some(NameForm::Initials),
+                    ..ContributorConfig::default()
+                }),
+                titles: Some(TitlesConfig {
+                    default: Some(TitleRendering {
+                        text_case: Some(TextCase::SentenceApa),
+                        ..TitleRendering::default()
+                    }),
+                    ..TitlesConfig::default()
+                }),
+                ..citum_schema::options::Config::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![
+                    author_with_name_options(),
+                    primary_title(Some(TextCase::SentenceApa)),
+                ]),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+        let bibliography = one_book_bibliography();
+
+        let before = Processor::new(style.clone(), bibliography.clone()).render_bibliography();
+        let after = Processor::new(refine_style(style), bibliography).render_bibliography();
+
+        assert_eq!(after, before);
+    }
+
+    fn one_book_bibliography() -> Bibliography {
+        let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+            r#"{
+                "id": "item-1",
+                "type": "book",
+                "author": [{"family": "Kuhn", "given": "Thomas S."}],
+                "title": "The Structure of Scientific Revolutions",
+                "issued": {"date-parts": [[1962]]},
+                "publisher": "University of Chicago Press"
+            }"#,
+        )
+        .expect("fixture should parse");
+        let mut bibliography = Bibliography::new();
+        bibliography.insert("item-1".to_string(), legacy.into());
+        bibliography
     }
 
     #[test]

--- a/docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md
+++ b/docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md
@@ -1,217 +1,238 @@
-# Migration Strategy Analysis: XML Compiler vs Output-Driven
+# Migration Strategy Analysis: Hybrid Converter and Evidence Pipeline
 
-## Context
+## Current Position
 
-Bean `csl26-rh2u` (now canceled/superseded) and the broader epic `csl26-ifiw` track bibliography-template quality problems in the migration pipeline. Historical results at the time of the original analysis were severe, but current baseline (2026-02-27) is improved: top-10 aggregate shows **100% citation match and 7/10 bibliography-perfect styles**. The remaining issues are concentrated in a smaller set of style-level deltas rather than global failure.
+`citum-migrate` is not the canonical authoring path for high-impact production
+styles. It is a hybrid migration and evidence tool: it extracts durable
+configuration from CSL 1.0 XML, resolves or synthesizes candidate templates,
+scores candidates against oracle output, assembles a concrete Citum style, and
+then refines the assembled result for Style Quality Index (SQI).
 
-**Design origin:** CSL 1.0 was designed with XSLT - a side-effect-free language where nodes are processed in document order and macro calls are simple substitutions. This means the XML node order in the layout IS the rendering order. The challenge is not node ordering itself, but that macros like `source` contain `choose/if/else` branches creating different component sequences for different reference types (e.g., journals get container-title + volume(issue) + pages, while chapters get editor + container-title + pages). Flattening these type-specific branches into one declarative template with overrides is the core difficulty.
+The strategic rule is the same as
+[`DESIGN_PRINCIPLES.md`](./DESIGN_PRINCIPLES.md): fidelity is the first
+constraint, SQI is secondary, and hand-authored or presetized parent styles are
+valid when automatic migration reaches a quality plateau. Generated YAML is
+acceptable only when downstream rendering and quality gates hold. A style that
+parses is not done; a style that renders correctly but is unreadable is still
+unfinished authoring work.
 
----
+The older "XML compiler vs output-driven inference" framing remains useful, but
+it is no longer the whole architecture. The current strategy is:
 
-## Approach A: XML Semantic Compiler (Status Quo)
+1. Use XML where XML is strongest: options, locale-ish signals, processing mode,
+   contributor/date/title defaults, substitutes, and latent branches.
+2. Use output-driven evidence where observed rendering is stronger than
+   procedural flattening: component order, delimiters, formatting, and exercised
+   type-specific suppression.
+3. Use measured selection and held-out validation to choose between candidate
+   styles rather than trusting one source unconditionally.
+4. Use hand-authored or presetized styles for high-impact parents where clean
+   style quality matters more than converter completeness.
+5. Run SQI refinement after assembly, never inside the semantic assembly phase.
 
-**How it works:** Parse CSL 1.0 XML, inline macros, upsample nodes to an intermediate representation, then compile into Citum's flat TemplateComponent model. Runs post-processing passes (reorder, deduplicate, group) to fix structural issues.
+The SQI refinement split is the intended architecture. In checkouts that include
+that split, assembly emits explicit templates and
+`citum_migrate::passes::sqi_refinement` performs post-assembly diffing,
+hoisting, pruning, and suppress cleanup. In older checkouts, read that boundary
+as the target architecture rather than the implemented crate state. See also
+[`SQI_REFINEMENT_PLAN.md`](../policies/SQI_REFINEMENT_PLAN.md) and
+[`crates/README.md`](../../crates/README.md).
 
-### Pros
+## Current `citum-migrate` Architecture
 
-1. **Semantic fidelity** - Works from the actual style definition, which encodes the author's intent across all reference types, not just observed output for tested types.
-2. **Complete conditional coverage** - Has access to ALL choose/if/else branches. APA has 126 choose blocks covering 50+ reference types; output-driven only sees what test data exercises.
-3. **Options extraction works well** - Global settings (name formatting, et-al rules, initialize-with, date forms, page-range-format) are reliably extracted from XML attributes. This is why citations already work at 87-100%.
-4. **Deterministic and scalable** - Same XML input always produces same Citum output. One compiler handles all 2,844 styles without per-style inference runs.
-5. **Provenance tracking** - When something fails, you can trace the exact CslNode to CslnNode to TemplateComponent chain. Debugging infrastructure already exists.
-6. **Handles latent features** - Substitute rules, disambiguation, subsequent-author-substitute, locale terms - all encoded in XML regardless of whether test data triggers them.
-7. **Significant investment** - 7,300 lines of working code. The options pipeline, upsampler, and preset detector are solid.
-
-### Cons
-
-1. **Fundamental model mismatch** - CSL 1.0 is procedural (macros, choose/if/else, groups with implicit suppression). Citum is declarative (flat templates with typed overrides). Bridging this is the hardest translation problem in the project.
-2. **Type-specific branch flattening is the unsolved problem** - While XML node order correctly reflects rendering order (per the XSLT design), macros like APA's `source` contain 50+ choose/if/else paths that produce different component sequences per reference type. The source_order tracking attempt (reverted in commit `1c9ad45`) correctly preserved node order but could not capture which components appear for which types. The hard problem is not ordering - it is inferring type-specific suppress overrides from deeply nested conditional logic.
-3. **Combinatorial explosion** - APA has 99 macros and 126 choose blocks. Flattening these into a flat template with correct suppress overrides for every type is an extremely high-dimensional mapping problem.
-4. **Heuristic passes are fragile** - The reorder, deduplicate, and grouping passes use pattern-matching heuristics. Fixing one style's layout frequently breaks another. *Update (2026-02-08):* Significant progress has been made by replacing hardcoded `style_id` checks with holistic style-family detection and explicit `type_mapping` configuration, making these passes more deterministic and less 'magical'.
-5. **Group semantics mismatch** - CSL 1.0 groups suppress their delimiter when a child is empty; Citum has no equivalent implicit behavior. This creates phantom components and incorrect spacing.
-6. **Diminishing returns** - The easy 87% came cheaply; the remaining gap involves the hardest cases where the two models diverge most.
-
----
-
-## Approach B: Output-Driven / Reverse Engineering
-
-**How it works:** Run citeproc-js with diverse test references, parse rendered output strings into structured components, cross-reference with input data to infer variable-to-output mappings, generate Citum YAML directly from observed patterns.
-
-### Pros
-
-1. **Directly targets the success criterion** - The oracle comparison IS the definition of correctness. Deriving the template from the output closes the loop: observed output leads to template leads to processor leads to same output.
-2. **Bypasses the branch-flattening problem entirely** - citeproc-js already resolves which choose/if/else path to take for each reference type. Component ordering and type-specific behavior are directly observed.
-3. **Naturally resolves group semantics** - Group delimiter behavior, implicit suppression, and macro interaction effects are all resolved by citeproc-js before inference begins. No need to replicate that logic.
-4. **Type-specific overrides emerge naturally** - Comparing outputs across reference types directly reveals differences: "publisher appears for chapters but not journals" becomes `suppress: true` for `article-journal`.
-5. **Human-intuitive** - Produces templates resembling what a style author would write by reading a style guide: "Author (Year). Title. *Journal*, volume(issue), pages."
-6. **Well-suited to Citum's design** - The flat template model was designed to be what a human would write. This approach produces exactly that.
-7. **Simpler conceptually** - No need to understand CSL 1.0's macro expansion, choose/if/else flattening, or group suppression.
-
-### Cons
-
-1. **Test data coverage problem** - You only learn about behavior you observe. CSL 1.0 has 50+ reference types; the current fixture has 16 items covering only 7 types (article-journal, book, chapter, report, thesis, paper-conference, webpage). Styles with rare type-specific behavior (legal, patent, dataset) will be missed.
-2. **Oracle parser fragility** - The existing oracle.js component parser (`parseComponents()`) uses fragile heuristics: publisher detection relies on 10-character prefix substring matching, container-title on 15-character prefixes, and title on 20-character prefixes. `findRefDataForEntry()` returns the first author match even when multiple references share an author. These must be substantially hardened before serving as a template generation foundation.
-3. **Ambiguous parsing** - Regex-based component extraction is inherently fragile. Is "Cambridge" a publisher or a place? Is "15" a volume or a page number? Context-dependent resolution requires complex heuristics.
-4. **Loses metadata linkage** - Output strings do not reveal which CSL variable produced which output token. Cross-referencing with input data helps but is not foolproof (e.g., "Smith" could be author or editor).
-5. **Cannot extract global options** - Output "Smith, J." does not tell you whether `initialize-with` is `. ` or the input only had initials. Options like name-as-sort-order, et-al, and page-range-format must still come from XML.
-6. **Delimiter and formatting inference** - Inferring delimiters between components (". " vs ", " vs ": ") and formatting (italics, bold) from rendered strings is non-trivial. "Nature" in italics looks the same as "Nature" in plain text unless the output format preserves markup.
-7. **Does not scale** - Each of 2,844 styles needs its own citeproc-js inference run with sufficient test data. This creates a permanent dependency on citeproc-js as infrastructure.
-8. **Non-deterministic** - Different test data sets may produce different inferred templates. The approach is probabilistic, not deterministic.
-9. **Cannot discover latent features** - Substitute rules, disambiguation, subsequent-author-substitute only trigger under specific conditions. Test data may never exercise them.
-10. **Locale conflation** - Output "pp. 1-10" does not reveal whether "pp." is a locale term or a hardcoded prefix. This matters for Citum's multilingual locale system.
-11. **Compensating errors** - If the Citum processor has bugs, the output-driven approach produces templates that compensate for those bugs rather than being correct.
-
----
-
-## Approach C: Hand-Authoring High-Impact Styles
-
-**How it works:** A human (or LLM-assisted human) reads the style guide and hand-authors Citum YAML templates, using the existing `../../examples/apa-style.yaml` as a model. This approach targets the top 10 parent styles covering 60% of dependent styles.
-
-### Pros
-
-1. **Proven to work** - `../../examples/apa-style.yaml` already exists: 11 components, correct ordering, proper type-specific overrides, correct delimiters. This is the gold standard.
-2. **Highest fidelity** - A knowledgeable author understands the intent behind a style guide, not just observed output. They can handle edge cases, locale terms, and rare types correctly.
-3. **No infrastructure dependency** - No need for oracle.js hardening, expanded test fixtures, or citeproc-js inference runs.
-4. **Directly produces the target format** - The Citum template model was designed to be human-readable and human-writable.
-
-### Cons
-
-1. **Does not scale** - Hand-authoring 300 parent styles is not feasible.
-2. **Requires domain expertise** - The author needs to understand both the style guide and the Citum template model.
-3. **Error-prone** - Manual work introduces human error, especially for complex styles with many type-specific overrides.
-4. **Still needs verification** - Oracle comparison is still needed to validate correctness.
-
----
-
-## Architect's Recommendation: Hybrid Approach
-
-**Verdict: Neither approach alone is sufficient. Use a hybrid strategy combining all three.**
-
-The critical insight is that these approaches fail at *different things*:
-
-| Capability | XML Compiler | Output-Driven | Hand-Authored |
-|---|---|---|---|
-| Global options (names, dates, et-al) | Excellent | Cannot do | Manual |
-| Template component ordering | Improved but still style-fragile (7/10 bib perfect in top-10) | Validated (6 styles correct) | Excellent |
-| Type-specific overrides/suppress | Fragile (heuristic) | Validated (observable) | Excellent |
-| Coverage of rare types | Complete | Test-data dependent | Domain-expert dependent |
-| Scalability to 2,844 styles | One compiler | Per-style inference | Not feasible |
-| Locale term handling | Direct | Cannot distinguish | Manual |
-| Substitute/disambiguation | Encoded in XML | Requires special test data | Manual |
-| Delimiter inference | Direct from XML | Validated (filtered voting) | Manual |
-
-### Concrete Architecture
-
-1. **Keep the XML pipeline for OPTIONS** - The options extractor, preset detector, locale handling, and processing mode detection all work. This is ~2,500 lines of solid code that does not need replacement.
-
-2. **Hand-author templates for the top 5-10 parent styles** - Starting from `../../examples/apa-style.yaml` as a model, use style guides and oracle verification to produce gold-standard templates. This covers 60% of dependent styles with the highest confidence.
-
-3. **Build output-driven template inference for the next tier** - For parent styles beyond the top 10, use citeproc-js output + input data cross-referencing to generate template structure. This requires hardening oracle.js first.
-
-4. **Retain the XML compiler as a fallback** - For the remaining parent styles, the XML compiler provides a reasonable starting point. It already gets citations right.
-
-5. **Use oracle comparison as cross-validation for all approaches** - Where hand-authored, output-inferred, and XML-compiled templates agree, confidence is high.
-
-### Why hybrid, not pure output-driven
-
-- You still need XML for options (the output-driven approach literally cannot extract `initialize-with`, `name-as-sort-order`, or `et-al-min` from rendered strings)
-- You still need XML for rare reference types not covered by test data
-- You still need XML for locale terms, substitute rules, and disambiguation
-- The existing options pipeline is proven and does not need replacement
-
-### Why hybrid, not pure XML compiler
-
-- The template compiler and pass chain remain the highest-risk area for residual bibliography deltas. Even with major progress, flattening type-specific choose/if/else behavior into declarative templates still introduces style-fragile edge cases that require targeted fixes.
-- The template structure for most styles is simple: 8-12 components in a predictable order. Hand-authoring or inferring this is far more reliable than deducing it from 126 choose blocks.
-
-### Estimated effort
-
-- Hand-authored top 10 templates: ~5-10 hours of domain-expert time (APA already done)
-- Oracle.js parser hardening: ~300-500 lines (replace substring matching with proper field-aware parsing)
-- Output-driven template inferrer: ~500-800 lines (extend hardened oracle.js + add variable cross-referencing)
-- Integration with options pipeline: ~200 lines
-- Test fixture expansion: ~200 lines of JSON (15 → 25-30 reference items)
-- Testing and validation: Use existing oracle infrastructure
-
-### Risk mitigation
-
-- Expand test fixtures from 16 references to 25-30, covering all major reference types (add article-newspaper, dataset, legal_case, entry at minimum)
-- Use the XML's choose/if type conditions as a validation checklist (ensure inferred template has overrides for all types the XML mentions)
-- Start with APA (the most complex, 99 macros) as proof-of-concept; the hand-authored version already exists
-- **Preserve citation template generation** - Current top-10 baseline is 100% citation match; any template changes must not regress this
-- Harden oracle.js component parser before building inference on top of it
-
----
-
-## Validation Results (2026-02-08)
-
-The output-driven template inferrer (`../../scripts/lib/template-inferrer.js`) was implemented and tested against 6 major parent styles. Results validate the hybrid approach.
-
-### What the inferrer demonstrated
-
-| Capability | Result | Notes |
+| Layer | Responsibility | Strategic status |
 |---|---|---|
-| Component ordering | Correct for all 6 styles | The problem that defeated the XML compiler falls out naturally from positional analysis |
-| Delimiter detection | APA `. `, IEEE `, `, others `. ` | Reliable once contributor/year/editor pairs filtered from voting |
-| Formatting inference | Italic and quote detection from HTML | Majority vote across entries; APA italic titles, IEEE quoted titles |
-| Parent-monograph detection | Serial vs monograph split | Inferred from reference types present in rendered output |
-| Type-specific suppress | Emerges from per-type component presence | No heuristic flattening of choose/if/else needed |
-| Confidence | 95-97% across styles | Per-type coverage metric |
+| XML parsing and macro expansion | Parse CSL 1.0, inline macros, preserve source provenance. | Necessary substrate. Good for semantic coverage, not sufficient for clean templates. |
+| Option extraction | Extract contributor, date, title, bibliography, locator, and processing options. | Strongest part of the XML pipeline. Keep and extend conservatively. |
+| XML compiler | Compile XML/IR into concrete citation and bibliography templates, including type templates. | Necessary fallback. Still risky for bibliography structure and type-conditioned macro flattening. |
+| Template resolver and inferred templates | Load embedded, curated, or generated template candidates when they exist. | Preferred when curated/generated evidence is stronger than raw XML compilation. |
+| Measured selection and synthesis | Score candidate citation/bibliography styles against citeproc-js fixtures and held-out validation. | Correct direction for bounded automatic improvement; limited by fixture coverage. |
+| Semantic fixups | Apply fidelity-preserving full-template corrections such as URL/accessed gating and media/type repairs. | Acceptable only with oracle evidence or clear CSL/Citum semantic mismatch. Keep localized. |
+| Assembly | Produce a standalone, explicit `citum_schema::Style` from selected sources. | Should be semantic and explicit. It must not hide differences through SQI compaction. |
+| SQI refinement | Generate exact diff-based `type-variants`, hoist safe options, prune inherited defaults, normalize serialization noise. | Post-assembly concern. It improves maintainability only after the style is semantically assembled. |
+| Lineage and wrappers | Attach `extends`, minimize wrappers, and emit evidence about standalone vs compressed forms. | Runs after standalone materialization so local diffs remain inspectable. |
 
-### Styles tested
+This separation matters. If assembly strips fields, hoists options, or compacts
+templates before diff generation, the diff engine compares already-mutated
+templates and can produce diffs that reflect compaction artifacts rather than
+semantic structure. Assembly should therefore prefer explicitness; SQI
+refinement should own concision.
 
-- **APA 7th** (783 dependents): `. ` delimiter, italic parent titles, both serial and monograph containers
-- **IEEE** (176 dependents): `, ` delimiter, quoted primary titles, italic parent titles
-- **Elsevier Harvard** (665 dependents): `. ` delimiter, no formatting (correct)
-- **Chicago Author-Date** (547 dependents): `. ` delimiter, italic parent titles
-- **Springer Basic** (460 dependents): `. ` delimiter
-- **Nature** (182 dependents): `. ` delimiter
+## Why Migrated Output Can Still Feel Wrong
 
-### Cons addressed by implementation
+Unsatisfying `citum-migrate` output usually falls into one of five buckets:
 
-Several Approach B cons identified in the original analysis have been mitigated:
-
-- **Con #2 (Parser fragility)**: The component parser was rewritten with exact field-aware matching, multi-field scoring for reference lookup, and digit-boundary guards for numeric fields. See `../../scripts/lib/component-parser.js`.
-- **Con #6 (Delimiter and formatting inference)**: Delimiter consensus uses filtered voting across all entry pairs. Formatting detection parses raw HTML output from citeproc-js to identify `<i>` tags and quote characters. Both work reliably.
-- **Con #8 (Non-deterministic)**: With sufficient entries per type (3+), the consensus-based approach produces stable results across runs.
-
-### Remaining gaps
-
-- **Test data coverage** (Con #1): Fixture has 28 items covering ~12 types; rare types (legal, patent) still underrepresented
-- **Locale conflation** (Con #10): "pp." detected as prefix but not distinguished from locale terms
-- **Latent features** (Con #9): Disambiguation, substitute rules still require XML or hand-authoring
-
-### Key architectural insight
-
-The inferrer validates that **template structure is often easier to solve from observed output than from procedural XML alone**. Early 0%-bibliography periods exposed the procedural-to-declarative translation difficulty; current results show this can be improved substantially but not fully eliminated with heuristics. Meanwhile, the XML pipeline remains the right tool for options extraction and currently sustains perfect citation match on the top-10 set.
-
-### Updated effort estimates
-
-| Task | Original estimate | Actual |
+| Symptom | Meaning | Correct response |
 |---|---|---|
-| Parser hardening | 300-500 lines | ~200 lines (component-parser.js rewrite) |
-| Template inferrer | 500-800 lines | ~400 lines (template-inferrer.js) |
-| Test fixture expansion | ~200 lines JSON | Done (28 items, 12+ types) |
-| Integration with options pipeline | ~200 lines | Not yet started |
+| Rendered output differs from citeproc-js or a style guide. | Fidelity failure. | Fix converter, schema, or engine behavior with oracle/workflow evidence. No SQI tradeoff is allowed. |
+| Rendered output is correct but YAML is verbose. | Structural ugliness, not necessarily semantic wrongness. | Improve SQI refinement, option hoisting, template presets, or hand-authored parent styles. |
+| Type variants are numerous or unnatural. | Procedural CSL conditionals did not map cleanly to a declarative spine. | Prefer curated parent templates or output-driven evidence; keep XML fallback for latent behavior. |
+| Behavior works only for exercised reference types. | Fixture coverage gap. | Expand selection and held-out fixtures before trusting output-driven inference. |
+| Fixups feel style-specific or fragile. | Heuristic debt in media/type handling or bibliography flattening. | Narrow the fixup, add regression cases, or move the rule into schema/style data if it is general. |
 
-### Future application: visual style creation
+This distinction is operationally important. A bad bibliography rendering is a
+hard bug. A correct but bulky template is a style-quality problem. A clean YAML
+file that only works for fixture-covered cases is not trustworthy enough for
+core parent styles.
 
-The same output-driven approach could power a visual style editor where users provide example formatted entries (by pasting, uploading, or modifying pre-selected reference data) and the system infers a Citum template. The component parser and template inferrer already perform the core task: given structured reference data and a formatted string, derive component ordering, delimiters, formatting, and type-specific behavior. This aligns with the progressive-refinement UI described in `./design/STYLE_EDITOR_VISION.md` and would allow style creation without requiring knowledge of any style language.
+## Operational Decision Rules
 
----
+| Situation | Default decision |
+|---|---|
+| Core parent style quality matters. | Hand-author or presetize the parent, then use migration output as evidence and regression input. |
+| Generated output is faithful but verbose. | Improve post-assembly SQI refinement or reusable presets; do not mutate assembly to chase concision. |
+| Generated output is unfaithful. | Fix converter, engine, schema, or fixtures with oracle evidence before SQI work. |
+| Fixture coverage is weak for affected behavior. | Expand selection and held-out fixtures before trusting output-driven inference. |
+| XML and measured output disagree. | Prefer measured output only for exercised behavior; retain XML fallback for latent branches, options, substitutes, and locale behavior. |
+| A heuristic fix helps one style and risks another. | Require a narrow regression test, family/type guard, or move the behavior into declarative style data. |
+| A style can be expressed with a generic spine plus few true outliers. | Prefer base templates, options, presets, and diff-based `type-variants` over many full type templates. |
+
+The goal is not to make the converter clever enough to author every style.
+The goal is to make it dependable as a source of explicit semantic candidates,
+evidence, and controlled automation while preserving a path to high-quality
+human-readable styles.
+
+## Historical Analysis: XML Compiler
+
+**How it works:** Parse CSL 1.0 XML, inline macros, upsample nodes to an
+intermediate representation, then compile into Citum's `TemplateComponent`
+model. Post-processing and fixups repair known structural mismatches.
+
+### Strengths
+
+1. **Semantic coverage** - XML contains the author's declared rules, including
+   rare reference types and branches fixtures may not exercise.
+2. **Options extraction** - Name formatting, et-al rules, initialize-with, date
+   forms, page-range-format, and processing mode are usually recoverable from
+   attributes and macro structure.
+3. **Determinism** - Same XML input produces the same candidate output.
+4. **Provenance** - Failures can be traced through the parsed CSL node and IR
+   pipeline.
+5. **Latent behavior** - Substitute rules, disambiguation hints, locale terms,
+   and subsequent-author-substitute exist whether or not test data triggers
+   them.
+
+### Weaknesses
+
+1. **Model mismatch** - CSL 1.0 is procedural: macros, conditionals, and groups
+   with implicit suppression. Citum is declarative and typed.
+2. **Type-conditioned flattening** - Macros such as APA's `source` contain many
+   `choose/if/else` paths that produce different component sequences per
+   reference type. Preserving XML order is not enough; the converter must infer
+   which structures belong to which types.
+3. **Group semantics** - CSL groups suppress delimiters when children are empty.
+   Citum templates do not have the same implicit behavior, so naive conversion
+   can create phantom punctuation or components.
+4. **Heuristic fragility** - Reordering, grouping, media/type repairs, and
+   bibliography flattening can become style-family heuristics unless tightly
+   tested.
+5. **Quality ceiling** - XML compilation can be faithful enough to render but
+   still produce YAML no human would choose to maintain.
+
+## Historical Analysis: Output-Driven Inference
+
+**How it works:** Run citeproc-js against fixture references, parse rendered
+output into components, cross-reference those components with input data, and
+generate or score Citum templates from observed behavior.
+
+### Strengths
+
+1. **Direct fidelity target** - Oracle output is the executable comparator for
+   CSL-derived behavior.
+2. **Resolved conditionals** - citeproc-js has already selected branches,
+   suppressed empty groups, and applied macro interactions for the exercised
+   reference.
+3. **Observed structure** - Component order, delimiters, formatting, and
+   type-specific suppression can be derived from actual output.
+4. **Human-readable bias** - The result tends to resemble the style a human
+   would write from examples.
+
+### Weaknesses
+
+1. **Coverage-bound** - It only knows behavior present in selection or held-out
+   fixtures.
+2. **Metadata ambiguity** - Output text does not always reveal whether a token
+   came from a contributor, editor, publisher, place, locale term, or literal.
+3. **Cannot replace XML options** - Output cannot reliably identify
+   initialize-with, name-as-sort-order, et-al thresholds, or latent substitute
+   behavior.
+4. **Locale conflation** - Rendered terms such as `pp.` may be locale terms,
+   hardcoded affixes, or style-specific literals.
+5. **Compensating errors** - If the Citum engine has a bug, inference can learn
+   a template that compensates for the bug rather than exposing it.
+
+### Current Result
+
+The output-driven parser and inferrer have already reduced several historical
+risks: component parsing is field-aware, delimiter inference uses filtered
+voting, HTML formatting is inspected, and fixture coverage is broader than the
+original 16-item set. This validates the hybrid approach, but it does not make
+output-driven inference a complete replacement for XML or hand-authored styles.
+
+## Historical Analysis: Hand-Authored Parent Styles
+
+**How it works:** A human or domain-assisted author writes Citum YAML directly
+from a style guide, examples, and oracle validation.
+
+### Strengths
+
+1. **Highest style quality** - The author can choose the clean generic spine,
+   presets, and meaningful type outliers directly.
+2. **Best authority handling** - Style guides and publisher instructions outrank
+   converter artifacts when they are clearer than CSL XML.
+3. **No inference ceiling** - Rare types, locale behavior, and edge cases can be
+   handled deliberately.
+
+### Weaknesses
+
+1. **Does not scale to every dependent style** - It is appropriate for high
+   leverage parent styles, not all migrated styles.
+2. **Requires domain judgment** - The author must understand both citation
+   behavior and Citum's declarative model.
+3. **Still needs executable validation** - Human-authored styles must pass the
+   same rendering and quality gates.
+
+## Strategic Recommendation
+
+The durable strategy is hybrid:
+
+1. **Keep XML for options and latent semantics.** This is the reliable part of
+   automatic migration and should not be discarded.
+2. **Use measured output for exercised template structure.** Let citeproc-js
+   settle concrete branch behavior where fixtures cover the case.
+3. **Retain XML compilation as a fallback and evidence source.** It remains the
+   only automatic path to rare unobserved branches.
+4. **Author or presetize top parent styles.** The core portfolio should not be
+   constrained by converter artifacts when a cleaner declarative style is known.
+5. **Separate semantic assembly from SQI refinement.** Keep templates explicit
+   until final refinement can diff, hoist, prune, and compact safely.
+6. **Treat oracle and workflow tests as gates.** SQI improvements that regress
+   fidelity are rejected.
+
+## Validation and Risk Controls
+
+Current and future migration work should be evaluated with layered checks:
+
+1. Targeted converter tests for assembly boundaries, template diffing, measured
+   selection, and SQI refinement.
+2. Oracle/workflow tests for representative legacy styles, especially parent
+   styles and styles whose generated output looks suspicious.
+3. Expanded selection and held-out fixtures when changing output-driven
+   inference or measured selection.
+4. SQI reports for maintainability regressions after fidelity is green.
+5. Manual review for high-impact parent styles, because clean Citum style design
+   is an authoring problem as well as a converter problem.
 
 ## Files Referenced
 
-- `../../crates/citum-migrate/src/template_compiler/mod.rs` - Current template compiler (2,077 lines), the bottleneck
-- `../../crates/citum-migrate/src/lib.rs` - MacroInliner with macro expansion logic
-- `../../crates/citum-migrate/src/upsampler.rs` - CslNode to CslnNode conversion (works well)
-- `../../crates/citum-migrate/src/options_extractor/` - Options pipeline (works well, keep)
-- `../../crates/citum-schema-style/src/template.rs` - Citum template model (target schema)
-- `../../scripts/oracle.js` - Oracle comparison test
-- `../../scripts/lib/component-parser.js` - Hardened component parser with field-aware matching
-- `../../scripts/lib/template-inferrer.js` - Output-driven template inference engine
-- `../../scripts/infer-template.js` - CLI wrapper for template inference
-- `../../examples/apa-style.yaml` - Hand-authored APA style (gold standard, 11 components)
-- `../../tests/fixtures/references-expanded.json` - Test fixture (28 items, 12+ types)
-- `../../.beans/csl26-rh2u--preserve-macro-call-order-from-csl-10-during-parsi.md` - The triggering bean
-- `../../.beans/csl26-m3lb--implement-hybrid-migration-strategy.md` - Implementation milestone
+- [`../../crates/citum-migrate/src/template_compiler/`](../../crates/citum-migrate/src/template_compiler/) - XML template compiler.
+- [`../../crates/citum-migrate/src/options_extractor/`](../../crates/citum-migrate/src/options_extractor/) - XML-derived options pipeline.
+- [`../../crates/citum-migrate/src/measured_citation.rs`](../../crates/citum-migrate/src/measured_citation.rs) - Oracle-scored candidate selection.
+- [`../../crates/citum-migrate/src/synthesis/`](../../crates/citum-migrate/src/synthesis/) - Bounded candidate mutation and held-out validation.
+- [`../../crates/citum-migrate/src/template_diff.rs`](../../crates/citum-migrate/src/template_diff.rs) - Diff-based `type-variants`.
+- [`../../scripts/oracle.js`](../../scripts/oracle.js) - citeproc-js comparison harness.
+- [`../../scripts/lib/component-parser.js`](../../scripts/lib/component-parser.js) - Field-aware output parser.
+- [`../../scripts/lib/template-inferrer.js`](../../scripts/lib/template-inferrer.js) - Output-driven template inference.
+- [`../../tests/fixtures/references-expanded.json`](../../tests/fixtures/references-expanded.json) - Selection fixture data.
+- [`../../tests/fixtures/references-heldout.json`](../../tests/fixtures/references-heldout.json) - Held-out validation fixture data.
+- [`../policies/SQI_REFINEMENT_PLAN.md`](../policies/SQI_REFINEMENT_PLAN.md) - Portfolio SQI policy.


### PR DESCRIPTION
## Summary

- Keeps `build_final_style` assembly explicit by emitting full bibliography type templates without type-diff generation or option pruning.
- Adds `citum_migrate::passes::sqi_refinement::refine_style` as the post-assembly SQI pass for type-variant diffing, contributor option hoisting, inherited-option pruning, and suppress cleanup.
- Moves `template_diff` onto the internal library surface and wires refinement immediately before serialization.
- Updates the migration strategy analysis to describe the current hybrid converter architecture and SQI boundary.
- Adds focused tests for the assembly/refinement boundary.

## Validation

- `cargo test -p citum-migrate assembly::tests`
- `cargo test -p citum-migrate template_diff::tests`
- `cargo test -p citum-migrate passes::sqi_refinement`
- `cargo test -p citum-migrate`
- `just pre-commit`
- Pre-push hook reran fmt, clippy, and `cargo nextest run`: 1645 passed, 0 skipped.
- `git diff --check`

## Not Run

- `just workflow-test styles-legacy/apa.csl` because `styles-legacy` is not checked out in the sibling worktree.
- `just oracle styles-legacy/apa.csl` because the local Node dependency `citeproc` is missing.
- `./scripts/validate-frontmatter.sh --copilot-strict` because local `scripts/node_modules/js-yaml` is missing.

Those checks require optional local migration/oracle or Node dependencies, and no submodule operation was performed.
