### PR TITLE
ci: use CHANGELOG.md for GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,18 +402,12 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # Fetch all tags so we can find the previous one reliably.
-          git fetch --tags --quiet
-          PREV_TAG="$(git tag --sort=-version:refname -l 'v*' | grep -vxF "$TAG" | head -n 1 || true)"
-          NOTES_START_ARG=()
-          if [[ -n "$PREV_TAG" ]]; then
-            NOTES_START_ARG=(--notes-start-tag "$PREV_TAG")
-          fi
+          VERSION="${TAG#v}"
+          awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" \
+            CHANGELOG.md > /tmp/release-notes.md
           gh release create "$TAG" \
             --title "$TAG" \
-            --generate-notes \
-            "${NOTES_START_ARG[@]}" \
-            --verify-tag \
+            --notes-file /tmp/release-notes.md \
             --verify-tag \
             release-artifacts/*.tar.gz \
             release-artifacts/SHA256SUMS \


### PR DESCRIPTION
## Summary

- Replace `--generate-notes` with extraction of the version section from `CHANGELOG.md`
- Remove the now-unused `PREV_TAG` / `NOTES_START_ARG` block (dead code)
- GitHub release bodies will now match the `git-cliff`-generated changelog exactly (grouped by type+scope, with commit links)

## Scope

Single file: `.github/workflows/release.yml` — the "Create release" step only.

## Validation

Workflow-only change; no Rust gate applies. Logic is a straightforward `awk` pattern:

```bash
VERSION="${TAG#v}"
awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" \
  CHANGELOG.md > /tmp/release-notes.md
```

The CHANGELOG.md section for the release version is already committed in the release PR before the tag is pushed, so it is present on the tagged commit that triggers this job.

## Risk

Low. If CHANGELOG.md were missing the version entry (shouldn't happen given the release PR flow), `/tmp/release-notes.md` would be empty and the release body would be blank — visible immediately and fixable by editing the release on GitHub.

## Follow-ups

None.
