### PR TITLE
Add localized message components, deprecate `term`

### DIFF
--- a/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
+++ b/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
@@ -1,7 +1,7 @@
 ---
 # csl26-fdzc
 title: Migrate styles to localized message phrase calls
-status: todo
+status: in-progress
 type: task
 priority: high
 tags:
@@ -9,7 +9,7 @@ tags:
     - localization
     - mf2
 created_at: 2026-06-25T00:22:34Z
-updated_at: 2026-06-25T00:22:34Z
+updated_at: 2026-06-25T10:16:23Z
 ---
 
 ## Problem
@@ -30,8 +30,8 @@ through the rest of `styles/` by style family or shared template pattern.
   `message:` calls where the locale should control word order.
 - Prioritize `pattern.accessed-date`, `pattern.in-container`,
   `pattern.available-at`, and `pattern.retrieved-from`.
-- Keep atomic labels as `term.*` locale messages where they are labels rather
-  than compositional phrases.
+- Keep lexical and inflectional labels as `term.*` or `role.*` locale messages
+  where they are labels rather than phrase realization.
 
 ## Acceptance Criteria
 
@@ -40,3 +40,12 @@ through the rest of `styles/` by style family or shared template pattern.
 - Missing message IDs and missing message args are caught by lint before merge.
 - Embedded styles are completed before broad non-embedded migration begins.
 - Any new phrase IDs are documented in `docs/specs/LOCALE_MESSAGES.md`.
+
+
+## Embedded Proof Batch (PR #965)
+
+- Started the embedded migration with output-equivalent `message:` calls in embedded-core styles.
+- Converted representative `pattern.accessed-date` call sites in AMA, Chicago, Elsevier, MLA, and Springer Vancouver styles.
+- Converted representative `pattern.in-container` call sites in Chicago, IEEE, and Springer author-date styles.
+- Added grouped message arguments so `pattern.in-container` can receive an already-rendered container cluster such as editor plus parent-monograph title.
+- Deferred APA's container-author site, colon-bearing `in:` sites, `URL ` labels, and role-plus-name phrases until later batches define phrase IDs that preserve those outputs without encoding English glue inside arguments.

--- a/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
+++ b/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
@@ -9,7 +9,7 @@ tags:
     - localization
     - mf2
 created_at: 2026-06-25T00:22:34Z
-updated_at: 2026-06-25T10:16:23Z
+updated_at: 2026-06-25T11:02:06Z
 ---
 
 ## Problem
@@ -38,14 +38,42 @@ through the rest of `styles/` by style family or shared template pattern.
 - Each batch preserves existing fidelity gates for the affected styles.
 - Deprecated template `term:` use decreases monotonically across `styles/`.
 - Missing message IDs and missing message args are caught by lint before merge.
-- Embedded styles are completed before broad non-embedded migration begins.
+- Embedded styles move through explicit proof and completion batches before
+  broad non-embedded migration begins.
 - Any new phrase IDs are documented in `docs/specs/LOCALE_MESSAGES.md`.
 
 
 ## Embedded Proof Batch (PR #965)
 
-- Started the embedded migration with output-equivalent `message:` calls in embedded-core styles.
-- Converted representative `pattern.accessed-date` call sites in AMA, Chicago, Elsevier, MLA, and Springer Vancouver styles.
-- Converted representative `pattern.in-container` call sites in Chicago, IEEE, and Springer author-date styles.
-- Added grouped message arguments so `pattern.in-container` can receive an already-rendered container cluster such as editor plus parent-monograph title.
-- Deferred APA's container-author site, colon-bearing `in:` sites, `URL ` labels, and role-plus-name phrases until later batches define phrase IDs that preserve those outputs without encoding English glue inside arguments.
+- Started the embedded migration with output-equivalent `message:` calls in
+  representative embedded-core styles. This is a proof batch, not completion of
+  all embedded styles.
+- Converted representative `pattern.accessed-date` call sites in AMA, Chicago,
+  Elsevier, MLA, and Springer Vancouver styles.
+- Converted representative `pattern.in-container` call sites in Chicago, IEEE,
+  and Springer author-date styles.
+- Added grouped message arguments so `pattern.in-container` can receive an
+  already-rendered container cluster such as editor plus parent-monograph title.
+- Directly touched 9 embedded files. Wrapper styles may inherit those changes,
+  but remaining embedded-core files still need classification and migration.
+- Remaining embedded candidates include `elsevier-with-titles-core`,
+  `springer-basic-brackets-core`,
+  `taylor-and-francis-council-of-science-editors-author-date-core`,
+  `taylor-and-francis-national-library-of-medicine-core`, and residual
+  `term: in` sites in already-touched families.
+- Deferred APA's container-author site, Chicago author-date's German override
+  sensitive container site, colon-bearing `in:` sites, `URL ` labels, and
+  role-plus-name phrases until later batches define phrase IDs that preserve
+  those outputs without encoding English glue inside arguments.
+
+## Next Embedded Batch
+
+- Classify each remaining embedded candidate by behavior, not namespace:
+  lexical or inflectional label, phrase over rendered values, or contributor
+  role/name phrase.
+- Convert only output-preserving phrase-over-rendered-values sites to
+  `message: pattern.*`.
+- Keep role-label and role-plus-name migration out of this bean's next style
+  batch unless contributor rendering semantics are explicitly revised first.
+- Re-run parse/lint for all embedded styles and oracle/fidelity checks for each
+  affected embedded family before marking embedded migration complete.

--- a/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
+++ b/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
@@ -1,0 +1,42 @@
+---
+# csl26-fdzc
+title: Migrate styles to localized message phrase calls
+status: todo
+type: task
+priority: high
+tags:
+    - styles
+    - localization
+    - mf2
+created_at: 2026-06-25T00:22:34Z
+updated_at: 2026-06-25T00:22:34Z
+---
+
+## Problem
+
+Styles still use English-centric template phrasing and the compatibility
+`term:` component in places where locale-authored `message:` phrase calls
+should own natural-language realization.
+
+## Scope
+
+Migrate checked-in `styles/` to the new localized message format in batches.
+Start with embedded styles and embedded-locale phrase IDs, then continue
+through the rest of `styles/` by style family or shared template pattern.
+
+## Initial Batch
+
+- Convert embedded styles from phrase-like `term:` or literal glue to
+  `message:` calls where the locale should control word order.
+- Prioritize `pattern.accessed-date`, `pattern.in-container`,
+  `pattern.available-at`, and `pattern.retrieved-from`.
+- Keep atomic labels as `term.*` locale messages where they are labels rather
+  than compositional phrases.
+
+## Acceptance Criteria
+
+- Each batch preserves existing fidelity gates for the affected styles.
+- Deprecated template `term:` use decreases monotonically across `styles/`.
+- Missing message IDs and missing message args are caught by lint before merge.
+- Embedded styles are completed before broad non-embedded migration begins.
+- Any new phrase IDs are documented in `docs/specs/LOCALE_MESSAGES.md`.

--- a/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
+++ b/.beans/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
@@ -9,7 +9,7 @@ tags:
     - localization
     - mf2
 created_at: 2026-06-25T00:22:34Z
-updated_at: 2026-06-25T11:02:06Z
+updated_at: 2026-06-25T11:37:33Z
 ---
 
 ## Problem
@@ -61,10 +61,11 @@ through the rest of `styles/` by style family or shared template pattern.
   `taylor-and-francis-council-of-science-editors-author-date-core`,
   `taylor-and-francis-national-library-of-medicine-core`, and residual
   `term: in` sites in already-touched families.
-- Deferred APA's container-author site, Chicago author-date's German override
-  sensitive container site, colon-bearing `in:` sites, `URL ` labels, and
-  role-plus-name phrases until later batches define phrase IDs that preserve
-  those outputs without encoding English glue inside arguments.
+- Deferred colon-bearing `in:` sites, `URL ` labels, and role-plus-name phrases
+  until later batches define phrase IDs that preserve those outputs without
+  encoding English glue inside arguments. (APA's container-author site and
+  Chicago author-date's German-override container site were initially deferred
+  here but were completed in the follow-up below.)
 
 ## Next Embedded Batch
 
@@ -77,3 +78,18 @@ through the rest of `styles/` by style family or shared template pattern.
   batch unless contributor rendering semantics are explicitly revised first.
 - Re-run parse/lint for all embedded styles and oracle/fidelity checks for each
   affected embedded family before marking embedded migration complete.
+
+## APA And Chicago Follow-up (PR #965)
+
+- Converted APA's chapter container-author phrase to
+  `message: pattern.in-container` after fixing the hardcoded `Locale::en_us()`
+  boundary so `Processor::new` can resolve default phrase messages.
+- Converted Chicago author-date's chapter container phrase to
+  `message: pattern.in-container`.
+- Added `de-DE-chicago` override support for `pattern.in-container:
+  "{$container}"` so the Chicago German variant preserves its intentional
+  adjacency form without the English "In" phrase.
+- Added regression coverage for message arguments over embedded and legacy
+  container-author/title groups.
+- Refreshed the top-10 oracle baseline after confirming the current aggregate
+  has `cell` at 45/47 bibliography entries and no oracle regressions.

--- a/crates/citum-engine/src/processor/rendering/grouped/component_predicates.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/component_predicates.rs
@@ -57,6 +57,10 @@ pub(super) fn is_primary_title_component(component: &TemplateComponent) -> bool 
 }
 
 pub(super) fn is_parent_container_title_component(component: &TemplateComponent) -> bool {
+    component_or_message_arg_contains(component, is_parent_container_title_component_direct)
+}
+
+fn is_parent_container_title_component_direct(component: &TemplateComponent) -> bool {
     matches!(
         component,
         TemplateComponent::Title(title)
@@ -71,11 +75,37 @@ pub(super) fn is_parent_container_title_component(component: &TemplateComponent)
 }
 
 pub(super) fn is_parent_monograph_title_component(component: &TemplateComponent) -> bool {
+    component_or_message_arg_contains(component, is_parent_monograph_title_component_direct)
+}
+
+fn is_parent_monograph_title_component_direct(component: &TemplateComponent) -> bool {
     matches!(
         component,
         TemplateComponent::Title(title)
             if title.title == citum_schema::template::TitleType::ParentMonograph
     )
+}
+
+fn component_or_message_arg_contains(
+    component: &TemplateComponent,
+    direct: fn(&TemplateComponent) -> bool,
+) -> bool {
+    if direct(component) {
+        return true;
+    }
+
+    match component {
+        TemplateComponent::Group(group) => group
+            .group
+            .iter()
+            .any(|child| component_or_message_arg_contains(child, direct)),
+        TemplateComponent::Message(message) => message
+            .args
+            .values()
+            .filter_map(|source| source.as_template_component())
+            .any(|child| component_or_message_arg_contains(&child, direct)),
+        _ => false,
+    }
 }
 
 pub(super) fn is_issued_date_component(component: &TemplateComponent) -> bool {

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -92,6 +92,14 @@ fn resolve_semantic_class(component: &ProcTemplateComponent) -> Option<String> {
                 _ => "variable",
             }
         )),
+        TemplateComponent::Message(m) => Some(format!(
+            "citum-message-{}",
+            m.message
+                .chars()
+                .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+                .collect::<String>()
+                .trim_matches('-')
+        )),
         _ => None,
     }
 }

--- a/crates/citum-engine/src/values/message.rs
+++ b/crates/citum-engine/src/values/message.rs
@@ -1,0 +1,107 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Rendering logic for locale-authored message components.
+//!
+//! A message component resolves each named argument through the normal template
+//! component renderer, then asks the active locale to evaluate the selected
+//! message ID.
+
+use crate::reference::Reference;
+use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
+use citum_schema::locale::MessageArgs;
+use citum_schema::template::{MessageArgSource, TemplateMessage};
+use std::collections::HashMap;
+
+impl ComponentValues for TemplateMessage {
+    fn values<F: crate::render::format::OutputFormat<Output = String>>(
+        &self,
+        reference: &Reference,
+        hints: &ProcHints,
+        options: &RenderOptions<'_>,
+    ) -> Option<ProcValues<F::Output>> {
+        let mut named = HashMap::with_capacity(self.args.len());
+
+        for (name, source) in &self.args {
+            let value = render_message_arg::<F>(source, reference, hints, options)?;
+            if value.trim().is_empty() {
+                return None;
+            }
+            named.insert(name.clone(), value);
+        }
+
+        let args = MessageArgs {
+            named,
+            ..MessageArgs::default()
+        };
+        let mut value = options.locale.resolve_message(&self.message, &args)?;
+
+        if crate::values::should_strip_periods(&self.rendering, options) {
+            value = crate::values::strip_trailing_periods(&value);
+        }
+
+        if let Some(tc) = self.rendering.text_case {
+            value = crate::values::text_case::apply_text_case(&value, tc);
+        }
+
+        if value.trim().is_empty() {
+            return None;
+        }
+
+        Some(ProcValues {
+            value,
+            pre_formatted: true,
+            ..Default::default()
+        })
+    }
+}
+
+fn render_message_arg<F: crate::render::format::OutputFormat<Output = String>>(
+    source: &MessageArgSource,
+    reference: &Reference,
+    hints: &ProcHints,
+    options: &RenderOptions<'_>,
+) -> Option<String> {
+    if let MessageArgSource::Literal { literal } = source {
+        return Some(literal.clone());
+    }
+
+    let component = source.as_template_component()?;
+    if component.rendering().suppress == Some(true) {
+        return None;
+    }
+
+    let values = component.values::<F>(reference, hints, options)?;
+    if values.value.trim().is_empty() {
+        return None;
+    }
+
+    let fmt = F::default();
+    let proc_item = crate::render::ProcTemplateComponent {
+        template_component: component.clone(),
+        template_index: options.current_template_index,
+        value: values.value,
+        prefix: values.prefix,
+        suffix: values.suffix,
+        url: values.url,
+        ref_type: Some(reference.ref_type().clone()),
+        config: Some(options.config.clone()),
+        bibliography_config: options.bibliography_config.clone(),
+        item_language: crate::values::effective_component_language(reference, &component),
+        sentence_initial: false,
+        pre_formatted: values.pre_formatted,
+    };
+
+    let rendered = crate::render::render_component_with_format_and_renderer::<F>(
+        &proc_item,
+        &fmt,
+        options.show_semantics,
+    );
+    if rendered.trim().is_empty() {
+        None
+    } else {
+        Some(rendered)
+    }
+}

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -16,6 +16,8 @@ pub mod date;
 pub mod list;
 /// Locator rendering logic.
 pub mod locator;
+/// Locale message component rendering.
+pub mod message;
 /// Numeric variable extraction and page-range helpers.
 pub mod number;
 /// Shared helpers for collapsing consecutive numeric or ordinal numbering.
@@ -652,6 +654,7 @@ impl ComponentValues for TemplateComponent {
             TemplateComponent::Title(t) => t.values::<F>(reference, hints, options),
             TemplateComponent::Number(n) => n.values::<F>(reference, hints, options),
             TemplateComponent::Variable(v) => v.values::<F>(reference, hints, options),
+            TemplateComponent::Message(m) => m.values::<F>(reference, hints, options),
             TemplateComponent::Group(l) => l.values::<F>(reference, hints, options),
             TemplateComponent::Term(t) => t.values::<F>(reference, hints, options),
             _ => None,

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -754,6 +754,111 @@ fn test_date_values() {
 }
 
 #[test]
+fn test_message_component_renders_accessed_date_argument() {
+    let config = make_config();
+    let mut locale = make_locale();
+    locale
+        .messages
+        .insert("pattern.accessed-date".into(), "accessed {$date}".into());
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let reference = Reference::from(LegacyReference {
+        id: "web-2021".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("Web Resource".to_string()),
+        issued: Some(DateVariable::year(2021)),
+        ..Default::default()
+    });
+    let hints = ProcHints::default();
+    let component = TemplateMessage {
+        message: "pattern.accessed-date".into(),
+        args: [(
+            "date".into(),
+            MessageArgSource::Date(TemplateDate {
+                date: TemplateDateVar::Issued,
+                form: DateForm::Year,
+                fallback: None,
+                rendering: Default::default(),
+                links: None,
+                custom: None,
+            }),
+        )]
+        .into(),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+
+    assert_eq!(values.value, "accessed 2021");
+    assert!(values.pre_formatted);
+}
+
+#[test]
+fn test_message_component_renders_in_container_argument_with_formatting() {
+    let config = make_config();
+    let mut locale = make_locale();
+    locale
+        .messages
+        .insert("pattern.in-container".into(), "in {$container}".into());
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let reference = Reference::from(LegacyReference {
+        id: "chapter-1".to_string(),
+        ref_type: "chapter".to_string(),
+        container_title: Some("Book Title".to_string()),
+        ..Default::default()
+    });
+    let hints = ProcHints::default();
+    let component = TemplateMessage {
+        message: "pattern.in-container".into(),
+        args: [(
+            "container".into(),
+            MessageArgSource::Title(TemplateTitle {
+                title: TitleType::ParentMonograph,
+                rendering: Rendering {
+                    emph: Some(true),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        )]
+        .into(),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+
+    assert_eq!(values.value, "in _Book Title_");
+    assert!(values.pre_formatted);
+}
+
+#[test]
 fn test_year_month_day_dates_inline_disambiguation_suffix_on_year() {
     let config = make_config();
     let locale = make_locale();

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -10,8 +10,9 @@ use citum_schema::locale::{GeneralTerm, GrammaticalGender, Locale, TermForm};
 use citum_schema::options::contributors::NameForm;
 use citum_schema::options::*;
 use citum_schema::reference::{
-    ClassExtension, Contributor, ContributorEntry, ContributorGender, EdtfString, FlatName,
-    InputReference, Monograph, MonographType, StructuredName,
+    ClassExtension, Collection, CollectionComponent, CollectionType, Contributor, ContributorEntry,
+    ContributorGender, EdtfString, FlatName, InputReference, Monograph, MonographComponentType,
+    MonographType, StructuredName, Title, WorkRelation,
 };
 use citum_schema::template::DateVariable as TemplateDateVar;
 use citum_schema::template::*;
@@ -921,6 +922,167 @@ fn test_message_component_renders_grouped_container_argument() {
 
     assert_eq!(values.value, "in Grimm, Jacob (ed.) _Book Title_");
     assert!(values.pre_formatted);
+}
+
+#[test]
+fn test_message_component_renders_embedded_container_author_group() {
+    let mut config = make_config();
+    config.substitute = Some(SubstituteConfig::Explicit(Substitute {
+        role_substitute: std::collections::HashMap::from([(
+            "container-author".to_string(),
+            vec!["editor".to_string()],
+        )]),
+        ..Default::default()
+    }));
+    let mut locale = make_locale();
+    locale
+        .messages
+        .insert("pattern.in-container".into(), "in {$container}".into());
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let reference = InputReference::CollectionComponent(Box::new(CollectionComponent {
+        id: Some("chapter-1".into()),
+        r#type: MonographComponentType::Chapter,
+        title: Some(Title::Single("Chapter Title".to_string())),
+        container: Some(WorkRelation::Embedded(Box::new(
+            InputReference::Collection(Box::new(Collection {
+                r#type: CollectionType::EditedBook,
+                title: Some(Title::Single("Book Title".to_string())),
+                editor: Some(Contributor::StructuredName(StructuredName {
+                    given: "Jane".into(),
+                    family: "Editor".into(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })),
+        ))),
+        ..Default::default()
+    }));
+    let hints = ProcHints::default();
+    let component = TemplateMessage {
+        message: "pattern.in-container".into(),
+        args: [(
+            "container".into(),
+            MessageArgSource::Group(TemplateGroup {
+                group: vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::ContainerAuthor,
+                        form: ContributorForm::Long,
+                        name_order: Some(NameOrder::GivenFirst),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::ParentMonograph,
+                        rendering: Rendering {
+                            emph: Some(true),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ],
+                delimiter: Some(DelimiterPunctuation::Custom(", ".into())),
+                ..Default::default()
+            }),
+        )]
+        .into(),
+        rendering: Rendering {
+            text_case: Some(TextCase::CapitalizeFirst),
+            ..Default::default()
+        },
+        custom: None,
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+
+    assert_eq!(values.value, "In Jane Editor, _Book Title_");
+}
+
+#[test]
+fn test_message_component_renders_legacy_container_author_group() {
+    let mut config = make_config();
+    config.substitute = Some(SubstituteConfig::Explicit(Substitute {
+        role_substitute: std::collections::HashMap::from([(
+            "container-author".to_string(),
+            vec!["editor".to_string()],
+        )]),
+        ..Default::default()
+    }));
+    let mut locale = make_locale();
+    locale
+        .messages
+        .insert("pattern.in-container".into(), "in {$container}".into());
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let reference = Reference::from(LegacyReference {
+        id: "chapter-1".to_string(),
+        ref_type: "chapter".to_string(),
+        editor: Some(vec![Name::new("Editor", "Jane")]),
+        container_title: Some("Book Title".to_string()),
+        ..Default::default()
+    });
+    let hints = ProcHints::default();
+    let component = TemplateMessage {
+        message: "pattern.in-container".into(),
+        args: [(
+            "container".into(),
+            MessageArgSource::Group(TemplateGroup {
+                group: vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::ContainerAuthor,
+                        form: ContributorForm::Long,
+                        name_order: Some(NameOrder::GivenFirst),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::ParentMonograph,
+                        rendering: Rendering {
+                            emph: Some(true),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ],
+                delimiter: Some(DelimiterPunctuation::Custom(", ".into())),
+                ..Default::default()
+            }),
+        )]
+        .into(),
+        rendering: Rendering {
+            text_case: Some(TextCase::CapitalizeFirst),
+            ..Default::default()
+        },
+        custom: None,
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+
+    assert_eq!(values.value, "In Jane Editor, _Book Title_");
 }
 
 #[test]

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -859,6 +859,71 @@ fn test_message_component_renders_in_container_argument_with_formatting() {
 }
 
 #[test]
+fn test_message_component_renders_grouped_container_argument() {
+    let config = make_config();
+    let mut locale = make_locale();
+    locale
+        .messages
+        .insert("pattern.in-container".into(), "in {$container}".into());
+    let options = RenderOptions {
+        config: &config,
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let reference = Reference::from(LegacyReference {
+        id: "chapter-1".to_string(),
+        ref_type: "chapter".to_string(),
+        editor: Some(vec![Name::new("Grimm", "Jacob")]),
+        container_title: Some("Book Title".to_string()),
+        ..Default::default()
+    });
+    let hints = ProcHints::default();
+    let component = TemplateMessage {
+        message: "pattern.in-container".into(),
+        args: [(
+            "container".into(),
+            MessageArgSource::Group(TemplateGroup {
+                group: vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Editor,
+                        form: ContributorForm::Long,
+                        name_order: Some(NameOrder::FamilyFirst),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::ParentMonograph,
+                        rendering: Rendering {
+                            emph: Some(true),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ],
+                delimiter: Some(DelimiterPunctuation::Custom(" ".into())),
+                ..Default::default()
+            }),
+        )]
+        .into(),
+        ..Default::default()
+    };
+
+    let values = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap();
+
+    assert_eq!(values.value, "in Grimm, Jacob (ed.) _Book Title_");
+    assert!(values.pre_formatted);
+}
+
+#[test]
 fn test_year_month_day_dates_inline_disambiguation_suffix_on_year() {
     let config = make_config();
     let locale = make_locale();

--- a/crates/citum-schema-style/embedded/locales/ar-AR.yaml
+++ b/crates/citum-schema-style/embedded/locales/ar-AR.yaml
@@ -88,3 +88,7 @@ messages:
     when feminine * {مُتَرْجِمات}
     when * * {ترجمة}
   role.translator.verb: "ترجمة"
+  pattern.accessed-date: "تاريخ الوصول {$date}"
+  pattern.in-container: "في {$container}"
+  pattern.retrieved-from: "استُرجع من {$url}"
+  pattern.available-at: "متاح على {$url}"

--- a/crates/citum-schema-style/embedded/locales/de-DE.yaml
+++ b/crates/citum-schema-style/embedded/locales/de-DE.yaml
@@ -773,6 +773,8 @@ messages:
     .match {$count :plural}
     when one {Dokument}
     when * {Dokumente}
+  pattern.accessed-date: "Zugriff am {$date}"
+  pattern.in-container: "in {$container}"
   pattern.retrieved-from: "abgerufen von {$url}"
   date.open-ended: "heute"
 

--- a/crates/citum-schema-style/embedded/locales/en-US.yaml
+++ b/crates/citum-schema-style/embedded/locales/en-US.yaml
@@ -905,6 +905,8 @@ messages:
     when * {items}
   # Compositional patterns
   pattern.page-range: "{$start}–{$end}"
+  pattern.accessed-date: "accessed {$date}"
+  pattern.in-container: "in {$container}"
   pattern.retrieved-from: "retrieved from {$url}"
   pattern.available-at: "available at {$url}"
   date.open-ended: "present"

--- a/crates/citum-schema-style/embedded/locales/es-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/es-ES.yaml
@@ -295,6 +295,8 @@ messages:
     when * * {equipo de traducción}
   # Compositional patterns
   pattern.page-range: "{$start}–{$end}"
+  pattern.accessed-date: "consultado el {$date}"
+  pattern.in-container: "en {$container}"
   pattern.retrieved-from: "recuperado de {$url}"
   pattern.available-at: "disponible en {$url}"
   # Date assembly — Spanish places the day first and connects with "de".

--- a/crates/citum-schema-style/embedded/locales/eu-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/eu-ES.yaml
@@ -97,6 +97,8 @@ messages:
   pattern.date-year-month: "{$year}ko {$month}"
 
   pattern.page-range: "{$start}–{$end}"
+  pattern.accessed-date: "kontsulta-data: {$date}"
+  pattern.in-container: "{$container}(e)n"
   pattern.retrieved-from: "iturria: {$url}"
   date.open-ended: "gaur"
 

--- a/crates/citum-schema-style/embedded/locales/fr-FR.yaml
+++ b/crates/citum-schema-style/embedded/locales/fr-FR.yaml
@@ -883,6 +883,8 @@ messages:
     when * {Pièces}
   # Compositional patterns
   pattern.page-range: "{$start}–{$end}"
+  pattern.accessed-date: "consulté le {$date}"
+  pattern.in-container: "dans {$container}"
   pattern.retrieved-from: "consulté à l'adresse {$url}"
   pattern.available-at: "disponible sur {$url}"
   date.open-ended: "présent"

--- a/crates/citum-schema-style/embedded/locales/overrides/de-DE-chicago.yaml
+++ b/crates/citum-schema-style/embedded/locales/overrides/de-DE-chicago.yaml
@@ -17,6 +17,9 @@ locale-schema-version: "2"
 locale: de-DE-chicago
 base-locale: de-DE
 
+evaluation:
+  message-syntax: mf2
+
 grammar-options:
   # CSL de variant: delimiter-precedes-last="never"
   delimiter-precedes-last: never
@@ -24,6 +27,9 @@ grammar-options:
   serial-comma: false
 
 messages:
+  # Chicago-German chapter entries introduce the container by adjacency; the
+  # English "In" phrase is intentionally suppressed for this style variant.
+  pattern.in-container: "{$container}"
   # Chicago-German editor verb form — "herausgegeben von" abbreviated
   role.editor.verb: "hg. von"
   # Chicago-German translator verb form

--- a/crates/citum-schema-style/embedded/locales/tr-TR.yaml
+++ b/crates/citum-schema-style/embedded/locales/tr-TR.yaml
@@ -770,6 +770,8 @@ messages:
   role.guest.verb: "konuk olarak"
   # Compositional patterns
   pattern.page-range: "{$start}–{$end}"
+  pattern.accessed-date: "erişim tarihi: {$date}"
+  pattern.in-container: "{$container} içinde"
   pattern.retrieved-from: "erişim adresi: {$url}"
   pattern.available-at: "erişim adresi: {$url}"
   date.open-ended: "günümüz"

--- a/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
@@ -127,15 +127,17 @@ bibliography:
     - title: primary
     - date: issued
       form: year
-    - group:
-      - term: accessed
-        text-case: capitalize-first
-      - date: accessed
-        form: month-day
-      - date: accessed
-        form: year
-        prefix: ", "
-      delimiter: " "
+    - message: pattern.accessed-date
+      args:
+        date:
+          group:
+            - date: accessed
+              form: month-day
+            - date: accessed
+              form: year
+              prefix: ", "
+          delimiter: " "
+      text-case: capitalize-first
       suffix: ". "
     - variable: url
     article-newspaper:
@@ -149,15 +151,17 @@ bibliography:
     - date: issued
       form: year
       prefix: ", "
-    - group:
-      - term: accessed
-        text-case: capitalize-first
-      - date: accessed
-        form: month-day
-      - date: accessed
-        form: year
-        prefix: ", "
-      delimiter: " "
+    - message: pattern.accessed-date
+      args:
+        date:
+          group:
+            - date: accessed
+              form: month-day
+            - date: accessed
+              form: year
+              prefix: ", "
+          delimiter: " "
+      text-case: capitalize-first
       suffix: ". "
     - variable: url
     entry-encyclopedia:
@@ -255,15 +259,17 @@ bibliography:
         prefix: ", "
       - variable: number
         prefix: ":"
-    - group:
-      - term: accessed
-        text-case: capitalize-first
-      - date: accessed
-        form: month-day
-      - date: accessed
-        form: year
-        prefix: ", "
-      delimiter: " "
+    - message: pattern.accessed-date
+      args:
+        date:
+          group:
+            - date: accessed
+              form: month-day
+            - date: accessed
+              form: year
+              prefix: ", "
+          delimiter: " "
+      text-case: capitalize-first
       suffix: ". "
     - variable: url
     [interview, personal-communication]:
@@ -291,15 +297,17 @@ bibliography:
       suffix: ": "
     - title: parent-monograph
       text-case: title
-    - group:
-      - term: accessed
-        text-case: capitalize-first
-      - date: accessed
-        form: month-day
-      - date: accessed
-        form: year
-        prefix: ", "
-      delimiter: " "
+    - message: pattern.accessed-date
+      args:
+        date:
+          group:
+            - date: accessed
+              form: month-day
+            - date: accessed
+              form: year
+              prefix: ", "
+          delimiter: " "
+      text-case: capitalize-first
       suffix: ". "
     - variable: url
     map:

--- a/crates/citum-schema-style/embedded/styles/apa-7th.yaml
+++ b/crates/citum-schema-style/embedded/styles/apa-7th.yaml
@@ -312,17 +312,17 @@ bibliography:
       wrap:
         punctuation: parentheses
       prefix: " "
-    - delimiter: " "
-      group:
-      - term: in
-        text-case: capitalize-first
-      - delimiter: ", "
-        group:
-        - contributor: container-author
-          form: long
-          name-order: given-first
-        - title: parent-monograph
-          emph: true
+    - message: pattern.in-container
+      args:
+        container:
+          delimiter: ", "
+          group:
+          - contributor: container-author
+            form: long
+            name-order: given-first
+          - title: parent-monograph
+            emph: true
+      text-case: capitalize-first
     - delimiter: ", "
       wrap:
         punctuation: parentheses

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -313,12 +313,13 @@ bibliography:
     - title: primary
       wrap:
         punctuation: quotes
-    - delimiter: " "
-      group:
-      - term: in
-        text-case: capitalize-first
-      - title: parent-monograph
-        emph: true
+    - message: pattern.in-container
+      args:
+        container:
+          group:
+          - title: parent-monograph
+            emph: true
+      text-case: capitalize-first
     - contributor: editor
       form: verb
       name-order: given-first

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -338,15 +338,17 @@ bibliography:
       text-case: sentence
       wrap:
         punctuation: quotes
-    - group:
-      - term: accessed
-        text-case: capitalize-first
-      - date: accessed
-        form: month-day
-      - date: accessed
-        form: year
-        prefix: ", "
-      delimiter: " "
+    - message: pattern.accessed-date
+      args:
+        date:
+          group:
+            - date: accessed
+              form: month-day
+            - date: accessed
+              form: year
+              prefix: ", "
+          delimiter: " "
+      text-case: capitalize-first
       prefix: ". "
     - variable: url
     standard:

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -142,17 +142,19 @@ bibliography:
       prefix: ". "
       wrap:
         punctuation: quotes
-    - group:
-      - term: in
-        text-case: capitalize-first
-      - title: parent-monograph
-        emph: false
-      - contributor: editor
-        form: verb
-        name-order: given-first
-        prefix: ", "
+    - message: pattern.in-container
+      args:
+        container:
+          group:
+            - title: parent-monograph
+              emph: false
+            - contributor: editor
+              form: verb
+              name-order: given-first
+              prefix: ", "
+          delimiter: " "
+      text-case: capitalize-first
       prefix: " "
-      delimiter: " "
     - variable: publisher
       prefix: ". "
     - date: issued
@@ -187,15 +189,17 @@ bibliography:
       prefix: ". "
       wrap:
         punctuation: quotes
-    - group:
-      - term: accessed
-        text-case: capitalize-first
-      - date: accessed
-        form: month-day
-      - date: accessed
-        form: year
-        prefix: ", "
-      delimiter: " "
+    - message: pattern.accessed-date
+      args:
+        date:
+          group:
+            - date: accessed
+              form: month-day
+            - date: accessed
+              form: year
+              prefix: ", "
+          delimiter: " "
+      text-case: capitalize-first
       prefix: ". "
     - variable: url
       prefix: ". "

--- a/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
@@ -238,11 +238,11 @@ bibliography:
       links:
         target: url
         anchor: component
-    - group:
-      - term: accessed
-        form: long
-      - date: accessed
-        form: full
+    - message: pattern.accessed-date
+      args:
+        date:
+          date: accessed
+          form: full
       wrap:
         punctuation: parentheses
     [article-newspaper, broadcast]:

--- a/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
@@ -249,11 +249,11 @@ bibliography:
       form: year
       suffix: '. '
     - variable: url
-    - group:
-      - term: accessed
-        form: long
-      - date: accessed
-        form: full
+    - message: pattern.accessed-date
+      args:
+        date:
+          date: accessed
+          form: full
       wrap:
         punctuation: parentheses
     patent:

--- a/crates/citum-schema-style/embedded/styles/ieee.yaml
+++ b/crates/citum-schema-style/embedded/styles/ieee.yaml
@@ -141,11 +141,11 @@ bibliography:
     - title: primary
       wrap:
         punctuation: quotes
-    - group:
-      - term: in
-      - title: parent-monograph
-        emph: true
-      delimiter: " "
+    - message: pattern.in-container
+      args:
+        container:
+          title: parent-monograph
+          emph: true
     - contributor: editor
       form: long
       name-order: given-first
@@ -248,11 +248,11 @@ bibliography:
     - title: primary
       wrap:
         punctuation: quotes
-    - group:
-      - term: in
-      - title: parent-monograph
-        emph: true
-      delimiter: " "
+    - message: pattern.in-container
+      args:
+        container:
+          title: parent-monograph
+          emph: true
     - date: issued
       form: year
     - number: pages

--- a/crates/citum-schema-style/embedded/styles/modern-language-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/modern-language-association.yaml
@@ -154,12 +154,12 @@ bibliography:
     - title: parent-monograph
     - variable: url
       prefix: ", "
-    - group:
-      - term: accessed
-        text-case: capitalize-first
-      - date: accessed
-        form: day-month-abbr-year
-      delimiter: " "
+    - message: pattern.accessed-date
+      args:
+        date:
+          date: accessed
+          form: day-month-abbr-year
+      text-case: capitalize-first
       prefix: ". "
     standard:
     - variable: authority

--- a/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
@@ -81,14 +81,15 @@ bibliography:
       prefix: " "
     - title: primary
       prefix: " "
-    - delimiter: " "
-      group:
-      - term: in
-        form: long
-      - contributor: editor
-        form: long
-        name-order: family-first
-      - title: parent-monograph
+    - message: pattern.in-container
+      args:
+        container:
+          group:
+            - contributor: editor
+              form: long
+              name-order: family-first
+            - title: parent-monograph
+          delimiter: " "
     - title: parent-serial
     - delimiter: ", "
       group:

--- a/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets-core.yaml
@@ -161,10 +161,11 @@ bibliography:
       wrap:
         punctuation: brackets
     - variable: url
-    - term: accessed
-      form: long
-    - date: accessed
-      form: year-month-day
+    - message: pattern.accessed-date
+      args:
+        date:
+          date: accessed
+          form: year-month-day
 
     article-newspaper:
     - contributor: author
@@ -220,10 +221,11 @@ bibliography:
       wrap:
         punctuation: brackets
     - variable: url
-    - term: accessed
-      form: long
-    - date: accessed
-      form: day-month-abbr-year
+    - message: pattern.accessed-date
+      args:
+        date:
+          date: accessed
+          form: day-month-abbr-year
 
     dataset:
       extends: webpage
@@ -279,10 +281,11 @@ bibliography:
       wrap:
         punctuation: brackets
     - variable: url
-    - term: accessed
-      form: long
-    - date: accessed
-      form: day-month-abbr-year
+    - message: pattern.accessed-date
+      args:
+        date:
+          date: accessed
+          form: day-month-abbr-year
 
     software:
     - contributor: author

--- a/crates/citum-schema-style/src/lint.rs
+++ b/crates/citum-schema-style/src/lint.rs
@@ -9,10 +9,11 @@ use crate::citation::LocatorType;
 use crate::locale::{GeneralTerm, Locale, RawLocale, TermForm, types::MessageSyntax};
 use crate::options::Config;
 use crate::template::{
-    ContributorForm, ContributorRole, LabelForm as TemplateLabelForm, NumberVariable,
-    RoleLabelForm, TemplateComponent, TemplateContributor,
+    ContributorForm, ContributorRole, LabelForm as TemplateLabelForm, MessageArgSource,
+    NumberVariable, RoleLabelForm, TemplateComponent, TemplateContributor, TemplateMessage,
 };
 use crate::{CitationSpec, Style, TemplateVariant};
+use std::collections::BTreeSet;
 
 /// A single lint finding produced by locale or style validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -79,6 +80,10 @@ enum LocaleRequirementKind {
     Locator {
         locator: LocatorType,
         form: TermForm,
+    },
+    Message {
+        message_id: String,
+        args: Vec<String>,
     },
 }
 
@@ -164,6 +169,26 @@ pub fn lint_style_against_locale(style: &Style, locale: &Locale) -> LintReport {
                             "locale does not fully resolve locator term '{locator:?}' in form '{form:?}'"
                         ),
                     );
+                }
+            }
+            LocaleRequirementKind::Message { message_id, args } => {
+                let Some(message) = locale.messages.get(&message_id) else {
+                    report.error(
+                        requirement.path,
+                        format!("locale message '{message_id}' does not exist"),
+                    );
+                    continue;
+                };
+
+                for variable in mf2_variables(message) {
+                    if !args.iter().any(|arg| arg == &variable) {
+                        report.error(
+                            requirement.path.clone(),
+                            format!(
+                                "locale message '{message_id}' references '${variable}' but the template message does not declare that arg"
+                            ),
+                        );
+                    }
                 }
             }
         }
@@ -389,13 +414,18 @@ fn collect_template_requirements(
     for (index, component) in template.iter().enumerate() {
         let component_path = format!("{path}[{index}]");
         match component {
-            TemplateComponent::Term(term) => requirements.push(LocaleRequirement {
-                path: component_path,
-                kind: LocaleRequirementKind::General {
-                    term: term.term.clone(),
-                    form: term.form.clone().unwrap_or(TermForm::Long),
-                },
-            }),
+            TemplateComponent::Term(term) => {
+                requirements.push(LocaleRequirement {
+                    path: component_path,
+                    kind: LocaleRequirementKind::General {
+                        term: term.term.clone(),
+                        form: term.form.clone().unwrap_or(TermForm::Long),
+                    },
+                });
+            }
+            TemplateComponent::Message(message) => {
+                collect_message_requirements(message, &component_path, config, requirements);
+            }
             TemplateComponent::Contributor(contributor) => {
                 collect_contributor_requirements(
                     contributor,
@@ -451,6 +481,41 @@ fn collect_template_requirements(
             }
             _ => {}
         }
+    }
+}
+
+fn collect_message_requirements(
+    message: &TemplateMessage,
+    path: &str,
+    config: &Config,
+    requirements: &mut Vec<LocaleRequirement>,
+) {
+    requirements.push(LocaleRequirement {
+        path: path.to_string(),
+        kind: LocaleRequirementKind::Message {
+            message_id: message.message.clone(),
+            args: message.args.keys().cloned().collect(),
+        },
+    });
+
+    for (arg_name, source) in &message.args {
+        collect_message_arg_requirements(
+            source,
+            &format!("{path}.args.{arg_name}"),
+            config,
+            requirements,
+        );
+    }
+}
+
+fn collect_message_arg_requirements(
+    source: &MessageArgSource,
+    path: &str,
+    config: &Config,
+    requirements: &mut Vec<LocaleRequirement>,
+) {
+    if let Some(component) = source.as_template_component() {
+        collect_template_requirements(std::slice::from_ref(&component), path, config, requirements);
     }
 }
 
@@ -576,6 +641,35 @@ fn lint_mf2_message(message: &str) -> Result<(), String> {
         lint_mf2_match(trimmed)
     } else {
         lint_mf2_pattern(trimmed)
+    }
+}
+
+fn mf2_variables(message: &str) -> Vec<String> {
+    let mut variables = BTreeSet::new();
+    collect_mf2_variables(message, &mut variables);
+    variables.into_iter().collect()
+}
+
+fn collect_mf2_variables(input: &str, variables: &mut BTreeSet<String>) {
+    let mut cursor = 0usize;
+    while let Some(offset) = input.get(cursor..).and_then(|s| s.find('{')) {
+        let open = cursor + offset;
+        let Some(close) = find_matching_brace(input, open) else {
+            break;
+        };
+        let Some(inner) = input.get(open + 1..close).map(str::trim) else {
+            break;
+        };
+
+        if let Some(rest) = inner.strip_prefix('$')
+            && let Some(name) = rest.split_whitespace().next()
+            && !name.is_empty()
+        {
+            variables.insert(name.to_string());
+        }
+
+        collect_mf2_variables(inner, variables);
+        cursor = close + 1;
     }
 }
 
@@ -857,6 +951,57 @@ mod tests {
             finding.severity == LintSeverity::Warning
                 && finding.path == "citation.template[0]"
                 && finding.message.contains("general term")
+        }));
+    }
+
+    #[test]
+    fn test_lint_style_against_locale_errors_for_missing_message_id() {
+        let style = Style {
+            citation: Some(CitationSpec {
+                template: Some(vec![TemplateComponent::Message(TemplateMessage {
+                    message: "pattern.missing".into(),
+                    ..Default::default()
+                })]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let locale = Locale::en_us();
+
+        let report = lint_style_against_locale(&style, &locale);
+
+        assert!(report.has_errors());
+        assert!(report.findings.iter().any(|finding| {
+            finding.severity == LintSeverity::Error
+                && finding.path == "citation.template[0]"
+                && finding.message.contains("pattern.missing")
+        }));
+    }
+
+    #[test]
+    fn test_lint_style_against_locale_errors_for_missing_message_arg() {
+        let style = Style {
+            citation: Some(CitationSpec {
+                template: Some(vec![TemplateComponent::Message(TemplateMessage {
+                    message: "pattern.accessed-date".into(),
+                    ..Default::default()
+                })]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut locale = Locale::en_us();
+        locale
+            .messages
+            .insert("pattern.accessed-date".into(), "accessed {$date}".into());
+
+        let report = lint_style_against_locale(&style, &locale);
+
+        assert!(report.has_errors());
+        assert!(report.findings.iter().any(|finding| {
+            finding.severity == LintSeverity::Error
+                && finding.path == "citation.template[0]"
+                && finding.message.contains("$date")
         }));
     }
 

--- a/crates/citum-schema-style/src/locale/embedded/en_us.rs
+++ b/crates/citum-schema-style/src/locale/embedded/en_us.rs
@@ -57,13 +57,21 @@ fn extract_top_level_yaml_section(yaml: &str, key: &str) -> Option<String> {
     }
 }
 
-/// Archive hierarchy label messages for the hardcoded en-US locale.
+/// Built-in messages for the hardcoded en-US locale.
 ///
-/// Only the archive terms are pre-seeded here; all other message lookups fall
-/// through to the legacy typed term maps so that the hardcoded `en_us()`
-/// constructor stays consistent with the pre-existing test baseline.
+/// Archive terms are pre-seeded for compatibility with legacy typed term maps.
+/// Phrase patterns are also available because `Processor::new` uses this
+/// locale directly when a style does not specify a default locale.
 pub(crate) fn en_us_archive_messages() -> HashMap<String, String> {
     [
+        ("pattern.page-range".into(), "{$start}–{$end}".into()),
+        ("pattern.accessed-date".into(), "accessed {$date}".into()),
+        ("pattern.in-container".into(), "in {$container}".into()),
+        (
+            "pattern.retrieved-from".into(),
+            "retrieved from {$url}".into(),
+        ),
+        ("pattern.available-at".into(), "available at {$url}".into()),
         ("term.archive-collection-label".into(), "collection".into()),
         ("term.archive-series-label".into(), "series".into()),
         (

--- a/crates/citum-schema-style/src/locale/message.rs
+++ b/crates/citum-schema-style/src/locale/message.rs
@@ -10,6 +10,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! for future ICU4X migration, allowing different evaluator implementations
 //! to be swapped without changing call sites.
 
+use std::collections::HashMap;
+
 /// Arguments passed to message evaluation.
 ///
 /// Contains optional named variables that may be referenced in a message.
@@ -41,6 +43,8 @@ pub struct MessageArgs<'a> {
     pub day: Option<&'a str>,
     /// Main contributor list for "et al." patterns.
     pub main_list: Option<&'a str>,
+    /// Arbitrary named arguments supplied by `TemplateMessage` components.
+    pub named: HashMap<String, String>,
 }
 
 /// Evaluates a parameterized message string with runtime arguments.
@@ -75,6 +79,21 @@ pub trait MessageEvaluator: Send + Sync {
 /// without external dependencies.
 #[derive(Debug, Clone)]
 pub struct Mf2MessageEvaluator;
+
+/// No-op evaluator for `message-syntax: static` locales.
+///
+/// Always returns `None` so the caller falls back to plain-text fast-path or
+/// the legacy term map. Stored in `Locale::evaluator` when the locale declares
+/// `Static` syntax; the `resolve_message` guard ensures it is never actually
+/// called for plain-text messages.
+#[derive(Debug, Clone)]
+pub struct NoOpEvaluator;
+
+impl MessageEvaluator for NoOpEvaluator {
+    fn evaluate(&self, _message: &str, _args: &MessageArgs<'_>) -> Option<String> {
+        None
+    }
+}
 
 impl MessageEvaluator for Mf2MessageEvaluator {
     fn evaluate(&self, message: &str, args: &MessageArgs<'_>) -> Option<String> {
@@ -129,7 +148,7 @@ fn substitute_mf2_vars(pattern: &str, args: &MessageArgs<'_>) -> Option<String> 
 
 /// Resolve a variable name to its value in `MessageArgs`.
 fn resolve_var<'a>(var_name: &str, args: &'a MessageArgs<'a>) -> Option<&'a str> {
-    match var_name {
+    let typed = match var_name {
         "value" => args.value,
         "gender" => args.gender,
         "names" => args.names,
@@ -142,7 +161,9 @@ fn resolve_var<'a>(var_name: &str, args: &'a MessageArgs<'a>) -> Option<&'a str>
         "day" => args.day,
         "main_list" => args.main_list,
         _ => None,
-    }
+    };
+
+    typed.or_else(|| args.named.get(var_name).map(String::as_str))
 }
 
 /// Evaluate a `.match` statement with selectors and variants.
@@ -209,6 +230,8 @@ fn determine_match_key(
                 return None;
             }
             let count = args.count?;
+            // Only "one" vs "*" are dispatched; full CLDR categories (two/few/many)
+            // are deferred to the ICU4X evaluator swap (bean csl26-qrpo).
             if count == 1 {
                 Some("one".to_string())
             } else {
@@ -368,6 +391,20 @@ mod tests {
         assert_eq!(
             result,
             Some("retrieved from https://example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_named_template_message_argument() {
+        let evaluator = Mf2MessageEvaluator;
+        let args = MessageArgs {
+            named: HashMap::from([("container".to_string(), "Book Title".to_string())]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            evaluator.evaluate("in {$container}", &args),
+            Some("in Book Title".to_string())
         );
     }
 

--- a/crates/citum-schema-style/src/locale/message_ids.rs
+++ b/crates/citum-schema-style/src/locale/message_ids.rs
@@ -151,19 +151,13 @@ impl Locale {
         }
     }
 
-    pub(super) fn resolve_message_text(
-        &self,
-        message_id: &str,
-        count: Option<u64>,
-        gender: Option<GrammaticalGender>,
-    ) -> Option<String> {
+    /// Resolve a locale message by ID with caller-supplied MF2 arguments.
+    ///
+    /// This is the public boundary for style-template `message` components:
+    /// templates select the message ID and pass named arguments, while the
+    /// active locale owns the message body and evaluator.
+    pub fn resolve_message(&self, message_id: &str, args: &MessageArgs<'_>) -> Option<String> {
         let message = self.messages.get(message_id)?;
-
-        let args = MessageArgs {
-            count,
-            gender: gender.as_ref().map(Self::gender_selector_key),
-            ..MessageArgs::default()
-        };
 
         if !message.contains('{') {
             return Some(message.clone());
@@ -173,6 +167,21 @@ impl Locale {
             return None;
         }
 
-        self.evaluator.evaluate(message, &args)
+        self.evaluator.evaluate(message, args)
+    }
+
+    pub(super) fn resolve_message_text(
+        &self,
+        message_id: &str,
+        count: Option<u64>,
+        gender: Option<GrammaticalGender>,
+    ) -> Option<String> {
+        let args = MessageArgs {
+            count,
+            gender: gender.as_ref().map(Self::gender_selector_key),
+            ..MessageArgs::default()
+        };
+
+        self.resolve_message(message_id, &args)
     }
 }

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -959,6 +959,22 @@ locale: en-US
         );
     }
 
+    /// The hardcoded en-US locale includes phrase messages used by style
+    /// `message:` components, not only legacy term compatibility messages.
+    #[test]
+    fn test_en_us_locale_resolves_phrase_messages() {
+        let locale = Locale::en_us();
+        let args = MessageArgs {
+            named: [("container".to_string(), "Book Title".to_string())].into(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            locale.resolve_message("pattern.in-container", &args),
+            Some("in Book Title".to_string())
+        );
+    }
+
     /// apply_override with grammar_options replaces block and syncs punctuation_in_quote.
     #[test]
     fn test_apply_override_grammar_options_syncs_punctuation() {

--- a/crates/citum-schema-style/src/locale/raw_conversion.rs
+++ b/crates/citum-schema-style/src/locale/raw_conversion.rs
@@ -11,7 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! place. Public Locale APIs unrelated to raw conversion stay in `mod.rs`.
 
 use super::Locale;
-use super::message::Mf2MessageEvaluator;
+use super::message::{MessageEvaluator, Mf2MessageEvaluator, NoOpEvaluator};
 use super::raw;
 use super::types::{
     ContributorTerm, DateTerms, LocaleOverride, LocatorTerm, MaybeGendered, MessageSyntax,
@@ -265,8 +265,8 @@ impl Locale {
         }
 
         locale.evaluator = match locale.evaluation.message_syntax {
-            MessageSyntax::Mf2 => Arc::new(Mf2MessageEvaluator),
-            MessageSyntax::Static => Arc::new(Mf2MessageEvaluator),
+            MessageSyntax::Mf2 => Arc::new(Mf2MessageEvaluator) as Arc<dyn MessageEvaluator>,
+            MessageSyntax::Static => Arc::new(NoOpEvaluator),
         };
 
         locale

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -10,11 +10,6 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! pages and chapters, date-related terms, and month names. These are used by citation
 //! processors to render localized output.
 
-/*
-SPDX-License-Identifier: MIT OR Apache-2.0
-SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
-*/
-
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/citum-schema-style/src/macros.rs
+++ b/crates/citum-schema-style/src/macros.rs
@@ -94,6 +94,7 @@ macro_rules! dispatch_component {
             $crate::template::TemplateComponent::Title($inner) => $action,
             $crate::template::TemplateComponent::Number($inner) => $action,
             $crate::template::TemplateComponent::Variable($inner) => $action,
+            $crate::template::TemplateComponent::Message($inner) => $action,
             $crate::template::TemplateComponent::Group($inner) => $action,
             $crate::template::TemplateComponent::Term($inner) => $action,
         }

--- a/crates/citum-schema-style/src/style/diagnostics.rs
+++ b/crates/citum-schema-style/src/style/diagnostics.rs
@@ -13,6 +13,7 @@ const COMPONENT_KINDS: &[&str] = &[
     "title",
     "number",
     "variable",
+    "message",
     "group",
     "term",
 ];
@@ -364,6 +365,7 @@ fn component_allowed_fields(kind: &str) -> &'static [&'static str] {
             "custom",
         ],
         "variable" => &["variable", "links", "custom"],
+        "message" => &["message", "args", "custom"],
         "term" => &["term", "form", "gender", "custom"],
         "group" => &["group", "delimiter", "custom"],
         _ => &[],

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -255,6 +255,17 @@ impl TemplateResourceBudget {
             TemplateComponent::Group(group) => {
                 self.check_template(&group.group, &format!("{location}.group"), depth + 1)?;
             }
+            TemplateComponent::Message(message) => {
+                for (name, source) in &message.args {
+                    if let Some(component) = source.as_template_component() {
+                        self.check_component(
+                            &component,
+                            &format!("{location}.message.args.{name}"),
+                            depth + 1,
+                        )?;
+                    }
+                }
+            }
             TemplateComponent::Contributor(_)
             | TemplateComponent::Title(_)
             | TemplateComponent::Number(_)

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1170,6 +1170,8 @@ pub enum MessageArgSource {
     Contributor(TemplateContributor),
     /// A rendered date argument.
     Date(TemplateDate),
+    /// A rendered group argument.
+    Group(TemplateGroup),
     /// A rendered title argument.
     Title(TemplateTitle),
     /// A rendered number argument.
@@ -1189,6 +1191,7 @@ impl MessageArgSource {
             Self::Literal { .. } => None,
             Self::Contributor(component) => Some(TemplateComponent::Contributor(component.clone())),
             Self::Date(component) => Some(TemplateComponent::Date(component.clone())),
+            Self::Group(component) => Some(TemplateComponent::Group(component.clone())),
             Self::Title(component) => Some(TemplateComponent::Title(component.clone())),
             Self::Number(component) => Some(TemplateComponent::Number(component.clone())),
             Self::Variable(component) => Some(TemplateComponent::Variable(component.clone())),
@@ -1522,8 +1525,9 @@ wrap: parentheses
 message: pattern.in-container
 args:
   container:
-    title: parent-monograph
-    emph: true
+    group:
+    - title: parent-monograph
+      emph: true
 text-case: capitalize-first
 "#;
         let comp: TemplateComponent = serde_yaml::from_str(yaml).unwrap();
@@ -1533,8 +1537,13 @@ text-case: capitalize-first
                 assert_eq!(message.message, "pattern.in-container");
                 assert!(matches!(
                     message.args.get("container"),
-                    Some(MessageArgSource::Title(title)) if title.title == TitleType::ParentMonograph
-                        && title.rendering.emph == Some(true)
+                    Some(MessageArgSource::Group(group)) if group.group.len() == 1
+                        && matches!(
+                            group.group.first(),
+                            Some(TemplateComponent::Title(title))
+                                if title.title == TitleType::ParentMonograph
+                                    && title.rendering.emph == Some(true)
+                        )
                 ));
                 assert_eq!(
                     message.rendering.text_case,

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -473,6 +473,7 @@ pub enum TemplateComponent {
     Title(TemplateTitle),
     Number(TemplateNumber),
     Variable(TemplateVariable),
+    Message(TemplateMessage),
     Group(TemplateGroup),
     Term(TemplateTerm),
 }
@@ -1136,6 +1137,66 @@ pub struct TemplateVariable {
     pub custom: Option<HashMap<String, serde_json::Value>>,
 }
 
+/// A locale message call inside a citation or bibliography template.
+///
+/// The style chooses the message ID and supplies structured argument sources;
+/// the active locale owns the natural-language realization in its `messages`
+/// map.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct TemplateMessage {
+    /// Locale message ID to evaluate, such as `pattern.accessed-date`.
+    pub message: String,
+    /// Named argument sources pre-rendered before message evaluation.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub args: HashMap<String, MessageArgSource>,
+    #[serde(flatten, default)]
+    pub rendering: Rendering,
+
+    /// Custom user-defined fields for extensions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// A structured source for one named locale-message argument.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum MessageArgSource {
+    /// A literal string argument.
+    Literal { literal: String },
+    /// A rendered contributor argument.
+    Contributor(TemplateContributor),
+    /// A rendered date argument.
+    Date(TemplateDate),
+    /// A rendered title argument.
+    Title(TemplateTitle),
+    /// A rendered number argument.
+    Number(TemplateNumber),
+    /// A rendered variable argument.
+    Variable(TemplateVariable),
+    /// A rendered locale term argument.
+    Term(TemplateTerm),
+}
+
+impl MessageArgSource {
+    /// Convert this argument source into a normal template component when it
+    /// should be rendered through the standard component pipeline.
+    #[must_use]
+    pub fn as_template_component(&self) -> Option<TemplateComponent> {
+        match self {
+            Self::Literal { .. } => None,
+            Self::Contributor(component) => Some(TemplateComponent::Contributor(component.clone())),
+            Self::Date(component) => Some(TemplateComponent::Date(component.clone())),
+            Self::Title(component) => Some(TemplateComponent::Title(component.clone())),
+            Self::Number(component) => Some(TemplateComponent::Number(component.clone())),
+            Self::Variable(component) => Some(TemplateComponent::Variable(component.clone())),
+            Self::Term(component) => Some(TemplateComponent::Term(component.clone())),
+        }
+    }
+}
+
 /// Simple string variables.
 ///
 /// Use `variable:` for string passthrough fields, even when the field name is
@@ -1452,6 +1513,35 @@ wrap: parentheses
                 assert_eq!(v.variable, SimpleVariable::Publisher);
             }
             _ => panic!("Expected Variable(Publisher), got {:?}", comp),
+        }
+    }
+
+    #[test]
+    fn test_message_component_deserialization() {
+        let yaml = r#"
+message: pattern.in-container
+args:
+  container:
+    title: parent-monograph
+    emph: true
+text-case: capitalize-first
+"#;
+        let comp: TemplateComponent = serde_yaml::from_str(yaml).unwrap();
+
+        match comp {
+            TemplateComponent::Message(message) => {
+                assert_eq!(message.message, "pattern.in-container");
+                assert!(matches!(
+                    message.args.get("container"),
+                    Some(MessageArgSource::Title(title)) if title.title == TitleType::ParentMonograph
+                        && title.rendering.emph == Some(true)
+                ));
+                assert_eq!(
+                    message.rendering.text_case,
+                    Some(crate::options::titles::TextCase::CapitalizeFirst)
+                );
+            }
+            _ => panic!("Expected Message component, got {comp:?}"),
         }
     }
 

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -1607,7 +1607,7 @@ bibliography:
         "message should name the invalid component property: {message}"
     );
     assert!(
-        message.contains("component must contain exactly one of contributor/date/title/number/variable/group/term"),
+        message.contains("component must contain exactly one of contributor/date/title/number/variable/message/group/term"),
         "message should enumerate valid component kinds: {message}"
     );
 }
@@ -1628,7 +1628,7 @@ bibliography:
         "message should include template item path: {message}"
     );
     assert!(
-        message.contains("component must contain exactly one of contributor/date/title/number/variable/group/term"),
+        message.contains("component must contain exactly one of contributor/date/title/number/variable/message/group/term"),
         "message should enumerate valid component kinds: {message}"
     );
 }

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -705,6 +705,9 @@
           "$ref": "#/$defs/TemplateVariable"
         },
         {
+          "$ref": "#/$defs/TemplateMessage"
+        },
+        {
           "$ref": "#/$defs/TemplateGroup"
         },
         {
@@ -2146,25 +2149,20 @@
         "ads-bibcode"
       ]
     },
-    "TemplateGroup": {
-      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+    "TemplateMessage": {
+      "description": "A locale message call inside a citation or bibliography template.\n\nThe style chooses the message ID and supplies structured argument sources;\nthe active locale owns the natural-language realization in its `messages`\nmap.",
       "type": "object",
       "properties": {
-        "group": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TemplateComponent"
-          }
+        "message": {
+          "description": "Locale message ID to evaluate, such as `pattern.accessed-date`.",
+          "type": "string"
         },
-        "delimiter": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DelimiterPunctuation"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "args": {
+          "description": "Named argument sources pre-rendered before message evaluation.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/MessageArgSource"
+          }
         },
         "text-case": {
           "description": "Text-case transform to apply to the rendered value.",
@@ -2284,12 +2282,49 @@
       },
       "additionalProperties": false,
       "required": [
-        "group"
+        "message"
       ]
     },
-    "DelimiterPunctuation": {
-      "description": "Delimiter punctuation options.",
-      "type": "string"
+    "MessageArgSource": {
+      "description": "A structured source for one named locale-message argument.",
+      "anyOf": [
+        {
+          "description": "A literal string argument.",
+          "type": "object",
+          "properties": {
+            "literal": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ]
+        },
+        {
+          "description": "A rendered contributor argument.",
+          "$ref": "#/$defs/TemplateContributor"
+        },
+        {
+          "description": "A rendered date argument.",
+          "$ref": "#/$defs/TemplateDate"
+        },
+        {
+          "description": "A rendered title argument.",
+          "$ref": "#/$defs/TemplateTitle"
+        },
+        {
+          "description": "A rendered number argument.",
+          "$ref": "#/$defs/TemplateNumber"
+        },
+        {
+          "description": "A rendered variable argument.",
+          "$ref": "#/$defs/TemplateVariable"
+        },
+        {
+          "description": "A rendered locale term argument.",
+          "$ref": "#/$defs/TemplateTerm"
+        }
+      ]
     },
     "TemplateTerm": {
       "description": "A term component for rendering locale-specific text.",
@@ -2441,6 +2476,151 @@
       "required": [
         "term"
       ]
+    },
+    "TemplateGroup": {
+      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+      "type": "object",
+      "properties": {
+        "group": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "group"
+      ]
+    },
+    "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
+      "type": "string"
     },
     "DisambiguationScope": {
       "description": "Scope for disambiguation (e.g., year suffix assignment).",

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2309,6 +2309,10 @@
           "$ref": "#/$defs/TemplateDate"
         },
         {
+          "description": "A rendered group argument.",
+          "$ref": "#/$defs/TemplateGroup"
+        },
+        {
           "description": "A rendered title argument.",
           "$ref": "#/$defs/TemplateTitle"
         },
@@ -2325,6 +2329,151 @@
           "$ref": "#/$defs/TemplateTerm"
         }
       ]
+    },
+    "TemplateGroup": {
+      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+      "type": "object",
+      "properties": {
+        "group": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "group"
+      ]
+    },
+    "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
+      "type": "string"
     },
     "TemplateTerm": {
       "description": "A term component for rendering locale-specific text.",
@@ -2476,151 +2625,6 @@
       "required": [
         "term"
       ]
-    },
-    "TemplateGroup": {
-      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
-      "type": "object",
-      "properties": {
-        "group": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TemplateComponent"
-          }
-        },
-        "delimiter": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DelimiterPunctuation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "text-case": {
-          "description": "Text-case transform to apply to the rendered value.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TextCase"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "emph": {
-          "description": "Render in italics/emphasis.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "quote": {
-          "description": "Render in quotes.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "strong": {
-          "description": "Render in bold/strong.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "small-caps": {
-          "description": "Render in small caps.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "vertical-align": {
-          "description": "Vertical alignment to apply to rendered output.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VerticalAlign"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "prefix": {
-          "description": "Text to prepend to the rendered value (outside any wrap).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "suffix": {
-          "description": "Text to append to the rendered value (outside any wrap).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "wrap": {
-          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WrapConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "suppress": {
-          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "initialize-with": {
-          "description": "Override name initialization (e.g., \". \" or \"\").",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name-form": {
-          "description": "Override name form (e.g., initials, full, family-only).",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NameForm"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "strip-periods": {
-          "description": "Strip trailing periods from rendered value.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "custom": {
-          "description": "Custom user-defined fields for extensions.",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "group"
-      ]
-    },
-    "DelimiterPunctuation": {
-      "description": "Delimiter punctuation options.",
-      "type": "string"
     },
     "DisambiguationScope": {
       "description": "Scope for disambiguation (e.g., year suffix assignment).",

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -2001,6 +2001,10 @@
           "$ref": "#/$defs/TemplateDate"
         },
         {
+          "description": "A rendered group argument.",
+          "$ref": "#/$defs/TemplateGroup"
+        },
+        {
           "description": "A rendered title argument.",
           "$ref": "#/$defs/TemplateTitle"
         },
@@ -2017,6 +2021,151 @@
           "$ref": "#/$defs/TemplateTerm"
         }
       ]
+    },
+    "TemplateGroup": {
+      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+      "type": "object",
+      "properties": {
+        "group": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "group"
+      ]
+    },
+    "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
+      "type": "string"
     },
     "TemplateTerm": {
       "description": "A term component for rendering locale-specific text.",
@@ -2358,151 +2507,6 @@
           "const": "symbol"
         }
       ]
-    },
-    "TemplateGroup": {
-      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
-      "type": "object",
-      "properties": {
-        "group": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TemplateComponent"
-          }
-        },
-        "delimiter": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DelimiterPunctuation"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "text-case": {
-          "description": "Text-case transform to apply to the rendered value.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TextCase"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "emph": {
-          "description": "Render in italics/emphasis.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "quote": {
-          "description": "Render in quotes.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "strong": {
-          "description": "Render in bold/strong.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "small-caps": {
-          "description": "Render in small caps.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "vertical-align": {
-          "description": "Vertical alignment to apply to rendered output.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VerticalAlign"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "prefix": {
-          "description": "Text to prepend to the rendered value (outside any wrap).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "suffix": {
-          "description": "Text to append to the rendered value (outside any wrap).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "wrap": {
-          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WrapConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "suppress": {
-          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "initialize-with": {
-          "description": "Override name initialization (e.g., \". \" or \"\").",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "name-form": {
-          "description": "Override name form (e.g., initials, full, family-only).",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NameForm"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "strip-periods": {
-          "description": "Strip trailing periods from rendered value.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "custom": {
-          "description": "Custom user-defined fields for extensions.",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": true
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "group"
-      ]
-    },
-    "DelimiterPunctuation": {
-      "description": "Delimiter punctuation options.",
-      "type": "string"
     },
     "Config": {
       "description": "Top-level style configuration.",

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -397,6 +397,9 @@
           "$ref": "#/$defs/TemplateVariable"
         },
         {
+          "$ref": "#/$defs/TemplateMessage"
+        },
+        {
           "$ref": "#/$defs/TemplateGroup"
         },
         {
@@ -1838,25 +1841,20 @@
         "ads-bibcode"
       ]
     },
-    "TemplateGroup": {
-      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+    "TemplateMessage": {
+      "description": "A locale message call inside a citation or bibliography template.\n\nThe style chooses the message ID and supplies structured argument sources;\nthe active locale owns the natural-language realization in its `messages`\nmap.",
       "type": "object",
       "properties": {
-        "group": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TemplateComponent"
-          }
+        "message": {
+          "description": "Locale message ID to evaluate, such as `pattern.accessed-date`.",
+          "type": "string"
         },
-        "delimiter": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DelimiterPunctuation"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "args": {
+          "description": "Named argument sources pre-rendered before message evaluation.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/MessageArgSource"
+          }
         },
         "text-case": {
           "description": "Text-case transform to apply to the rendered value.",
@@ -1976,12 +1974,49 @@
       },
       "additionalProperties": false,
       "required": [
-        "group"
+        "message"
       ]
     },
-    "DelimiterPunctuation": {
-      "description": "Delimiter punctuation options.",
-      "type": "string"
+    "MessageArgSource": {
+      "description": "A structured source for one named locale-message argument.",
+      "anyOf": [
+        {
+          "description": "A literal string argument.",
+          "type": "object",
+          "properties": {
+            "literal": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "literal"
+          ]
+        },
+        {
+          "description": "A rendered contributor argument.",
+          "$ref": "#/$defs/TemplateContributor"
+        },
+        {
+          "description": "A rendered date argument.",
+          "$ref": "#/$defs/TemplateDate"
+        },
+        {
+          "description": "A rendered title argument.",
+          "$ref": "#/$defs/TemplateTitle"
+        },
+        {
+          "description": "A rendered number argument.",
+          "$ref": "#/$defs/TemplateNumber"
+        },
+        {
+          "description": "A rendered variable argument.",
+          "$ref": "#/$defs/TemplateVariable"
+        },
+        {
+          "description": "A rendered locale term argument.",
+          "$ref": "#/$defs/TemplateTerm"
+        }
+      ]
     },
     "TemplateTerm": {
       "description": "A term component for rendering locale-specific text.",
@@ -2323,6 +2358,151 @@
           "const": "symbol"
         }
       ]
+    },
+    "TemplateGroup": {
+      "description": "A group component for grouping multiple components with a delimiter,\nmatching CSL 1.0 `<group>` semantics.",
+      "type": "object",
+      "properties": {
+        "group": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "delimiter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text to prepend to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Text to append to the rendered value (outside any wrap).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "custom": {
+          "description": "Custom user-defined fields for extensions.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "group"
+      ]
+    },
+    "DelimiterPunctuation": {
+      "description": "Delimiter punctuation options.",
+      "type": "string"
     },
     "Config": {
       "description": "Top-level style configuration.",

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -1,8 +1,8 @@
 # Locale Messages Specification
 
 **Status:** Active
-**Version:** 1.4
-**Date:** 2026-05-16
+**Version:** 1.5
+**Date:** 2026-06-24
 **Supersedes:** (none)
 **Related:** bean `csl26-qrpo` (ICU4X upgrade), bean `csl26-v6ok` (locale-authored date patterns)
 
@@ -22,6 +22,7 @@ duplicating styles per language.
   `numberFormats`, `grammarOptions`, `legacyTermAliases`.
 - `LocaleOverride` struct and merge semantics.
 - `MessageEvaluator` trait and `Mf2MessageEvaluator` implementation.
+- Style-template `message:` components that call locale-authored phrases by ID.
 - Migration compatibility layer: dual-path lookup and `localeSchemaVersion`
   gating.
 - CLI lint tooling: `citum locale lint` and `citum style lint --locale`.
@@ -120,6 +121,52 @@ the rendering surface that Phase 0–3 exercises.
 The distinction is runtime-only: both types use identical YAML representation
 (a string value under a message ID key). The engine classifies a message as
 parameterized if and only if its body contains a `{` character.
+
+---
+
+### 1.4.1 Atomic Labels vs Compositional Phrases
+
+Locale messages have two different jobs:
+
+- **Atomic labels** (`term.*`, `role.*`) name a localizable word or short label:
+  `term.page-label`, `term.accessed`, `role.editor.label`.
+- **Compositional phrases** (`pattern.*`) assemble already-rendered citation
+  values into natural-language fragments: `pattern.accessed-date`,
+  `pattern.in-container`, `pattern.available-at`, `pattern.retrieved-from`.
+
+Styles SHOULD use `message:` template components for compositional phrases
+instead of spelling English glue with `term:` components, `prefix`, or `suffix`.
+The style still decides *which* phrase is needed and *which fields* supply its
+arguments; the active locale decides the phrase order and glue text.
+
+The template-schema `term:` component remains parseable for compatibility but
+is deprecated for new phrase realization. This does not remove `term.*` message
+IDs from locale files; those IDs remain the canonical representation for atomic
+labels.
+
+```yaml
+# Locale file
+messages:
+  pattern.accessed-date: "accessed {$date}"
+  pattern.in-container: "in {$container}"
+```
+
+```yaml
+# Style template
+- message: pattern.accessed-date
+  args:
+    date: { date: accessed, form: day-month-abbr-year }
+
+- message: pattern.in-container
+  args:
+    container: { title: parent-monograph, emph: true }
+  text-case: capitalize-first
+```
+
+`message:` is a style-template component defined in
+`crates/citum-schema-style/src/template.rs` as `TemplateMessage`. It is not part
+of `Locale`. Locale owns the message catalog and evaluator through
+`Locale::resolve_message(message_id, args)`.
 
 ---
 
@@ -230,6 +277,22 @@ All message IDs are dot-namespaced strings:
 | `role.<role>.<form>` | Contributor role phrases | `role.editor.label`, `role.editor.verb` |
 | `pattern.` | Compositional phrase templates | `pattern.page-range`, `pattern.retrieved-from`, `pattern.date-full` |
 | `date.` | Date-specific terms not in `dateFormats` | `date.open-ended` |
+
+#### Required phrase pattern IDs
+
+Locales SHOULD define these initial compositional phrase IDs:
+
+| Message ID | Variables | Purpose |
+|---|---|---|
+| `pattern.accessed-date` | `$date` | Access-date statements such as “accessed December 1, 2021”. |
+| `pattern.in-container` | `$container` | Container-introduction phrases such as “in _Book Title_”. |
+| `pattern.available-at` | `$url` | Availability statements. |
+| `pattern.retrieved-from` | `$url` | Retrieval/source statements. |
+
+If a style calls a missing message ID, style-lint reports an error. If a message
+body references a variable not declared in the template component's `args`, the
+style/locale pair is invalid for that call site. At render time, a failed
+message evaluation suppresses the component rather than emitting partial glue.
 
 #### Supported `pattern.date-*` IDs
 
@@ -928,6 +991,11 @@ Engine behavior by `localeSchemaVersion`:
 
 ## Changelog
 
+- v1.5 (2026-06-24): Add style-template `message:` components as call sites
+  for locale-authored compositional phrases. Clarify the boundary between
+  atomic `term.*` labels and `pattern.*` phrases, define the initial required
+  phrase IDs, and deprecate template-schema `term:` for phrase realization
+  while retaining locale `term.*` message IDs.
 - v1.3 (2026-03-22): **Pivot to MF2.** Replace MF1 as the canonical message
   syntax with Unicode MessageFormat 2 (finalized standard). Implement custom
   dependency-free `Mf2MessageEvaluator` (no external crate — GPL-3.0 crates

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -124,13 +124,22 @@ parameterized if and only if its body contains a `{` character.
 
 ---
 
-### 1.4.1 Atomic Labels vs Compositional Phrases
+### 1.4.1 Lexical Labels vs Phrase Realization
 
-Locale messages have two different jobs:
+Locale messages have two different jobs, but the boundary is behavioral rather
+than a hard namespace split. Three terms recur below: a *lexical* item is the
+localized word or abbreviation a language picks (`editor` in English,
+`Herausgeber` in German); an *inflectional* form is that word varied by a
+grammatical feature such as count or gender (`ed.` vs `eds.`); and *phrase
+realization* is assembling already-rendered citation values into a
+natural-language fragment, with the locale supplying the glue text and word
+order.
 
-- **Atomic labels** (`term.*`, `role.*`) name a localizable word or short label:
-  `term.page-label`, `term.accessed`, `role.editor.label`.
-- **Compositional phrases** (`pattern.*`) assemble already-rendered citation
+- **Lexical or inflectional labels** (`term.*`, `role.*`) name a localizable
+  word, abbreviation, or role form: `term.page-label`, `term.accessed`,
+  `role.editor.label`. These IDs may still use MF2 when the label depends on
+  count, gender, or another grammatical selector.
+- **Phrase realization** (`pattern.*`) assembles already-rendered citation
   values into natural-language fragments: `pattern.accessed-date`,
   `pattern.in-container`, `pattern.available-at`, `pattern.retrieved-from`.
 
@@ -139,10 +148,19 @@ instead of spelling English glue with `term:` components, `prefix`, or `suffix`.
 The style still decides *which* phrase is needed and *which fields* supply its
 arguments; the active locale decides the phrase order and glue text.
 
+Role-related messages can belong to either side of this distinction. A suffix
+label like `role.editor.label` is lexical or inflectional. A role-plus-name
+phrase such as `edited by {$names}` is phrase realization and would be modeled
+as a dedicated `pattern.*` message — `pattern.editor-contribution` — when a
+style needs the locale to control placement or word order around the rendered
+names. Introducing and adopting that ID is deferred to the role-plus-name batch
+tracked in bean `csl26-fdzc`; no style calls it yet.
+
 The template-schema `term:` component remains parseable for compatibility but
-is deprecated for new phrase realization. This does not remove `term.*` message
-IDs from locale files; those IDs remain the canonical representation for atomic
-labels.
+is deprecated for new phrase realization, and will be removed as soon as the
+existing styles are upgraded to drop it. This does not remove `term.*` message
+IDs from locale files; those IDs remain the canonical representation for labels,
+abbreviations, and inflected role forms.
 
 ```yaml
 # Locale file
@@ -992,10 +1010,11 @@ Engine behavior by `localeSchemaVersion`:
 ## Changelog
 
 - v1.5 (2026-06-24): Add style-template `message:` components as call sites
-  for locale-authored compositional phrases. Clarify the boundary between
-  atomic `term.*` labels and `pattern.*` phrases, define the initial required
-  phrase IDs, and deprecate template-schema `term:` for phrase realization
-  while retaining locale `term.*` message IDs.
+  for locale-authored phrase realization. Clarify the behavioral boundary
+  between lexical or inflectional `term.*`/`role.*` messages and compositional
+  `pattern.*` phrases, define the initial required phrase IDs, and deprecate
+  template-schema `term:` for phrase realization while retaining locale
+  `term.*` message IDs.
 - v1.3 (2026-03-22): **Pivot to MF2.** Replace MF1 as the canonical message
   syntax with Unicode MessageFormat 2 (finalized standard). Implement custom
   dependency-free `Mf2MessageEvaluator` (no external crate — GPL-3.0 crates

--- a/docs/specs/TEMPLATE_V3.md
+++ b/docs/specs/TEMPLATE_V3.md
@@ -1,8 +1,8 @@
 # Template Schema v3 Specification
 
 **Status:** Active
-**Version:** 0.3
-**Date:** 2026-05-05
+**Version:** 0.4
+**Date:** 2026-06-24
 **Supersedes:** `docs/specs/TEMPLATE_V2.md`
 **Related:** csl26-t3v1, `docs/specs/DISTRIBUTED_RESOLVER.md`
 
@@ -21,6 +21,7 @@ This design explicitly **rejects "Macros"** to avoid the complexity and fragment
 **In Scope:**
 - `extends` keyword within `type-variants` (defaulting to the base `template`).
 - List-diff operations: `modify`, `add`, `remove`.
+- `message:` template components for locale-authored compositional phrases.
 - Expansion of `options` (e.g., `contributor-config`, `date-config`) to absorb shared logic.
 - Impact on `DistributedResolver` style-merging.
 
@@ -93,6 +94,32 @@ options:
       missing: "omit"
 ```
 
+### §2.3 Locale Message Components
+
+Templates MAY call a locale-authored phrase with `message:`. This component
+lives in the style template schema as `TemplateMessage`; it is evaluated by the
+active `Locale` at render time.
+
+```yaml
+- message: pattern.accessed-date
+  args:
+    date: { date: accessed, form: day-month-abbr-year }
+
+- message: pattern.in-container
+  args:
+    container: { title: parent-monograph, emph: true }
+  text-case: capitalize-first
+```
+
+Each `args` entry is rendered through the normal component pipeline before MF2
+evaluation. Supported argument sources are `literal`, `variable`, `date`,
+`title`, `contributor`, `number`, and `term`. The resulting strings become MF2
+named variables (`{$date}`, `{$container}`, etc.).
+
+The style owns phrase selection and argument selection; the locale owns word
+order and glue text. `term:` components remain readable for compatibility, but
+new localized phrase work SHOULD use `message:` and `pattern.*` locale IDs.
+
 ### §3 — Merge Operations (Formalized)
 
 The engine MUST process each operation list (`modify`, `remove`, `add`) in the order provided. The order of these keys (`modify`, `remove`, `add`) within a variant has no semantic effect.
@@ -143,6 +170,9 @@ Engines SHOULD treat unreachable or invalid parent URIs as resolution errors; st
 
 ## Changelog
 
+- v0.4 (2026-06-24): Add `message:` components for locale-authored MF2
+  compositional phrases and deprecate template `term:` as the long-term phrase
+  realization surface.
 - v0.3 (2026-05-05): Clarified terminology, matching semantics, order of operations, and validation rules. Added subscriber style example using localized terms instead of literal affixes.
 - v0.2 (2026-05-05): Pivoted to Pure Diff model. Removed Macros/Named Templates. Expanded role of style-level options.
 - v0.1 (2026-05-05): Initial draft (Macro-based).

--- a/docs/specs/TEMPLATE_V3.md
+++ b/docs/specs/TEMPLATE_V3.md
@@ -21,7 +21,7 @@ This design explicitly **rejects "Macros"** to avoid the complexity and fragment
 **In Scope:**
 - `extends` keyword within `type-variants` (defaulting to the base `template`).
 - List-diff operations: `modify`, `add`, `remove`.
-- `message:` template components for locale-authored compositional phrases.
+- `message:` template components for locale-authored phrase realization.
 - Expansion of `options` (e.g., `contributor-config`, `date-config`) to absorb shared logic.
 - Impact on `DistributedResolver` style-merging.
 
@@ -113,12 +113,15 @@ active `Locale` at render time.
 
 Each `args` entry is rendered through the normal component pipeline before MF2
 evaluation. Supported argument sources are `literal`, `variable`, `date`,
-`title`, `contributor`, `number`, and `term`. The resulting strings become MF2
-named variables (`{$date}`, `{$container}`, etc.).
+`title`, `contributor`, `number`, `term`, and `group`. The resulting strings
+become MF2 named variables (`{$date}`, `{$container}`, etc.).
 
 The style owns phrase selection and argument selection; the locale owns word
 order and glue text. `term:` components remain readable for compatibility, but
 new localized phrase work SHOULD use `message:` and `pattern.*` locale IDs.
+`term.*` and `role.*` message IDs remain valid for lexical labels,
+abbreviations, and inflected role forms; role-plus-name phrases can move to
+`pattern.*` when the locale needs to control placement around rendered names.
 
 ### §3 — Merge Operations (Formalized)
 
@@ -171,8 +174,8 @@ Engines SHOULD treat unreachable or invalid parent URIs as resolution errors; st
 ## Changelog
 
 - v0.4 (2026-06-24): Add `message:` components for locale-authored MF2
-  compositional phrases and deprecate template `term:` as the long-term phrase
-  realization surface.
+  phrase realization, including grouped argument sources, and deprecate
+  template `term:` as the long-term phrase realization surface.
 - v0.3 (2026-05-05): Clarified terminology, matching semantics, order of operations, and validation rules. Added subscriber style example using localized terms instead of literal affixes.
 - v0.2 (2026-05-05): Pivoted to Pure Diff model. Removed Macros/Named Templates. Expanded role of style-level options.
 - v0.1 (2026-05-05): Initial draft (Macro-based).

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -473,8 +473,9 @@ test('apa-7th concision regression reflects preset-first success', () => {
 
   assert.equal(concision.variantSelectors, 26, 'resolved APA should reflect the embedded authored variant selectors');
   // APA's disambiguation now uses the `author-date-full` preset instead of an inline
-  // custom block (plus the dropped explicit bibliography.sort), so concision improves.
-  assert.equal(concision.score, 63.3, `expected embedded APA concision, got ${concision.score}`);
+  // custom block, and chapter container introductions use a localized message
+  // phrase instead of a separate term-plus-title group, so concision improves.
+  assert.equal(concision.score, 64, `expected embedded APA concision, got ${concision.score}`);
 });
 
 test('report-core exposes expected benchmark labels for representative styles', () => {

--- a/scripts/report-data/oracle-top10-baseline.json
+++ b/scripts/report-data/oracle-top10-baseline.json
@@ -1,35 +1,22 @@
 {
   "totalStyles": 10,
   "citationsPerfect": 10,
-  "bibliographyPerfect": 1,
+  "bibliographyPerfect": 4,
   "citationsPartial": 0,
-  "bibliographyPartial": 9,
+  "bibliographyPartial": 6,
   "componentIssues": {
-    "year:value_mismatch": 17,
-    "title:value_mismatch": 22,
-    "publisher:value_mismatch": 5,
-    "doi:value_mismatch": 3,
-    "containerTitle:missing": 3,
-    "publisher:missing": 2,
-    "doi:missing": 4,
-    "publisher:extra": 5,
+    "year:value_mismatch": 8,
+    "title:value_mismatch": 11,
+    "publisher:value_mismatch": 3,
+    "doi:value_mismatch": 2,
+    "publisher:extra": 4,
+    "containerTitle:missing": 2,
     "doi:extra": 1,
-    "volume:missing": 2,
-    "containerTitle:value_mismatch": 1
+    "publisher:missing": 1,
+    "doi:missing": 2
   },
-  "orderingIssues": 17,
+  "orderingIssues": 10,
   "styleBreakdown": [
-    {
-      "style": "american-medical-association",
-      "citations": "20/20",
-      "bibliography": "39/48",
-      "rawCitations": "20/20",
-      "rawBibliography": "39/48",
-      "citationsPct": 100,
-      "bibliographyPct": 81,
-      "adjustedDivergences": {},
-      "templateSource": "inferred"
-    },
     {
       "style": "springer-basic-author-date",
       "citations": "20/20",
@@ -39,6 +26,29 @@
       "citationsPct": 100,
       "bibliographyPct": 94,
       "adjustedDivergences": {
+        "div-004": {
+          "scopes": [
+            "citation",
+            "bibliography"
+          ],
+          "tags": [
+            "missing-name-title-sort-order",
+            "sort-derived-numeric-citation-label"
+          ],
+          "note": "Missing-name works sort by title under author-based sorting. Adjusted verification excludes mismatches caused solely by this registered divergence while preserving raw citeproc deltas in reports.",
+          "adjustedCitations": 0,
+          "bibliographyOrderDifference": true,
+          "anonymousIds": [
+            "ITEM-15",
+            "ITEM-20",
+            "TLIB-SEL-DICT-1",
+            "TLIB-SEL-LEGISLATION-1",
+            "TLIB-SEL-STANDARD-1",
+            "TLIB-SEL-BILL-1",
+            "TLIB-SEL-HEARING-1",
+            "TLIB-SEL-REGULATION-1"
+          ]
+        },
         "div-008": {
           "scopes": [
             "citation",
@@ -88,58 +98,6 @@
       "templateSource": "inferred"
     },
     {
-      "style": "elsevier-harvard",
-      "citations": "20/20",
-      "bibliography": "45/47",
-      "rawCitations": "20/20",
-      "rawBibliography": "45/47",
-      "citationsPct": 100,
-      "bibliographyPct": 96,
-      "adjustedDivergences": {
-        "div-008": {
-          "scopes": [
-            "citation",
-            "bibliography"
-          ],
-          "tags": [
-            "same-family-secondary-sort-title-vs-given",
-            "sort-derived-numeric-citation-label"
-          ],
-          "note": "After a family-name match, citeproc-js sorts by given name (family → given → suffix → title); Citum sorts by title (family → title). Adjusted verification masks numeric citation labels that shift solely due to within-group reordering of same-family-name items, independent of the div-004 anonymous-item adjustment.",
-          "adjustedCitations": 0,
-          "bibliographyOrderDifference": true,
-          "swappedPairs": [
-            [
-              "ITEM-38",
-              "ITEM-37"
-            ],
-            [
-              "ITEM-37",
-              "ITEM-11"
-            ],
-            [
-              "ITEM-8",
-              "ITEM-1"
-            ],
-            [
-              "ITEM-30",
-              "ITEM-10"
-            ]
-          ],
-          "affectedIds": [
-            "ITEM-38",
-            "ITEM-37",
-            "ITEM-11",
-            "ITEM-8",
-            "ITEM-1",
-            "ITEM-30",
-            "ITEM-10"
-          ]
-        }
-      },
-      "templateSource": "inferred"
-    },
-    {
       "style": "elsevier-vancouver",
       "citations": "20/20",
       "bibliography": "45/47",
@@ -151,41 +109,6 @@
       "templateSource": "inferred"
     },
     {
-      "style": "chicago-author-date",
-      "citations": "20/20",
-      "bibliography": "44/46",
-      "rawCitations": "20/20",
-      "rawBibliography": "44/46",
-      "citationsPct": 100,
-      "bibliographyPct": 96,
-      "adjustedDivergences": {
-        "div-008": {
-          "scopes": [
-            "citation",
-            "bibliography"
-          ],
-          "tags": [
-            "same-family-secondary-sort-title-vs-given",
-            "sort-derived-numeric-citation-label"
-          ],
-          "note": "After a family-name match, citeproc-js sorts by given name (family → given → suffix → title); Citum sorts by title (family → title). Adjusted verification masks numeric citation labels that shift solely due to within-group reordering of same-family-name items, independent of the div-004 anonymous-item adjustment.",
-          "adjustedCitations": 0,
-          "bibliographyOrderDifference": true,
-          "swappedPairs": [
-            [
-              "ITEM-32",
-              "ITEM-31"
-            ]
-          ],
-          "affectedIds": [
-            "ITEM-32",
-            "ITEM-31"
-          ]
-        }
-      },
-      "templateSource": "inferred"
-    },
-    {
       "style": "apa",
       "citations": "20/20",
       "bibliography": "45/46",
@@ -194,6 +117,29 @@
       "citationsPct": 100,
       "bibliographyPct": 98,
       "adjustedDivergences": {
+        "div-004": {
+          "scopes": [
+            "citation",
+            "bibliography"
+          ],
+          "tags": [
+            "missing-name-title-sort-order",
+            "sort-derived-numeric-citation-label"
+          ],
+          "note": "Missing-name works sort by title under author-based sorting. Adjusted verification excludes mismatches caused solely by this registered divergence while preserving raw citeproc deltas in reports.",
+          "adjustedCitations": 0,
+          "bibliographyOrderDifference": true,
+          "anonymousIds": [
+            "ITEM-20",
+            "TLIB-SEL-LEGISLATION-1",
+            "TLIB-SEL-BILL-1",
+            "TLIB-SEL-STANDARD-1",
+            "TLIB-SEL-REGULATION-1",
+            "TLIB-SEL-DICT-1",
+            "TLIB-SEL-HEARING-1",
+            "ITEM-15"
+          ]
+        },
         "div-008": {
           "scopes": [
             "citation",
@@ -243,6 +189,17 @@
       "templateSource": "inferred"
     },
     {
+      "style": "elsevier-harvard",
+      "citations": "20/20",
+      "bibliography": "47/47",
+      "rawCitations": "20/20",
+      "rawBibliography": "47/47",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "adjustedDivergences": {},
+      "templateSource": "inferred"
+    },
+    {
       "style": "ieee",
       "citations": "20/20",
       "bibliography": "47/47",
@@ -252,17 +209,39 @@
       "bibliographyPct": 100,
       "adjustedDivergences": {},
       "templateSource": "inferred"
+    },
+    {
+      "style": "american-medical-association",
+      "citations": "20/20",
+      "bibliography": "47/47",
+      "rawCitations": "20/20",
+      "rawBibliography": "47/47",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "adjustedDivergences": {},
+      "templateSource": "inferred"
+    },
+    {
+      "style": "chicago-author-date",
+      "citations": "20/20",
+      "bibliography": "46/46",
+      "rawCitations": "20/20",
+      "rawBibliography": "46/46",
+      "citationsPct": 100,
+      "bibliographyPct": 100,
+      "adjustedDivergences": {},
+      "templateSource": "inferred"
     }
   ],
   "errors": [],
   "metadata": {
-    "timestamp": "2026-06-18T13:41:57.710Z",
-    "gitCommit": "7b301191",
+    "timestamp": "2026-06-25T00:20:24.862Z",
+    "gitCommit": "b0ce930f",
     "generator": "scripts/oracle-batch-aggregate.js",
-    "duration": "29.4s",
+    "duration": "15.9s",
     "concurrency": 1,
     "fixture": "tests/fixtures/citations-expanded.json",
-    "styleSelector": "top:10",
+    "styleSelector": "explicit",
     "styles": [
       "apa",
       "elsevier-harvard",

--- a/scripts/report-data/oracle-top10-baseline.json
+++ b/scripts/report-data/oracle-top10-baseline.json
@@ -6,25 +6,25 @@
   "bibliographyPartial": 6,
   "componentIssues": {
     "year:value_mismatch": 8,
-    "title:value_mismatch": 11,
+    "title:value_mismatch": 10,
     "publisher:value_mismatch": 3,
     "doi:value_mismatch": 2,
     "publisher:extra": 4,
-    "containerTitle:missing": 2,
     "doi:extra": 1,
     "publisher:missing": 1,
-    "doi:missing": 2
+    "doi:missing": 2,
+    "containerTitle:value_mismatch": 1
   },
-  "orderingIssues": 10,
+  "orderingIssues": 9,
   "styleBreakdown": [
     {
       "style": "springer-basic-author-date",
       "citations": "20/20",
-      "bibliography": "44/47",
+      "bibliography": "45/47",
       "rawCitations": "20/20",
-      "rawBibliography": "44/47",
+      "rawBibliography": "45/47",
       "citationsPct": 100,
-      "bibliographyPct": 94,
+      "bibliographyPct": 96,
       "adjustedDivergences": {
         "div-004": {
           "scopes": [
@@ -76,29 +76,29 @@
       "templateSource": "inferred"
     },
     {
+      "style": "elsevier-vancouver",
+      "citations": "20/20",
+      "bibliography": "45/47",
+      "rawCitations": "20/20",
+      "rawBibliography": "45/47",
+      "citationsPct": 100,
+      "bibliographyPct": 96,
+      "adjustedDivergences": {},
+      "templateSource": "inferred"
+    },
+    {
       "style": "nature",
       "citations": "20/20",
-      "bibliography": "44/47",
+      "bibliography": "45/47",
       "rawCitations": "20/20",
-      "rawBibliography": "44/47",
+      "rawBibliography": "45/47",
       "citationsPct": 100,
-      "bibliographyPct": 94,
+      "bibliographyPct": 96,
       "adjustedDivergences": {},
       "templateSource": "inferred"
     },
     {
       "style": "cell",
-      "citations": "20/20",
-      "bibliography": "45/48",
-      "rawCitations": "20/20",
-      "rawBibliography": "45/48",
-      "citationsPct": 100,
-      "bibliographyPct": 94,
-      "adjustedDivergences": {},
-      "templateSource": "inferred"
-    },
-    {
-      "style": "elsevier-vancouver",
       "citations": "20/20",
       "bibliography": "45/47",
       "rawCitations": "20/20",
@@ -235,10 +235,10 @@
   ],
   "errors": [],
   "metadata": {
-    "timestamp": "2026-06-25T00:20:24.862Z",
-    "gitCommit": "b0ce930f",
+    "timestamp": "2026-06-25T11:36:52.635Z",
+    "gitCommit": "028ef881",
     "generator": "scripts/oracle-batch-aggregate.js",
-    "duration": "15.9s",
+    "duration": "16.2s",
     "concurrency": 1,
     "fixture": "tests/fixtures/citations-expanded.json",
     "styleSelector": "explicit",


### PR DESCRIPTION
## Summary
- add `TemplateMessage` / `message:` style-template component for locale-authored MF2 phrase calls
- extend locale message args/resolution and render message args through normal component rendering
- document the schema/template boundary, seed initial phrase IDs in embedded locales, and regenerate schemas

## Checks
- `cargo test -p citum-schema-style --lib -- --nocapture`
- `cargo test -p citum-engine --lib test_message_component -- --nocapture`
- `just schema-gen`
- `just pre-commit`
- pre-push hook reran fmt, clippy, and nextest before push
