### PR TITLE
fix(cli): clean up render --help noise

### DIFF
--- a/crates/citum-cli/src/args.rs
+++ b/crates/citum-cli/src/args.rs
@@ -91,10 +91,7 @@ pub(crate) enum OutputFormat {
     Plain,
     Html,
     Djot,
-    /// CommonMark (Markdown) output — citations rendered inline, body markup
-    /// passed through verbatim. Suitable for piping to pandoc or any
-    /// CommonMark-aware formatter. Note styles emit `[^n]` footnote syntax
-    /// (Pandoc/GFM extension — use `pandoc --from commonmark+footnotes`).
+    /// CommonMark output; pipe to pandoc or any CommonMark-aware tool
     Markdown,
     Latex,
     Typst,
@@ -589,6 +586,7 @@ pub(crate) struct RenderDocArgs {
     /// Path(s) to bibliography input files (repeat for multiple)
     #[arg(short, long, required = true, action = ArgAction::Append)]
     pub(crate) bibliography: Vec<PathBuf>,
+    /// Path(s) to citations input files (repeat for multiple)
     #[arg(short = 'c', long, action = ArgAction::Append)]
     pub(crate) citations: Vec<PathBuf>,
 
@@ -611,11 +609,11 @@ pub(crate) struct RenderDocArgs {
 
     /// Compile Typst output to PDF (not in v1 cargo-install builds; use
     /// `-f typst` then `typst compile`)
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub(crate) pdf: bool,
 
     /// Preserve generated Typst source next to the PDF output
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub(crate) typst_keep_source: bool,
 
     /// Locale ID (e.g. "de-DE", "fr-FR") to override the style's default locale


### PR DESCRIPTION
## Summary

- Hide `--pdf` and `--typst-keep-source` from `render doc --help` — both flags are non-functional in standard cargo-install builds; `--pdf` already tells users to use `-f typst` instead, so showing it as a first-class option is misleading
- Trim `OutputFormat::Markdown` doc comment from four lines to one — footnote-syntax detail belongs in docs, not the possible-values list (also fixes `render refs --help`)
- Add missing description for `-c/--citations` in `RenderDocArgs` (was rendering as a blank line)

## Test plan

- [x] `cargo run --bin citum -- render doc --help` — `--pdf` and `--typst-keep-source` absent; `--format markdown` is one line; `--citations` has a description
- [x] `cargo run --bin citum -- render refs --help` — `--format markdown` is one line
- [x] CI gate (fmt + clippy + nextest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
