### PR TITLE
chore(beans): close stale migrate-wave beans

### DIFF
--- a/.beans/archive/csl26-1861--migrate-fix-eager-disambiguation-defaults-bypassin.md
+++ b/.beans/archive/csl26-1861--migrate-fix-eager-disambiguation-defaults-bypassin.md
@@ -1,14 +1,14 @@
 ---
 # csl26-1861
 title: 'migrate: fix eager disambiguation defaults bypassing Processing presets'
-status: in-progress
+status: completed
 type: task
 priority: normal
 tags:
     - migrate
     - fidelity
 created_at: 2026-06-13T11:55:30Z
-updated_at: 2026-06-13T14:20:00Z
+updated_at: 2026-06-20T18:51:10Z
 ---
 
 Deferred from the synthesis-loop PR (bean csl26-8txa). Surfaced while documenting
@@ -104,3 +104,7 @@ Resolved:
   (where it notes XML is read "only for declarative attributes and options
   (… disambiguation …)"): disambiguation is not synthesized; it is set by
   class-based `Processing` defaults during extraction.
+
+## Summary of Changes
+
+Delivered the documentation scope only. `docs/reference/PROCESSING_MIGRATION.md` committed in `07500b64`; one-line pointer added to `OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md`. The code fix (delta-based extraction to eliminate eager disambiguation-default materialization) is deferred to a follow-up bean.

--- a/.beans/archive/csl26-2e3d--strip-spurious-suppress-false-from-migrated-full-t.md
+++ b/.beans/archive/csl26-2e3d--strip-spurious-suppress-false-from-migrated-full-t.md
@@ -1,7 +1,7 @@
 ---
 # csl26-2e3d
 title: 'Strip spurious suppress: false from migrated full templates'
-status: in-progress
+status: scrapped
 type: task
 priority: high
 tags:
@@ -10,7 +10,7 @@ tags:
     - cleanup
     - template
 created_at: 2026-06-16T12:54:57Z
-updated_at: 2026-06-16T12:54:57Z
+updated_at: 2026-06-20T18:51:00Z
 ---
 
 Occurrence-compiler (template_compiler/compilation.rs:477) sets suppress=Some(false) as a 'visible by default' marker. It leaks into serialized YAML (~24 noise lines in ACME) because suppress uses skip_serializing_if=Option::is_none, so only Some(false) emits. Some(false) is semantically identical to None.
@@ -28,3 +28,7 @@ Call it at the END of assembly.rs::finalize_bibliography_variants (after build_t
 - [ ] just pre-commit green; amended into 74706439
 
 Folds into PR #932.
+
+## Reasons for Scrapping
+
+Parent migrate wave (csl26-vmcr) stopped below bar 2026-06-11. Five code todos remain unstarted. No active sponsor for the full-first architecture refactor this work depends on.

--- a/.beans/archive/csl26-aynr--migrate-output-driven-template-synthesis.md
+++ b/.beans/archive/csl26-aynr--migrate-output-driven-template-synthesis.md
@@ -1,7 +1,7 @@
 ---
 # csl26-aynr
 title: 'migrate: output-driven template synthesis'
-status: in-progress
+status: scrapped
 type: feature
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - fidelity
     - architecture
 created_at: 2026-06-11T16:06:50Z
-updated_at: 2026-06-12T20:45:34Z
+updated_at: 2026-06-20T18:51:01Z
 ---
 
 Direction surfaced while closing the csl26-vmcr wave (pointer in docs/architecture/audits/2026-06-11_MIGRATE_IMPROVEMENT_WAVE_OUTCOME.md) and was reinforced by PR #910's measured-candidate selection work. Motivation: every fragile bug that wave fixed or exposed (C3 order scrambling, conditional leakage, suppressed-variable poison, wrapper variants) lived in the structural XML layout compiler -- compiling a procedural CSL layout tree into declarative templates is a semantic mismatch patched bug by bug. XML attribute/options extraction was never the problem.
@@ -30,3 +30,7 @@ codex/migrate-synthesis-prereqs:
 - [x] Held-out fixture set tests/fixtures/references-heldout.json with post-selection validation reporting
 - [x] CandidateBudget caps on measured candidate generation
 - [ ] Synthesis loop implementation (tracked in child bean)
+
+## Reasons for Scrapping
+
+Parent migrate wave (csl26-vmcr) stopped below bar 2026-06-11. One remaining open todo (complete output-driven synthesis end-to-end) has no active sponsor. Four completed subtasks' artefacts remain in the codebase as prior work.

--- a/.beans/archive/csl26-e94m--migrate-spurious-urlaccessed-on-non-web-types-spli.md
+++ b/.beans/archive/csl26-e94m--migrate-spurious-urlaccessed-on-non-web-types-spli.md
@@ -1,11 +1,11 @@
 ---
 # csl26-e94m
 title: 'migrate: spurious url/accessed on non-web types (split from ivjp)'
-status: in-progress
+status: scrapped
 type: bug
 priority: normal
 created_at: 2026-06-15T00:09:28Z
-updated_at: 2026-06-15T16:16:11Z
+updated_at: 2026-06-20T18:50:56Z
 parent: csl26-vmcr
 ---
 
@@ -57,3 +57,7 @@ The spec defines the **Full-first, normalize-later** design:
 - [ ] Restore `engine_validate_variants` as the Phase 2 round-trip safety net.
 - [ ] Implement `gate_web_only_url_accessed` as a Phase 1 fixup per the spec.
 - [ ] Verify Brown passes and url/accessed leak is fixed; full batch shows no regression.
+
+## Reasons for Scrapping
+
+Parent migrate wave (csl26-vmcr) stopped below bar 2026-06-11. Implementation was already pivoted to spec-only (MIGRATE_FULL_FIRST_ARCHITECTURE.md); the five remaining code todos have no active sponsor. The spec document remains as future design reference.

--- a/.beans/csl26-vpae--migrate-delta-based-extraction-to-fix-eager-disamb.md
+++ b/.beans/csl26-vpae--migrate-delta-based-extraction-to-fix-eager-disamb.md
@@ -1,0 +1,11 @@
+---
+# csl26-vpae
+title: 'migrate: delta-based extraction to fix eager disambiguation-default materialization'
+status: todo
+type: bug
+priority: normal
+created_at: 2026-06-20T18:51:16Z
+updated_at: 2026-06-20T18:51:16Z
+---
+
+The migrate options-extractor eagerly materializes disambiguation defaults (e.g. year_suffix: unwrap_or(true)) before comparing against named Processing presets, so fold_to_named_processing can never match. Fix: leave unset CSL attributes as None and record only explicit overrides that differ from the preset — the same delta philosophy as extends:. Design decisions captured in docs/reference/PROCESSING_MIGRATION.md (csl26-1861); implementation deferred from that bean's doc-only scope.


### PR DESCRIPTION
## Summary

- **Scrap** csl26-e94m (spurious url/accessed) — wave stopped, spec-only pivot, 5 todos unstarted
- **Scrap** csl26-2e3d (strip spurious suppress:false) — wave stopped, 5 todos unstarted
- **Scrap** csl26-aynr (output-driven synthesis) — wave stopped, 1 todo remaining, prior artefacts stay
- **Complete** csl26-1861 (eager disambiguation defaults) — docs scope delivered in `07500b64`; code fix split to new bean csl26-vpae

## New bean

**csl26-vpae** `todo` — delta-based disambiguation extraction: leave unset CSL attrs as `None`, fold to named preset where possible. No sponsor yet; parks the design decisions from `docs/reference/PROCESSING_MIGRATION.md`.

## Test plan

- [x] Beans-only change; no Rust gate required
- [ ] CI: bean hygiene passes (verified locally)
