### PR TITLE
fix(styles): tune chicago author-date periodicals

### DIFF
--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -187,8 +187,25 @@ bibliography:
     - title: parent-serial
       emph: true
     - date: issued
-      form: month
+      form: month-day
       prefix: ", "
+    - variable: url
+    article-newspaper:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - date: issued
+      form: year
+    - title: primary
+    - title: parent-serial
+      emph: true
+    - date: issued
+      form: month-day
+      prefix: ", "
+    - variable: url
     bill-proceeding:
     - title: primary
     - variable: publisher


### PR DESCRIPTION
## Summary
- tune the embedded `chicago-author-date-18th` periodical bibliography templates
- render magazine issued dates with month-day precision and include URLs
- add a newspaper bibliography template, clearing the newspaper cluster
- regenerate `docs/compat.html` with the new Chicago fidelity snapshot

## Impact
- raises `chicago-author-date-18th` fidelity from 78.3% to 80.8%
- raises Chicago bibliography matches from 381/500 to 395/500
- raises the counted `chicago-zotero-bibliography` benchmark from 284/402 to 298/402
- turns the counted Chicago Zotero bibliography benchmark from fail to pass

## Residual Classification
- `personal_communication` stays suppressed: citeproc omits private communications from the bibliography, and a generic template creates extra entries
- `book`, `document`, `speech`, `song`, `broadcast`, and `motion_picture` residuals are dominated by note-derived roles, event data, original publication data, and conditional suppression that are not safely expressible as a single type template
- those clusters need converter/accessor or conditional template-routing work rather than more broad YAML variants

## Test Plan
- `node scripts/report-core.js --style chicago-author-date-18th > /tmp/chicago-author-date-18th-final.json`
- `node scripts/report-core.js > /tmp/core-report.json`
- `node scripts/report-core.js --write-html > /tmp/core-report-html.json`
- `node scripts/check-core-quality.js --report /tmp/core-report.json --baseline scripts/report-data/core-quality-baseline.json`
- `node scripts/check-testing-infra.js`
- `git diff --check`
