### PR TITLE
fix(ci): add .cargo/audit.toml for audit ignores

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,17 @@
+# cargo-audit configuration.
+#
+# This ignore list MUST stay in sync with the `[advisories].ignore` block in
+# `deny.toml`. cargo-audit does not read deny.toml, so the two tools need
+# parallel suppression lists.
+#
+# All four are *unmaintained* / *unsound* informational advisories on
+# transitive dependencies with no upstream fix available. They are NOT
+# patchable vulnerabilities, so Renovate `vulnerabilityAlerts` will never
+# auto-resolve them — they must be suppressed explicitly.
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0320",  # yaml-rust unmaintained (transitive via syntect)
+    "RUSTSEC-2024-0436",  # paste unmaintained (transitive via V8/hayagriva/biblatex)
+    "RUSTSEC-2025-0141",  # bincode unmaintained (transitive via deno_core/syntect)
+    "RUSTSEC-2026-0186",  # memmap2 unsound (transitive via gix stack)
+]

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,8 @@
 version = 2
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
+# NOTE: cargo-audit does not read this file. Its ignore list is maintained
+# separately in .cargo/audit.toml and must be kept in sync with this block.
 ignore = [
     { id = "RUSTSEC-2024-0320", reason = "Transitive through syntect in the current Typst stack; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2024-0436", reason = "Transitive through V8, hayagriva, and biblatex; no direct dependency or safe local replacement in this PR." },


### PR DESCRIPTION
## Problem

Commit 2a12950c removed four inline `--ignore` flags from `cargo audit --deny warnings` in CI, expecting Renovate `vulnerabilityAlerts` to update the affected crates. But all four advisories are **unmaintained/unsound informational warnings on transitive dependencies** with no upstream fix — Renovate never resolves them. This caused the Security Audit job on release PR #956 to fail with "4 denied warnings found."

Note: `deny.toml` already ignores all four (with reasons), but `cargo-audit` does not read `deny.toml` — it needs its own config.

## Fix

Add `.cargo/audit.toml` (which `cargo-audit` reads by default) with the same four RUSTSEC suppression entries as `deny.toml`'s ignore block. Add a cross-reference comment in `deny.toml` so both lists stay in sync.

The CI command (`cargo audit --deny warnings`) is unchanged.

**Suppressed advisories (all transitive; no upstream fix):**
| ID | Crate | Reason | Dep chain |
|---|---|---|---|
| RUSTSEC-2024-0320 | yaml-rust 0.4.5 | unmaintained | via syntect |
| RUSTSEC-2024-0436 | paste 1.0.15 | unmaintained | via V8/hayagriva/biblatex |
| RUSTSEC-2025-0141 | bincode 1.3.3 | unmaintained | via deno_core/syntect |
| RUSTSEC-2026-0186 | memmap2 0.9.10 | unsound | via gix stack |

## Test plan

- [x] Security Audit CI job passes green
- [x] Rust CI (Lint + Test) unaffected — no `.rs`/`Cargo.toml` changes
- [ ] Once merged, release PR #956 absorbs fix automatically on rebase
