### PR TITLE
refactor(cli,migrate): break module cycles

### DIFF
--- a/crates/citum-cli/src/commands/catalog.rs
+++ b/crates/citum-cli/src/commands/catalog.rs
@@ -3,68 +3,17 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-//! Style catalog: row type, source filter, pagination, formatting, and
-//! source-aggregating lookup.
+//! Style catalog source filtering, pagination, formatting, and aggregation.
 
 use super::CliResult;
 use super::registry::load_registry_chain;
 use crate::args::StyleCatalogFormat;
+use crate::style_catalog::StyleCatalogRow;
 use crate::table::build_table;
 use citum_schema::RegistryEntry;
 use citum_store::{StoreConfig, StoreResolver, platform_data_dir};
-use serde::Serialize;
 use std::error::Error;
 use std::fmt::Write as _;
-
-/// A single row in a style listing. `pub(crate)` so `style_browser` can take
-/// rows in its config.
-#[derive(Clone, Debug, Serialize)]
-pub(crate) struct StyleCatalogRow {
-    pub(crate) source: String,
-    pub(crate) id: String,
-    pub(crate) aliases: Vec<String>,
-    pub(crate) title: Option<String>,
-    pub(crate) description: Option<String>,
-    pub(crate) fields: Vec<String>,
-    pub(crate) url: Option<String>,
-}
-
-impl StyleCatalogRow {
-    /// Build a row from a registry entry, resolving the title from embedded
-    /// style metadata when the entry omits one.
-    pub(super) fn from_entry(source: &str, entry: &RegistryEntry) -> Self {
-        let title = entry.title.clone().or_else(|| {
-            entry.builtin.as_ref().and_then(|builtin| {
-                citum_schema::embedded::get_embedded_style(builtin)
-                    .and_then(Result::ok)
-                    .and_then(|style| style.info.title)
-            })
-        });
-
-        Self {
-            source: source.to_string(),
-            id: entry.id.clone(),
-            aliases: entry.aliases.clone(),
-            title,
-            description: entry.description.clone(),
-            fields: entry.fields.clone(),
-            url: entry.url.clone(),
-        }
-    }
-
-    /// Build a row for a user-installed style, where only the id is known.
-    pub(super) fn installed(id: String) -> Self {
-        Self {
-            source: "installed".to_string(),
-            id,
-            aliases: Vec::new(),
-            title: None,
-            description: None,
-            fields: Vec::new(),
-            url: None,
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum CatalogSourceFilter<'a> {

--- a/crates/citum-cli/src/commands/mod.rs
+++ b/crates/citum-cli/src/commands/mod.rs
@@ -21,8 +21,6 @@ mod style;
 mod style_install;
 mod util;
 
-pub(crate) use catalog::StyleCatalogRow;
-
 use crate::args::{CheckArgs, Cli, Commands, InputFormat, RefsFormat, RenderDocArgs};
 use citum_io::RefsFormat as EngineRefsFormat;
 use clap::{CommandFactory, Parser};

--- a/crates/citum-cli/src/commands/style.rs
+++ b/crates/citum-cli/src/commands/style.rs
@@ -10,13 +10,14 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use super::CliResult;
 use super::catalog::{
-    CatalogSourceFilter, StyleCatalogPage, StyleCatalogRow, paginate_style_catalog_rows,
-    print_style_catalog_rows, style_catalog_entries, style_row_matches_query,
+    CatalogSourceFilter, StyleCatalogPage, paginate_style_catalog_rows, print_style_catalog_rows,
+    style_catalog_entries, style_row_matches_query,
 };
 use super::lint::run_lint_style;
 use super::style_install::{CliStyleBrowserActions, run_style_add, run_style_remove};
 use crate::args::{StyleCatalogFormat, StyleCommands};
 use crate::style_browser::{StyleBrowserConfig, run_style_browser};
+use crate::style_catalog::StyleCatalogRow;
 use citum_schema::{Locale, Style};
 use citum_store::{StoreConfig, StoreResolver, platform_data_dir};
 use std::error::Error;

--- a/crates/citum-cli/src/commands/style_install.rs
+++ b/crates/citum-cli/src/commands/style_install.rs
@@ -6,11 +6,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! Install and remove user-installed styles, and the style-browser action shim.
 
 use super::CliResult;
-use super::catalog::{
-    CatalogSourceFilter, StyleCatalogRow, style_catalog_entries, style_row_matches_query,
-};
+use super::catalog::{CatalogSourceFilter, style_catalog_entries, style_row_matches_query};
 use super::util::{confirm, validate_resource_name};
 use crate::style_browser::StyleBrowserActions;
+use crate::style_catalog::StyleCatalogRow;
 use crate::style_resolver::load_any_style;
 use citum_schema::Style;
 use citum_store::{StoreConfig, StoreResolver, platform_data_dir};

--- a/crates/citum-cli/src/main.rs
+++ b/crates/citum-cli/src/main.rs
@@ -14,6 +14,7 @@ mod args;
 mod commands;
 mod output;
 mod style_browser;
+mod style_catalog;
 mod style_resolver;
 mod table;
 mod typst_pdf;

--- a/crates/citum-cli/src/style_browser.rs
+++ b/crates/citum-cli/src/style_browser.rs
@@ -3,7 +3,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-use crate::commands::StyleCatalogRow;
+use crate::style_catalog::StyleCatalogRow;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     execute,

--- a/crates/citum-cli/src/style_catalog.rs
+++ b/crates/citum-cli/src/style_catalog.rs
@@ -1,0 +1,65 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Shared style catalog row data used by CLI commands and the style browser.
+
+use citum_schema::RegistryEntry;
+use serde::Serialize;
+
+/// A single row in a style listing or browser view.
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct StyleCatalogRow {
+    /// Source label for the row, such as `embedded`, `installed`, or `registry:<name>`.
+    pub(crate) source: String,
+    /// Canonical style identifier.
+    pub(crate) id: String,
+    /// Alternate names that resolve to the same style.
+    pub(crate) aliases: Vec<String>,
+    /// Human-readable style title, when known.
+    pub(crate) title: Option<String>,
+    /// Optional catalog summary.
+    pub(crate) description: Option<String>,
+    /// Citation fields associated with the style catalog entry.
+    pub(crate) fields: Vec<String>,
+    /// Remote or registry URL for the style, when known.
+    pub(crate) url: Option<String>,
+}
+
+impl StyleCatalogRow {
+    /// Build a row from a registry entry, resolving the title from embedded
+    /// style metadata when the entry omits one.
+    pub(crate) fn from_entry(source: &str, entry: &RegistryEntry) -> Self {
+        let title = entry.title.clone().or_else(|| {
+            entry.builtin.as_ref().and_then(|builtin| {
+                citum_schema::embedded::get_embedded_style(builtin)
+                    .and_then(Result::ok)
+                    .and_then(|style| style.info.title)
+            })
+        });
+
+        Self {
+            source: source.to_string(),
+            id: entry.id.clone(),
+            aliases: entry.aliases.clone(),
+            title,
+            description: entry.description.clone(),
+            fields: entry.fields.clone(),
+            url: entry.url.clone(),
+        }
+    }
+
+    /// Build a row for a user-installed style, where only the id is known.
+    pub(crate) fn installed(id: String) -> Self {
+        Self {
+            source: "installed".to_string(),
+            id,
+            aliases: Vec::new(),
+            title: None,
+            description: None,
+            fields: Vec::new(),
+            url: None,
+        }
+    }
+}

--- a/crates/citum-migrate/src/template_compiler/compilation.rs
+++ b/crates/citum-migrate/src/template_compiler/compilation.rs
@@ -6,6 +6,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use super::{
     BranchContext, ComponentOccurrence, IndexMap, Node, TemplateCompiler, TemplateComponent,
     TemplateGroup,
+    formatting::{
+        apply_wrap_to_component, convert_formatting, extract_source_order, get_component_rendering,
+        infer_wrap_from_affixes, map_delimiter, set_component_rendering,
+    },
 };
 
 impl TemplateCompiler {
@@ -26,20 +30,20 @@ impl TemplateCompiler {
         let mut next_comp = self.compile_node(next_node)?;
 
         // Merge text into prefix
-        let mut rendering = self.get_component_rendering(&next_comp);
+        let mut rendering = get_component_rendering(&next_comp);
         let mut new_prefix = text_value.to_string();
         if let Some(p) = rendering.prefix {
             new_prefix.push_str(&p);
         }
         rendering.prefix = Some(new_prefix);
-        self.set_component_rendering(&mut next_comp, rendering);
+        set_component_rendering(&mut next_comp, rendering);
 
         // Apply inherited wrap if applicable
         if inherited_wrap.0.is_some() && matches!(&next_comp, TemplateComponent::Date(_)) {
-            self.apply_wrap_to_component(&mut next_comp, inherited_wrap);
+            apply_wrap_to_component(&mut next_comp, inherited_wrap);
         }
 
-        let source_order = self.extract_source_order(next_node);
+        let source_order = extract_source_order(next_node);
         Some((next_comp, source_order))
     }
 
@@ -86,9 +90,9 @@ impl TemplateCompiler {
             if let Some(mut component) = self.compile_node(node) {
                 // Apply inherited wrap to date components
                 if inherited_wrap.0.is_some() && matches!(&component, TemplateComponent::Date(_)) {
-                    self.apply_wrap_to_component(&mut component, inherited_wrap);
+                    apply_wrap_to_component(&mut component, inherited_wrap);
                 }
-                let source_order = self.extract_source_order(node);
+                let source_order = extract_source_order(node);
                 occurrences.push(ComponentOccurrence {
                     component,
                     context: context.clone(),
@@ -150,9 +154,9 @@ impl TemplateCompiler {
 
             if let Some(mut component) = self.compile_node(node) {
                 if inherited_wrap.0.is_some() && matches!(&component, TemplateComponent::Date(_)) {
-                    self.apply_wrap_to_component(&mut component, inherited_wrap);
+                    apply_wrap_to_component(&mut component, inherited_wrap);
                 }
-                let source_order = self.extract_source_order(node);
+                let source_order = extract_source_order(node);
                 occurrences.push(ComponentOccurrence {
                     component,
                     context: context.clone(),
@@ -194,7 +198,7 @@ impl TemplateCompiler {
         occurrences: &mut Vec<ComponentOccurrence>,
     ) {
         // Check if this group has its own wrap
-        let group_wrap = Self::infer_wrap_from_affixes(&g.formatting.prefix, &g.formatting.suffix);
+        let group_wrap = infer_wrap_from_affixes(&g.formatting.prefix, &g.formatting.suffix);
         let effective_wrap = if group_wrap.0.is_some() {
             group_wrap.clone()
         } else {
@@ -238,8 +242,8 @@ impl TemplateCompiler {
         if (should_be_list || must_preserve_as_group) && !group_components.is_empty() {
             let list = TemplateComponent::Group(TemplateGroup {
                 group: group_components,
-                delimiter: self.map_delimiter(&g.delimiter),
-                rendering: self.convert_formatting(&g.formatting),
+                delimiter: map_delimiter(&g.delimiter),
+                rendering: convert_formatting(&g.formatting),
                 ..Default::default()
             });
             let source_order = g.source_order;
@@ -265,7 +269,7 @@ impl TemplateCompiler {
         context: &BranchContext,
         occurrences: &mut Vec<ComponentOccurrence>,
     ) {
-        let group_wrap = Self::infer_wrap_from_affixes(&g.formatting.prefix, &g.formatting.suffix);
+        let group_wrap = infer_wrap_from_affixes(&g.formatting.prefix, &g.formatting.suffix);
         let effective_wrap = if group_wrap.0.is_some() {
             group_wrap.clone()
         } else {
@@ -302,8 +306,8 @@ impl TemplateCompiler {
         if (should_be_list || must_preserve_as_group) && !group_components.is_empty() {
             let list = TemplateComponent::Group(TemplateGroup {
                 group: group_components,
-                delimiter: self.map_delimiter(&g.delimiter),
-                rendering: self.convert_formatting(&g.formatting),
+                delimiter: map_delimiter(&g.delimiter),
+                rendering: convert_formatting(&g.formatting),
                 ..Default::default()
             });
             occurrences.push(ComponentOccurrence {
@@ -473,15 +477,15 @@ impl TemplateCompiler {
 
             if has_default {
                 // Component appears in default branch → visible by default
-                let mut base_rendering = self.get_component_rendering(&merged);
+                let mut base_rendering = get_component_rendering(&merged);
                 base_rendering.suppress = Some(false);
-                self.set_component_rendering(&mut merged, base_rendering);
+                set_component_rendering(&mut merged, base_rendering);
             } else {
                 // Component ONLY in type-specific branches → hidden by default
                 // Type-variants entries (from compile_for_type) handle per-type visibility.
-                let mut base_rendering = self.get_component_rendering(&merged);
+                let mut base_rendering = get_component_rendering(&merged);
                 base_rendering.suppress = Some(true);
-                self.set_component_rendering(&mut merged, base_rendering);
+                set_component_rendering(&mut merged, base_rendering);
             }
 
             // Position the merged component by its default-branch occurrence when

--- a/crates/citum-migrate/src/template_compiler/deduplication.rs
+++ b/crates/citum-migrate/src/template_compiler/deduplication.rs
@@ -3,7 +3,10 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-use super::{Node, Rendering, TemplateCompiler, TemplateComponent, TemplateGroup};
+use super::{
+    Node, Rendering, TemplateCompiler, TemplateComponent, TemplateGroup,
+    formatting::{get_component_rendering, set_component_rendering},
+};
 
 impl TemplateCompiler {
     pub(super) fn has_variable_recursive(
@@ -119,7 +122,7 @@ impl TemplateCompiler {
 
         for component in components.iter() {
             if let TemplateComponent::Group(list) = component {
-                let base_rendering = self.get_component_rendering(component);
+                let base_rendering = get_component_rendering(component);
                 let is_default_visible = base_rendering.suppress != Some(true);
 
                 if is_default_visible {
@@ -142,9 +145,9 @@ impl TemplateCompiler {
             if let Some(var_key) = self.get_variable_key(component)
                 && default_list_vars.contains(&var_key)
             {
-                let mut rendering = self.get_component_rendering(component);
+                let mut rendering = get_component_rendering(component);
                 rendering.suppress = Some(true);
-                self.set_component_rendering(component, rendering);
+                set_component_rendering(component, rendering);
             }
         }
     }

--- a/crates/citum-migrate/src/template_compiler/formatting.rs
+++ b/crates/citum-migrate/src/template_compiler/formatting.rs
@@ -3,255 +3,260 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-use super::{
-    DelimiterPunctuation, FormattingOptions, Node, Rendering, TemplateCompiler, TemplateComponent,
-};
+use crate::ir::{FormattingOptions, Node};
+use citum_schema::template::{DelimiterPunctuation, Rendering, TemplateComponent};
+use std::sync::OnceLock;
 
-impl TemplateCompiler {
-    pub(super) fn map_label_form(
-        &self,
-        form: &crate::ir::LabelForm,
-    ) -> citum_schema::template::LabelForm {
-        match form {
-            crate::ir::LabelForm::Long => citum_schema::template::LabelForm::Long,
-            crate::ir::LabelForm::Short => citum_schema::template::LabelForm::Short,
-            crate::ir::LabelForm::Symbol => citum_schema::template::LabelForm::Symbol,
-            // Verb and VerbShort don't exist in template::LabelForm, map to Long
-            crate::ir::LabelForm::Verb | crate::ir::LabelForm::VerbShort => {
-                citum_schema::template::LabelForm::Long
-            }
+pub(super) fn map_label_form(form: &crate::ir::LabelForm) -> citum_schema::template::LabelForm {
+    match form {
+        crate::ir::LabelForm::Long => citum_schema::template::LabelForm::Long,
+        crate::ir::LabelForm::Short => citum_schema::template::LabelForm::Short,
+        crate::ir::LabelForm::Symbol => citum_schema::template::LabelForm::Symbol,
+        // Verb and VerbShort don't exist in template::LabelForm, map to Long
+        crate::ir::LabelForm::Verb | crate::ir::LabelForm::VerbShort => {
+            citum_schema::template::LabelForm::Long
         }
     }
+}
 
-    /// Convert `FormattingOptions` to Rendering.
-    pub(super) fn convert_formatting(&self, fmt: &FormattingOptions) -> Rendering {
-        use citum_schema::template::{WrapConfig, WrapPunctuation};
+/// Convert `FormattingOptions` to Rendering.
+pub(super) fn convert_formatting(fmt: &FormattingOptions) -> Rendering {
+    use citum_schema::template::{WrapConfig, WrapPunctuation};
 
-        // Infer wrap from prefix/suffix patterns
-        let (mut wrap_punct, remaining_prefix, remaining_suffix) =
-            Self::infer_wrap_from_affixes(&fmt.prefix, &fmt.suffix);
+    // Infer wrap from prefix/suffix patterns
+    let (mut wrap_punct, remaining_prefix, remaining_suffix) =
+        infer_wrap_from_affixes(&fmt.prefix, &fmt.suffix);
 
-        // quotes="true" in CSL maps to wrap: quotes in Citum. This is the
-        // single owner of quote rendering; the `quote` field below is left
-        // unset so the engine does not apply quotation marks twice.
-        if fmt.quotes == Some(true) {
-            wrap_punct = Some(WrapPunctuation::Quotes);
-        }
+    // quotes="true" in CSL maps to wrap: quotes in Citum. This is the
+    // single owner of quote rendering; the `quote` field below is left
+    // unset so the engine does not apply quotation marks twice.
+    if fmt.quotes == Some(true) {
+        wrap_punct = Some(WrapPunctuation::Quotes);
+    }
 
-        // If wrap is detected, remaining affixes are INNER.
-        // If no wrap, affixes are OUTER (default prefix/suffix).
-        let (prefix, suffix, wrap) = if let Some(punct) = wrap_punct {
+    // If wrap is detected, remaining affixes are INNER.
+    // If no wrap, affixes are OUTER (default prefix/suffix).
+    let (prefix, suffix, wrap) = if let Some(punct) = wrap_punct {
+        (
+            None,
+            None,
+            Some(WrapConfig {
+                punctuation: punct,
+                inner_prefix: remaining_prefix,
+                inner_suffix: remaining_suffix,
+            }),
+        )
+    } else {
+        (remaining_prefix, remaining_suffix, None)
+    };
+
+    Rendering {
+        text_case: None,
+        emph: fmt
+            .font_style
+            .as_ref()
+            .map(|s| matches!(s, crate::ir::FontStyle::Italic)),
+        strong: fmt
+            .font_weight
+            .as_ref()
+            .map(|w| matches!(w, crate::ir::FontWeight::Bold)),
+        small_caps: fmt
+            .font_variant
+            .as_ref()
+            .map(|v| matches!(v, crate::ir::FontVariant::SmallCaps)),
+        vertical_align: fmt.vertical_align.clone(),
+        // Quote rendering is owned by the `wrap: quotes` path above; emitting
+        // it here as well caused doubled quotation marks (`““Title””`).
+        quote: None,
+        prefix,
+        suffix,
+        wrap,
+        suppress: None,
+        initialize_with: None,
+        name_form: None,
+        strip_periods: fmt.strip_periods,
+    }
+}
+
+/// Infer wrap type from prefix/suffix patterns.
+///
+/// CSL 1.0 uses `prefix="("` and `suffix=")"` for parentheses wrapping.
+/// Citum prefers explicit `wrap: parentheses` for cleaner representation.
+///
+/// Returns (wrap, `remaining_prefix`, `remaining_suffix`) where the wrap chars
+/// have been extracted and remaining affixes are returned.
+pub(super) fn infer_wrap_from_affixes(
+    prefix: &Option<String>,
+    suffix: &Option<String>,
+) -> (
+    Option<citum_schema::template::WrapPunctuation>,
+    Option<String>,
+    Option<String>,
+) {
+    use citum_schema::template::WrapPunctuation;
+
+    match (prefix.as_deref(), suffix.as_deref()) {
+        // Clean parentheses: prefix ends with "(", suffix starts with ")"
+        (Some(p), Some(s)) if p.ends_with('(') && s.starts_with(')') => {
+            let remaining_prefix = p
+                .strip_suffix('(')
+                .map(std::string::ToString::to_string)
+                .filter(|s| !s.is_empty());
+            let remaining_suffix = s
+                .strip_prefix(')')
+                .map(std::string::ToString::to_string)
+                .filter(|s| !s.is_empty());
             (
-                None,
-                None,
-                Some(WrapConfig {
-                    punctuation: punct,
-                    inner_prefix: remaining_prefix,
-                    inner_suffix: remaining_suffix,
-                }),
+                Some(WrapPunctuation::Parentheses),
+                remaining_prefix,
+                remaining_suffix,
             )
-        } else {
-            (remaining_prefix, remaining_suffix, None)
-        };
-
-        Rendering {
-            text_case: None,
-            emph: fmt
-                .font_style
-                .as_ref()
-                .map(|s| matches!(s, crate::ir::FontStyle::Italic)),
-            strong: fmt
-                .font_weight
-                .as_ref()
-                .map(|w| matches!(w, crate::ir::FontWeight::Bold)),
-            small_caps: fmt
-                .font_variant
-                .as_ref()
-                .map(|v| matches!(v, crate::ir::FontVariant::SmallCaps)),
-            vertical_align: fmt.vertical_align.clone(),
-            // Quote rendering is owned by the `wrap: quotes` path above; emitting
-            // it here as well caused doubled quotation marks (`““Title””`).
-            quote: None,
-            prefix,
-            suffix,
-            wrap,
-            suppress: None,
-            initialize_with: None,
-            name_form: None,
-            strip_periods: fmt.strip_periods,
         }
+        // Clean brackets
+        (Some(p), Some(s)) if p.ends_with('[') && s.starts_with(']') => {
+            let remaining_prefix = p
+                .strip_suffix('[')
+                .map(std::string::ToString::to_string)
+                .filter(|s| !s.is_empty());
+            let remaining_suffix = s
+                .strip_prefix(']')
+                .map(std::string::ToString::to_string)
+                .filter(|s| !s.is_empty());
+            (
+                Some(WrapPunctuation::Brackets),
+                remaining_prefix,
+                remaining_suffix,
+            )
+        }
+        // No wrap pattern found - keep original affixes
+        _ => (None, prefix.clone(), suffix.clone()),
     }
+}
 
-    /// Infer wrap type from prefix/suffix patterns.
-    ///
-    /// CSL 1.0 uses `prefix="("` and `suffix=")"` for parentheses wrapping.
-    /// Citum prefers explicit `wrap: parentheses` for cleaner representation.
-    ///
-    /// Returns (wrap, `remaining_prefix`, `remaining_suffix`) where the wrap chars
-    /// have been extracted and remaining affixes are returned.
-    pub(super) fn infer_wrap_from_affixes(
-        prefix: &Option<String>,
-        suffix: &Option<String>,
-    ) -> (
+/// Apply wrap formatting from a parent group to a component.
+///
+/// When a group with `prefix="(" suffix=")"` wraps a date, the date
+/// should inherit the wrap property since groups are flattened.
+pub(super) fn apply_wrap_to_component(
+    component: &mut TemplateComponent,
+    group_wrap: &(
         Option<citum_schema::template::WrapPunctuation>,
         Option<String>,
         Option<String>,
-    ) {
-        use citum_schema::template::WrapPunctuation;
+    ),
+) {
+    use citum_schema::template::WrapConfig;
 
-        match (prefix.as_deref(), suffix.as_deref()) {
-            // Clean parentheses: prefix ends with "(", suffix starts with ")"
-            (Some(p), Some(s)) if p.ends_with('(') && s.starts_with(')') => {
-                let remaining_prefix = p
-                    .strip_suffix('(')
-                    .map(std::string::ToString::to_string)
-                    .filter(|s| !s.is_empty());
-                let remaining_suffix = s
-                    .strip_prefix(')')
-                    .map(std::string::ToString::to_string)
-                    .filter(|s| !s.is_empty());
-                (
-                    Some(WrapPunctuation::Parentheses),
-                    remaining_prefix,
-                    remaining_suffix,
+    let (wrap_punct, prefix, suffix) = group_wrap;
+
+    // Helper to apply rendering
+    let apply = |rendering: &mut Rendering| {
+        if rendering.wrap.is_none() && wrap_punct.is_some() {
+            rendering.wrap = wrap_punct.clone().map(|punct| WrapConfig {
+                punctuation: punct,
+                inner_prefix: prefix.clone(),
+                inner_suffix: suffix.clone(),
+            });
+        }
+
+        // If no wrap is being applied, affixes are outer.
+        if wrap_punct.is_none() {
+            if rendering.prefix.is_none() && prefix.is_some() {
+                rendering.prefix = prefix.clone();
+            }
+            if rendering.suffix.is_none() && suffix.is_some() {
+                rendering.suffix = suffix.clone();
+            }
+        }
+    };
+
+    match component {
+        TemplateComponent::Date(d) => apply(&mut d.rendering),
+        TemplateComponent::Contributor(c) => apply(&mut c.rendering),
+        TemplateComponent::Title(t) => apply(&mut t.rendering),
+        TemplateComponent::Number(n) => apply(&mut n.rendering),
+        TemplateComponent::Variable(v) => apply(&mut v.rendering),
+        _ => {} // List, Term, and future variants - don't modify
+    }
+}
+
+/// Map a String delimiter to `DelimiterPunctuation`.
+/// Preserves custom delimiters that don't match standard patterns.
+pub(super) fn map_delimiter(delimiter: &Option<String>) -> Option<DelimiterPunctuation> {
+    delimiter
+        .as_deref()
+        .map(DelimiterPunctuation::from_csl_string)
+}
+
+/// Get the rendering options from a component.
+pub(super) fn get_component_rendering(component: &TemplateComponent) -> Rendering {
+    match component {
+        TemplateComponent::Contributor(c) => c.rendering.clone(),
+        TemplateComponent::Date(d) => d.rendering.clone(),
+        TemplateComponent::Number(n) => n.rendering.clone(),
+        TemplateComponent::Title(t) => t.rendering.clone(),
+        TemplateComponent::Variable(v) => v.rendering.clone(),
+        TemplateComponent::Group(l) => l.rendering.clone(),
+        TemplateComponent::Term(t) => t.rendering.clone(),
+        _ => Rendering::default(),
+    }
+}
+
+/// Set the rendering options for a component.
+pub(super) fn set_component_rendering(component: &mut TemplateComponent, rendering: Rendering) {
+    match component {
+        TemplateComponent::Contributor(c) => c.rendering = rendering,
+        TemplateComponent::Date(d) => d.rendering = rendering,
+        TemplateComponent::Number(n) => n.rendering = rendering,
+        TemplateComponent::Title(t) => t.rendering = rendering,
+        TemplateComponent::Variable(v) => v.rendering = rendering,
+        TemplateComponent::Group(l) => l.rendering = rendering,
+        TemplateComponent::Term(t) => t.rendering = rendering,
+        _ => {}
+    }
+}
+
+/// Extracts the `source_order` from a `Node`, if present.
+/// Returns the order value or `usize::MAX` if not set (sorts last).
+pub(super) fn extract_source_order(node: &Node) -> Option<usize> {
+    let order = match node {
+        Node::Variable(v) => v.source_order,
+        Node::Date(d) => d.source_order,
+        Node::Names(n) => n.source_order,
+        Node::Group(g) => g.source_order,
+        Node::Term(t) => t.source_order,
+        _ => None,
+    };
+    if migrate_debug_enabled() {
+        tracing::debug!(
+            "TemplateCompiler: extract_source_order({:?}) = {:?}",
+            match node {
+                Node::Variable(v) => format!("Variable({:?})", v.variable),
+                Node::Date(d) => format!("Date({:?})", d.variable),
+                Node::Names(n) => format!("Names({:?})", n.variable),
+                Node::Group(_) => "Group".to_string(),
+                Node::Text { value } => format!("Text({value})"),
+                Node::Condition(_) => "Condition".to_string(),
+                Node::Term(t) => format!("Term({:?})", t.term),
+            },
+            order
+        );
+    }
+    order
+}
+
+fn migrate_debug_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("CITUM_MIGRATE_DEBUG")
+            .map(|value| {
+                matches!(
+                    value.to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
                 )
-            }
-            // Clean brackets
-            (Some(p), Some(s)) if p.ends_with('[') && s.starts_with(']') => {
-                let remaining_prefix = p
-                    .strip_suffix('[')
-                    .map(std::string::ToString::to_string)
-                    .filter(|s| !s.is_empty());
-                let remaining_suffix = s
-                    .strip_prefix(']')
-                    .map(std::string::ToString::to_string)
-                    .filter(|s| !s.is_empty());
-                (
-                    Some(WrapPunctuation::Brackets),
-                    remaining_prefix,
-                    remaining_suffix,
-                )
-            }
-            // No wrap pattern found - keep original affixes
-            _ => (None, prefix.clone(), suffix.clone()),
-        }
-    }
-
-    /// Apply wrap formatting from a parent group to a component.
-    ///
-    /// When a group with `prefix="(" suffix=")"` wraps a date, the date
-    /// should inherit the wrap property since groups are flattened.
-    pub(super) fn apply_wrap_to_component(
-        &self,
-        component: &mut TemplateComponent,
-        group_wrap: &(
-            Option<citum_schema::template::WrapPunctuation>,
-            Option<String>,
-            Option<String>,
-        ),
-    ) {
-        use citum_schema::template::WrapConfig;
-
-        let (wrap_punct, prefix, suffix) = group_wrap;
-
-        // Helper to apply rendering
-        let apply = |rendering: &mut Rendering| {
-            if rendering.wrap.is_none() && wrap_punct.is_some() {
-                rendering.wrap = wrap_punct.clone().map(|punct| WrapConfig {
-                    punctuation: punct,
-                    inner_prefix: prefix.clone(),
-                    inner_suffix: suffix.clone(),
-                });
-            }
-
-            // If no wrap is being applied, affixes are outer.
-            if wrap_punct.is_none() {
-                if rendering.prefix.is_none() && prefix.is_some() {
-                    rendering.prefix = prefix.clone();
-                }
-                if rendering.suffix.is_none() && suffix.is_some() {
-                    rendering.suffix = suffix.clone();
-                }
-            }
-        };
-
-        match component {
-            TemplateComponent::Date(d) => apply(&mut d.rendering),
-            TemplateComponent::Contributor(c) => apply(&mut c.rendering),
-            TemplateComponent::Title(t) => apply(&mut t.rendering),
-            TemplateComponent::Number(n) => apply(&mut n.rendering),
-            TemplateComponent::Variable(v) => apply(&mut v.rendering),
-            _ => {} // List, Term, and future variants - don't modify
-        }
-    }
-    /// Map a String delimiter to `DelimiterPunctuation`.
-    /// Preserves custom delimiters that don't match standard patterns.
-    pub(super) fn map_delimiter(&self, delimiter: &Option<String>) -> Option<DelimiterPunctuation> {
-        delimiter
-            .as_deref()
-            .map(DelimiterPunctuation::from_csl_string)
-    }
-
-    /// Get the rendering options from a component.
-    pub(super) fn get_component_rendering(&self, component: &TemplateComponent) -> Rendering {
-        match component {
-            TemplateComponent::Contributor(c) => c.rendering.clone(),
-            TemplateComponent::Date(d) => d.rendering.clone(),
-            TemplateComponent::Number(n) => n.rendering.clone(),
-            TemplateComponent::Title(t) => t.rendering.clone(),
-            TemplateComponent::Variable(v) => v.rendering.clone(),
-            TemplateComponent::Group(l) => l.rendering.clone(),
-            TemplateComponent::Term(t) => t.rendering.clone(),
-            _ => Rendering::default(),
-        }
-    }
-
-    /// Set the rendering options for a component.
-    pub(super) fn set_component_rendering(
-        &self,
-        component: &mut TemplateComponent,
-        rendering: Rendering,
-    ) {
-        match component {
-            TemplateComponent::Contributor(c) => c.rendering = rendering,
-            TemplateComponent::Date(d) => d.rendering = rendering,
-            TemplateComponent::Number(n) => n.rendering = rendering,
-            TemplateComponent::Title(t) => t.rendering = rendering,
-            TemplateComponent::Variable(v) => v.rendering = rendering,
-            TemplateComponent::Group(l) => l.rendering = rendering,
-            TemplateComponent::Term(t) => t.rendering = rendering,
-            _ => {}
-        }
-    }
-
-    /// Extracts the `source_order` from a `Node`, if present.
-    /// Returns the order value or `usize::MAX` if not set (sorts last).
-    pub(super) fn extract_source_order(&self, node: &Node) -> Option<usize> {
-        let order = match node {
-            Node::Variable(v) => v.source_order,
-            Node::Date(d) => d.source_order,
-            Node::Names(n) => n.source_order,
-            Node::Group(g) => g.source_order,
-            Node::Term(t) => t.source_order,
-            _ => None,
-        };
-        if super::migrate_debug_enabled() {
-            tracing::debug!(
-                "TemplateCompiler: extract_source_order({:?}) = {:?}",
-                match node {
-                    Node::Variable(v) => format!("Variable({:?})", v.variable),
-                    Node::Date(d) => format!("Date({:?})", d.variable),
-                    Node::Names(n) => format!("Names({:?})", n.variable),
-                    Node::Group(_) => "Group".to_string(),
-                    Node::Text { value } => format!("Text({value})"),
-                    Node::Condition(_) => "Condition".to_string(),
-                    Node::Term(t) => format!("Term({:?})", t.term),
-                },
-                order
-            );
-        }
-        order
-    }
+            })
+            .unwrap_or(false)
+    })
 }
 
 #[cfg(test)]
@@ -268,7 +273,6 @@ impl TemplateCompiler {
 )]
 mod tests {
     use super::*;
-    use crate::TemplateCompiler;
     use citum_schema::locale::GeneralTerm;
     use citum_schema::template::WrapPunctuation;
 
@@ -276,10 +280,7 @@ mod tests {
     #[test]
     fn test_infer_wrap_from_affixes_parentheses() {
         let (wrap_punct, remaining_prefix, remaining_suffix) =
-            TemplateCompiler::infer_wrap_from_affixes(
-                &Some("(".to_string()),
-                &Some(")".to_string()),
-            );
+            infer_wrap_from_affixes(&Some("(".to_string()), &Some(")".to_string()));
 
         assert_eq!(wrap_punct, Some(WrapPunctuation::Parentheses));
         assert_eq!(remaining_prefix, None);
@@ -290,10 +291,7 @@ mod tests {
     #[test]
     fn test_infer_wrap_with_inner_affixes() {
         let (wrap_punct, remaining_prefix, remaining_suffix) =
-            TemplateCompiler::infer_wrap_from_affixes(
-                &Some("text (".to_string()),
-                &Some(") more".to_string()),
-            );
+            infer_wrap_from_affixes(&Some("text (".to_string()), &Some(") more".to_string()));
 
         assert_eq!(wrap_punct, Some(WrapPunctuation::Parentheses));
         assert_eq!(remaining_prefix, Some("text ".to_string()));
@@ -304,7 +302,6 @@ mod tests {
     /// Terms should NOT receive wrap (they inherit it via group containment instead).
     #[test]
     fn test_apply_wrap_does_not_modify_term() {
-        let compiler = TemplateCompiler;
         let group_wrap = (Some(WrapPunctuation::Parentheses), None, None);
 
         // Create a Term component
@@ -317,7 +314,7 @@ mod tests {
         });
 
         // Apply wrap to the term
-        compiler.apply_wrap_to_component(&mut term, &group_wrap);
+        apply_wrap_to_component(&mut term, &group_wrap);
 
         // Verify that Term's wrap remains None (not modified)
         if let TemplateComponent::Term(t) = term {
@@ -335,13 +332,12 @@ mod tests {
     /// would make the engine emit doubled quotation marks.
     #[test]
     fn given_quotes_true_when_convert_formatting_then_only_wrap_owns_quotes() {
-        let compiler = TemplateCompiler;
         let fmt = crate::ir::FormattingOptions {
             quotes: Some(true),
             ..Default::default()
         };
 
-        let rendering = compiler.convert_formatting(&fmt);
+        let rendering = convert_formatting(&fmt);
 
         assert_eq!(
             rendering.wrap.map(|w| w.punctuation),

--- a/crates/citum-migrate/src/template_compiler/mod.rs
+++ b/crates/citum-migrate/src/template_compiler/mod.rs
@@ -8,10 +8,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! This is the final step in migration: converting the upsampled node tree
 //! into the clean, declarative TemplateComponent format.
 
-use crate::ir::{FormattingOptions, ItemType, Node, Variable};
+use crate::ir::{ItemType, Node, Variable};
 use citum_schema::template::{
-    ContributorForm, ContributorRole, DateForm, DateVariable, DelimiterPunctuation, NumberVariable,
-    Rendering, SimpleVariable, TemplateComponent, TemplateContributor, TemplateDate, TemplateGroup,
+    ContributorForm, ContributorRole, DateForm, DateVariable, NumberVariable, Rendering,
+    SimpleVariable, TemplateComponent, TemplateContributor, TemplateDate, TemplateGroup,
     TemplateNumber, TemplateTitle, TemplateVariable, TitleType,
 };
 use indexmap::IndexMap;

--- a/crates/citum-migrate/src/template_compiler/node_compiler.rs
+++ b/crates/citum-migrate/src/template_compiler/node_compiler.rs
@@ -7,6 +7,7 @@ use super::{
     ContributorForm, ContributorRole, DateForm, DateVariable, Node, NumberVariable, SimpleVariable,
     TemplateCompiler, TemplateComponent, TemplateContributor, TemplateDate, TemplateNumber,
     TemplateTitle, TemplateVariable, TitleType, Variable,
+    formatting::{convert_formatting, map_label_form},
 };
 
 impl TemplateCompiler {
@@ -90,7 +91,7 @@ impl TemplateCompiler {
             }
         });
 
-        let mut rendering = self.convert_formatting(&names.formatting);
+        let mut rendering = convert_formatting(&names.formatting);
         if let Some(label) = &names.options.label {
             rendering.strip_periods = label.formatting.strip_periods.or(rendering.strip_periods);
         }
@@ -155,7 +156,7 @@ impl TemplateCompiler {
         Some(TemplateComponent::Date(TemplateDate {
             date: date_var,
             form,
-            rendering: self.convert_formatting(&date.formatting),
+            rendering: convert_formatting(&date.formatting),
             ..Default::default()
         }))
     }
@@ -178,7 +179,7 @@ impl TemplateCompiler {
             citum_schema::template::TemplateTerm {
                 term: term.term.clone(),
                 form: Some(term.form.clone()),
-                rendering: self.convert_formatting(&term.formatting),
+                rendering: convert_formatting(&term.formatting),
                 ..Default::default()
             },
         ))
@@ -196,7 +197,7 @@ impl TemplateCompiler {
                 form: ContributorForm::Long,
                 name_order: None, // Use global setting by default
                 delimiter: None,
-                rendering: self.convert_formatting(&var.formatting),
+                rendering: convert_formatting(&var.formatting),
                 ..Default::default()
             }));
         }
@@ -206,21 +207,21 @@ impl TemplateCompiler {
             return Some(TemplateComponent::Title(TemplateTitle {
                 title: title_type,
                 form: None,
-                rendering: self.convert_formatting(&var.formatting),
+                rendering: convert_formatting(&var.formatting),
                 ..Default::default()
             }));
         }
 
         // Check if it's a number
         if let Some(num_var) = self.map_variable_to_number(&var.variable) {
-            let mut rendering = self.convert_formatting(&var.formatting);
+            let mut rendering = convert_formatting(&var.formatting);
             if let Some(label) = &var.label {
                 rendering.strip_periods =
                     label.formatting.strip_periods.or(rendering.strip_periods);
             }
 
             // Extract label form if present
-            let label_form = var.label.as_ref().map(|l| self.map_label_form(&l.form));
+            let label_form = var.label.as_ref().map(|l| map_label_form(&l.form));
 
             return Some(TemplateComponent::Number(TemplateNumber {
                 number: num_var,
@@ -233,7 +234,7 @@ impl TemplateCompiler {
 
         // Check if it's a simple variable
         if let Some(simple_var) = self.map_variable_to_simple(&var.variable) {
-            let mut rendering = self.convert_formatting(&var.formatting);
+            let mut rendering = convert_formatting(&var.formatting);
 
             if let Some(label) = &var.label
                 && !matches!(simple_var, SimpleVariable::Locator)


### PR DESCRIPTION
## Summary

- Extracts CLI `StyleCatalogRow` into a root `style_catalog` module so catalog commands and the style browser share the row type without routing through `commands/mod.rs`.
- Decouples `citum-migrate` template formatting helpers from `TemplateCompiler` and `template_compiler/mod.rs` by making formatting operations module-level helpers with direct lower-level imports.
- Updates the affected CLI and migrate call sites to use the new dependency direction without changing CLI behavior, output fields, or template compilation behavior.

## Why

Two static analyzer findings flagged module dependency cycles. Both were reasonable module-ownership concerns, but the migrate finding needed a Rust-specific adjustment: `mod.rs -> formatting.rs` is the module declaration edge, while the removable back edge was `formatting.rs -> mod.rs` through `super::{..., TemplateCompiler, ...}` and `super::migrate_debug_enabled()`.

The resulting ownership is lower-level shared data/helpers first, with commands and compiler orchestration depending on them instead of utility modules importing back through command/compiler roots.

## Validation

- `cargo fmt --check`
- `cargo test -p citum style_browser --locked`
- `cargo test -p citum catalog --locked`
- `cargo clippy -p citum --all-targets --all-features -- -D warnings`
- `cargo test -p citum-migrate template_compiler::formatting --locked`
- `cargo test -p citum-migrate template_compiler --locked`
- `cargo clippy -p citum-migrate --all-targets --all-features -- -D warnings`
- `just pre-commit`
- pre-push hook on `codex/break-style-browser-cycle`: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run` (1689 passed)
