### PR TITLE
chore(ci): automate security dep updates via Renovate

### DIFF
--- a/.beans/archive/csl26-p12i--automate-security-dependency-updates-via-renovate.md
+++ b/.beans/archive/csl26-p12i--automate-security-dependency-updates-via-renovate.md
@@ -1,0 +1,17 @@
+---
+# csl26-p12i
+title: Automate security dependency updates via Renovate vulnerability alerts
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-22T23:31:54Z
+updated_at: 2026-06-22T23:33:33Z
+---
+
+Add vulnerabilityAlerts to renovate.json so security-fixable advisories get immediate PRs (bypassing the weekly Monday schedule). Also consolidate duplicate RUSTSEC ignore list from ci.yml into deny.toml.
+
+## Summary of Changes
+
+- Added `vulnerabilityAlerts` block to `renovate.json` with `"schedule": ["at any time"]`, `prPriority: 10`, `groupName: null`
+- Removed 4 duplicate `--ignore RUSTSEC-*` flags from `cargo audit` step in `ci.yml`; deny.toml is now sole source of truth
+- PR: https://github.com/citum/citum-core/pull/959

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,12 +278,7 @@ jobs:
           tool: cargo-audit,cargo-deny,cargo-fuzz
 
       - name: Check RustSec advisories
-        run: >
-          cargo audit --deny warnings
-          --ignore RUSTSEC-2024-0320
-          --ignore RUSTSEC-2024-0436
-          --ignore RUSTSEC-2025-0141
-          --ignore RUSTSEC-2026-0186
+        run: cargo audit --deny warnings
 
       - name: Check dependency policy
         run: cargo deny check advisories licenses bans sources

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,13 @@
   "commitMessageAction": "update",
   "commitBody": "",
   "commitBodyTable": false,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "schedule": ["at any time"],
+    "prPriority": 10,
+    "groupName": null
+  },
   "packageRules": [
     {
       "matchManagers": ["cargo"],


### PR DESCRIPTION
## Summary

- Add `vulnerabilityAlerts` to `renovate.json` so Renovate raises individual, high-priority PRs immediately when GitHub detects a fixable advisory — bypassing the weekly Monday batch schedule
- Remove duplicate `--ignore RUSTSEC-*` flags from `cargo audit` in `ci.yml`; `deny.toml` is now the sole source of truth for unfixable transitive advisory ignores (all four entries were already present there)

## Motivation

PR #958 required manual intervention to bump `quinn-proto` in response to a security advisory. With Renovate on a Monday-only schedule, a fixable advisory can block CI for up to 7 days. This change makes the response automatic and within hours.

## Behaviour after this PR

| Scenario | Before | After |
|---|---|---|
| New advisory, fix available | CI red until human notices + manual PR | Renovate opens individual PR within hours |
| New advisory, no fix | Must add to both `ci.yml` and `deny.toml` | Add only to `deny.toml` |
| Routine dep updates | Weekly Monday batch PR | Unchanged |

## Test plan

- [x] CI passes on this branch (no Rust changes; security job still runs `cargo audit --deny warnings` + `cargo deny check`)
- [ ] Verify Renovate bot shows vulnerability alerts enabled after merge (Settings → Security)
