### PR TITLE
rename effective issued date accessor

### DIFF
--- a/crates/citum-engine/src/grouping/sorting.rs
+++ b/crates/citum-engine/src/grouping/sorting.rs
@@ -364,7 +364,7 @@ impl<'a> GroupSorter<'a> {
 
     fn issued_year(reference: &Reference) -> Option<i32> {
         reference
-            .csl_issued_date()
+            .effective_issued_date()
             .and_then(|d| d.year().parse::<i32>().ok())
             .filter(|year| *year != 0)
     }

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -802,7 +802,7 @@ impl Processor {
                 format_contributors_short(&names, &options)
             }),
             year: reference
-                .csl_issued_date()
+                .effective_issued_date()
                 .map(|issued| issued.year().clone()),
             title: reference.title().map(|title| {
                 use citum_schema::reference::types::{MultilingualString, Title};

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -840,7 +840,7 @@ impl<'a> Disambiguator<'a> {
         key.push_str(author_key);
         key.push(':');
         let Some(year) = reference
-            .csl_issued_date()
+            .effective_issued_date()
             .and_then(|d| d.year().parse::<i32>().ok())
         else {
             return key;

--- a/crates/citum-engine/src/processor/labels.rs
+++ b/crates/citum-engine/src/processor/labels.rs
@@ -86,7 +86,7 @@ fn generate_name_part(reference: &Reference, params: &LabelParams) -> String {
 
 fn generate_year_part(reference: &Reference, year_digits: u8) -> String {
     reference
-        .csl_issued_date()
+        .effective_issued_date()
         .and_then(|d| d.year().parse::<i32>().ok())
         .map(|y| {
             let y_str = y.to_string();

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1155,7 +1155,7 @@ impl Renderer<'_> {
                 date: citum_schema::template::DateVariable::Issued,
                 ..
             })
-        ) || reference.csl_issued_date().is_some()
+        ) || reference.effective_issued_date().is_some()
             || self.preferred_no_date_term_form() != citum_schema::locale::TermForm::Long
         {
             return;

--- a/crates/citum-engine/src/processor/sorting.rs
+++ b/crates/citum-engine/src/processor/sorting.rs
@@ -101,11 +101,11 @@ impl<'a> Sorter<'a> {
                         }
                         SortKey::Year => {
                             let a_year = a
-                                .csl_issued_date()
+                                .effective_issued_date()
                                 .and_then(|d| d.year().parse::<i32>().ok())
                                 .filter(|year| *year != 0);
                             let b_year = b
-                                .csl_issued_date()
+                                .effective_issued_date()
                                 .and_then(|d| d.year().parse::<i32>().ok())
                                 .filter(|year| *year != 0);
 

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -739,7 +739,7 @@ impl ComponentValues for TemplateDate {
     ) -> Option<ProcValues<F::Output>> {
         let fmt = F::default();
         let date_opt: Option<EdtfString> = match self.date {
-            TemplateDateVar::Issued => reference.csl_issued_date(),
+            TemplateDateVar::Issued => reference.effective_issued_date(),
             TemplateDateVar::Accessed => reference.accessed(),
             TemplateDateVar::OriginalPublished => reference.original_date(),
             _ => None,

--- a/crates/citum-io/src/formats/csl_json.rs
+++ b/crates/citum-io/src/formats/csl_json.rs
@@ -20,7 +20,7 @@ pub(crate) fn input_reference_to_csl_json(reference: &InputReference) -> LegacyR
     r.language = reference.language().map(|lang| lang.to_string());
     r.note = reference.note().map(|rt| rt.raw().to_string());
     r.doi = reference.doi();
-    r.issued = reference.csl_issued_date().and_then(|d| {
+    r.issued = reference.effective_issued_date().and_then(|d| {
         let year = d.0.get(0..4)?.parse::<i32>().ok()?;
         Some(DateVariable::year(year))
     });

--- a/crates/citum-io/src/formats/output.rs
+++ b/crates/citum-io/src/formats/output.rs
@@ -46,7 +46,7 @@ pub(crate) fn render_biblatex(input: &InputBibliography) -> String {
                 let _ = writeln!(&mut out, "  author = {{{}}},", names.join(" and "));
             }
         }
-        if let Some(issued) = reference.csl_issued_date()
+        if let Some(issued) = reference.effective_issued_date()
             && let Some(year) = issued.0.get(0..4)
         {
             let _ = writeln!(&mut out, "  year = {{{year}}},");
@@ -80,7 +80,7 @@ pub(crate) fn render_ris(input: &InputBibliography) -> String {
                 let _ = writeln!(&mut out, "AU  - {name}");
             }
         }
-        if let Some(issued) = reference.csl_issued_date()
+        if let Some(issued) = reference.effective_issued_date()
             && let Some(year) = issued.0.get(0..4)
         {
             let _ = writeln!(&mut out, "PY  - {year}");

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -567,8 +567,9 @@ impl InputReference {
         }
     }
 
-    /// Return the effective issued date used for compatibility layers.
-    pub fn csl_issued_date(&self) -> Option<EdtfString> {
+    /// Return the effective issued date, falling back to the created date when
+    /// no explicit issued date is present.
+    pub fn effective_issued_date(&self) -> Option<EdtfString> {
         self.issued().or_else(|| self.created())
     }
 
@@ -1329,7 +1330,7 @@ impl InputReference {
 
     /// Return the original publication date.
     pub fn original_date(&self) -> Option<EdtfString> {
-        self.original_embedded()?.csl_issued_date()
+        self.original_embedded()?.effective_issued_date()
     }
 
     /// Return the original title.

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -446,11 +446,11 @@ fn unpublished_legacy_records_promote_issued_to_created() {
 
     assert_eq!(reference.created().unwrap().0, "1973-01-01");
     assert_eq!(reference.issued().unwrap().0, "1973-01-01");
-    assert_eq!(reference.csl_issued_date().unwrap().0, "1973-01-01");
+    assert_eq!(reference.effective_issued_date().unwrap().0, "1973-01-01");
 }
 
 #[test]
-fn created_date_backfills_csl_issued_compatibility() {
+fn created_date_backfills_effective_issued_date() {
     let reference = InputReference::Monograph(Box::new(Monograph {
         id: Some("created-only".into()),
         r#type: MonographType::Manuscript,
@@ -461,7 +461,7 @@ fn created_date_backfills_csl_issued_compatibility() {
 
     assert_eq!(reference.issued(), None);
     assert_eq!(reference.created().unwrap().0, "1954-05-17");
-    assert_eq!(reference.csl_issued_date().unwrap().0, "1954-05-17");
+    assert_eq!(reference.effective_issued_date().unwrap().0, "1954-05-17");
 }
 
 #[test]

--- a/docs/specs/DISAMBIGUATION.md
+++ b/docs/specs/DISAMBIGUATION.md
@@ -43,7 +43,7 @@ names, joined by commas, with the et-al suffix included when the name list is
 abbreviated by the style's `shorten` config. This matches what the style will
 visually show, so disambiguation keys track rendered output without re-rendering.
 
-**Year key** (`build_group_key`): the `issued` year (`csl_issued_date()`),
+**Year key** (`build_group_key`): the `issued` year (`effective_issued_date()`),
 appended to the author key. **No other date field participates in the key.**
 
 #### Year-suffix when the original-publication date differs

--- a/docs/specs/ORIGINAL_PUBLICATION_RELATION_SUPPORT.md
+++ b/docs/specs/ORIGINAL_PUBLICATION_RELATION_SUPPORT.md
@@ -37,7 +37,7 @@ The accessor methods in `InputReference` will be updated to match all variants.
 
 - **Files**: `crates/citum-schema-data/src/reference/mod.rs`
 - **Methods**: `original_date()`, `original_title()`, `original_publisher_str()`, `original_publisher_place()`.
-- **Logic Change**: In `original_date()`, the embedded reference's date will be fetched via `p.csl_issued_date()` instead of `p.issued()`. This ensures that if the original work only has a `created` date (common for unpublished works or archival items), it is correctly picked up as the "original date".
+- **Logic Change**: In `original_date()`, the embedded reference's date will be fetched via `p.effective_issued_date()` instead of `p.issued()`. This ensures that if the original work only has a `created` date (common for unpublished works or archival items), it is correctly picked up as the "original date".
 
 ### 3. Legacy CSL-JSON Migration
 The CSL-JSON to Citum conversion logic will be updated to read `original-title` from the structured `csl_legacy::csl_json::Reference.original_title` field and extract the remaining legacy `original-*` data (`original-author`, `original-date`, `original-publisher`, `original-publisher-place`) from the `extra` map, then populate the `original` struct.


### PR DESCRIPTION
## Summary
- Rename `InputReference::csl_issued_date()` to `effective_issued_date()`.
- Update engine, IO, schema-data tests, and specs to use the Citum-domain name.
- Keep behavior unchanged: explicit `issued()` still wins, with `created()` as fallback.

## Validation
- `rg "csl_issued_date" crates docs`
- `cargo test -p citum-schema-data --features legacy-convert created_date_backfills_effective_issued_date`
- `cargo test -p citum-engine`
- `cargo test -p citum-io`
- `just pre-commit`
- pre-push hook: fmt, clippy, and 1689 nextest tests passed
