### PR TITLE
ci(hooks): add vouch contributor gating

### DIFF
--- a/.beans/archive/csl26-c0lk--integrate-vouch-for-pr-contributor-gating.md
+++ b/.beans/archive/csl26-c0lk--integrate-vouch-for-pr-contributor-gating.md
@@ -1,0 +1,23 @@
+---
+# csl26-c0lk
+title: Integrate vouch for PR contributor gating
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-20T14:07:52Z
+updated_at: 2026-06-20T14:10:35Z
+---
+
+Add mitchellh/vouch to gate PR/issue creation against VOUCHED.td allowlist; rewrite CONTRIBUTING.md to document the policy.
+
+## Tasks
+
+- [x] Create .github/VOUCHED.td with bdarcus pre-vouched
+- [x] Create .github/vouch-close.md (auto-close message template)
+- [x] Create .github/workflows/vouch-check.yml (PR + issue gating)
+- [x] Create .github/workflows/vouch-manage.yml (maintainer vouch management)
+- [x] Rewrite CONTRIBUTING.md with vouch policy section
+
+## Summary of Changes
+
+Added vouch-based contributor gating: .github/VOUCHED.td allowlist, two GitHub Actions workflows (vouch-check.yml, vouch-manage.yml), a close-message template, and a rewritten CONTRIBUTING.md. Committed on branch ci/vouch-contributor-gating.

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,4 @@
+# Citum Core — vouched contributors
+# Maintainers manage this list via: vouch @user (in the Contributor Access issue)
+# Denounced users: prefix with -
+bdarcus

--- a/.github/vouch-close.md
+++ b/.github/vouch-close.md
@@ -1,0 +1,9 @@
+Thanks for your interest in contributing to Citum!
+
+This project requires contributors to be vouched before pull requests can be accepted. This policy exists to maintain code quality and prevent unreviewed AI-generated submissions.
+
+**To request access:** open a GitHub issue introducing yourself and describing what you'd like to contribute. A maintainer will review it and, if appropriate, vouch you. Issues are open to everyone — no vouch required.
+
+Once vouched, your pull requests will proceed normally through our review process.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contribution guide.

--- a/.github/workflows/vouch-check.yml
+++ b/.github/workflows/vouch-check.yml
@@ -1,0 +1,25 @@
+name: Vouch — check PR
+
+on:
+  # Required by vouch: reads VOUCHED.td from the base branch and closes fork
+  # PRs. No untrusted code is checked out or executed.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@baeb3bf7c7e6c12d6e33bab3870b7e936580a934  # main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          auto-close: true
+          require-vouch: true
+          template-file: .github/vouch-close.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vouch-manage.yml
+++ b/.github/workflows/vouch-manage.yml
@@ -1,0 +1,29 @@
+name: Vouch — manage contributors
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - uses: mitchellh/vouch/action/manage-by-issue@baeb3bf7c7e6c12d6e33bab3870b7e936580a934  # main
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,18 @@
 # Contributing to Citum
 
-Citum is a declarative, type-safe Rust implementation for managing and processing citation styles. We welcome contributions from domain experts, style authors, developers, and community members.
+## Contributor Access
+
+Citum uses [vouch](https://github.com/mitchellh/vouch) to manage contributor access. Pull requests from unknown GitHub accounts are automatically closed. **Issues are open to everyone** — no vouch required, so opening an issue is the right first step.
+
+**To request access:** open a GitHub issue introducing yourself and describing what you'd like to contribute. A maintainer will review and vouch you if appropriate. Once vouched, your pull requests proceed normally through code review.
+
+Trusted contributors are listed in [`.github/VOUCHED.td`](.github/VOUCHED.td). Maintainers manage the list by commenting `vouch @user` or `denounce @user <reason>` on vouch-request issues.
+
+---
 
 ## How to Contribute
+
+Citum is a declarative, type-safe Rust implementation for managing and processing citation styles. We welcome contributions from domain experts, style authors, and developers.
 
 While the core of this project was developed unassisted in [2023](https://github.com/bdarcus/csln), Citum follows an **AI-first development model** that values expertise over implementation speed. The most impactful contributions come from those who understand citation semantics:
 
@@ -16,9 +26,13 @@ While the core of this project was developed unassisted in [2023](https://github
 - Focus on core engine architecture (`citum_engine`), schema design (`citum_schema`), and agent tooling
 - Ensure all Rust code changes pass mandatory pre-commit checks before committing
 
+---
+
 ## AI & LLM Contributions
 
 Because Citum follows an AI-first development model, we rely heavily on LLMs and agentic workflows to build and maintain the project. However, to protect the structural integrity of the codebase and the time of our maintainers, we enforce a strict, zero-tolerance policy for AI "slop."
+
+The vouch gate is the first line of defense: unrecognized accounts cannot open PRs at all. For vouched contributors, the following rules apply unconditionally.
 
 We welcome AI assistance, but **you are solely responsible for the output.** If you use LLMs to draft, generate, or refactor code for a pull request, you must adhere to the following rules:
 
@@ -27,7 +41,9 @@ We welcome AI assistance, but **you are solely responsible for the output.** If 
 3. **No "Drive-By" Generative PRs:** Pull requests containing massive, AI-generated refactors or unrequested features will be closed unreviewed. If you intend to use an LLM to tackle a significant architectural change, open an issue to discuss the approach with maintainers *first*.
 4. **CI is the First Line of Defense (Not the Last):** We maintain rigorous git pre-commit hooks and a comprehensive CI pipeline precisely to guard against sloppy code and LLM hallucinations. An AI-assisted PR *must* have a green CI run before a maintainer will look at it. However, while our CI guarantees the code compiles, lints cleanly, and passes tests, it cannot verify architectural intent. A green CI does not excuse you from Rule 1.
 
-Contributors who repeatedly bypass pre-commit hooks, ignore CI failures on their PRs, or submit AI-generated code that violates our design principles—even if the tests pass—will have their PRs closed.
+Contributors who repeatedly bypass pre-commit hooks, ignore CI failures on their PRs, or submit AI-generated code that violates our design principles—even if the tests pass—will have their PRs closed and may be denounced in VOUCHED.td.
+
+---
 
 ## Development Setup
 
@@ -37,6 +53,8 @@ Quick start:
 ```bash
 rustup update && cargo build && cargo test
 ```
+
+---
 
 ## Task Management
 
@@ -53,6 +71,8 @@ Quick task commands:
 
 See `.claude/skills/beans/SKILL.md` for full reference.
 
+---
+
 ## Code Quality
 
 **All Rust code changes must pass these checks before committing:**
@@ -68,6 +88,8 @@ If `cargo nextest` is not installed, use `cargo test` as fallback.
 These checks are **mandatory** for all `.rs` files, `Cargo.toml`, and `Cargo.lock` changes. Documentation-only and style-only changes do not require these checks.
 
 **Do not commit if any check fails — fix the issues first.**
+
+---
 
 ## Schema & Style Design Philosophy
 
@@ -168,6 +190,8 @@ if ref_type == RefType::ArticleJournal {
 For the full rationale, see
 [docs/architecture/DESIGN_PRINCIPLES.md](./docs/architecture/DESIGN_PRINCIPLES.md).
 
+---
+
 ## Commit Conventions
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/) format:
@@ -204,6 +228,8 @@ or empty in input reference data.
 
 Refs: #127
 ```
+
+---
 
 ## Maintainer-Level Development
 


### PR DESCRIPTION
This is probably premature, but I'd rather put this in place now in case I do start to get PRs.

## Summary

- Adds [vouch](https://github.com/mitchellh/vouch) to gate PR and issue creation against a cryptographic allowlist (`.github/VOUCHED.td`)
- Unvouched accounts get auto-closed PRs with a template directing them to open a vouch-request issue
- Maintainers vouch contributors by commenting `vouch @user` on any issue; a workflow commits the VOUCHED.td update automatically
- `CONTRIBUTING.md` rewritten to lead with the access policy

## New files

| File | Purpose |
|------|---------|
| `.github/VOUCHED.td` | Allowlist — `bdarcus` pre-seeded; denounced users prefixed with `-` |
| `.github/vouch-close.md` | Auto-close message template shown to rejected PR authors |
| `.github/workflows/vouch-check.yml` | Fires on `pull_request_target` + `issues` opened; auto-closes unvouched PRs |
| `.github/workflows/vouch-manage.yml` | Fires on `issue_comment`; lets maintainers run `vouch @user` / `denounce @user` |

## Post-merge steps

1. **Create a pinned issue** titled "Contributor Access Requests" — this is where `vouch @user` comments go
2. **Consider pinning actions to a SHA** once smoke-tested (good practice for `pull_request_target` workflows that carry write permissions)

## Test plan

- [ ] Merge PR
- [ ] Open a test PR from a non-vouched account → confirm auto-close fires with template message
- [ ] Comment `vouch @testuser` on the access-requests issue → confirm VOUCHED.td PR is auto-created
- [ ] Merge that PR; re-open test PR → confirm it now passes vouch check

Refs: csl26-c0lk
