### PR TITLE
fix(security): bump quinn-proto 0.11.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,6 @@ jobs:
           --ignore RUSTSEC-2024-0320
           --ignore RUSTSEC-2024-0436
           --ignore RUSTSEC-2025-0141
-          --ignore RUSTSEC-2026-0185
           --ignore RUSTSEC-2026-0186
 
       - name: Check dependency policy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,9 +4856,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,6 @@ ignore = [
     { id = "RUSTSEC-2024-0320", reason = "Transitive through syntect in the current Typst stack; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2024-0436", reason = "Transitive through V8, hayagriva, and biblatex; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2025-0141", reason = "Transitive through deno_core and syntect; no direct dependency or safe local replacement in this PR." },
-    { id = "RUSTSEC-2026-0185", reason = "quinn-proto memory exhaustion: fixed in quinn-proto 0.11.15; Cargo.lock update tracked in release PR." },
     { id = "RUSTSEC-2026-0186", reason = "memmap2 unsound: transitive through gix-ref/gix-protocol/gix; no upstream memmap2 fix available in the gix ecosystem yet." },
 ]
 


### PR DESCRIPTION
## Summary

- Updates `quinn-proto` 0.11.14 → 0.11.15 to fix **RUSTSEC-2026-0185** (remote memory exhaustion via unbounded out-of-order stream reassembly, severity 7.5).
- Removes the `--ignore RUSTSEC-2026-0185` workaround from `ci.yml` and `deny.toml` that was added in the wave3 style PR as a temporary bridge. The actual dependency upgrade supersedes it.

## Test plan

- [ ] Security Audit CI check passes (no RUSTSEC-2026-0185 failure)
- [ ] Rust CI passes (quinn-proto is a runtime dep, no API changes)
