### PR TITLE
docs(style): add tune mode and embedded-core tier quality contract

### DIFF
--- a/.beans/archive/csl26-199f--add-tune-mode-and-embedded-tier-quality-contract-t.md
+++ b/.beans/archive/csl26-199f--add-tune-mode-and-embedded-tier-quality-contract-t.md
@@ -1,11 +1,11 @@
 ---
 # csl26-199f
 title: Add tune mode and embedded-tier quality contract to style-evolve skills
-status: in-progress
+status: completed
 type: feature
 priority: normal
 created_at: 2026-06-24T14:50:59Z
-updated_at: 2026-06-24T14:55:51Z
+updated_at: 2026-06-24T15:00:56Z
 ---
 
 Refactor style-evolve skill family to reflect the LLM hand-tuning era: add a new 'tune' mode for driving embedded-core styles to 100% fidelity + clean SQI, establish embedded-tier portfolio concept, make SQI a co-primary gate for embedded styles, reposition citum-migrate as evidence/seed. Changes span shared docs, both .skills/ and .claude/skills/ mirrors.
@@ -22,5 +22,14 @@ Refactor style-evolve skill family to reflect the LLM hand-tuning era: add a new
 - [x] Update .claude/skills/style-migrate-enhance/SKILL.md (migrate-as-seed framing)
 - [x] Update docs/guides/AGENT_SKILLS.md (tune mode table)
 - [x] Update docs/architecture/SKILL_AGENT_REFACTOR.md (topology note)
-- [ ] Verify docs/beans hygiene check passes
-- [ ] Commit + PR
+- [x] Verify docs/beans hygiene check passes
+- [x] Commit + PR
+
+## Summary of Changes
+
+Added a fourth public mode 'tune' to the style-evolve skill family. Established
+the embedded-core portfolio tier (16 binary-embedded styles) with both fidelity
+and SQI as hard gates. Repositioned citum-migrate output as a seed/evidence source
+for embedded-core targets, not a terminal deliverable. Created new style-tune
+sub-skill owning the hand-tuning loop. Updated style-qa to be tier-aware.
+PR: https://github.com/citum/citum-core/pull/963

--- a/.beans/csl26-199f--add-tune-mode-and-embedded-tier-quality-contract-t.md
+++ b/.beans/csl26-199f--add-tune-mode-and-embedded-tier-quality-contract-t.md
@@ -1,0 +1,26 @@
+---
+# csl26-199f
+title: Add tune mode and embedded-tier quality contract to style-evolve skills
+status: in-progress
+type: feature
+priority: normal
+created_at: 2026-06-24T14:50:59Z
+updated_at: 2026-06-24T14:55:51Z
+---
+
+Refactor style-evolve skill family to reflect the LLM hand-tuning era: add a new 'tune' mode for driving embedded-core styles to 100% fidelity + clean SQI, establish embedded-tier portfolio concept, make SQI a co-primary gate for embedded styles, reposition citum-migrate as evidence/seed. Changes span shared docs, both .skills/ and .claude/skills/ mirrors.
+
+## Todo
+
+- [x] Create branch feat/style-evolve-tune-mode
+- [x] Update docs/policies/STYLE_WORKFLOW_DECISION_RULES.md (tier axis, SQI gate)
+- [x] Update docs/guides/STYLE_WORKFLOW_EXECUTION.md (tier-aware verification, tune loop)
+- [x] Update .skills/style-evolve/SKILL.md (tune mode)
+- [x] Update .claude/skills/style-evolve/SKILL.md (tune mode, routing)
+- [x] Create .claude/skills/style-tune/SKILL.md (new hand-tuning sub-skill)
+- [x] Update .claude/skills/style-qa/SKILL.md (tier-aware gates)
+- [x] Update .claude/skills/style-migrate-enhance/SKILL.md (migrate-as-seed framing)
+- [x] Update docs/guides/AGENT_SKILLS.md (tune mode table)
+- [x] Update docs/architecture/SKILL_AGENT_REFACTOR.md (topology note)
+- [ ] Verify docs/beans hygiene check passes
+- [ ] Commit + PR

--- a/.claude/skills/style-evolve/SKILL.md
+++ b/.claude/skills/style-evolve/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: style-evolve
 type: user-invocable, agent-invocable
-description: "Single human-facing command for all Citum style work. Use whenever someone asks to fix, improve, convert, or create a citation style. Routes to upgrade, migrate, or create. Always use this rather than calling style-maintain or style-migrate-enhance directly."
+description: "Single human-facing command for all Citum style work. Use whenever someone asks to fix, improve, convert, create, or tune a citation style. Routes to upgrade, migrate, create, or tune. Always use this rather than calling internal skills directly."
 model: sonnet
-routes-to: style-maintain, style-migrate-enhance, style-qa
+routes-to: style-maintain, style-migrate-enhance, style-tune, style-qa
 ---
 
 # Style Evolve
@@ -14,6 +14,7 @@ routes-to: style-maintain, style-migrate-enhance, style-qa
 /style-evolve upgrade <style-path>
 /style-evolve migrate <csl-path>
 /style-evolve create
+/style-evolve tune <embedded-style-id>
 ```
 
 Do not ask users to call internal skills directly.
@@ -41,6 +42,11 @@ Route to `../style-migrate-enhance/SKILL.md`.
 ### 3. create
 Build a new Citum style from source evidence. Escalate to `@dplanner` for design.
 
+### 4. tune
+Route to `../style-tune/SKILL.md`. Use when the target is an `embedded-core`
+style and the goal is 100% fidelity **and** clean SQI. Both are hard gates for
+this mode. The migrate output is the seed, not the deliverable.
+
 ## Co-Evolution Rule
 
 Use `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` for failure classification and stop conditions. Keep the router focused on dispatch and host entrypoint behavior.
@@ -48,9 +54,11 @@ Use `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` for failure classification 
 ## Shared Gates
 
 - Compatibility fidelity regression is never allowed unless the task explicitly chooses a documented semantic divergence from legacy CSL behavior.
-- SQI is optimization-only after fidelity is stable.
-- Before editing a style, classify it by semantic class and implementation form
-  using the shared workflow docs and `docs/specs/STYLE_TAXONOMY.md`.
+- **SQI is a hard gate for `embedded-core` styles** (fidelity AND SQI both required).
+  For `dependent` styles, SQI is optimization-only after fidelity is stable.
+  See `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` for the tier definition and quality bar.
+- Before editing a style, classify it by semantic class, implementation form, and
+  portfolio tier using the shared workflow docs and `docs/specs/STYLE_TAXONOMY.md`.
 - Profile-family work may require a `create` pass for a hidden family root
   followed by `upgrade` reduction of the public handles.
 - Journal/profile reductions must choose parents from guide-backed authority,

--- a/.claude/skills/style-migrate-enhance/SKILL.md
+++ b/.claude/skills/style-migrate-enhance/SKILL.md
@@ -10,11 +10,23 @@ model: sonnet
 Authoritative shared process docs:
 - `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`
 - `docs/guides/STYLE_WORKFLOW_EXECUTION.md`
+- `docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md` — converter role and limits
 
 ## Use This Skill When
-- The task is portfolio migration.
+- The task is portfolio migration (long-tail / dependent styles).
 - You need repeatable before/after/rerun metrics.
 - You want concrete recommendations for `citum_migrate` improvements from observed gaps.
+- You need to produce a migrate **seed** for a subsequent `tune` pass on an
+  embedded-core style.
+
+## Role of Migrate Output
+
+For **dependent** styles, the migrate output is the deliverable (subject to the
+fidelity hard gate). For **embedded-core** styles, the migrate output is a **seed
+and evidence source** feeding a subsequent `style-tune` pass — it is not a
+finished embedded style. See `docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md`
+for the strategic basis: the converter is an evidence tool, not the canonical
+authoring path for high-impact styles.
 
 ## Input Contract
 - Legacy style path(s) under `styles-legacy/`.
@@ -42,7 +54,8 @@ Run the full wave without pausing between styles. Use the shared docs for the co
 ## Hard Gates
 - Never accept a fidelity regression.
 - Never classify a registered divergence as a migration or engine bug without updating adjudication first.
-- SQI is tie-breaker and optimization only.
+- SQI is tie-breaker and optimization only for dependent styles. For embedded-core
+  targets, SQI is not a gate here — the `tune` pass owns SQI to green.
 - After bounded retries with no progress, note it in the wave summary and move to the next style rather than halting the entire wave.
 
 ## Required Artifacts

--- a/.claude/skills/style-qa/SKILL.md
+++ b/.claude/skills/style-qa/SKILL.md
@@ -13,25 +13,32 @@ Authoritative shared process docs:
 
 ## Gate Inputs
 - Style path(s) changed.
+- Portfolio tier: `embedded-core` or `dependent` (from `citum style list --source embedded`).
 - Oracle JSON result(s).
+- Optional SQI report from `node scripts/report-core.js --style <name>`.
 - Optional baseline metrics for comparison.
 - Optional docs/beans diff when task updates `.md` or `.beans/*`.
 
 ## Required Checks
 1. Fidelity summary.
-2. SQI drift summary as a secondary metric only.
+2. SQI summary — tier-weighted (see Decision Rules).
 3. Formatting audit.
 4. Regression surface.
 5. Docs/beans hygiene when docs or beans are touched.
 
 ## Decision Rules
-- Reject when fidelity regresses.
+- Reject when fidelity regresses — applies to all tiers.
+- **Reject when SQI is not clean for `embedded-core` styles.** SQI is a hard
+  gate alongside fidelity for the embedded portfolio.
+- For `dependent` styles, SQI drift is advisory only; do not reject on SQI alone.
 - Reject when a registered divergence is reported as an unexplained defect.
 - Reject when formatting defects are introduced.
-- Approve when fidelity is preserved or improved and formatting is clean.
+- Approve when fidelity is preserved or improved, formatting is clean, and (for
+  `embedded-core`) SQI is clean.
 
 ## Standard Output
 - Verdict: `approve` or `reject`
-- Metrics line: citations + bibliography + SQI delta
+- Tier: `embedded-core` or `dependent`
+- Metrics line: citations + bibliography + SQI score (and delta from baseline)
 - Findings: short numbered list
 - Next step: merge, iterate, or escalate to planner/processor

--- a/.claude/skills/style-tune/SKILL.md
+++ b/.claude/skills/style-tune/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: style-tune
+type: agent-invocable
+description: Iterative LLM hand-tuning loop for embedded-core styles. Drives a style to 100% fidelity and clean SQI. Both are hard gates. Seeded from migrate evidence, not from the converter output as a terminal deliverable.
+model: sonnet
+---
+
+# Style Tune
+
+Authoritative shared process docs:
+- `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` — tier definition, quality bar,
+  failure classification
+- `docs/guides/STYLE_WORKFLOW_EXECUTION.md` — the `tune` loop definition (seed →
+  fidelity loop → SQI loop → QA), stop conditions, and shared escalation rules
+
+## Use This Skill When
+- The target is an `embedded-core` style (verified via `citum style list --source embedded`
+  or by checking `crates/citum-schema-style/src/embedded/styles.rs`).
+- The goal is **both** 100% oracle fidelity **and** clean SQI.
+- Migrate output is available (or can be generated) as the starting seed.
+
+## What This Skill Is NOT
+- Not for long-tail or dependent styles (use `style-maintain` or `style-migrate-enhance`).
+- Not a batch wave tool — one embedded style per run.
+- Not a converter fix tool — `citum-migrate` issues are escalated separately.
+
+## Input Contract
+- Embedded style ID (e.g. `apa-7th`, `ieee`).
+- Legacy CSL path in `styles-legacy/` for oracle comparison.
+- Citum YAML path in `crates/citum-schema-style/embedded/styles/`.
+- Authority basis: publisher guide or style manual (primary authority first).
+
+## Hard Gates
+- Fidelity: 100% oracle pass rate (`node scripts/oracle.js <legacy> --json`).
+- SQI: clean score (`node scripts/report-core.js --style <name>`).
+- A `tune` pass is not complete until **both** gates are green.
+- Never accept a fidelity regression as a tradeoff for SQI improvement.
+
+## Execution Loop
+
+Follow the full `tune` loop from `docs/guides/STYLE_WORKFLOW_EXECUTION.md`:
+
+1. **Seed** — run `citum-migrate` or accept the existing YAML. Record baseline
+   oracle fidelity and SQI.
+2. **Fidelity loop** — oracle → classify failure → smallest correct YAML fix →
+   re-run. Repeat until 100%.
+3. **SQI loop** (only after fidelity is green) — `report-core` → hoist/preset/prune
+   → oracle re-check → repeat until clean.
+4. **QA gate** — hand off to `../style-qa/SKILL.md` with `tier: embedded-core`.
+
+## Failure Classification
+Use the shared decision rules for all mismatches:
+- `style-defect` → fix in YAML.
+- `migration-artifact` → note gap, do not cycle YAML to compensate; fix the seed
+  if a converter improvement is available, otherwise hand-author around it.
+- `processor-defect` → escalate to Rust workflow; stop YAML iteration on that cluster.
+- `intentional divergence` → record ID, exclude from counts.
+
+## Stop Conditions
+- Two distinct approaches fail on the same cluster → reclassify.
+- Residual explained by a registered divergence → record, do not count.
+- Residual is `processor-defect` → escalate; move on.
+- Migrate cannot produce a usable seed → switch to pure `create` path (hand-author
+  from guide evidence directly).
+
+## Output Contract
+Every completed tune pass delivers:
+- embedded style ID and authority basis
+- tier: `embedded-core`
+- seed baseline: oracle fidelity %, SQI score
+- final: oracle fidelity %, SQI score
+- fidelity changes made (per mismatch cluster)
+- SQI changes made (hoisting, presets, type-variant compression)
+- residuals reclassified (processor-defect / divergence IDs)
+- QA verdict
+- commit SHA and message
+
+## Verification
+- Oracle: `node scripts/oracle.js styles-legacy/<name>.csl --json`
+- SQI: `node scripts/report-core.js --style <name>`
+- Render smoke-check: `cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s crates/citum-schema-style/embedded/styles/<name>.yaml`
+- QA handoff: `../style-qa/SKILL.md` with `tier: embedded-core`

--- a/.skills/style-evolve/SKILL.md
+++ b/.skills/style-evolve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: style-evolve
-description: "Public entrypoint for Citum style work. Activate on: 'upgrade', 'migrate', 'create', any style authoring request, or any request to fix/improve/convert a Citum or CSL citation style. Route to the shared workflow docs and internal roles."
+description: "Public entrypoint for Citum style work. Activate on: 'upgrade', 'migrate', 'create', 'tune', any style authoring request, or any request to fix/improve/convert a Citum or CSL citation style. Route to the shared workflow docs and internal roles."
 ---
 
 # Style Evolve
@@ -20,6 +20,9 @@ Read first:
 - `upgrade`: improve an existing Citum style.
 - `migrate`: convert CSL 1.0 source into Citum style YAML.
 - `create`: author a new Citum style from source evidence.
+- `tune`: drive an embedded-core style to 100% fidelity + clean SQI via
+  iterative LLM authoring, seeded by migrate evidence. Both fidelity and SQI
+  are hard gates for this mode. Loop defined in `docs/guides/STYLE_WORKFLOW_EXECUTION.md`.
 
 ## Routing
 
@@ -30,8 +33,11 @@ Read first:
 
 ## Operating Rules
 
-- Keep fidelity as the hard gate.
-- Treat SQI as secondary optimization only.
+- Fidelity is the hard gate for all tiers.
+- SQI is a **hard gate for embedded-core styles**; advisory/tie-breaker for dependent
+  styles. See `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` for the tier definition
+  and quality bar.
+- For embedded-core targets, use `tune` rather than treating migrate output as final.
 - Before editing a style, classify it by semantic class and implementation
   form using `docs/specs/STYLE_TAXONOMY.md` and the shared workflow docs.
 - Profile-family work may require a `create` pass for a hidden family root

--- a/docs/architecture/SKILL_AGENT_REFACTOR.md
+++ b/docs/architecture/SKILL_AGENT_REFACTOR.md
@@ -50,3 +50,35 @@ The repo also mirrors the public skill surface with repo-owned skill folders und
 - Lower token and iteration cost for common style tasks.
 - Fewer planner/implementer handoff ambiguities.
 - Faster, more consistent PRs with explicit quality evidence.
+
+---
+
+## Topology Update (2026-06-24): tune mode + embedded-core tier
+
+Following the recognition of deterministic migration limits (see
+`docs/architecture/MIGRATION_STRATEGY_ANALYSIS.md` and
+`docs/specs/MIGRATE_FULL_FIRST_ARCHITECTURE.md`), the skill topology was
+extended:
+
+### Changes
+- **`style-evolve`**: added a 4th public mode — `tune`. Routes to `.claude/skills/style-tune/`.
+- **`.claude/skills/style-tune/`**: new sub-skill. Owns the iterative LLM
+  hand-tuning loop for embedded-core styles (seed from migrate → fidelity loop →
+  SQI loop → QA). Model: sonnet.
+- **`style-qa`**: made tier-aware. SQI is a **hard gate for embedded-core styles**;
+  advisory for dependent styles.
+- **`style-migrate-enhance`**: migrate output repositioned as a **seed/evidence**
+  source for embedded-core targets (not a terminal deliverable). Long-tail batch
+  behavior unchanged.
+- **Shared docs** (`STYLE_WORKFLOW_DECISION_RULES.md`,
+  `STYLE_WORKFLOW_EXECUTION.md`): added a third classification axis (portfolio
+  tier: `embedded-core` vs `dependent`), tier-dependent quality bar, and the
+  `tune` execution loop definition.
+
+### Rationale
+The embedded portfolio (16 styles, baked into the binary) sets the
+maintainability standard for the whole portfolio. Achieving perfect fidelity and
+clean SQI for those styles requires iterative LLM authoring — the converter
+cannot reliably reach that bar autonomously. The `tune` mode and the
+`embedded-core` tier make this a first-class workflow rather than an implicit
+expectation.

--- a/docs/guides/AGENT_SKILLS.md
+++ b/docs/guides/AGENT_SKILLS.md
@@ -40,10 +40,23 @@ maintaining parallel copies.
 
 | Skill | Description |
 |-------|-------------|
-| `style-evolve` | Route style work: upgrade, migrate, or create a Citum style |
+| `style-evolve` | Route style work: upgrade, migrate, create, or tune a Citum style |
 | `migrate-research` | Autonomous research loop for citum_migrate fidelity gaps |
 | `rust-simplify` | One-file Rust quality pass using jcodemunch analysis |
 | `test-soundness-review` | Audit tests against the governing spec and update the soundness ledger |
+
+### style-evolve modes
+
+| Mode | Use when |
+|------|----------|
+| `upgrade` | Improve fidelity or quality of an existing Citum style |
+| `migrate` | Convert a CSL 1.0 XML source into a Citum style YAML |
+| `create` | Author a new Citum style from guide evidence |
+| `tune` | Drive an **embedded-core** style to 100% fidelity + clean SQI via iterative LLM authoring |
+
+The `tune` mode routes to the `.claude/skills/style-tune/` sub-skill (Claude
+Code host). Both fidelity and SQI are hard gates for `tune`. The migrate output
+is the seed, not the deliverable, for embedded-core styles.
 
 These skills are for citum-core contributors only. They require the repo to be present
 locally and reference internal docs by path.

--- a/docs/guides/STYLE_EVOLVE_WORKFLOW.md
+++ b/docs/guides/STYLE_EVOLVE_WORKFLOW.md
@@ -19,8 +19,10 @@ targeting.
 - Typical goal: increase SQI while preserving or improving fidelity.
 
 2. `migrate`
-- Convert one or more CSL 1.0 styles into high-quality Citum styles.
+- Convert one or more CSL 1.0 styles into Citum styles.
 - Typical goal: high oracle parity plus maintainable templates.
+- For embedded-core targets, the output is a **seed** for a `tune` pass, not a
+  finished embedded style.
 
 3. `create`
 - Create a style from reference evidence.
@@ -30,24 +32,33 @@ targeting.
   - `--source-issue`
   - `--source-file`
 
+4. `tune`
+- Drive an **embedded-core** style to 100% fidelity **and** clean SQI via
+  iterative LLM authoring, seeded by migrate evidence.
+- Both fidelity and SQI are hard gates. Use only for styles in
+  `citum style list --source embedded`.
+
 ## Examples
 ```bash
 /style-evolve upgrade --styles styles/elsevier-harvard.yaml --target-sqi 0.90
 /style-evolve migrate --legacy styles-legacy/apa.csl --count 1
 /style-evolve create --source-url https://example-style-guide.org --source-text "example citations and bibliography"
+/style-evolve tune ieee
 ```
 
 ## Quality Policy
-- Fidelity to the declared primary authority is the hard gate.
-- SQI is a secondary optimization metric.
+- Fidelity to the declared primary authority is the hard gate for all styles.
+- **SQI is a hard gate for embedded-core styles.** Both fidelity and clean SQI
+  are required for any embedded-core style pass. For dependent/long-tail styles,
+  SQI is a secondary optimization metric.
 - For styles with configured `benchmark_runs`, official rich-input evidence is auto-run as supplemental advisory output.
 - Every iteration must assess both:
   - style-level edits
   - processor/preset/feature opportunities
-- Before editing YAML, classify the target using the shared two-axis taxonomy:
-  semantic class (`base`, `profile`, `journal`, `independent`) and
-  implementation form (`alias`, `config-wrapper`, `structural-wrapper`,
-  `standalone`).
+- Before editing YAML, classify the target using the shared three-axis taxonomy:
+  semantic class (`base`, `profile`, `journal`, `independent`),
+  implementation form (`alias`, `config-wrapper`, `structural-wrapper`, `standalone`),
+  and portfolio tier (`embedded-core` or `dependent`).
 - Profile work must preserve the config-wrapper contract: scoped options and
   metadata only, with no local templates, no local `type-variants`, and no
   template-clearing `null`.
@@ -64,20 +75,20 @@ targeting.
 
 ## Wave Guidance
 
-A style wave is a bounded cohort executed through repeated `upgrade`,
-`migrate`, or `create` passes under the shared workflow docs.
+A style wave is a bounded cohort executed through repeated `upgrade`, `migrate`,
+`create`, or `tune` passes under the shared workflow docs.
 
 - Keep one wave to one family or one clearly related cohort per PR.
 - Profile-family work may require a `create` pass for a hidden family root,
   followed by `upgrade` passes to reduce the public handles.
-- `style-evolve` remains a three-mode public entrypoint. A wave is execution
-  scope, not a fourth mode.
+- A wave is execution scope, not a separate mode.
 
 ## Internal Pipeline (For Maintainers)
 `/style-evolve` routes internally to:
 - `style-maintain` (upgrade path)
 - `style-migrate-enhance` (migrate path)
-- `style-qa` (required gate)
+- `style-tune` (tune path — Claude Code host)
+- `style-qa` (required gate — tier-aware)
 - `pr-workflow-fast` (branch/PR efficiency)
 
 `/styleauthor` remains available as a legacy alias and forwards to `/style-evolve`.

--- a/docs/guides/STYLE_WORKFLOW_EXECUTION.md
+++ b/docs/guides/STYLE_WORKFLOW_EXECUTION.md
@@ -3,7 +3,9 @@
 **Status:** Active
 **Version:** 1.0
 **Date:** 2026-04-04
-**Related:** `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`, `docs/specs/MIGRATE_RESEARCH_RICH_INPUTS.md`
+**Related:** [STYLE_WORKFLOW_DECISION_RULES.md](../policies/STYLE_WORKFLOW_DECISION_RULES.md),
+[MIGRATE_RESEARCH_RICH_INPUTS.md](../specs/MIGRATE_RESEARCH_RICH_INPUTS.md),
+[MIGRATION_STRATEGY_ANALYSIS.md](../architecture/MIGRATION_STRATEGY_ANALYSIS.md)
 
 ## Purpose
 This guide defines the shared execution flow for Citum style workflows so Claude skills and Codex agents can reference the same process without duplicating it.
@@ -23,10 +25,11 @@ Out of scope:
 ## Design
 ### Shared execution order
 1. Establish the workflow mode and target scope.
-2. Classify the target on two axes before editing:
-   semantic class (`base`, `profile`, `journal`, `independent`) and
-   implementation form (`alias`, `config-wrapper`, `structural-wrapper`,
-   `standalone`).
+2. Classify the target on **three** axes before editing:
+   - semantic class (`base`, `profile`, `journal`, `independent`)
+   - implementation form (`alias`, `config-wrapper`, `structural-wrapper`, `standalone`)
+   - portfolio tier (`embedded-core` or `dependent`) — see the decision rules for
+     the predicate (`citum style list --source embedded`)
 3. Establish source authority before reading implementation artifacts:
    publisher guide first, then publisher house rules, then parent-style guidance.
 4. Capture the smallest trustworthy evidence surface first.
@@ -37,8 +40,10 @@ Out of scope:
 9. Stop when the cluster is reclassified, converged, or proven out of scope.
 
 ### Shared verification logic
-- Fidelity to the declared primary authority is the hard gate.
-- SQI or other secondary metrics are advisory unless a workflow explicitly promotes them.
+- Fidelity to the declared primary authority is a hard gate for all tiers.
+- **SQI is a hard gate for `embedded-core` styles** (both fidelity and SQI must
+  be green for a pass verdict). For `dependent` styles, SQI is advisory and a
+  tie-breaker only.
 - QA must reject regressions and formatting defects.
 - Supplemental rich-input evidence is confirmation, not the first debugging surface.
 - CSL structure is verification evidence, not the source of truth for wrapper thickness.
@@ -52,7 +57,7 @@ Out of scope:
 ### Shared output shape
 Every workflow should report:
 - target or cluster chosen
-- semantic class and implementation form
+- semantic class, implementation form, and portfolio tier
 - classification and rationale
 - before/after evidence
 - exact change made, if any
@@ -69,14 +74,49 @@ Every workflow should report:
 
 ## Waves
 
-A style wave is a bounded cohort executed through repeated `upgrade`,
-`migrate`, or `create` passes under this same execution flow.
+A style wave is a bounded cohort executed through repeated `upgrade`, `migrate`,
+`create`, or `tune` passes under this same execution flow.
 
 - Keep one wave to one family or one clearly related cohort per PR.
 - For profile-family work, it is valid to use `create` to author a hidden family
   root first and then `upgrade` to reduce the public handles.
 - Do not add a separate public "wave" command surface; waves are an execution
   pattern, not a new mode.
+
+## The `tune` loop (embedded-core styles)
+
+`tune` is the correct mode whenever the goal is to bring an `embedded-core`
+style to **100% fidelity and clean SQI**. Deterministic migration (`citum-migrate`)
+cannot reliably reach this bar on its own — see
+[MIGRATION_STRATEGY_ANALYSIS.md](../architecture/MIGRATION_STRATEGY_ANALYSIS.md). The converter's output is a
+**seed**: a starting candidate whose oracle score and SQI baseline ground the
+first iteration.
+
+### Execution order
+1. **Seed:** run `citum-migrate` (or accept the existing Citum YAML) to produce
+   a concrete candidate. Record oracle fidelity baseline and SQI baseline.
+2. **Fidelity loop:**
+   a. Run the oracle (`node scripts/oracle.js <legacy-style> --json`).
+   b. Classify each failure per the shared decision rules.
+   c. Apply the smallest correct YAML change toward the target reference output.
+   d. Re-run oracle. Repeat until fidelity is 100%.
+   e. If a residual is clearly a `processor-defect` or `intentional divergence`,
+      reclassify and exclude — do not keep iterating.
+3. **SQI loop (begins only when fidelity is green):**
+   a. Run `node scripts/report-core.js --style <name>` to get the SQI score.
+   b. Apply SQI improvements — hoist shared options, use presets, introduce
+      diff-based `type-variants`, prune redundant defaults — without regressing
+      fidelity. Re-run oracle after each SQI change to confirm.
+   c. Continue until SQI is clean (no actionable SQI findings remain).
+4. **QA gate:** hand off to `style-qa` with tier = `embedded-core`.
+
+### Stop conditions (same as all shared workflows)
+- Two distinct approaches fail on the same cluster → reclassify.
+- Residual explained by a registered divergence → record ID, do not count as failure.
+- Residual is a `processor-defect` → escalate to Rust workflow; do not keep
+  cycling YAML.
+- Migrate cannot produce a usable seed → hand-author from guide evidence
+  directly (the `create` path).
 
 ## Implementation Notes
 - Use this guide as the canonical place for the evidence ladder and convergence language currently repeated across style workflows.
@@ -86,8 +126,16 @@ A style wave is a bounded cohort executed through repeated `upgrade`,
 - [x] Shared style workflows reference this guide instead of duplicating the same loop text.
 - [x] The evidence ladder is defined here exactly once.
 - [x] The shared output contract is expressed here in host-neutral terms.
+- [x] Portfolio tier is part of the classification and output contract.
+- [x] `tune` loop is defined here once, not in individual skill files.
 
 ## Changelog
+- 2026-06-24: Added portfolio tier to the three-axis classification and output
+  shape. Replaced the universal "SQI is advisory" rule with a tier-aware rule
+  (embedded-core promotes SQI to a hard gate; dependent stays advisory). Added
+  the `tune` execution loop section, including seed, fidelity loop, SQI loop,
+  and stop conditions. Cross-linked `MIGRATION_STRATEGY_ANALYSIS.md`. Added
+  `tune` to the wave pass types.
 - 2026-04-23: Added explicit semantic-class vs implementation-form
   classification, profile-contract verification, journal structural-wrapper
   acceptance, and bounded-wave guidance.

--- a/docs/policies/STYLE_WORKFLOW_DECISION_RULES.md
+++ b/docs/policies/STYLE_WORKFLOW_DECISION_RULES.md
@@ -1,9 +1,11 @@
 # Style Workflow Decision Rules
 
 **Status:** Active
-**Version:** 1.0
+**Version:** 1.3
 **Date:** 2026-04-04
-**Related:** `docs/guides/STYLE_WORKFLOW_EXECUTION.md`, `docs/architecture/SKILL_AGENT_REFACTOR.md`
+**Related:** [STYLE_WORKFLOW_EXECUTION.md](../guides/STYLE_WORKFLOW_EXECUTION.md),
+[SKILL_AGENT_REFACTOR.md](../architecture/SKILL_AGENT_REFACTOR.md),
+[MIGRATION_STRATEGY_ANALYSIS.md](../architecture/MIGRATION_STRATEGY_ANALYSIS.md)
 
 ## Rule
 Shared style-workflow agents must classify each mismatch as `style-defect`, `migration-artifact`, `processor-defect`, or `intentional divergence`, and must stop iterating once a cluster is clearly outside the active workflow's scope.
@@ -15,15 +17,37 @@ Style-authority decisions for existing journals must follow this order:
 4. CSL implementation evidence
 5. existing Citum YAML structure
 
-Before editing YAML, shared style workflows must classify the target on two
-axes:
+Before editing YAML, shared style workflows must classify the target on **three** axes:
 1. semantic class: `base`, `profile`, `journal`, or `independent`
-2. implementation form: `alias`, `config-wrapper`, `structural-wrapper`, or
-   `standalone`
+2. implementation form: `alias`, `config-wrapper`, `structural-wrapper`, or `standalone`
+3. portfolio tier: `embedded-core` or `dependent`
 
-This classification is operational, not cosmetic. It determines whether the
-style should be reduced to a thin wrapper, kept structural, or left
-self-contained.
+All three classifications are operational, not cosmetic.
+
+### Portfolio tier
+
+The **embedded-core** tier is the set of styles baked into the Citum binary at
+compile time. The canonical registry is
+[embedded/styles.rs](../../crates/citum-schema-style/src/embedded/styles.rs) (the `include_bytes!` match
+arms). The CLI exposes the predicate: `citum style list --source embedded`.
+All other styles are **dependent** (long-tail or external).
+
+Tier determines the quality bar:
+
+| Tier | Fidelity | SQI |
+|---|---|---|
+| `embedded-core` | Hard gate — 100% required | **Hard gate** — clean SQI required alongside fidelity |
+| `dependent` | Hard gate | Advisory / tie-breaker only |
+
+For `embedded-core` styles, the `citum-migrate` converter is a **seed and evidence
+source**, not the canonical authoring path. The correct authoring path is `create`
+or `tune` (iterative LLM authoring against oracle, guide, and SQI), as documented
+in [MIGRATION_STRATEGY_ANALYSIS.md](../architecture/MIGRATION_STRATEGY_ANALYSIS.md). A migrated candidate is
+acceptable only after it has been hand-tuned to satisfy both gates.
+
+This distinction is operationally important: a correct-but-bulky migrated YAML is
+not a finished embedded style. SQI matters here because the embedded set ships
+with the binary and defines the maintainability standard for the whole portfolio.
 
 ## Rationale
 Style work in Citum repeatedly follows the same decision logic: determine whether the defect belongs in YAML, migration, engine behavior, or adjudication, then route the work accordingly. Putting that logic in one policy keeps the Claude and Codex wrappers thin and reduces drift between hosts.
@@ -49,14 +73,19 @@ Style work in Citum repeatedly follows the same decision logic: determine whethe
 - If the same scenario fails with identical output after two distinct approaches, stop iterating on that scenario and reclassify it.
 - If a registered divergence explains the failure, record the divergence ID instead of treating it as a fresh bug.
 - A style wave is a bounded cohort executed through repeated `upgrade`,
-  `migrate`, or `create` passes under these same rules. Keep waves scoped to one
-  family or one clearly related cohort per PR.
+  `migrate`, `create`, or `tune` passes under these same rules. Keep waves scoped
+  to one family or one clearly related cohort per PR.
 
 ## Exceptions
 - Host-specific routing, model choice, and permission semantics stay in the wrapper files.
 - Rich-input evidence ordering and per-skill output phrasing live in the execution guide.
 
 ## Changelog
+- v1.3 (2026-06-24): Added the third classification axis (portfolio tier:
+  `embedded-core` vs `dependent`), tier-dependent quality bar (SQI is a hard
+  gate for embedded-core), and the embedded-tier authoring rule (migrate as
+  seed, not deliverable). Cross-linked `MIGRATION_STRATEGY_ANALYSIS.md`.
+  Added `tune` to the list of wave pass types.
 - v1.2 (2026-04-23): Added the two-axis taxonomy as an operational workflow
   rule, made the config-wrapper profile contract explicit, clarified that
   journal descendants may remain structural, and added the infrastructure-stop


### PR DESCRIPTION
## Summary

- Adds a fourth public mode `tune` to `style-evolve` for driving embedded-core styles to **100% fidelity and clean SQI** via iterative LLM authoring
- Establishes the **embedded-core portfolio tier** (the 16 binary-embedded styles) as having *both* fidelity and SQI as hard gates — long-tail dependent styles keep SQI advisory
- Repositions `citum-migrate` output as a seed/evidence source for embedded-core targets (not a terminal deliverable), per `MIGRATION_STRATEGY_ANALYSIS.md`

## Context

The `style-evolve` skill family predates our recognition of deterministic migration limits. The converter is now an evidence tool, not the authoring path for high-impact styles. The skills hadn't caught up — no portfolio-tier concept, SQI hardcoded as "advisory everywhere," migrate framed as a deliverable, no first-class hand-tuning loop.

## Files changed

| File | Change |
|------|--------|
| `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` | Add third axis (portfolio tier), tier quality bar, migrate-as-seed rule (v1.3) |
| `docs/guides/STYLE_WORKFLOW_EXECUTION.md` | Tier-aware verification, `tune` loop definition (v1.2) |
| `docs/guides/STYLE_EVOLVE_WORKFLOW.md` | Add `tune` mode, tier-aware SQI, three-axis taxonomy |
| `docs/guides/AGENT_SKILLS.md` | Modes table with `tune` |
| `docs/architecture/SKILL_AGENT_REFACTOR.md` | 2026-06-24 topology update note |
| `.skills/style-evolve/SKILL.md` | `tune` mode, tier-aware SQI rule |
| `.claude/skills/style-evolve/SKILL.md` | `tune` routing, UX, gates |
| `.claude/skills/style-tune/SKILL.md` | **New** — hand-tuning sub-skill (seed → fidelity → SQI → QA) |
| `.claude/skills/style-qa/SKILL.md` | Tier-aware SQI gate |
| `.claude/skills/style-migrate-enhance/SKILL.md` | Embedded-core seed framing |

## Test plan

- [x] `./scripts/check-bean-hygiene.sh` — passes
- [x] `./scripts/validate-frontmatter.sh --copilot-strict` — passes (40 files)
- [x] Pre-push alint/conventional-commit hooks — all 23 rules pass
- [x] No unqualified "SQI is advisory" left in skill/workflow files
- [x] `style-evolve → tune → style-tune → style-qa` routing coherent across both `.skills/` and `.claude/skills/` mirrors
- [x] Embedded-tier predicate verified against `citum style list --source embedded` (16 styles, canonical registry `crates/citum-schema-style/src/embedded/styles.rs`)
- [x] No Rust files changed — cargo gate correctly skipped

Bean: csl26-199f
