### PR TITLE
Track contributor phrase localization follow-up

### DIFF
--- a/.beans/archive/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
+++ b/.beans/archive/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md
@@ -1,7 +1,7 @@
 ---
 # csl26-fdzc
 title: Migrate styles to localized message phrase calls
-status: in-progress
+status: completed
 type: task
 priority: high
 tags:
@@ -9,7 +9,7 @@ tags:
     - localization
     - mf2
 created_at: 2026-06-25T00:22:34Z
-updated_at: 2026-06-26T11:40:06Z
+updated_at: 2026-06-26T12:29:28Z
 ---
 
 ## Problem
@@ -94,7 +94,7 @@ through the rest of `styles/` by style family or shared template pattern.
 - Refreshed the top-10 oracle baseline after confirming the current aggregate
   has `cell` at 45/47 bibliography entries and no oracle regressions.
 
-## PR #966 Follow-up Documentation
+## PR #966 Completion And Split-Out
 
 - PR #966 completes the checked-in template `term:` migration without taking on
   richer contributor phrase semantics. The immediate invariant remains:
@@ -108,10 +108,11 @@ through the rest of `styles/` by style family or shared template pattern.
   italicized `In` inside a locale phrase. A future message pipeline should
   return format-neutral inline fragments before MF2 markup elements or any
   constrained inline message-body markup is enabled.
-- Contributor-plus-role phrase realization is deferred. AMA-style `In:`
-  editor/title phrasing and APA-style container contributor/title phrasing need
-  future `pattern.*` messages with a designed argument shape; exact message IDs
-  are intentionally not reserved in this batch.
+- Contributor-plus-role phrase realization is split out to `csl26-eh5c`.
+  AMA-style `In:` editor/title phrasing and APA-style container
+  contributor/title phrasing need future `pattern.*` messages with a designed
+  argument shape; exact message IDs are intentionally not reserved in this
+  completed migration batch.
 - The durable design boundary is documented in
   `docs/specs/LOCALE_MESSAGES.md`, with a cross-reference from
   `docs/specs/DJOT_RICH_TEXT.md`.

--- a/.beans/csl26-eh5c--design-locale-authored-contributor-phrase-messages.md
+++ b/.beans/csl26-eh5c--design-locale-authored-contributor-phrase-messages.md
@@ -1,0 +1,56 @@
+---
+# csl26-eh5c
+title: Design locale-authored contributor phrase messages
+status: todo
+type: feature
+priority: high
+tags:
+    - localization
+    - mf2
+    - contributors
+    - styles
+created_at: 2026-06-26T12:29:18Z
+updated_at: 2026-06-26T12:29:18Z
+---
+
+## Problem
+
+PR #966 migrated checked-in style phrase glue away from rendered template
+`term:` components and into locale-owned `message: pattern.*` calls. It
+deliberately did not solve contributor-plus-role phrase realization.
+
+AMA-style `In:` editor/title phrasing and APA-style container
+contributor/title phrasing still need a locale-owned message model. The locale
+needs to control how rendered names, role labels, counts, genders, punctuation,
+and rendered container/title fragments are ordered around each other without
+forcing English glue back into style templates.
+
+## Scope
+
+Design the contributor phrase message model before implementation. This bean
+owns the argument shape, initial motivating cases, and acceptance criteria for a
+later implementation PR.
+
+Do not treat contributor `label.term` as deprecated template `term:`.
+`label.term` remains the schema-native lexical role-label mechanism until and
+unless the contributor phrase model deliberately replaces a complete
+role-plus-name phrase.
+
+## Acceptance Criteria
+
+- Define the argument model for contributor phrase messages: rendered names,
+  role label/form, contributor count/gender where needed, and rendered
+  container/title fragments.
+- Decide initial `pattern.*` IDs in the design/implementation PR, not in this
+  tracking bean.
+- Cover motivating cases from AMA `In:` editor/title phrasing and APA
+  container-contributor/title phrasing.
+- Preserve `label.term` for lexical role labels; do not treat it as deprecated template `term:`.
+- Add tests or fidelity checks in the eventual implementation PR for AMA, APA,
+  and at least one reordered locale example.
+
+## Related
+
+- Split from `csl26-fdzc` after PR #966 completed the checked-in rendered
+  template `term:` migration.
+- Spec context: `docs/specs/LOCALE_MESSAGES.md`.

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -5,7 +5,8 @@
 **Date:** 2026-06-26
 **Supersedes:** (none)
 **Related:** bean `csl26-qrpo` (ICU4X upgrade), bean `csl26-v6ok`
-(locale-authored date patterns), bean `csl26-fdzc` (style phrase migration)
+(locale-authored date patterns), bean `csl26-fdzc` (style phrase migration),
+bean `csl26-eh5c` (contributor phrase messages)
 
 ## Purpose
 
@@ -154,8 +155,8 @@ label like `role.editor.label` is lexical or inflectional. A role-plus-name
 phrase such as `edited by {$names}` is phrase realization and would be modeled
 as a dedicated `pattern.*` message — `pattern.editor-contribution` — when a
 style needs the locale to control placement or word order around the rendered
-names. Introducing and adopting that ID is deferred to the role-plus-name batch
-tracked in bean `csl26-fdzc`; no style calls it yet.
+names. Introducing and adopting that ID is deferred to the contributor phrase
+batch tracked in bean `csl26-eh5c`; no style calls it yet.
 
 Two current style families motivate that deferred batch:
 
@@ -253,7 +254,7 @@ placeholder fragments.
 
 This boundary keeps the current style migration narrow: phrase localization
 moves English glue into `pattern.*` messages, while rich message bodies and full
-contributor phrase realization remain future work under bean `csl26-fdzc`.
+contributor phrase realization remain future work under bean `csl26-eh5c`.
 
 ---
 


### PR DESCRIPTION
## Summary

- create `csl26-eh5c` to track locale-authored contributor phrase messages
- retarget contributor phrase references in `LOCALE_MESSAGES.md` from the completed migration bean to the new bean
- archive `csl26-fdzc` as the completed PR #966 term-template migration task

## Why

PR #966 intentionally deferred contributor-plus-role phrase realization while completing the rendered `term:` migration. That future work needs its own open owner instead of being implied by the completed migration bean.

## Validation

- `beans show csl26-eh5c`
- `rg "role-plus-name|contributor phrase|csl26-fdzc|csl26-eh5c" docs/specs/LOCALE_MESSAGES.md .beans/csl26-eh5c--design-locale-authored-contributor-phrase-messages.md .beans/archive/csl26-fdzc--migrate-styles-to-localized-message-phrase-calls.md`
- `./scripts/check-bean-hygiene.sh`
- `git diff --check`
