### PR TITLE
Resolve security audit warnings

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,7 +4,7 @@
 # `deny.toml`. cargo-audit does not read deny.toml, so the two tools need
 # parallel suppression lists.
 #
-# All four are *unmaintained* / *unsound* informational advisories on
+# All five are *unmaintained* / *unsound* informational advisories on
 # transitive dependencies with no upstream fix available. They are NOT
 # patchable vulnerabilities, so Renovate `vulnerabilityAlerts` will never
 # auto-resolve them — they must be suppressed explicitly.
@@ -14,4 +14,5 @@ ignore = [
     "RUSTSEC-2024-0436",  # paste unmaintained (transitive via V8/hayagriva/biblatex)
     "RUSTSEC-2025-0141",  # bincode unmaintained (transitive via deno_core/syntect)
     "RUSTSEC-2026-0186",  # memmap2 unsound (transitive via gix stack)
+    "RUSTSEC-2026-0192",  # ttf-parser unmaintained (transitive via Typst stack)
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ ignore = [
     { id = "RUSTSEC-2024-0436", reason = "Transitive through V8, hayagriva, and biblatex; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2025-0141", reason = "Transitive through deno_core and syntect; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2026-0186", reason = "memmap2 unsound: transitive through gix-ref/gix-protocol/gix; no upstream memmap2 fix available in the gix ecosystem yet." },
+    { id = "RUSTSEC-2026-0192", reason = "ttf-parser unmaintained: transitive through the current Typst stack; no direct dependency or actionable local patch path in this PR." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- Updates `anyhow` from `1.0.102` to `1.0.103` in `Cargo.lock` to resolve the patchable RustSec advisory.
- Adds `RUSTSEC-2026-0192` for transitive `ttf-parser` to both cargo-audit and cargo-deny advisory ignore lists.
- Keeps the ignore lists synchronized per the repo policy comments.

## Validation

- `cargo audit --deny warnings`
- `cargo deny check advisories`
- `just pre-commit`
- Pre-push hook: `cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo nextest run`

## Notes

`cargo deny check advisories` still reports the pre-existing `RUSTSEC-2026-0186` ignore as not encountered. This is a warning only and is not changed in this PR.
